### PR TITLE
policy/workflow: Auto-promote reusable external incidents from task findings (DA1JVW)

### DIFF
--- a/.agentplane/policy/governance.md
+++ b/.agentplane/policy/governance.md
@@ -6,15 +6,14 @@
 - Incident-derived and situational rules MUST be added only to `incidents.md`.
 - MUST NOT create additional incident policy files under `.agentplane/policy/`.
 - New reusable operational incidents SHOULD be promoted from task `Findings` via `agentplane finish` or `agentplane incidents collect <task-id>`.
-- Auto-promotion is reserved for explicit `incident-candidate` blocks marked `IncidentExternal: true`; repository-fixable defects stay task-local unless curated manually.
+- Auto-promotion is reserved for resolved external findings marked `Fixability: external` or `IncidentExternal: true`; optional `IncidentScope`, `IncidentAdvice`, `IncidentRule`, `IncidentTags`, and `IncidentMatch` fields override the inferred registry entry when needed.
 - Normal startup MUST NOT bulk-load `incidents.md`; targeted lookup for analogous work is allowed through `task start-ready` and `agentplane incidents advise`.
 
 ## Stabilization criteria
 
-Use `stabilized` only when one of these is true:
+Use `stabilized` only when the same failure class recurs at least 2 times in 30 days.
 
-1. The same failure class recurs at least 2 times in 30 days.
-2. A single Sev-1 / production-blocking failure has reproducible steps and evidence.
+First auto-promoted external incidents may stay `open`, but targeted advice lookup is still allowed to use them so analogous work can reuse the recovery guidance before the second recurrence.
 
 Promotion from `incidents.md` into canonical policy modules is allowed only when:
 

--- a/.agentplane/policy/incidents.md
+++ b/.agentplane/policy/incidents.md
@@ -9,6 +9,7 @@ This is the single file for incident-derived and situational policy rules.
 - New machine-matched entries SHOULD also include: `tags`, `match`, `advice`, `source_task`, `fixability`.
 - `rule` MUST be concrete and testable (`MUST` / `MUST NOT`).
 - `fixability: external` means the issue cannot be removed by changing only repository code and should stay as reusable operational advice.
+- First auto-promoted external incidents normally enter as `open` and still participate in targeted advice lookup; recurring equivalent incidents can append later `stabilized` entries.
 - `state` values: `open`, `stabilized`, `promoted`.
 
 ## Entry template

--- a/.agentplane/policy/workflow.branch_pr.md
+++ b/.agentplane/policy/workflow.branch_pr.md
@@ -30,7 +30,7 @@ agentplane finish <task-id> --author INTEGRATOR --body "Verified: ..." --result 
 - Task documentation updates MAY be batched within one turn before approval.
 - MUST run `task plan approve` then `task start-ready` as `Step 1 -> wait -> Step 2` (never parallel).
 - `task start-ready` MAY surface targeted incident advice for analogous scope/tags; follow it before widening scope.
-- Keep structured external `incident-candidate` findings in the task README; base-branch `finish` or `agentplane incidents collect <task-id>` promotes valid entries into `.agentplane/policy/incidents.md`.
+- Keep structured resolved external findings in the task README; mark reusable ones with `Fixability: external` (or `IncidentExternal: true`) and let base-branch `finish` or `agentplane incidents collect <task-id>` promote them into `.agentplane/policy/incidents.md`, using optional `Incident*` fields only when the inferred scope/advice needs refinement.
 - MUST stop and request re-approval on material drift.
 - Planning and closure happen on base checkout.
 - Do not export task snapshots from task branches.

--- a/.agentplane/policy/workflow.direct.md
+++ b/.agentplane/policy/workflow.direct.md
@@ -38,7 +38,7 @@ If any step fails:
    - `doc_version=3`: task `Findings`
 3. Mark task blocked: `agentplane block <task-id> --author <ROLE> --body "Blocked: ..."`.
 4. Request re-approval before scope/risk changes.
-5. If failure is external/process-related and should become reusable advice, record a structured `incident-candidate` block in `Findings` and let `agentplane finish` or `agentplane incidents collect <task-id>` promote it.
+5. If failure is external/process-related and should become reusable advice, record a structured `Observation` / `Impact` / `Resolution` block in `Findings` and mark it with `Fixability: external` (or `IncidentExternal: true`); optional `Incident*` fields refine the promoted registry entry.
 
 ## Constraints
 
@@ -47,7 +47,7 @@ If any step fails:
 - MUST run `task plan approve` then `task start-ready` as `Step 1 -> wait -> Step 2` (never parallel).
 - `task start-ready` MAY surface targeted incident advice for analogous scope/tags; follow it before widening scope.
 - In direct mode, `finish` auto-creates the deterministic close commit by default; use `--no-close-commit` only for explicit manual handling.
-- `finish` evaluates structured external `incident-candidate` findings and appends valid entries to `.agentplane/policy/incidents.md`.
+- `finish` evaluates structured resolved external findings, auto-derives incident advice when only `Observation` / `Impact` / `Resolution` plus `Fixability: external` are present, and appends valid entries to `.agentplane/policy/incidents.md`.
 - MUST stop and request re-approval on material drift.
 - Do not use worktrees in direct mode.
 - Do not perform `branch_pr`-only operations.

--- a/.agentplane/tasks/202604031627-DA1JVW/README.md
+++ b/.agentplane/tasks/202604031627-DA1JVW/README.md
@@ -1,0 +1,118 @@
+---
+id: "202604031627-DA1JVW"
+title: "Auto-promote reusable external incidents from task findings"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "policy"
+  - "workflow"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-04-03T16:28:22.848Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-04-03T16:40:24.330Z"
+  updated_by: "CODER"
+  note: "Verified: incidents promotion now accepts resolved external Findings marked with Fixability: external or IncidentExternal: true, first occurrences stay open but still surface through advice lookup, recurring equivalents stabilize on later entries, and the shipped policy/docs/help text matches that contract. Commands: bunx vitest run packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/cli/run-cli.core.tasks.test.ts --hookTimeout 60000 --testTimeout 60000; bunx vitest run packages/agentplane/src/cli/run-cli.core.help-snap.test.ts packages/agentplane/src/cli/command-guide.test.ts -u --hookTimeout 60000 --testTimeout 60000; bun run --filter=agentplane build; bun run docs:bootstrap:generate; node packages/agentplane/dist/cli.js docs cli --out docs/user/cli-reference.generated.mdx; node .agentplane/policy/check-routing.mjs; agentplane doctor; bun run docs:bootstrap:check; bun run docs:cli:check; bun run docs:onboarding:check."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: align incidents promotion with the intended external-incident memory model, make advice lookup useful for first and recurring analogous tasks, and keep the contract documented."
+events:
+  -
+    type: "status"
+    at: "2026-04-03T16:29:32.162Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: align incidents promotion with the intended external-incident memory model, make advice lookup useful for first and recurring analogous tasks, and keep the contract documented."
+  -
+    type: "verify"
+    at: "2026-04-03T16:40:24.330Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: incidents promotion now accepts resolved external Findings marked with Fixability: external or IncidentExternal: true, first occurrences stay open but still surface through advice lookup, recurring equivalents stabilize on later entries, and the shipped policy/docs/help text matches that contract. Commands: bunx vitest run packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/cli/run-cli.core.tasks.test.ts --hookTimeout 60000 --testTimeout 60000; bunx vitest run packages/agentplane/src/cli/run-cli.core.help-snap.test.ts packages/agentplane/src/cli/command-guide.test.ts -u --hookTimeout 60000 --testTimeout 60000; bun run --filter=agentplane build; bun run docs:bootstrap:generate; node packages/agentplane/dist/cli.js docs cli --out docs/user/cli-reference.generated.mdx; node .agentplane/policy/check-routing.mjs; agentplane doctor; bun run docs:bootstrap:check; bun run docs:cli:check; bun run docs:onboarding:check."
+doc_version: 3
+doc_updated_at: "2026-04-03T16:40:24.353Z"
+doc_updated_by: "CODER"
+description: "Make finish/task workflows infer reusable external incident advice from resolved Findings blocks, keep incident states honest, and align advice lookup with scope/tag recurrence semantics."
+sections:
+  Summary: |-
+    Auto-promote reusable external incidents from task findings
+    
+    Make finish/task workflows infer reusable external incident advice from resolved Findings blocks, keep incident states honest, and align advice lookup with scope/tag recurrence semantics.
+  Scope: |-
+    - In scope: Make finish/task workflows infer reusable external incident advice from resolved Findings blocks, keep incident states honest, and align advice lookup with scope/tag recurrence semantics.
+    - Out of scope: unrelated refactors not required for "Auto-promote reusable external incidents from task findings".
+  Plan: "1. Relax incident promotion so finish can infer reusable external incident advice from structured Findings blocks instead of requiring fully manual Incident* metadata. 2. Make registry state semantics honest: default new external incidents to open, surface open incidents in advice lookup, and stabilize only on recurrence. 3. Keep lookup centered on analogous scope/tags/title, add focused regression coverage, and sync docs/help for the updated incidents contract."
+  Verify Steps: |-
+    1. Run focused incidents runtime and CLI/task workflow tests covering auto-promotion, recurrence state, and advice lookup. Expected: new external findings promote deterministically and analogous tasks receive the expected advice.
+    2. Run docs/policy routing validation for the updated incidents contract. Expected: routing and policy invariants remain valid after the contract changes.
+    3. Build the agentplane package. Expected: the CLI/runtime compiles cleanly with no new type or bundling errors.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-04-03T16:40:24.330Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: incidents promotion now accepts resolved external Findings marked with Fixability: external or IncidentExternal: true, first occurrences stay open but still surface through advice lookup, recurring equivalents stabilize on later entries, and the shipped policy/docs/help text matches that contract. Commands: bunx vitest run packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/cli/run-cli.core.tasks.test.ts --hookTimeout 60000 --testTimeout 60000; bunx vitest run packages/agentplane/src/cli/run-cli.core.help-snap.test.ts packages/agentplane/src/cli/command-guide.test.ts -u --hookTimeout 60000 --testTimeout 60000; bun run --filter=agentplane build; bun run docs:bootstrap:generate; node packages/agentplane/dist/cli.js docs cli --out docs/user/cli-reference.generated.mdx; node .agentplane/policy/check-routing.mjs; agentplane doctor; bun run docs:bootstrap:check; bun run docs:cli:check; bun run docs:onboarding:check.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-03T16:29:32.173Z, excerpt_hash=sha256:bd7df8a7b0aba1fbc42051d40dead0841f8ba904897691a8cf58a4a520d8ca41
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Auto-promote reusable external incidents from task findings
+
+Make finish/task workflows infer reusable external incident advice from resolved Findings blocks, keep incident states honest, and align advice lookup with scope/tag recurrence semantics.
+
+## Scope
+
+- In scope: Make finish/task workflows infer reusable external incident advice from resolved Findings blocks, keep incident states honest, and align advice lookup with scope/tag recurrence semantics.
+- Out of scope: unrelated refactors not required for "Auto-promote reusable external incidents from task findings".
+
+## Plan
+
+1. Relax incident promotion so finish can infer reusable external incident advice from structured Findings blocks instead of requiring fully manual Incident* metadata. 2. Make registry state semantics honest: default new external incidents to open, surface open incidents in advice lookup, and stabilize only on recurrence. 3. Keep lookup centered on analogous scope/tags/title, add focused regression coverage, and sync docs/help for the updated incidents contract.
+
+## Verify Steps
+
+1. Run focused incidents runtime and CLI/task workflow tests covering auto-promotion, recurrence state, and advice lookup. Expected: new external findings promote deterministically and analogous tasks receive the expected advice.
+2. Run docs/policy routing validation for the updated incidents contract. Expected: routing and policy invariants remain valid after the contract changes.
+3. Build the agentplane package. Expected: the CLI/runtime compiles cleanly with no new type or bundling errors.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-04-03T16:40:24.330Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: incidents promotion now accepts resolved external Findings marked with Fixability: external or IncidentExternal: true, first occurrences stay open but still surface through advice lookup, recurring equivalents stabilize on later entries, and the shipped policy/docs/help text matches that contract. Commands: bunx vitest run packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/cli/run-cli.core.tasks.test.ts --hookTimeout 60000 --testTimeout 60000; bunx vitest run packages/agentplane/src/cli/run-cli.core.help-snap.test.ts packages/agentplane/src/cli/command-guide.test.ts -u --hookTimeout 60000 --testTimeout 60000; bun run --filter=agentplane build; bun run docs:bootstrap:generate; node packages/agentplane/dist/cli.js docs cli --out docs/user/cli-reference.generated.mdx; node .agentplane/policy/check-routing.mjs; agentplane doctor; bun run docs:bootstrap:check; bun run docs:cli:check; bun run docs:onboarding:check.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-03T16:29:32.173Z, excerpt_hash=sha256:bd7df8a7b0aba1fbc42051d40dead0841f8ba904897691a8cf58a4a520d8ca41
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202604031627-DA1JVW/pr/diffstat.txt
+++ b/.agentplane/tasks/202604031627-DA1JVW/pr/diffstat.txt
@@ -1,10 +1,14 @@
+ .agentplane/policy/governance.md                   |   7 +-
+ .agentplane/policy/incidents.md                    |   1 +
+ .agentplane/policy/workflow.branch_pr.md           |   2 +-
+ .agentplane/policy/workflow.direct.md              |   4 +-
  .agentplane/tasks/202604031627-DA1JVW/README.md    | 118 ++++++++++++++
- .../tasks/202604031627-DA1JVW/pr/diffstat.txt      |   0
- .../tasks/202604031627-DA1JVW/pr/github-body.md    |  50 ++++++
+ .../tasks/202604031627-DA1JVW/pr/diffstat.txt      |  26 ++++
+ .../tasks/202604031627-DA1JVW/pr/github-body.md    |  75 +++++++++
  .../tasks/202604031627-DA1JVW/pr/github-title.txt  |   1 +
  .agentplane/tasks/202604031627-DA1JVW/pr/meta.json |  14 ++
  .../tasks/202604031627-DA1JVW/pr/notes.jsonl       |   0
- .agentplane/tasks/202604031627-DA1JVW/pr/review.md |  57 +++++++
+ .agentplane/tasks/202604031627-DA1JVW/pr/review.md |  82 ++++++++++
  .../tasks/202604031627-DA1JVW/pr/verify.log        |   0
  docs/user/agent-bootstrap.generated.mdx            |   4 +-
  docs/user/agents.mdx                               |   2 +-
@@ -23,4 +27,4 @@
  .../src/runtime/incidents/resolve.test.ts          |  86 +++++++++--
  .../agentplane/src/runtime/incidents/resolve.ts    | 169 ++++++++++++++++++---
  packages/agentplane/src/runtime/incidents/types.ts |   4 +-
- 25 files changed, 493 insertions(+), 77 deletions(-)
+ 29 files changed, 576 insertions(+), 84 deletions(-)

--- a/.agentplane/tasks/202604031627-DA1JVW/pr/diffstat.txt
+++ b/.agentplane/tasks/202604031627-DA1JVW/pr/diffstat.txt
@@ -1,0 +1,26 @@
+ .agentplane/tasks/202604031627-DA1JVW/README.md    | 118 ++++++++++++++
+ .../tasks/202604031627-DA1JVW/pr/diffstat.txt      |   0
+ .../tasks/202604031627-DA1JVW/pr/github-body.md    |  50 ++++++
+ .../tasks/202604031627-DA1JVW/pr/github-title.txt  |   1 +
+ .agentplane/tasks/202604031627-DA1JVW/pr/meta.json |  14 ++
+ .../tasks/202604031627-DA1JVW/pr/notes.jsonl       |   0
+ .agentplane/tasks/202604031627-DA1JVW/pr/review.md |  57 +++++++
+ .../tasks/202604031627-DA1JVW/pr/verify.log        |   0
+ docs/user/agent-bootstrap.generated.mdx            |   4 +-
+ docs/user/agents.mdx                               |   2 +-
+ docs/user/cli-reference.generated.mdx              |   6 +-
+ packages/agentplane/assets/policy/governance.md    |   7 +-
+ packages/agentplane/assets/policy/incidents.md     |   1 +
+ .../agentplane/assets/policy/workflow.branch_pr.md |   2 +-
+ .../agentplane/assets/policy/workflow.direct.md    |   4 +-
+ .../run-cli.core.help-snap.test.ts.snap            |   2 +-
+ packages/agentplane/src/cli/bootstrap-guide.ts     |   4 +-
+ .../src/cli/run-cli.core.incidents.test.ts         |  14 +-
+ .../agentplane/src/cli/run-cli.core.tasks.test.ts  |  15 +-
+ .../src/commands/incidents/collect.command.ts      |   5 +-
+ .../src/commands/incidents/incidents.command.ts    |   2 +-
+ .../agentplane/src/commands/incidents/shared.ts    |   3 +-
+ .../src/runtime/incidents/resolve.test.ts          |  86 +++++++++--
+ .../agentplane/src/runtime/incidents/resolve.ts    | 169 ++++++++++++++++++---
+ packages/agentplane/src/runtime/incidents/types.ts |   4 +-
+ 25 files changed, 493 insertions(+), 77 deletions(-)

--- a/.agentplane/tasks/202604031627-DA1JVW/pr/github-body.md
+++ b/.agentplane/tasks/202604031627-DA1JVW/pr/github-body.md
@@ -39,18 +39,22 @@ Make finish/task workflows infer reusable external incident advice from resolved
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-03T16:41:53.361Z
+- Updated: 2026-04-03T16:42:32.226Z
 - Branch: task/202604031627-DA1JVW/incidents-auto-promotion
-- Head: 2740da03d7a1
+- Head: 24fe2c746f45
 
 ```text
+ .agentplane/policy/governance.md                   |   7 +-
+ .agentplane/policy/incidents.md                    |   1 +
+ .agentplane/policy/workflow.branch_pr.md           |   2 +-
+ .agentplane/policy/workflow.direct.md              |   4 +-
  .agentplane/tasks/202604031627-DA1JVW/README.md    | 118 ++++++++++++++
- .../tasks/202604031627-DA1JVW/pr/diffstat.txt      |   0
- .../tasks/202604031627-DA1JVW/pr/github-body.md    |  50 ++++++
+ .../tasks/202604031627-DA1JVW/pr/diffstat.txt      |  26 ++++
+ .../tasks/202604031627-DA1JVW/pr/github-body.md    |  75 +++++++++
  .../tasks/202604031627-DA1JVW/pr/github-title.txt  |   1 +
  .agentplane/tasks/202604031627-DA1JVW/pr/meta.json |  14 ++
  .../tasks/202604031627-DA1JVW/pr/notes.jsonl       |   0
- .agentplane/tasks/202604031627-DA1JVW/pr/review.md |  57 +++++++
+ .agentplane/tasks/202604031627-DA1JVW/pr/review.md |  82 ++++++++++
  .../tasks/202604031627-DA1JVW/pr/verify.log        |   0
  docs/user/agent-bootstrap.generated.mdx            |   4 +-
  docs/user/agents.mdx                               |   2 +-
@@ -69,7 +73,7 @@ Make finish/task workflows infer reusable external incident advice from resolved
  .../src/runtime/incidents/resolve.test.ts          |  86 +++++++++--
  .../agentplane/src/runtime/incidents/resolve.ts    | 169 ++++++++++++++++++---
  packages/agentplane/src/runtime/incidents/types.ts |   4 +-
- 25 files changed, 493 insertions(+), 77 deletions(-)
+ 29 files changed, 576 insertions(+), 84 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202604031627-DA1JVW/pr/github-body.md
+++ b/.agentplane/tasks/202604031627-DA1JVW/pr/github-body.md
@@ -39,12 +39,37 @@ Make finish/task workflows infer reusable external incident advice from resolved
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-03T16:29:32.214Z
+- Updated: 2026-04-03T16:41:53.361Z
 - Branch: task/202604031627-DA1JVW/incidents-auto-promotion
-- Head: add4d7927505
+- Head: 2740da03d7a1
 
 ```text
-No changes detected.
+ .agentplane/tasks/202604031627-DA1JVW/README.md    | 118 ++++++++++++++
+ .../tasks/202604031627-DA1JVW/pr/diffstat.txt      |   0
+ .../tasks/202604031627-DA1JVW/pr/github-body.md    |  50 ++++++
+ .../tasks/202604031627-DA1JVW/pr/github-title.txt  |   1 +
+ .agentplane/tasks/202604031627-DA1JVW/pr/meta.json |  14 ++
+ .../tasks/202604031627-DA1JVW/pr/notes.jsonl       |   0
+ .agentplane/tasks/202604031627-DA1JVW/pr/review.md |  57 +++++++
+ .../tasks/202604031627-DA1JVW/pr/verify.log        |   0
+ docs/user/agent-bootstrap.generated.mdx            |   4 +-
+ docs/user/agents.mdx                               |   2 +-
+ docs/user/cli-reference.generated.mdx              |   6 +-
+ packages/agentplane/assets/policy/governance.md    |   7 +-
+ packages/agentplane/assets/policy/incidents.md     |   1 +
+ .../agentplane/assets/policy/workflow.branch_pr.md |   2 +-
+ .../agentplane/assets/policy/workflow.direct.md    |   4 +-
+ .../run-cli.core.help-snap.test.ts.snap            |   2 +-
+ packages/agentplane/src/cli/bootstrap-guide.ts     |   4 +-
+ .../src/cli/run-cli.core.incidents.test.ts         |  14 +-
+ .../agentplane/src/cli/run-cli.core.tasks.test.ts  |  15 +-
+ .../src/commands/incidents/collect.command.ts      |   5 +-
+ .../src/commands/incidents/incidents.command.ts    |   2 +-
+ .../agentplane/src/commands/incidents/shared.ts    |   3 +-
+ .../src/runtime/incidents/resolve.test.ts          |  86 +++++++++--
+ .../agentplane/src/runtime/incidents/resolve.ts    | 169 ++++++++++++++++++---
+ packages/agentplane/src/runtime/incidents/types.ts |   4 +-
+ 25 files changed, 493 insertions(+), 77 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202604031627-DA1JVW/pr/github-body.md
+++ b/.agentplane/tasks/202604031627-DA1JVW/pr/github-body.md
@@ -1,0 +1,50 @@
+## Summary
+
+Auto-promote reusable external incidents from task findings
+
+Make finish/task workflows infer reusable external incident advice from resolved Findings blocks, keep incident states honest, and align advice lookup with scope/tag recurrence semantics.
+
+## Scope
+
+- In scope: Make finish/task workflows infer reusable external incident advice from resolved Findings blocks, keep incident states honest, and align advice lookup with scope/tag recurrence semantics.
+- Out of scope: unrelated refactors not required for "Auto-promote reusable external incidents from task findings".
+
+## Verification
+
+### Plan
+
+1. Run focused incidents runtime and CLI/task workflow tests covering auto-promotion, recurrence state, and advice lookup. Expected: new external findings promote deterministically and analogous tasks receive the expected advice.
+2. Run docs/policy routing validation for the updated incidents contract. Expected: routing and policy invariants remain valid after the contract changes.
+3. Build the agentplane package. Expected: the CLI/runtime compiles cleanly with no new type or bundling errors.
+
+### Current Status
+
+- State: ok
+- Note: Verified: incidents promotion now accepts resolved external Findings marked with Fixability: external or IncidentExternal: true, first occurrences stay open but still surface through advice lookup, recurring equivalents stabilize on later entries, and the shipped policy/docs/help text matches that contract. Commands: bunx vitest run packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/cli/run-cli.core.tasks.test.ts --hookTimeout 60000 --testTimeout 60000; bunx vitest run packages/agentplane/src/cli/run-cli.core.help-snap.test.ts packages/agentplane/src/cli/command-guide.test.ts -u --hookTimeout 60000 --testTimeout 60000; bun run --filter=agentplane build; bun run docs:bootstrap:generate; node packages/agentplane/dist/cli.js docs cli --out docs/user/cli-reference.generated.mdx; node .agentplane/policy/check-routing.mjs; agentplane doctor; bun run docs:bootstrap:check; bun run docs:cli:check; bun run docs:onboarding:check.
+
+## Risks
+
+- Risk level: not recorded
+- Breaking change: no
+
+### Rollback
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-04-03T16:29:32.214Z
+- Branch: task/202604031627-DA1JVW/incidents-auto-promotion
+- Head: add4d7927505
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202604031627-DA1JVW/pr/github-title.txt
+++ b/.agentplane/tasks/202604031627-DA1JVW/pr/github-title.txt
@@ -1,0 +1,1 @@
+policy/workflow: Auto-promote reusable external incidents from task findings (DA1JVW)

--- a/.agentplane/tasks/202604031627-DA1JVW/pr/meta.json
+++ b/.agentplane/tasks/202604031627-DA1JVW/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202604031627-DA1JVW/incidents-auto-promotion",
   "created_at": "2026-04-03T16:29:32.214Z",
-  "head_sha": "2740da03d7a1f3408d581e5c6cbcbd167cfa307e",
+  "head_sha": "24fe2c746f453afc8019fea7d56aeff6776036b0",
   "last_verified_at": "2026-04-03T16:40:24.330Z",
   "last_verified_sha": "add4d7927505d07744a044fa1ea3acd57b2d907a",
   "schema_version": 1,
   "task_id": "202604031627-DA1JVW",
-  "updated_at": "2026-04-03T16:41:53.361Z",
+  "updated_at": "2026-04-03T16:42:32.226Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202604031627-DA1JVW/pr/meta.json
+++ b/.agentplane/tasks/202604031627-DA1JVW/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202604031627-DA1JVW/incidents-auto-promotion",
   "created_at": "2026-04-03T16:29:32.214Z",
-  "head_sha": "add4d7927505d07744a044fa1ea3acd57b2d907a",
+  "head_sha": "2740da03d7a1f3408d581e5c6cbcbd167cfa307e",
   "last_verified_at": "2026-04-03T16:40:24.330Z",
   "last_verified_sha": "add4d7927505d07744a044fa1ea3acd57b2d907a",
   "schema_version": 1,
   "task_id": "202604031627-DA1JVW",
-  "updated_at": "2026-04-03T16:29:32.214Z",
+  "updated_at": "2026-04-03T16:41:53.361Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202604031627-DA1JVW/pr/meta.json
+++ b/.agentplane/tasks/202604031627-DA1JVW/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202604031627-DA1JVW/incidents-auto-promotion",
+  "created_at": "2026-04-03T16:29:32.214Z",
+  "head_sha": "add4d7927505d07744a044fa1ea3acd57b2d907a",
+  "last_verified_at": "2026-04-03T16:40:24.330Z",
+  "last_verified_sha": "add4d7927505d07744a044fa1ea3acd57b2d907a",
+  "schema_version": 1,
+  "task_id": "202604031627-DA1JVW",
+  "updated_at": "2026-04-03T16:29:32.214Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202604031627-DA1JVW/pr/review.md
+++ b/.agentplane/tasks/202604031627-DA1JVW/pr/review.md
@@ -45,12 +45,37 @@ Make finish/task workflows infer reusable external incident advice from resolved
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-03T16:29:32.214Z
+- Updated: 2026-04-03T16:41:53.361Z
 - Branch: task/202604031627-DA1JVW/incidents-auto-promotion
-- Head: add4d7927505
+- Head: 2740da03d7a1
 
 ```text
-No changes detected.
+ .agentplane/tasks/202604031627-DA1JVW/README.md    | 118 ++++++++++++++
+ .../tasks/202604031627-DA1JVW/pr/diffstat.txt      |   0
+ .../tasks/202604031627-DA1JVW/pr/github-body.md    |  50 ++++++
+ .../tasks/202604031627-DA1JVW/pr/github-title.txt  |   1 +
+ .agentplane/tasks/202604031627-DA1JVW/pr/meta.json |  14 ++
+ .../tasks/202604031627-DA1JVW/pr/notes.jsonl       |   0
+ .agentplane/tasks/202604031627-DA1JVW/pr/review.md |  57 +++++++
+ .../tasks/202604031627-DA1JVW/pr/verify.log        |   0
+ docs/user/agent-bootstrap.generated.mdx            |   4 +-
+ docs/user/agents.mdx                               |   2 +-
+ docs/user/cli-reference.generated.mdx              |   6 +-
+ packages/agentplane/assets/policy/governance.md    |   7 +-
+ packages/agentplane/assets/policy/incidents.md     |   1 +
+ .../agentplane/assets/policy/workflow.branch_pr.md |   2 +-
+ .../agentplane/assets/policy/workflow.direct.md    |   4 +-
+ .../run-cli.core.help-snap.test.ts.snap            |   2 +-
+ packages/agentplane/src/cli/bootstrap-guide.ts     |   4 +-
+ .../src/cli/run-cli.core.incidents.test.ts         |  14 +-
+ .../agentplane/src/cli/run-cli.core.tasks.test.ts  |  15 +-
+ .../src/commands/incidents/collect.command.ts      |   5 +-
+ .../src/commands/incidents/incidents.command.ts    |   2 +-
+ .../agentplane/src/commands/incidents/shared.ts    |   3 +-
+ .../src/runtime/incidents/resolve.test.ts          |  86 +++++++++--
+ .../agentplane/src/runtime/incidents/resolve.ts    | 169 ++++++++++++++++++---
+ packages/agentplane/src/runtime/incidents/types.ts |   4 +-
+ 25 files changed, 493 insertions(+), 77 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202604031627-DA1JVW/pr/review.md
+++ b/.agentplane/tasks/202604031627-DA1JVW/pr/review.md
@@ -1,0 +1,57 @@
+# PR Review
+
+Created: 2026-04-03T16:29:32.214Z
+Branch: task/202604031627-DA1JVW/incidents-auto-promotion
+
+## Summary
+
+Auto-promote reusable external incidents from task findings
+
+Make finish/task workflows infer reusable external incident advice from resolved Findings blocks, keep incident states honest, and align advice lookup with scope/tag recurrence semantics.
+
+## Scope
+
+- In scope: Make finish/task workflows infer reusable external incident advice from resolved Findings blocks, keep incident states honest, and align advice lookup with scope/tag recurrence semantics.
+- Out of scope: unrelated refactors not required for "Auto-promote reusable external incidents from task findings".
+
+## Verification
+
+### Plan
+
+1. Run focused incidents runtime and CLI/task workflow tests covering auto-promotion, recurrence state, and advice lookup. Expected: new external findings promote deterministically and analogous tasks receive the expected advice.
+2. Run docs/policy routing validation for the updated incidents contract. Expected: routing and policy invariants remain valid after the contract changes.
+3. Build the agentplane package. Expected: the CLI/runtime compiles cleanly with no new type or bundling errors.
+
+### Current Status
+
+- State: ok
+- Note: Verified: incidents promotion now accepts resolved external Findings marked with Fixability: external or IncidentExternal: true, first occurrences stay open but still surface through advice lookup, recurring equivalents stabilize on later entries, and the shipped policy/docs/help text matches that contract. Commands: bunx vitest run packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/cli/run-cli.core.tasks.test.ts --hookTimeout 60000 --testTimeout 60000; bunx vitest run packages/agentplane/src/cli/run-cli.core.help-snap.test.ts packages/agentplane/src/cli/command-guide.test.ts -u --hookTimeout 60000 --testTimeout 60000; bun run --filter=agentplane build; bun run docs:bootstrap:generate; node packages/agentplane/dist/cli.js docs cli --out docs/user/cli-reference.generated.mdx; node .agentplane/policy/check-routing.mjs; agentplane doctor; bun run docs:bootstrap:check; bun run docs:cli:check; bun run docs:onboarding:check.
+
+## Risks
+
+- Risk level: not recorded
+- Breaking change: no
+
+### Rollback
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-04-03T16:29:32.214Z
+- Branch: task/202604031627-DA1JVW/incidents-auto-promotion
+- Head: add4d7927505
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202604031627-DA1JVW/pr/review.md
+++ b/.agentplane/tasks/202604031627-DA1JVW/pr/review.md
@@ -45,18 +45,22 @@ Make finish/task workflows infer reusable external incident advice from resolved
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-03T16:41:53.361Z
+- Updated: 2026-04-03T16:42:32.226Z
 - Branch: task/202604031627-DA1JVW/incidents-auto-promotion
-- Head: 2740da03d7a1
+- Head: 24fe2c746f45
 
 ```text
+ .agentplane/policy/governance.md                   |   7 +-
+ .agentplane/policy/incidents.md                    |   1 +
+ .agentplane/policy/workflow.branch_pr.md           |   2 +-
+ .agentplane/policy/workflow.direct.md              |   4 +-
  .agentplane/tasks/202604031627-DA1JVW/README.md    | 118 ++++++++++++++
- .../tasks/202604031627-DA1JVW/pr/diffstat.txt      |   0
- .../tasks/202604031627-DA1JVW/pr/github-body.md    |  50 ++++++
+ .../tasks/202604031627-DA1JVW/pr/diffstat.txt      |  26 ++++
+ .../tasks/202604031627-DA1JVW/pr/github-body.md    |  75 +++++++++
  .../tasks/202604031627-DA1JVW/pr/github-title.txt  |   1 +
  .agentplane/tasks/202604031627-DA1JVW/pr/meta.json |  14 ++
  .../tasks/202604031627-DA1JVW/pr/notes.jsonl       |   0
- .agentplane/tasks/202604031627-DA1JVW/pr/review.md |  57 +++++++
+ .agentplane/tasks/202604031627-DA1JVW/pr/review.md |  82 ++++++++++
  .../tasks/202604031627-DA1JVW/pr/verify.log        |   0
  docs/user/agent-bootstrap.generated.mdx            |   4 +-
  docs/user/agents.mdx                               |   2 +-
@@ -75,7 +79,7 @@ Make finish/task workflows infer reusable external incident advice from resolved
  .../src/runtime/incidents/resolve.test.ts          |  86 +++++++++--
  .../agentplane/src/runtime/incidents/resolve.ts    | 169 ++++++++++++++++++---
  packages/agentplane/src/runtime/incidents/types.ts |   4 +-
- 25 files changed, 493 insertions(+), 77 deletions(-)
+ 29 files changed, 576 insertions(+), 84 deletions(-)
 ```
 
 </details>

--- a/docs/user/agent-bootstrap.generated.mdx
+++ b/docs/user/agent-bootstrap.generated.mdx
@@ -53,7 +53,7 @@ When a repository is intentionally configured for direct mode, use one short rou
 
 ## 3. Verification and incident reuse
 
-Reuse historical incident advice only through targeted lookup, and validate promotable external incident candidates before `finish`.
+Reuse historical incident advice only through targeted lookup, and validate promotable resolved external findings before `finish`.
 
 - `agentplane task verify-show <task-id>`
 - `agentplane verify <task-id> --ok|--rework --by <ROLE> --note "..."`
@@ -63,7 +63,7 @@ Reuse historical incident advice only through targeted lookup, and validate prom
 - `node .agentplane/policy/check-routing.mjs`
 
 - Use `agentplane incidents advise <task-id>` after `start-ready` when analogous scope or tags might have prior external failure modes.
-- Use `agentplane incidents collect <task-id> --check` before `finish` when task `Findings` contains reusable external `incident-candidate` blocks.
+- Use `agentplane incidents collect <task-id> --check` before `finish` when task `Findings` contains reusable external `Observation` / `Impact` / `Resolution` blocks marked with `Fixability: external` (or `IncidentExternal: true`).
 - Keep repository-fixable defects task-local; only external or process incidents belong in `.agentplane/policy/incidents.md`.
 
 ## 4. Fallbacks and recovery

--- a/docs/user/agents.mdx
+++ b/docs/user/agents.mdx
@@ -29,7 +29,7 @@ Bundled agent profiles are intentionally narrow overlays, not a second policy ga
 - Each profile should own one clear decision boundary and one dominant deliverable type.
 - Profiles should prefer explicit assumptions, stop conditions, and escalation rules over long narrative guidance.
 - Outputs should be evidence-oriented: changed files, checks run, remaining risks, and follow-up boundaries.
-- Task-local observations belong in task `## Findings` (or legacy `## Notes` on v2 tasks); only curated strong patterns are promoted into `.agentplane/policy/incidents.md`.
+- Task-local observations belong in task `## Findings` (or legacy `## Notes` on v2 tasks); reusable external ones can be promoted into `.agentplane/policy/incidents.md` by recording `Observation` / `Impact` / `Resolution` plus `Fixability: external` (or `IncidentExternal: true`), with optional `Incident*` overrides when the inferred advice needs refinement.
 - When a profile conflicts with `AGENTS.md`, CLI enforcement, or policy modules, the higher-priority source wins.
 
 ## Startup path

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -1251,7 +1251,7 @@ agentplane incidents <collect|advise> [args] [options]
 
 Notes:
 
-- Use \`incidents collect\` to promote structured incident-candidate findings into \`.agentplane/policy/incidents.md\`.
+- Use \`incidents collect\` to promote resolved reusable external findings into \`.agentplane/policy/incidents.md\`.
 - Use \`incidents advise\` to query registry advice by task id or lightweight scope/tags.
 
 ### incidents advise
@@ -1275,7 +1275,7 @@ Options:
 
 ### incidents collect
 
-Promote structured external incident-candidates from a task into the incident registry.
+Promote reusable resolved external findings from a task into the incident registry.
 
 Usage:
 
@@ -1300,7 +1300,7 @@ agentplane incidents collect 202604031416-HEJWTM
 agentplane incidents collect 202604031416-HEJWTM --check --json
 ```
 
-- Validate that incident-candidate blocks are complete before finish.
+- Validate that reusable resolved external findings are complete before finish.
 
 ## PR
 

--- a/packages/agentplane/assets/policy/governance.md
+++ b/packages/agentplane/assets/policy/governance.md
@@ -6,15 +6,14 @@
 - Incident-derived and situational rules MUST be added only to `incidents.md`.
 - MUST NOT create additional incident policy files under `.agentplane/policy/`.
 - New reusable operational incidents SHOULD be promoted from task `Findings` via `agentplane finish` or `agentplane incidents collect <task-id>`.
-- Auto-promotion is reserved for explicit `incident-candidate` blocks marked `IncidentExternal: true`; repository-fixable defects stay task-local unless curated manually.
+- Auto-promotion is reserved for resolved external findings marked `Fixability: external` or `IncidentExternal: true`; optional `IncidentScope`, `IncidentAdvice`, `IncidentRule`, `IncidentTags`, and `IncidentMatch` fields override the inferred registry entry when needed.
 - Normal startup MUST NOT bulk-load `incidents.md`; targeted lookup for analogous work is allowed through `task start-ready` and `agentplane incidents advise`.
 
 ## Stabilization criteria
 
-Use `stabilized` only when one of these is true:
+Use `stabilized` only when the same failure class recurs at least 2 times in 30 days.
 
-1. The same failure class recurs at least 2 times in 30 days.
-2. A single Sev-1 / production-blocking failure has reproducible steps and evidence.
+First auto-promoted external incidents may stay `open`, but targeted advice lookup is still allowed to use them so analogous work can reuse the recovery guidance before the second recurrence.
 
 Promotion from `incidents.md` into canonical policy modules is allowed only when:
 

--- a/packages/agentplane/assets/policy/incidents.md
+++ b/packages/agentplane/assets/policy/incidents.md
@@ -9,6 +9,7 @@ This is the single file for incident-derived and situational policy rules.
 - New machine-matched entries SHOULD also include: `tags`, `match`, `advice`, `source_task`, `fixability`.
 - `rule` MUST be concrete and testable (`MUST` / `MUST NOT`).
 - `fixability: external` means the issue cannot be removed by changing only repository code and should stay as reusable operational advice.
+- First auto-promoted external incidents normally enter as `open` and still participate in targeted advice lookup; recurring equivalent incidents can append later `stabilized` entries.
 - `state` values: `open`, `stabilized`, `promoted`.
 
 ## Entry template

--- a/packages/agentplane/assets/policy/workflow.branch_pr.md
+++ b/packages/agentplane/assets/policy/workflow.branch_pr.md
@@ -30,7 +30,7 @@ agentplane finish <task-id> --author INTEGRATOR --body "Verified: ..." --result 
 - Task documentation updates MAY be batched within one turn before approval.
 - MUST run `task plan approve` then `task start-ready` as `Step 1 -> wait -> Step 2` (never parallel).
 - `task start-ready` MAY surface targeted incident advice for analogous scope/tags; follow it before widening scope.
-- Keep structured external `incident-candidate` findings in the task README; base-branch `finish` or `agentplane incidents collect <task-id>` promotes valid entries into `.agentplane/policy/incidents.md`.
+- Keep structured resolved external findings in the task README; mark reusable ones with `Fixability: external` (or `IncidentExternal: true`) and let base-branch `finish` or `agentplane incidents collect <task-id>` promote them into `.agentplane/policy/incidents.md`, using optional `Incident*` fields only when the inferred scope/advice needs refinement.
 - MUST stop and request re-approval on material drift.
 - Planning and closure happen on base checkout.
 - Do not export task snapshots from task branches.

--- a/packages/agentplane/assets/policy/workflow.direct.md
+++ b/packages/agentplane/assets/policy/workflow.direct.md
@@ -38,7 +38,7 @@ If any step fails:
    - `doc_version=3`: task `Findings`
 3. Mark task blocked: `agentplane block <task-id> --author <ROLE> --body "Blocked: ..."`.
 4. Request re-approval before scope/risk changes.
-5. If failure is external/process-related and should become reusable advice, record a structured `incident-candidate` block in `Findings` and let `agentplane finish` or `agentplane incidents collect <task-id>` promote it.
+5. If failure is external/process-related and should become reusable advice, record a structured `Observation` / `Impact` / `Resolution` block in `Findings` and mark it with `Fixability: external` (or `IncidentExternal: true`); optional `Incident*` fields refine the promoted registry entry.
 
 ## Constraints
 
@@ -47,7 +47,7 @@ If any step fails:
 - MUST run `task plan approve` then `task start-ready` as `Step 1 -> wait -> Step 2` (never parallel).
 - `task start-ready` MAY surface targeted incident advice for analogous scope/tags; follow it before widening scope.
 - In direct mode, `finish` auto-creates the deterministic close commit by default; use `--no-close-commit` only for explicit manual handling.
-- `finish` evaluates structured external `incident-candidate` findings and appends valid entries to `.agentplane/policy/incidents.md`.
+- `finish` evaluates structured resolved external findings, auto-derives incident advice when only `Observation` / `Impact` / `Resolution` plus `Fixability: external` are present, and appends valid entries to `.agentplane/policy/incidents.md`.
 - MUST stop and request re-approval on material drift.
 - Do not use worktrees in direct mode.
 - Do not perform `branch_pr`-only operations.

--- a/packages/agentplane/src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap
+++ b/packages/agentplane/src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap
@@ -59,7 +59,7 @@ Commands:
   Policy:
     incidents  Promote external incident advice and resolve incident hints for analogous tasks.
     incidents advise  Resolve relevant incident advice for a task or an ad hoc scope/tag query.
-    incidents collect  Promote structured external incident-candidates from a task into the incident registry.
+    incidents collect  Promote reusable resolved external findings from a task into the incident registry.
   PR:
     integrate  Integrate a task branch into the base branch (branch_pr workflow).
     pr  Manage local PR review and GitHub publication artifacts for a task (branch_pr workflow).

--- a/packages/agentplane/src/cli/bootstrap-guide.ts
+++ b/packages/agentplane/src/cli/bootstrap-guide.ts
@@ -75,11 +75,11 @@ export const BOOTSTRAP_SECTIONS: readonly BootstrapSection[] = [
   {
     heading: "3. Verification and incident reuse",
     summary:
-      "Reuse historical incident advice only through targeted lookup, and validate promotable external incident candidates before `finish`.",
+      "Reuse historical incident advice only through targeted lookup, and validate promotable resolved external findings before `finish`.",
     commands: BOOTSTRAP_VERIFICATION_COMMANDS,
     notes: [
       "Use `agentplane incidents advise <task-id>` after `start-ready` when analogous scope or tags might have prior external failure modes.",
-      "Use `agentplane incidents collect <task-id> --check` before `finish` when task `Findings` contains reusable external `incident-candidate` blocks.",
+      "Use `agentplane incidents collect <task-id> --check` before `finish` when task `Findings` contains reusable external `Observation` / `Impact` / `Resolution` blocks marked with `Fixability: external` (or `IncidentExternal: true`).",
       "Keep repository-fixable defects task-local; only external or process incidents belong in `.agentplane/policy/incidents.md`.",
     ],
   },

--- a/packages/agentplane/src/cli/run-cli.core.incidents.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.incidents.test.ts
@@ -72,13 +72,7 @@ describe("runCli incidents", () => {
             "- Observation: external release recovery instructions drifted outside the repository fix.",
             "  Impact: operators repeated the same manual recovery mistakes.",
             "  Resolution: keep one reusable recovery note in the incident registry.",
-            "  Promotion: incident-candidate",
-            "  IncidentScope: release recovery manual steps",
-            "  IncidentTags: release, operations",
-            "  IncidentMatch: release, recovery, manual",
-            "  IncidentAdvice: review the recorded release recovery steps before rerunning manual remediation",
-            "  IncidentRule: Release recovery MUST review the recorded manual recovery steps before rerunning remediation.",
-            "  IncidentExternal: true",
+            "  Fixability: external",
           ].join("\n"),
           "--root",
           root,
@@ -104,12 +98,14 @@ describe("runCli incidents", () => {
       const payload = JSON.parse(io.stdout) as {
         task_id: string;
         checked_only: boolean;
-        promotable: { fixability: string | null }[];
+        promotable: { fixability: string | null; state: string; advice: string | null }[];
       };
       expect(payload.task_id).toBe(taskId);
       expect(payload.checked_only).toBe(true);
       expect(payload.promotable).toHaveLength(1);
       expect(payload.promotable[0].fixability).toBe("external");
+      expect(payload.promotable[0].state).toBe("open");
+      expect(payload.promotable[0].advice).toContain("reusable recovery note");
     } finally {
       io.restore();
     }
@@ -137,7 +133,7 @@ describe("runCli incidents", () => {
         "  enforcement: manual",
         "  source_task: 202604031416-HEJWTM",
         "  fixability: external",
-        "  state: stabilized",
+        "  state: open",
         "",
       ].join("\n"),
       "utf8",

--- a/packages/agentplane/src/cli/run-cli.core.tasks.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.tasks.test.ts
@@ -824,7 +824,7 @@ describe("runCli", () => {
         "  enforcement: manual",
         "  source_task: 202603091054-V2X1QB",
         "  fixability: external",
-        "  state: stabilized",
+        "  state: open",
         "",
       ].join("\n"),
       "utf8",
@@ -1163,13 +1163,7 @@ describe("runCli", () => {
           "- Observation: workflow_dispatch on release tags can still hang while waiting on exact-SHA push runs that never existed.",
           "  Impact: manual release recovery stalls even after the repository fix is known.",
           "  Resolution: validate the exact release ref inside the workflow before rerunning recovery.",
-          "  Promotion: incident-candidate",
-          "  IncidentScope: release publish workflow_dispatch",
-          "  IncidentTags: release, github-actions",
-          "  IncidentMatch: publish, workflow_dispatch, release-tag",
-          "  IncidentAdvice: validate the exact release ref inside the workflow before rerunning release recovery",
-          "  IncidentRule: Release recovery MUST validate the exact ref inside the workflow before rerunning manual publish recovery.",
-          "  IncidentExternal: true",
+          "  Fixability: external",
         ].join("\n"),
       ],
     ] as const) {
@@ -1269,7 +1263,10 @@ describe("runCli", () => {
     );
     expect(incidents).toContain(`source_task: ${taskId}`);
     expect(incidents).toContain("fixability: external");
-    expect(incidents).toContain("Release recovery MUST validate the exact ref inside the workflow");
+    expect(incidents).toContain("state: open");
+    expect(incidents).toContain(
+      "validate the exact release ref inside the workflow before rerunning recovery",
+    );
   });
 
   it("task update supports replace flags", async () => {

--- a/packages/agentplane/src/commands/incidents/collect.command.ts
+++ b/packages/agentplane/src/commands/incidents/collect.command.ts
@@ -14,8 +14,7 @@ const output = createCliEmitter();
 export const incidentsCollectSpec: CommandSpec<IncidentsCollectParsed> = {
   id: ["incidents", "collect"],
   group: "Policy",
-  summary:
-    "Promote structured external incident-candidates from a task into the incident registry.",
+  summary: "Promote reusable resolved external findings from a task into the incident registry.",
   args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
   options: [
     {
@@ -39,7 +38,7 @@ export const incidentsCollectSpec: CommandSpec<IncidentsCollectParsed> = {
     },
     {
       cmd: "agentplane incidents collect 202604031416-HEJWTM --check --json",
-      why: "Validate that incident-candidate blocks are complete before finish.",
+      why: "Validate that reusable resolved external findings are complete before finish.",
     },
   ],
   parse: (raw) => ({

--- a/packages/agentplane/src/commands/incidents/incidents.command.ts
+++ b/packages/agentplane/src/commands/incidents/incidents.command.ts
@@ -13,7 +13,7 @@ export const incidentsSpec: CommandSpec<GroupCommandParsed> = {
   synopsis: ["agentplane incidents <collect|advise> [args] [options]"],
   args: [{ name: "cmd", required: false, variadic: true, valueHint: "<command>" }],
   notes: [
-    "Use `incidents collect` to promote structured incident-candidate findings into `.agentplane/policy/incidents.md`.",
+    "Use `incidents collect` to promote resolved reusable external findings into `.agentplane/policy/incidents.md`.",
     "Use `incidents advise` to query registry advice by task id or lightweight scope/tags.",
   ],
   parse: (raw) => parseGroupCommand(raw),

--- a/packages/agentplane/src/commands/incidents/shared.ts
+++ b/packages/agentplane/src/commands/incidents/shared.ts
@@ -100,7 +100,7 @@ export function formatIncidentCollectionIssues(
     return `line ${issue.candidate.line}: ${scope} -> missing ${issue.missingFields.join(", ")}`;
   });
   return [
-    `${taskId}: incident-candidate entries require explicit external incident metadata before promotion.`,
+    `${taskId}: reusable external findings need explicit external marking and enough recovery detail before promotion.`,
     "Required fields:",
     ...issueLines.map((line) => `- ${line}`),
   ].join("\n");
@@ -127,6 +127,7 @@ export async function collectTaskIncidents(opts: {
       id: loaded.task.id,
       title: loaded.task.title,
       description: loaded.task.description,
+      scope: loaded.scope,
       tags: loaded.task.tags ?? [],
       commitHash: loaded.task.commit?.hash ?? null,
     },

--- a/packages/agentplane/src/runtime/incidents/resolve.test.ts
+++ b/packages/agentplane/src/runtime/incidents/resolve.test.ts
@@ -40,7 +40,7 @@ describe("incidents runtime", () => {
     expect(registry.entries[0]?.sourceTask).toBe("202603091222-JWN7RB");
   });
 
-  it("plans promotion only for structured external incident candidates and dedupes existing entries", () => {
+  it("plans promotion from external findings and dedupes same-task reruns", () => {
     const registry = parseIncidentRegistry(
       [
         createIncidentRegistrySkeleton().trimEnd(),
@@ -98,19 +98,18 @@ describe("incidents runtime", () => {
     expect(plan.duplicates).toHaveLength(1);
     expect(plan.issues).toHaveLength(1);
     expect(plan.issues[0]?.missingFields).toEqual([
-      "IncidentExternal: true",
-      "IncidentRule",
-      "IncidentAdvice",
+      "Fixability: external or IncidentExternal: true",
     ]);
   });
 
-  it("appends new entries and resolves advice by tags and scope", () => {
+  it("auto-promotes first external findings as open incidents and resolves advice by tags and scope", () => {
     const base = createIncidentRegistrySkeleton();
     const plan = planIncidentCollection({
       task: {
         id: "TASK-2",
         title: "Release recovery",
         description: "Handle workflow_dispatch on release tags",
+        scope: "- In scope: Repair release publish workflow_dispatch recovery.",
         tags: ["release", "github-actions"],
         commitHash: "1234567890abcdef",
       },
@@ -118,19 +117,18 @@ describe("incidents runtime", () => {
         "- Observation: workflow_dispatch on release tags waited on exact-SHA push runs that never existed.",
         "  Impact: release recovery stalled.",
         "  Resolution: validate the exact release ref inside the workflow itself.",
-        "  Promotion: incident-candidate",
-        "  IncidentScope: release publish workflow_dispatch",
-        "  IncidentTags: release, github-actions",
-        "  IncidentMatch: publish, workflow_dispatch, release-tag",
-        "  IncidentAdvice: validate the exact release ref inside the publish workflow before rerunning release recovery",
-        "  IncidentRule: Release recovery MUST validate the exact ref inside the workflow.",
-        "  IncidentExternal: true",
+        "  Fixability: external",
       ].join("\n"),
       registry: parseIncidentRegistry(base),
       now: new Date("2026-04-03T10:00:00.000Z"),
     });
 
     expect(plan.promotable).toHaveLength(1);
+    expect(plan.promotable[0]?.entry.state).toBe("open");
+    expect(plan.promotable[0]?.entry.scope).toBe(
+      "Repair release publish workflow_dispatch recovery.",
+    );
+    expect(plan.promotable[0]?.entry.advice).toContain("validate the exact release ref");
     const updated = parseIncidentRegistry(
       appendIncidentRegistryEntries(
         base,
@@ -150,5 +148,69 @@ describe("incidents runtime", () => {
     expect(matches).toHaveLength(1);
     expect(matches[0]?.entry.sourceTask).toBe("TASK-2");
     expect(renderIncidentAdvice(matches)).toContain("validate the exact release ref");
+  });
+
+  it("stabilizes recurring incidents and dedupes advice output by signature", () => {
+    const base = parseIncidentRegistry(
+      [
+        createIncidentRegistrySkeleton().trimEnd(),
+        "",
+        "- id: INC-20260403-01",
+        "  date: 2026-04-03",
+        "  scope: release publish workflow_dispatch",
+        "  tags: release, github-actions",
+        "  match: publish, workflow_dispatch, release-tag",
+        "  failure: publish deadlocked on exact-SHA push waits",
+        "  advice: validate the exact release ref inside the publish workflow",
+        "  rule: Analogous release publish workflow_dispatch work MUST review and apply the recorded external incident advice before retrying.",
+        "  evidence: task TASK-2",
+        "  enforcement: manual",
+        "  source_task: TASK-2",
+        "  fixability: external",
+        "  state: open",
+        "",
+      ].join("\n"),
+    );
+
+    const plan = planIncidentCollection({
+      task: {
+        id: "TASK-4",
+        title: "Repeat release recovery",
+        description: "Repair workflow_dispatch on release tags again",
+        tags: ["release", "github-actions"],
+      },
+      findings: [
+        "- Observation: publish deadlocked on exact-SHA push waits",
+        "  Impact: release recovery stalled again.",
+        "  Resolution: validate the exact release ref inside the publish workflow",
+        "  IncidentScope: release publish workflow_dispatch",
+        "  IncidentRule: Analogous release publish workflow_dispatch work MUST review and apply the recorded external incident advice before retrying.",
+        "  Fixability: external",
+      ].join("\n"),
+      registry: base,
+      now: new Date("2026-04-10T10:00:00.000Z"),
+    });
+
+    expect(plan.promotable).toHaveLength(1);
+    expect(plan.promotable[0]?.entry.state).toBe("stabilized");
+    const updated = parseIncidentRegistry(
+      appendIncidentRegistryEntries(createIncidentRegistrySkeleton(), [
+        ...base.entries,
+        ...plan.promotable.map((item) => item.entry),
+      ]),
+    );
+    const matches = resolveIncidentAdviceMatches({
+      query: buildIncidentAdviceQueryFromTask({
+        taskId: "TASK-5",
+        title: "Release recovery keeps hanging",
+        description: "workflow_dispatch on release tag is hanging again",
+        tags: ["release", "github-actions"],
+      }),
+      registry: updated,
+    });
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.entry.sourceTask).toBe("TASK-4");
+    expect(matches[0]?.entry.state).toBe("stabilized");
   });
 });

--- a/packages/agentplane/src/runtime/incidents/resolve.ts
+++ b/packages/agentplane/src/runtime/incidents/resolve.ts
@@ -75,6 +75,14 @@ function parseBoolean(value: string | null | undefined): boolean {
   return normalized === "true" || normalized === "yes" || normalized === "y" || normalized === "1";
 }
 
+function parseFixability(value: string | null | undefined): "external" | null {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase() === "external"
+    ? "external"
+    : null;
+}
+
 function parseEntryState(value: string | null | undefined): IncidentRegistryEntryState {
   return value === "open" || value === "promoted" ? value : "stabilized";
 }
@@ -92,24 +100,103 @@ function appendFieldValue(
   record[key] = `${record[key]}${joiner}${value.trim()}`.trim();
 }
 
-function buildIncidentFingerprint(
-  entry: Pick<IncidentRegistryEntry, "sourceTask" | "scope" | "failure" | "rule">,
+function buildIncidentSignature(
+  entry: Pick<IncidentRegistryEntry, "scope" | "failure" | "rule">,
 ): string {
   return [
-    entry.sourceTask ?? "",
     normalizeSearchText(entry.scope),
     normalizeSearchText(entry.failure),
     normalizeSearchText(entry.rule),
   ].join("|");
 }
 
+function buildIncidentFingerprint(
+  entry: Pick<IncidentRegistryEntry, "sourceTask" | "scope" | "failure" | "rule">,
+): string {
+  return [entry.sourceTask ?? "", buildIncidentSignature(entry)].join("|");
+}
+
 function buildMatchTerms(opts: {
   scope: string;
   tags: readonly string[];
   explicitMatch: readonly string[];
+  extraText?: readonly string[];
 }): string[] {
   const scopeTokens = tokenize(opts.scope);
-  return dedupeCaseInsensitive([...opts.explicitMatch, ...opts.tags, ...scopeTokens]).slice(0, 12);
+  const extraTokens = (opts.extraText ?? []).flatMap((value) => tokenize(value));
+  return dedupeCaseInsensitive([
+    ...opts.explicitMatch,
+    ...opts.tags,
+    ...scopeTokens,
+    ...extraTokens,
+  ]).slice(0, 16);
+}
+
+function parseDateOnly(value: string): number | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const parsed = Date.parse(`${value}T00:00:00.000Z`);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function occursWithinDays(date: string, now: Date, days: number): boolean {
+  const timestamp = parseDateOnly(date);
+  if (timestamp === null) return false;
+  const delta = now.getTime() - timestamp;
+  if (delta < 0) return false;
+  return delta <= days * 24 * 60 * 60 * 1000;
+}
+
+function entryStateRank(state: IncidentRegistryEntryState): number {
+  if (state === "promoted") return 2;
+  if (state === "stabilized") return 1;
+  return 0;
+}
+
+function compareIncidentAdviceMatch(left: IncidentAdviceMatch, right: IncidentAdviceMatch): number {
+  if (right.score !== left.score) return right.score - left.score;
+  const rightState = entryStateRank(right.entry.state);
+  const leftState = entryStateRank(left.entry.state);
+  if (rightState !== leftState) return rightState - leftState;
+  return right.entry.date.localeCompare(left.entry.date);
+}
+
+function summarizeTaskScope(scope: string | null | undefined, title: string): string {
+  const lines = normalizeLines(scope ?? "");
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let candidate = trimmed.replace(/^-+\s*/, "");
+    candidate = candidate.replace(/^in scope:\s*/i, "").trim();
+    if (!candidate || /^out of scope:/i.test(candidate)) continue;
+    return candidate;
+  }
+  return title.trim();
+}
+
+function buildDerivedIncidentRule(scope: string): string {
+  return `Analogous ${scope} work MUST review and apply the recorded external incident advice before retrying.`;
+}
+
+function resolveIncidentState(opts: {
+  registry: IncidentRegistry;
+  entry: Pick<IncidentRegistryEntry, "scope" | "failure" | "rule">;
+  now: Date;
+}): IncidentRegistryEntryState {
+  const signature = buildIncidentSignature(opts.entry);
+  const similarEntries = opts.registry.entries.filter(
+    (candidate) => buildIncidentSignature(candidate) === signature,
+  );
+  if (
+    similarEntries.some(
+      (candidate) =>
+        candidate.state === "promoted" ||
+        candidate.state === "stabilized" ||
+        occursWithinDays(candidate.date, opts.now, 30),
+    )
+  ) {
+    return "stabilized";
+  }
+  return "open";
 }
 
 export function createIncidentRegistrySkeleton(): string {
@@ -122,7 +209,8 @@ export function createIncidentRegistrySkeleton(): string {
     "- Every entry MUST include: `id`, `date`, `scope`, `failure`, `rule`, `evidence`, `enforcement`, `state`.",
     "- New machine-matched entries SHOULD also include: `tags`, `match`, `advice`, `source_task`, `fixability`.",
     "- `rule` MUST be concrete and testable (`MUST` / `MUST NOT`).",
-    "- `fixability: external` means the issue cannot be removed by changing only repository code and should instead stay as reusable operational advice.",
+    "- `fixability: external` means the issue cannot be removed by changing only repository code and should stay as reusable operational advice.",
+    "- First auto-promoted external incidents normally enter as `open` and still participate in targeted advice lookup; recurring equivalent incidents can append later `stabilized` entries.",
     "- `state` values: `open`, `stabilized`, `promoted`.",
     "",
     "## Entry template",
@@ -272,8 +360,12 @@ export function extractIncidentCandidatesFromFindings(
 
   const flush = () => {
     if (!currentFields) return;
-    const promotion = currentFields.promotion?.trim() ?? "";
-    if (promotion.toLowerCase() !== "incident-candidate") {
+    const promotion = currentFields.promotion?.trim() || null;
+    const fixability = parseFixability(currentFields.fixability);
+    const incidentExternal =
+      parseBoolean(currentFields.incidentexternal) || fixability === "external";
+    const shouldPromote = promotion?.toLowerCase() === "incident-candidate" || incidentExternal;
+    if (!shouldPromote) {
       currentFields = null;
       currentKey = null;
       currentLine = 0;
@@ -296,7 +388,8 @@ export function extractIncidentCandidatesFromFindings(
       incidentAdvice: currentFields.incidentadvice?.trim() || null,
       incidentTags: parseCsvList(currentFields.incidenttags),
       incidentMatch: parseCsvList(currentFields.incidentmatch),
-      incidentExternal: parseBoolean(currentFields.incidentexternal),
+      incidentExternal,
+      fixability,
       line: currentLine,
       rawFields: { ...currentFields },
     });
@@ -369,10 +462,12 @@ function nextIncidentId(entries: readonly IncidentRegistryEntry[], now: Date): s
 
 function buildPromotionIssues(candidate: IncidentFindingCandidate): IncidentPromotionIssue | null {
   const missingFields: string[] = [];
-  if (!candidate.incidentExternal) missingFields.push("IncidentExternal: true");
-  if (!candidate.incidentScope) missingFields.push("IncidentScope");
-  if (!candidate.incidentRule) missingFields.push("IncidentRule");
-  if (!candidate.incidentAdvice) missingFields.push("IncidentAdvice");
+  if (!candidate.incidentExternal && candidate.fixability !== "external") {
+    missingFields.push("Fixability: external or IncidentExternal: true");
+  }
+  if (!candidate.incidentAdvice && !candidate.resolution) {
+    missingFields.push("Resolution or IncidentAdvice");
+  }
   return missingFields.length > 0 ? { candidate, missingFields } : null;
 }
 
@@ -380,30 +475,45 @@ function buildIncidentRegistryEntry(opts: {
   task: IncidentPromotionTaskContext;
   candidate: IncidentFindingCandidate;
   now: Date;
-  existingEntries: readonly IncidentRegistryEntry[];
+  registry: IncidentRegistry;
 }): IncidentRegistryEntry {
   const date = opts.now.toISOString().slice(0, 10);
+  const scope =
+    opts.candidate.incidentScope ?? summarizeTaskScope(opts.task.scope, opts.task.title);
   const tags = dedupeCaseInsensitive([
     ...opts.candidate.incidentTags,
     ...opts.task.tags.map((tag) => tag.trim()),
   ]);
+  const advice =
+    opts.candidate.incidentAdvice ?? opts.candidate.resolution ?? opts.candidate.observation;
+  const rule = opts.candidate.incidentRule ?? buildDerivedIncidentRule(scope);
+  const state = resolveIncidentState({
+    registry: opts.registry,
+    entry: {
+      scope,
+      failure: opts.candidate.observation,
+      rule,
+    },
+    now: opts.now,
+  });
   const match = buildMatchTerms({
-    scope: opts.candidate.incidentScope ?? opts.task.title,
+    scope,
     tags,
     explicitMatch: opts.candidate.incidentMatch,
+    extraText: [opts.task.title, opts.task.description, advice],
   });
   return {
-    id: nextIncidentId(opts.existingEntries, opts.now),
+    id: nextIncidentId(opts.registry.entries, opts.now),
     date,
-    scope: opts.candidate.incidentScope ?? opts.task.title,
+    scope,
     failure: opts.candidate.observation,
-    rule: opts.candidate.incidentRule ?? "",
+    rule,
     evidence: `task ${opts.task.id}${opts.task.commitHash ? `; commit ${opts.task.commitHash.slice(0, 12)}` : ""}`,
     enforcement: "manual",
-    state: "stabilized",
+    state,
     tags,
     match,
-    advice: opts.candidate.incidentAdvice,
+    advice,
     sourceTask: opts.task.id,
     fixability: "external",
     rawFields: {},
@@ -436,7 +546,12 @@ export function planIncidentCollection(opts: {
       task: opts.task,
       candidate,
       now,
-      existingEntries: [...opts.registry.entries, ...promotable.map((item) => item.entry)],
+      registry: parseIncidentRegistry(
+        appendIncidentRegistryEntries(createIncidentRegistrySkeleton(), [
+          ...opts.registry.entries,
+          ...promotable.map((item) => item.entry),
+        ]),
+      ),
     });
     const fingerprint = buildIncidentFingerprint(entry);
     const draft: IncidentPromotionDraft = { candidate, entry, fingerprint };
@@ -477,10 +592,9 @@ export function resolveIncidentAdviceMatches(opts: {
   const haystack = [opts.query.title, opts.query.description, opts.query.scope ?? ""].join(" ");
   const normalizedHaystack = normalizeSearchText(haystack);
   const queryTokens = new Set([...tokenize(haystack), ...tagSet]);
-  const matches: IncidentAdviceMatch[] = [];
+  const matchesBySignature = new Map<string, IncidentAdviceMatch>();
 
   for (const entry of opts.registry.entries) {
-    if (entry.state === "open") continue;
     const matchedTags = entry.tags.filter((tag) => tagSet.has(tag.trim().toLowerCase()));
     const matchedTerms = entry.match.filter(
       (term) =>
@@ -491,12 +605,17 @@ export function resolveIncidentAdviceMatches(opts: {
     const scopeMatched = normalizedScope.length > 0 && normalizedHaystack.includes(normalizedScope);
     const score = matchedTags.length * 5 + matchedTerms.length * 2 + (scopeMatched ? 3 : 0);
     if (score <= 0) continue;
-    matches.push({ entry, score, matchedTags, matchedTerms, scopeMatched });
+    const match: IncidentAdviceMatch = { entry, score, matchedTags, matchedTerms, scopeMatched };
+    const signature = buildIncidentSignature(entry);
+    const existing = matchesBySignature.get(signature);
+    if (!existing || compareIncidentAdviceMatch(match, existing) < 0) {
+      matchesBySignature.set(signature, match);
+    }
   }
 
+  const matches = [...matchesBySignature.values()];
   matches.sort((left, right) => {
-    if (right.score !== left.score) return right.score - left.score;
-    return right.entry.date.localeCompare(left.entry.date);
+    return compareIncidentAdviceMatch(left, right);
   });
   return matches.slice(0, limit);
 }

--- a/packages/agentplane/src/runtime/incidents/types.ts
+++ b/packages/agentplane/src/runtime/incidents/types.ts
@@ -26,13 +26,14 @@ export type IncidentFindingCandidate = {
   observation: string;
   impact: string | null;
   resolution: string | null;
-  promotion: string;
+  promotion: string | null;
   incidentScope: string | null;
   incidentRule: string | null;
   incidentAdvice: string | null;
   incidentTags: string[];
   incidentMatch: string[];
   incidentExternal: boolean;
+  fixability: "external" | null;
   line: number;
   rawFields: Record<string, string>;
 };
@@ -41,6 +42,7 @@ export type IncidentPromotionTaskContext = {
   id: string;
   title: string;
   description: string;
+  scope?: string | null;
   tags: string[];
   commitHash?: string | null;
 };


### PR DESCRIPTION
## Summary

Auto-promote reusable external incidents from task findings

Make finish/task workflows infer reusable external incident advice from resolved Findings blocks, keep incident states honest, and align advice lookup with scope/tag recurrence semantics.

## Scope

- In scope: Make finish/task workflows infer reusable external incident advice from resolved Findings blocks, keep incident states honest, and align advice lookup with scope/tag recurrence semantics.
- Out of scope: unrelated refactors not required for "Auto-promote reusable external incidents from task findings".

## Verification

### Plan

1. Run focused incidents runtime and CLI/task workflow tests covering auto-promotion, recurrence state, and advice lookup. Expected: new external findings promote deterministically and analogous tasks receive the expected advice.
2. Run docs/policy routing validation for the updated incidents contract. Expected: routing and policy invariants remain valid after the contract changes.
3. Build the agentplane package. Expected: the CLI/runtime compiles cleanly with no new type or bundling errors.

### Current Status

- State: ok
- Note: Verified: incidents promotion now accepts resolved external Findings marked with Fixability: external or IncidentExternal: true, first occurrences stay open but still surface through advice lookup, recurring equivalents stabilize on later entries, and the shipped policy/docs/help text matches that contract. Commands: bunx vitest run packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/cli/run-cli.core.tasks.test.ts --hookTimeout 60000 --testTimeout 60000; bunx vitest run packages/agentplane/src/cli/run-cli.core.help-snap.test.ts packages/agentplane/src/cli/command-guide.test.ts -u --hookTimeout 60000 --testTimeout 60000; bun run --filter=agentplane build; bun run docs:bootstrap:generate; node packages/agentplane/dist/cli.js docs cli --out docs/user/cli-reference.generated.mdx; node .agentplane/policy/check-routing.mjs; agentplane doctor; bun run docs:bootstrap:check; bun run docs:cli:check; bun run docs:onboarding:check.

## Risks

- Risk level: not recorded
- Breaking change: no

### Rollback

- Revert task-related commit(s).
- Re-run required checks to confirm rollback safety.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-04-03T16:42:32.226Z
- Branch: task/202604031627-DA1JVW/incidents-auto-promotion
- Head: 24fe2c746f45

```text
 .agentplane/policy/governance.md                   |   7 +-
 .agentplane/policy/incidents.md                    |   1 +
 .agentplane/policy/workflow.branch_pr.md           |   2 +-
 .agentplane/policy/workflow.direct.md              |   4 +-
 .agentplane/tasks/202604031627-DA1JVW/README.md    | 118 ++++++++++++++
 .../tasks/202604031627-DA1JVW/pr/diffstat.txt      |  26 ++++
 .../tasks/202604031627-DA1JVW/pr/github-body.md    |  75 +++++++++
 .../tasks/202604031627-DA1JVW/pr/github-title.txt  |   1 +
 .agentplane/tasks/202604031627-DA1JVW/pr/meta.json |  14 ++
 .../tasks/202604031627-DA1JVW/pr/notes.jsonl       |   0
 .agentplane/tasks/202604031627-DA1JVW/pr/review.md |  82 ++++++++++
 .../tasks/202604031627-DA1JVW/pr/verify.log        |   0
 docs/user/agent-bootstrap.generated.mdx            |   4 +-
 docs/user/agents.mdx                               |   2 +-
 docs/user/cli-reference.generated.mdx              |   6 +-
 packages/agentplane/assets/policy/governance.md    |   7 +-
 packages/agentplane/assets/policy/incidents.md     |   1 +
 .../agentplane/assets/policy/workflow.branch_pr.md |   2 +-
 .../agentplane/assets/policy/workflow.direct.md    |   4 +-
 .../run-cli.core.help-snap.test.ts.snap            |   2 +-
 packages/agentplane/src/cli/bootstrap-guide.ts     |   4 +-
 .../src/cli/run-cli.core.incidents.test.ts         |  14 +-
 .../agentplane/src/cli/run-cli.core.tasks.test.ts  |  15 +-
 .../src/commands/incidents/collect.command.ts      |   5 +-
 .../src/commands/incidents/incidents.command.ts    |   2 +-
 .../agentplane/src/commands/incidents/shared.ts    |   3 +-
 .../src/runtime/incidents/resolve.test.ts          |  86 +++++++++--
 .../agentplane/src/runtime/incidents/resolve.ts    | 169 ++++++++++++++++++---
 packages/agentplane/src/runtime/incidents/types.ts |   4 +-
 29 files changed, 576 insertions(+), 84 deletions(-)
```

</details>
