### PR TITLE
519VFX: reconcile hosted merged refactor backlog

### DIFF
--- a/.agentplane/tasks/202603251535-DNNMD4/README.md
+++ b/.agentplane/tasks/202603251535-DNNMD4/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202603251535-DNNMD4"
 title: "Introduce TaskDocContract and unify task entity projections"
-status: "TODO"
+result_summary: "Merged on GitHub main via PR #13 after the TaskDocContract refactor landed."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on:
@@ -24,8 +25,13 @@ verification:
   updated_at: "2026-03-26T17:08:05.094Z"
   updated_by: "CODER"
   note: "Local checks passed after tightening TaskDocContract validation, strict ISO metadata checks, and doc-version section enforcement."
-commit: null
-comments: []
+commit:
+  hash: "5980bbae43e6ff287924125fa439c1b9639ab84f"
+  message: "✨ DNNMD4 task: unify task doc contract (#13)"
+comments:
+  -
+    author: "INTEGRATOR"
+    body: "Verified: Merged on GitHub main via PR #13 after the TaskDocContract refactor landed."
 events:
   -
     type: "verify"
@@ -39,9 +45,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Local checks passed after tightening TaskDocContract validation, strict ISO metadata checks, and doc-version section enforcement."
+  -
+    type: "status"
+    at: "2026-03-27T19:07:11.224Z"
+    author: "INTEGRATOR"
+    from: "TODO"
+    to: "DONE"
+    note: "Verified: Merged on GitHub main via PR #13 after the TaskDocContract refactor landed."
 doc_version: 3
-doc_updated_at: "2026-03-26T17:08:05.099Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-03-27T19:07:11.225Z"
+doc_updated_by: "INTEGRATOR"
 description: "Centralize task document versioning, section order, required sections, and projection rules, and reduce duplicate task entity shapes across core and backend projection layers."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202603251535-H2EGEM/README.md
+++ b/.agentplane/tasks/202603251535-H2EGEM/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202603251535-H2EGEM"
 title: "Type PR artifact state and decouple integrate/finalize from finish command reuse"
-status: "DOING"
+result_summary: "Merged on GitHub main via PR #18 after typed PR artifact state landed."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on:
@@ -24,11 +25,16 @@ verification:
   updated_at: "2026-03-26T19:39:17.463Z"
   updated_by: "CODER"
   note: "Command: bunx vitest run packages/core/src/tasks/task-artifact-schema.test.ts packages/agentplane/src/commands/shared/pr-meta.test.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/cli/run-cli.core.pr-flow.integrate.test.ts packages/agentplane/src/cli/run-cli.core.pr-flow.pr.test.ts; bun run --filter=@agentplaneorg/core build; bun run --filter=agentplane build; bunx eslint packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/task/finish-shared.ts packages/agentplane/src/commands/shared/pr-meta.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts; bunx prettier --check packages/core/src/tasks/task-artifact-schema.ts packages/core/schemas/pr-meta.schema.json packages/spec/schemas/pr-meta.schema.json packages/spec/examples/pr-meta.json packages/agentplane/src/commands/shared/pr-meta.ts packages/agentplane/src/commands/shared/pr-meta.test.ts packages/agentplane/src/commands/task/finish-shared.ts packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/pr/open.ts packages/agentplane/src/commands/pr/update.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts. Result: pass. Evidence: 7 test files / 88 tests passed; focused finish unit passed; core and agentplane builds passed after worktree-local core symlink bootstrap. Scope: PR meta typing, integrate finalize close path, finish handoff, schema sync."
-commit: null
+commit:
+  hash: "c53b7024b92fc489ee6e8aa7a4f1fccf20c6d57e"
+  message: "H2EGEM: type PR artifact state and decouple integrate finalization (#18)"
 comments:
   -
     author: "CODER"
     body: "Start: introduce a typed PR artifact state contract and decouple integrate/finalize from finish-command reuse without changing merge or close semantics."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: Merged on GitHub main via PR #18 after typed PR artifact state landed."
 events:
   -
     type: "status"
@@ -43,9 +49,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Command: bunx vitest run packages/core/src/tasks/task-artifact-schema.test.ts packages/agentplane/src/commands/shared/pr-meta.test.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/cli/run-cli.core.pr-flow.integrate.test.ts packages/agentplane/src/cli/run-cli.core.pr-flow.pr.test.ts; bun run --filter=@agentplaneorg/core build; bun run --filter=agentplane build; bunx eslint packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/task/finish-shared.ts packages/agentplane/src/commands/shared/pr-meta.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts; bunx prettier --check packages/core/src/tasks/task-artifact-schema.ts packages/core/schemas/pr-meta.schema.json packages/spec/schemas/pr-meta.schema.json packages/spec/examples/pr-meta.json packages/agentplane/src/commands/shared/pr-meta.ts packages/agentplane/src/commands/shared/pr-meta.test.ts packages/agentplane/src/commands/task/finish-shared.ts packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/pr/open.ts packages/agentplane/src/commands/pr/update.ts packages/agentplane/src/commands/pr/integrate/internal/prepare.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts. Result: pass. Evidence: 7 test files / 88 tests passed; focused finish unit passed; core and agentplane builds passed after worktree-local core symlink bootstrap. Scope: PR meta typing, integrate finalize close path, finish handoff, schema sync."
+  -
+    type: "status"
+    at: "2026-03-27T19:07:11.588Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: Merged on GitHub main via PR #18 after typed PR artifact state landed."
 doc_version: 3
-doc_updated_at: "2026-03-26T19:39:17.464Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-03-27T19:07:11.588Z"
+doc_updated_by: "INTEGRATOR"
 description: "Introduce a typed PR state contract and stop integrating through loose Record-based PR metadata plus recursive finish-command reuse inside finalize flows."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202603251538-CMY5ZN/README.md
+++ b/.agentplane/tasks/202603251538-CMY5ZN/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202603251538-CMY5ZN"
 title: "Extract recipe domain into packages/recipes and narrow scenario coupling"
-status: "DOING"
+result_summary: "Merged on GitHub main via PR #25 after the recipe domain extraction landed."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on:
@@ -24,11 +25,16 @@ verification:
   updated_at: "2026-03-27T18:02:24.585Z"
   updated_by: "CODER"
   note: "Extracted the pure recipe domain into @agentplane/recipes (types, normalize/constants, manifest and scenario parsing), wired the package into installed-recipe, resolver, install/explain, and recipe facade consumers, and verified the seam with package build plus recipe/scenario/runner-focused regressions."
-commit: null
+commit:
+  hash: "c12a3e7c3272bf7e209dd83273f53f328bdbce2f"
+  message: "CMY5ZN: extract recipe domain into packages/recipes (#25)"
 comments:
   -
     author: "CODER"
     body: "Start: extract the pure recipe contracts and parsers into packages/recipes first, then rewire resolver/scenario consumers around that package so the domain move lands before any broader scenario or runner cleanup."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: Merged on GitHub main via PR #25 after the recipe domain extraction landed."
 events:
   -
     type: "status"
@@ -43,9 +49,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Extracted the pure recipe domain into @agentplane/recipes (types, normalize/constants, manifest and scenario parsing), wired the package into installed-recipe, resolver, install/explain, and recipe facade consumers, and verified the seam with package build plus recipe/scenario/runner-focused regressions."
+  -
+    type: "status"
+    at: "2026-03-27T19:07:13.335Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: Merged on GitHub main via PR #25 after the recipe domain extraction landed."
 doc_version: 3
-doc_updated_at: "2026-03-27T18:02:24.589Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-03-27T19:07:13.335Z"
+doc_updated_by: "INTEGRATOR"
 description: "Move recipe schema parsing, installed-state logic, compatibility resolution, and catalog/runtime helpers into packages/recipes, then reduce scenario execution glue so delivery concerns no longer own the recipe domain directly."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202603251538-CZ19GT/README.md
+++ b/.agentplane/tasks/202603251538-CZ19GT/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202603251538-CZ19GT"
 title: "Split TaskBackend ports and separate summary/full task reads"
-status: "DOING"
+result_summary: "Merged on GitHub main via PR #19 after TaskBackend port split landed."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on:
@@ -24,11 +25,16 @@ verification:
   updated_at: "2026-03-27T09:17:21.152Z"
   updated_by: "CODER"
   note: "Command: bun run --filter=@agentplaneorg/core build && bun run --filter=agentplane build; bunx vitest run packages/agentplane/src/backends/task-backend.local.test.ts packages/agentplane/src/backends/task-backend.redmine.test.ts packages/agentplane/src/commands/shared/task-backend.test.ts packages/agentplane/src/cli/run-cli.core.tasks.query.test.ts packages/agentplane/src/cli/run-cli.core.pr-flow.cleanup-merged.test.ts; bunx eslint touched backend/query files; bunx prettier --check touched backend/query files. Result: pass. Evidence: 5 test files / 122 tests passed. Scope: TaskBackend port split, summary projection reads, local/redmine backend projection typing, summary-consumer command helpers."
-commit: null
+commit:
+  hash: "1c2939524795a0649e9e4a45c44067fae9e46cf1"
+  message: "Refactor TaskBackend ports and separate summary/full task reads (#19)"
 comments:
   -
     author: "CODER"
     body: "Start: split TaskBackend into explicit ports and separate summary reads from full task loads before touching runner/backend consumers."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: Merged on GitHub main via PR #19 after TaskBackend port split landed."
 events:
   -
     type: "status"
@@ -43,9 +49,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Command: bun run --filter=@agentplaneorg/core build && bun run --filter=agentplane build; bunx vitest run packages/agentplane/src/backends/task-backend.local.test.ts packages/agentplane/src/backends/task-backend.redmine.test.ts packages/agentplane/src/commands/shared/task-backend.test.ts packages/agentplane/src/cli/run-cli.core.tasks.query.test.ts packages/agentplane/src/cli/run-cli.core.pr-flow.cleanup-merged.test.ts; bunx eslint touched backend/query files; bunx prettier --check touched backend/query files. Result: pass. Evidence: 5 test files / 122 tests passed. Scope: TaskBackend port split, summary projection reads, local/redmine backend projection typing, summary-consumer command helpers."
+  -
+    type: "status"
+    at: "2026-03-27T19:07:11.931Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: Merged on GitHub main via PR #19 after TaskBackend port split landed."
 doc_version: 3
-doc_updated_at: "2026-03-27T09:17:21.157Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-03-27T19:07:11.931Z"
+doc_updated_by: "INTEGRATOR"
 description: "Refactor task backend contracts into explicit query, mutation, doc, sync, export, and inspection ports, and introduce distinct summary versus full task entity reads so commands and backends stop overloading one task shape for every persistence surface."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202603251538-NQSPGC/README.md
+++ b/.agentplane/tasks/202603251538-NQSPGC/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202603251538-NQSPGC"
 title: "Generate group commands and simplify CLI harness layers"
-status: "DOING"
+result_summary: "Merged on GitHub main via PR #23 after generated group commands landed."
+status: "DONE"
 priority: "med"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on:
@@ -24,11 +25,16 @@ verification:
   updated_at: "2026-03-27T16:25:46.422Z"
   updated_by: "CODER"
   note: "Implemented canonical group-command helpers, removed duplicated CLI harness shims, and verified targeted CLI registry/help/pr-flow/scaffold regressions plus build, eslint, and prettier."
-commit: null
+commit:
+  hash: "58fa30ba17f639f830f5c6a403d21150ac461d72"
+  message: "Generate group commands and simplify CLI harness layers (#23)"
 comments:
   -
     author: "CODER"
     body: "Start: VJ5GHJ is already merged on GitHub main via PR #21; proceed from the canonical CLI registry baseline to generate group commands and collapse duplicate CLI harness layers."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: Merged on GitHub main via PR #23 after generated group commands landed."
 events:
   -
     type: "status"
@@ -43,9 +49,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Implemented canonical group-command helpers, removed duplicated CLI harness shims, and verified targeted CLI registry/help/pr-flow/scaffold regressions plus build, eslint, and prettier."
+  -
+    type: "status"
+    at: "2026-03-27T19:07:12.989Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: Merged on GitHub main via PR #23 after generated group commands landed."
 doc_version: 3
-doc_updated_at: "2026-03-27T16:25:46.427Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-03-27T19:07:12.990Z"
+doc_updated_by: "INTEGRATOR"
 description: "Derive group-command surfaces and help output from the canonical CLI registry, then reduce duplicated CLI harness layers so parser, help, and command execution tests share a narrower set of runtime helpers."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202603251538-VJ5GHJ/README.md
+++ b/.agentplane/tasks/202603251538-VJ5GHJ/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202603251538-VJ5GHJ"
 title: "Unify CLI registry, routing, and bootstrap metadata"
-status: "DOING"
+result_summary: "Merged on GitHub main via PR #21 after CLI registry and routing unification landed."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on:
@@ -24,11 +25,16 @@ verification:
   updated_at: "2026-03-27T10:51:45.655Z"
   updated_by: "CODER"
   note: "Verified CLI registry unification: command-catalog now owns the runtime matcher, canonical invocation strings are shared between registry entries and bootstrap/quickstart guidance, help/quickstart CLI regressions passed, and core/agentplane builds are clean after removing the extra catalog seam."
-commit: null
+commit:
+  hash: "8c9bb5a56ac94438b573dbcc3625c247d89fe433"
+  message: "cli: unify registry, routing, and bootstrap metadata (#21)"
 comments:
   -
     author: "CODER"
     body: "Start: unify the cli registry so routing, help/spec generation, and bootstrap metadata all read from one canonical command contract."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: Merged on GitHub main via PR #21 after CLI registry and routing unification landed."
 events:
   -
     type: "status"
@@ -43,9 +49,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified CLI registry unification: command-catalog now owns the runtime matcher, canonical invocation strings are shared between registry entries and bootstrap/quickstart guidance, help/quickstart CLI regressions passed, and core/agentplane builds are clean after removing the extra catalog seam."
+  -
+    type: "status"
+    at: "2026-03-27T19:07:12.644Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: Merged on GitHub main via PR #21 after CLI registry and routing unification landed."
 doc_version: 3
-doc_updated_at: "2026-03-27T10:51:45.663Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-03-27T19:07:12.645Z"
+doc_updated_by: "INTEGRATOR"
 description: "Replace duplicated command catalog and registry matching with one canonical CLI registry that owns command matching, bootstrap requirements, metadata, and help/spec generation, while keeping business logic outside the CLI glue layer."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202603251538-Y8DE9D/README.md
+++ b/.agentplane/tasks/202603251538-Y8DE9D/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202603251538-Y8DE9D"
 title: "Introduce RunnerRunRepository and canonical invocation/result contracts"
-status: "DOING"
+result_summary: "Merged on GitHub main via PR #20 after RunnerRunRepository landed."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on:
@@ -24,11 +25,16 @@ verification:
   updated_at: "2026-03-27T10:05:00.200Z"
   updated_by: "CODER"
   note: "Verified RunnerRunRepository refactor: task-run, task-run-lifecycle, and task-run-inspect now load bundle/state/events through repository APIs; codex/custom adapters use the same repository seam for state/event persistence; targeted runner regressions and core/agentplane builds passed."
-commit: null
+commit:
+  hash: "df97183086761dce47b51908c0d1f2f8ea608a13"
+  message: "runner: introduce RunnerRunRepository and canonical invocation/result contracts (#20)"
 comments:
   -
     author: "CODER"
     body: "Start: introduce a runner repository boundary for invocation/state/result persistence before changing adapter and task-projection seams."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: Merged on GitHub main via PR #20 after RunnerRunRepository landed."
 events:
   -
     type: "status"
@@ -43,9 +49,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified RunnerRunRepository refactor: task-run, task-run-lifecycle, and task-run-inspect now load bundle/state/events through repository APIs; codex/custom adapters use the same repository seam for state/event persistence; targeted runner regressions and core/agentplane builds passed."
+  -
+    type: "status"
+    at: "2026-03-27T19:07:12.275Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: Merged on GitHub main via PR #20 after RunnerRunRepository landed."
 doc_version: 3
-doc_updated_at: "2026-03-27T10:05:00.257Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-03-27T19:07:12.275Z"
+doc_updated_by: "INTEGRATOR"
 description: "Separate runner persistence from task projection by introducing a dedicated run repository, canonical invocation snapshot, and one normalized result contract that lifecycle operations and adapters reuse instead of rebuilding state from mutable config and per-adapter conventions."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202603251539-1WNAZX/README.md
+++ b/.agentplane/tasks/202603251539-1WNAZX/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202603251539-1WNAZX"
 title: "Consolidate upgrade and release into one operator pipeline"
-status: "DOING"
+result_summary: "Merged on GitHub main via PR #26 after the shared operator pipeline landed."
+status: "DONE"
 priority: "med"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on:
@@ -24,11 +25,16 @@ verification:
   updated_at: "2026-03-27T18:17:54.146Z"
   updated_by: "CODER"
   note: "Introduced a shared operator pipeline shell for release apply and upgrade, rewired both flows through the common init/preflight/materialize/execute/finalize shape without collapsing their domain-specific commit/tag/managed-file semantics, and verified the seam with focused release/upgrade regressions plus build, lint, and format checks."
-commit: null
+commit:
+  hash: "fcdacf8d387309457d3bbf2790c58f0524cedba4"
+  message: "1WNAZX: consolidate release and upgrade onto a shared operator shell (#26)"
 comments:
   -
     author: "CODER"
     body: "Start: extract the shared operator-run shell first, then rewire release and upgrade around that seam without collapsing their command-specific guards or prompts."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: Merged on GitHub main via PR #26 after the shared operator pipeline landed."
 events:
   -
     type: "status"
@@ -43,9 +49,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Introduced a shared operator pipeline shell for release apply and upgrade, rewired both flows through the common init/preflight/materialize/execute/finalize shape without collapsing their domain-specific commit/tag/managed-file semantics, and verified the seam with focused release/upgrade regressions plus build, lint, and format checks."
+  -
+    type: "status"
+    at: "2026-03-27T19:07:13.693Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: Merged on GitHub main via PR #26 after the shared operator pipeline landed."
 doc_version: 3
-doc_updated_at: "2026-03-27T18:17:54.150Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-03-27T19:07:13.693Z"
+doc_updated_by: "INTEGRATOR"
 description: "Refactor upgrade and release flows onto a shared operator pipeline for source acquisition, reconcile, verification, and post-apply side effects, so both surfaces reuse one execution model instead of parallel bespoke orchestration stacks."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202603251539-YTQX10/README.md
+++ b/.agentplane/tasks/202603251539-YTQX10/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202603251539-YTQX10"
 title: "Consolidate CI, freshness, and sync tooling into shared generators"
-status: "DOING"
+result_summary: "Merged on GitHub main via PR #27 after the tooling generator consolidation landed."
+status: "DONE"
 priority: "med"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on:
@@ -24,11 +25,16 @@ verification:
   updated_at: "2026-03-27T18:41:28.926Z"
   updated_by: "CODER"
   note: "Consolidated generated-artifact freshness scripts onto shared helpers, consolidated sync scripts onto shared directory/schema helpers, and collapsed run-local-ci baseline step duplication. Verified with docs freshness scripts, sync checks, local-ci selection tests, prettier, eslint, and agentplane build."
-commit: null
+commit:
+  hash: "ee0e7698eb5cf8fa567b68090d22a80f61a388a4"
+  message: "YTQX10: consolidate CI, freshness, and sync tooling (#27)"
 comments:
   -
     author: "CODER"
     body: "Start: extracting shared freshness and sync harnesses for generated artifacts and local CI orchestration without changing task routing semantics or broadening the refactor surface."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: Merged on GitHub main via PR #27 after the tooling generator consolidation landed."
 events:
   -
     type: "status"
@@ -43,9 +49,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Consolidated generated-artifact freshness scripts onto shared helpers, consolidated sync scripts onto shared directory/schema helpers, and collapsed run-local-ci baseline step duplication. Verified with docs freshness scripts, sync checks, local-ci selection tests, prettier, eslint, and agentplane build."
+  -
+    type: "status"
+    at: "2026-03-27T19:07:14.036Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: Merged on GitHub main via PR #27 after the tooling generator consolidation landed."
 doc_version: 3
-doc_updated_at: "2026-03-27T18:41:28.940Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-03-27T19:07:14.037Z"
+doc_updated_by: "INTEGRATOR"
 description: "Replace duplicated CI orchestration, freshness checks, and mirror-sync scripts with declarative shared helpers so generated docs, inventories, schemas, and local CI pipelines derive from one reusable control model."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202603252024-0RTC81/README.md
+++ b/.agentplane/tasks/202603252024-0RTC81/README.md
@@ -1,0 +1,108 @@
+---
+id: "202603252024-0RTC81"
+title: "Fix presentation route to open static HTML without Docusaurus chrome"
+result_summary: "Superseded by KAR6C2 and resolved by the merged presentation recursion fix on GitHub main."
+status: "DONE"
+priority: "med"
+owner: "CODER"
+revision: 2
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "website"
+  - "presentation"
+verify: []
+plan_approval:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+commit:
+  hash: "87b87cc6895fa411fff946763d5cda48c2120fa9"
+  message: "✨ KAR6C2 site: fix AIMindset presentation route recursion (#17)"
+comments:
+  -
+    author: "INTEGRATOR"
+    body: "Verified: Superseded by KAR6C2 and resolved by the merged presentation recursion fix on GitHub main."
+events:
+  -
+    type: "status"
+    at: "2026-03-27T19:07:16.167Z"
+    author: "INTEGRATOR"
+    from: "TODO"
+    to: "DONE"
+    note: "Verified: Superseded by KAR6C2 and resolved by the merged presentation recursion fix on GitHub main."
+doc_version: 3
+doc_updated_at: "2026-03-27T19:07:16.167Z"
+doc_updated_by: "INTEGRATOR"
+description: "Change the AIMindset presentation route to bypass the Docusaurus Layout wrapper so /presentation/aimindset20260325 opens the standalone static presentation without extra site navbars."
+sections:
+  Summary: |-
+    Fix presentation route to open static HTML without Docusaurus chrome
+    
+    Change the AIMindset presentation route to bypass the Docusaurus Layout wrapper so /presentation/aimindset20260325 opens the standalone static presentation without extra site navbars.
+  Scope: |-
+    - In scope: Change the AIMindset presentation route to bypass the Docusaurus Layout wrapper so /presentation/aimindset20260325 opens the standalone static presentation without extra site navbars.
+    - Out of scope: unrelated refactors not required for "Fix presentation route to open static HTML without Docusaurus chrome".
+  Plan: |-
+    1. Implement the change for "Fix presentation route to open static HTML without Docusaurus chrome".
+    2. Run required checks and capture verification evidence.
+    3. Finalize task findings and finish with traceable commit metadata.
+  Verify Steps: |-
+    <!-- TODO: REPLACE WITH TASK-SPECIFIC ACCEPTANCE STEPS -->
+    
+    1. Review the changed artifact or behavior. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Fix presentation route to open static HTML without Docusaurus chrome
+
+Change the AIMindset presentation route to bypass the Docusaurus Layout wrapper so /presentation/aimindset20260325 opens the standalone static presentation without extra site navbars.
+
+## Scope
+
+- In scope: Change the AIMindset presentation route to bypass the Docusaurus Layout wrapper so /presentation/aimindset20260325 opens the standalone static presentation without extra site navbars.
+- Out of scope: unrelated refactors not required for "Fix presentation route to open static HTML without Docusaurus chrome".
+
+## Plan
+
+1. Implement the change for "Fix presentation route to open static HTML without Docusaurus chrome".
+2. Run required checks and capture verification evidence.
+3. Finalize task findings and finish with traceable commit metadata.
+
+## Verify Steps
+
+<!-- TODO: REPLACE WITH TASK-SPECIFIC ACCEPTANCE STEPS -->
+
+1. Review the changed artifact or behavior. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202603261739-GWD3WX/README.md
+++ b/.agentplane/tasks/202603261739-GWD3WX/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202603261739-GWD3WX"
 title: "Audit GitHub protection and required-check flow"
-status: "DOING"
+result_summary: "Merged on GitHub main via PR #14 after the GitHub protection audit landed."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -38,11 +39,16 @@ verification:
     Result: pass
     Evidence: formatting and lint both passed for the touched script, test, docs, and package script surface.
     Scope: touched code/docs hygiene.
-commit: null
+commit:
+  hash: "b653bdeb8f31745c126d775eda078a83b316f073"
+  message: "✨ GWD3WX workflow: audit GitHub protection contract (#14)"
 comments:
   -
     author: "CODER"
     body: "Start: audit GitHub branch protection, codify a required-check drift guard, and document the canonical branch_pr merge diagnostics so Expected-without-reported-status failures are caught early."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: Merged on GitHub main via PR #14 after the GitHub protection audit landed."
 events:
   -
     type: "status"
@@ -71,9 +77,16 @@ events:
       Result: pass
       Evidence: formatting and lint both passed for the touched script, test, docs, and package script surface.
       Scope: touched code/docs hygiene.
+  -
+    type: "status"
+    at: "2026-03-27T19:07:14.387Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: Merged on GitHub main via PR #14 after the GitHub protection audit landed."
 doc_version: 3
-doc_updated_at: "2026-03-26T17:49:43.912Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-03-27T19:07:14.387Z"
+doc_updated_by: "INTEGRATOR"
 description: "Analyze the current GitHub branch protection and Actions check behavior, codify a repository-level audit for required check drift, and document the canonical branch_pr merge gate so Expected-without-reported-status regressions are detected automatically."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202603261754-VG6FTM/README.md
+++ b/.agentplane/tasks/202603261754-VG6FTM/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202603261754-VG6FTM"
 title: "Make branch_pr task branches start from current remote base"
-status: "DOING"
+result_summary: "Merged on GitHub main via PR #15 after the stale-base guard landed."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -33,11 +34,16 @@ verification:
     Result: pass
     Evidence: formatting and lint both passed for the touched code/docs surfaces.
     Scope: touched guard implementation and docs.
-commit: null
+commit:
+  hash: "ef8bacdbde11a1fee971d4d1eb4932a91092b85c"
+  message: "✨ VG6FTM workflow: guard stale base before work start (#15)"
 comments:
   -
     author: "CODER"
     body: "Start: add a stale-base guard to branch_pr work start so task branches fail fast when the pinned base branch lags its upstream tracking ref, then cover it with integration tests and update workflow guidance."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: Merged on GitHub main via PR #15 after the stale-base guard landed."
 events:
   -
     type: "status"
@@ -61,9 +67,16 @@ events:
       Result: pass
       Evidence: formatting and lint both passed for the touched code/docs surfaces.
       Scope: touched guard implementation and docs.
+  -
+    type: "status"
+    at: "2026-03-27T19:07:14.730Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: Merged on GitHub main via PR #15 after the stale-base guard landed."
 doc_version: 3
-doc_updated_at: "2026-03-26T18:02:27.962Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-03-27T19:07:14.730Z"
+doc_updated_by: "INTEGRATOR"
 description: "Fix the branch_pr bootstrap flow so task branches and hosted PRs do not inherit stale local main history. The workflow should make the base branch explicit and current before branch/worktree execution, or fail with a precise actionable diagnostic instead of producing DIRTY PRs."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202603261911-KAR6C2/README.md
+++ b/.agentplane/tasks/202603261911-KAR6C2/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202603261911-KAR6C2"
 title: "Fix presentation route recursion for AIMindset deck"
-status: "DOING"
+result_summary: "Merged on GitHub main via PR #17 after the presentation route recursion fix landed."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -32,11 +33,16 @@ verification:
     Result: pass
     Evidence: the built file starts with the static Russian presentation document title and deck markup, not a docs-shell page.
     Scope: generated presentation artifact for /presentation/aimindset20260325/.
-commit: null
+commit:
+  hash: "87b87cc6895fa411fff946763d5cda48c2120fa9"
+  message: "✨ KAR6C2 site: fix AIMindset presentation route recursion (#17)"
 comments:
   -
     author: "CODER"
     body: "Start: remove the recursive Docusaurus route so the AIMindset presentation path resolves directly to the static deck."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: Merged on GitHub main via PR #17 after the presentation route recursion fix landed."
 events:
   -
     type: "status"
@@ -60,9 +66,16 @@ events:
       Result: pass
       Evidence: the built file starts with the static Russian presentation document title and deck markup, not a docs-shell page.
       Scope: generated presentation artifact for /presentation/aimindset20260325/.
+  -
+    type: "status"
+    at: "2026-03-27T19:07:15.076Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: Merged on GitHub main via PR #17 after the presentation route recursion fix landed."
 doc_version: 3
-doc_updated_at: "2026-03-26T19:13:16.846Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-03-27T19:07:15.076Z"
+doc_updated_by: "INTEGRATOR"
 description: "Remove the Docusaurus route that shadows /presentation/aimindset20260325/index.html so the public URL serves the static presentation instead of recursively embedding the same page."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202603271156-EAMB43/README.md
+++ b/.agentplane/tasks/202603271156-EAMB43/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202603271156-EAMB43"
 title: "Make framework dev bootstrap first-class"
-status: "DOING"
+result_summary: "Merged on GitHub main via PR #22 after framework dev bootstrap became first-class."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 10
+revision: 11
 origin:
   system: "manual"
 depends_on: []
@@ -24,11 +25,16 @@ verification:
   updated_at: "2026-03-27T12:30:28.762Z"
   updated_by: "CODER"
   note: "Extended the framework bootstrap contract by sanitizing hook-propagated git env before local CI subprocesses; full contaminated run-local-ci path now passes without mutating the active task branch."
-commit: null
+commit:
+  hash: "59dc9c5053f3ecd15318ffca6a1c76147104eb6a"
+  message: "EAMB43: make framework dev bootstrap first-class (#22)"
 comments:
   -
     author: "CODER"
     body: "Start: make fresh framework clones and worktrees self-bootstrap into a repo-local runtime contract, then repoint wrapper/runtime/doctor/local-CI to that canonical bootstrap surface."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: Merged on GitHub main via PR #22 after framework dev bootstrap became first-class."
 events:
   -
     type: "status"
@@ -49,9 +55,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Extended the framework bootstrap contract by sanitizing hook-propagated git env before local CI subprocesses; full contaminated run-local-ci path now passes without mutating the active task branch."
+  -
+    type: "status"
+    at: "2026-03-27T19:07:15.429Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: Merged on GitHub main via PR #22 after framework dev bootstrap became first-class."
 doc_version: 3
-doc_updated_at: "2026-03-27T12:30:42.339Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-03-27T19:07:15.429Z"
+doc_updated_by: "INTEGRATOR"
 description: "Establish a deterministic repo-local development runtime for the framework itself so fresh clones and worktrees can run lifecycle commands, hooks, tests, and local CLI flows without manual dist symlinks, package-level node_modules wiring, or stale-dist overrides. Keep installed/PATH agentplane as a separate smoke and compatibility path, not the default inner-loop runtime."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202603271724-HJXDV0/README.md
+++ b/.agentplane/tasks/202603271724-HJXDV0/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202603271724-HJXDV0"
 title: "Make branch_pr task projection converge after hosted merges"
-status: "DOING"
+result_summary: "Merged on GitHub main via PR #24 after hosted-merge task projection reconcile landed."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -24,11 +25,16 @@ verification:
   updated_at: "2026-03-27T17:38:08.326Z"
   updated_by: "CODER"
   note: "Added hosted-merge reconciliation to task normalize: branch_pr local clones can now query GitHub by PR artifact branch name, persist merged PR meta, and normalize stale local task state to DONE without relying on hidden local close-commit history on main. Verified with focused CLI/tests plus build/help snapshots."
-commit: null
+commit:
+  hash: "b9d372365e3dddeed56a20cb4e4e69bec7a18aad"
+  message: "HJXDV0: reconcile hosted merges during task normalize (#24)"
 comments:
   -
     author: "CODER"
     body: "Start: make ordinary branch_pr task reads converge on hosted-merge reality by deriving an effective merged state from local PR artifacts and reachable base history, then wire task list/show/doctor through that shared projection path."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: Merged on GitHub main via PR #24 after hosted-merge task projection reconcile landed."
 events:
   -
     type: "status"
@@ -43,9 +49,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Added hosted-merge reconciliation to task normalize: branch_pr local clones can now query GitHub by PR artifact branch name, persist merged PR meta, and normalize stale local task state to DONE without relying on hidden local close-commit history on main. Verified with focused CLI/tests plus build/help snapshots."
+  -
+    type: "status"
+    at: "2026-03-27T19:07:15.772Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: Merged on GitHub main via PR #24 after hosted-merge task projection reconcile landed."
 doc_version: 3
-doc_updated_at: "2026-03-27T17:38:08.339Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-03-27T19:07:15.772Z"
+doc_updated_by: "INTEGRATOR"
 description: "Stop ordinary task reads from showing stale TODO/DOING state after a task branch is already merged on GitHub main. Introduce a deterministic merge-aware task projection or reconcile path so fresh local clones can recover effective task state without relying on hidden local close-commit history on main."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202603271901-519VFX/README.md
+++ b/.agentplane/tasks/202603271901-519VFX/README.md
@@ -1,0 +1,145 @@
+---
+id: "202603271901-519VFX"
+title: "Reconcile hosted merged refactor tasks into local task projection"
+result_summary: "Closed stale branch_pr refactor backlog by reconciling hosted merges into the local task projection."
+status: "DONE"
+priority: "high"
+owner: "CODER"
+revision: 7
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "workflow"
+  - "tasks"
+  - "backlog"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-03-27T19:01:18.797Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-03-27T19:07:41.928Z"
+  updated_by: "CODER"
+  note: "Backfilled merged refactor tasks and the superseded presentation task into final DONE state, leaving only the active handoff task open. Verified with hosted-merge reconcile, targeted finish updates, and a clean local backlog view under repo-local runtime."
+commit:
+  hash: "ee0e7698eb5cf8fa567b68090d22a80f61a388a4"
+  message: "YTQX10: consolidate CI, freshness, and sync tooling (#27)"
+comments:
+  -
+    author: "CODER"
+    body: "Start: Reconcile stale hosted-merge task projection on top of server main, close already-merged refactor tasks without one-by-one README surgery, and leave the backlog clean before implementing handoff."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: Reconciled hosted merged refactor tasks into the local task projection, backfilled stale merged tasks without reverting to direct mode, and left only the active handoff task open."
+events:
+  -
+    type: "status"
+    at: "2026-03-27T19:06:20.889Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Reconcile stale hosted-merge task projection on top of server main, close already-merged refactor tasks without one-by-one README surgery, and leave the backlog clean before implementing handoff."
+  -
+    type: "verify"
+    at: "2026-03-27T19:07:41.928Z"
+    author: "CODER"
+    state: "ok"
+    note: "Backfilled merged refactor tasks and the superseded presentation task into final DONE state, leaving only the active handoff task open. Verified with hosted-merge reconcile, targeted finish updates, and a clean local backlog view under repo-local runtime."
+  -
+    type: "status"
+    at: "2026-03-27T19:07:51.659Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: Reconciled hosted merged refactor tasks into the local task projection, backfilled stale merged tasks without reverting to direct mode, and left only the active handoff task open."
+doc_version: 3
+doc_updated_at: "2026-03-27T19:07:51.659Z"
+doc_updated_by: "INTEGRATOR"
+description: "Use the hosted-merge reconciliation path to update stale branch_pr task state on main after hosted PR merges, then normalize the local projection so the refactor backlog reflects actual merged work before starting handoff."
+sections:
+  Summary: |-
+    Reconcile hosted merged refactor tasks into local task projection
+    
+    Use the hosted-merge reconciliation path to update stale branch_pr task state on main after hosted PR merges, then normalize the local projection so the refactor backlog reflects actual merged work before starting handoff.
+  Scope: |-
+    - In scope: Use the hosted-merge reconciliation path to update stale branch_pr task state on main after hosted PR merges, then normalize the local projection so the refactor backlog reflects actual merged work before starting handoff.
+    - Out of scope: unrelated refactors not required for "Reconcile hosted merged refactor tasks into local task projection".
+  Plan: |-
+    1. Implement the change for "Reconcile hosted merged refactor tasks into local task projection".
+    2. Run required checks and capture verification evidence.
+    3. Finalize task findings and finish with traceable commit metadata.
+  Verify Steps: |-
+    1. Run hosted-merge reconcile against the local task projection. Expected: merged branch_pr tasks move to their final local state without manual README surgery.
+    2. Inspect task list after normalization. Expected: the refactor backlog only contains genuinely open work and no already-merged tasks remain in TODO/DOING.
+    3. Confirm the explanation for branch_pr noise and the reason not to switch back to direct mode is recorded in the task findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-03-27T19:07:41.928Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Backfilled merged refactor tasks and the superseded presentation task into final DONE state, leaving only the active handoff task open. Verified with hosted-merge reconcile, targeted finish updates, and a clean local backlog view under repo-local runtime.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-27T19:07:41.838Z, excerpt_hash=sha256:b421ac45f92c6304b93f4c10cf1a1472d115796795eadb9747472b6a7d7cd6a8
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - branch_pr backlog noise came from split-state: hosted PR merges advanced GitHub main, while local task projection still expected explicit close updates.
+    - Switching back to direct would remove the hosted gate but would not solve stale projection; it would only trade one consistency problem for weaker remote-green guarantees.
+    - The short-term repair is targeted hosted-merge reconcile plus explicit finish backfill for tasks that never persisted pr/meta on main. The longer-term fix is automatic reconcile after hosted merge, not a workflow-mode rollback.
+    - Framework dev bootstrap still misses the extracted @agentplane/recipes build edge and fresh worktree readiness; that remains a separate process bug, not evidence against branch_pr itself.
+id_source: "generated"
+---
+## Summary
+
+Reconcile hosted merged refactor tasks into local task projection
+
+Use the hosted-merge reconciliation path to update stale branch_pr task state on main after hosted PR merges, then normalize the local projection so the refactor backlog reflects actual merged work before starting handoff.
+
+## Scope
+
+- In scope: Use the hosted-merge reconciliation path to update stale branch_pr task state on main after hosted PR merges, then normalize the local projection so the refactor backlog reflects actual merged work before starting handoff.
+- Out of scope: unrelated refactors not required for "Reconcile hosted merged refactor tasks into local task projection".
+
+## Plan
+
+1. Implement the change for "Reconcile hosted merged refactor tasks into local task projection".
+2. Run required checks and capture verification evidence.
+3. Finalize task findings and finish with traceable commit metadata.
+
+## Verify Steps
+
+1. Run hosted-merge reconcile against the local task projection. Expected: merged branch_pr tasks move to their final local state without manual README surgery.
+2. Inspect task list after normalization. Expected: the refactor backlog only contains genuinely open work and no already-merged tasks remain in TODO/DOING.
+3. Confirm the explanation for branch_pr noise and the reason not to switch back to direct mode is recorded in the task findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-03-27T19:07:41.928Z — VERIFY — ok
+
+By: CODER
+
+Note: Backfilled merged refactor tasks and the superseded presentation task into final DONE state, leaving only the active handoff task open. Verified with hosted-merge reconcile, targeted finish updates, and a clean local backlog view under repo-local runtime.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-27T19:07:41.838Z, excerpt_hash=sha256:b421ac45f92c6304b93f4c10cf1a1472d115796795eadb9747472b6a7d7cd6a8
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- branch_pr backlog noise came from split-state: hosted PR merges advanced GitHub main, while local task projection still expected explicit close updates.
+- Switching back to direct would remove the hosted gate but would not solve stale projection; it would only trade one consistency problem for weaker remote-green guarantees.
+- The short-term repair is targeted hosted-merge reconcile plus explicit finish backfill for tasks that never persisted pr/meta on main. The longer-term fix is automatic reconcile after hosted merge, not a workflow-mode rollback.
+- Framework dev bootstrap still misses the extracted @agentplane/recipes build edge and fresh worktree readiness; that remains a separate process bug, not evidence against branch_pr itself.


### PR DESCRIPTION
## Summary
- reconcile stale branch_pr refactor tasks into final DONE state after their hosted merges
- backfill the few merged tasks that never persisted local pr artifacts on main
- close the superseded presentation task so the refactor backlog is fully clean before handoff work

## Verification
- node packages/agentplane/bin/agentplane.js task list
- node packages/agentplane/bin/agentplane.js verify 202603271901-519VFX --ok ...
- git status --short
