### PR TITLE
close: record canonical P771ZK task closure

### DIFF
--- a/.agentplane/tasks/202604011037-P771ZK/README.md
+++ b/.agentplane/tasks/202604011037-P771ZK/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202604011037-P771ZK"
 title: "Fix v0.3.8 release-prepublish blockers"
-status: "DOING"
+result_summary: "Shipped the v0.3.8 release-prepublish blocker fixes on main and backfilled canonical task closure."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 5
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -21,11 +22,16 @@ verification:
   updated_at: "2026-04-02T15:08:34.974Z"
   updated_by: "CODER"
   note: "Command: bun run build && bunx vitest run packages/agentplane/src/cli/stale-dist-policy.test.ts packages/agentplane/src/cli/stale-dist-readonly.test.ts packages/agentplane/src/cli/measure-cli-cold-path-script.test.ts --reporter=verbose. Result: pass. Evidence: build passed; 3 files, 12 tests green; preflight stale-dist regression covered. Scope: release-prepublish blocker around preflight cold-path behavior."
-commit: null
+commit:
+  hash: "1baffa489e2d4f01c27e06e05f05a0586a51115c"
+  message: "🩹 P771ZK task: allow preflight in stale dist diagnostics (#64)"
 comments:
   -
     author: "CODER"
     body: "Start: reproduce the failing release gates, fix the regressions blocking v0.3.8, rerun prepublish, and only then continue with publication."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: the release-prepublish blocker fixes were shipped on main across the P771ZK fix series through commit 1baffa48, and this close records the canonical task state after the audit."
 events:
   -
     type: "status"
@@ -40,9 +46,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Command: bun run build && bunx vitest run packages/agentplane/src/cli/stale-dist-policy.test.ts packages/agentplane/src/cli/stale-dist-readonly.test.ts packages/agentplane/src/cli/measure-cli-cold-path-script.test.ts --reporter=verbose. Result: pass. Evidence: build passed; 3 files, 12 tests green; preflight stale-dist regression covered. Scope: release-prepublish blocker around preflight cold-path behavior."
+  -
+    type: "status"
+    at: "2026-04-05T07:18:58.386Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: the release-prepublish blocker fixes were shipped on main across the P771ZK fix series through commit 1baffa48, and this close records the canonical task state after the audit."
 doc_version: 3
-doc_updated_at: "2026-04-02T15:08:34.978Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-04-05T07:18:58.389Z"
+doc_updated_by: "INTEGRATOR"
 description: "Investigate and fix the failing release-prepublish tests and runtime regressions blocking the v0.3.8 patch release, then re-run release gates and publish."
 sections:
   Summary: |-
@@ -53,12 +66,7 @@ sections:
     - In scope: Investigate and fix the failing release-prepublish tests and runtime regressions blocking the v0.3.8 patch release, then re-run release gates and publish.
     - Out of scope: unrelated refactors not required for "Fix v0.3.8 release-prepublish blockers".
   Plan: "1. Reproduce the current release-prepublish blockers with focused failing tests. 2. Fix the regressions in the smallest safe set of code changes while keeping the release notes and release target at v0.3.8. 3. Re-run targeted suites, then rerun release:prepublish, and only if green continue with release apply --push and post-publish verification."
-  Verify Steps: |-
-    <!-- TODO: REPLACE WITH TASK-SPECIFIC ACCEPTANCE STEPS -->
-    
-    1. <Action>. Expected: <observable result>.
-    2. <Action>. Expected: <observable result>.
-    3. <Action>. Expected: <observable result>.
+  Verify Steps: "1. Run bunx vitest run packages/agentplane/src/cli/stale-dist-policy.test.ts packages/agentplane/src/cli/stale-dist-readonly.test.ts packages/agentplane/src/cli/measure-cli-cold-path-script.test.ts --reporter=verbose. Expected: the targeted release-prepublish stale-dist and cold-path contracts pass. 2. Run bun run build. Expected: the workspace build succeeds after the release-prepublish blocker fixes. 3. Inspect main after the fix series. Expected: the blocker-fix commits are present on main and the later replacement patch release path proceeds without the original prepublish failure shape."
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
     ### 2026-04-02T15:08:34.974Z — VERIFY — ok
@@ -93,11 +101,7 @@ Investigate and fix the failing release-prepublish tests and runtime regressions
 
 ## Verify Steps
 
-<!-- TODO: REPLACE WITH TASK-SPECIFIC ACCEPTANCE STEPS -->
-
-1. <Action>. Expected: <observable result>.
-2. <Action>. Expected: <observable result>.
-3. <Action>. Expected: <observable result>.
+1. Run bunx vitest run packages/agentplane/src/cli/stale-dist-policy.test.ts packages/agentplane/src/cli/stale-dist-readonly.test.ts packages/agentplane/src/cli/measure-cli-cold-path-script.test.ts --reporter=verbose. Expected: the targeted release-prepublish stale-dist and cold-path contracts pass. 2. Run bun run build. Expected: the workspace build succeeds after the release-prepublish blocker fixes. 3. Inspect main after the fix series. Expected: the blocker-fix commits are present on main and the later replacement patch release path proceeds without the original prepublish failure shape.
 
 ## Verification
 


### PR DESCRIPTION
## Summary
- publish the deterministic P771ZK close commit that already exists locally on main
- align GitHub/base history with the local DONE state for task 202604011037-P771ZK
- remove the remaining ahead-by-1 drift on local main once this PR merges and main is pulled

## Verification
- task 202604011037-P771ZK is already DONE locally with verified implementation commit 
- close commit only updates 