### PR TITLE
🔧 WKK8C5 runtime: clarify framework worktree bootstrap guidance

### DIFF
--- a/.agentplane/tasks/202603300819-WKK8C5/README.md
+++ b/.agentplane/tasks/202603300819-WKK8C5/README.md
@@ -1,0 +1,145 @@
+---
+id: "202603300819-WKK8C5"
+title: "Make framework task worktrees runnable without manual runtime surprises"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 7
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "workflow"
+  - "bootstrap"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-03-30T08:20:46.971Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-03-30T08:44:42.941Z"
+  updated_by: "CODER"
+  note: "OK: bunx vitest run packages/agentplane/src/cli/repo-local-handoff.test.ts packages/agentplane/src/cli/pre-commit-hook-script.test.ts --hookTimeout 60000 --testTimeout 60000"
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: reproduce the framework task-worktree runtime/bootstrap failures, then implement a supported fallback or diagnostic path so task lifecycle commands and related hooks do not fail opaquely."
+events:
+  -
+    type: "status"
+    at: "2026-03-30T08:21:53.922Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: reproduce the framework task-worktree runtime/bootstrap failures, then implement a supported fallback or diagnostic path so task lifecycle commands and related hooks do not fail opaquely."
+  -
+    type: "verify"
+    at: "2026-03-30T08:29:11.175Z"
+    author: "CODER"
+    state: "ok"
+    note: "Validated repo-local handoff guidance and hook bootstrap fallback with narrow vitest coverage."
+  -
+    type: "verify"
+    at: "2026-03-30T08:44:42.941Z"
+    author: "CODER"
+    state: "ok"
+    note: "OK: bunx vitest run packages/agentplane/src/cli/repo-local-handoff.test.ts packages/agentplane/src/cli/pre-commit-hook-script.test.ts --hookTimeout 60000 --testTimeout 60000"
+doc_version: 3
+doc_updated_at: "2026-03-30T08:44:42.993Z"
+doc_updated_by: "CODER"
+description: "Remove or reduce the need for AGENTPLANE_USE_GLOBAL_IN_FRAMEWORK=1 and bootstrap guesswork in framework task worktrees by fixing repo-local handoff behavior, diagnostics, or fallback paths so task lifecycle and commit hooks fail less opaquely."
+sections:
+  Summary: |-
+    Make framework task worktrees runnable without manual runtime surprises
+    
+    Remove or reduce the need for AGENTPLANE_USE_GLOBAL_IN_FRAMEWORK=1 and bootstrap guesswork in framework task worktrees by fixing repo-local handoff behavior, diagnostics, or fallback paths so task lifecycle and commit hooks fail less opaquely.
+  Scope: |-
+    - In scope: Remove or reduce the need for AGENTPLANE_USE_GLOBAL_IN_FRAMEWORK=1 and bootstrap guesswork in framework task worktrees by fixing repo-local handoff behavior, diagnostics, or fallback paths so task lifecycle and commit hooks fail less opaquely.
+    - Out of scope: unrelated refactors not required for "Make framework task worktrees runnable without manual runtime surprises".
+  Plan: |-
+    1. Reproduce the current framework task-worktree failures around repo-local dist handoff, AGENTPLANE_USE_GLOBAL_IN_FRAMEWORK fallback, and pre-commit/bootstrap usability.
+    2. Implement a supported fallback, clearer diagnostics, or bootstrap-aware behavior so framework task worktrees are usable without opaque runtime surprises.
+    3. Add or update targeted runtime/handoff tests and verify the improved behavior in a task worktree-like scenario.
+  Verify Steps: |-
+    1. Reproduce the framework task-worktree path that previously required `AGENTPLANE_USE_GLOBAL_IN_FRAMEWORK=1` or failed on missing local dist. Expected: the resulting behavior is supported and actionable rather than opaque.
+    2. Run targeted repo-local handoff/runtime tests. Expected: all updated tests pass.
+    3. Validate the touched task-lifecycle or hook path in a framework checkout scenario. Expected: no silent/opaque failure remains for the supported path.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-03-30T08:29:11.175Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Validated repo-local handoff guidance and hook bootstrap fallback with narrow vitest coverage.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-30T08:21:53.924Z, excerpt_hash=sha256:369b1f6e336cb8f8cdbd1ce7b979defbbd75da063eb2c8f84b686f1c05834eb0
+    
+    ### 2026-03-30T08:44:42.941Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: OK: bunx vitest run packages/agentplane/src/cli/repo-local-handoff.test.ts packages/agentplane/src/cli/pre-commit-hook-script.test.ts --hookTimeout 60000 --testTimeout 60000
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-30T08:29:11.178Z, excerpt_hash=sha256:369b1f6e336cb8f8cdbd1ce7b979defbbd75da063eb2c8f84b686f1c05834eb0
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Make framework task worktrees runnable without manual runtime surprises
+
+Remove or reduce the need for AGENTPLANE_USE_GLOBAL_IN_FRAMEWORK=1 and bootstrap guesswork in framework task worktrees by fixing repo-local handoff behavior, diagnostics, or fallback paths so task lifecycle and commit hooks fail less opaquely.
+
+## Scope
+
+- In scope: Remove or reduce the need for AGENTPLANE_USE_GLOBAL_IN_FRAMEWORK=1 and bootstrap guesswork in framework task worktrees by fixing repo-local handoff behavior, diagnostics, or fallback paths so task lifecycle and commit hooks fail less opaquely.
+- Out of scope: unrelated refactors not required for "Make framework task worktrees runnable without manual runtime surprises".
+
+## Plan
+
+1. Reproduce the current framework task-worktree failures around repo-local dist handoff, AGENTPLANE_USE_GLOBAL_IN_FRAMEWORK fallback, and pre-commit/bootstrap usability.
+2. Implement a supported fallback, clearer diagnostics, or bootstrap-aware behavior so framework task worktrees are usable without opaque runtime surprises.
+3. Add or update targeted runtime/handoff tests and verify the improved behavior in a task worktree-like scenario.
+
+## Verify Steps
+
+1. Reproduce the framework task-worktree path that previously required `AGENTPLANE_USE_GLOBAL_IN_FRAMEWORK=1` or failed on missing local dist. Expected: the resulting behavior is supported and actionable rather than opaque.
+2. Run targeted repo-local handoff/runtime tests. Expected: all updated tests pass.
+3. Validate the touched task-lifecycle or hook path in a framework checkout scenario. Expected: no silent/opaque failure remains for the supported path.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-03-30T08:29:11.175Z — VERIFY — ok
+
+By: CODER
+
+Note: Validated repo-local handoff guidance and hook bootstrap fallback with narrow vitest coverage.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-30T08:21:53.924Z, excerpt_hash=sha256:369b1f6e336cb8f8cdbd1ce7b979defbbd75da063eb2c8f84b686f1c05834eb0
+
+### 2026-03-30T08:44:42.941Z — VERIFY — ok
+
+By: CODER
+
+Note: OK: bunx vitest run packages/agentplane/src/cli/repo-local-handoff.test.ts packages/agentplane/src/cli/pre-commit-hook-script.test.ts --hookTimeout 60000 --testTimeout 60000
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-30T08:29:11.178Z, excerpt_hash=sha256:369b1f6e336cb8f8cdbd1ce7b979defbbd75da063eb2c8f84b686f1c05834eb0
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/packages/agentplane/bin/agentplane.js
+++ b/packages/agentplane/bin/agentplane.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { distExists, isPackageBuildFresh } from "./dist-guard.js";
 import {
   FRAMEWORK_DEV_BOOTSTRAP_COMMAND,
+  FRAMEWORK_DEV_FORCE_GLOBAL_EXAMPLE,
   FRAMEWORK_DEV_MANUAL_REPAIR_COMMANDS,
 } from "./framework-dev-contract.js";
 import { getWatchedRuntimePathsForPackage } from "./runtime-watch.js";
@@ -130,11 +131,14 @@ async function assertDistUpToDate() {
   const allowStale = (process.env.AGENTPLANE_DEV_ALLOW_STALE_DIST ?? "").trim() === "1";
   if (!(await distExists(agentplaneRoot))) {
     process.stderr.write(
-      "error: agentplane dist is missing for this repo checkout.\n" +
+      "error: agentplane dist is missing for this framework checkout.\n" +
+        "This worktree is not bootstrapped yet.\n" +
         "Fix:\n" +
         `  ${FRAMEWORK_DEV_BOOTSTRAP_COMMAND}\n` +
         "Manual fallback:\n" +
-        FRAMEWORK_DEV_MANUAL_REPAIR_COMMANDS.map((command) => `  ${command}\n`).join(""),
+        FRAMEWORK_DEV_MANUAL_REPAIR_COMMANDS.map((command) => `  ${command}\n`).join("") +
+        "Supported global override when you intentionally want the installed binary:\n" +
+        `  ${FRAMEWORK_DEV_FORCE_GLOBAL_EXAMPLE}\n`,
     );
     process.exitCode = 2;
     return false;

--- a/packages/agentplane/src/cli/pre-commit-hook-script.test.ts
+++ b/packages/agentplane/src/cli/pre-commit-hook-script.test.ts
@@ -1,0 +1,60 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const tempRoots: string[] = [];
+const workspaceRoot = process.cwd();
+const hookScriptPath = path.join(workspaceRoot, "scripts", "run-pre-commit-hook.mjs");
+
+async function setupTempGitRepo() {
+  const root = await mkdtemp(path.join(os.tmpdir(), "agentplane-pre-commit-hook-"));
+  tempRoots.push(root);
+
+  await execFileAsync("git", ["init", "-q"], { cwd: root });
+  await mkdir(path.join(root, "src"), { recursive: true });
+  await writeFile(path.join(root, "README.md"), "# demo\n", "utf8");
+  await writeFile(path.join(root, "src", "app.ts"), "export const app = true;\n", "utf8");
+  await execFileAsync("git", ["add", "README.md", "src/app.ts"], { cwd: root });
+
+  return root;
+}
+
+afterEach(async () => {
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (!root) continue;
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+describe("run-pre-commit-hook.mjs", () => {
+  it("prints bootstrap guidance when local hook tools are missing", async () => {
+    const root = await setupTempGitRepo();
+
+    try {
+      await execFileAsync(process.execPath, [hookScriptPath], {
+        cwd: root,
+        encoding: "utf8",
+      });
+      throw new Error("expected hook script to fail");
+    } catch (error) {
+      const err = error as { stdout?: string; stderr?: string };
+      expect(err.stderr ?? "").toContain(
+        "pre-commit hook dependencies are missing for this checkout.",
+      );
+      expect(err.stderr ?? "").toContain("Missing local tools:");
+      expect(err.stderr ?? "").toContain("prettier:");
+      expect(err.stderr ?? "").toContain("eslint:");
+      expect(err.stderr ?? "").toContain("bun run framework:dev:bootstrap");
+      expect(err.stderr ?? "").toContain(
+        "AGENTPLANE_USE_GLOBAL_IN_FRAMEWORK=1 agentplane <command>",
+      );
+      expect(err.stdout ?? "").toBe("");
+    }
+  });
+});

--- a/packages/agentplane/src/cli/repo-local-handoff.test.ts
+++ b/packages/agentplane/src/cli/repo-local-handoff.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { chmod, copyFile, mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { chmod, copyFile, mkdtemp, mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -112,6 +112,32 @@ async function setupFrameworkCheckout() {
   };
 }
 
+async function setupFrameworkCheckoutWithoutDist() {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "agentplane-framework-checkout-"));
+  tempRoots.push(repoRoot);
+  const binDir = path.join(repoRoot, "packages", "agentplane", "bin");
+  const srcDir = path.join(repoRoot, "packages", "agentplane", "src", "nested");
+  await mkdir(binDir, { recursive: true });
+  await mkdir(srcDir, { recursive: true });
+  for (const entry of await readdir(path.join(workspaceRoot, "packages", "agentplane", "bin"))) {
+    if (!entry.endsWith(".js")) continue;
+    await copyFile(
+      path.join(workspaceRoot, "packages", "agentplane", "bin", entry),
+      path.join(binDir, entry),
+    );
+  }
+  await writeFile(
+    path.join(repoRoot, "packages", "agentplane", "src", "cli.ts"),
+    "export const cli = true;\n",
+    "utf8",
+  );
+
+  return {
+    repoRoot,
+    nestedCwd: srcDir,
+  };
+}
+
 afterEach(async () => {
   while (tempRoots.length > 0) {
     const root = tempRoots.pop();
@@ -205,5 +231,28 @@ describe("repo-local handoff wrapper", () => {
 
     const local = parsePayload(stdout, "LOCAL");
     expect(local.args).toEqual(["help", "help", "--compact"]);
+  });
+
+  it("reports bootstrap guidance when repo-local dist is missing", async () => {
+    const globalInstall = await setupGlobalInstall();
+    const framework = await setupFrameworkCheckoutWithoutDist();
+
+    try {
+      await execFileAsync(process.execPath, [globalInstall.binPath, "help"], {
+        cwd: framework.nestedCwd,
+        encoding: "utf8",
+        env: buildChildEnv(),
+      });
+      throw new Error("expected command to fail");
+    } catch (error) {
+      const err = error as { stderr?: string; stdout?: string };
+      expect(err.stderr ?? "").toContain("agentplane dist is missing for this framework checkout");
+      expect(err.stderr ?? "").toContain("This worktree is not bootstrapped yet.");
+      expect(err.stderr ?? "").toContain("bun run framework:dev:bootstrap");
+      expect(err.stderr ?? "").toContain(
+        "AGENTPLANE_USE_GLOBAL_IN_FRAMEWORK=1 agentplane <command>",
+      );
+      expect(err.stdout ?? "").toBe("");
+    }
   });
 });

--- a/scripts/run-pre-commit-hook.mjs
+++ b/scripts/run-pre-commit-hook.mjs
@@ -1,6 +1,11 @@
 import { execFileSync } from "node:child_process";
+import { access } from "node:fs/promises";
 import path from "node:path";
 
+import {
+  FRAMEWORK_DEV_BOOTSTRAP_COMMAND,
+  FRAMEWORK_DEV_FORCE_GLOBAL_EXAMPLE,
+} from "../packages/agentplane/bin/framework-dev-contract.js";
 import { eslintTargets, prettierTargets } from "./lib/pre-commit-staged-files.mjs";
 
 function run(command, args, env) {
@@ -30,19 +35,56 @@ function localBin(root, name) {
   return path.join(root, "node_modules", ".bin", `${name}${ext}`);
 }
 
+async function ensureLocalTool(root, name) {
+  const toolPath = localBin(root, name);
+  try {
+    await access(toolPath);
+    return toolPath;
+  } catch {
+    return null;
+  }
+}
+
+function printMissingToolError(root, missingTools) {
+  process.stderr.write(
+    "error: pre-commit hook dependencies are missing for this checkout.\n" +
+      `Missing local tool${missingTools.length > 1 ? "s" : ""}:\n` +
+      missingTools.map((tool) => `  ${tool}: ${localBin(root, tool)}\n`).join("") +
+      "Fix:\n" +
+      `  ${FRAMEWORK_DEV_BOOTSTRAP_COMMAND}\n` +
+      "If you intentionally want to force the installed CLI inside a framework checkout:\n" +
+      `  ${FRAMEWORK_DEV_FORCE_GLOBAL_EXAMPLE}\n`,
+  );
+}
+
+async function runChecked(root, tool, args, missingTools) {
+  const toolPath = await ensureLocalTool(root, tool);
+  if (!toolPath) {
+    missingTools.push(tool);
+    return;
+  }
+  run(toolPath, args);
+}
+
 const root = repoRoot();
 const files = stagedFiles();
+const missingTools = [];
 
 const prettierFiles = prettierTargets(files);
 if (prettierFiles.length > 0) {
-  run(localBin(root, "prettier"), ["--check", ...prettierFiles]);
+  await runChecked(root, "prettier", ["--check", ...prettierFiles], missingTools);
 } else {
   process.stdout.write("pre-commit: no staged files for Prettier, skipping.\n");
 }
 
 const eslintFiles = eslintTargets(files);
 if (eslintFiles.length > 0) {
-  run(localBin(root, "eslint"), eslintFiles);
+  await runChecked(root, "eslint", eslintFiles, missingTools);
 } else {
   process.stdout.write("pre-commit: no staged files for ESLint, skipping.\n");
+}
+
+if (missingTools.length > 0) {
+  printMissingToolError(root, [...new Set(missingTools)]);
+  process.exitCode = 2;
 }


### PR DESCRIPTION
## Summary
- make missing repo-local framework dist fail with explicit bootstrap guidance instead of an opaque runtime error
- document the supported global override path for framework checkouts without local bootstrap
- make the pre-commit hook report missing local tooling with one actionable bootstrap error instead of raw ENOENT
- cover the runtime and hook path with targeted handoff/script tests

## Verification
- bunx vitest run packages/agentplane/src/cli/repo-local-handoff.test.ts packages/agentplane/src/cli/pre-commit-hook-script.test.ts --hookTimeout 60000 --testTimeout 60000