### PR TITLE
fix(init): accept all setup-profile presets in CLI flags

### DIFF
--- a/docs/user/setup.mdx
+++ b/docs/user/setup.mdx
@@ -41,9 +41,11 @@ If `.git` does not exist in that folder, `init` creates a new git repository the
 `agentplane init` now starts with a setup profile:
 
 - `prod` (default): compact flow with essential prompts only (typically setup profile + backend).
+- `prod-strict`: compact flow with stricter defaults (hooks on, strict unsafe confirmations).
 - `dev`: full questionnaire (workflow, hooks, approvals, execution profile, recipes).
+- `dev-safe`: full questionnaire with stricter unsafe-action confirmations by default.
 
-Use `--setup-profile dev` to force full prompts.
+Use `--setup-profile dev` (or `dev-safe`) to force full prompts.
 
 Non-interactive setup is available through flags:
 

--- a/packages/agentplane/src/cli/run-cli.core.init-upgrade-backend.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.init-upgrade-backend.test.ts
@@ -898,6 +898,18 @@ describe("runCli", () => {
     }
   });
 
+  it("init accepts setup-profile strict variants", async () => {
+    const root1 = await mkGitRepoRoot();
+    await configureGitUser(root1);
+    let code = await runCli(["init", "--yes", "--setup-profile", "prod-strict", "--root", root1]);
+    expect(code).toBe(0);
+
+    const root2 = await mkGitRepoRoot();
+    await configureGitUser(root2);
+    code = await runCli(["init", "--yes", "--setup-profile", "dev-safe", "--root", root2]);
+    expect(code).toBe(0);
+  });
+
   it("init rejects invalid --workflow values", async () => {
     const root = await mkGitRepoRoot();
     const io = captureStdIO();

--- a/packages/agentplane/src/cli/run-cli/commands/init.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init.ts
@@ -31,7 +31,7 @@ import { ensureInitRedmineEnvTemplate } from "./init/write-env.js";
 import { renderInitSection, renderInitWelcome } from "./init/ui.js";
 
 type InitFlags = {
-  setupProfile?: "prod" | "dev";
+  setupProfile?: SetupProfilePreset;
   ide?: "codex" | "cursor" | "windsurf";
   workflow?: "direct" | "branch_pr";
   backend?: "local" | "redmine";
@@ -119,10 +119,10 @@ export const initSpec: CommandSpec<InitParsed> = {
     {
       kind: "string",
       name: "setup-profile",
-      valueHint: "<prod|dev>",
-      choices: ["prod", "dev"],
+      valueHint: "<prod|prod-strict|dev|dev-safe>",
+      choices: ["prod", "prod-strict", "dev", "dev-safe"],
       description:
-        "Interactive preset. prod is the default and asks only essential questions; dev asks the full setup questionnaire.",
+        "Interactive preset. prod is default; prod-strict enables stricter defaults, dev asks the full questionnaire, and dev-safe adds stricter unsafe-action confirmations.",
     },
     {
       kind: "string",
@@ -334,7 +334,7 @@ async function cmdInit(opts: {
   let requireVerifyApproval = flags.requireVerifyApproval ?? defaults.requireVerifyApproval;
   let executionProfile = flags.executionProfile ?? defaults.executionProfile;
   let strictUnsafeConfirm = flags.strictUnsafeConfirm ?? defaults.strictUnsafeConfirm;
-  let setupProfile: "prod" | "dev" = flags.setupProfile ?? "prod";
+  let setupProfile: "prod" | "dev" = setupProfilePresets[flags.setupProfile ?? "prod"].mode;
   let setupProfilePreset: SetupProfilePreset = flags.setupProfile ?? "prod";
   const isInteractive = process.stdin.isTTY && !flags.yes;
 


### PR DESCRIPTION
## Summary

Aligns `init --setup-profile` CLI validation with the actual preset set used by init flow.

## Problem

The init flow supports `prod`, `prod-strict`, `dev`, and `dev-safe`, but CLI flag validation for `--setup-profile` allowed only `prod|dev`.

## Changes

- expand `--setup-profile` option choices/value hint to include:
  - `prod`
  - `prod-strict`
  - `dev`
  - `dev-safe`
- update typing in init command handling
- add test coverage for strict variants
- refresh setup docs section with all presets

## Validation

- `npx vitest run packages/agentplane/src/cli/run-cli.core.init-upgrade-backend.test.ts`
- repository hooks (`pre-commit`, `pre-push`) passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduces two new setup profile options: prod-strict and dev-safe, enabling more granular control over initialization configurations alongside existing options.

* **Documentation**
  * Updates setup guidance to document all available setup profile options and their respective behaviors.

* **Tests**
  * Adds test coverage for new setup profile variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->