### PR TITLE
fix(cli): preserve default in promptYesNo for invalid input

### DIFF
--- a/packages/agentplane/src/cli/prompts.test.ts
+++ b/packages/agentplane/src/cli/prompts.test.ts
@@ -62,6 +62,14 @@ describe("cli/prompts", () => {
     await expect(promptYesNo("Continue", true)).resolves.toBe(false);
   });
 
+  it("promptYesNo falls back to default for invalid input", async () => {
+    mocks.state.nextAnswer = "definitely";
+    await expect(promptYesNo("Continue", true)).resolves.toBe(true);
+
+    mocks.state.nextAnswer = "definitely";
+    await expect(promptYesNo("Continue", false)).resolves.toBe(false);
+  });
+
   it("promptInput trims input", async () => {
     mocks.state.nextAnswer = "  hello ";
 

--- a/packages/agentplane/src/cli/prompts.ts
+++ b/packages/agentplane/src/cli/prompts.ts
@@ -25,7 +25,10 @@ export async function promptYesNo(prompt: string, defaultValue: boolean): Promis
   rl.close();
   const trimmed = answer.trim().toLowerCase();
   if (!trimmed) return defaultValue;
-  return ["y", "yes", "true", "1", "on"].includes(trimmed);
+
+  if (["y", "yes", "true", "1", "on"].includes(trimmed)) return true;
+  if (["n", "no", "false", "0", "off"].includes(trimmed)) return false;
+  return defaultValue;
 }
 
 export async function promptInput(prompt: string): Promise<string> {


### PR DESCRIPTION
## Summary

Fixes `promptYesNo` behavior for invalid non-empty input.

## Problem

`promptYesNo` previously returned `false` for any non-empty input that was not in the affirmative list. This incorrectly overrode `defaultValue=true` on invalid input.

## Changes

- update `promptYesNo` parsing to handle both affirmative and negative tokens explicitly
- for unknown input, fallback to `defaultValue`
- add unit test coverage for invalid-input fallback

## Validation

- `npx vitest run packages/agentplane/src/cli/prompts.test.ts`
- repository hooks (`pre-commit`, `pre-push`) passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid input responses to yes/no prompts with better fallback behavior when unrecognized input is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->