### PR TITLE
close: apply hosted closure for XYXG7Y

### DIFF
--- a/.agentplane/tasks/202604062101-XYXG7Y/README.md
+++ b/.agentplane/tasks/202604062101-XYXG7Y/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202604062101-XYXG7Y"
 title: "Retry hosted merge sync gh fallback on transient transport errors"
-status: "TODO"
+result_summary: "integrate: squash task/202604062101-XYXG7Y/hosted-merge-retry"
+status: "DONE"
 priority: "med"
 owner: "CODER"
-revision: 10
+revision: 11
 origin:
   system: "manual"
 depends_on: []
@@ -22,8 +23,13 @@ verification:
   updated_at: "2026-04-06T21:33:07.730Z"
   updated_by: "CODER"
   note: "Focused vitest, eslint, and prettier check passed on the committed CI parity fix for hosted-merge-sync.test.ts; scope: XYXG7Y hosted merge sync retry path."
-commit: null
-comments: []
+commit:
+  hash: "4dbb69711f7a7c7bdcf2f1d9446c1cd8cfcc2c47"
+  message: "📝 XYXG7Y task: refresh PR artifacts after CI parity fix"
+comments:
+  -
+    author: "INTEGRATOR"
+    body: "Verified: Integrated via squash; verify=skipped(no commands); pr=.agentplane/tasks/202604062101-XYXG7Y/pr."
 events:
   -
     type: "verify"
@@ -43,9 +49,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Focused vitest, eslint, and prettier check passed on the committed CI parity fix for hosted-merge-sync.test.ts; scope: XYXG7Y hosted merge sync retry path."
+  -
+    type: "status"
+    at: "2026-04-06T21:46:49.800Z"
+    author: "INTEGRATOR"
+    from: "TODO"
+    to: "DONE"
+    note: "Verified: Integrated via squash; verify=skipped(no commands); pr=.agentplane/tasks/202604062101-XYXG7Y/pr."
 doc_version: 3
-doc_updated_at: "2026-04-06T21:33:07.751Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-04-06T21:46:49.807Z"
+doc_updated_by: "INTEGRATOR"
 description: "Harden the gh-based hosted merge sync fallback by retrying transient EOF/TLS failures so reconcile paths survive flaky GitHub transport without manual loops."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202604062101-XYXG7Y/pr/diffstat.txt
+++ b/.agentplane/tasks/202604062101-XYXG7Y/pr/diffstat.txt
@@ -1,11 +1,11 @@
- .agentplane/tasks/202604062101-XYXG7Y/README.md    | 152 +++++++++++++++++++++
+ .agentplane/tasks/202604062101-XYXG7Y/README.md    | 174 +++++++++++++++++++++
  .../tasks/202604062101-XYXG7Y/pr/diffstat.txt      |  11 ++
- .../tasks/202604062101-XYXG7Y/pr/github-body.md    |  60 ++++++++
+ .../tasks/202604062101-XYXG7Y/pr/github-body.md    |  60 +++++++
  .../tasks/202604062101-XYXG7Y/pr/github-title.txt  |   1 +
  .agentplane/tasks/202604062101-XYXG7Y/pr/meta.json |  14 ++
  .../tasks/202604062101-XYXG7Y/pr/notes.jsonl       |   0
- .agentplane/tasks/202604062101-XYXG7Y/pr/review.md |  67 +++++++++
+ .agentplane/tasks/202604062101-XYXG7Y/pr/review.md |  67 ++++++++
  .../tasks/202604062101-XYXG7Y/pr/verify.log        |   0
- .../src/commands/task/hosted-merge-sync.test.ts    |  64 ++++++++-
- .../src/commands/task/hosted-merge-sync.ts         | 111 ++++++++++++---
- 10 files changed, 458 insertions(+), 22 deletions(-)
+ .../src/commands/task/hosted-merge-sync.test.ts    |  64 +++++++-
+ .../src/commands/task/hosted-merge-sync.ts         | 111 ++++++++++---
+ 10 files changed, 480 insertions(+), 22 deletions(-)

--- a/.agentplane/tasks/202604062101-XYXG7Y/pr/meta.json
+++ b/.agentplane/tasks/202604062101-XYXG7Y/pr/meta.json
@@ -2,12 +2,16 @@
   "base": "main",
   "branch": "task/202604062101-XYXG7Y/hosted-merge-retry",
   "created_at": "2026-04-06T21:06:56.760Z",
-  "head_sha": "116e33f8484b8ba0d4fde618b212724474d064eb",
+  "head_sha": "e1163c1ee6b44eb0ee9bf8eabd5cf67da1c94981",
   "last_verified_at": "2026-04-06T21:33:07.730Z",
   "last_verified_sha": "116e33f8484b8ba0d4fde618b212724474d064eb",
+  "merge_commit": "4dbb69711f7a7c7bdcf2f1d9446c1cd8cfcc2c47",
+  "merge_strategy": "squash",
+  "merged_at": "2026-04-06T21:46:49.752Z",
   "schema_version": 1,
+  "status": "MERGED",
   "task_id": "202604062101-XYXG7Y",
-  "updated_at": "2026-04-06T21:33:07.801Z",
+  "updated_at": "2026-04-06T21:46:49.752Z",
   "verify": {
     "status": "pass"
   }


### PR DESCRIPTION
Apply the hosted closure update for task 202604062101-XYXG7Y after PR #91 merged. This PR carries the task README and pr/* state that hosted-close could not publish because the merge object was absent in the runner checkout.