### PR TITLE
🔧 ZESZG8 workflow: prefer local PR artifacts in pr check

### DIFF
--- a/.agentplane/tasks/202603301249-ZESZG8/README.md
+++ b/.agentplane/tasks/202603301249-ZESZG8/README.md
@@ -1,0 +1,119 @@
+---
+id: "202603301249-ZESZG8"
+title: "Make pr check prefer local artifacts before branch fallback"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "workflow"
+  - "branch_pr"
+  - "cli"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-03-30T13:15:24.868Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-03-30T14:50:35.738Z"
+  updated_by: "CODER"
+  note: "OK: bunx vitest run packages/agentplane/src/cli/run-cli.core.pr-flow.pr.test.ts -t 'pr check passes when artifacts exist|pr check falls back to PR artifacts committed on the task branch|pr check prefers local PR artifacts when multiple task branches match|pr check still reports multiple task branches when fallback is required' --hookTimeout 60000 --testTimeout 60000; local pr-check logic now prefers active-worktree artifacts and preserves multiple-branch validation only for true fallback cases."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: reproduce the confirmed pr check ambiguity in a clean task worktree, change artifact resolution so local pr files win over branch fallback, and lock the fix with targeted PR-flow tests before reopening the command in the same reproduced state."
+events:
+  -
+    type: "status"
+    at: "2026-03-30T14:05:35.387Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: reproduce the confirmed pr check ambiguity in a clean task worktree, change artifact resolution so local pr files win over branch fallback, and lock the fix with targeted PR-flow tests before reopening the command in the same reproduced state."
+  -
+    type: "verify"
+    at: "2026-03-30T14:50:35.738Z"
+    author: "CODER"
+    state: "ok"
+    note: "OK: bunx vitest run packages/agentplane/src/cli/run-cli.core.pr-flow.pr.test.ts -t 'pr check passes when artifacts exist|pr check falls back to PR artifacts committed on the task branch|pr check prefers local PR artifacts when multiple task branches match|pr check still reports multiple task branches when fallback is required' --hookTimeout 60000 --testTimeout 60000; local pr-check logic now prefers active-worktree artifacts and preserves multiple-branch validation only for true fallback cases."
+doc_version: 3
+doc_updated_at: "2026-03-30T14:50:35.749Z"
+doc_updated_by: "CODER"
+description: "Fix branch_pr PR checking so  reads local  artifacts first and only falls back to task-branch discovery when local artifacts are absent, avoiding false  failures in active worktrees."
+sections:
+  Summary: |-
+    Make pr check prefer local artifacts before branch fallback
+    
+    Fix branch_pr PR checking so  reads local  artifacts first and only falls back to task-branch discovery when local artifacts are absent, avoiding false  failures in active worktrees.
+  Scope: |-
+    - In scope: Fix branch_pr PR checking so  reads local  artifacts first and only falls back to task-branch discovery when local artifacts are absent, avoiding false  failures in active worktrees.
+    - Out of scope: unrelated refactors not required for "Make pr check prefer local artifacts before branch fallback".
+  Plan: "1. Reproduce the current  failure when multiple local task branches match the same task id even though local  artifacts exist in the active worktree. 2. Update the PR-check artifact resolution flow so local artifacts are validated first and task-branch discovery is used only as a fallback when local files are absent. 3. Add targeted tests for local-artifact preference and multi-branch fallback behavior, then verify the fix with narrow PR-flow coverage."
+  Verify Steps: |-
+    1. Reproduce the active-worktree case with local PR artifacts and more than one local task branch for the same task id. Expected: pr check uses local artifacts instead of failing on branch ambiguity.
+    2. Run targeted PR-flow tests for the touched check logic. Expected: updated tests pass.
+    3. Re-run pr check in the reproduced worktree after the fix. Expected: the command no longer reports Multiple task branches match when local artifacts are present.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-03-30T14:50:35.738Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: OK: bunx vitest run packages/agentplane/src/cli/run-cli.core.pr-flow.pr.test.ts -t 'pr check passes when artifacts exist|pr check falls back to PR artifacts committed on the task branch|pr check prefers local PR artifacts when multiple task branches match|pr check still reports multiple task branches when fallback is required' --hookTimeout 60000 --testTimeout 60000; local pr-check logic now prefers active-worktree artifacts and preserves multiple-branch validation only for true fallback cases.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-30T14:05:35.394Z, excerpt_hash=sha256:6456640e85e22016be178576b7f009b0095679f60cdd715969e989cff174cb2b
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Make pr check prefer local artifacts before branch fallback
+
+Fix branch_pr PR checking so  reads local  artifacts first and only falls back to task-branch discovery when local artifacts are absent, avoiding false  failures in active worktrees.
+
+## Scope
+
+- In scope: Fix branch_pr PR checking so  reads local  artifacts first and only falls back to task-branch discovery when local artifacts are absent, avoiding false  failures in active worktrees.
+- Out of scope: unrelated refactors not required for "Make pr check prefer local artifacts before branch fallback".
+
+## Plan
+
+1. Reproduce the current  failure when multiple local task branches match the same task id even though local  artifacts exist in the active worktree. 2. Update the PR-check artifact resolution flow so local artifacts are validated first and task-branch discovery is used only as a fallback when local files are absent. 3. Add targeted tests for local-artifact preference and multi-branch fallback behavior, then verify the fix with narrow PR-flow coverage.
+
+## Verify Steps
+
+1. Reproduce the active-worktree case with local PR artifacts and more than one local task branch for the same task id. Expected: pr check uses local artifacts instead of failing on branch ambiguity.
+2. Run targeted PR-flow tests for the touched check logic. Expected: updated tests pass.
+3. Re-run pr check in the reproduced worktree after the fix. Expected: the command no longer reports Multiple task branches match when local artifacts are present.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-03-30T14:50:35.738Z — VERIFY — ok
+
+By: CODER
+
+Note: OK: bunx vitest run packages/agentplane/src/cli/run-cli.core.pr-flow.pr.test.ts -t 'pr check passes when artifacts exist|pr check falls back to PR artifacts committed on the task branch|pr check prefers local PR artifacts when multiple task branches match|pr check still reports multiple task branches when fallback is required' --hookTimeout 60000 --testTimeout 60000; local pr-check logic now prefers active-worktree artifacts and preserves multiple-branch validation only for true fallback cases.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-30T14:05:35.394Z, excerpt_hash=sha256:6456640e85e22016be178576b7f009b0095679f60cdd715969e989cff174cb2b
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202603301249-ZESZG8/pr/diffstat.txt
+++ b/.agentplane/tasks/202603301249-ZESZG8/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ .agentplane/tasks/202603301249-ZESZG8/README.md    | 119 +++++++++++++++++++++
+ .../src/cli/run-cli.core.pr-flow.pr.test.ts        | 110 +++++++++++++++++++
+ packages/agentplane/src/commands/pr/check.ts       |  33 ++++--
+ 3 files changed, 254 insertions(+), 8 deletions(-)

--- a/.agentplane/tasks/202603301249-ZESZG8/pr/meta.json
+++ b/.agentplane/tasks/202603301249-ZESZG8/pr/meta.json
@@ -1,0 +1,12 @@
+{
+  "branch": "task/202603301249-ZESZG8/pr-check-local-artifact-precedence",
+  "created_at": "2026-03-30T14:52:59.154Z",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202603301249-ZESZG8",
+  "updated_at": "2026-03-30T14:53:06.604Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202603301249-ZESZG8/pr/review.md
+++ b/.agentplane/tasks/202603301249-ZESZG8/pr/review.md
@@ -1,0 +1,32 @@
+# PR Review
+
+Opened by CODER on 2026-03-30T14:52:59.154Z
+Branch: task/202603301249-ZESZG8/pr-check-local-artifact-precedence
+
+## Summary
+
+- 
+
+## Checklist
+
+- [ ] Tests added/updated
+- [ ] Lint/format passes
+- [ ] Verify passed
+- [ ] Docs updated (if needed)
+
+## Handoff Notes
+
+<!-- Add review notes here. -->
+
+<!-- BEGIN AUTO SUMMARY -->
+- Updated: 2026-03-30T14:53:06.602Z
+- Branch: task/202603301249-ZESZG8/pr-check-local-artifact-precedence
+- Head: 683c76de2e80
+- Diffstat:
+```
+ .agentplane/tasks/202603301249-ZESZG8/README.md    | 119 +++++++++++++++++++++
+ .../src/cli/run-cli.core.pr-flow.pr.test.ts        | 110 +++++++++++++++++++
+ packages/agentplane/src/commands/pr/check.ts       |  33 ++++--
+ 3 files changed, 254 insertions(+), 8 deletions(-)
+```
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/cli/run-cli.core.pr-flow.pr.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.pr-flow.pr.test.ts
@@ -486,6 +486,116 @@ describe("runCli", () => {
     }
   });
 
+  it("pr check prefers local PR artifacts when multiple task branches match", async () => {
+    const root = await mkGitRepoRootWithBranch("main");
+    const config = defaultConfig();
+    config.workflow_mode = "branch_pr";
+    await writeConfig(root, config);
+    await configureGitUser(root);
+
+    const execFileAsync = promisify(execFile);
+    await writeFile(path.join(root, "seed.txt"), "seed", "utf8");
+    await execFileAsync("git", ["add", "seed.txt"], { cwd: root });
+    await execFileAsync("git", ["commit", "-m", "seed"], { cwd: root });
+
+    let taskId = "";
+    const ioTask = captureStdIO();
+    try {
+      const code = await runCli([
+        "task",
+        "new",
+        "--title",
+        "PR check local artifact preference",
+        "--description",
+        "Local PR artifacts should beat ambiguous branch fallback",
+        "--priority",
+        "med",
+        "--owner",
+        "CODER",
+        "--tag",
+        "nodejs",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(0);
+      taskId = ioTask.stdout.trim();
+    } finally {
+      ioTask.restore();
+    }
+
+    await runCliSilent([
+      "pr",
+      "open",
+      taskId,
+      "--author",
+      "CODER",
+      "--branch",
+      `task/${taskId}/pr-check-primary`,
+      "--root",
+      root,
+    ]);
+    await execFileAsync("git", ["branch", `task/${taskId}/pr-check-secondary`], { cwd: root });
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["pr", "check", taskId, "--root", root]);
+      expect(code).toBe(0);
+      expect(io.stdout).toContain("✅ pr check");
+    } finally {
+      io.restore();
+    }
+  });
+
+  it("pr check still reports multiple task branches when fallback is required", async () => {
+    const root = await mkGitRepoRootWithBranch("main");
+    const config = defaultConfig();
+    config.workflow_mode = "branch_pr";
+    await writeConfig(root, config);
+    await configureGitUser(root);
+
+    const execFileAsync = promisify(execFile);
+    await writeFile(path.join(root, "seed.txt"), "seed", "utf8");
+    await execFileAsync("git", ["add", "seed.txt"], { cwd: root });
+    await execFileAsync("git", ["commit", "-m", "seed"], { cwd: root });
+
+    let taskId = "";
+    const ioTask = captureStdIO();
+    try {
+      const code = await runCli([
+        "task",
+        "new",
+        "--title",
+        "PR check ambiguous fallback",
+        "--description",
+        "Fallback should stay strict when multiple task branches match",
+        "--priority",
+        "med",
+        "--owner",
+        "CODER",
+        "--tag",
+        "nodejs",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(0);
+      taskId = ioTask.stdout.trim();
+    } finally {
+      ioTask.restore();
+    }
+
+    await execFileAsync("git", ["branch", `task/${taskId}/pr-check-primary`], { cwd: root });
+    await execFileAsync("git", ["branch", `task/${taskId}/pr-check-secondary`], { cwd: root });
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["pr", "check", taskId, "--root", root]);
+      expect(code).toBe(3);
+      expect(io.stderr).toContain("Multiple task branches match");
+    } finally {
+      io.restore();
+    }
+  });
+
   it("pr open requires --author", async () => {
     const root = await mkGitRepoRootWithBranch("main");
     const config = defaultConfig();

--- a/packages/agentplane/src/commands/pr/check.ts
+++ b/packages/agentplane/src/commands/pr/check.ts
@@ -39,21 +39,30 @@ async function resolveArtifactBranch(opts: {
 }
 
 async function readPrArtifactWithOptionalBranch(opts: {
+  ctx: CommandContext;
   resolved: { gitRoot: string };
   prDir: string;
   fileName: string;
-  branch: string | null;
+  taskId: string;
+  branchCache: { value?: string | null };
 }): Promise<string | null> {
   const localPath = path.join(opts.prDir, opts.fileName);
   if (await fileExists(localPath)) {
     return await readFile(localPath, "utf8");
   }
-  if (!opts.branch) return null;
+  if (opts.branchCache.value === undefined) {
+    opts.branchCache.value = await resolveArtifactBranch({
+      ctx: opts.ctx,
+      resolved: opts.resolved,
+      taskId: opts.taskId,
+    });
+  }
+  if (!opts.branchCache.value) return null;
   return await readPrArtifact({
     resolved: opts.resolved,
     prDir: opts.prDir,
     fileName: opts.fileName,
-    branch: opts.branch,
+    branch: opts.branchCache.value,
   });
 }
 
@@ -90,14 +99,16 @@ export async function cmdPrCheck(opts: {
     const relDiffstatPath = path.relative(resolved.gitRoot, diffstatPath);
     const relVerifyLogPath = path.relative(resolved.gitRoot, verifyLogPath);
     const relReviewPath = path.relative(resolved.gitRoot, reviewPath);
-    const branch = await resolveArtifactBranch({ ctx, resolved, taskId: task.id });
+    const branchCache: { value?: string | null } = {};
 
     let meta: PrMeta | null = null;
     const metaText = await readPrArtifactWithOptionalBranch({
+      ctx,
       resolved,
       prDir,
       fileName: "meta.json",
-      branch,
+      taskId: task.id,
+      branchCache,
     });
     if (metaText) {
       try {
@@ -111,30 +122,36 @@ export async function cmdPrCheck(opts: {
     }
 
     const diffstatText = await readPrArtifactWithOptionalBranch({
+      ctx,
       resolved,
       prDir,
       fileName: "diffstat.txt",
-      branch,
+      taskId: task.id,
+      branchCache,
     });
     if (diffstatText === null) {
       errors.push(`Missing ${relDiffstatPath}`);
     }
 
     const verifyLogText = await readPrArtifactWithOptionalBranch({
+      ctx,
       resolved,
       prDir,
       fileName: "verify.log",
-      branch,
+      taskId: task.id,
+      branchCache,
     });
     if (verifyLogText === null) {
       errors.push(`Missing ${relVerifyLogPath}`);
     }
 
     const reviewText = await readPrArtifactWithOptionalBranch({
+      ctx,
       resolved,
       prDir,
       fileName: "review.md",
-      branch,
+      taskId: task.id,
+      branchCache,
     });
     if (reviewText) {
       validateReviewContents(reviewText, errors);


### PR DESCRIPTION
## Summary
- make agentplane pr check validate local .agentplane/tasks/<task-id>/pr artifacts before task-branch fallback
- keep branch ambiguity validation for true fallback cases where local artifacts are absent
- add PR-flow regression coverage for local-artifact precedence and multi-branch fallback behavior
- refresh local PR artifacts for the task branch after verification

## Verification
- bunx vitest run packages/agentplane/src/cli/run-cli.core.pr-flow.pr.test.ts -t "pr check passes when artifacts exist|pr check falls back to PR artifacts committed on the task branch|pr check prefers local PR artifacts when multiple task branches match|pr check still reports multiple task branches when fallback is required" --hookTimeout 60000 --testTimeout 60000
- full pre-push hook pipeline passed during git push origin task/202603301249-ZESZG8/pr-check-local-artifact-precedence