### PR TITLE
H2EGEM: type PR artifact state and decouple integrate finalization

### DIFF
--- a/.agentplane/tasks/202603251535-3DZ26K/README.md
+++ b/.agentplane/tasks/202603251535-3DZ26K/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202603251535-3DZ26K"
 title: "Introduce unified workflow transition service for task lifecycle mutations"
-status: "DOING"
+result_summary: "Merged on GitHub main via PR #16 after green CI."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 7
+revision: 8
 origin:
   system: "manual"
 depends_on:
@@ -38,11 +39,16 @@ verification:
     Result: pass
     Evidence: all touched lifecycle files passed lint and formatting checks after the service extraction.
     Scope: touched source files and the new unit test.
-commit: null
+commit:
+  hash: "035858b8170fdc4c802ab501fcb00f6f81584563"
+  message: "✨ 3DZ26K task: unify workflow transition mutations (#16)"
 comments:
   -
     author: "CODER"
     body: "Start: implement the shared workflow transition service and migrate task lifecycle mutation paths without changing observable task or verification behavior."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: Hosted PR #16 merged on main after fresh green checks; local verification evidence from the task branch already covers the extracted transition service and migrated lifecycle flows."
 events:
   -
     type: "verify"
@@ -91,9 +97,16 @@ events:
       Result: pass
       Evidence: all touched lifecycle files passed lint and formatting checks after the service extraction.
       Scope: touched source files and the new unit test.
+  -
+    type: "status"
+    at: "2026-03-26T19:06:26.876Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: Hosted PR #16 merged on main after fresh green checks; local verification evidence from the task branch already covers the extracted transition service and migrated lifecycle flows."
 doc_version: 3
-doc_updated_at: "2026-03-26T18:56:18.063Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-03-26T19:06:26.876Z"
+doc_updated_by: "INTEGRATOR"
 description: "Replace ad hoc task state mutations across start, block, set-status, verify, and finish with one transition service that owns status, plan approval, verification, commit, and comment/event side effects."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202603251535-H2EGEM/README.md
+++ b/.agentplane/tasks/202603251535-H2EGEM/README.md
@@ -1,10 +1,10 @@
 ---
 id: "202603251535-H2EGEM"
 title: "Type PR artifact state and decouple integrate/finalize from finish command reuse"
-status: "TODO"
+status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 1
+revision: 6
 origin:
   system: "manual"
 depends_on:
@@ -15,20 +15,36 @@ tags:
   - "refactor"
 verify: []
 plan_approval:
-  state: "pending"
-  updated_at: null
-  updated_by: null
+  state: "approved"
+  updated_at: "2026-03-26T19:08:10.301Z"
+  updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-03-26T19:39:17.463Z"
+  updated_by: "CODER"
+  note: "Command: bunx vitest run packages/core/src/tasks/task-artifact-schema.test.ts packages/agentplane/src/commands/shared/pr-meta.test.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/cli/run-cli.core.pr-flow.integrate.test.ts packages/agentplane/src/cli/run-cli.core.pr-flow.pr.test.ts; bun run --filter=@agentplaneorg/core build; bun run --filter=agentplane build; bunx eslint packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/task/finish-shared.ts packages/agentplane/src/commands/shared/pr-meta.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts; bunx prettier --check packages/core/src/tasks/task-artifact-schema.ts packages/core/schemas/pr-meta.schema.json packages/spec/schemas/pr-meta.schema.json packages/spec/examples/pr-meta.json packages/agentplane/src/commands/shared/pr-meta.ts packages/agentplane/src/commands/shared/pr-meta.test.ts packages/agentplane/src/commands/task/finish-shared.ts packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/pr/open.ts packages/agentplane/src/commands/pr/update.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts. Result: pass. Evidence: 7 test files / 88 tests passed; focused finish unit passed; core and agentplane builds passed after worktree-local core symlink bootstrap. Scope: PR meta typing, integrate finalize close path, finish handoff, schema sync."
 commit: null
-comments: []
-events: []
+comments:
+  -
+    author: "CODER"
+    body: "Start: introduce a typed PR artifact state contract and decouple integrate/finalize from finish-command reuse without changing merge or close semantics."
+events:
+  -
+    type: "status"
+    at: "2026-03-26T19:08:46.087Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: introduce a typed PR artifact state contract and decouple integrate/finalize from finish-command reuse without changing merge or close semantics."
+  -
+    type: "verify"
+    at: "2026-03-26T19:39:17.463Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: bunx vitest run packages/core/src/tasks/task-artifact-schema.test.ts packages/agentplane/src/commands/shared/pr-meta.test.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/cli/run-cli.core.pr-flow.integrate.test.ts packages/agentplane/src/cli/run-cli.core.pr-flow.pr.test.ts; bun run --filter=@agentplaneorg/core build; bun run --filter=agentplane build; bunx eslint packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/task/finish-shared.ts packages/agentplane/src/commands/shared/pr-meta.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts; bunx prettier --check packages/core/src/tasks/task-artifact-schema.ts packages/core/schemas/pr-meta.schema.json packages/spec/schemas/pr-meta.schema.json packages/spec/examples/pr-meta.json packages/agentplane/src/commands/shared/pr-meta.ts packages/agentplane/src/commands/shared/pr-meta.test.ts packages/agentplane/src/commands/task/finish-shared.ts packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/pr/open.ts packages/agentplane/src/commands/pr/update.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts. Result: pass. Evidence: 7 test files / 88 tests passed; focused finish unit passed; core and agentplane builds passed after worktree-local core symlink bootstrap. Scope: PR meta typing, integrate finalize close path, finish handoff, schema sync."
 doc_version: 3
-doc_updated_at: "2026-03-25T15:35:08.448Z"
+doc_updated_at: "2026-03-26T19:39:17.464Z"
 doc_updated_by: "CODER"
 description: "Introduce a typed PR state contract and stop integrating through loose Record-based PR metadata plus recursive finish-command reuse inside finalize flows."
 sections:
@@ -40,17 +56,23 @@ sections:
     - In scope: Introduce a typed PR state contract and stop integrating through loose Record-based PR metadata plus recursive finish-command reuse inside finalize flows.
     - Out of scope: unrelated refactors not required for "Type PR artifact state and decouple integrate/finalize from finish command reuse".
   Plan: |-
-    1. Implement the change for "Type PR artifact state and decouple integrate/finalize from finish command reuse".
-    2. Run required checks and capture verification evidence.
-    3. Finalize task findings and finish with traceable commit metadata.
+    1. Inventory the current PR artifact read/write seams across pr open/update/check and integrate/finalize, and define one typed PR artifact state contract that replaces loose Record-based metadata access.
+    2. Refactor finalize/integrate flows to consume that typed PR state and remove recursive finish-command reuse, keeping merge/verification/close behavior stable.
+    3. Add focused regression coverage for PR artifact parsing plus integrate/finalize orchestration, then run the smallest targeted build/test surface and record any residual follow-up in Findings.
   Verify Steps: |-
-    <!-- TODO: REPLACE WITH TASK-SPECIFIC ACCEPTANCE STEPS -->
-    
-    1. Review the changed artifact or behavior. Expected: the requested outcome is visible and matches the approved scope.
-    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched scope.
-    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+    1. Inspect the PR artifact readers/writers and integrate/finalize orchestration. Expected: PR state is loaded through one typed contract, and finalize no longer depends on recursive finish-command reuse to close tasks.
+    2. Run focused PR-flow and lifecycle regressions around pr open/update/check, integrate, finalize, and finish handoff paths. Expected: merge metadata, verification evidence, and close semantics remain stable for the touched flows.
+    3. Run the smallest relevant package builds for core and agentplane. Expected: typed PR artifact state compiles cleanly and no downstream command/import breakage appears in touched workflow paths.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-03-26T19:39:17.463Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Command: bunx vitest run packages/core/src/tasks/task-artifact-schema.test.ts packages/agentplane/src/commands/shared/pr-meta.test.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/cli/run-cli.core.pr-flow.integrate.test.ts packages/agentplane/src/cli/run-cli.core.pr-flow.pr.test.ts; bun run --filter=@agentplaneorg/core build; bun run --filter=agentplane build; bunx eslint packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/task/finish-shared.ts packages/agentplane/src/commands/shared/pr-meta.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts; bunx prettier --check packages/core/src/tasks/task-artifact-schema.ts packages/core/schemas/pr-meta.schema.json packages/spec/schemas/pr-meta.schema.json packages/spec/examples/pr-meta.json packages/agentplane/src/commands/shared/pr-meta.ts packages/agentplane/src/commands/shared/pr-meta.test.ts packages/agentplane/src/commands/task/finish-shared.ts packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/pr/open.ts packages/agentplane/src/commands/pr/update.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts. Result: pass. Evidence: 7 test files / 88 tests passed; focused finish unit passed; core and agentplane builds passed after worktree-local core symlink bootstrap. Scope: PR meta typing, integrate finalize close path, finish handoff, schema sync.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-26T19:08:46.088Z, excerpt_hash=sha256:b848cf91dfba1bfdaba93e847ef0bdfca1ac00049da69866f7b3a88aa9de9f20
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -71,21 +93,27 @@ Introduce a typed PR state contract and stop integrating through loose Record-ba
 
 ## Plan
 
-1. Implement the change for "Type PR artifact state and decouple integrate/finalize from finish command reuse".
-2. Run required checks and capture verification evidence.
-3. Finalize task findings and finish with traceable commit metadata.
+1. Inventory the current PR artifact read/write seams across pr open/update/check and integrate/finalize, and define one typed PR artifact state contract that replaces loose Record-based metadata access.
+2. Refactor finalize/integrate flows to consume that typed PR state and remove recursive finish-command reuse, keeping merge/verification/close behavior stable.
+3. Add focused regression coverage for PR artifact parsing plus integrate/finalize orchestration, then run the smallest targeted build/test surface and record any residual follow-up in Findings.
 
 ## Verify Steps
 
-<!-- TODO: REPLACE WITH TASK-SPECIFIC ACCEPTANCE STEPS -->
-
-1. Review the changed artifact or behavior. Expected: the requested outcome is visible and matches the approved scope.
-2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched scope.
-3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+1. Inspect the PR artifact readers/writers and integrate/finalize orchestration. Expected: PR state is loaded through one typed contract, and finalize no longer depends on recursive finish-command reuse to close tasks.
+2. Run focused PR-flow and lifecycle regressions around pr open/update/check, integrate, finalize, and finish handoff paths. Expected: merge metadata, verification evidence, and close semantics remain stable for the touched flows.
+3. Run the smallest relevant package builds for core and agentplane. Expected: typed PR artifact state compiles cleanly and no downstream command/import breakage appears in touched workflow paths.
 
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-03-26T19:39:17.463Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: bunx vitest run packages/core/src/tasks/task-artifact-schema.test.ts packages/agentplane/src/commands/shared/pr-meta.test.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/cli/run-cli.core.pr-flow.integrate.test.ts packages/agentplane/src/cli/run-cli.core.pr-flow.pr.test.ts; bun run --filter=@agentplaneorg/core build; bun run --filter=agentplane build; bunx eslint packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/task/finish-shared.ts packages/agentplane/src/commands/shared/pr-meta.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts; bunx prettier --check packages/core/src/tasks/task-artifact-schema.ts packages/core/schemas/pr-meta.schema.json packages/spec/schemas/pr-meta.schema.json packages/spec/examples/pr-meta.json packages/agentplane/src/commands/shared/pr-meta.ts packages/agentplane/src/commands/shared/pr-meta.test.ts packages/agentplane/src/commands/task/finish-shared.ts packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/pr/open.ts packages/agentplane/src/commands/pr/update.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts. Result: pass. Evidence: 7 test files / 88 tests passed; focused finish unit passed; core and agentplane builds passed after worktree-local core symlink bootstrap. Scope: PR meta typing, integrate finalize close path, finish handoff, schema sync.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-26T19:08:46.088Z, excerpt_hash=sha256:b848cf91dfba1bfdaba93e847ef0bdfca1ac00049da69866f7b3a88aa9de9f20
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202603251535-H2EGEM/pr/diffstat.txt
+++ b/.agentplane/tasks/202603251535-H2EGEM/pr/diffstat.txt
@@ -1,0 +1,15 @@
+ .../agentplane/src/commands/pr/integrate/cmd.ts    |   2 +
+ .../pr/integrate/internal/finalize.test.ts         |  71 ++++--
+ .../src/commands/pr/integrate/internal/finalize.ts |  81 ++++---
+ .../src/commands/pr/integrate/internal/prepare.ts  |   2 +-
+ packages/agentplane/src/commands/pr/open.ts        |  16 +-
+ packages/agentplane/src/commands/pr/update.ts      |  10 +-
+ .../agentplane/src/commands/shared/pr-meta.test.ts |  42 +++-
+ packages/agentplane/src/commands/shared/pr-meta.ts |  78 +++++++
+ .../agentplane/src/commands/task/finish-shared.ts  | 246 ++++++++++++++++++++
+ packages/agentplane/src/commands/task/finish.ts    | 248 +++------------------
+ packages/core/schemas/pr-meta.schema.json          |  24 ++
+ packages/core/src/tasks/task-artifact-schema.ts    |  12 +
+ packages/spec/examples/pr-meta.json                |   1 +
+ packages/spec/schemas/pr-meta.schema.json          |  24 ++
+ 14 files changed, 552 insertions(+), 305 deletions(-)

--- a/.agentplane/tasks/202603251535-H2EGEM/pr/meta.json
+++ b/.agentplane/tasks/202603251535-H2EGEM/pr/meta.json
@@ -1,0 +1,12 @@
+{
+  "branch": "task/202603251535-H2EGEM/pr-artifact-state",
+  "created_at": "2026-03-26T19:40:10.943Z",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202603251535-H2EGEM",
+  "updated_at": "2026-03-26T19:40:16.297Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202603251535-H2EGEM/pr/review.md
+++ b/.agentplane/tasks/202603251535-H2EGEM/pr/review.md
@@ -1,0 +1,43 @@
+# PR Review
+
+Opened by CODER on 2026-03-26T19:40:10.943Z
+Branch: task/202603251535-H2EGEM/pr-artifact-state
+
+## Summary
+
+- 
+
+## Checklist
+
+- [ ] Tests added/updated
+- [ ] Lint/format passes
+- [ ] Verify passed
+- [ ] Docs updated (if needed)
+
+## Handoff Notes
+
+<!-- Add review notes here. -->
+
+<!-- BEGIN AUTO SUMMARY -->
+- Updated: 2026-03-26T19:40:16.296Z
+- Branch: task/202603251535-H2EGEM/pr-artifact-state
+- Head: e9a0e935fa6a
+- Diffstat:
+```
+ .../agentplane/src/commands/pr/integrate/cmd.ts    |   2 +
+ .../pr/integrate/internal/finalize.test.ts         |  71 ++++--
+ .../src/commands/pr/integrate/internal/finalize.ts |  81 ++++---
+ .../src/commands/pr/integrate/internal/prepare.ts  |   2 +-
+ packages/agentplane/src/commands/pr/open.ts        |  16 +-
+ packages/agentplane/src/commands/pr/update.ts      |  10 +-
+ .../agentplane/src/commands/shared/pr-meta.test.ts |  42 +++-
+ packages/agentplane/src/commands/shared/pr-meta.ts |  78 +++++++
+ .../agentplane/src/commands/task/finish-shared.ts  | 246 ++++++++++++++++++++
+ packages/agentplane/src/commands/task/finish.ts    | 248 +++------------------
+ packages/core/schemas/pr-meta.schema.json          |  24 ++
+ packages/core/src/tasks/task-artifact-schema.ts    |  12 +
+ packages/spec/examples/pr-meta.json                |   1 +
+ packages/spec/schemas/pr-meta.schema.json          |  24 ++
+ 14 files changed, 552 insertions(+), 305 deletions(-)
+```
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/pr/integrate/cmd.ts
+++ b/packages/agentplane/src/commands/pr/integrate/cmd.ts
@@ -165,6 +165,8 @@ export async function cmdIntegrate(opts: {
     }
 
     await finalizeIntegrate({
+      ctx: prepared.ctx,
+      task,
       cwd: opts.cwd,
       rootOverride: opts.rootOverride,
       gitRoot: resolved.gitRoot,

--- a/packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts
+++ b/packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts
@@ -10,7 +10,10 @@ const mocks = vi.hoisted(() => ({
   gitDiffStat: vi.fn(),
   appendVerifyLog: vi.fn(),
   parsePrMeta: vi.fn(),
-  cmdFinish: vi.fn(),
+  buildIntegratedPrMeta: vi.fn(),
+  readCommitInfo: vi.fn(),
+  writeFinishedTasks: vi.fn(),
+  createTaskCloseCommit: vi.fn(),
 }));
 
 vi.mock("../../../../cli/fs-utils.js", () => ({ fileExists: mocks.fileExists }));
@@ -23,12 +26,19 @@ vi.mock("../../../shared/git-diff.js", () => ({ gitDiffStat: mocks.gitDiffStat }
 vi.mock("../../../shared/pr-meta.js", () => ({
   appendVerifyLog: mocks.appendVerifyLog,
   parsePrMeta: mocks.parsePrMeta,
+  buildIntegratedPrMeta: mocks.buildIntegratedPrMeta,
 }));
-vi.mock("../../../task/index.js", () => ({ cmdFinish: mocks.cmdFinish }));
+vi.mock("../../../task/shared.js", () => ({ readCommitInfo: mocks.readCommitInfo }));
+vi.mock("../../../task/finish-shared.js", () => ({
+  writeFinishedTasks: mocks.writeFinishedTasks,
+  createTaskCloseCommit: mocks.createTaskCloseCommit,
+}));
 
 function baseOpts() {
   return {
     cwd: "/repo",
+    ctx: { config: {}, git: {}, taskBackend: {} },
+    task: { id: "T-1", status: "DOING", title: "Task" },
     gitRoot: "/repo",
     prDir: "/repo/.agentplane/tasks/T-1/pr",
     metaPath: "/repo/.agentplane/tasks/T-1/pr/meta.json",
@@ -67,11 +77,19 @@ describe("pr/integrate/internal/finalize", () => {
     mocks.fileExists.mockResolvedValue(true);
     mocks.readFile.mockResolvedValue('{"verify":{"status":"skipped"}}');
     mocks.parsePrMeta.mockReturnValue({
+      schema_version: 1,
+      task_id: "T-1",
       verify: { status: "skipped" },
       merged_at: "2026-02-10T00:00:00.000Z",
     });
+    mocks.buildIntegratedPrMeta.mockReturnValue({
+      schema_version: 1,
+      task_id: "T-1",
+      status: "MERGED",
+      verify: { status: "pass" },
+    });
     mocks.gitDiffStat.mockResolvedValue(" src/app.ts | 1 +");
-    mocks.cmdFinish.mockResolvedValue(0);
+    mocks.readCommitInfo.mockResolvedValue({ hash: "deadbeef", message: "merge" });
 
     await finalizeIntegrate({
       ...baseOpts(),
@@ -82,21 +100,30 @@ describe("pr/integrate/internal/finalize", () => {
 
     expect(mocks.appendVerifyLog).toHaveBeenCalledTimes(1);
     expect(mocks.writeJsonStableIfChanged).toHaveBeenCalledTimes(1);
-    const writeMetaCall = mocks.writeJsonStableIfChanged.mock.calls.at(-1)?.[1] as Record<
-      string,
-      unknown
-    >;
-    expect(writeMetaCall.status).toBe("MERGED");
-    expect((writeMetaCall.verify as Record<string, unknown>)?.status).toBe("pass");
+    expect(mocks.buildIntegratedPrMeta).toHaveBeenCalledWith(
+      expect.objectContaining({
+        branch: "task/T-1",
+        base: "main",
+        mergeStrategy: "squash",
+        verifyCommands: ["bun test"],
+      }),
+    );
     expect(mocks.writeTextIfChanged).toHaveBeenCalledWith(
       "/repo/.agentplane/tasks/T-1/pr/diffstat.txt",
       " src/app.ts | 1 +\n",
     );
-    expect(mocks.cmdFinish).toHaveBeenCalledTimes(1);
-    expect(mocks.cmdFinish).toHaveBeenCalledWith(
+    expect(mocks.writeFinishedTasks).toHaveBeenCalledTimes(1);
+    expect(mocks.writeFinishedTasks).toHaveBeenCalledWith(
       expect.objectContaining({
-        taskIds: ["T-1"],
-        closeCommit: true,
+        loadedTasks: [{ taskId: "T-1", task: { id: "T-1", status: "DOING", title: "Task" } }],
+        metaTaskId: "T-1",
+        taskCommitInfo: { hash: "deadbeef", message: "merge" },
+      }),
+    );
+    expect(mocks.createTaskCloseCommit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: "T-1",
+        baseBranchOverride: "main",
       }),
     );
   });
@@ -105,17 +132,19 @@ describe("pr/integrate/internal/finalize", () => {
     const { finalizeIntegrate } = await import("./finalize.js");
     mocks.fileExists.mockResolvedValue(true);
     mocks.readFile.mockResolvedValue("{}");
-    mocks.parsePrMeta.mockReturnValue({});
+    mocks.parsePrMeta.mockReturnValue({ schema_version: 1, task_id: "T-1" });
+    mocks.buildIntegratedPrMeta.mockReturnValue({ schema_version: 1, task_id: "T-1" });
     mocks.gitDiffStat.mockResolvedValue("");
-    mocks.cmdFinish.mockResolvedValue(0);
+    mocks.readCommitInfo.mockResolvedValue({ hash: "deadbeef", message: "merge" });
 
     await finalizeIntegrate(baseOpts());
 
-    const writeMetaCall = mocks.writeJsonStableIfChanged.mock.calls[0]?.[1] as Record<
-      string,
-      unknown
-    >;
-    expect(writeMetaCall.last_verified_sha).toBeUndefined();
-    expect(writeMetaCall.verify).toBeUndefined();
+    expect(mocks.buildIntegratedPrMeta).toHaveBeenCalledWith(
+      expect.objectContaining({
+        verifyCommands: [],
+        shouldRunVerify: false,
+        alreadyVerifiedSha: null,
+      }),
+    );
   });
 });

--- a/packages/agentplane/src/commands/pr/integrate/internal/finalize.ts
+++ b/packages/agentplane/src/commands/pr/integrate/internal/finalize.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { readFile } from "node:fs/promises";
 
+import type { TaskData } from "../../../../backends/task-backend.js";
 import { fileExists } from "../../../../cli/fs-utils.js";
 import { successMessage } from "../../../../cli/output.js";
 import { CliError } from "../../../../shared/errors.js";
@@ -9,15 +10,23 @@ import {
   writeTextIfChanged,
 } from "../../../../shared/write-if-changed.js";
 import { gitDiffStat } from "../../../shared/git-diff.js";
-import { appendVerifyLog, parsePrMeta } from "../../../shared/pr-meta.js";
-
-import { cmdFinish } from "../../../task/index.js";
+import {
+  appendVerifyLog,
+  buildIntegratedPrMeta,
+  parsePrMeta,
+  type PrMeta,
+} from "../../../shared/pr-meta.js";
+import { readCommitInfo } from "../../../task/shared.js";
+import { createTaskCloseCommit, writeFinishedTasks } from "../../../task/finish-shared.js";
+import type { CommandContext } from "../../../shared/task-backend.js";
 
 function nowIso(): string {
   return new Date().toISOString();
 }
 
 export async function finalizeIntegrate(opts: {
+  ctx: CommandContext;
+  task: TaskData;
   cwd: string;
   rootOverride?: string;
   gitRoot: string;
@@ -58,25 +67,18 @@ export async function finalizeIntegrate(opts: {
   const rawMeta = await readFile(opts.metaPath, "utf8");
   const mergedMeta = parsePrMeta(rawMeta, opts.taskId);
   const now = nowIso();
-  const nextMeta: Record<string, unknown> = {
-    ...mergedMeta,
+  const nextMeta: PrMeta = buildIntegratedPrMeta({
+    meta: mergedMeta,
     branch: opts.branch,
     base: opts.base,
-    merge_strategy: opts.mergeStrategy,
-    status: "MERGED",
-    merged_at: (mergedMeta as Record<string, unknown>).merged_at ?? now,
-    merge_commit: opts.mergeHash,
-    head_sha: opts.branchHeadSha,
-    updated_at: now,
-  };
-
-  if (opts.verifyCommands.length > 0 && (opts.shouldRunVerify || opts.alreadyVerifiedSha)) {
-    nextMeta.last_verified_sha = opts.branchHeadSha;
-    nextMeta.last_verified_at = now;
-    nextMeta.verify = mergedMeta.verify
-      ? { ...mergedMeta.verify, status: "pass" }
-      : { status: "pass", command: opts.verifyCommands.join(" && ") };
-  }
+    mergeStrategy: opts.mergeStrategy,
+    mergeHash: opts.mergeHash,
+    branchHeadSha: opts.branchHeadSha,
+    at: now,
+    verifyCommands: opts.verifyCommands,
+    shouldRunVerify: opts.shouldRunVerify,
+    alreadyVerifiedSha: opts.alreadyVerifiedSha,
+  });
   await writeJsonStableIfChanged(opts.metaPath, nextMeta);
 
   const diffstat = await gitDiffStat(opts.gitRoot, opts.baseShaBeforeMerge, opts.branch);
@@ -94,31 +96,26 @@ export async function finalizeIntegrate(opts: {
     opts.gitRoot,
     opts.prDir,
   )}.`;
-
-  await cmdFinish({
-    cwd: opts.cwd,
-    rootOverride: opts.rootOverride,
-    taskIds: [opts.taskId],
+  const resultSummary = `integrate: ${opts.mergeStrategy} ${opts.branch}`;
+  const taskCommitInfo = await readCommitInfo(opts.gitRoot, opts.mergeHash);
+  await writeFinishedTasks({
+    ctx: opts.ctx,
+    loadedTasks: [{ taskId: opts.taskId, task: opts.task }],
+    metaTaskId: opts.taskId,
     author: "INTEGRATOR",
     body: finishBody,
-    result: `integrate: ${opts.mergeStrategy} ${opts.branch}`,
-    risk: undefined,
-    breaking: false,
-    commit: opts.mergeHash,
     force: false,
-    commitFromComment: false,
-    commitEmoji: undefined,
-    commitAllow: [],
-    commitAutoAllow: false,
-    commitAllowTasks: false,
-    commitRequireClean: false,
-    statusCommit: false,
-    statusCommitEmoji: undefined,
-    statusCommitAllow: [],
-    statusCommitAutoAllow: false,
-    statusCommitRequireClean: false,
-    confirmStatusCommit: false,
-    closeCommit: true,
+    resultProvided: true,
+    resultSummary,
+    riskLevel: undefined,
+    breaking: false,
+    taskCommitInfo,
+  });
+  await createTaskCloseCommit({
+    ctx: opts.ctx,
+    cwd: opts.cwd,
+    rootOverride: opts.rootOverride,
+    taskId: opts.taskId,
     baseBranchOverride: opts.base,
     quiet: opts.quiet,
   });

--- a/packages/agentplane/src/commands/pr/integrate/internal/prepare.ts
+++ b/packages/agentplane/src/commands/pr/integrate/internal/prepare.ts
@@ -157,7 +157,7 @@ export async function prepareIntegrate(opts: {
       ),
       task.id,
     );
-  const baseCandidate = opts.base ?? (metaSource as Record<string, unknown>).base ?? baseBranch;
+  const baseCandidate = opts.base ?? metaSource.base ?? baseBranch;
   const base =
     typeof baseCandidate === "string" && baseCandidate.trim().length > 0
       ? baseCandidate.trim()

--- a/packages/agentplane/src/commands/pr/open.ts
+++ b/packages/agentplane/src/commands/pr/open.ts
@@ -10,7 +10,7 @@ import { successMessage, workflowModeMessage } from "../../cli/output.js";
 import { CliError } from "../../shared/errors.js";
 import { writeJsonStableIfChanged, writeTextIfChanged } from "../../shared/write-if-changed.js";
 import { gitCurrentBranch } from "../shared/git-ops.js";
-import { parsePrMeta, type PrMeta } from "../shared/pr-meta.js";
+import { buildOpenedPrMeta, parsePrMeta, type PrMeta } from "../shared/pr-meta.js";
 import {
   loadBackendTask,
   loadCommandContext,
@@ -80,16 +80,12 @@ export async function cmdPrOpen(opts: {
       meta = parsePrMeta(raw, task.id);
     }
     const createdAt = meta?.created_at ?? now;
-    const nextMeta: PrMeta = {
-      schema_version: 1,
-      task_id: task.id,
+    const nextMeta: PrMeta = buildOpenedPrMeta({
+      taskId: task.id,
       branch,
-      created_at: createdAt,
-      updated_at: now,
-      last_verified_sha: meta?.last_verified_sha ?? null,
-      last_verified_at: meta?.last_verified_at ?? null,
-      verify: meta?.verify ?? { status: "skipped" },
-    };
+      at: now,
+      previousMeta: meta,
+    });
     await writeJsonStableIfChanged(metaPath, nextMeta);
 
     await writeTextIfChanged(diffstatPath, "");

--- a/packages/agentplane/src/commands/pr/update.ts
+++ b/packages/agentplane/src/commands/pr/update.ts
@@ -10,7 +10,7 @@ import { CliError } from "../../shared/errors.js";
 import { writeJsonStableIfChanged, writeTextIfChanged } from "../../shared/write-if-changed.js";
 import { execFileAsync, gitEnv } from "../shared/git.js";
 import { gitCurrentBranch } from "../shared/git-ops.js";
-import { parsePrMeta, type PrMeta } from "../shared/pr-meta.js";
+import { buildUpdatedPrMeta, parsePrMeta, type PrMeta } from "../shared/pr-meta.js";
 import {
   loadBackendTask,
   loadCommandContext,
@@ -107,13 +107,7 @@ export async function cmdPrUpdate(opts: {
 
     const rawMeta = await readFile(metaPath, "utf8");
     const meta = parsePrMeta(rawMeta, opts.taskId);
-    const nextMeta: PrMeta = {
-      ...meta,
-      branch,
-      updated_at: nowIso(),
-      last_verified_sha: meta.last_verified_sha ?? null,
-      last_verified_at: meta.last_verified_at ?? null,
-    };
+    const nextMeta: PrMeta = buildUpdatedPrMeta({ meta, branch, at: nowIso() });
     await writeJsonStableIfChanged(metaPath, nextMeta);
 
     process.stdout.write(

--- a/packages/agentplane/src/commands/shared/pr-meta.test.ts
+++ b/packages/agentplane/src/commands/shared/pr-meta.test.ts
@@ -2,7 +2,12 @@ import os from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as git from "./git.js";
-import { parsePrMeta, resolveShellInvocation, runShellCommand } from "./pr-meta.js";
+import {
+  buildIntegratedPrMeta,
+  parsePrMeta,
+  resolveShellInvocation,
+  runShellCommand,
+} from "./pr-meta.js";
 
 describe("pr-meta shell invocations", () => {
   let originalComspec: string | undefined;
@@ -78,5 +83,40 @@ describe("pr-meta shell invocations", () => {
         "202601010101-ABCDE",
       ),
     ).toThrow(/pr\/meta\.json schema validation failed/u);
+  });
+
+  it("builds typed merged PR metadata without record casts", () => {
+    expect(
+      buildIntegratedPrMeta({
+        meta: {
+          schema_version: 1,
+          task_id: "202601010101-ABCDE",
+          branch: "task/202601010101-ABCDE/example",
+          created_at: "2026-01-27T00:00:00Z",
+          updated_at: "2026-01-27T00:00:00Z",
+          verify: { status: "skipped" },
+        },
+        branch: "task/202601010101-ABCDE/example",
+        base: "main",
+        mergeStrategy: "squash",
+        mergeHash: "deadbeef",
+        branchHeadSha: "deadbeef",
+        at: "2026-01-28T00:00:00Z",
+        verifyCommands: ["bun test"],
+        shouldRunVerify: true,
+        alreadyVerifiedSha: null,
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        base: "main",
+        status: "MERGED",
+        merge_strategy: "squash",
+        merge_commit: "deadbeef",
+        head_sha: "deadbeef",
+        merged_at: "2026-01-28T00:00:00Z",
+        last_verified_sha: "deadbeef",
+        last_verified_at: "2026-01-28T00:00:00Z",
+      }),
+    );
   });
 });

--- a/packages/agentplane/src/commands/shared/pr-meta.ts
+++ b/packages/agentplane/src/commands/shared/pr-meta.ts
@@ -7,6 +7,84 @@ import { validateTaskPrMeta, type TaskPrMeta } from "@agentplaneorg/core";
 import { execFileAsync } from "./git.js";
 
 export type PrMeta = TaskPrMeta;
+export type PrArtifactTextState = {
+  diffstatText: string | null;
+  verifyLogText: string | null;
+  reviewText: string | null;
+};
+
+export type PrArtifactState = PrArtifactTextState & {
+  meta: PrMeta;
+};
+
+function nowOrExisting(value: string | undefined, fallback: string): string {
+  const trimmed = value?.trim() ?? "";
+  return trimmed || fallback;
+}
+
+export function buildOpenedPrMeta(opts: {
+  taskId: string;
+  branch: string;
+  at: string;
+  previousMeta: PrMeta | null;
+}): PrMeta {
+  return {
+    schema_version: 1,
+    task_id: opts.taskId,
+    branch: opts.branch,
+    created_at: opts.previousMeta?.created_at ?? opts.at,
+    updated_at: opts.at,
+    last_verified_sha: opts.previousMeta?.last_verified_sha ?? null,
+    last_verified_at: opts.previousMeta?.last_verified_at ?? null,
+    verify: opts.previousMeta?.verify ?? { status: "skipped" },
+    base: opts.previousMeta?.base,
+  };
+}
+
+export function buildUpdatedPrMeta(opts: { meta: PrMeta; branch: string; at: string }): PrMeta {
+  return {
+    ...opts.meta,
+    branch: opts.branch,
+    updated_at: opts.at,
+    last_verified_sha: opts.meta.last_verified_sha ?? null,
+    last_verified_at: opts.meta.last_verified_at ?? null,
+  };
+}
+
+export function buildIntegratedPrMeta(opts: {
+  meta: PrMeta;
+  branch: string;
+  base: string;
+  mergeStrategy: "squash" | "merge" | "rebase";
+  mergeHash: string;
+  branchHeadSha: string;
+  at: string;
+  verifyCommands: string[];
+  shouldRunVerify: boolean;
+  alreadyVerifiedSha: string | null;
+}): PrMeta {
+  const nextMeta: PrMeta = {
+    ...opts.meta,
+    branch: opts.branch,
+    base: opts.base,
+    merge_strategy: opts.mergeStrategy,
+    status: "MERGED",
+    merged_at: nowOrExisting(opts.meta.merged_at, opts.at),
+    merge_commit: opts.mergeHash,
+    head_sha: opts.branchHeadSha,
+    updated_at: opts.at,
+  };
+
+  if (opts.verifyCommands.length > 0 && (opts.shouldRunVerify || opts.alreadyVerifiedSha)) {
+    nextMeta.last_verified_sha = opts.branchHeadSha;
+    nextMeta.last_verified_at = opts.at;
+    nextMeta.verify = opts.meta.verify
+      ? { ...opts.meta.verify, status: "pass" }
+      : { status: "pass", command: opts.verifyCommands.join(" && ") };
+  }
+
+  return nextMeta;
+}
 
 export type ShellInvocation = {
   command: string;

--- a/packages/agentplane/src/commands/task/finish-shared.ts
+++ b/packages/agentplane/src/commands/task/finish-shared.ts
@@ -1,0 +1,246 @@
+import { ensureDocSections } from "@agentplaneorg/core";
+
+import type { TaskData } from "../../backends/task-backend.js";
+import { CliError } from "../../shared/errors.js";
+import { cmdCommit } from "../guard/index.js";
+import { loadTaskFromContext, type CommandContext } from "../shared/task-backend.js";
+import { backendIsLocalFileBackend, getTaskStore, mutateTaskStore } from "../shared/task-store.js";
+
+import {
+  buildTaskStatusTransition,
+  ensureAgentFilledRequiredDocSections,
+  ensureVerificationSatisfiedIfRequired,
+  nowIso,
+  resolvePrimaryTag,
+  toStringArray,
+} from "./shared.js";
+
+export type ResolvedCommitInfo = {
+  hash: string;
+  message: string;
+};
+
+export type LoadedFinishTask = {
+  taskId: string;
+  task: TaskData;
+};
+
+export function existingCommitInfo(task: TaskData): ResolvedCommitInfo | null {
+  const hash = typeof task.commit?.hash === "string" ? task.commit.hash.trim() : "";
+  if (!hash) return null;
+  const message = typeof task.commit?.message === "string" ? task.commit.message.trim() : "";
+  return { hash, message };
+}
+
+export function assertTaskCanFinish(opts: {
+  task: TaskData;
+  config: CommandContext["config"];
+  taskCount: number;
+  isMetaTask: boolean;
+  resultProvided: boolean;
+  resultSummary: string;
+  force: boolean;
+}): void {
+  if (!opts.force && String(opts.task.status || "TODO").toUpperCase() === "DONE") {
+    throw new CliError({
+      exitCode: 2,
+      code: "E_USAGE",
+      message: `Task is already DONE: ${opts.task.id} (use --force to override)`,
+    });
+  }
+
+  ensureVerificationSatisfiedIfRequired(opts.task, opts.config);
+  const normalizedDoc = ensureDocSections(
+    typeof opts.task.doc === "string" ? opts.task.doc : "",
+    opts.config.tasks.doc.required_sections,
+  );
+  ensureAgentFilledRequiredDocSections({
+    task: opts.task,
+    config: opts.config,
+    doc: normalizedDoc,
+    action: "finish task",
+  });
+
+  if (!opts.isMetaTask) return;
+
+  const tags = Array.isArray(opts.task.tags)
+    ? opts.task.tags.filter((t): t is string => typeof t === "string")
+    : [];
+  const isSpike = tags.includes("spike");
+  if (!isSpike && opts.taskCount === 1 && !opts.resultSummary) {
+    throw new CliError({
+      exitCode: 2,
+      code: "E_USAGE",
+      message: "Missing required --result for non-spike tasks.",
+    });
+  }
+  if (opts.resultProvided && !opts.resultSummary) {
+    throw new CliError({
+      exitCode: 2,
+      code: "E_USAGE",
+      message: "Invalid value for --result: empty.",
+    });
+  }
+}
+
+export async function loadTaskForFinish(opts: {
+  ctx: CommandContext;
+  store: ReturnType<typeof getTaskStore> | null;
+  useStore: boolean;
+  taskId: string;
+  taskCount: number;
+  metaTaskId: string;
+  resultProvided: boolean;
+  resultSummary: string;
+  force: boolean;
+  capturePrimaryLifecycleMeta: boolean;
+}): Promise<{
+  loaded: LoadedFinishTask;
+  primaryStatusFrom: string | null;
+  primaryTag: string | null;
+}> {
+  if (opts.useStore) {
+    let captured: TaskData | null = null;
+    let primaryStatusFrom: string | null = null;
+    let primaryTag: string | null = null;
+    await mutateTaskStore(opts.store!, opts.taskId, (currentTask) => {
+      assertTaskCanFinish({
+        task: currentTask,
+        config: opts.ctx.config,
+        taskCount: opts.taskCount,
+        isMetaTask: opts.taskId === opts.metaTaskId,
+        resultProvided: opts.resultProvided,
+        resultSummary: opts.resultSummary,
+        force: opts.force,
+      });
+      captured = currentTask;
+      if (opts.capturePrimaryLifecycleMeta) {
+        primaryStatusFrom = String(currentTask.status || "TODO").toUpperCase();
+        primaryTag = resolvePrimaryTag(toStringArray(currentTask.tags), opts.ctx).primary;
+      }
+      return [];
+    });
+    if (!captured) {
+      throw new CliError({
+        exitCode: 4,
+        code: "E_IO",
+        message: `Task not found: ${opts.taskId}`,
+      });
+    }
+    return {
+      loaded: { taskId: opts.taskId, task: captured },
+      primaryStatusFrom,
+      primaryTag,
+    };
+  }
+
+  const task = await loadTaskFromContext({ ctx: opts.ctx, taskId: opts.taskId });
+  assertTaskCanFinish({
+    task,
+    config: opts.ctx.config,
+    taskCount: opts.taskCount,
+    isMetaTask: opts.taskId === opts.metaTaskId,
+    resultProvided: opts.resultProvided,
+    resultSummary: opts.resultSummary,
+    force: opts.force,
+  });
+  return {
+    loaded: { taskId: opts.taskId, task },
+    primaryStatusFrom: opts.capturePrimaryLifecycleMeta
+      ? String(task.status || "TODO").toUpperCase()
+      : null,
+    primaryTag: opts.capturePrimaryLifecycleMeta
+      ? resolvePrimaryTag(toStringArray(task.tags), opts.ctx).primary
+      : null,
+  };
+}
+
+export async function writeFinishedTasks(opts: {
+  ctx: CommandContext;
+  loadedTasks: LoadedFinishTask[];
+  metaTaskId: string;
+  author: string;
+  body: string;
+  force: boolean;
+  resultProvided: boolean;
+  resultSummary: string;
+  riskLevel?: "low" | "med" | "high";
+  breaking: boolean;
+  taskCommitInfo: ResolvedCommitInfo | null;
+}): Promise<void> {
+  const useStore = backendIsLocalFileBackend(opts.ctx);
+  const store = useStore ? getTaskStore(opts.ctx) : null;
+  const taskCount = opts.loadedTasks.length;
+
+  for (const { taskId, task } of opts.loadedTasks) {
+    const at = nowIso();
+    const applyTransition = (currentTask: TaskData) => {
+      assertTaskCanFinish({
+        task: currentTask,
+        config: opts.ctx.config,
+        taskCount,
+        isMetaTask: taskId === opts.metaTaskId,
+        resultProvided: opts.resultProvided,
+        resultSummary: opts.resultSummary,
+        force: opts.force,
+      });
+      return buildTaskStatusTransition({
+        task: currentTask,
+        at,
+        toStatus: "DONE",
+        eventAuthor: opts.author,
+        updatedBy: opts.author,
+        note: opts.body,
+        comment: { author: opts.author, body: opts.body },
+        commit: opts.taskCommitInfo
+          ? { hash: opts.taskCommitInfo.hash, message: opts.taskCommitInfo.message }
+          : undefined,
+        extraFields: {
+          ...(taskId === opts.metaTaskId && opts.resultSummary
+            ? { result_summary: opts.resultSummary }
+            : {}),
+          ...(taskId === opts.metaTaskId && opts.riskLevel ? { risk_level: opts.riskLevel } : {}),
+          ...(taskId === opts.metaTaskId && opts.breaking ? { breaking: true } : {}),
+        },
+      });
+    };
+
+    await (useStore
+      ? mutateTaskStore(store!, taskId, (currentTask) => applyTransition(currentTask).intents)
+      : opts.ctx.taskBackend.writeTask(applyTransition(task).nextTask));
+  }
+}
+
+export async function createTaskCloseCommit(opts: {
+  ctx: CommandContext;
+  cwd: string;
+  rootOverride?: string;
+  taskId: string;
+  baseBranchOverride?: string;
+  quiet: boolean;
+  closeUnstageOthers?: boolean;
+}): Promise<void> {
+  opts.ctx.git.invalidateStatus();
+  await cmdCommit({
+    ctx: opts.ctx,
+    cwd: opts.cwd,
+    rootOverride: opts.rootOverride,
+    baseBranchOverride: opts.baseBranchOverride ?? null,
+    taskId: opts.taskId,
+    message: "",
+    close: true,
+    allow: [],
+    autoAllow: false,
+    allowTasks: true,
+    allowBase: opts.ctx.config.workflow_mode === "branch_pr",
+    allowPolicy: false,
+    allowConfig: false,
+    allowHooks: false,
+    allowCI: false,
+    requireClean: true,
+    quiet: opts.quiet,
+    closeUnstageOthers: opts.closeUnstageOthers === true,
+    closeCheckOnly: false,
+    closeStageTaskArtifacts: opts.ctx.config.workflow_mode === "branch_pr",
+  });
+}

--- a/packages/agentplane/src/commands/task/finish.ts
+++ b/packages/agentplane/src/commands/task/finish.ts
@@ -1,5 +1,3 @@
-import { type TaskData } from "../../backends/task-backend.js";
-import { ensureDocSections } from "@agentplaneorg/core";
 import { mapBackendError } from "../../cli/error-map.js";
 import { infoMessage, invalidValueMessage, successMessage } from "../../cli/output.js";
 import { formatCommentBodyForCommit } from "../../shared/comment-format.js";
@@ -7,29 +5,27 @@ import { CliError } from "../../shared/errors.js";
 import { readFile, rm } from "node:fs/promises";
 import path from "node:path";
 
-import { cmdCommit, commitFromComment } from "../guard/index.js";
+import { commitFromComment } from "../guard/index.js";
 import { ensureActionApproved } from "../shared/approval-requirements.js";
 import { ensureReconciledBeforeMutation } from "../shared/reconcile-check.js";
-import {
-  loadCommandContext,
-  loadTaskFromContext,
-  type CommandContext,
-} from "../shared/task-backend.js";
-import { backendIsLocalFileBackend, getTaskStore, mutateTaskStore } from "../shared/task-store.js";
+import { loadCommandContext, type CommandContext } from "../shared/task-backend.js";
+import { backendIsLocalFileBackend, getTaskStore } from "../shared/task-store.js";
 
 import { readDirectWorkLock } from "../../shared/direct-work-lock.js";
+import {
+  createTaskCloseCommit,
+  existingCommitInfo,
+  loadTaskForFinish,
+  type LoadedFinishTask,
+  type ResolvedCommitInfo,
+  writeFinishedTasks,
+} from "./finish-shared.js";
 
 import {
-  buildTaskStatusTransition,
   defaultCommitEmojiForStatus,
   enforceStatusCommitPolicy,
-  ensureAgentFilledRequiredDocSections,
-  ensureVerificationSatisfiedIfRequired,
-  nowIso,
   readCommitInfo,
   requireStructuredComment,
-  resolvePrimaryTag,
-  toStringArray,
 } from "./shared.js";
 
 async function clearDirectWorkLockIfMatches(opts: {
@@ -46,142 +42,6 @@ async function clearDirectWorkLockIfMatches(opts: {
     await rm(lockPath, { force: true });
   } catch {
     // best-effort
-  }
-}
-
-type ResolvedCommitInfo = { hash: string; message: string };
-type LoadedFinishTask = {
-  taskId: string;
-  task: TaskData;
-};
-
-function existingCommitInfo(task: TaskData): ResolvedCommitInfo | null {
-  const hash = typeof task.commit?.hash === "string" ? task.commit.hash.trim() : "";
-  if (!hash) return null;
-  const message = typeof task.commit?.message === "string" ? task.commit.message.trim() : "";
-  return { hash, message };
-}
-
-async function loadTaskForFinish(opts: {
-  ctx: CommandContext;
-  store: ReturnType<typeof getTaskStore> | null;
-  useStore: boolean;
-  taskId: string;
-  taskCount: number;
-  metaTaskId: string;
-  resultProvided: boolean;
-  resultSummary: string;
-  force: boolean;
-  capturePrimaryLifecycleMeta: boolean;
-}): Promise<{
-  loaded: LoadedFinishTask;
-  primaryStatusFrom: string | null;
-  primaryTag: string | null;
-}> {
-  let primaryStatusFrom: string | null = null;
-  let primaryTag: string | null = null;
-  if (opts.useStore) {
-    let captured: TaskData | null = null;
-    await mutateTaskStore(opts.store!, opts.taskId, (current) => {
-      assertTaskCanFinish({
-        task: current,
-        config: opts.ctx.config,
-        taskCount: opts.taskCount,
-        isMetaTask: opts.taskId === opts.metaTaskId,
-        resultProvided: opts.resultProvided,
-        resultSummary: opts.resultSummary,
-        force: opts.force,
-      });
-      captured = current;
-      if (opts.capturePrimaryLifecycleMeta) {
-        primaryStatusFrom = String(current.status || "TODO").toUpperCase();
-        primaryTag = resolvePrimaryTag(toStringArray(current.tags), opts.ctx).primary;
-      }
-      return [];
-    });
-    if (!captured) {
-      throw new CliError({
-        exitCode: 4,
-        code: "E_IO",
-        message: `Task not found: ${opts.taskId}`,
-      });
-    }
-    return {
-      loaded: { taskId: opts.taskId, task: captured },
-      primaryStatusFrom,
-      primaryTag,
-    };
-  }
-
-  const task = await loadTaskFromContext({ ctx: opts.ctx, taskId: opts.taskId });
-  assertTaskCanFinish({
-    task,
-    config: opts.ctx.config,
-    taskCount: opts.taskCount,
-    isMetaTask: opts.taskId === opts.metaTaskId,
-    resultProvided: opts.resultProvided,
-    resultSummary: opts.resultSummary,
-    force: opts.force,
-  });
-  if (opts.capturePrimaryLifecycleMeta) {
-    primaryStatusFrom = String(task.status || "TODO").toUpperCase();
-    primaryTag = resolvePrimaryTag(toStringArray(task.tags), opts.ctx).primary;
-  }
-  return {
-    loaded: { taskId: opts.taskId, task },
-    primaryStatusFrom,
-    primaryTag,
-  };
-}
-
-function assertTaskCanFinish(opts: {
-  task: TaskData;
-  config: CommandContext["config"];
-  taskCount: number;
-  isMetaTask: boolean;
-  resultProvided: boolean;
-  resultSummary: string;
-  force: boolean;
-}): void {
-  if (!opts.force && String(opts.task.status || "TODO").toUpperCase() === "DONE") {
-    throw new CliError({
-      exitCode: 2,
-      code: "E_USAGE",
-      message: `Task is already DONE: ${opts.task.id} (use --force to override)`,
-    });
-  }
-
-  ensureVerificationSatisfiedIfRequired(opts.task, opts.config);
-  const normalizedDoc = ensureDocSections(
-    typeof opts.task.doc === "string" ? opts.task.doc : "",
-    opts.config.tasks.doc.required_sections,
-  );
-  ensureAgentFilledRequiredDocSections({
-    task: opts.task,
-    config: opts.config,
-    doc: normalizedDoc,
-    action: "finish task",
-  });
-
-  if (!opts.isMetaTask) return;
-
-  const tags = Array.isArray(opts.task.tags)
-    ? opts.task.tags.filter((t): t is string => typeof t === "string")
-    : [];
-  const isSpike = tags.includes("spike");
-  if (!isSpike && opts.taskCount === 1 && !opts.resultSummary) {
-    throw new CliError({
-      exitCode: 2,
-      code: "E_USAGE",
-      message: "Missing required --result for non-spike tasks.",
-    });
-  }
-  if (opts.resultProvided && !opts.resultSummary) {
-    throw new CliError({
-      exitCode: 2,
-      code: "E_USAGE",
-      message: "Invalid value for --result: empty.",
-    });
   }
 }
 
@@ -476,92 +336,36 @@ export async function cmdFinish(opts: {
       });
     }
 
-    for (const { taskId, task } of loadedTasks) {
-      const at = nowIso();
-      await (useStore
-        ? mutateTaskStore(store!, taskId, (current) => {
-            assertTaskCanFinish({
-              task: current,
-              config: ctx.config,
-              taskCount: opts.taskIds.length,
-              isMetaTask: taskId === metaTaskId,
-              resultProvided,
-              resultSummary,
-              force: opts.force,
-            });
-            return buildTaskStatusTransition({
-              task: current,
-              at,
-              toStatus: "DONE",
-              eventAuthor: opts.author,
-              updatedBy: opts.author,
-              note: opts.body,
-              comment: { author: opts.author, body: opts.body },
-              commit: taskCommitInfo
-                ? { hash: taskCommitInfo.hash, message: taskCommitInfo.message }
-                : undefined,
-              extraFields: {
-                ...(taskId === metaTaskId && resultSummary
-                  ? { result_summary: resultSummary }
-                  : {}),
-                ...(taskId === metaTaskId && riskLevel ? { risk_level: riskLevel } : {}),
-                ...(taskId === metaTaskId && breaking ? { breaking: true } : {}),
-              },
-            }).intents;
-          })
-        : ctx.taskBackend.writeTask(
-            buildTaskStatusTransition({
-              task,
-              at,
-              toStatus: "DONE",
-              eventAuthor: opts.author,
-              updatedBy: opts.author,
-              note: opts.body,
-              comment: { author: opts.author, body: opts.body },
-              commit: taskCommitInfo
-                ? { hash: taskCommitInfo.hash, message: taskCommitInfo.message }
-                : undefined,
-              extraFields: {
-                ...(taskId === metaTaskId && resultSummary
-                  ? { result_summary: resultSummary }
-                  : {}),
-                ...(taskId === metaTaskId && riskLevel ? { risk_level: riskLevel } : {}),
-                ...(taskId === metaTaskId && breaking ? { breaking: true } : {}),
-              },
-            }).nextTask,
-          ));
-    }
+    await writeFinishedTasks({
+      ctx,
+      loadedTasks,
+      metaTaskId,
+      author: opts.author,
+      body: opts.body,
+      force: opts.force,
+      resultProvided,
+      resultSummary,
+      riskLevel,
+      breaking,
+      taskCommitInfo,
+    });
 
     // tasks.json is export-only; generated via `agentplane task export`.
 
     if (shouldCloseCommit && primaryTaskId) {
-      ctx.git.invalidateStatus();
       if (!opts.quiet) {
         process.stdout.write(
           `${infoMessage("task marked DONE; creating deterministic close commit")}\n`,
         );
       }
-      await cmdCommit({
+      await createTaskCloseCommit({
         ctx,
         cwd: opts.cwd,
         rootOverride: opts.rootOverride,
-        baseBranchOverride: opts.baseBranchOverride ?? null,
         taskId: primaryTaskId,
-        message: "",
-        close: true,
-        allow: [],
-        autoAllow: false,
-        allowTasks: true,
-        allowBase: ctx.config.workflow_mode === "branch_pr",
-        allowPolicy: false,
-        allowConfig: false,
-        allowHooks: false,
-        allowCI: false,
-        requireClean: true,
+        baseBranchOverride: opts.baseBranchOverride,
         quiet: opts.quiet,
         closeUnstageOthers: opts.closeCommit === true && opts.closeUnstageOthers === true,
-        closeCheckOnly: false,
-        closeStageTaskArtifacts: ctx.config.workflow_mode === "branch_pr",
       });
     }
 

--- a/packages/core/schemas/pr-meta.schema.json
+++ b/packages/core/schemas/pr-meta.schema.json
@@ -18,6 +18,10 @@
       "type": "string",
       "minLength": 1
     },
+    "base": {
+      "type": "string",
+      "minLength": 1
+    },
     "created_at": {
       "type": "string",
       "format": "date-time"
@@ -25,6 +29,26 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["MERGED"]
+    },
+    "merge_strategy": {
+      "type": "string",
+      "enum": ["squash", "merge", "rebase"]
+    },
+    "merged_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "merge_commit": {
+      "type": "string",
+      "minLength": 1
+    },
+    "head_sha": {
+      "type": "string",
+      "minLength": 1
     },
     "last_verified_sha": {
       "type": ["string", "null"],

--- a/packages/core/src/tasks/task-artifact-schema.ts
+++ b/packages/core/src/tasks/task-artifact-schema.ts
@@ -9,8 +9,14 @@ export type TaskPrMeta = {
   schema_version: 1;
   task_id: string;
   branch?: string;
+  base?: string;
   created_at: string;
   updated_at: string;
+  status?: "MERGED";
+  merge_strategy?: "squash" | "merge" | "rebase";
+  merged_at?: string;
+  merge_commit?: string;
+  head_sha?: string;
   last_verified_sha?: string | null;
   last_verified_at?: string | null;
   verify?: {
@@ -395,8 +401,14 @@ export const TASK_PR_META_SCHEMA = {
     schema_version: { type: "integer", const: 1 },
     task_id: { type: "string", minLength: 1 },
     branch: { type: "string", minLength: 1 },
+    base: { type: "string", minLength: 1 },
     created_at: { type: "string", format: "date-time" },
     updated_at: { type: "string", format: "date-time" },
+    status: { type: "string", enum: ["MERGED"] },
+    merge_strategy: { type: "string", enum: ["squash", "merge", "rebase"] },
+    merged_at: { type: "string", format: "date-time" },
+    merge_commit: { type: "string", minLength: 1 },
+    head_sha: { type: "string", minLength: 1 },
     last_verified_sha: { type: ["string", "null"], minLength: 7 },
     last_verified_at: { type: ["string", "null"], format: "date-time" },
     verify: {

--- a/packages/spec/examples/pr-meta.json
+++ b/packages/spec/examples/pr-meta.json
@@ -2,6 +2,7 @@
   "schema_version": 1,
   "task_id": "202601010101-ABCDE",
   "branch": "task/202601010101-ABCDE/example",
+  "base": "main",
   "created_at": "2026-01-27T00:00:00Z",
   "updated_at": "2026-01-27T00:00:00Z",
   "last_verified_sha": null,

--- a/packages/spec/schemas/pr-meta.schema.json
+++ b/packages/spec/schemas/pr-meta.schema.json
@@ -18,6 +18,10 @@
       "type": "string",
       "minLength": 1
     },
+    "base": {
+      "type": "string",
+      "minLength": 1
+    },
     "created_at": {
       "type": "string",
       "format": "date-time"
@@ -25,6 +29,26 @@
     "updated_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["MERGED"]
+    },
+    "merge_strategy": {
+      "type": "string",
+      "enum": ["squash", "merge", "rebase"]
+    },
+    "merged_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "merge_commit": {
+      "type": "string",
+      "minLength": 1
+    },
+    "head_sha": {
+      "type": "string",
+      "minLength": 1
     },
     "last_verified_sha": {
       "type": ["string", "null"],


### PR DESCRIPTION
## Summary
- type PR artifact metadata transitions in a shared helper instead of ad-hoc Record casts
- route integrate finalization through a narrow finish service instead of calling cmdFinish directly
- keep PR artifact schema/example/spec synchronized with the richer merged-state contract

## Verification
- bunx vitest run packages/core/src/tasks/task-artifact-schema.test.ts packages/agentplane/src/commands/shared/pr-meta.test.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/cli/run-cli.core.pr-flow.integrate.test.ts packages/agentplane/src/cli/run-cli.core.pr-flow.pr.test.ts
- bun run --filter=@agentplaneorg/core build
- bun run --filter=agentplane build
- bunx eslint packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/task/finish-shared.ts packages/agentplane/src/commands/shared/pr-meta.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts
- bunx prettier --check packages/core/src/tasks/task-artifact-schema.ts packages/core/schemas/pr-meta.schema.json packages/spec/schemas/pr-meta.schema.json packages/spec/examples/pr-meta.json packages/agentplane/src/commands/shared/pr-meta.ts packages/agentplane/src/commands/shared/pr-meta.test.ts packages/agentplane/src/commands/task/finish-shared.ts packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/pr/open.ts packages/agentplane/src/commands/pr/update.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts