### PR TITLE
fix: bootstrap submodules in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -160,6 +160,7 @@ jobs:
         with:
           ref: ${{ needs.detect.outputs.ref }}
           fetch-depth: 0
+          submodules: recursive
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.6"

--- a/packages/agentplane/src/commands/release/publish-workflow-contract.test.ts
+++ b/packages/agentplane/src/commands/release/publish-workflow-contract.test.ts
@@ -22,6 +22,14 @@ describe("publish workflow contract", () => {
     expect(workflow).toContain("if: always()");
   });
 
+  it("checks out recursive submodules before running the exact-ref release prepublish gate", async () => {
+    const workflow = await readFile(PUBLISH_WORKFLOW_PATH, "utf8");
+
+    expect(workflow).toContain("fetch-depth: 0");
+    expect(workflow).toContain("submodules: recursive");
+    expect(workflow).toContain("Run exact-ref release prepublish gate");
+  });
+
   it("prefers an explicit workflow_dispatch sha over a mutable ref", async () => {
     const workflow = await readFile(PUBLISH_WORKFLOW_PATH, "utf8");
 


### PR DESCRIPTION
## Summary
- fetch recursive submodules in the publish workflow checkout step
- lock the contract with a workflow test

## Why
The hosted npm publish job failed on v0.3.8 because  requires the  submodule, and the workflow checkout did not initialize submodules.

## Scope
This PR only fixes the hosted release pipeline for the already prepared v0.3.8 release.