### PR TITLE
test(cli): lock help-routing contract behavior

### DIFF
--- a/.agentplane/tasks/202603301721-9ZMFDY/README.md
+++ b/.agentplane/tasks/202603301721-9ZMFDY/README.md
@@ -1,0 +1,124 @@
+---
+id: "202603301721-9ZMFDY"
+title: "Lock current help-routing behavior with CLI contract tests"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "refactor"
+  - "cli"
+  - "tests"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-03-30T17:28:28.530Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-03-30T17:32:07.030Z"
+  updated_by: "CODER"
+  note: "OK: bunx vitest run packages/agentplane/src/cli/run-cli.core.help-contract.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts; added focused help-routing contract coverage for --help, task --help, task plan --help, and unknown-command suggestion flows."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: locking current help, --help, help <cmd>, and unknown-command suggestion behavior with targeted CLI contract tests only; no router refactor in this task."
+events:
+  -
+    type: "status"
+    at: "2026-03-30T17:29:20.399Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: locking current help, --help, help <cmd>, and unknown-command suggestion behavior with targeted CLI contract tests only; no router refactor in this task."
+  -
+    type: "verify"
+    at: "2026-03-30T17:32:07.030Z"
+    author: "CODER"
+    state: "ok"
+    note: "OK: bunx vitest run packages/agentplane/src/cli/run-cli.core.help-contract.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts; added focused help-routing contract coverage for --help, task --help, task plan --help, and unknown-command suggestion flows."
+doc_version: 3
+doc_updated_at: "2026-03-30T17:32:07.032Z"
+doc_updated_by: "CODER"
+description: "Implement Epic 0 / R0.1 by adding behavior-locking tests for help routing, including help, --help, help <cmd>, and unknown-command suggestion flows, so later routing refactors can remove duplication without changing behavior."
+sections:
+  Summary: |-
+    Lock current help-routing behavior with CLI contract tests
+    
+    Implement Epic 0 / R0.1 by adding behavior-locking tests for help routing, including help, --help, help <cmd>, and unknown-command suggestion flows, so later routing refactors can remove duplication without changing behavior.
+  Scope: |-
+    - In scope: Implement Epic 0 / R0.1 by adding behavior-locking tests for help routing, including help, --help, help <cmd>, and unknown-command suggestion flows, so later routing refactors can remove duplication without changing behavior.
+    - Out of scope: unrelated refactors not required for "Lock current help-routing behavior with CLI contract tests".
+  Plan: |-
+    1. Audit existing CLI test coverage for help, --help, help <cmd>, and unknown-command suggestion behavior.
+    2. Add the smallest set of contract tests that lock the current help-routing behavior without refactoring the router itself.
+    3. Verify the targeted test slice and keep the task scoped to Epic 0 / R0.1 only.
+  Verify Steps: |-
+    1. Run the targeted CLI help-routing test slice. Expected: help, --help, help <cmd>, and unknown-command suggestion flows are asserted by stable tests.
+    2. Inspect the changed test files. Expected: the task adds behavior-locking tests only and does not refactor runtime routing logic.
+    3. Re-run the exact targeted tests after any snapshot or assertion updates. Expected: the safety-net slice passes cleanly.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-03-30T17:32:07.030Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: OK: bunx vitest run packages/agentplane/src/cli/run-cli.core.help-contract.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts; added focused help-routing contract coverage for --help, task --help, task plan --help, and unknown-command suggestion flows.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-30T17:29:20.400Z, excerpt_hash=sha256:e5b2e95e24860bccadfe214854e189318f3301cb254e136e0aeeec942c41d76a
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Lock current help-routing behavior with CLI contract tests
+
+Implement Epic 0 / R0.1 by adding behavior-locking tests for help routing, including help, --help, help <cmd>, and unknown-command suggestion flows, so later routing refactors can remove duplication without changing behavior.
+
+## Scope
+
+- In scope: Implement Epic 0 / R0.1 by adding behavior-locking tests for help routing, including help, --help, help <cmd>, and unknown-command suggestion flows, so later routing refactors can remove duplication without changing behavior.
+- Out of scope: unrelated refactors not required for "Lock current help-routing behavior with CLI contract tests".
+
+## Plan
+
+1. Audit existing CLI test coverage for help, --help, help <cmd>, and unknown-command suggestion behavior.
+2. Add the smallest set of contract tests that lock the current help-routing behavior without refactoring the router itself.
+3. Verify the targeted test slice and keep the task scoped to Epic 0 / R0.1 only.
+
+## Verify Steps
+
+1. Run the targeted CLI help-routing test slice. Expected: help, --help, help <cmd>, and unknown-command suggestion flows are asserted by stable tests.
+2. Inspect the changed test files. Expected: the task adds behavior-locking tests only and does not refactor runtime routing logic.
+3. Re-run the exact targeted tests after any snapshot or assertion updates. Expected: the safety-net slice passes cleanly.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-03-30T17:32:07.030Z — VERIFY — ok
+
+By: CODER
+
+Note: OK: bunx vitest run packages/agentplane/src/cli/run-cli.core.help-contract.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts; added focused help-routing contract coverage for --help, task --help, task plan --help, and unknown-command suggestion flows.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-30T17:29:20.400Z, excerpt_hash=sha256:e5b2e95e24860bccadfe214854e189318f3301cb254e136e0aeeec942c41d76a
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202603301721-9ZMFDY/pr/diffstat.txt
+++ b/.agentplane/tasks/202603301721-9ZMFDY/pr/diffstat.txt
@@ -1,4 +1,8 @@
  .agentplane/tasks/202603301721-9ZMFDY/README.md    | 124 +++++++++++++++++++++
+ .../tasks/202603301721-9ZMFDY/pr/diffstat.txt      |   4 +
+ .agentplane/tasks/202603301721-9ZMFDY/pr/meta.json |  12 ++
+ .agentplane/tasks/202603301721-9ZMFDY/pr/review.md |  32 ++++++
+ .../tasks/202603301721-9ZMFDY/pr/verify.log        |   0
  .../run-cli.core.help-snap.test.ts.snap            |   1 +
  .../src/cli/run-cli.core.help-contract.test.ts     |  61 ++++++++++
- 3 files changed, 186 insertions(+)
+ 7 files changed, 234 insertions(+)

--- a/.agentplane/tasks/202603301721-9ZMFDY/pr/diffstat.txt
+++ b/.agentplane/tasks/202603301721-9ZMFDY/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ .agentplane/tasks/202603301721-9ZMFDY/README.md    | 124 +++++++++++++++++++++
+ .../run-cli.core.help-snap.test.ts.snap            |   1 +
+ .../src/cli/run-cli.core.help-contract.test.ts     |  61 ++++++++++
+ 3 files changed, 186 insertions(+)

--- a/.agentplane/tasks/202603301721-9ZMFDY/pr/meta.json
+++ b/.agentplane/tasks/202603301721-9ZMFDY/pr/meta.json
@@ -5,7 +5,7 @@
   "last_verified_sha": null,
   "schema_version": 1,
   "task_id": "202603301721-9ZMFDY",
-  "updated_at": "2026-03-30T17:34:03.491Z",
+  "updated_at": "2026-03-30T17:57:13.455Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202603301721-9ZMFDY/pr/meta.json
+++ b/.agentplane/tasks/202603301721-9ZMFDY/pr/meta.json
@@ -1,0 +1,12 @@
+{
+  "branch": "task/202603301721-9ZMFDY/lock-help-routing-contracts",
+  "created_at": "2026-03-30T17:33:58.469Z",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202603301721-9ZMFDY",
+  "updated_at": "2026-03-30T17:34:03.491Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202603301721-9ZMFDY/pr/review.md
+++ b/.agentplane/tasks/202603301721-9ZMFDY/pr/review.md
@@ -1,0 +1,32 @@
+# PR Review
+
+Opened by CODER on 2026-03-30T17:33:58.469Z
+Branch: task/202603301721-9ZMFDY/lock-help-routing-contracts
+
+## Summary
+
+- 
+
+## Checklist
+
+- [ ] Tests added/updated
+- [ ] Lint/format passes
+- [ ] Verify passed
+- [ ] Docs updated (if needed)
+
+## Handoff Notes
+
+<!-- Add review notes here. -->
+
+<!-- BEGIN AUTO SUMMARY -->
+- Updated: 2026-03-30T17:34:03.490Z
+- Branch: task/202603301721-9ZMFDY/lock-help-routing-contracts
+- Head: 6a40e62b3f35
+- Diffstat:
+```
+ .agentplane/tasks/202603301721-9ZMFDY/README.md    | 124 +++++++++++++++++++++
+ .../run-cli.core.help-snap.test.ts.snap            |   1 +
+ .../src/cli/run-cli.core.help-contract.test.ts     |  61 ++++++++++
+ 3 files changed, 186 insertions(+)
+```
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202603301721-9ZMFDY/pr/review.md
+++ b/.agentplane/tasks/202603301721-9ZMFDY/pr/review.md
@@ -19,14 +19,18 @@ Branch: task/202603301721-9ZMFDY/lock-help-routing-contracts
 <!-- Add review notes here. -->
 
 <!-- BEGIN AUTO SUMMARY -->
-- Updated: 2026-03-30T17:34:03.490Z
+- Updated: 2026-03-30T17:57:13.454Z
 - Branch: task/202603301721-9ZMFDY/lock-help-routing-contracts
-- Head: 6a40e62b3f35
+- Head: 755efe4d20a8
 - Diffstat:
 ```
  .agentplane/tasks/202603301721-9ZMFDY/README.md    | 124 +++++++++++++++++++++
+ .../tasks/202603301721-9ZMFDY/pr/diffstat.txt      |   4 +
+ .agentplane/tasks/202603301721-9ZMFDY/pr/meta.json |  12 ++
+ .agentplane/tasks/202603301721-9ZMFDY/pr/review.md |  32 ++++++
+ .../tasks/202603301721-9ZMFDY/pr/verify.log        |   0
  .../run-cli.core.help-snap.test.ts.snap            |   1 +
  .../src/cli/run-cli.core.help-contract.test.ts     |  61 ++++++++++
- 3 files changed, 186 insertions(+)
+ 7 files changed, 234 insertions(+)
 ```
 <!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap
+++ b/packages/agentplane/src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap
@@ -103,6 +103,7 @@ Commands:
     task handoff  Task handoff commands (record/show).
     task handoff record  Record a task handoff snapshot with runner recovery hints.
     task handoff show  Show the latest persisted task handoff snapshot.
+    task hosted-close  Close a branch_pr task on the current branch from a merged hosted PR event payload.
     task lint  Lint the exported tasks JSON file (schema + invariants).
     task list  List tasks (optionally filtered by status/owner/tag).
     task migrate  Import tasks from an exported JSON file into the configured backend.

--- a/packages/agentplane/src/cli/run-cli.core.help-contract.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.help-contract.test.ts
@@ -42,6 +42,27 @@ afterEach(() => {
 });
 
 describe("cli2 help contract", () => {
+  it("top-level --help matches help output", async () => {
+    const helpIo = captureStdIO();
+    let helpStdout = "";
+    try {
+      const code = await runCli(["help"]);
+      expect(code).toBe(0);
+      helpStdout = helpIo.stdout;
+    } finally {
+      helpIo.restore();
+    }
+
+    const flagIo = captureStdIO();
+    try {
+      const code = await runCli(["--help"]);
+      expect(code).toBe(0);
+      expect(flagIo.stdout).toBe(helpStdout);
+    } finally {
+      flagIo.restore();
+    }
+  });
+
   it("help --json returns a stable, internally consistent registry", async () => {
     const io = captureStdIO();
     try {
@@ -86,5 +107,45 @@ describe("cli2 help contract", () => {
     const runIdsWithoutHelp = runIds.filter((id) => id !== "help");
     expect(runIdsWithoutHelp).toEqual(commandCatalogIdsSorted());
     expect(runIds).toContain("help");
+  });
+
+  it("task --help routes to task namespace help", async () => {
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["task", "--help"]);
+      expect(code).toBe(0);
+      expect(io.stdout).toContain("task - Task lifecycle and task-store commands.");
+      expect(io.stdout).toContain("agentplane task <subcommand> [args] [options]");
+      expect(io.stdout).toContain("agentplane task plan set <task-id> --text");
+      expect(io.stdout).not.toContain("Unknown command: task");
+    } finally {
+      io.restore();
+    }
+  });
+
+  it("task plan --help routes to task plan namespace help", async () => {
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["task", "plan", "--help"]);
+      expect(code).toBe(0);
+      expect(io.stdout).toContain("task plan - Task plan commands (set/approve/reject).");
+      expect(io.stdout).toContain("agentplane task plan <set|approve|reject> [args] [options]");
+      expect(io.stdout).toContain("agentplane task plan set <task-id> --text");
+      expect(io.stdout).not.toContain("Unknown command: task plan");
+    } finally {
+      io.restore();
+    }
+  });
+
+  it("unknown commands surface close-match suggestions", async () => {
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["taks"]);
+      expect(code).toBe(2);
+      expect(io.stderr).toContain("Unknown command: taks. Did you mean: task?");
+      expect(io.stderr).toContain("agentplane help help --compact");
+    } finally {
+      io.restore();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add contract coverage for top-level `--help`, `task --help`, and `task plan --help`
- lock the top-level unknown-command suggestion path (`taks` -> `task`)
- refresh the help snapshot to match the current command surface (`task hosted-close`)

## Verification
- bunx vitest run packages/agentplane/src/cli/run-cli.core.help-contract.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts
- git pull --rebase origin main
- git push origin task/202603301721-9ZMFDY/lock-help-routing-contracts
