### PR TITLE
Resolve legacy PRs #5 and #7 on current main

### DIFF
--- a/.agentplane/tasks/202603301639-X82Y1W/README.md
+++ b/.agentplane/tasks/202603301639-X82Y1W/README.md
@@ -1,0 +1,113 @@
+---
+id: "202603301639-X82Y1W"
+title: "Resolve remaining legacy PRs #5 and #7 on current main"
+status: "TODO"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "github"
+  - "cleanup"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-03-30T16:39:57.725Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-03-30T16:42:03.461Z"
+  updated_by: "CODER"
+  note: "OK: bunx vitest run packages/agentplane/src/cli/prompts.test.ts; bunx vitest run packages/agentplane/src/shared/agent-emoji.unit.test.ts packages/core/src/config/config.test.ts"
+commit: null
+comments: []
+events:
+  -
+    type: "verify"
+    at: "2026-03-30T16:42:03.461Z"
+    author: "CODER"
+    state: "ok"
+    note: "OK: bunx vitest run packages/agentplane/src/cli/prompts.test.ts; bunx vitest run packages/agentplane/src/shared/agent-emoji.unit.test.ts packages/core/src/config/config.test.ts"
+doc_version: 3
+doc_updated_at: "2026-03-30T16:42:03.462Z"
+doc_updated_by: "CODER"
+description: "Apply the still-valid promptYesNo bugfix from legacy PR #5 and the low-risk documentation clarifications from legacy PR #7 onto current main through a fresh branch_pr task, then close the old hosted PRs as superseded once the new task PR lands."
+sections:
+  Summary: |-
+    Resolve remaining legacy PRs #5 and #7 on current main
+    
+    Apply the still-valid promptYesNo bugfix from legacy PR #5 and the low-risk documentation clarifications from legacy PR #7 onto current main through a fresh branch_pr task, then close the old hosted PRs as superseded once the new task PR lands.
+  Scope: |-
+    - In scope: Apply the still-valid promptYesNo bugfix from legacy PR #5 and the low-risk documentation clarifications from legacy PR #7 onto current main through a fresh branch_pr task, then close the old hosted PRs as superseded once the new task PR lands.
+    - Out of scope: unrelated refactors not required for "Resolve remaining legacy PRs #5 and #7 on current main".
+  Plan: |-
+    1. Reconfirm that legacy PR #5 still fixes a live bug in current prompts.ts and that the PR #7 comment clarifications still apply cleanly to current files.
+    2. Start a fresh branch_pr task branch/worktree, apply the minimal current-main equivalent of those changes, and add the narrow tests needed for the #5 promptYesNo behavior.
+    3. Open a new task PR, wait for hosted checks, merge it, then close legacy PRs #5 and #7 as superseded by the new integrated task PR.
+  Verify Steps: |-
+    1. Inspect current packages/agentplane/src/cli/prompts.ts and compare it with legacy PR #5. Expected: invalid non-empty input still falls through to false instead of honoring defaultValue, so the bug remains live.
+    2. Run the narrow prompt test slice after applying the fix. Expected: promptYesNo returns defaultValue for invalid input and existing affirmative/negative cases still pass.
+    3. Confirm the legacy PR cleanup state after the new task PR lands. Expected: old PRs #5 and #7 are closed as superseded and no longer remain in the open PR set.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-03-30T16:42:03.461Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: OK: bunx vitest run packages/agentplane/src/cli/prompts.test.ts; bunx vitest run packages/agentplane/src/shared/agent-emoji.unit.test.ts packages/core/src/config/config.test.ts
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-30T16:39:50.750Z, excerpt_hash=sha256:154b7eee1817d0bc0e482aecaa8a9b41dedd1d7d0b083d8741d6265b09cf6b47
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Resolve remaining legacy PRs #5 and #7 on current main
+
+Apply the still-valid promptYesNo bugfix from legacy PR #5 and the low-risk documentation clarifications from legacy PR #7 onto current main through a fresh branch_pr task, then close the old hosted PRs as superseded once the new task PR lands.
+
+## Scope
+
+- In scope: Apply the still-valid promptYesNo bugfix from legacy PR #5 and the low-risk documentation clarifications from legacy PR #7 onto current main through a fresh branch_pr task, then close the old hosted PRs as superseded once the new task PR lands.
+- Out of scope: unrelated refactors not required for "Resolve remaining legacy PRs #5 and #7 on current main".
+
+## Plan
+
+1. Reconfirm that legacy PR #5 still fixes a live bug in current prompts.ts and that the PR #7 comment clarifications still apply cleanly to current files.
+2. Start a fresh branch_pr task branch/worktree, apply the minimal current-main equivalent of those changes, and add the narrow tests needed for the #5 promptYesNo behavior.
+3. Open a new task PR, wait for hosted checks, merge it, then close legacy PRs #5 and #7 as superseded by the new integrated task PR.
+
+## Verify Steps
+
+1. Inspect current packages/agentplane/src/cli/prompts.ts and compare it with legacy PR #5. Expected: invalid non-empty input still falls through to false instead of honoring defaultValue, so the bug remains live.
+2. Run the narrow prompt test slice after applying the fix. Expected: promptYesNo returns defaultValue for invalid input and existing affirmative/negative cases still pass.
+3. Confirm the legacy PR cleanup state after the new task PR lands. Expected: old PRs #5 and #7 are closed as superseded and no longer remain in the open PR set.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-03-30T16:42:03.461Z — VERIFY — ok
+
+By: CODER
+
+Note: OK: bunx vitest run packages/agentplane/src/cli/prompts.test.ts; bunx vitest run packages/agentplane/src/shared/agent-emoji.unit.test.ts packages/core/src/config/config.test.ts
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-30T16:39:50.750Z, excerpt_hash=sha256:154b7eee1817d0bc0e482aecaa8a9b41dedd1d7d0b083d8741d6265b09cf6b47
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202603301639-X82Y1W/README.md
+++ b/.agentplane/tasks/202603301639-X82Y1W/README.md
@@ -1,10 +1,10 @@
 ---
 id: "202603301639-X82Y1W"
 title: "Resolve remaining legacy PRs #5 and #7 on current main"
-status: "TODO"
+status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -24,7 +24,10 @@ verification:
   updated_by: "CODER"
   note: "OK: bunx vitest run packages/agentplane/src/cli/prompts.test.ts; bunx vitest run packages/agentplane/src/shared/agent-emoji.unit.test.ts packages/core/src/config/config.test.ts"
 commit: null
-comments: []
+comments:
+  -
+    author: "CODER"
+    body: "Start: applying current-main equivalents of legacy PR #5 and #7, then superseding the legacy hosted PRs after integration."
 events:
   -
     type: "verify"
@@ -32,8 +35,15 @@ events:
     author: "CODER"
     state: "ok"
     note: "OK: bunx vitest run packages/agentplane/src/cli/prompts.test.ts; bunx vitest run packages/agentplane/src/shared/agent-emoji.unit.test.ts packages/core/src/config/config.test.ts"
+  -
+    type: "status"
+    at: "2026-03-30T16:46:28.959Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: applying current-main equivalents of legacy PR #5 and #7, then superseding the legacy hosted PRs after integration."
 doc_version: 3
-doc_updated_at: "2026-03-30T16:42:03.462Z"
+doc_updated_at: "2026-03-30T16:46:28.960Z"
 doc_updated_by: "CODER"
 description: "Apply the still-valid promptYesNo bugfix from legacy PR #5 and the low-risk documentation clarifications from legacy PR #7 onto current main through a fresh branch_pr task, then close the old hosted PRs as superseded once the new task PR lands."
 sections:

--- a/.agentplane/tasks/202603301639-X82Y1W/pr/diffstat.txt
+++ b/.agentplane/tasks/202603301639-X82Y1W/pr/diffstat.txt
@@ -1,7 +1,11 @@
- .agentplane/tasks/202603301639-X82Y1W/README.md | 113 ++++++++++++++++++++++++
- packages/agentplane/src/cli/prompts.test.ts     |   8 ++
- packages/agentplane/src/cli/prompts.ts          |   4 +-
- packages/agentplane/src/shared/agent-emoji.ts   |   1 +
- packages/agentplane/src/shared/guards.ts        |   1 +
- packages/core/src/tasks/task-id.ts              |   1 +
- 6 files changed, 127 insertions(+), 1 deletion(-)
+ .agentplane/tasks/202603301639-X82Y1W/README.md    | 123 +++++++++++++++++++++
+ .../tasks/202603301639-X82Y1W/pr/diffstat.txt      |   7 ++
+ .agentplane/tasks/202603301639-X82Y1W/pr/meta.json |  12 ++
+ .agentplane/tasks/202603301639-X82Y1W/pr/review.md |  35 ++++++
+ .../tasks/202603301639-X82Y1W/pr/verify.log        |   0
+ packages/agentplane/src/cli/prompts.test.ts        |   8 ++
+ packages/agentplane/src/cli/prompts.ts             |   4 +-
+ packages/agentplane/src/shared/agent-emoji.ts      |   1 +
+ packages/agentplane/src/shared/guards.ts           |   1 +
+ packages/core/src/tasks/task-id.ts                 |   1 +
+ 10 files changed, 191 insertions(+), 1 deletion(-)

--- a/.agentplane/tasks/202603301639-X82Y1W/pr/diffstat.txt
+++ b/.agentplane/tasks/202603301639-X82Y1W/pr/diffstat.txt
@@ -1,0 +1,7 @@
+ .agentplane/tasks/202603301639-X82Y1W/README.md | 113 ++++++++++++++++++++++++
+ packages/agentplane/src/cli/prompts.test.ts     |   8 ++
+ packages/agentplane/src/cli/prompts.ts          |   4 +-
+ packages/agentplane/src/shared/agent-emoji.ts   |   1 +
+ packages/agentplane/src/shared/guards.ts        |   1 +
+ packages/core/src/tasks/task-id.ts              |   1 +
+ 6 files changed, 127 insertions(+), 1 deletion(-)

--- a/.agentplane/tasks/202603301639-X82Y1W/pr/meta.json
+++ b/.agentplane/tasks/202603301639-X82Y1W/pr/meta.json
@@ -1,0 +1,12 @@
+{
+  "branch": "task/202603301639-X82Y1W/resolve-legacy-prs",
+  "created_at": "2026-03-30T16:43:14.725Z",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202603301639-X82Y1W",
+  "updated_at": "2026-03-30T16:46:44.718Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202603301639-X82Y1W/pr/meta.json
+++ b/.agentplane/tasks/202603301639-X82Y1W/pr/meta.json
@@ -5,7 +5,7 @@
   "last_verified_sha": null,
   "schema_version": 1,
   "task_id": "202603301639-X82Y1W",
-  "updated_at": "2026-03-30T16:46:44.718Z",
+  "updated_at": "2026-03-30T16:51:15.654Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202603301639-X82Y1W/pr/review.md
+++ b/.agentplane/tasks/202603301639-X82Y1W/pr/review.md
@@ -19,17 +19,21 @@ Branch: task/202603301639-X82Y1W/resolve-legacy-prs
 <!-- Add review notes here. -->
 
 <!-- BEGIN AUTO SUMMARY -->
-- Updated: 2026-03-30T16:46:44.717Z
+- Updated: 2026-03-30T16:51:15.653Z
 - Branch: task/202603301639-X82Y1W/resolve-legacy-prs
-- Head: 637fe312aab4
+- Head: e967079e8ace
 - Diffstat:
 ```
- .agentplane/tasks/202603301639-X82Y1W/README.md | 113 ++++++++++++++++++++++++
- packages/agentplane/src/cli/prompts.test.ts     |   8 ++
- packages/agentplane/src/cli/prompts.ts          |   4 +-
- packages/agentplane/src/shared/agent-emoji.ts   |   1 +
- packages/agentplane/src/shared/guards.ts        |   1 +
- packages/core/src/tasks/task-id.ts              |   1 +
- 6 files changed, 127 insertions(+), 1 deletion(-)
+ .agentplane/tasks/202603301639-X82Y1W/README.md    | 123 +++++++++++++++++++++
+ .../tasks/202603301639-X82Y1W/pr/diffstat.txt      |   7 ++
+ .agentplane/tasks/202603301639-X82Y1W/pr/meta.json |  12 ++
+ .agentplane/tasks/202603301639-X82Y1W/pr/review.md |  35 ++++++
+ .../tasks/202603301639-X82Y1W/pr/verify.log        |   0
+ packages/agentplane/src/cli/prompts.test.ts        |   8 ++
+ packages/agentplane/src/cli/prompts.ts             |   4 +-
+ packages/agentplane/src/shared/agent-emoji.ts      |   1 +
+ packages/agentplane/src/shared/guards.ts           |   1 +
+ packages/core/src/tasks/task-id.ts                 |   1 +
+ 10 files changed, 191 insertions(+), 1 deletion(-)
 ```
 <!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202603301639-X82Y1W/pr/review.md
+++ b/.agentplane/tasks/202603301639-X82Y1W/pr/review.md
@@ -1,0 +1,35 @@
+# PR Review
+
+Opened by CODER on 2026-03-30T16:43:14.725Z
+Branch: task/202603301639-X82Y1W/resolve-legacy-prs
+
+## Summary
+
+- 
+
+## Checklist
+
+- [ ] Tests added/updated
+- [ ] Lint/format passes
+- [ ] Verify passed
+- [ ] Docs updated (if needed)
+
+## Handoff Notes
+
+<!-- Add review notes here. -->
+
+<!-- BEGIN AUTO SUMMARY -->
+- Updated: 2026-03-30T16:46:44.717Z
+- Branch: task/202603301639-X82Y1W/resolve-legacy-prs
+- Head: 637fe312aab4
+- Diffstat:
+```
+ .agentplane/tasks/202603301639-X82Y1W/README.md | 113 ++++++++++++++++++++++++
+ packages/agentplane/src/cli/prompts.test.ts     |   8 ++
+ packages/agentplane/src/cli/prompts.ts          |   4 +-
+ packages/agentplane/src/shared/agent-emoji.ts   |   1 +
+ packages/agentplane/src/shared/guards.ts        |   1 +
+ packages/core/src/tasks/task-id.ts              |   1 +
+ 6 files changed, 127 insertions(+), 1 deletion(-)
+```
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/cli/prompts.test.ts
+++ b/packages/agentplane/src/cli/prompts.test.ts
@@ -62,6 +62,14 @@ describe("cli/prompts", () => {
     await expect(promptYesNo("Continue", true)).resolves.toBe(false);
   });
 
+  it("promptYesNo falls back to default for invalid input", async () => {
+    mocks.state.nextAnswer = "definitely";
+    await expect(promptYesNo("Continue", true)).resolves.toBe(true);
+
+    mocks.state.nextAnswer = "definitely";
+    await expect(promptYesNo("Continue", false)).resolves.toBe(false);
+  });
+
   it("promptInput trims input", async () => {
     mocks.state.nextAnswer = "  hello ";
 

--- a/packages/agentplane/src/cli/prompts.ts
+++ b/packages/agentplane/src/cli/prompts.ts
@@ -25,7 +25,9 @@ export async function promptYesNo(prompt: string, defaultValue: boolean): Promis
   rl.close();
   const trimmed = answer.trim().toLowerCase();
   if (!trimmed) return defaultValue;
-  return ["y", "yes", "true", "1", "on"].includes(trimmed);
+  if (["y", "yes", "true", "1", "on"].includes(trimmed)) return true;
+  if (["n", "no", "false", "0", "off"].includes(trimmed)) return false;
+  return defaultValue;
 }
 
 export async function promptInput(prompt: string): Promise<string> {

--- a/packages/agentplane/src/shared/agent-emoji.ts
+++ b/packages/agentplane/src/shared/agent-emoji.ts
@@ -32,6 +32,7 @@ function fallbackEmojiForAgentId(agentId: string): string {
   return FALLBACK_EMOJIS[idx] ?? "🧩";
 }
 
+// Prefer an explicit agent-level commit_emoji before falling back to deterministic defaults.
 export async function resolveCommitEmojiForAgent(opts: {
   agentsDirAbs: string;
   agentId: string;

--- a/packages/agentplane/src/shared/guards.ts
+++ b/packages/agentplane/src/shared/guards.ts
@@ -1,3 +1,4 @@
+// Narrow unknown values to plain object-like records.
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }

--- a/packages/core/src/tasks/task-id.ts
+++ b/packages/core/src/tasks/task-id.ts
@@ -1,5 +1,6 @@
 import { randomInt } from "node:crypto";
 
+// Crockford base32 omits lookalikes I, L, O and skips U.
 export const TASK_ID_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 
 export function timestampIdPrefix(date: Date): string {


### PR DESCRIPTION
## Summary
- fix `promptYesNo` so invalid non-empty input falls back to `defaultValue`
- add the narrow regression test for that prompt behavior
- carry forward the still-valid low-risk code comments from legacy PR #7

## Verification
- bunx vitest run packages/agentplane/src/cli/prompts.test.ts
- bunx vitest run packages/agentplane/src/shared/agent-emoji.unit.test.ts packages/core/src/config/config.test.ts
- git push origin task/202603301639-X82Y1W/resolve-legacy-prs

## Supersedes
- #5
- #7

Task: 202603301639-X82Y1W