### PR TITLE
Follow-up refactor: derive command child names from canonical graph

### DIFF
--- a/.agentplane/tasks/202603301857-M5MBBB/README.md
+++ b/.agentplane/tasks/202603301857-M5MBBB/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202603301857-M5MBBB"
 title: "Derive direct subcommand names from the canonical command graph"
-status: "DOING"
+result_summary: "integrate: squash task/202603301857-M5MBBB/derived-child-names-from-command-graph"
+status: "DONE"
 priority: "med"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on:
@@ -24,11 +25,16 @@ verification:
   updated_at: "2026-03-31T10:17:17.010Z"
   updated_by: "CODER"
   note: "Focused group-command and command-graph tests plus eslint passed after moving direct child-name derivation onto command ids and canonical graph helpers."
-commit: null
+commit:
+  hash: "ab3390d555f6786a82f828db475a9085a0c6d27d"
+  message: "🧩 M5MBBB integrate: squash task/202603301857-M5MBBB/derived-child-names-from-command-graph"
 comments:
   -
     author: "CODER"
     body: "Start: derive reusable direct-child-name lookup from canonical command ids and graph helpers without migrating all group command entry modules yet."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: Integrated via squash; verify=skipped(no commands); pr=.agentplane/tasks/202603301857-M5MBBB/pr."
 events:
   -
     type: "status"
@@ -43,9 +49,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Focused group-command and command-graph tests plus eslint passed after moving direct child-name derivation onto command ids and canonical graph helpers."
+  -
+    type: "status"
+    at: "2026-03-31T10:19:25.423Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: Integrated via squash; verify=skipped(no commands); pr=.agentplane/tasks/202603301857-M5MBBB/pr."
 doc_version: 3
-doc_updated_at: "2026-03-31T10:17:17.014Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-03-31T10:19:25.428Z"
+doc_updated_by: "INTEGRATOR"
 description: "Implement Epic 5 / R5.1 from REFACTOR.md. child command discovery is computed from command ids instead of manually listed arrays."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202603301857-M5MBBB/README.md
+++ b/.agentplane/tasks/202603301857-M5MBBB/README.md
@@ -1,10 +1,10 @@
 ---
 id: "202603301857-M5MBBB"
 title: "Derive direct subcommand names from the canonical command graph"
-status: "TODO"
+status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 3
+revision: 6
 origin:
   system: "manual"
 depends_on:
@@ -15,21 +15,37 @@ tags:
   - "cli"
 verify: []
 plan_approval:
-  state: "pending"
-  updated_at: null
-  updated_by: null
+  state: "approved"
+  updated_at: "2026-03-31T10:13:07.601Z"
+  updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-03-31T10:17:17.010Z"
+  updated_by: "CODER"
+  note: "Focused group-command and command-graph tests plus eslint passed after moving direct child-name derivation onto command ids and canonical graph helpers."
 commit: null
-comments: []
-events: []
+comments:
+  -
+    author: "CODER"
+    body: "Start: derive reusable direct-child-name lookup from canonical command ids and graph helpers without migrating all group command entry modules yet."
+events:
+  -
+    type: "status"
+    at: "2026-03-31T10:13:54.682Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: derive reusable direct-child-name lookup from canonical command ids and graph helpers without migrating all group command entry modules yet."
+  -
+    type: "verify"
+    at: "2026-03-31T10:17:17.010Z"
+    author: "CODER"
+    state: "ok"
+    note: "Focused group-command and command-graph tests plus eslint passed after moving direct child-name derivation onto command ids and canonical graph helpers."
 doc_version: 3
-doc_updated_at: "2026-03-30T18:57:10.579Z"
-doc_updated_by: "PLANNER"
+doc_updated_at: "2026-03-31T10:17:17.014Z"
+doc_updated_by: "CODER"
 description: "Implement Epic 5 / R5.1 from REFACTOR.md. child command discovery is computed from command ids instead of manually listed arrays."
 sections:
   Summary: |-
@@ -49,6 +65,14 @@ sections:
     3. Re-run the focused checks after final edits. Expected: child command discovery is computed from command ids instead of manually listed arrays.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-03-31T10:17:17.010Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Focused group-command and command-graph tests plus eslint passed after moving direct child-name derivation onto command ids and canonical graph helpers.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-31T10:13:54.684Z, excerpt_hash=sha256:19c14f311d406bf385b831c42ca2a7fe965625eeee50d83aece5196bbb8c420c
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -82,6 +106,14 @@ Implement Epic 5 / R5.1 from REFACTOR.md. child command discovery is computed fr
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-03-31T10:17:17.010Z — VERIFY — ok
+
+By: CODER
+
+Note: Focused group-command and command-graph tests plus eslint passed after moving direct child-name derivation onto command ids and canonical graph helpers.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-03-31T10:13:54.684Z, excerpt_hash=sha256:19c14f311d406bf385b831c42ca2a7fe965625eeee50d83aece5196bbb8c420c
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202603301857-M5MBBB/pr/diffstat.txt
+++ b/.agentplane/tasks/202603301857-M5MBBB/pr/diffstat.txt
@@ -1,8 +1,12 @@
  .agentplane/tasks/202603301857-M5MBBB/README.md    | 58 +++++++++++++++++-----
+ .../tasks/202603301857-M5MBBB/pr/diffstat.txt      |  8 +++
+ .agentplane/tasks/202603301857-M5MBBB/pr/meta.json | 12 +++++
+ .agentplane/tasks/202603301857-M5MBBB/pr/review.md | 36 ++++++++++++++
+ .../tasks/202603301857-M5MBBB/pr/verify.log        |  0
  packages/agentplane/src/cli/group-command.test.ts  | 14 +++++-
  packages/agentplane/src/cli/group-command.ts       | 18 +++++--
  .../src/cli/run-cli/command-catalog.test.ts        |  6 +++
  .../agentplane/src/cli/run-cli/command-catalog.ts  |  4 ++
  packages/agentplane/src/cli/spec/registry.test.ts  |  3 ++
  packages/agentplane/src/cli/spec/registry.ts       | 10 ++++
- 7 files changed, 94 insertions(+), 19 deletions(-)
+ 11 files changed, 150 insertions(+), 19 deletions(-)

--- a/.agentplane/tasks/202603301857-M5MBBB/pr/diffstat.txt
+++ b/.agentplane/tasks/202603301857-M5MBBB/pr/diffstat.txt
@@ -1,0 +1,8 @@
+ .agentplane/tasks/202603301857-M5MBBB/README.md    | 58 +++++++++++++++++-----
+ packages/agentplane/src/cli/group-command.test.ts  | 14 +++++-
+ packages/agentplane/src/cli/group-command.ts       | 18 +++++--
+ .../src/cli/run-cli/command-catalog.test.ts        |  6 +++
+ .../agentplane/src/cli/run-cli/command-catalog.ts  |  4 ++
+ packages/agentplane/src/cli/spec/registry.test.ts  |  3 ++
+ packages/agentplane/src/cli/spec/registry.ts       | 10 ++++
+ 7 files changed, 94 insertions(+), 19 deletions(-)

--- a/.agentplane/tasks/202603301857-M5MBBB/pr/meta.json
+++ b/.agentplane/tasks/202603301857-M5MBBB/pr/meta.json
@@ -1,0 +1,12 @@
+{
+  "branch": "task/202603301857-M5MBBB/derived-child-names-from-command-graph",
+  "created_at": "2026-03-31T10:18:05.338Z",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202603301857-M5MBBB",
+  "updated_at": "2026-03-31T10:18:10.521Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202603301857-M5MBBB/pr/meta.json
+++ b/.agentplane/tasks/202603301857-M5MBBB/pr/meta.json
@@ -1,11 +1,17 @@
 {
+  "base": "main",
   "branch": "task/202603301857-M5MBBB/derived-child-names-from-command-graph",
   "created_at": "2026-03-31T10:18:05.338Z",
+  "head_sha": "f299e65904ced89c5e7dccfd30537d10923ec021",
   "last_verified_at": null,
   "last_verified_sha": null,
+  "merge_commit": "ab3390d555f6786a82f828db475a9085a0c6d27d",
+  "merge_strategy": "squash",
+  "merged_at": "2026-03-31T10:19:25.379Z",
   "schema_version": 1,
+  "status": "MERGED",
   "task_id": "202603301857-M5MBBB",
-  "updated_at": "2026-03-31T10:18:10.521Z",
+  "updated_at": "2026-03-31T10:19:25.379Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202603301857-M5MBBB/pr/review.md
+++ b/.agentplane/tasks/202603301857-M5MBBB/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Opened by CODER on 2026-03-31T10:18:05.338Z
+Branch: task/202603301857-M5MBBB/derived-child-names-from-command-graph
+
+## Summary
+
+- 
+
+## Checklist
+
+- [ ] Tests added/updated
+- [ ] Lint/format passes
+- [ ] Verify passed
+- [ ] Docs updated (if needed)
+
+## Handoff Notes
+
+<!-- Add review notes here. -->
+
+<!-- BEGIN AUTO SUMMARY -->
+- Updated: 2026-03-31T10:18:10.519Z
+- Branch: task/202603301857-M5MBBB/derived-child-names-from-command-graph
+- Head: c76752adf39a
+- Diffstat:
+```
+ .agentplane/tasks/202603301857-M5MBBB/README.md    | 58 +++++++++++++++++-----
+ packages/agentplane/src/cli/group-command.test.ts  | 14 +++++-
+ packages/agentplane/src/cli/group-command.ts       | 18 +++++--
+ .../src/cli/run-cli/command-catalog.test.ts        |  6 +++
+ .../agentplane/src/cli/run-cli/command-catalog.ts  |  4 ++
+ packages/agentplane/src/cli/spec/registry.test.ts  |  3 ++
+ packages/agentplane/src/cli/spec/registry.ts       | 10 ++++
+ 7 files changed, 94 insertions(+), 19 deletions(-)
+```
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/cli/group-command.test.ts
+++ b/packages/agentplane/src/cli/group-command.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { throwGroupCommandUsage, directSubcommandNames } from "./group-command.js";
-import type { CommandSpec } from "./spec/spec.js";
+import {
+  throwGroupCommandUsage,
+  directSubcommandNames,
+  directSubcommandNamesFromIds,
+} from "./group-command.js";
+import type { CommandId, CommandSpec } from "./spec/spec.js";
 
 const rootSpec: CommandSpec<{ cmd: string[] }> = {
   id: ["demo"],
@@ -19,9 +23,15 @@ const childSpecs: readonly CommandSpec<unknown>[] = [
   { id: ["demo"], group: "Test", summary: "root" },
 ] as const;
 
+const childIds: readonly CommandId[] = childSpecs.map((spec) => spec.id);
+
 describe("group-command helper", () => {
   it("derives direct subcommands uniquely and in sorted order", () => {
     expect(directSubcommandNames(["demo"], childSpecs)).toEqual(["alpha", "beta"]);
+  });
+
+  it("derives direct subcommands from command ids without leaking grandchildren", () => {
+    expect(directSubcommandNamesFromIds(["demo"], childIds)).toEqual(["alpha", "beta"]);
   });
 
   it("renders usage errors with suggestions for unknown subcommands", () => {

--- a/packages/agentplane/src/cli/group-command.ts
+++ b/packages/agentplane/src/cli/group-command.ts
@@ -17,11 +17,21 @@ export function directSubcommandNames(
   prefix: CommandId,
   specs: readonly CommandSpec<unknown>[],
 ): string[] {
+  return directSubcommandNamesFromIds(
+    prefix,
+    specs.map((spec) => spec.id),
+  );
+}
+
+export function directSubcommandNamesFromIds(
+  prefix: CommandId,
+  ids: readonly CommandId[],
+): string[] {
   const names = new Set<string>();
-  for (const spec of specs) {
-    if (spec.id.length <= prefix.length) continue;
-    if (!prefix.every((segment, index) => spec.id[index] === segment)) continue;
-    const next = spec.id[prefix.length];
+  for (const id of ids) {
+    if (id.length <= prefix.length) continue;
+    if (!prefix.every((segment, index) => id[index] === segment)) continue;
+    const next = id[prefix.length];
     if (typeof next === "string" && next.length > 0) names.add(next);
   }
   return [...names].toSorted((left, right) => left.localeCompare(right));

--- a/packages/agentplane/src/cli/run-cli/command-catalog.test.ts
+++ b/packages/agentplane/src/cli/run-cli/command-catalog.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   findCommandEntry,
   getDirectChildCommandEntries,
+  getDirectChildCommandNames,
   matchCommandCatalog,
 } from "./command-catalog.js";
 
@@ -37,5 +38,10 @@ describe("command catalog graph", () => {
     );
     expect(taskPlanChildren).not.toContain("task new");
     expect(getDirectChildCommandEntries(["missing", "command"])).toEqual([]);
+  });
+
+  it("derives direct child names from the canonical graph", () => {
+    expect(getDirectChildCommandNames(["task", "plan"])).toEqual(["approve", "reject", "set"]);
+    expect(getDirectChildCommandNames(["missing", "command"])).toEqual([]);
   });
 });

--- a/packages/agentplane/src/cli/run-cli/command-catalog.ts
+++ b/packages/agentplane/src/cli/run-cli/command-catalog.ts
@@ -41,6 +41,10 @@ export function getDirectChildCommandEntries(parentId: CommandId = []): readonly
   return CATALOG_GRAPH.directChildren(parentId);
 }
 
+export function getDirectChildCommandNames(parentId: CommandId = []): readonly string[] {
+  return CATALOG_GRAPH.directChildSegments(parentId);
+}
+
 export function getCommandInvocation(id: CommandId): string {
   const entry = findCommandEntry(id);
   if (!entry) {

--- a/packages/agentplane/src/cli/spec/registry.test.ts
+++ b/packages/agentplane/src/cli/spec/registry.test.ts
@@ -54,5 +54,8 @@ describe("CommandRegistry", () => {
     expect(
       registry.directChildren(["task", "plan"]).map((entry) => entry.spec.id.join(" ")),
     ).toEqual(["task plan set"]);
+    expect(registry.directChildSegments(["task"])).toEqual(["new", "plan"]);
+    expect(registry.directChildSegments(["task", "plan"])).toEqual(["set"]);
+    expect(registry.directChildSegments(["missing"])).toEqual([]);
   });
 });

--- a/packages/agentplane/src/cli/spec/registry.ts
+++ b/packages/agentplane/src/cli/spec/registry.ts
@@ -89,6 +89,12 @@ export class CommandGraph<T> {
     );
   }
 
+  directChildSegments(parentId: CommandId = []): readonly string[] {
+    const parent = this.resolveNode(parentId);
+    if (!parent) return [];
+    return [...parent.children.keys()].toSorted((left, right) => left.localeCompare(right));
+  }
+
   private resolveNode(id: CommandId): CommandGraphNode<T> | null {
     let node = this.root;
     for (const segment of id) {
@@ -137,6 +143,10 @@ export class CommandRegistry {
     parentId: CommandId = [],
   ): readonly { spec: CommandSpec; handler: CommandHandler }[] {
     return this.graph.directChildren(parentId);
+  }
+
+  directChildSegments(parentId: CommandId = []): readonly string[] {
+    return this.graph.directChildSegments(parentId);
   }
 }
 


### PR DESCRIPTION
## Summary
- publish the local follow-up wave for task M5MBBB
- derive direct subcommand names from canonical command ids instead of manual child arrays
- carry the already-integrated local follow-up commits from main to GitHub

## Notes
- This PR contains the local main follow-up commits after PR #56/#57.
- Active task 3KGV43 remains separate and is not folded into this PR.
