### PR TITLE
🔧 5NMDDW workflow: sync artifacts after config changes

### DIFF
--- a/.agentplane/WORKFLOW.md
+++ b/.agentplane/WORKFLOW.md
@@ -5,7 +5,7 @@ approvals:
   require_verify: false
 in_scope_paths:
   - "packages/**"
-mode: "direct"
+mode: "branch_pr"
 owners:
   orchestrator: "ORCHESTRATOR"
 retry_policy:
@@ -19,7 +19,7 @@ version: 1
 
 ## Prompt Template
 Repository: agentplane
-Workflow mode: direct
+Workflow mode: branch_pr
 
 ## Checks
 - preflight

--- a/.agentplane/tasks/202603300819-5NMDDW/README.md
+++ b/.agentplane/tasks/202603300819-5NMDDW/README.md
@@ -1,0 +1,123 @@
+---
+id: "202603300819-5NMDDW"
+title: "Align workflow artifact output with branch_pr config"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "workflow"
+  - "policy"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-03-30T08:20:46.928Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-03-30T08:44:43.355Z"
+  updated_by: "CODER"
+  note: "OK: bunx vitest run packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.test.ts packages/agentplane/src/commands/doctor.fast.test.ts --hookTimeout 60000 --testTimeout 60000; AGENTPLANE_USE_GLOBAL_IN_FRAMEWORK=1 agentplane doctor"
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: trace the workflow artifact generation and validation path, align the published WORKFLOW.md with branch_pr config, and lock the fix with targeted doctor/workflow tests."
+events:
+  -
+    type: "status"
+    at: "2026-03-30T08:21:43.386Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: trace the workflow artifact generation and validation path, align the published WORKFLOW.md with branch_pr config, and lock the fix with targeted doctor/workflow tests."
+  -
+    type: "verify"
+    at: "2026-03-30T08:44:43.355Z"
+    author: "CODER"
+    state: "ok"
+    note: "OK: bunx vitest run packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.test.ts packages/agentplane/src/commands/doctor.fast.test.ts --hookTimeout 60000 --testTimeout 60000; AGENTPLANE_USE_GLOBAL_IN_FRAMEWORK=1 agentplane doctor"
+doc_version: 3
+doc_updated_at: "2026-03-30T08:44:43.383Z"
+doc_updated_by: "CODER"
+description: "Fix the current repo-wide workflow artifact mismatch so agentplane doctor no longer reports WORKFLOW.md=direct while .agentplane/config.json is branch_pr, and update the generation/validation path plus targeted tests accordingly."
+sections:
+  Summary: |-
+    Align workflow artifact output with branch_pr config
+    
+    Fix the current repo-wide workflow artifact mismatch so agentplane doctor no longer reports WORKFLOW.md=direct while .agentplane/config.json is branch_pr, and update the generation/validation path plus targeted tests accordingly.
+  Scope: |-
+    - In scope: Fix the current repo-wide workflow artifact mismatch so agentplane doctor no longer reports WORKFLOW.md=direct while .agentplane/config.json is branch_pr, and update the generation/validation path plus targeted tests accordingly.
+    - Out of scope: unrelated refactors not required for "Align workflow artifact output with branch_pr config".
+  Plan: |-
+    1. Trace the workflow artifact generation, publication, and validation path that produces .agentplane/WORKFLOW.md and doctor mismatch findings.
+    2. Update the canonical artifact/template or generation logic so branch_pr repositories publish and validate a branch_pr workflow artifact rather than a stale direct-mode artifact.
+    3. Add or update targeted tests, then verify that doctor no longer reports the WORKFLOW.md/config mode mismatch.
+  Verify Steps: |-
+    1. Inspect `.agentplane/WORKFLOW.md` after the fix. Expected: the effective workflow artifact matches `workflow_mode=branch_pr` instead of `direct`.
+    2. Run targeted workflow/doctor tests for artifact generation and validation. Expected: all updated tests pass.
+    3. Run `agentplane doctor`. Expected: the `WF_POLICY_MISMATCH ... WORKFLOW.md=direct, config=branch_pr` error is gone.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-03-30T08:44:43.355Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: OK: bunx vitest run packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.test.ts packages/agentplane/src/commands/doctor.fast.test.ts --hookTimeout 60000 --testTimeout 60000; AGENTPLANE_USE_GLOBAL_IN_FRAMEWORK=1 agentplane doctor
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-30T08:21:43.388Z, excerpt_hash=sha256:021f9fcc2b788078352afddbc28514f3a1ea3106ad99efa2b319dbb603c69314
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Align workflow artifact output with branch_pr config
+
+Fix the current repo-wide workflow artifact mismatch so agentplane doctor no longer reports WORKFLOW.md=direct while .agentplane/config.json is branch_pr, and update the generation/validation path plus targeted tests accordingly.
+
+## Scope
+
+- In scope: Fix the current repo-wide workflow artifact mismatch so agentplane doctor no longer reports WORKFLOW.md=direct while .agentplane/config.json is branch_pr, and update the generation/validation path plus targeted tests accordingly.
+- Out of scope: unrelated refactors not required for "Align workflow artifact output with branch_pr config".
+
+## Plan
+
+1. Trace the workflow artifact generation, publication, and validation path that produces .agentplane/WORKFLOW.md and doctor mismatch findings.
+2. Update the canonical artifact/template or generation logic so branch_pr repositories publish and validate a branch_pr workflow artifact rather than a stale direct-mode artifact.
+3. Add or update targeted tests, then verify that doctor no longer reports the WORKFLOW.md/config mode mismatch.
+
+## Verify Steps
+
+1. Inspect `.agentplane/WORKFLOW.md` after the fix. Expected: the effective workflow artifact matches `workflow_mode=branch_pr` instead of `direct`.
+2. Run targeted workflow/doctor tests for artifact generation and validation. Expected: all updated tests pass.
+3. Run `agentplane doctor`. Expected: the `WF_POLICY_MISMATCH ... WORKFLOW.md=direct, config=branch_pr` error is gone.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-03-30T08:44:43.355Z — VERIFY — ok
+
+By: CODER
+
+Note: OK: bunx vitest run packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.test.ts packages/agentplane/src/commands/doctor.fast.test.ts --hookTimeout 60000 --testTimeout 60000; AGENTPLANE_USE_GLOBAL_IN_FRAMEWORK=1 agentplane doctor
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-30T08:21:43.388Z, excerpt_hash=sha256:021f9fcc2b788078352afddbc28514f3a1ea3106ad99efa2b319dbb603c69314
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/workflows/last-known-good.md
+++ b/.agentplane/workflows/last-known-good.md
@@ -5,7 +5,7 @@ approvals:
   require_verify: false
 in_scope_paths:
   - "packages/**"
-mode: "direct"
+mode: "branch_pr"
 owners:
   orchestrator: "ORCHESTRATOR"
 retry_policy:
@@ -19,7 +19,7 @@ version: 1
 
 ## Prompt Template
 Repository: agentplane
-Workflow mode: direct
+Workflow mode: branch_pr
 
 ## Checks
 - preflight

--- a/packages/agentplane/src/cli/run-cli.core.init.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.init.test.ts
@@ -101,6 +101,30 @@ describe("runCli", () => {
     }
   });
 
+  it("mode set syncs workflow artifacts when agent scaffolding exists", async () => {
+    const root = await mkGitRepoRoot();
+    await mkdir(path.join(root, ".agentplane", "agents"), { recursive: true });
+    await writeFile(path.join(root, ".agentplane", "agents", "ORCHESTRATOR.json"), "{}\n", "utf8");
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["mode", "set", "branch_pr", "--root", root]);
+      expect(code).toBe(0);
+      expect(io.stdout.trim()).toBe("branch_pr");
+    } finally {
+      io.restore();
+    }
+
+    const workflowText = await readFile(path.join(root, ".agentplane", "WORKFLOW.md"), "utf8");
+    const lastKnownGoodText = await readFile(
+      path.join(root, ".agentplane", "workflows", "last-known-good.md"),
+      "utf8",
+    );
+    expect(workflowText).toContain('mode: "branch_pr"');
+    expect(workflowText).toContain("Workflow mode: branch_pr");
+    expect(lastKnownGoodText).toContain('mode: "branch_pr"');
+  });
+
   it("mode set rejects invalid values", async () => {
     const root = await mkGitRepoRoot();
     const io = captureStdIO();

--- a/packages/agentplane/src/cli/run-cli.core.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.test.ts
@@ -776,11 +776,13 @@ describe("runCli", () => {
     }
   });
 
-  it("config set writes .agentplane/config.json", async () => {
+  it("config set syncs workflow artifacts when workflow_mode changes", async () => {
     const root = await mkGitRepoRoot();
+    await mkdir(path.join(root, ".agentplane", "agents"), { recursive: true });
+    await writeFile(path.join(root, ".agentplane", "agents", "ORCHESTRATOR.json"), "{}\n", "utf8");
     const io = captureStdIO();
     try {
-      const code = await runCli(["config", "set", "workflow_mode", "direct", "--root", root]);
+      const code = await runCli(["config", "set", "workflow_mode", "branch_pr", "--root", root]);
       expect(code).toBe(0);
     } finally {
       io.restore();
@@ -788,6 +790,13 @@ describe("runCli", () => {
 
     const configPath = path.join(root, ".agentplane", "config.json");
     const text = await readFile(configPath, "utf8");
-    expect(text).toContain('"workflow_mode": "direct"');
+    expect(text).toContain('"workflow_mode": "branch_pr"');
+    const workflowText = await readFile(path.join(root, ".agentplane", "WORKFLOW.md"), "utf8");
+    const lastKnownGoodText = await readFile(
+      path.join(root, ".agentplane", "workflows", "last-known-good.md"),
+      "utf8",
+    );
+    expect(workflowText).toContain('mode: "branch_pr"');
+    expect(lastKnownGoodText).toContain('mode: "branch_pr"');
   });
 });

--- a/packages/agentplane/src/cli/run-cli/commands/config.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/config.ts
@@ -1,9 +1,11 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 
-import { buildExecutionProfile, saveConfig, setByDottedKey } from "@agentplaneorg/core";
+import { buildExecutionProfile, loadConfig, saveConfig, setByDottedKey } from "@agentplaneorg/core";
 
 import { usageError } from "../../spec/errors.js";
 import type { CommandHandler, CommandSpec } from "../../spec/spec.js";
+import { ensureWorkflowArtifacts } from "../../../shared/workflow-artifacts.js";
 import type { RunDeps } from "../command-catalog.js";
 import { wrapCommand } from "./wrap-command.js";
 
@@ -31,6 +33,39 @@ async function cmdConfigShow(opts: {
 
 export function makeRunConfigShowHandler(deps: RunDeps): CommandHandler<ConfigShowParsed> {
   return (ctx) => cmdConfigShow({ cwd: ctx.cwd, rootOverride: ctx.rootOverride, deps });
+}
+
+function shouldRefreshWorkflowArtifactsForKey(key: string): boolean {
+  const normalized = key.trim();
+  return normalized === "workflow_mode" || normalized.startsWith("agents.approvals.");
+}
+
+async function syncWorkflowArtifactsFromSavedConfig(opts: {
+  gitRoot: string;
+  agentplaneDir: string;
+}): Promise<boolean> {
+  try {
+    const agentEntries = await fs.readdir(path.join(opts.agentplaneDir, "agents"), {
+      withFileTypes: true,
+    });
+    if (!agentEntries.some((entry) => entry.isFile() && entry.name.endsWith(".json"))) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+
+  const refreshed = await loadConfig(opts.agentplaneDir);
+  await ensureWorkflowArtifacts({
+    gitRoot: opts.gitRoot,
+    workflowMode: refreshed.config.workflow_mode,
+    approvals: {
+      requirePlanApproval: refreshed.config.agents?.approvals?.require_plan ?? true,
+      requireVerifyApproval: refreshed.config.agents?.approvals?.require_verify ?? true,
+      requireNetworkApproval: refreshed.config.agents?.approvals?.require_network ?? true,
+    },
+  });
+  return true;
 }
 
 type ConfigSetParsed = { key: string; value: string };
@@ -72,6 +107,12 @@ async function cmdConfigSet(opts: {
       const raw = { ...loaded.raw };
       setByDottedKey(raw, opts.key, opts.value);
       await saveConfig(resolved.agentplaneDir, raw);
+      if (shouldRefreshWorkflowArtifactsForKey(opts.key)) {
+        await syncWorkflowArtifactsFromSavedConfig({
+          gitRoot: resolved.gitRoot,
+          agentplaneDir: resolved.agentplaneDir,
+        });
+      }
       process.stdout.write(
         `${path.relative(resolved.gitRoot, path.join(resolved.agentplaneDir, "config.json"))}\n`,
       );
@@ -155,6 +196,10 @@ async function cmdModeSet(opts: {
       const raw = { ...loaded.raw };
       setByDottedKey(raw, "workflow_mode", opts.mode);
       await saveConfig(resolved.agentplaneDir, raw);
+      await syncWorkflowArtifactsFromSavedConfig({
+        gitRoot: resolved.gitRoot,
+        agentplaneDir: resolved.agentplaneDir,
+      });
       process.stdout.write(`${opts.mode}\n`);
       return 0;
     },
@@ -264,6 +309,10 @@ async function cmdProfileSet(opts: {
       setByDottedKey(raw, "execution", JSON.stringify(execution));
 
       await saveConfig(resolved.agentplaneDir, raw);
+      await syncWorkflowArtifactsFromSavedConfig({
+        gitRoot: resolved.gitRoot,
+        agentplaneDir: resolved.agentplaneDir,
+      });
       process.stdout.write(`${opts.profile}\n`);
       return 0;
     },

--- a/packages/agentplane/src/commands/doctor.fast.test.ts
+++ b/packages/agentplane/src/commands/doctor.fast.test.ts
@@ -145,6 +145,36 @@ describe("doctor.fast", () => {
     expect(rc).toBe(0);
   });
 
+  it("doctor --fix realigns a stale direct workflow artifact with branch_pr config", async () => {
+    const ws = await mkWorkspace();
+    await writeFile(
+      path.join(ws.root, ".agentplane", "config.json"),
+      '{\n  "version": 1,\n  "workflow_mode": "branch_pr",\n  "agents": {\n    "approvals": {\n      "require_plan": false,\n      "require_verify": false,\n      "require_network": true\n    }\n  }\n}\n',
+      "utf8",
+    );
+
+    const rcBefore = await runDoctor(
+      { cwd: ws.root, rootOverride: null } as unknown as Parameters<typeof runDoctor>[0],
+      { fix: false, dev: false },
+    );
+    expect(rcBefore).toBe(1);
+
+    const rcAfter = await runDoctor(
+      { cwd: ws.root, rootOverride: null } as unknown as Parameters<typeof runDoctor>[0],
+      { fix: true, dev: false },
+    );
+    expect(rcAfter).toBe(0);
+
+    const workflowText = await readFile(path.join(ws.root, ".agentplane", "WORKFLOW.md"), "utf8");
+    const lastKnownGoodText = await readFile(
+      path.join(ws.root, ".agentplane", "workflows", "last-known-good.md"),
+      "utf8",
+    );
+    expect(workflowText).toContain('mode: "branch_pr"');
+    expect(workflowText).toContain("Workflow mode: {{ workflow.mode }}");
+    expect(lastKnownGoodText).toContain('mode: "branch_pr"');
+  });
+
   it("fails when both policy gateway files are missing", async () => {
     const ws = await mkWorkspace();
     await rm(path.join(ws.root, "AGENTS.md"), { force: true });

--- a/packages/agentplane/src/commands/doctor/workflow.ts
+++ b/packages/agentplane/src/commands/doctor/workflow.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { loadConfig } from "@agentplaneorg/core";
 
 import {
   emitWorkflowEvent,
@@ -37,7 +38,15 @@ export async function safeFixWorkflow(
     }
   }
 
-  const fixed = safeAutofixWorkflowText(current);
+  const loaded = await loadConfig(path.join(repoRoot, ".agentplane"));
+  const fixed = safeAutofixWorkflowText(current, {
+    mode: loaded.config.workflow_mode,
+    approvals: {
+      require_plan: loaded.config.agents?.approvals?.require_plan ?? true,
+      require_verify: loaded.config.agents?.approvals?.require_verify ?? true,
+      require_network: loaded.config.agents?.approvals?.require_network ?? true,
+    },
+  });
   if (fixed.diagnostics.some((d) => d.code === "WF_FIX_SKIPPED_UNSAFE")) {
     const details = fixed.diagnostics.map((d) => `${d.path}`).join(", ");
     return {

--- a/packages/agentplane/src/workflow-runtime/fix.ts
+++ b/packages/agentplane/src/workflow-runtime/fix.ts
@@ -7,6 +7,15 @@ type WorkflowFixResult = {
   diagnostics: WorkflowDiagnostic[];
 };
 
+type ExpectedWorkflowPolicy = {
+  mode: "direct" | "branch_pr";
+  approvals: {
+    require_plan: boolean;
+    require_verify: boolean;
+    require_network: boolean;
+  };
+};
+
 const DEFAULT_FRONT_MATTER: WorkflowFrontMatter = {
   version: 1,
   mode: "direct",
@@ -89,7 +98,10 @@ function withDefaults(raw: Record<string, unknown>): Record<string, unknown> {
   return out;
 }
 
-export function safeAutofixWorkflowText(text: string): WorkflowFixResult {
+export function safeAutofixWorkflowText(
+  text: string,
+  expectedPolicy?: ExpectedWorkflowPolicy,
+): WorkflowFixResult {
   const parsed = parseWorkflowMarkdown(text);
   const diagnostics: WorkflowDiagnostic[] = [];
   const unknownKeyDiagnostics = Object.keys(parsed.document.frontMatterRaw)
@@ -119,6 +131,14 @@ export function safeAutofixWorkflowText(text: string): WorkflowFixResult {
   }
 
   const nextFrontMatter = withDefaults(parsed.document.frontMatterRaw);
+  if (expectedPolicy) {
+    nextFrontMatter.mode = expectedPolicy.mode;
+    nextFrontMatter.approvals = {
+      require_plan: expectedPolicy.approvals.require_plan,
+      require_verify: expectedPolicy.approvals.require_verify,
+      require_network: expectedPolicy.approvals.require_network,
+    };
+  }
   const sections = {
     ...parsed.document.sections,
     "Prompt Template": parsed.document.sections["Prompt Template"] ?? "",


### PR DESCRIPTION
## Summary
- keep \.agentplane/WORKFLOW.md and last-known-good.md aligned with workflow_mode=branch_pr
- sync workflow artifacts after config set, mode set, and profile set when agent scaffolding exists
- make agentplane doctor --fix rewrite stale workflow artifact front matter from the active config
- lock the behavior with targeted init/config/doctor tests

## Verification
- bunx vitest run packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.test.ts packages/agentplane/src/commands/doctor.fast.test.ts --hookTimeout 60000 --testTimeout 60000
- AGENTPLANE_USE_GLOBAL_IN_FRAMEWORK=1 agentplane doctor