### PR TITLE
workflow: set hosted-close identity to DEUS

### DIFF
--- a/.agentplane/tasks/202603301808-WRE297/README.md
+++ b/.agentplane/tasks/202603301808-WRE297/README.md
@@ -1,0 +1,125 @@
+---
+id: "202603301808-WRE297"
+title: "Set hosted-close workflow git identity to DEUS"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "workflow"
+  - "github"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-03-30T18:08:46.725Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-03-30T18:10:22.740Z"
+  updated_by: "CODER"
+  note: "OK: rg -n 'agentplane-bot@example.com|agentplane-bot' .github/workflows packages/agentplane/src/commands/task -S only returns the negative assertions in the focused contract test; bunx vitest run packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts passed; Prettier and the workflow diff confirm task-hosted-close now uses DEUS <deus@agentplane.org> for both author and committer identity."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: replace the hardcoded hosted-close bot git identity with DEUS and add a focused guard so future close commits stop using agentplane-bot@example.com."
+events:
+  -
+    type: "status"
+    at: "2026-03-30T18:09:14.473Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: replace the hardcoded hosted-close bot git identity with DEUS and add a focused guard so future close commits stop using agentplane-bot@example.com."
+  -
+    type: "verify"
+    at: "2026-03-30T18:10:22.740Z"
+    author: "CODER"
+    state: "ok"
+    note: "OK: rg -n 'agentplane-bot@example.com|agentplane-bot' .github/workflows packages/agentplane/src/commands/task -S only returns the negative assertions in the focused contract test; bunx vitest run packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts passed; Prettier and the workflow diff confirm task-hosted-close now uses DEUS <deus@agentplane.org> for both author and committer identity."
+doc_version: 3
+doc_updated_at: "2026-03-30T18:10:22.743Z"
+doc_updated_by: "CODER"
+description: "The hosted-close GitHub Actions workflow hardcodes GIT_AUTHOR_NAME/GIT_AUTHOR_EMAIL and GIT_COMMITTER_NAME/GIT_COMMITTER_EMAIL to agentplane-bot@example.com, so every close commit and downstream GitHub metadata attributes the work to agentplane-bot even though local repository git identity is already DEUS <deus@agentplane.org>. Replace the workflow identity with DEUS and add a focused check so future closure commits stop using the bot identity."
+sections:
+  Summary: |-
+    Set hosted-close workflow git identity to DEUS
+    
+    The hosted-close GitHub Actions workflow hardcodes GIT_AUTHOR_NAME/GIT_AUTHOR_EMAIL and GIT_COMMITTER_NAME/GIT_COMMITTER_EMAIL to agentplane-bot@example.com, so every close commit and downstream GitHub metadata attributes the work to agentplane-bot even though local repository git identity is already DEUS <deus@agentplane.org>. Replace the workflow identity with DEUS and add a focused check so future closure commits stop using the bot identity.
+  Scope: |-
+    - In scope: The hosted-close GitHub Actions workflow hardcodes GIT_AUTHOR_NAME/GIT_AUTHOR_EMAIL and GIT_COMMITTER_NAME/GIT_COMMITTER_EMAIL to agentplane-bot@example.com, so every close commit and downstream GitHub metadata attributes the work to agentplane-bot even though local repository git identity is already DEUS <deus@agentplane.org>. Replace the workflow identity with DEUS and add a focused check so future closure commits stop using the bot identity.
+    - Out of scope: unrelated refactors not required for "Set hosted-close workflow git identity to DEUS".
+  Plan: |-
+    1. Confirm every current bot-authored close commit originates from .github/workflows/task-hosted-close.yml rather than local repository git config.
+    2. Replace the hosted-close workflow author/committer identity with DEUS <deus@agentplane.org>.
+    3. Add a focused verification check that fails if task-hosted-close reintroduces agentplane-bot identity values.
+    4. Publish the fix as a branch_pr PR and verify the workflow file plus the new check.
+  Verify Steps: |-
+    1. Run a repo search for `agentplane-bot@example.com` and `agentplane-bot`. Expected: task-hosted-close no longer uses the bot identity and no replacement path reintroduces it.
+    2. Run the focused workflow-identity test or targeted validation added in this task. Expected: it passes and locks the workflow identity to DEUS.
+    3. Inspect the generated diff for .github/workflows/task-hosted-close.yml. Expected: hosted-close author/committer env values are DEUS <deus@agentplane.org> and nothing else changed outside task scope.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-03-30T18:10:22.740Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: OK: rg -n 'agentplane-bot@example.com|agentplane-bot' .github/workflows packages/agentplane/src/commands/task -S only returns the negative assertions in the focused contract test; bunx vitest run packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts passed; Prettier and the workflow diff confirm task-hosted-close now uses DEUS <deus@agentplane.org> for both author and committer identity.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-30T18:09:14.474Z, excerpt_hash=sha256:9a36a5d55ff42a97d9e915119f07bffd3ec47215c1eeaa09d9bf5627d9ca744f
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Set hosted-close workflow git identity to DEUS
+
+The hosted-close GitHub Actions workflow hardcodes GIT_AUTHOR_NAME/GIT_AUTHOR_EMAIL and GIT_COMMITTER_NAME/GIT_COMMITTER_EMAIL to agentplane-bot@example.com, so every close commit and downstream GitHub metadata attributes the work to agentplane-bot even though local repository git identity is already DEUS <deus@agentplane.org>. Replace the workflow identity with DEUS and add a focused check so future closure commits stop using the bot identity.
+
+## Scope
+
+- In scope: The hosted-close GitHub Actions workflow hardcodes GIT_AUTHOR_NAME/GIT_AUTHOR_EMAIL and GIT_COMMITTER_NAME/GIT_COMMITTER_EMAIL to agentplane-bot@example.com, so every close commit and downstream GitHub metadata attributes the work to agentplane-bot even though local repository git identity is already DEUS <deus@agentplane.org>. Replace the workflow identity with DEUS and add a focused check so future closure commits stop using the bot identity.
+- Out of scope: unrelated refactors not required for "Set hosted-close workflow git identity to DEUS".
+
+## Plan
+
+1. Confirm every current bot-authored close commit originates from .github/workflows/task-hosted-close.yml rather than local repository git config.
+2. Replace the hosted-close workflow author/committer identity with DEUS <deus@agentplane.org>.
+3. Add a focused verification check that fails if task-hosted-close reintroduces agentplane-bot identity values.
+4. Publish the fix as a branch_pr PR and verify the workflow file plus the new check.
+
+## Verify Steps
+
+1. Run a repo search for `agentplane-bot@example.com` and `agentplane-bot`. Expected: task-hosted-close no longer uses the bot identity and no replacement path reintroduces it.
+2. Run the focused workflow-identity test or targeted validation added in this task. Expected: it passes and locks the workflow identity to DEUS.
+3. Inspect the generated diff for .github/workflows/task-hosted-close.yml. Expected: hosted-close author/committer env values are DEUS <deus@agentplane.org> and nothing else changed outside task scope.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-03-30T18:10:22.740Z — VERIFY — ok
+
+By: CODER
+
+Note: OK: rg -n 'agentplane-bot@example.com|agentplane-bot' .github/workflows packages/agentplane/src/commands/task -S only returns the negative assertions in the focused contract test; bunx vitest run packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts passed; Prettier and the workflow diff confirm task-hosted-close now uses DEUS <deus@agentplane.org> for both author and committer identity.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-30T18:09:14.474Z, excerpt_hash=sha256:9a36a5d55ff42a97d9e915119f07bffd3ec47215c1eeaa09d9bf5627d9ca744f
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202603301808-WRE297/pr/diffstat.txt
+++ b/.agentplane/tasks/202603301808-WRE297/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ .agentplane/tasks/202603301808-WRE297/README.md    | 125 +++++++++++++++++++++
+ .github/workflows/task-hosted-close.yml            |   8 +-
+ .../task/hosted-close-workflow-contract.test.ts    |   6 +
+ 3 files changed, 135 insertions(+), 4 deletions(-)

--- a/.agentplane/tasks/202603301808-WRE297/pr/meta.json
+++ b/.agentplane/tasks/202603301808-WRE297/pr/meta.json
@@ -1,0 +1,12 @@
+{
+  "branch": "task/202603301808-WRE297/hosted-close-deus-identity",
+  "created_at": "2026-03-30T18:16:50.642Z",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202603301808-WRE297",
+  "updated_at": "2026-03-30T18:18:40.742Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202603301808-WRE297/pr/review.md
+++ b/.agentplane/tasks/202603301808-WRE297/pr/review.md
@@ -1,0 +1,32 @@
+# PR Review
+
+Opened by CODER on 2026-03-30T18:16:50.642Z
+Branch: task/202603301808-WRE297/hosted-close-deus-identity
+
+## Summary
+
+- 
+
+## Checklist
+
+- [ ] Tests added/updated
+- [ ] Lint/format passes
+- [ ] Verify passed
+- [ ] Docs updated (if needed)
+
+## Handoff Notes
+
+<!-- Add review notes here. -->
+
+<!-- BEGIN AUTO SUMMARY -->
+- Updated: 2026-03-30T18:18:40.736Z
+- Branch: task/202603301808-WRE297/hosted-close-deus-identity
+- Head: 479fc1917392
+- Diffstat:
+```
+ .agentplane/tasks/202603301808-WRE297/README.md    | 125 +++++++++++++++++++++
+ .github/workflows/task-hosted-close.yml            |   8 +-
+ .../task/hosted-close-workflow-contract.test.ts    |   6 +
+ 3 files changed, 135 insertions(+), 4 deletions(-)
+```
+<!-- END AUTO SUMMARY -->

--- a/.github/workflows/task-hosted-close.yml
+++ b/.github/workflows/task-hosted-close.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ github.token }}
-      GIT_AUTHOR_NAME: agentplane-bot
-      GIT_AUTHOR_EMAIL: agentplane-bot@example.com
-      GIT_COMMITTER_NAME: agentplane-bot
-      GIT_COMMITTER_EMAIL: agentplane-bot@example.com
+      GIT_AUTHOR_NAME: DEUS
+      GIT_AUTHOR_EMAIL: deus@agentplane.org
+      GIT_COMMITTER_NAME: DEUS
+      GIT_COMMITTER_EMAIL: deus@agentplane.org
     steps:
       - uses: actions/checkout@v4
         with:

--- a/packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
+++ b/packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
@@ -20,5 +20,11 @@ describe("Task hosted-close workflow contract", () => {
     expect(workflow).toContain("task hosted-close");
     expect(workflow).toContain("gh pr create");
     expect(workflow).toContain("gh pr merge --auto --squash");
+    expect(workflow).toContain("GIT_AUTHOR_NAME: DEUS");
+    expect(workflow).toContain("GIT_AUTHOR_EMAIL: deus@agentplane.org");
+    expect(workflow).toContain("GIT_COMMITTER_NAME: DEUS");
+    expect(workflow).toContain("GIT_COMMITTER_EMAIL: deus@agentplane.org");
+    expect(workflow).not.toContain("agentplane-bot@example.com");
+    expect(workflow).not.toContain("GIT_AUTHOR_NAME: agentplane-bot");
   });
 });


### PR DESCRIPTION
## Summary
- replace hardcoded hosted-close author/committer bot identity with DEUS <deus@agentplane.org>
- add a focused workflow contract test that fails if agentplane-bot identity returns
- record task verification for WRE297

## Verification
- rg -n 'agentplane-bot@example.com|agentplane-bot' .github/workflows packages/agentplane/src/commands/task -S
- bunx vitest run packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
- ./node_modules/.bin/prettier --check .github/workflows/task-hosted-close.yml packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts .agentplane/tasks/202603301808-WRE297/README.md