### PR TITLE
workflow: reconcile local close-tail task projections

### DIFF
--- a/.agentplane/tasks/202603271853-R98CCP/README.md
+++ b/.agentplane/tasks/202603271853-R98CCP/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202603271853-R98CCP"
 title: "Add first-class task handoff and recovery artifacts"
-status: "DOING"
+result_summary: "Merged into main via PR #29."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -23,11 +24,16 @@ verification:
   updated_at: "2026-03-27T19:25:59.929Z"
   updated_by: "CODER"
   note: "Command: bunx vitest run packages/core/src/tasks/task-artifact-schema.test.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts packages/agentplane/src/cli/help.all-commands.contract.test.ts packages/agentplane/src/cli/run-cli.core.help-contract.test.ts; Result: pass; Evidence: 5 files, 24 tests passed and help snapshot updated for new task handoff commands. Scope: schema, CLI registry/help, handoff/reclaim/resume-context flows. Command: bun run --filter=@agentplaneorg/core build && bun run --filter=agentplane build; Result: pass; Evidence: both package builds succeeded after bootstrap. Scope: core and agentplane compile surfaces. Command: bunx eslint packages/agentplane/src/commands/shared/task-handoff.ts packages/agentplane/src/commands/task/handoff.shared.ts packages/agentplane/src/commands/task/handoff.command.ts packages/agentplane/src/commands/task/handoff-record.command.ts packages/agentplane/src/commands/task/handoff-show.command.ts packages/agentplane/src/commands/task/resume-context.command.ts packages/agentplane/src/commands/task/reclaim.command.ts packages/agentplane/src/commands/task/task.command.ts packages/agentplane/src/cli/run-cli/command-catalog/task.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/core/src/tasks/task-artifact-schema.ts packages/core/src/tasks/task-artifact-schema.test.ts packages/core/src/index.ts; Result: pass; Evidence: no lint errors on changed implementation files. Scope: new handoff surface and artifact schema wiring. Command: bunx prettier --check packages/agentplane/src/commands/shared/task-handoff.ts packages/agentplane/src/commands/task/handoff.shared.ts packages/agentplane/src/commands/task/handoff.command.ts packages/agentplane/src/commands/task/handoff-record.command.ts packages/agentplane/src/commands/task/handoff-show.command.ts packages/agentplane/src/commands/task/resume-context.command.ts packages/agentplane/src/commands/task/reclaim.command.ts packages/agentplane/src/commands/task/task.command.ts packages/agentplane/src/cli/run-cli/command-catalog/task.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/core/src/tasks/task-artifact-schema.ts packages/core/src/tasks/task-artifact-schema.test.ts packages/core/src/index.ts packages/spec/README.md packages/core/schemas/task-handoff.schema.json packages/spec/schemas/task-handoff.schema.json packages/spec/examples/task-handoff.json; Result: pass; Evidence: formatting clean for all changed handoff files and schemas. Scope: changed source, spec, and schema artifacts."
-commit: null
+commit:
+  hash: "c0719cd317fb51cb23cde526441a821d1deb187f"
+  message: "Type task handoff and recovery artifacts (#29)"
 comments:
   -
     author: "CODER"
     body: "Start: implementing a canonical task handoff artifact plus show, resume-context, and reclaim commands that reuse existing runner inspection and lifecycle seams rather than creating a second recovery model."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: hosted PR #29 merged on main after schema, CLI, and help surfaces passed targeted checks and local fast CI."
 events:
   -
     type: "status"
@@ -42,9 +48,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Command: bunx vitest run packages/core/src/tasks/task-artifact-schema.test.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts packages/agentplane/src/cli/help.all-commands.contract.test.ts packages/agentplane/src/cli/run-cli.core.help-contract.test.ts; Result: pass; Evidence: 5 files, 24 tests passed and help snapshot updated for new task handoff commands. Scope: schema, CLI registry/help, handoff/reclaim/resume-context flows. Command: bun run --filter=@agentplaneorg/core build && bun run --filter=agentplane build; Result: pass; Evidence: both package builds succeeded after bootstrap. Scope: core and agentplane compile surfaces. Command: bunx eslint packages/agentplane/src/commands/shared/task-handoff.ts packages/agentplane/src/commands/task/handoff.shared.ts packages/agentplane/src/commands/task/handoff.command.ts packages/agentplane/src/commands/task/handoff-record.command.ts packages/agentplane/src/commands/task/handoff-show.command.ts packages/agentplane/src/commands/task/resume-context.command.ts packages/agentplane/src/commands/task/reclaim.command.ts packages/agentplane/src/commands/task/task.command.ts packages/agentplane/src/cli/run-cli/command-catalog/task.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/core/src/tasks/task-artifact-schema.ts packages/core/src/tasks/task-artifact-schema.test.ts packages/core/src/index.ts; Result: pass; Evidence: no lint errors on changed implementation files. Scope: new handoff surface and artifact schema wiring. Command: bunx prettier --check packages/agentplane/src/commands/shared/task-handoff.ts packages/agentplane/src/commands/task/handoff.shared.ts packages/agentplane/src/commands/task/handoff.command.ts packages/agentplane/src/commands/task/handoff-record.command.ts packages/agentplane/src/commands/task/handoff-show.command.ts packages/agentplane/src/commands/task/resume-context.command.ts packages/agentplane/src/commands/task/reclaim.command.ts packages/agentplane/src/commands/task/task.command.ts packages/agentplane/src/cli/run-cli/command-catalog/task.ts packages/agentplane/src/cli/run-cli.core.task-handoff.test.ts packages/core/src/tasks/task-artifact-schema.ts packages/core/src/tasks/task-artifact-schema.test.ts packages/core/src/index.ts packages/spec/README.md packages/core/schemas/task-handoff.schema.json packages/spec/schemas/task-handoff.schema.json packages/spec/examples/task-handoff.json; Result: pass; Evidence: formatting clean for all changed handoff files and schemas. Scope: changed source, spec, and schema artifacts."
+  -
+    type: "status"
+    at: "2026-03-27T19:33:24.770Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: hosted PR #29 merged on main after schema, CLI, and help surfaces passed targeted checks and local fast CI."
 doc_version: 3
-doc_updated_at: "2026-03-27T19:25:59.931Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-03-27T19:33:24.770Z"
+doc_updated_by: "INTEGRATOR"
 description: "Introduce a canonical task handoff artifact plus CLI commands to record handoff state, show the latest handoff, reclaim orphaned work, and print a deterministic resume context that reuses runner inspection and lifecycle seams."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202603280326-N2JYDX/README.md
+++ b/.agentplane/tasks/202603280326-N2JYDX/README.md
@@ -1,0 +1,140 @@
+---
+id: "202603280326-N2JYDX"
+title: "Close superseded refactor PR #9 after merged task lineage"
+result_summary: "Confirmed the superseded DPZ4NN PR was already closed."
+status: "DONE"
+priority: "med"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "workflow"
+  - "github"
+  - "cleanup"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-03-28T03:26:47.002Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-03-28T03:27:20.924Z"
+  updated_by: "CODER"
+  note: "Verified: gh pr view 9 confirms the stale DPZ4NN PR is already closed; gh pr list now shows only unrelated historical PRs #3-#7 still open. Result: pass. Evidence: current refactor backlog is fully DONE, and no active cleanup is still required for the superseded DPZ4NN PR."
+commit:
+  hash: "f8b3e66b0f8555b88ba0f38750cc881c6bf946ea"
+  message: "✅ R98CCP close: Merged into main via PR #29. (202603271853-R98CCP) [code,runner,workflow]"
+comments:
+  -
+    author: "CODER"
+    body: "Start: confirm that hosted PR #9 is now superseded by the merged DPZ4NN refactor lineage, then close that stale PR on GitHub with an explicit note so repository hygiene no longer shows an obsolete implementation branch for already-merged work."
+  -
+    author: "CODER"
+    body: "Verified: PR #9 had already been closed before cleanup execution, so no further GitHub action was required."
+events:
+  -
+    type: "status"
+    at: "2026-03-28T03:26:55.407Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: confirm that hosted PR #9 is now superseded by the merged DPZ4NN refactor lineage, then close that stale PR on GitHub with an explicit note so repository hygiene no longer shows an obsolete implementation branch for already-merged work."
+  -
+    type: "verify"
+    at: "2026-03-28T03:27:20.924Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: gh pr view 9 confirms the stale DPZ4NN PR is already closed; gh pr list now shows only unrelated historical PRs #3-#7 still open. Result: pass. Evidence: current refactor backlog is fully DONE, and no active cleanup is still required for the superseded DPZ4NN PR."
+  -
+    type: "status"
+    at: "2026-03-28T03:32:53.720Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: PR #9 had already been closed before cleanup execution, so no further GitHub action was required."
+doc_version: 3
+doc_updated_at: "2026-03-28T03:32:53.720Z"
+doc_updated_by: "CODER"
+description: "Close the stale hosted PR for DPZ4NN now that the refactor task was merged and completed through later clean PRs, so repository hygiene no longer shows an obsolete open implementation PR for already-merged work."
+sections:
+  Summary: |-
+    Close superseded refactor PR #9 after merged task lineage
+    
+    Close the stale hosted PR for DPZ4NN now that the refactor task was merged and completed through later clean PRs, so repository hygiene no longer shows an obsolete open implementation PR for already-merged work.
+  Scope: |-
+    - In scope: Close the stale hosted PR for DPZ4NN now that the refactor task was merged and completed through later clean PRs, so repository hygiene no longer shows an obsolete open implementation PR for already-merged work.
+    - Out of scope: unrelated refactors not required for "Close superseded refactor PR #9 after merged task lineage".
+  Plan: |-
+    1. Confirm that PR #9 is stale because the DPZ4NN refactor was merged later through clean hosted PRs and the task itself is already DONE on main.
+    2. Close PR #9 on GitHub with an explicit superseded note pointing to the merged refactor lineage, without modifying implementation code or touching unrelated historical PRs.
+    3. Verify repository hygiene after the close action and record that only legacy unrelated open PRs remain outside this cleanup scope.
+  Verify Steps: |-
+    <!-- TODO: REPLACE WITH TASK-SPECIFIC ACCEPTANCE STEPS -->
+    
+    1. <Action>. Expected: <observable result>.
+    2. <Action>. Expected: <observable result>.
+    3. <Action>. Expected: <observable result>.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-03-28T03:27:20.924Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: gh pr view 9 confirms the stale DPZ4NN PR is already closed; gh pr list now shows only unrelated historical PRs #3-#7 still open. Result: pass. Evidence: current refactor backlog is fully DONE, and no active cleanup is still required for the superseded DPZ4NN PR.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-28T03:26:55.408Z, excerpt_hash=sha256:5d419a099ca6ed7132cf75ede098e500ba03c9ec835a77f962f63f83b789e100
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Close superseded refactor PR #9 after merged task lineage
+
+Close the stale hosted PR for DPZ4NN now that the refactor task was merged and completed through later clean PRs, so repository hygiene no longer shows an obsolete open implementation PR for already-merged work.
+
+## Scope
+
+- In scope: Close the stale hosted PR for DPZ4NN now that the refactor task was merged and completed through later clean PRs, so repository hygiene no longer shows an obsolete open implementation PR for already-merged work.
+- Out of scope: unrelated refactors not required for "Close superseded refactor PR #9 after merged task lineage".
+
+## Plan
+
+1. Confirm that PR #9 is stale because the DPZ4NN refactor was merged later through clean hosted PRs and the task itself is already DONE on main.
+2. Close PR #9 on GitHub with an explicit superseded note pointing to the merged refactor lineage, without modifying implementation code or touching unrelated historical PRs.
+3. Verify repository hygiene after the close action and record that only legacy unrelated open PRs remain outside this cleanup scope.
+
+## Verify Steps
+
+<!-- TODO: REPLACE WITH TASK-SPECIFIC ACCEPTANCE STEPS -->
+
+1. <Action>. Expected: <observable result>.
+2. <Action>. Expected: <observable result>.
+3. <Action>. Expected: <observable result>.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-03-28T03:27:20.924Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: gh pr view 9 confirms the stale DPZ4NN PR is already closed; gh pr list now shows only unrelated historical PRs #3-#7 still open. Result: pass. Evidence: current refactor backlog is fully DONE, and no active cleanup is still required for the superseded DPZ4NN PR.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-28T03:26:55.408Z, excerpt_hash=sha256:5d419a099ca6ed7132cf75ede098e500ba03c9ec835a77f962f63f83b789e100
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202603280331-Z3NTCT/README.md
+++ b/.agentplane/tasks/202603280331-Z3NTCT/README.md
@@ -1,0 +1,140 @@
+---
+id: "202603280331-Z3NTCT"
+title: "Close superseded init setup-profile PR #6 after preset-model rewrite"
+result_summary: "Closed stale init preset PR #6 as superseded."
+status: "DONE"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "workflow"
+  - "github"
+  - "cleanup"
+verify: []
+plan_approval:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-03-28T03:32:10.799Z"
+  updated_by: "CODER"
+  note: "Verified: gh pr view 6 confirms the stale init preset PR is now closed unmerged, and gh pr list shows only the still-live historical proposals #3, #4, #5, and #7 remaining open. Result: pass. Evidence: current main already carries a newer setup-profile contract, so closing #6 removed only an obsolete implementation branch."
+commit:
+  hash: "f8b3e66b0f8555b88ba0f38750cc881c6bf946ea"
+  message: "✅ R98CCP close: Merged into main via PR #29. (202603271853-R98CCP) [code,runner,workflow]"
+comments:
+  -
+    author: "CODER"
+    body: "Start: prove that the old init preset PR is stale against the current setup-profile contract on main, then close only that hosted PR with an explicit superseded note while leaving still-live historical proposals untouched."
+  -
+    author: "CODER"
+    body: "Verified: PR #6 was closed as stale after confirming that main already carries the newer init setup-profile contract."
+events:
+  -
+    type: "status"
+    at: "2026-03-28T03:31:30.745Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: prove that the old init preset PR is stale against the current setup-profile contract on main, then close only that hosted PR with an explicit superseded note while leaving still-live historical proposals untouched."
+  -
+    type: "verify"
+    at: "2026-03-28T03:32:10.799Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: gh pr view 6 confirms the stale init preset PR is now closed unmerged, and gh pr list shows only the still-live historical proposals #3, #4, #5, and #7 remaining open. Result: pass. Evidence: current main already carries a newer setup-profile contract, so closing #6 removed only an obsolete implementation branch."
+  -
+    type: "status"
+    at: "2026-03-28T03:33:01.502Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: PR #6 was closed as stale after confirming that main already carries the newer init setup-profile contract."
+doc_version: 3
+doc_updated_at: "2026-03-28T03:33:01.503Z"
+doc_updated_by: "CODER"
+description: "Close the stale hosted PR for the old setup-profile preset model now that init evolved past prod/dev-safe semantics and the supported setup-profile surface on main already covers the capability through a different preset contract."
+sections:
+  Summary: |-
+    Close superseded init setup-profile PR #6 after preset-model rewrite
+    
+    Close the stale hosted PR for the old setup-profile preset model now that init evolved past prod/dev-safe semantics and the supported setup-profile surface on main already covers the capability through a different preset contract.
+  Scope: |-
+    - In scope: Close the stale hosted PR for the old setup-profile preset model now that init evolved past prod/dev-safe semantics and the supported setup-profile surface on main already covers the capability through a different preset contract.
+    - Out of scope: unrelated refactors not required for "Close superseded init setup-profile PR #6 after preset-model rewrite".
+  Plan: |-
+    1. Compare PR #6 against current init/setup-profile surface on main and confirm that its prod/dev-safe preset model is obsolete because main now ships a different expanded preset contract.
+    2. Close PR #6 on GitHub with an explicit superseded note pointing to the newer init preset model, without touching unrelated historical PRs.
+    3. Verify that PR #6 is closed and that the remaining open historical PRs are only the still-live proposals #3, #4, #5, and #7.
+  Verify Steps: |-
+    <!-- TODO: REPLACE WITH TASK-SPECIFIC ACCEPTANCE STEPS -->
+    
+    1. <Action>. Expected: <observable result>.
+    2. <Action>. Expected: <observable result>.
+    3. <Action>. Expected: <observable result>.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-03-28T03:32:10.799Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: gh pr view 6 confirms the stale init preset PR is now closed unmerged, and gh pr list shows only the still-live historical proposals #3, #4, #5, and #7 remaining open. Result: pass. Evidence: current main already carries a newer setup-profile contract, so closing #6 removed only an obsolete implementation branch.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-28T03:31:30.746Z, excerpt_hash=sha256:5d419a099ca6ed7132cf75ede098e500ba03c9ec835a77f962f63f83b789e100
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Close superseded init setup-profile PR #6 after preset-model rewrite
+
+Close the stale hosted PR for the old setup-profile preset model now that init evolved past prod/dev-safe semantics and the supported setup-profile surface on main already covers the capability through a different preset contract.
+
+## Scope
+
+- In scope: Close the stale hosted PR for the old setup-profile preset model now that init evolved past prod/dev-safe semantics and the supported setup-profile surface on main already covers the capability through a different preset contract.
+- Out of scope: unrelated refactors not required for "Close superseded init setup-profile PR #6 after preset-model rewrite".
+
+## Plan
+
+1. Compare PR #6 against current init/setup-profile surface on main and confirm that its prod/dev-safe preset model is obsolete because main now ships a different expanded preset contract.
+2. Close PR #6 on GitHub with an explicit superseded note pointing to the newer init preset model, without touching unrelated historical PRs.
+3. Verify that PR #6 is closed and that the remaining open historical PRs are only the still-live proposals #3, #4, #5, and #7.
+
+## Verify Steps
+
+<!-- TODO: REPLACE WITH TASK-SPECIFIC ACCEPTANCE STEPS -->
+
+1. <Action>. Expected: <observable result>.
+2. <Action>. Expected: <observable result>.
+3. <Action>. Expected: <observable result>.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-03-28T03:32:10.799Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: gh pr view 6 confirms the stale init preset PR is now closed unmerged, and gh pr list shows only the still-live historical proposals #3, #4, #5, and #7 remaining open. Result: pass. Evidence: current main already carries a newer setup-profile contract, so closing #6 removed only an obsolete implementation branch.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-28T03:31:30.746Z, excerpt_hash=sha256:5d419a099ca6ed7132cf75ede098e500ba03c9ec835a77f962f63f83b789e100
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202603291332-23HTWZ/README.md
+++ b/.agentplane/tasks/202603291332-23HTWZ/README.md
@@ -1,0 +1,101 @@
+---
+id: "202603291332-23HTWZ"
+title: "Reconcile local close-tail task projections into hosted main"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "workflow"
+  - "github"
+  - "tasks"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-03-29T13:32:28.241Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: reconcile only the three task README close updates currently stranded on local main into a clean hosted branch from origin/main, so hosted main and local task projection converge again without carrying a local-only tail."
+events:
+  -
+    type: "status"
+    at: "2026-03-29T13:34:01.861Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: reconcile only the three task README close updates currently stranded on local main into a clean hosted branch from origin/main, so hosted main and local task projection converge again without carrying a local-only tail."
+doc_version: 3
+doc_updated_at: "2026-03-29T13:35:04.750Z"
+doc_updated_by: "CODER"
+description: "Promote the three local close-tail task README updates on main into a normal hosted PR so local main no longer stays ahead of origin/main solely because of task-state commits."
+sections:
+  Summary: |-
+    Reconcile local close-tail task projections into hosted main
+    
+    Promote the three local close-tail task README updates on main into a normal hosted PR so local main no longer stays ahead of origin/main solely because of task-state commits.
+  Scope: |-
+    - In scope: Promote the three local close-tail task README updates on main into a normal hosted PR so local main no longer stays ahead of origin/main solely because of task-state commits.
+    - Out of scope: unrelated refactors not required for "Reconcile local close-tail task projections into hosted main".
+  Plan: |-
+    1. Implement the change for "Reconcile local close-tail task projections into hosted main".
+    2. Run required checks and capture verification evidence.
+    3. Finalize task findings and finish with traceable commit metadata.
+  Verify Steps: |-
+    1.  in the task worktree. Expected: only , , , and the active task’s own artifacts appear.
+    2. . Expected: local task README and PR packet are internally consistent and the branch is publishable.
+    3. Hosted PR merges into , then 0	3 on the base checkout returns  after syncing. Expected: no local-only close-tail remains for these three tasks.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Reconcile local close-tail task projections into hosted main
+
+Promote the three local close-tail task README updates on main into a normal hosted PR so local main no longer stays ahead of origin/main solely because of task-state commits.
+
+## Scope
+
+- In scope: Promote the three local close-tail task README updates on main into a normal hosted PR so local main no longer stays ahead of origin/main solely because of task-state commits.
+- Out of scope: unrelated refactors not required for "Reconcile local close-tail task projections into hosted main".
+
+## Plan
+
+1. Implement the change for "Reconcile local close-tail task projections into hosted main".
+2. Run required checks and capture verification evidence.
+3. Finalize task findings and finish with traceable commit metadata.
+
+## Verify Steps
+
+1.  in the task worktree. Expected: only , , , and the active task’s own artifacts appear.
+2. . Expected: local task README and PR packet are internally consistent and the branch is publishable.
+3. Hosted PR merges into , then 0	3 on the base checkout returns  after syncing. Expected: no local-only close-tail remains for these three tasks.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202603291332-23HTWZ/README.md
+++ b/.agentplane/tasks/202603291332-23HTWZ/README.md
@@ -4,7 +4,7 @@ title: "Reconcile local close-tail task projections into hosted main"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 4
+revision: 5
 origin:
   system: "manual"
 depends_on: []
@@ -37,7 +37,7 @@ events:
     to: "DOING"
     note: "Start: reconcile only the three task README close updates currently stranded on local main into a clean hosted branch from origin/main, so hosted main and local task projection converge again without carrying a local-only tail."
 doc_version: 3
-doc_updated_at: "2026-03-29T13:35:04.750Z"
+doc_updated_at: "2026-03-29T13:36:39.940Z"
 doc_updated_by: "CODER"
 description: "Promote the three local close-tail task README updates on main into a normal hosted PR so local main no longer stays ahead of origin/main solely because of task-state commits."
 sections:
@@ -53,9 +53,9 @@ sections:
     2. Run required checks and capture verification evidence.
     3. Finalize task findings and finish with traceable commit metadata.
   Verify Steps: |-
-    1.  in the task worktree. Expected: only , , , and the active task’s own artifacts appear.
-    2. . Expected: local task README and PR packet are internally consistent and the branch is publishable.
-    3. Hosted PR merges into , then 0	3 on the base checkout returns  after syncing. Expected: no local-only close-tail remains for these three tasks.
+    1. Run git diff --name-only origin/main..HEAD in the task worktree. Expected: only .agentplane/tasks/202603271853-R98CCP/README.md, .agentplane/tasks/202603280326-N2JYDX/README.md, .agentplane/tasks/202603280331-Z3NTCT/README.md, and the active task artifacts for 202603291332-23HTWZ appear.
+    2. Run agentplane pr check 202603291332-23HTWZ. Expected: local task README and PR packet are internally consistent and the branch is publishable.
+    3. After hosted merge, run git rev-list --left-right --count origin/main...main on the base checkout. Expected: 0 0 after syncing, so these three task closures no longer exist only in local history.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
     <!-- END VERIFICATION RESULTS -->
@@ -84,9 +84,9 @@ Promote the three local close-tail task README updates on main into a normal hos
 
 ## Verify Steps
 
-1.  in the task worktree. Expected: only , , , and the active task’s own artifacts appear.
-2. . Expected: local task README and PR packet are internally consistent and the branch is publishable.
-3. Hosted PR merges into , then 0	3 on the base checkout returns  after syncing. Expected: no local-only close-tail remains for these three tasks.
+1. Run git diff --name-only origin/main..HEAD in the task worktree. Expected: only .agentplane/tasks/202603271853-R98CCP/README.md, .agentplane/tasks/202603280326-N2JYDX/README.md, .agentplane/tasks/202603280331-Z3NTCT/README.md, and the active task artifacts for 202603291332-23HTWZ appear.
+2. Run agentplane pr check 202603291332-23HTWZ. Expected: local task README and PR packet are internally consistent and the branch is publishable.
+3. After hosted merge, run git rev-list --left-right --count origin/main...main on the base checkout. Expected: 0 0 after syncing, so these three task closures no longer exist only in local history.
 
 ## Verification
 

--- a/.agentplane/tasks/202603291332-23HTWZ/README.md
+++ b/.agentplane/tasks/202603291332-23HTWZ/README.md
@@ -4,7 +4,7 @@ title: "Reconcile local close-tail task projections into hosted main"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -19,10 +19,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-03-29T13:37:31.398Z"
+  updated_by: "CODER"
+  note: "Command: git diff --name-only origin/main..HEAD; Result: pass; Evidence: only the three reconciled task README paths plus the active task packet are present, with no product code files. Scope: .agentplane/tasks/202603271853-R98CCP, .agentplane/tasks/202603280326-N2JYDX, .agentplane/tasks/202603280331-Z3NTCT, and the active task artifacts. Command: agentplane pr check 202603291332-23HTWZ; Result: pass; Evidence: local task README and PR packet are internally consistent and publishable. Scope: .agentplane/tasks/202603291332-23HTWZ/pr and active README. Command: bun run framework:dev:bootstrap; Result: pass; Evidence: repo-local runtime rebuilt successfully in the clean worktree so branch_pr lifecycle commands execute against the local framework binary. Scope: worktree bootstrap for this hosted reconcile task."
 commit: null
 comments:
   -
@@ -36,8 +36,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: reconcile only the three task README close updates currently stranded on local main into a clean hosted branch from origin/main, so hosted main and local task projection converge again without carrying a local-only tail."
+  -
+    type: "verify"
+    at: "2026-03-29T13:37:31.398Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: git diff --name-only origin/main..HEAD; Result: pass; Evidence: only the three reconciled task README paths plus the active task packet are present, with no product code files. Scope: .agentplane/tasks/202603271853-R98CCP, .agentplane/tasks/202603280326-N2JYDX, .agentplane/tasks/202603280331-Z3NTCT, and the active task artifacts. Command: agentplane pr check 202603291332-23HTWZ; Result: pass; Evidence: local task README and PR packet are internally consistent and publishable. Scope: .agentplane/tasks/202603291332-23HTWZ/pr and active README. Command: bun run framework:dev:bootstrap; Result: pass; Evidence: repo-local runtime rebuilt successfully in the clean worktree so branch_pr lifecycle commands execute against the local framework binary. Scope: worktree bootstrap for this hosted reconcile task."
 doc_version: 3
-doc_updated_at: "2026-03-29T13:36:39.940Z"
+doc_updated_at: "2026-03-29T13:37:31.401Z"
 doc_updated_by: "CODER"
 description: "Promote the three local close-tail task README updates on main into a normal hosted PR so local main no longer stays ahead of origin/main solely because of task-state commits."
 sections:
@@ -58,6 +64,14 @@ sections:
     3. After hosted merge, run git rev-list --left-right --count origin/main...main on the base checkout. Expected: 0 0 after syncing, so these three task closures no longer exist only in local history.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-03-29T13:37:31.398Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Command: git diff --name-only origin/main..HEAD; Result: pass; Evidence: only the three reconciled task README paths plus the active task packet are present, with no product code files. Scope: .agentplane/tasks/202603271853-R98CCP, .agentplane/tasks/202603280326-N2JYDX, .agentplane/tasks/202603280331-Z3NTCT, and the active task artifacts. Command: agentplane pr check 202603291332-23HTWZ; Result: pass; Evidence: local task README and PR packet are internally consistent and publishable. Scope: .agentplane/tasks/202603291332-23HTWZ/pr and active README. Command: bun run framework:dev:bootstrap; Result: pass; Evidence: repo-local runtime rebuilt successfully in the clean worktree so branch_pr lifecycle commands execute against the local framework binary. Scope: worktree bootstrap for this hosted reconcile task.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-29T13:36:39.940Z, excerpt_hash=sha256:c8420966f955e1477e765da9c64baadbe278fc164c6b32b58e4ee16b0c0be6be
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -91,6 +105,14 @@ Promote the three local close-tail task README updates on main into a normal hos
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-03-29T13:37:31.398Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: git diff --name-only origin/main..HEAD; Result: pass; Evidence: only the three reconciled task README paths plus the active task packet are present, with no product code files. Scope: .agentplane/tasks/202603271853-R98CCP, .agentplane/tasks/202603280326-N2JYDX, .agentplane/tasks/202603280331-Z3NTCT, and the active task artifacts. Command: agentplane pr check 202603291332-23HTWZ; Result: pass; Evidence: local task README and PR packet are internally consistent and publishable. Scope: .agentplane/tasks/202603291332-23HTWZ/pr and active README. Command: bun run framework:dev:bootstrap; Result: pass; Evidence: repo-local runtime rebuilt successfully in the clean worktree so branch_pr lifecycle commands execute against the local framework binary. Scope: worktree bootstrap for this hosted reconcile task.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-29T13:36:39.940Z, excerpt_hash=sha256:c8420966f955e1477e765da9c64baadbe278fc164c6b32b58e4ee16b0c0be6be
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202603291332-23HTWZ/pr/diffstat.txt
+++ b/.agentplane/tasks/202603291332-23HTWZ/pr/diffstat.txt
@@ -1,0 +1,5 @@
+ .agentplane/tasks/202603271853-R98CCP/README.md |  23 +++-
+ .agentplane/tasks/202603280326-N2JYDX/README.md | 140 ++++++++++++++++++++++++
+ .agentplane/tasks/202603280331-Z3NTCT/README.md | 140 ++++++++++++++++++++++++
+ .agentplane/tasks/202603291332-23HTWZ/README.md | 101 +++++++++++++++++
+ 4 files changed, 399 insertions(+), 5 deletions(-)

--- a/.agentplane/tasks/202603291332-23HTWZ/pr/diffstat.txt
+++ b/.agentplane/tasks/202603291332-23HTWZ/pr/diffstat.txt
@@ -1,5 +1,9 @@
- .agentplane/tasks/202603271853-R98CCP/README.md |  23 +++-
- .agentplane/tasks/202603280326-N2JYDX/README.md | 140 ++++++++++++++++++++++++
- .agentplane/tasks/202603280331-Z3NTCT/README.md | 140 ++++++++++++++++++++++++
- .agentplane/tasks/202603291332-23HTWZ/README.md | 101 +++++++++++++++++
- 4 files changed, 399 insertions(+), 5 deletions(-)
+ .agentplane/tasks/202603271853-R98CCP/README.md    |  23 +++-
+ .agentplane/tasks/202603280326-N2JYDX/README.md    | 140 +++++++++++++++++++++
+ .agentplane/tasks/202603280331-Z3NTCT/README.md    | 140 +++++++++++++++++++++
+ .agentplane/tasks/202603291332-23HTWZ/README.md    | 101 +++++++++++++++
+ .../tasks/202603291332-23HTWZ/pr/diffstat.txt      |   5 +
+ .agentplane/tasks/202603291332-23HTWZ/pr/meta.json |  12 ++
+ .agentplane/tasks/202603291332-23HTWZ/pr/review.md |  33 +++++
+ .../tasks/202603291332-23HTWZ/pr/verify.log        |   0
+ 8 files changed, 449 insertions(+), 5 deletions(-)

--- a/.agentplane/tasks/202603291332-23HTWZ/pr/meta.json
+++ b/.agentplane/tasks/202603291332-23HTWZ/pr/meta.json
@@ -5,7 +5,7 @@
   "last_verified_sha": null,
   "schema_version": 1,
   "task_id": "202603291332-23HTWZ",
-  "updated_at": "2026-03-29T13:36:51.009Z",
+  "updated_at": "2026-03-29T13:38:13.073Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202603291332-23HTWZ/pr/meta.json
+++ b/.agentplane/tasks/202603291332-23HTWZ/pr/meta.json
@@ -1,0 +1,12 @@
+{
+  "branch": "task/202603291332-23HTWZ/hosted-close-tail-reconcile",
+  "created_at": "2026-03-29T13:36:24.652Z",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202603291332-23HTWZ",
+  "updated_at": "2026-03-29T13:36:51.009Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202603291332-23HTWZ/pr/review.md
+++ b/.agentplane/tasks/202603291332-23HTWZ/pr/review.md
@@ -19,15 +19,19 @@ Branch: task/202603291332-23HTWZ/hosted-close-tail-reconcile
 <!-- Add review notes here. -->
 
 <!-- BEGIN AUTO SUMMARY -->
-- Updated: 2026-03-29T13:36:51.004Z
+- Updated: 2026-03-29T13:38:13.070Z
 - Branch: task/202603291332-23HTWZ/hosted-close-tail-reconcile
-- Head: 671dcf5ff7d9
+- Head: 2a687141a41e
 - Diffstat:
 ```
- .agentplane/tasks/202603271853-R98CCP/README.md |  23 +++-
- .agentplane/tasks/202603280326-N2JYDX/README.md | 140 ++++++++++++++++++++++++
- .agentplane/tasks/202603280331-Z3NTCT/README.md | 140 ++++++++++++++++++++++++
- .agentplane/tasks/202603291332-23HTWZ/README.md | 101 +++++++++++++++++
- 4 files changed, 399 insertions(+), 5 deletions(-)
+ .agentplane/tasks/202603271853-R98CCP/README.md    |  23 +++-
+ .agentplane/tasks/202603280326-N2JYDX/README.md    | 140 +++++++++++++++++++++
+ .agentplane/tasks/202603280331-Z3NTCT/README.md    | 140 +++++++++++++++++++++
+ .agentplane/tasks/202603291332-23HTWZ/README.md    | 101 +++++++++++++++
+ .../tasks/202603291332-23HTWZ/pr/diffstat.txt      |   5 +
+ .agentplane/tasks/202603291332-23HTWZ/pr/meta.json |  12 ++
+ .agentplane/tasks/202603291332-23HTWZ/pr/review.md |  33 +++++
+ .../tasks/202603291332-23HTWZ/pr/verify.log        |   0
+ 8 files changed, 449 insertions(+), 5 deletions(-)
 ```
 <!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202603291332-23HTWZ/pr/review.md
+++ b/.agentplane/tasks/202603291332-23HTWZ/pr/review.md
@@ -1,0 +1,33 @@
+# PR Review
+
+Opened by CODER on 2026-03-29T13:36:24.652Z
+Branch: task/202603291332-23HTWZ/hosted-close-tail-reconcile
+
+## Summary
+
+- 
+
+## Checklist
+
+- [ ] Tests added/updated
+- [ ] Lint/format passes
+- [ ] Verify passed
+- [ ] Docs updated (if needed)
+
+## Handoff Notes
+
+<!-- Add review notes here. -->
+
+<!-- BEGIN AUTO SUMMARY -->
+- Updated: 2026-03-29T13:36:51.004Z
+- Branch: task/202603291332-23HTWZ/hosted-close-tail-reconcile
+- Head: 671dcf5ff7d9
+- Diffstat:
+```
+ .agentplane/tasks/202603271853-R98CCP/README.md |  23 +++-
+ .agentplane/tasks/202603280326-N2JYDX/README.md | 140 ++++++++++++++++++++++++
+ .agentplane/tasks/202603280331-Z3NTCT/README.md | 140 ++++++++++++++++++++++++
+ .agentplane/tasks/202603291332-23HTWZ/README.md | 101 +++++++++++++++++
+ 4 files changed, 399 insertions(+), 5 deletions(-)
+```
+<!-- END AUTO SUMMARY -->


### PR DESCRIPTION
## Summary
- promote the three task README close updates currently stranded on local main into hosted main
- reconcile task projections for R98CCP, N2JYDX, and Z3NTCT without touching product code
- keep the active cleanup task packet alongside the hosted reconcile branch for traceability

## Verification
- git diff --name-only origin/main..HEAD
- agentplane pr check 202603291332-23HTWZ
- bun run framework:dev:bootstrap