### PR TITLE
Type task handoff and recovery artifacts

### DIFF
--- a/.agentplane/tasks/202603271853-R98CCP/README.md
+++ b/.agentplane/tasks/202603271853-R98CCP/README.md
@@ -1,0 +1,101 @@
+---
+id: "202603271853-R98CCP"
+title: "Add first-class task handoff and recovery artifacts"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "workflow"
+  - "runner"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-03-27T18:54:03.256Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implementing a canonical task handoff artifact plus show, resume-context, and reclaim commands that reuse existing runner inspection and lifecycle seams rather than creating a second recovery model."
+events:
+  -
+    type: "status"
+    at: "2026-03-27T18:54:04.765Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implementing a canonical task handoff artifact plus show, resume-context, and reclaim commands that reuse existing runner inspection and lifecycle seams rather than creating a second recovery model."
+doc_version: 3
+doc_updated_at: "2026-03-27T18:54:04.767Z"
+doc_updated_by: "CODER"
+description: "Introduce a canonical task handoff artifact plus CLI commands to record handoff state, show the latest handoff, reclaim orphaned work, and print a deterministic resume context that reuses runner inspection and lifecycle seams."
+sections:
+  Summary: |-
+    Add first-class task handoff and recovery artifacts
+    
+    Introduce a canonical task handoff artifact plus CLI commands to record handoff state, show the latest handoff, reclaim orphaned work, and print a deterministic resume context that reuses runner inspection and lifecycle seams.
+  Scope: |-
+    - In scope: Introduce a canonical task handoff artifact plus CLI commands to record handoff state, show the latest handoff, reclaim orphaned work, and print a deterministic resume context that reuses runner inspection and lifecycle seams.
+    - Out of scope: unrelated refactors not required for "Add first-class task handoff and recovery artifacts".
+  Plan: |-
+    1. Introduce a canonical task handoff artifact contract in the task domain, with typed read/write helpers and a stable on-disk layout under the task workflow directory.
+    2. Add CLI commands to record a handoff snapshot, show the latest handoff, print a deterministic resume-context, and reclaim orphaned work by combining task state with runner inspection/lifecycle seams instead of inventing a separate recovery stack.
+    3. Add focused command/usecase regressions, verify the new handoff/reclaim flows against runner metadata and task docs, and record any remaining process gaps explicitly in Findings.
+  Verify Steps: |-
+    1. Create a handoff snapshot for a task and inspect it through both machine-readable and human-readable surfaces. Expected: the latest handoff captures branch/head/run hints and is stored deterministically under the task workflow directory.
+    2. Exercise resume-context and reclaim behavior against tasks with and without runner state. Expected: the commands reuse existing runner inspection/lifecycle data and choose deterministic next actions instead of inventing inconsistent recovery heuristics.
+    3. Run targeted handoff/task-run/task-command regressions and the smallest relevant build/lint pass. Expected: the new commands integrate cleanly into the existing task command registry without breaking current task or runner surfaces.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add first-class task handoff and recovery artifacts
+
+Introduce a canonical task handoff artifact plus CLI commands to record handoff state, show the latest handoff, reclaim orphaned work, and print a deterministic resume context that reuses runner inspection and lifecycle seams.
+
+## Scope
+
+- In scope: Introduce a canonical task handoff artifact plus CLI commands to record handoff state, show the latest handoff, reclaim orphaned work, and print a deterministic resume context that reuses runner inspection and lifecycle seams.
+- Out of scope: unrelated refactors not required for "Add first-class task handoff and recovery artifacts".
+
+## Plan
+
+1. Introduce a canonical task handoff artifact contract in the task domain, with typed read/write helpers and a stable on-disk layout under the task workflow directory.
+2. Add CLI commands to record a handoff snapshot, show the latest handoff, print a deterministic resume-context, and reclaim orphaned work by combining task state with runner inspection/lifecycle seams instead of inventing a separate recovery stack.
+3. Add focused command/usecase regressions, verify the new handoff/reclaim flows against runner metadata and task docs, and record any remaining process gaps explicitly in Findings.
+
+## Verify Steps
+
+1. Create a handoff snapshot for a task and inspect it through both machine-readable and human-readable surfaces. Expected: the latest handoff captures branch/head/run hints and is stored deterministically under the task workflow directory.
+2. Exercise resume-context and reclaim behavior against tasks with and without runner state. Expected: the commands reuse existing runner inspection/lifecycle data and choose deterministic next actions instead of inventing inconsistent recovery heuristics.
+3. Run targeted handoff/task-run/task-command regressions and the smallest relevant build/lint pass. Expected: the new commands integrate cleanly into the existing task command registry without breaking current task or runner surfaces.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202603271853-R98CCP/README.md
+++ b/.agentplane/tasks/202603271853-R98CCP/README.md
@@ -4,7 +4,7 @@ title: "Add first-class task handoff and recovery artifacts"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -19,10 +19,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-03-27T19:25:59.929Z"
+  updated_by: "CODER"
+  note: "Command: bunx vitest run packages/core/src/tasks/task-artifact-schema.test.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts packages/agentplane/src/cli/help.all-commands.contract.test.ts packages/agentplane/src/cli/run-cli.core.help-contract.test.ts; Result: pass; Evidence: 5 files, 24 tests passed and help snapshot updated for new task handoff commands. Scope: schema, CLI registry/help, handoff/reclaim/resume-context flows. Command: bun run --filter=@agentplaneorg/core build && bun run --filter=agentplane build; Result: pass; Evidence: both package builds succeeded after bootstrap. Scope: core and agentplane compile surfaces. Command: bunx eslint packages/agentplane/src/commands/shared/task-handoff.ts packages/agentplane/src/commands/task/handoff.shared.ts packages/agentplane/src/commands/task/handoff.command.ts packages/agentplane/src/commands/task/handoff-record.command.ts packages/agentplane/src/commands/task/handoff-show.command.ts packages/agentplane/src/commands/task/resume-context.command.ts packages/agentplane/src/commands/task/reclaim.command.ts packages/agentplane/src/commands/task/task.command.ts packages/agentplane/src/cli/run-cli/command-catalog/task.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/core/src/tasks/task-artifact-schema.ts packages/core/src/tasks/task-artifact-schema.test.ts packages/core/src/index.ts; Result: pass; Evidence: no lint errors on changed implementation files. Scope: new handoff surface and artifact schema wiring. Command: bunx prettier --check packages/agentplane/src/commands/shared/task-handoff.ts packages/agentplane/src/commands/task/handoff.shared.ts packages/agentplane/src/commands/task/handoff.command.ts packages/agentplane/src/commands/task/handoff-record.command.ts packages/agentplane/src/commands/task/handoff-show.command.ts packages/agentplane/src/commands/task/resume-context.command.ts packages/agentplane/src/commands/task/reclaim.command.ts packages/agentplane/src/commands/task/task.command.ts packages/agentplane/src/cli/run-cli/command-catalog/task.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/core/src/tasks/task-artifact-schema.ts packages/core/src/tasks/task-artifact-schema.test.ts packages/core/src/index.ts packages/spec/README.md packages/core/schemas/task-handoff.schema.json packages/spec/schemas/task-handoff.schema.json packages/spec/examples/task-handoff.json; Result: pass; Evidence: formatting clean for all changed handoff files and schemas. Scope: changed source, spec, and schema artifacts."
 commit: null
 comments:
   -
@@ -36,8 +36,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: implementing a canonical task handoff artifact plus show, resume-context, and reclaim commands that reuse existing runner inspection and lifecycle seams rather than creating a second recovery model."
+  -
+    type: "verify"
+    at: "2026-03-27T19:25:59.929Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: bunx vitest run packages/core/src/tasks/task-artifact-schema.test.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts packages/agentplane/src/cli/help.all-commands.contract.test.ts packages/agentplane/src/cli/run-cli.core.help-contract.test.ts; Result: pass; Evidence: 5 files, 24 tests passed and help snapshot updated for new task handoff commands. Scope: schema, CLI registry/help, handoff/reclaim/resume-context flows. Command: bun run --filter=@agentplaneorg/core build && bun run --filter=agentplane build; Result: pass; Evidence: both package builds succeeded after bootstrap. Scope: core and agentplane compile surfaces. Command: bunx eslint packages/agentplane/src/commands/shared/task-handoff.ts packages/agentplane/src/commands/task/handoff.shared.ts packages/agentplane/src/commands/task/handoff.command.ts packages/agentplane/src/commands/task/handoff-record.command.ts packages/agentplane/src/commands/task/handoff-show.command.ts packages/agentplane/src/commands/task/resume-context.command.ts packages/agentplane/src/commands/task/reclaim.command.ts packages/agentplane/src/commands/task/task.command.ts packages/agentplane/src/cli/run-cli/command-catalog/task.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/core/src/tasks/task-artifact-schema.ts packages/core/src/tasks/task-artifact-schema.test.ts packages/core/src/index.ts; Result: pass; Evidence: no lint errors on changed implementation files. Scope: new handoff surface and artifact schema wiring. Command: bunx prettier --check packages/agentplane/src/commands/shared/task-handoff.ts packages/agentplane/src/commands/task/handoff.shared.ts packages/agentplane/src/commands/task/handoff.command.ts packages/agentplane/src/commands/task/handoff-record.command.ts packages/agentplane/src/commands/task/handoff-show.command.ts packages/agentplane/src/commands/task/resume-context.command.ts packages/agentplane/src/commands/task/reclaim.command.ts packages/agentplane/src/commands/task/task.command.ts packages/agentplane/src/cli/run-cli/command-catalog/task.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/core/src/tasks/task-artifact-schema.ts packages/core/src/tasks/task-artifact-schema.test.ts packages/core/src/index.ts packages/spec/README.md packages/core/schemas/task-handoff.schema.json packages/spec/schemas/task-handoff.schema.json packages/spec/examples/task-handoff.json; Result: pass; Evidence: formatting clean for all changed handoff files and schemas. Scope: changed source, spec, and schema artifacts."
 doc_version: 3
-doc_updated_at: "2026-03-27T18:54:04.767Z"
+doc_updated_at: "2026-03-27T19:25:59.931Z"
 doc_updated_by: "CODER"
 description: "Introduce a canonical task handoff artifact plus CLI commands to record handoff state, show the latest handoff, reclaim orphaned work, and print a deterministic resume context that reuses runner inspection and lifecycle seams."
 sections:
@@ -58,6 +64,14 @@ sections:
     3. Run targeted handoff/task-run/task-command regressions and the smallest relevant build/lint pass. Expected: the new commands integrate cleanly into the existing task command registry without breaking current task or runner surfaces.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-03-27T19:25:59.929Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Command: bunx vitest run packages/core/src/tasks/task-artifact-schema.test.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts packages/agentplane/src/cli/help.all-commands.contract.test.ts packages/agentplane/src/cli/run-cli.core.help-contract.test.ts; Result: pass; Evidence: 5 files, 24 tests passed and help snapshot updated for new task handoff commands. Scope: schema, CLI registry/help, handoff/reclaim/resume-context flows. Command: bun run --filter=@agentplaneorg/core build && bun run --filter=agentplane build; Result: pass; Evidence: both package builds succeeded after bootstrap. Scope: core and agentplane compile surfaces. Command: bunx eslint packages/agentplane/src/commands/shared/task-handoff.ts packages/agentplane/src/commands/task/handoff.shared.ts packages/agentplane/src/commands/task/handoff.command.ts packages/agentplane/src/commands/task/handoff-record.command.ts packages/agentplane/src/commands/task/handoff-show.command.ts packages/agentplane/src/commands/task/resume-context.command.ts packages/agentplane/src/commands/task/reclaim.command.ts packages/agentplane/src/commands/task/task.command.ts packages/agentplane/src/cli/run-cli/command-catalog/task.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/core/src/tasks/task-artifact-schema.ts packages/core/src/tasks/task-artifact-schema.test.ts packages/core/src/index.ts; Result: pass; Evidence: no lint errors on changed implementation files. Scope: new handoff surface and artifact schema wiring. Command: bunx prettier --check packages/agentplane/src/commands/shared/task-handoff.ts packages/agentplane/src/commands/task/handoff.shared.ts packages/agentplane/src/commands/task/handoff.command.ts packages/agentplane/src/commands/task/handoff-record.command.ts packages/agentplane/src/commands/task/handoff-show.command.ts packages/agentplane/src/commands/task/resume-context.command.ts packages/agentplane/src/commands/task/reclaim.command.ts packages/agentplane/src/commands/task/task.command.ts packages/agentplane/src/cli/run-cli/command-catalog/task.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/core/src/tasks/task-artifact-schema.ts packages/core/src/tasks/task-artifact-schema.test.ts packages/core/src/index.ts packages/spec/README.md packages/core/schemas/task-handoff.schema.json packages/spec/schemas/task-handoff.schema.json packages/spec/examples/task-handoff.json; Result: pass; Evidence: formatting clean for all changed handoff files and schemas. Scope: changed source, spec, and schema artifacts.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-27T18:54:04.767Z, excerpt_hash=sha256:8a5335495442663248223c9d8f29cea96e570fd2a596b4c5016f47e8462617ff
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -91,6 +105,14 @@ Introduce a canonical task handoff artifact plus CLI commands to record handoff 
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-03-27T19:25:59.929Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: bunx vitest run packages/core/src/tasks/task-artifact-schema.test.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts packages/agentplane/src/cli/help.all-commands.contract.test.ts packages/agentplane/src/cli/run-cli.core.help-contract.test.ts; Result: pass; Evidence: 5 files, 24 tests passed and help snapshot updated for new task handoff commands. Scope: schema, CLI registry/help, handoff/reclaim/resume-context flows. Command: bun run --filter=@agentplaneorg/core build && bun run --filter=agentplane build; Result: pass; Evidence: both package builds succeeded after bootstrap. Scope: core and agentplane compile surfaces. Command: bunx eslint packages/agentplane/src/commands/shared/task-handoff.ts packages/agentplane/src/commands/task/handoff.shared.ts packages/agentplane/src/commands/task/handoff.command.ts packages/agentplane/src/commands/task/handoff-record.command.ts packages/agentplane/src/commands/task/handoff-show.command.ts packages/agentplane/src/commands/task/resume-context.command.ts packages/agentplane/src/commands/task/reclaim.command.ts packages/agentplane/src/commands/task/task.command.ts packages/agentplane/src/cli/run-cli/command-catalog/task.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/core/src/tasks/task-artifact-schema.ts packages/core/src/tasks/task-artifact-schema.test.ts packages/core/src/index.ts; Result: pass; Evidence: no lint errors on changed implementation files. Scope: new handoff surface and artifact schema wiring. Command: bunx prettier --check packages/agentplane/src/commands/shared/task-handoff.ts packages/agentplane/src/commands/task/handoff.shared.ts packages/agentplane/src/commands/task/handoff.command.ts packages/agentplane/src/commands/task/handoff-record.command.ts packages/agentplane/src/commands/task/handoff-show.command.ts packages/agentplane/src/commands/task/resume-context.command.ts packages/agentplane/src/commands/task/reclaim.command.ts packages/agentplane/src/commands/task/task.command.ts packages/agentplane/src/cli/run-cli/command-catalog/task.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/core/src/tasks/task-artifact-schema.ts packages/core/src/tasks/task-artifact-schema.test.ts packages/core/src/index.ts packages/spec/README.md packages/core/schemas/task-handoff.schema.json packages/spec/schemas/task-handoff.schema.json packages/spec/examples/task-handoff.json; Result: pass; Evidence: formatting clean for all changed handoff files and schemas. Scope: changed source, spec, and schema artifacts.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-27T18:54:04.767Z, excerpt_hash=sha256:8a5335495442663248223c9d8f29cea96e570fd2a596b4c5016f47e8462617ff
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -99,6 +99,9 @@ This page is generated from the CLI command specs. Do not edit it by hand; edit 
   - [task doc set](#task-doc-set)
   - [task doc show](#task-doc-show)
   - [task export](#task-export)
+  - [task handoff](#task-handoff)
+  - [task handoff record](#task-handoff-record)
+  - [task handoff show](#task-handoff-show)
   - [task lint](#task-lint)
   - [task list](#task-list)
   - [task migrate](#task-migrate)
@@ -111,6 +114,8 @@ This page is generated from the CLI command specs. Do not edit it by hand; edit 
   - [task plan reject](#task-plan-reject)
   - [task plan set](#task-plan-set)
   - [task rebuild-index](#task-rebuild-index)
+  - [task reclaim](#task-reclaim)
+  - [task resume-context](#task-resume-context)
   - [task run](#task-run)
   - [task run cancel](#task-run-cancel)
   - [task run resume](#task-run-resume)
@@ -2020,6 +2025,18 @@ agentplane task run <task-id>
 
 - Run an existing task through the shared runner flow.
 
+```sh
+agentplane task handoff record <task-id> --from CODER --reason "Paused for handoff"
+```
+
+- Persist a first-class handoff snapshot.
+
+```sh
+agentplane task resume-context <task-id>
+```
+
+- Inspect deterministic recovery context before resuming or retrying a run.
+
 ### task add
 
 Create one or more tasks with explicit ids (prints the created task ids).
@@ -2262,6 +2279,54 @@ agentplane task export
 ```
 
 - Write tasks export JSON and print the path.
+
+### task handoff
+
+Task handoff commands (record/show).
+
+Usage:
+
+```text
+agentplane task handoff record <task-id> --from <role> --reason <text> [--to <role>] [--run-id <id>]
+agentplane task handoff show <task-id> [--json]
+```
+
+### task handoff record
+
+Record a task handoff snapshot with runner recovery hints.
+
+Usage:
+
+```text
+agentplane task handoff record <task-id> [options]
+```
+
+Options:
+
+- `--from <role>`: Role handing off the task.
+- `--to <role>`: Optional. Intended receiving role.
+- `--reason <text>`: Why the handoff is happening.
+- `--note <text>`: Optional. Free-form handoff note.
+- `--run-id <run-id>`: Optional. Pin handoff hints to a specific runner run.
+- `--next-action <text>`: Repeatable. Human next actions for the receiving agent. (repeatable)
+- `--risk <text>`: Repeatable. Risks or watch-outs that remain open. (repeatable)
+- `--question <text>`: Repeatable. Open questions for the next agent. (repeatable)
+- `--evidence-path <path>`: Repeatable. Relevant evidence or artifact paths. (repeatable)
+- `--json`: Emit the persisted handoff snapshot as JSON. (default=false)
+
+### task handoff show
+
+Show the latest persisted task handoff snapshot.
+
+Usage:
+
+```text
+agentplane task handoff show <task-id> [options]
+```
+
+Options:
+
+- `--json`: Emit machine-readable handoff JSON. (default=false)
 
 ### task lint
 
@@ -2606,6 +2671,37 @@ agentplane task rebuild-index
 ```
 
 - Rebuild tasks index cache.
+
+### task reclaim
+
+Claim an interrupted task and persist a recovery handoff snapshot.
+
+Usage:
+
+```text
+agentplane task reclaim <task-id> [options]
+```
+
+Options:
+
+- `--author <role>`: Role reclaiming the task.
+- `--reason <text>`: Why the task is being reclaimed.
+- `--force`: Allow reclaim even when the latest run still appears alive. (default=false)
+- `--json`: Emit the persisted reclaim handoff as JSON. (default=false)
+
+### task resume-context
+
+Print deterministic recovery context for continuing a task after interruption.
+
+Usage:
+
+```text
+agentplane task resume-context <task-id> [[run-id]] [options]
+```
+
+Options:
+
+- `--json`: Emit machine-readable resume context JSON. (default=false)
 
 ### task run
 

--- a/packages/agentplane/src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap
+++ b/packages/agentplane/src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap
@@ -100,6 +100,9 @@ Commands:
     task doc set  Update a task README section.
     task doc show  Print task README content (entire doc or one section).
     task export  Export tasks to the configured tasks export path (typically .agentplane/tasks.json).
+    task handoff  Task handoff commands (record/show).
+    task handoff record  Record a task handoff snapshot with runner recovery hints.
+    task handoff show  Show the latest persisted task handoff snapshot.
     task lint  Lint the exported tasks JSON file (schema + invariants).
     task list  List tasks (optionally filtered by status/owner/tag).
     task migrate  Import tasks from an exported JSON file into the configured backend.
@@ -112,6 +115,8 @@ Commands:
     task plan reject  Reject the current task plan (requires a note).
     task plan set  Set a task plan (writes the Plan section and resets plan approval to pending).
     task rebuild-index  Rebuild the task index cache for the configured backend (best-effort).
+    task reclaim  Claim an interrupted task and persist a recovery handoff snapshot.
+    task resume-context  Print deterministic recovery context for continuing a task after interruption.
     task run  Prepare or run a task through the shared runner contract.
     task run cancel  Cancel an existing runner run and stop the supervised process when present.
     task run resume  Resume an existing execute-mode runner run in place.

--- a/packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts
@@ -1,0 +1,232 @@
+import { chmod, mkdir, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { defaultConfig } from "@agentplaneorg/core";
+
+import { runCli } from "./run-cli.js";
+import {
+  captureStdIO,
+  installRunCliIntegrationHarness,
+  mkGitRepoRoot,
+  runCliSilent,
+  writeConfig,
+} from "./run-cli.test-helpers.js";
+
+installRunCliIntegrationHarness();
+
+describe("runCli task handoff and recovery", () => {
+  it("task reclaim records a deterministic handoff for a task without runner state", async () => {
+    const root = await mkGitRepoRoot();
+    await writeConfig(root, defaultConfig());
+
+    let taskId = "";
+    {
+      const io = captureStdIO();
+      try {
+        expect(
+          await runCli([
+            "task",
+            "new",
+            "--title",
+            "Handoff without run",
+            "--description",
+            "Capture reclaim state without any runner artifacts yet.",
+            "--owner",
+            "CODER",
+            "--tag",
+            "workflow",
+            "--root",
+            root,
+          ]),
+        ).toBe(0);
+        taskId = io.stdout.trim();
+      } finally {
+        io.restore();
+      }
+    }
+
+    await runCliSilent(["task", "plan", "approve", taskId, "--by", "ORCHESTRATOR", "--root", root]);
+    await runCliSilent([
+      "task",
+      "start-ready",
+      taskId,
+      "--author",
+      "CODER",
+      "--body",
+      "Start: move the task into DOING before reclaiming it through the handoff surface.",
+      "--root",
+      root,
+    ]);
+
+    const io = captureStdIO();
+    try {
+      expect(
+        await runCli([
+          "task",
+          "reclaim",
+          taskId,
+          "--author",
+          "CODER",
+          "--reason",
+          "Original agent disconnected before any runner execution started.",
+          "--json",
+          "--root",
+          root,
+        ]),
+      ).toBe(0);
+      const payload = JSON.parse(io.stdout) as {
+        task_id: string;
+        to_role?: string | null;
+        runner?: { next_action?: string | null; next_command?: string | null };
+      };
+      expect(payload.task_id).toBe(taskId);
+      expect(payload.to_role).toBe("CODER");
+      expect(payload.runner?.next_action).toBe("run");
+      expect(payload.runner?.next_command).toBe(`agentplane task run ${taskId}`);
+    } finally {
+      io.restore();
+    }
+  });
+
+  it("task handoff record/show/resume-context reuse the latest failed runner state", async () => {
+    const root = await mkGitRepoRoot();
+    const config = defaultConfig();
+    config.runner.default_adapter = "custom";
+    config.runner.custom = {
+      command: ["custom-runner"],
+    };
+    await writeConfig(root, config);
+
+    let taskId = "";
+    {
+      const io = captureStdIO();
+      try {
+        expect(
+          await runCli([
+            "task",
+            "new",
+            "--title",
+            "Handoff failed run",
+            "--description",
+            "Capture deterministic recovery hints from the latest failed runner run.",
+            "--owner",
+            "CODER",
+            "--tag",
+            "workflow",
+            "--root",
+            root,
+          ]),
+        ).toBe(0);
+        taskId = io.stdout.trim();
+      } finally {
+        io.restore();
+      }
+    }
+
+    await runCliSilent(["task", "plan", "approve", taskId, "--by", "ORCHESTRATOR", "--root", root]);
+    await runCliSilent([
+      "task",
+      "start-ready",
+      taskId,
+      "--author",
+      "CODER",
+      "--body",
+      "Start: move the task into DOING before creating a failed runner run for handoff testing.",
+      "--root",
+      root,
+    ]);
+
+    const fakeBinDir = path.join(root, "bin");
+    const fakeRunnerPath = path.join(fakeBinDir, "custom-runner");
+    await mkdir(fakeBinDir, { recursive: true });
+    await writeFile(
+      fakeRunnerPath,
+      "#!/bin/sh\ncat >/dev/null\nprintf 'runner failed\\n' 1>&2\nexit 1\n",
+      "utf8",
+    );
+    await chmod(fakeRunnerPath, 0o755);
+
+    const originalPath = process.env.PATH;
+    try {
+      process.env.PATH = `${fakeBinDir}${path.delimiter}${originalPath ?? ""}`;
+      expect(await runCliSilent(["task", "run", taskId, "--root", root])).toBe(1);
+    } finally {
+      process.env.PATH = originalPath;
+    }
+
+    const runsRoot = path.join(root, ".agentplane", "tasks", taskId, "runs");
+    const runEntries = await readdir(runsRoot);
+    const runIds = runEntries.toSorted();
+    const runId = runIds[0] ?? "";
+    expect(runId).toBeTruthy();
+
+    {
+      const io = captureStdIO();
+      try {
+        expect(
+          await runCli([
+            "task",
+            "handoff",
+            "record",
+            taskId,
+            "--from",
+            "CODER",
+            "--to",
+            "CODER",
+            "--reason",
+            "Agent disconnected after a failed run and needs deterministic recovery hints.",
+            "--json",
+            "--root",
+            root,
+          ]),
+        ).toBe(0);
+        const payload = JSON.parse(io.stdout) as {
+          task_id: string;
+          runner?: {
+            run_id?: string | null;
+            status?: string | null;
+            next_action?: string | null;
+            retry_command?: string | null;
+          };
+        };
+        expect(payload.task_id).toBe(taskId);
+        expect(payload.runner?.run_id).toBe(runId);
+        expect(payload.runner?.status).toBe("failed");
+        expect(payload.runner?.next_action).toBe("retry");
+        expect(payload.runner?.retry_command).toBe(`agentplane task run retry ${taskId} ${runId}`);
+      } finally {
+        io.restore();
+      }
+    }
+
+    {
+      const io = captureStdIO();
+      try {
+        expect(await runCli(["task", "handoff", "show", taskId, "--json", "--root", root])).toBe(0);
+        const payload = JSON.parse(io.stdout) as { runner?: { run_id?: string | null } };
+        expect(payload.runner?.run_id).toBe(runId);
+      } finally {
+        io.restore();
+      }
+    }
+
+    {
+      const io = captureStdIO();
+      try {
+        expect(await runCli(["task", "resume-context", taskId, "--json", "--root", root])).toBe(0);
+        const payload = JSON.parse(io.stdout) as {
+          task_id: string;
+          latest_handoff?: { reason?: string } | null;
+          runner?: { next_action?: string | null; next_command?: string | null };
+        };
+        expect(payload.task_id).toBe(taskId);
+        expect(payload.latest_handoff?.reason).toContain("Agent disconnected");
+        expect(payload.runner?.next_action).toBe("retry");
+        expect(payload.runner?.next_command).toBe(`agentplane task run retry ${taskId} ${runId}`);
+      } finally {
+        io.restore();
+      }
+    }
+  }, 20_000);
+});

--- a/packages/agentplane/src/cli/run-cli/command-catalog/task.ts
+++ b/packages/agentplane/src/cli/run-cli/command-catalog/task.ts
@@ -7,6 +7,9 @@ import { taskDocSetSpec } from "../../../commands/task/doc-set.command.js";
 import { taskDocShowSpec } from "../../../commands/task/doc-show.command.js";
 import { taskDocSpec } from "../../../commands/task/doc.command.js";
 import { taskExportSpec } from "../../../commands/task/export.command.js";
+import { taskHandoffRecordSpec } from "../../../commands/task/handoff-record.command.js";
+import { taskHandoffShowSpec } from "../../../commands/task/handoff-show.command.js";
+import { taskHandoffSpec } from "../../../commands/task/handoff.command.js";
 import { taskLintSpec } from "../../../commands/task/lint.command.js";
 import { taskListSpec } from "../../../commands/task/list.spec.js";
 import { taskMigrateDocSpec } from "../../../commands/task/migrate-doc.command.js";
@@ -19,6 +22,8 @@ import { taskPlanRejectSpec } from "../../../commands/task/plan-reject.command.j
 import { taskPlanSetSpec } from "../../../commands/task/plan-set.command.js";
 import { taskPlanSpec } from "../../../commands/task/plan.command.js";
 import { taskRebuildIndexSpec } from "../../../commands/task/rebuild-index.command.js";
+import { taskReclaimSpec } from "../../../commands/task/reclaim.command.js";
+import { taskResumeContextSpec } from "../../../commands/task/resume-context.command.js";
 import { taskRunSpec } from "../../../commands/task/run.spec.js";
 import { taskRunCancelSpec } from "../../../commands/task/run-cancel.spec.js";
 import { taskRunResumeSpec } from "../../../commands/task/run-resume.spec.js";
@@ -48,6 +53,21 @@ export const TASK_COMMANDS = [
     needsConfig: false,
     needsTaskContext: false,
   }),
+  entry(
+    taskHandoffSpec,
+    () => import("../../../commands/task/handoff.command.js").then((m) => m.runTaskHandoff),
+    {
+      needsProject: false,
+      needsConfig: false,
+      needsTaskContext: false,
+    },
+  ),
+  entry(taskHandoffRecordSpec, () =>
+    import("../../../commands/task/handoff-record.command.js").then((m) => m.runTaskHandoffRecord),
+  ),
+  entry(taskHandoffShowSpec, () =>
+    import("../../../commands/task/handoff-show.command.js").then((m) => m.runTaskHandoffShow),
+  ),
   entry(
     taskListSpec,
     (deps) =>
@@ -259,5 +279,11 @@ export const TASK_COMMANDS = [
     import("../../../commands/task/rebuild-index.command.js").then((m) =>
       m.makeRunTaskRebuildIndexHandler(deps.getCtx),
     ),
+  ),
+  entry(taskResumeContextSpec, () =>
+    import("../../../commands/task/resume-context.command.js").then((m) => m.runTaskResumeContext),
+  ),
+  entry(taskReclaimSpec, () =>
+    import("../../../commands/task/reclaim.command.js").then((m) => m.runTaskReclaim),
   ),
 ] as const satisfies readonly CommandEntry[];

--- a/packages/agentplane/src/commands/shared/task-handoff.ts
+++ b/packages/agentplane/src/commands/shared/task-handoff.ts
@@ -1,0 +1,225 @@
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  validateTaskHandoff,
+  type TaskHandoff,
+  type TaskHandoffRunnerNextAction,
+  type TaskHandoffRunnerState,
+} from "@agentplaneorg/core";
+
+import { CliError } from "../../shared/errors.js";
+import { execFileAsync, gitEnv } from "./git.js";
+import type { CommandContext } from "./task-backend.js";
+import { writeJsonStableIfChanged } from "../../shared/write-if-changed.js";
+
+export type TaskHandoffArtifact = TaskHandoff;
+export type TaskHandoffRunnerHint = TaskHandoffRunnerState;
+
+export type TaskHandoffPaths = {
+  handoff_dir: string;
+  latest_path: string;
+  history_path: string;
+};
+
+function trimOrNull(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeStringList(values: string[] | undefined): string[] | undefined {
+  if (!values?.length) return undefined;
+  const normalized = values.map((value) => value.trim()).filter((value) => value.length > 0);
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+export function resolveTaskHandoffPaths(opts: {
+  git_root: string;
+  workflow_dir: string;
+  task_id: string;
+}): TaskHandoffPaths {
+  const handoff_dir = path.join(opts.git_root, opts.workflow_dir, opts.task_id, "handoff");
+  return {
+    handoff_dir,
+    latest_path: path.join(handoff_dir, "latest.json"),
+    history_path: path.join(handoff_dir, "history.jsonl"),
+  };
+}
+
+export async function readTaskHandoffLatest(
+  paths: TaskHandoffPaths,
+): Promise<TaskHandoffArtifact | null> {
+  try {
+    const raw = await readFile(paths.latest_path, "utf8");
+    return validateTaskHandoff(JSON.parse(raw) as unknown);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | null)?.code;
+    if (code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+export async function readTaskHandoffLatestRequired(opts: {
+  task_id: string;
+  paths: TaskHandoffPaths;
+}): Promise<TaskHandoffArtifact> {
+  const handoff = await readTaskHandoffLatest(opts.paths);
+  if (handoff) return handoff;
+  throw new CliError({
+    exitCode: 4,
+    code: "E_IO",
+    message: `Task handoff artifact not found for ${opts.task_id} (${opts.paths.latest_path})`,
+  });
+}
+
+export async function writeTaskHandoff(opts: {
+  paths: TaskHandoffPaths;
+  handoff: TaskHandoffArtifact;
+}): Promise<void> {
+  await mkdir(opts.paths.handoff_dir, { recursive: true });
+  await writeJsonStableIfChanged(opts.paths.latest_path, opts.handoff);
+  await appendFile(opts.paths.history_path, `${JSON.stringify(opts.handoff)}\n`, "utf8");
+}
+
+export async function currentGitBranch(gitRoot: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["branch", "--show-current"], {
+      cwd: gitRoot,
+      env: gitEnv(),
+    });
+    return trimOrNull(stdout);
+  } catch {
+    return null;
+  }
+}
+
+export async function readTaskPrBranch(opts: {
+  ctx: CommandContext;
+  task_id: string;
+}): Promise<string | null> {
+  const summary = await readTaskPrMetaSummary(opts);
+  return summary.branch;
+}
+
+export async function readTaskPrMetaSummary(opts: {
+  ctx: CommandContext;
+  task_id: string;
+}): Promise<{ branch: string | null; base: string | null }> {
+  const prMetaPath = path.join(
+    opts.ctx.resolvedProject.gitRoot,
+    opts.ctx.config.paths.workflow_dir,
+    opts.task_id,
+    "pr",
+    "meta.json",
+  );
+  try {
+    const raw = JSON.parse(await readFile(prMetaPath, "utf8")) as {
+      branch?: string;
+      base?: string;
+    };
+    return {
+      branch: trimOrNull(raw.branch),
+      base: trimOrNull(raw.base),
+    };
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | null)?.code;
+    if (code === "ENOENT") return { branch: null, base: null };
+    throw err;
+  }
+}
+
+export function buildTaskHandoffArtifact(opts: {
+  task_id: string;
+  created_at: string;
+  from_role: string;
+  to_role?: string | null;
+  reason: string;
+  note?: string;
+  branch?: string | null;
+  base_branch?: string | null;
+  head_sha?: string | null;
+  workspace_root?: string | null;
+  pr_branch?: string | null;
+  runner?: TaskHandoffRunnerHint | undefined;
+  next_actions?: string[] | undefined;
+  risks?: string[] | undefined;
+  open_questions?: string[] | undefined;
+  evidence_paths?: string[] | undefined;
+}): TaskHandoffArtifact {
+  return validateTaskHandoff({
+    schema_version: 1,
+    task_id: opts.task_id,
+    created_at: opts.created_at,
+    from_role: opts.from_role.trim(),
+    to_role: trimOrNull(opts.to_role),
+    reason: opts.reason.trim(),
+    note: trimOrNull(opts.note) ?? undefined,
+    branch: trimOrNull(opts.branch),
+    base_branch: trimOrNull(opts.base_branch),
+    head_sha: trimOrNull(opts.head_sha),
+    workspace_root: trimOrNull(opts.workspace_root),
+    pr_branch: trimOrNull(opts.pr_branch),
+    runner: opts.runner,
+    next_actions: normalizeStringList(opts.next_actions),
+    risks: normalizeStringList(opts.risks),
+    open_questions: normalizeStringList(opts.open_questions),
+    evidence_paths: normalizeStringList(opts.evidence_paths),
+  } satisfies TaskHandoffArtifact);
+}
+
+export function buildRunnerHintCommands(opts: {
+  task_id: string;
+  run_id: string | null;
+  status: string | null;
+}): {
+  next_action: TaskHandoffRunnerNextAction;
+  next_command: string | null;
+  resume_command: string | null;
+  retry_command: string | null;
+} {
+  const taskRunCommand = `agentplane task run ${opts.task_id}`;
+  const resumeCommand = opts.run_id
+    ? `agentplane task run resume ${opts.task_id} ${opts.run_id}`
+    : null;
+  const retryCommand = opts.run_id
+    ? `agentplane task run retry ${opts.task_id} ${opts.run_id}`
+    : null;
+  if (!opts.run_id || !opts.status) {
+    return {
+      next_action: "run",
+      next_command: taskRunCommand,
+      resume_command: null,
+      retry_command: null,
+    };
+  }
+  if (opts.status === "prepared") {
+    return {
+      next_action: "resume",
+      next_command: resumeCommand,
+      resume_command: resumeCommand,
+      retry_command: retryCommand,
+    };
+  }
+  if (opts.status === "failed" || opts.status === "cancelled") {
+    return {
+      next_action: "retry",
+      next_command: retryCommand,
+      resume_command: resumeCommand,
+      retry_command: retryCommand,
+    };
+  }
+  if (opts.status === "success") {
+    return {
+      next_action: "none",
+      next_command: null,
+      resume_command: resumeCommand,
+      retry_command: retryCommand,
+    };
+  }
+  return {
+    next_action: "wait",
+    next_command: null,
+    resume_command: resumeCommand,
+    retry_command: retryCommand,
+  };
+}

--- a/packages/agentplane/src/commands/task/handoff-record.command.ts
+++ b/packages/agentplane/src/commands/task/handoff-record.command.ts
@@ -1,0 +1,155 @@
+import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
+import { usageError } from "../../cli/spec/errors.js";
+import { infoMessage } from "../../cli/output.js";
+
+import { buildRecordedTaskHandoff } from "./handoff.shared.js";
+import { resolveTaskHandoffPaths, writeTaskHandoff } from "../shared/task-handoff.js";
+
+export type TaskHandoffRecordParsed = {
+  taskId: string;
+  fromRole: string;
+  toRole?: string;
+  reason: string;
+  note?: string;
+  runId?: string;
+  nextActions: string[];
+  risks: string[];
+  openQuestions: string[];
+  evidencePaths: string[];
+  json: boolean;
+};
+
+export const taskHandoffRecordSpec: CommandSpec<TaskHandoffRecordParsed> = {
+  id: ["task", "handoff", "record"],
+  group: "Task",
+  summary: "Record a task handoff snapshot with runner recovery hints.",
+  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
+  options: [
+    {
+      kind: "string",
+      name: "from",
+      valueHint: "<role>",
+      description: "Role handing off the task.",
+    },
+    {
+      kind: "string",
+      name: "to",
+      valueHint: "<role>",
+      description: "Optional. Intended receiving role.",
+    },
+    {
+      kind: "string",
+      name: "reason",
+      valueHint: "<text>",
+      description: "Why the handoff is happening.",
+    },
+    {
+      kind: "string",
+      name: "note",
+      valueHint: "<text>",
+      description: "Optional. Free-form handoff note.",
+    },
+    {
+      kind: "string",
+      name: "run-id",
+      valueHint: "<run-id>",
+      description: "Optional. Pin handoff hints to a specific runner run.",
+    },
+    {
+      kind: "string",
+      name: "next-action",
+      valueHint: "<text>",
+      repeatable: true,
+      description: "Repeatable. Human next actions for the receiving agent.",
+    },
+    {
+      kind: "string",
+      name: "risk",
+      valueHint: "<text>",
+      repeatable: true,
+      description: "Repeatable. Risks or watch-outs that remain open.",
+    },
+    {
+      kind: "string",
+      name: "question",
+      valueHint: "<text>",
+      repeatable: true,
+      description: "Repeatable. Open questions for the next agent.",
+    },
+    {
+      kind: "string",
+      name: "evidence-path",
+      valueHint: "<path>",
+      repeatable: true,
+      description: "Repeatable. Relevant evidence or artifact paths.",
+    },
+    {
+      kind: "boolean",
+      name: "json",
+      default: false,
+      description: "Emit the persisted handoff snapshot as JSON.",
+    },
+  ],
+  validateRaw: (raw) => {
+    for (const key of ["from", "reason"] as const) {
+      const value = raw.opts[key];
+      if (typeof value !== "string" || value.trim() === "") {
+        throw usageError({
+          spec: taskHandoffRecordSpec,
+          message: `Missing required option: --${key}.`,
+        });
+      }
+    }
+  },
+  parse: (raw) => ({
+    taskId: String(raw.args["task-id"]),
+    fromRole: String(raw.opts.from),
+    toRole: typeof raw.opts.to === "string" ? raw.opts.to : undefined,
+    reason: String(raw.opts.reason),
+    note: typeof raw.opts.note === "string" ? raw.opts.note : undefined,
+    runId: typeof raw.opts["run-id"] === "string" ? raw.opts["run-id"] : undefined,
+    nextActions: (raw.opts["next-action"] as string[] | undefined) ?? [],
+    risks: (raw.opts.risk as string[] | undefined) ?? [],
+    openQuestions: (raw.opts.question as string[] | undefined) ?? [],
+    evidencePaths: (raw.opts["evidence-path"] as string[] | undefined) ?? [],
+    json: raw.opts.json === true,
+  }),
+};
+
+export const runTaskHandoffRecord = async (ctx: CommandCtx, parsed: TaskHandoffRecordParsed) => {
+  const built = await buildRecordedTaskHandoff({
+    cwd: ctx.cwd,
+    rootOverride: ctx.rootOverride ?? null,
+    task_id: parsed.taskId,
+    from_role: parsed.fromRole,
+    to_role: parsed.toRole,
+    reason: parsed.reason,
+    note: parsed.note,
+    run_id: parsed.runId,
+    next_actions: parsed.nextActions,
+    risks: parsed.risks,
+    open_questions: parsed.openQuestions,
+    evidence_paths: parsed.evidencePaths,
+  });
+  const paths = resolveTaskHandoffPaths({
+    git_root: built.ctx.resolvedProject.gitRoot,
+    workflow_dir: built.ctx.config.paths.workflow_dir,
+    task_id: parsed.taskId,
+  });
+  await writeTaskHandoff({ paths, handoff: built.handoff });
+  if (parsed.json) {
+    process.stdout.write(`${JSON.stringify(built.handoff, null, 2)}\n`);
+    return 0;
+  }
+  process.stdout.write(`${infoMessage(`task handoff recorded: ${parsed.taskId}`)}\n`);
+  process.stdout.write(`from: ${built.handoff.from_role}\n`);
+  process.stdout.write(`to: ${built.handoff.to_role ?? "unassigned"}\n`);
+  process.stdout.write(`reason: ${built.handoff.reason}\n`);
+  if (built.handoff.runner?.run_id) {
+    process.stdout.write(`run_id: ${built.handoff.runner.run_id}\n`);
+    process.stdout.write(`runner_status: ${built.handoff.runner.status ?? "unknown"}\n`);
+    process.stdout.write(`runner_next_action: ${built.handoff.runner.next_action ?? "none"}\n`);
+  }
+  process.stdout.write(`latest: ${paths.latest_path}\n`);
+  return 0;
+};

--- a/packages/agentplane/src/commands/task/handoff-show.command.ts
+++ b/packages/agentplane/src/commands/task/handoff-show.command.ts
@@ -1,0 +1,79 @@
+import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
+import { infoMessage } from "../../cli/output.js";
+
+import { loadCommandContext } from "../shared/task-backend.js";
+import { readTaskHandoffLatestRequired, resolveTaskHandoffPaths } from "../shared/task-handoff.js";
+
+export type TaskHandoffShowParsed = {
+  taskId: string;
+  json: boolean;
+};
+
+export const taskHandoffShowSpec: CommandSpec<TaskHandoffShowParsed> = {
+  id: ["task", "handoff", "show"],
+  group: "Task",
+  summary: "Show the latest persisted task handoff snapshot.",
+  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
+  options: [
+    {
+      kind: "boolean",
+      name: "json",
+      default: false,
+      description: "Emit machine-readable handoff JSON.",
+    },
+  ],
+  parse: (raw) => ({
+    taskId: String(raw.args["task-id"]),
+    json: raw.opts.json === true,
+  }),
+};
+
+export const runTaskHandoffShow = async (ctx: CommandCtx, parsed: TaskHandoffShowParsed) => {
+  const commandCtx = await loadCommandContext({
+    cwd: ctx.cwd,
+    rootOverride: ctx.rootOverride ?? null,
+  });
+  const paths = resolveTaskHandoffPaths({
+    git_root: commandCtx.resolvedProject.gitRoot,
+    workflow_dir: commandCtx.config.paths.workflow_dir,
+    task_id: parsed.taskId,
+  });
+  const handoff = await readTaskHandoffLatestRequired({
+    task_id: parsed.taskId,
+    paths,
+  });
+  if (parsed.json) {
+    process.stdout.write(`${JSON.stringify(handoff, null, 2)}\n`);
+    return 0;
+  }
+  process.stdout.write(`${infoMessage(`task handoff show: ${parsed.taskId}`)}\n`);
+  process.stdout.write(`from: ${handoff.from_role}\n`);
+  process.stdout.write(`to: ${handoff.to_role ?? "unassigned"}\n`);
+  process.stdout.write(`created_at: ${handoff.created_at}\n`);
+  process.stdout.write(`reason: ${handoff.reason}\n`);
+  if (handoff.branch) process.stdout.write(`branch: ${handoff.branch}\n`);
+  if (handoff.base_branch) process.stdout.write(`base_branch: ${handoff.base_branch}\n`);
+  if (handoff.head_sha) process.stdout.write(`head_sha: ${handoff.head_sha}\n`);
+  if (handoff.pr_branch) process.stdout.write(`pr_branch: ${handoff.pr_branch}\n`);
+  if (handoff.runner?.run_id) {
+    process.stdout.write(`run_id: ${handoff.runner.run_id}\n`);
+    process.stdout.write(`runner_status: ${handoff.runner.status ?? "unknown"}\n`);
+    process.stdout.write(`runner_next_action: ${handoff.runner.next_action ?? "none"}\n`);
+    if (handoff.runner.next_command) {
+      process.stdout.write(`runner_next_command: ${handoff.runner.next_command}\n`);
+    }
+  }
+  for (const action of handoff.next_actions ?? []) {
+    process.stdout.write(`next_action: ${action}\n`);
+  }
+  for (const risk of handoff.risks ?? []) {
+    process.stdout.write(`risk: ${risk}\n`);
+  }
+  for (const question of handoff.open_questions ?? []) {
+    process.stdout.write(`open_question: ${question}\n`);
+  }
+  for (const evidence of handoff.evidence_paths ?? []) {
+    process.stdout.write(`evidence_path: ${evidence}\n`);
+  }
+  return 0;
+};

--- a/packages/agentplane/src/commands/task/handoff.command.ts
+++ b/packages/agentplane/src/commands/task/handoff.command.ts
@@ -1,0 +1,33 @@
+import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
+import { directSubcommandNames, throwGroupCommandUsage } from "../../cli/group-command.js";
+
+import { taskHandoffRecordSpec } from "./handoff-record.command.js";
+import { taskHandoffShowSpec } from "./handoff-show.command.js";
+
+export type TaskHandoffParsed = {
+  subcommand?: string;
+};
+
+const TASK_HANDOFF_CHILD_SPECS = [taskHandoffRecordSpec, taskHandoffShowSpec] as const;
+
+export const taskHandoffSpec: CommandSpec<TaskHandoffParsed> = {
+  id: ["task", "handoff"],
+  group: "Task",
+  summary: "Task handoff commands (record/show).",
+  synopsis: [
+    "agentplane task handoff record <task-id> --from <role> --reason <text> [--to <role>] [--run-id <id>]",
+    "agentplane task handoff show <task-id> [--json]",
+  ],
+  args: [{ name: "subcommand", required: false, valueHint: "<record|show>" }],
+  parse: (raw) => ({
+    subcommand: typeof raw.args.subcommand === "string" ? raw.args.subcommand : undefined,
+  }),
+};
+
+export function runTaskHandoff(_ctx: CommandCtx, p: TaskHandoffParsed): Promise<number> {
+  throwGroupCommandUsage({
+    spec: taskHandoffSpec,
+    cmd: p.subcommand ? [p.subcommand] : [],
+    subcommands: directSubcommandNames(["task", "handoff"], TASK_HANDOFF_CHILD_SPECS),
+  });
+}

--- a/packages/agentplane/src/commands/task/handoff.shared.ts
+++ b/packages/agentplane/src/commands/task/handoff.shared.ts
@@ -1,0 +1,187 @@
+import { resolveBaseBranch } from "@agentplaneorg/core";
+
+import type { TaskData } from "../../backends/task-backend.js";
+import {
+  loadCommandContext,
+  loadTaskFromContext,
+  type CommandContext,
+} from "../shared/task-backend.js";
+import {
+  buildRunnerHintCommands,
+  buildTaskHandoffArtifact,
+  currentGitBranch,
+  readTaskHandoffLatest,
+  readTaskPrMetaSummary,
+  resolveTaskHandoffPaths,
+  type TaskHandoffArtifact,
+  type TaskHandoffRunnerHint,
+} from "../shared/task-handoff.js";
+import { isProcessAlive } from "../../runner/process-supervision.js";
+import { loadTaskRunnerInspection } from "../../runner/usecases/task-run-inspect.js";
+import { CliError } from "../../shared/errors.js";
+
+export type TaskResumeContext = {
+  task_id: string;
+  task_status: string;
+  branch: string | null;
+  base_branch: string | null;
+  head_sha: string | null;
+  workspace_root: string;
+  pr_branch: string | null;
+  latest_handoff: TaskHandoffArtifact | null;
+  runner: TaskHandoffRunnerHint;
+};
+
+function taskStatus(task: TaskData): string {
+  return String(task.status || "TODO")
+    .trim()
+    .toUpperCase();
+}
+
+function nullIfCliIo(err: unknown): null {
+  if (err instanceof CliError && err.code === "E_IO") return null;
+  throw err;
+}
+
+export async function buildTaskResumeContext(opts: {
+  ctx?: CommandContext;
+  cwd: string;
+  rootOverride?: string | null;
+  task_id: string;
+  run_id?: string;
+}): Promise<TaskResumeContext> {
+  const ctx =
+    opts.ctx ??
+    (await loadCommandContext({ cwd: opts.cwd, rootOverride: opts.rootOverride ?? null }));
+  const task = await loadTaskFromContext({ ctx, taskId: opts.task_id });
+  const handoffPaths = resolveTaskHandoffPaths({
+    git_root: ctx.resolvedProject.gitRoot,
+    workflow_dir: ctx.config.paths.workflow_dir,
+    task_id: opts.task_id,
+  });
+  const [branch, latest_handoff, prMeta] = await Promise.all([
+    currentGitBranch(ctx.resolvedProject.gitRoot),
+    readTaskHandoffLatest(handoffPaths),
+    readTaskPrMetaSummary({ ctx, task_id: opts.task_id }),
+  ]);
+  const head_sha = await ctx.git.headCommit().catch(() => null);
+  const base_branch =
+    prMeta.base ??
+    (await resolveBaseBranch({
+      cwd: ctx.resolvedProject.gitRoot,
+      rootOverride: ctx.resolvedProject.gitRoot,
+      mode: ctx.config.workflow_mode,
+    }).catch(() => null));
+
+  let runner: TaskHandoffRunnerHint;
+  try {
+    const inspection = await loadTaskRunnerInspection({
+      ctx,
+      cwd: opts.cwd,
+      rootOverride: opts.rootOverride ?? null,
+      task_id: opts.task_id,
+      run_id: opts.run_id,
+    });
+    const commands = buildRunnerHintCommands({
+      task_id: opts.task_id,
+      run_id: inspection.run_id,
+      status: inspection.state.status,
+    });
+    runner = {
+      run_id: inspection.run_id,
+      status: inspection.state.status,
+      heartbeat_at: inspection.state.supervision?.heartbeat_at ?? null,
+      state_path: inspection.paths.state_path,
+      trace_path: inspection.paths.trace_path,
+      ...commands,
+    };
+    if (inspection.state.status === "running") {
+      const pid = inspection.state.supervision?.pid;
+      if (typeof pid === "number") {
+        const alive = isProcessAlive(pid);
+        runner.next_action = alive ? "wait" : "cancel_then_resume";
+        runner.next_command = alive
+          ? null
+          : `agentplane task run cancel ${opts.task_id} ${inspection.run_id} && agentplane task run resume ${opts.task_id} ${inspection.run_id}`;
+      } else {
+        runner.next_action = "cancel_then_resume";
+        runner.next_command = `agentplane task run cancel ${opts.task_id} ${inspection.run_id} && agentplane task run resume ${opts.task_id} ${inspection.run_id}`;
+      }
+    }
+  } catch (err) {
+    const noRun = nullIfCliIo(err);
+    runner = {
+      run_id: null,
+      status: null,
+      heartbeat_at: null,
+      state_path: null,
+      trace_path: null,
+      ...buildRunnerHintCommands({
+        task_id: opts.task_id,
+        run_id: noRun,
+        status: null,
+      }),
+    };
+  }
+
+  return {
+    task_id: opts.task_id,
+    task_status: taskStatus(task),
+    branch,
+    base_branch,
+    head_sha,
+    workspace_root: ctx.resolvedProject.gitRoot,
+    pr_branch: prMeta.branch,
+    latest_handoff,
+    runner,
+  };
+}
+
+export async function buildRecordedTaskHandoff(opts: {
+  ctx?: CommandContext;
+  cwd: string;
+  rootOverride?: string | null;
+  task_id: string;
+  from_role: string;
+  to_role?: string | null;
+  reason: string;
+  note?: string;
+  next_actions?: string[];
+  risks?: string[];
+  open_questions?: string[];
+  evidence_paths?: string[];
+  run_id?: string;
+}): Promise<{ ctx: CommandContext; handoff: TaskHandoffArtifact }> {
+  const ctx =
+    opts.ctx ??
+    (await loadCommandContext({ cwd: opts.cwd, rootOverride: opts.rootOverride ?? null }));
+  await loadTaskFromContext({ ctx, taskId: opts.task_id });
+  const resume = await buildTaskResumeContext({
+    ctx,
+    cwd: opts.cwd,
+    rootOverride: opts.rootOverride ?? null,
+    task_id: opts.task_id,
+    run_id: opts.run_id,
+  });
+  return {
+    ctx,
+    handoff: buildTaskHandoffArtifact({
+      task_id: opts.task_id,
+      created_at: new Date().toISOString(),
+      from_role: opts.from_role,
+      to_role: opts.to_role,
+      reason: opts.reason,
+      note: opts.note,
+      branch: resume.branch,
+      base_branch: resume.base_branch,
+      head_sha: resume.head_sha,
+      workspace_root: resume.workspace_root,
+      pr_branch: resume.pr_branch,
+      runner: resume.runner,
+      next_actions: opts.next_actions,
+      risks: opts.risks,
+      open_questions: opts.open_questions,
+      evidence_paths: opts.evidence_paths,
+    }),
+  };
+}

--- a/packages/agentplane/src/commands/task/reclaim.command.ts
+++ b/packages/agentplane/src/commands/task/reclaim.command.ts
@@ -1,0 +1,110 @@
+import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
+import { usageError } from "../../cli/spec/errors.js";
+import { infoMessage } from "../../cli/output.js";
+
+import { buildRecordedTaskHandoff, buildTaskResumeContext } from "./handoff.shared.js";
+import { resolveTaskHandoffPaths, writeTaskHandoff } from "../shared/task-handoff.js";
+
+export type TaskReclaimParsed = {
+  taskId: string;
+  author: string;
+  reason: string;
+  force: boolean;
+  json: boolean;
+};
+
+export const taskReclaimSpec: CommandSpec<TaskReclaimParsed> = {
+  id: ["task", "reclaim"],
+  group: "Task",
+  summary: "Claim an interrupted task and persist a recovery handoff snapshot.",
+  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
+  options: [
+    {
+      kind: "string",
+      name: "author",
+      valueHint: "<role>",
+      description: "Role reclaiming the task.",
+    },
+    {
+      kind: "string",
+      name: "reason",
+      valueHint: "<text>",
+      description: "Why the task is being reclaimed.",
+    },
+    {
+      kind: "boolean",
+      name: "force",
+      default: false,
+      description: "Allow reclaim even when the latest run still appears alive.",
+    },
+    {
+      kind: "boolean",
+      name: "json",
+      default: false,
+      description: "Emit the persisted reclaim handoff as JSON.",
+    },
+  ],
+  validateRaw: (raw) => {
+    for (const key of ["author", "reason"] as const) {
+      const value = raw.opts[key];
+      if (typeof value !== "string" || value.trim() === "") {
+        throw usageError({
+          spec: taskReclaimSpec,
+          message: `Missing required option: --${key}.`,
+        });
+      }
+    }
+  },
+  parse: (raw) => ({
+    taskId: String(raw.args["task-id"]),
+    author: String(raw.opts.author),
+    reason: String(raw.opts.reason),
+    force: raw.opts.force === true,
+    json: raw.opts.json === true,
+  }),
+};
+
+export const runTaskReclaim = async (ctx: CommandCtx, parsed: TaskReclaimParsed) => {
+  const resume = await buildTaskResumeContext({
+    cwd: ctx.cwd,
+    rootOverride: ctx.rootOverride ?? null,
+    task_id: parsed.taskId,
+  });
+  if (resume.runner.next_action === "wait" && !parsed.force) {
+    throw usageError({
+      spec: taskReclaimSpec,
+      message:
+        `Refusing to reclaim ${parsed.taskId}: the latest runner still appears alive. ` +
+        `Use --force only if the handoff really is orphaned.`,
+    });
+  }
+  const built = await buildRecordedTaskHandoff({
+    cwd: ctx.cwd,
+    rootOverride: ctx.rootOverride ?? null,
+    task_id: parsed.taskId,
+    from_role: resume.latest_handoff?.to_role ?? resume.latest_handoff?.from_role ?? "UNASSIGNED",
+    to_role: parsed.author,
+    reason: parsed.reason,
+    next_actions: [
+      `Reclaim by ${parsed.author}: follow runner_next_action=${resume.runner.next_action ?? "none"}.`,
+    ],
+  });
+  const paths = resolveTaskHandoffPaths({
+    git_root: built.ctx.resolvedProject.gitRoot,
+    workflow_dir: built.ctx.config.paths.workflow_dir,
+    task_id: parsed.taskId,
+  });
+  await writeTaskHandoff({ paths, handoff: built.handoff });
+  if (parsed.json) {
+    process.stdout.write(`${JSON.stringify(built.handoff, null, 2)}\n`);
+    return 0;
+  }
+  process.stdout.write(`${infoMessage(`task reclaimed: ${parsed.taskId}`)}\n`);
+  process.stdout.write(`author: ${parsed.author}\n`);
+  process.stdout.write(`runner_next_action: ${built.handoff.runner?.next_action ?? "none"}\n`);
+  if (built.handoff.runner?.next_command) {
+    process.stdout.write(`runner_next_command: ${built.handoff.runner.next_command}\n`);
+  }
+  process.stdout.write(`latest: ${paths.latest_path}\n`);
+  return 0;
+};

--- a/packages/agentplane/src/commands/task/resume-context.command.ts
+++ b/packages/agentplane/src/commands/task/resume-context.command.ts
@@ -1,0 +1,68 @@
+import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
+import { infoMessage } from "../../cli/output.js";
+
+import { buildTaskResumeContext } from "./handoff.shared.js";
+
+export type TaskResumeContextParsed = {
+  taskId: string;
+  runId?: string;
+  json: boolean;
+};
+
+export const taskResumeContextSpec: CommandSpec<TaskResumeContextParsed> = {
+  id: ["task", "resume-context"],
+  group: "Task",
+  summary: "Print deterministic recovery context for continuing a task after interruption.",
+  args: [
+    { name: "task-id", required: true, valueHint: "<task-id>" },
+    { name: "run-id", required: false, valueHint: "[run-id]" },
+  ],
+  options: [
+    {
+      kind: "boolean",
+      name: "json",
+      default: false,
+      description: "Emit machine-readable resume context JSON.",
+    },
+  ],
+  parse: (raw) => ({
+    taskId: String(raw.args["task-id"]),
+    runId: typeof raw.args["run-id"] === "string" ? raw.args["run-id"] : undefined,
+    json: raw.opts.json === true,
+  }),
+};
+
+export const runTaskResumeContext = async (ctx: CommandCtx, parsed: TaskResumeContextParsed) => {
+  const resume = await buildTaskResumeContext({
+    cwd: ctx.cwd,
+    rootOverride: ctx.rootOverride ?? null,
+    task_id: parsed.taskId,
+    run_id: parsed.runId,
+  });
+  if (parsed.json) {
+    process.stdout.write(`${JSON.stringify(resume, null, 2)}\n`);
+    return 0;
+  }
+  process.stdout.write(`${infoMessage(`task resume-context: ${parsed.taskId}`)}\n`);
+  process.stdout.write(`task_status: ${resume.task_status}\n`);
+  process.stdout.write(`branch: ${resume.branch ?? "<unknown>"}\n`);
+  process.stdout.write(`base_branch: ${resume.base_branch ?? "<unknown>"}\n`);
+  process.stdout.write(`head_sha: ${resume.head_sha ?? "<unknown>"}\n`);
+  if (resume.pr_branch) process.stdout.write(`pr_branch: ${resume.pr_branch}\n`);
+  process.stdout.write(`runner_status: ${resume.runner.status ?? "none"}\n`);
+  process.stdout.write(`runner_next_action: ${resume.runner.next_action ?? "none"}\n`);
+  if (resume.runner.next_command)
+    process.stdout.write(`runner_next_command: ${resume.runner.next_command}\n`);
+  if (resume.runner.resume_command)
+    process.stdout.write(`runner_resume_command: ${resume.runner.resume_command}\n`);
+  if (resume.runner.retry_command)
+    process.stdout.write(`runner_retry_command: ${resume.runner.retry_command}\n`);
+  if (resume.latest_handoff) {
+    process.stdout.write(`handoff_from: ${resume.latest_handoff.from_role}\n`);
+    process.stdout.write(`handoff_to: ${resume.latest_handoff.to_role ?? "unassigned"}\n`);
+    process.stdout.write(`handoff_reason: ${resume.latest_handoff.reason}\n`);
+  } else {
+    process.stdout.write("handoff: none\n");
+  }
+  return 0;
+};

--- a/packages/agentplane/src/commands/task/task.command.ts
+++ b/packages/agentplane/src/commands/task/task.command.ts
@@ -12,6 +12,9 @@ import { taskCommentSpec } from "./comment.command.js";
 import { taskDeriveSpec } from "./derive.command.js";
 import { taskDocSpec } from "./doc.command.js";
 import { taskExportSpec } from "./export.command.js";
+import { taskHandoffSpec } from "./handoff.command.js";
+import { taskHandoffRecordSpec } from "./handoff-record.command.js";
+import { taskHandoffShowSpec } from "./handoff-show.command.js";
 import { taskLintSpec } from "./lint.command.js";
 import { taskListSpec } from "./list.spec.js";
 import { taskMigrateDocSpec } from "./migrate-doc.command.js";
@@ -21,6 +24,8 @@ import { taskNextSpec } from "./next.spec.js";
 import { taskNormalizeSpec } from "./normalize.command.js";
 import { taskPlanSpec } from "./plan.command.js";
 import { taskRebuildIndexSpec } from "./rebuild-index.command.js";
+import { taskReclaimSpec } from "./reclaim.command.js";
+import { taskResumeContextSpec } from "./resume-context.command.js";
 import { taskRunSpec } from "./run.spec.js";
 import { taskScrubSpec } from "./scrub.command.js";
 import { taskSearchSpec } from "./search.spec.js";
@@ -39,6 +44,9 @@ const TASK_CHILD_SPECS = [
   taskDeriveSpec,
   taskDocSpec,
   taskExportSpec,
+  taskHandoffSpec,
+  taskHandoffRecordSpec,
+  taskHandoffShowSpec,
   taskLintSpec,
   taskListSpec,
   taskMigrateSpec,
@@ -48,6 +56,8 @@ const TASK_CHILD_SPECS = [
   taskNormalizeSpec,
   taskPlanSpec,
   taskRebuildIndexSpec,
+  taskReclaimSpec,
+  taskResumeContextSpec,
   taskRunSpec,
   taskScrubSpec,
   taskSearchSpec,
@@ -91,6 +101,14 @@ export const taskSpec: CommandSpec<TaskGroupParsed> = {
     {
       cmd: "agentplane task run <task-id>",
       why: "Run an existing task through the shared runner flow.",
+    },
+    {
+      cmd: 'agentplane task handoff record <task-id> --from CODER --reason "Paused for handoff"',
+      why: "Persist a first-class handoff snapshot.",
+    },
+    {
+      cmd: "agentplane task resume-context <task-id>",
+      why: "Inspect deterministic recovery context before resuming or retrying a run.",
     },
   ],
   parse: (raw) => parseGroupCommand(raw),

--- a/packages/core/schemas/task-handoff.schema.json
+++ b/packages/core/schemas/task-handoff.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://agentplane.dev/schemas/task-handoff.schema.json",
+  "title": "Task handoff artifact (v1)",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["schema_version", "task_id", "created_at", "from_role", "reason"],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "task_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "from_role": {
+      "type": "string",
+      "minLength": 1
+    },
+    "to_role": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "note": {
+      "type": "string"
+    },
+    "branch": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "base_branch": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "head_sha": {
+      "type": ["string", "null"],
+      "minLength": 7
+    },
+    "workspace_root": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "pr_branch": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "runner": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "run_id": {
+          "type": ["string", "null"],
+          "minLength": 1
+        },
+        "status": {
+          "type": ["string", "null"],
+          "enum": ["prepared", "running", "success", "failed", "cancelled", null]
+        },
+        "heartbeat_at": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "next_action": {
+          "type": ["string", "null"],
+          "enum": ["run", "resume", "retry", "wait", "cancel_then_resume", "none", null]
+        },
+        "next_command": {
+          "type": ["string", "null"]
+        },
+        "resume_command": {
+          "type": ["string", "null"]
+        },
+        "retry_command": {
+          "type": ["string", "null"]
+        },
+        "state_path": {
+          "type": ["string", "null"]
+        },
+        "trace_path": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "next_actions": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "open_questions": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "evidence_paths": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,16 +45,22 @@ export {
 export { readTaskReadme, updateTaskReadmeAtomic } from "./tasks/task-readme-io.js";
 
 export {
+  listTaskHandoffSchemaErrors,
   listTaskPrMetaSchemaErrors,
   listTaskReadmeFrontmatterSchemaErrors,
   listTasksExportSnapshotSchemaErrors,
+  renderTaskHandoffSchemaJson,
   renderTaskPrMetaSchemaJson,
   renderTaskReadmeFrontmatterSchemaJson,
   renderTasksExportSchemaJson,
+  validateTaskHandoff,
   validateTaskPrMeta,
   validateTaskReadmeFrontmatter,
   validateTasksExportSnapshot,
   withTaskReadmeFrontmatterDefaults,
+  type TaskHandoff,
+  type TaskHandoffRunnerNextAction,
+  type TaskHandoffRunnerState,
   type TaskPrMeta,
 } from "./tasks/task-artifact-schema.js";
 

--- a/packages/core/src/tasks/task-artifact-schema.test.ts
+++ b/packages/core/src/tasks/task-artifact-schema.test.ts
@@ -4,9 +4,11 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import {
+  renderTaskHandoffSchemaJson,
   renderTaskPrMetaSchemaJson,
   renderTaskReadmeFrontmatterSchemaJson,
   renderTasksExportSchemaJson,
+  validateTaskHandoff,
   validateTaskPrMeta,
   validateTaskReadmeFrontmatter,
   validateTasksExportSnapshot,
@@ -24,48 +26,62 @@ describe("task-artifact-schema", () => {
       import.meta.url,
     );
     const specPrMetaUrl = new URL("../../../spec/schemas/pr-meta.schema.json", import.meta.url);
+    const specTaskHandoffUrl = new URL(
+      "../../../spec/schemas/task-handoff.schema.json",
+      import.meta.url,
+    );
     const coreTaskReadmeUrl = new URL(
       "../../schemas/task-readme-frontmatter.schema.json",
       import.meta.url,
     );
     const coreTasksExportUrl = new URL("../../schemas/tasks-export.schema.json", import.meta.url);
     const corePrMetaUrl = new URL("../../schemas/pr-meta.schema.json", import.meta.url);
+    const coreTaskHandoffUrl = new URL("../../schemas/task-handoff.schema.json", import.meta.url);
 
     const renderedTaskReadme = JSON.parse(renderTaskReadmeFrontmatterSchemaJson()) as unknown;
     const renderedTasksExport = JSON.parse(renderTasksExportSchemaJson()) as unknown;
     const renderedPrMeta = JSON.parse(renderTaskPrMetaSchemaJson()) as unknown;
+    const renderedTaskHandoff = JSON.parse(renderTaskHandoffSchemaJson()) as unknown;
 
     const [
       specTaskReadme,
       specTasksExport,
       specPrMeta,
+      specTaskHandoff,
       coreTaskReadme,
       coreTasksExport,
       corePrMeta,
+      coreTaskHandoff,
     ] = await Promise.all([
       readFile(fileURLToPath(specTaskReadmeUrl), "utf8"),
       readFile(fileURLToPath(specTasksExportUrl), "utf8"),
       readFile(fileURLToPath(specPrMetaUrl), "utf8"),
+      readFile(fileURLToPath(specTaskHandoffUrl), "utf8"),
       readFile(fileURLToPath(coreTaskReadmeUrl), "utf8"),
       readFile(fileURLToPath(coreTasksExportUrl), "utf8"),
       readFile(fileURLToPath(corePrMetaUrl), "utf8"),
+      readFile(fileURLToPath(coreTaskHandoffUrl), "utf8"),
     ]);
 
     expect(JSON.parse(specTaskReadme)).toEqual(renderedTaskReadme);
     expect(JSON.parse(specTasksExport)).toEqual(renderedTasksExport);
     expect(JSON.parse(specPrMeta)).toEqual(renderedPrMeta);
+    expect(JSON.parse(specTaskHandoff)).toEqual(renderedTaskHandoff);
     expect(JSON.parse(coreTaskReadme)).toEqual(renderedTaskReadme);
     expect(JSON.parse(coreTasksExport)).toEqual(renderedTasksExport);
     expect(JSON.parse(corePrMeta)).toEqual(renderedPrMeta);
+    expect(JSON.parse(coreTaskHandoff)).toEqual(renderedTaskHandoff);
   });
 
   it("runtime validators accept the published spec examples", async () => {
     const examplesRoot = path.join(process.cwd(), "packages", "spec", "examples");
-    const [taskReadmeExample, tasksExportExample, prMetaExample] = await Promise.all([
-      readFile(path.join(examplesRoot, "task-readme-frontmatter.json"), "utf8"),
-      readFile(path.join(examplesRoot, "tasks.json"), "utf8"),
-      readFile(path.join(examplesRoot, "pr-meta.json"), "utf8"),
-    ]);
+    const [taskReadmeExample, tasksExportExample, prMetaExample, taskHandoffExample] =
+      await Promise.all([
+        readFile(path.join(examplesRoot, "task-readme-frontmatter.json"), "utf8"),
+        readFile(path.join(examplesRoot, "tasks.json"), "utf8"),
+        readFile(path.join(examplesRoot, "pr-meta.json"), "utf8"),
+        readFile(path.join(examplesRoot, "task-handoff.json"), "utf8"),
+      ]);
 
     expect(() =>
       validateTaskReadmeFrontmatter(JSON.parse(taskReadmeExample) as unknown),
@@ -74,6 +90,7 @@ describe("task-artifact-schema", () => {
       validateTasksExportSnapshot(JSON.parse(tasksExportExample) as unknown),
     ).not.toThrow();
     expect(() => validateTaskPrMeta(JSON.parse(prMetaExample) as unknown)).not.toThrow();
+    expect(() => validateTaskHandoff(JSON.parse(taskHandoffExample) as unknown)).not.toThrow();
   });
 
   it("accepts short non-git commit hashes in task README frontmatter", () => {

--- a/packages/core/src/tasks/task-artifact-schema.ts
+++ b/packages/core/src/tasks/task-artifact-schema.ts
@@ -25,6 +25,46 @@ export type TaskPrMeta = {
   };
 };
 
+export type TaskHandoffRunnerNextAction =
+  | "run"
+  | "resume"
+  | "retry"
+  | "wait"
+  | "cancel_then_resume"
+  | "none";
+
+export type TaskHandoffRunnerState = {
+  run_id?: string | null;
+  status?: "prepared" | "running" | "success" | "failed" | "cancelled" | null;
+  heartbeat_at?: string | null;
+  next_action?: TaskHandoffRunnerNextAction | null;
+  next_command?: string | null;
+  resume_command?: string | null;
+  retry_command?: string | null;
+  state_path?: string | null;
+  trace_path?: string | null;
+};
+
+export type TaskHandoff = {
+  schema_version: 1;
+  task_id: string;
+  created_at: string;
+  from_role: string;
+  to_role?: string | null;
+  reason: string;
+  note?: string;
+  branch?: string | null;
+  base_branch?: string | null;
+  head_sha?: string | null;
+  workspace_root?: string | null;
+  pr_branch?: string | null;
+  runner?: TaskHandoffRunnerState;
+  next_actions?: string[];
+  risks?: string[];
+  open_questions?: string[];
+  evidence_paths?: string[];
+};
+
 type AjvInstance = {
   compile: <T>(schema: unknown) => ValidateFunction<T>;
   errorsText: (errors?: ErrorObject[] | null, opts?: { dataVar?: string }) => string;
@@ -422,11 +462,72 @@ export const TASK_PR_META_SCHEMA = {
   },
 } as const;
 
+export const TASK_HANDOFF_SCHEMA = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  $id: "https://agentplane.dev/schemas/task-handoff.schema.json",
+  title: "Task handoff artifact (v1)",
+  type: "object",
+  additionalProperties: true,
+  required: ["schema_version", "task_id", "created_at", "from_role", "reason"],
+  properties: {
+    schema_version: { type: "integer", const: 1 },
+    task_id: { type: "string", minLength: 1 },
+    created_at: { type: "string", format: "date-time" },
+    from_role: { type: "string", minLength: 1 },
+    to_role: { type: ["string", "null"], minLength: 1 },
+    reason: { type: "string", minLength: 1 },
+    note: { type: "string" },
+    branch: { type: ["string", "null"], minLength: 1 },
+    base_branch: { type: ["string", "null"], minLength: 1 },
+    head_sha: { type: ["string", "null"], minLength: 7 },
+    workspace_root: { type: ["string", "null"], minLength: 1 },
+    pr_branch: { type: ["string", "null"], minLength: 1 },
+    runner: {
+      type: "object",
+      additionalProperties: true,
+      properties: {
+        run_id: { type: ["string", "null"], minLength: 1 },
+        status: {
+          type: ["string", "null"],
+          enum: ["prepared", "running", "success", "failed", "cancelled", null],
+        },
+        heartbeat_at: { type: ["string", "null"], format: "date-time" },
+        next_action: {
+          type: ["string", "null"],
+          enum: ["run", "resume", "retry", "wait", "cancel_then_resume", "none", null],
+        },
+        next_command: { type: ["string", "null"] },
+        resume_command: { type: ["string", "null"] },
+        retry_command: { type: ["string", "null"] },
+        state_path: { type: ["string", "null"] },
+        trace_path: { type: ["string", "null"] },
+      },
+    },
+    next_actions: {
+      type: "array",
+      items: { type: "string", minLength: 1 },
+    },
+    risks: {
+      type: "array",
+      items: { type: "string", minLength: 1 },
+    },
+    open_questions: {
+      type: "array",
+      items: { type: "string", minLength: 1 },
+    },
+    evidence_paths: {
+      type: "array",
+      items: { type: "string", minLength: 1 },
+    },
+  },
+} as const;
+
 const validateTaskReadmeFrontmatterSchema = AJV.compile<TaskFrontmatter>(
   TASK_README_FRONTMATTER_SCHEMA,
 );
 const validateTasksExportSnapshotSchema = AJV.compile<TasksExportSnapshot>(TASKS_EXPORT_SCHEMA);
 const validateTaskPrMetaSchema = AJV.compile<TaskPrMeta>(TASK_PR_META_SCHEMA);
+const validateTaskHandoffSchema = AJV.compile<TaskHandoff>(TASK_HANDOFF_SCHEMA);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -528,6 +629,14 @@ export function validateTaskPrMeta(value: unknown): TaskPrMeta {
   return assertValid("pr/meta.json", validateTaskPrMetaSchema, value);
 }
 
+export function listTaskHandoffSchemaErrors(value: unknown): string[] {
+  return schemaErrors("handoff/latest.json", validateTaskHandoffSchema, value);
+}
+
+export function validateTaskHandoff(value: unknown): TaskHandoff {
+  return assertValid("handoff/latest.json", validateTaskHandoffSchema, value);
+}
+
 export function renderTaskReadmeFrontmatterSchemaJson(): string {
   return `${JSON.stringify(TASK_README_FRONTMATTER_SCHEMA, null, 2)}\n`;
 }
@@ -538,4 +647,8 @@ export function renderTasksExportSchemaJson(): string {
 
 export function renderTaskPrMetaSchemaJson(): string {
   return `${JSON.stringify(TASK_PR_META_SCHEMA, null, 2)}\n`;
+}
+
+export function renderTaskHandoffSchemaJson(): string {
+  return `${JSON.stringify(TASK_HANDOFF_SCHEMA, null, 2)}\n`;
 }

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -8,6 +8,7 @@ v1 focuses on stabilizing:
 - Task README frontmatter (YAML, represented here as a JSON object schema)
 - `tasks.json` export snapshot (including checksum metadata)
 - PR artifact metadata (`pr/meta.json`)
+- Task handoff metadata (`handoff/latest.json`)
 
 ## Canonicalization notes (checksum-bearing files)
 
@@ -32,9 +33,11 @@ packages/spec/
     task-readme-frontmatter.schema.json
     tasks-export.schema.json
     pr-meta.schema.json
+    task-handoff.schema.json
   examples/
     config.json
     task-readme-frontmatter.json
     tasks.json
     pr-meta.json
+    task-handoff.json
 ```

--- a/packages/spec/examples/task-handoff.json
+++ b/packages/spec/examples/task-handoff.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "task_id": "202603271853-R98CCP",
+  "created_at": "2026-03-27T18:53:00.000Z",
+  "from_role": "CODER",
+  "to_role": "CODER",
+  "reason": "Agent disconnected after a failed run and left deterministic recovery hints.",
+  "note": "Resume after checking the latest failed run trace.",
+  "branch": "task/202603271853-R98CCP/task-handoff-recovery",
+  "base_branch": "main",
+  "head_sha": "abcdef1234567890abcdef1234567890abcdef12",
+  "workspace_root": "/repo",
+  "pr_branch": "task/202603271853-R98CCP/task-handoff-recovery",
+  "runner": {
+    "run_id": "run_20260327_abc123",
+    "status": "failed",
+    "heartbeat_at": "2026-03-27T18:52:30.000Z",
+    "next_action": "retry",
+    "next_command": "agentplane task run retry 202603271853-R98CCP run_20260327_abc123",
+    "resume_command": "agentplane task run resume 202603271853-R98CCP run_20260327_abc123",
+    "retry_command": "agentplane task run retry 202603271853-R98CCP run_20260327_abc123",
+    "state_path": "/repo/.agentplane/tasks/202603271853-R98CCP/runs/run_20260327_abc123/run-state.json",
+    "trace_path": "/repo/.agentplane/tasks/202603271853-R98CCP/runs/run_20260327_abc123/agent-trace.jsonl"
+  },
+  "next_actions": [
+    "Inspect the failed run trace before retrying.",
+    "Retry the run only after confirming the workspace is still clean."
+  ],
+  "risks": ["The previous run failed after partially updating generated artifacts."],
+  "open_questions": ["Should the retry reuse the same run id or start a fresh one?"],
+  "evidence_paths": [
+    ".agentplane/tasks/202603271853-R98CCP/runs/run_20260327_abc123/agent-trace.jsonl"
+  ]
+}

--- a/packages/spec/schemas/task-handoff.schema.json
+++ b/packages/spec/schemas/task-handoff.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://agentplane.dev/schemas/task-handoff.schema.json",
+  "title": "Task handoff artifact (v1)",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["schema_version", "task_id", "created_at", "from_role", "reason"],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "task_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "from_role": {
+      "type": "string",
+      "minLength": 1
+    },
+    "to_role": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "note": {
+      "type": "string"
+    },
+    "branch": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "base_branch": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "head_sha": {
+      "type": ["string", "null"],
+      "minLength": 7
+    },
+    "workspace_root": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "pr_branch": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "runner": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "run_id": {
+          "type": ["string", "null"],
+          "minLength": 1
+        },
+        "status": {
+          "type": ["string", "null"],
+          "enum": ["prepared", "running", "success", "failed", "cancelled", null]
+        },
+        "heartbeat_at": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "next_action": {
+          "type": ["string", "null"],
+          "enum": ["run", "resume", "retry", "wait", "cancel_then_resume", "none", null]
+        },
+        "next_command": {
+          "type": ["string", "null"]
+        },
+        "resume_command": {
+          "type": ["string", "null"]
+        },
+        "retry_command": {
+          "type": ["string", "null"]
+        },
+        "state_path": {
+          "type": ["string", "null"]
+        },
+        "trace_path": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "next_actions": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "open_questions": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "evidence_paths": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add first-class task handoff artifacts and schema
- add task handoff, reclaim, and resume-context CLI commands
- derive deterministic runner recovery hints from existing runner inspection state

## Verification
- bunx vitest run packages/core/src/tasks/task-artifact-schema.test.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts packages/agentplane/src/cli/help.all-commands.contract.test.ts packages/agentplane/src/cli/run-cli.core.help-contract.test.ts
- bun run --filter=@agentplaneorg/core build && bun run --filter=agentplane build
- bunx eslint packages/agentplane/src/commands/shared/task-handoff.ts packages/agentplane/src/commands/task/handoff.shared.ts packages/agentplane/src/commands/task/handoff.command.ts packages/agentplane/src/commands/task/handoff-record.command.ts packages/agentplane/src/commands/task/handoff-show.command.ts packages/agentplane/src/commands/task/resume-context.command.ts packages/agentplane/src/commands/task/reclaim.command.ts packages/agentplane/src/commands/task/task.command.ts packages/agentplane/src/cli/run-cli/command-catalog/task.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/core/src/tasks/task-artifact-schema.ts packages/core/src/tasks/task-artifact-schema.test.ts packages/core/src/index.ts
- bunx prettier --check packages/agentplane/src/commands/shared/task-handoff.ts packages/agentplane/src/commands/task/handoff.shared.ts packages/agentplane/src/commands/task/handoff.command.ts packages/agentplane/src/commands/task/handoff-record.command.ts packages/agentplane/src/commands/task/handoff-show.command.ts packages/agentplane/src/commands/task/resume-context.command.ts packages/agentplane/src/commands/task/reclaim.command.ts packages/agentplane/src/commands/task/task.command.ts packages/agentplane/src/cli/run-cli/command-catalog/task.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/core/src/tasks/task-artifact-schema.ts packages/core/src/tasks/task-artifact-schema.test.ts packages/core/src/index.ts packages/spec/README.md packages/core/schemas/task-handoff.schema.json packages/spec/schemas/task-handoff.schema.json packages/spec/examples/task-handoff.json