### PR TITLE
workflow: Expose skipped incident findings in lifecycle diagnostics (ZBNXE7)

### DIFF
--- a/.agentplane/tasks/202604062309-ZBNXE7/README.md
+++ b/.agentplane/tasks/202604062309-ZBNXE7/README.md
@@ -1,0 +1,107 @@
+---
+id: "202604062309-ZBNXE7"
+title: "Expose skipped incident findings in lifecycle diagnostics"
+status: "TODO"
+priority: "high"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "workflow"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-04-06T23:10:41.193Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-04-06T23:18:14.227Z"
+  updated_by: "CODER"
+  note: "Focused incidents diagnostics coverage passed after worktree bootstrap: bun x vitest run packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts; bun x eslint packages/agentplane/src/runtime/incidents/types.ts packages/agentplane/src/runtime/incidents/index.ts packages/agentplane/src/runtime/incidents/resolve.ts packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/commands/incidents/shared.ts packages/agentplane/src/commands/incidents/collect.command.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts packages/agentplane/src/commands/task/hosted-close.command.ts. Result: pass. Evidence: empty incident findings now differ from skipped structured findings, and lifecycle diagnostics surface the distinction without changing promotion semantics."
+commit: null
+comments: []
+events:
+  -
+    type: "verify"
+    at: "2026-04-06T23:18:14.227Z"
+    author: "CODER"
+    state: "ok"
+    note: "Focused incidents diagnostics coverage passed after worktree bootstrap: bun x vitest run packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts; bun x eslint packages/agentplane/src/runtime/incidents/types.ts packages/agentplane/src/runtime/incidents/index.ts packages/agentplane/src/runtime/incidents/resolve.ts packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/commands/incidents/shared.ts packages/agentplane/src/commands/incidents/collect.command.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts packages/agentplane/src/commands/task/hosted-close.command.ts. Result: pass. Evidence: empty incident findings now differ from skipped structured findings, and lifecycle diagnostics surface the distinction without changing promotion semantics."
+doc_version: 3
+doc_updated_at: "2026-04-06T23:18:14.231Z"
+doc_updated_by: "CODER"
+description: "Differentiate no external incidents from structured findings that were parsed but not promotable, and surface that distinction in incidents collection and lifecycle output."
+sections:
+  Summary: |-
+    Expose skipped incident findings in lifecycle diagnostics
+    
+    Differentiate no external incidents from structured findings that were parsed but not promotable, and surface that distinction in incidents collection and lifecycle output.
+  Scope: |-
+    - In scope: Differentiate no external incidents from structured findings that were parsed but not promotable, and surface that distinction in incidents collection and lifecycle output.
+    - Out of scope: unrelated refactors not required for "Expose skipped incident findings in lifecycle diagnostics".
+  Plan: "1. Extend incident collection planning so structured findings that were parsed but not promotable are reported explicitly instead of collapsing into the same no-op message as truly empty external findings. 2. Thread the richer incident outcome through incidents collect and lifecycle output without mutating the registry semantics. 3. Add focused runtime/CLI regressions for skipped-candidate diagnostics and verify the updated messages."
+  Verify Steps: |-
+    1. Run focused incidents runtime and CLI tests covering parsed-but-not-promotable findings. Expected: the plan distinguishes empty findings from skipped candidates and the new output is asserted.
+    2. Run eslint on the touched incidents and lifecycle command files. Expected: no lint errors in touched scope.
+    3. Review lifecycle output for the new diagnostics path. Expected: commands explicitly report skipped structured findings instead of collapsing everything into the same no-op message.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-04-06T23:18:14.227Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Focused incidents diagnostics coverage passed after worktree bootstrap: bun x vitest run packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts; bun x eslint packages/agentplane/src/runtime/incidents/types.ts packages/agentplane/src/runtime/incidents/index.ts packages/agentplane/src/runtime/incidents/resolve.ts packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/commands/incidents/shared.ts packages/agentplane/src/commands/incidents/collect.command.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts packages/agentplane/src/commands/task/hosted-close.command.ts. Result: pass. Evidence: empty incident findings now differ from skipped structured findings, and lifecycle diagnostics surface the distinction without changing promotion semantics.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-06T23:09:41.336Z, excerpt_hash=sha256:c3e786a01fa1fa01aa669e808ea335c4ba4e8b84cf1bdfbd5f0f56fb3b4c56cb
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Expose skipped incident findings in lifecycle diagnostics
+
+Differentiate no external incidents from structured findings that were parsed but not promotable, and surface that distinction in incidents collection and lifecycle output.
+
+## Scope
+
+- In scope: Differentiate no external incidents from structured findings that were parsed but not promotable, and surface that distinction in incidents collection and lifecycle output.
+- Out of scope: unrelated refactors not required for "Expose skipped incident findings in lifecycle diagnostics".
+
+## Plan
+
+1. Extend incident collection planning so structured findings that were parsed but not promotable are reported explicitly instead of collapsing into the same no-op message as truly empty external findings. 2. Thread the richer incident outcome through incidents collect and lifecycle output without mutating the registry semantics. 3. Add focused runtime/CLI regressions for skipped-candidate diagnostics and verify the updated messages.
+
+## Verify Steps
+
+1. Run focused incidents runtime and CLI tests covering parsed-but-not-promotable findings. Expected: the plan distinguishes empty findings from skipped candidates and the new output is asserted.
+2. Run eslint on the touched incidents and lifecycle command files. Expected: no lint errors in touched scope.
+3. Review lifecycle output for the new diagnostics path. Expected: commands explicitly report skipped structured findings instead of collapsing everything into the same no-op message.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-04-06T23:18:14.227Z — VERIFY — ok
+
+By: CODER
+
+Note: Focused incidents diagnostics coverage passed after worktree bootstrap: bun x vitest run packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts; bun x eslint packages/agentplane/src/runtime/incidents/types.ts packages/agentplane/src/runtime/incidents/index.ts packages/agentplane/src/runtime/incidents/resolve.ts packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/commands/incidents/shared.ts packages/agentplane/src/commands/incidents/collect.command.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts packages/agentplane/src/commands/task/hosted-close.command.ts. Result: pass. Evidence: empty incident findings now differ from skipped structured findings, and lifecycle diagnostics surface the distinction without changing promotion semantics.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-06T23:09:41.336Z, excerpt_hash=sha256:c3e786a01fa1fa01aa669e808ea335c4ba4e8b84cf1bdfbd5f0f56fb3b4c56cb
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202604062309-ZBNXE7/pr/diffstat.txt
+++ b/.agentplane/tasks/202604062309-ZBNXE7/pr/diffstat.txt
@@ -1,0 +1,21 @@
+ .agentplane/tasks/202604062309-ZBNXE7/README.md    | 107 +++++++++++++++++++++
+ .../tasks/202604062309-ZBNXE7/pr/diffstat.txt      |   0
+ .../tasks/202604062309-ZBNXE7/pr/github-body.md    |  50 ++++++++++
+ .../tasks/202604062309-ZBNXE7/pr/github-title.txt  |   1 +
+ .agentplane/tasks/202604062309-ZBNXE7/pr/meta.json |  14 +++
+ .../tasks/202604062309-ZBNXE7/pr/notes.jsonl       |   0
+ .agentplane/tasks/202604062309-ZBNXE7/pr/review.md |  57 +++++++++++
+ .../tasks/202604062309-ZBNXE7/pr/verify.log        |   0
+ .../src/cli/run-cli.core.incidents.test.ts         |  95 ++++++++++++++++++
+ .../src/commands/incidents/collect.command.ts      |   6 +-
+ .../agentplane/src/commands/incidents/shared.ts    |  36 +++++++
+ .../pr/integrate/internal/finalize.test.ts         |  32 +++++-
+ .../src/commands/pr/integrate/internal/finalize.ts |   4 +-
+ packages/agentplane/src/commands/task/finish.ts    |  18 +++-
+ .../src/commands/task/finish.unit.test.ts          |  72 +++++++++++++-
+ .../src/commands/task/hosted-close.command.ts      |   4 +-
+ packages/agentplane/src/runtime/incidents/index.ts |   1 +
+ .../src/runtime/incidents/resolve.test.ts          |  28 ++++++
+ .../agentplane/src/runtime/incidents/resolve.ts    |  33 +++++--
+ packages/agentplane/src/runtime/incidents/types.ts |   8 ++
+ 20 files changed, 545 insertions(+), 21 deletions(-)

--- a/.agentplane/tasks/202604062309-ZBNXE7/pr/diffstat.txt
+++ b/.agentplane/tasks/202604062309-ZBNXE7/pr/diffstat.txt
@@ -1,21 +1,21 @@
  .agentplane/tasks/202604062309-ZBNXE7/README.md    | 107 +++++++++++++++++++++
- .../tasks/202604062309-ZBNXE7/pr/diffstat.txt      |   0
- .../tasks/202604062309-ZBNXE7/pr/github-body.md    |  50 ++++++++++
+ .../tasks/202604062309-ZBNXE7/pr/diffstat.txt      |  21 ++++
+ .../tasks/202604062309-ZBNXE7/pr/github-body.md    |  70 ++++++++++++++
  .../tasks/202604062309-ZBNXE7/pr/github-title.txt  |   1 +
  .agentplane/tasks/202604062309-ZBNXE7/pr/meta.json |  14 +++
  .../tasks/202604062309-ZBNXE7/pr/notes.jsonl       |   0
- .agentplane/tasks/202604062309-ZBNXE7/pr/review.md |  57 +++++++++++
+ .agentplane/tasks/202604062309-ZBNXE7/pr/review.md |  77 +++++++++++++++
  .../tasks/202604062309-ZBNXE7/pr/verify.log        |   0
  .../src/cli/run-cli.core.incidents.test.ts         |  95 ++++++++++++++++++
  .../src/commands/incidents/collect.command.ts      |   6 +-
  .../agentplane/src/commands/incidents/shared.ts    |  36 +++++++
- .../pr/integrate/internal/finalize.test.ts         |  32 +++++-
+ .../pr/integrate/internal/finalize.test.ts         |  39 +++++++-
  .../src/commands/pr/integrate/internal/finalize.ts |   4 +-
- packages/agentplane/src/commands/task/finish.ts    |  18 +++-
+ packages/agentplane/src/commands/task/finish.ts    |  15 ++-
  .../src/commands/task/finish.unit.test.ts          |  72 +++++++++++++-
  .../src/commands/task/hosted-close.command.ts      |   4 +-
  packages/agentplane/src/runtime/incidents/index.ts |   1 +
  .../src/runtime/incidents/resolve.test.ts          |  28 ++++++
  .../agentplane/src/runtime/incidents/resolve.ts    |  33 +++++--
  packages/agentplane/src/runtime/incidents/types.ts |   8 ++
- 20 files changed, 545 insertions(+), 21 deletions(-)
+ 20 files changed, 610 insertions(+), 21 deletions(-)

--- a/.agentplane/tasks/202604062309-ZBNXE7/pr/github-body.md
+++ b/.agentplane/tasks/202604062309-ZBNXE7/pr/github-body.md
@@ -1,0 +1,50 @@
+## Summary
+
+Expose skipped incident findings in lifecycle diagnostics
+
+Differentiate no external incidents from structured findings that were parsed but not promotable, and surface that distinction in incidents collection and lifecycle output.
+
+## Scope
+
+- In scope: Differentiate no external incidents from structured findings that were parsed but not promotable, and surface that distinction in incidents collection and lifecycle output.
+- Out of scope: unrelated refactors not required for "Expose skipped incident findings in lifecycle diagnostics".
+
+## Verification
+
+### Plan
+
+1. Run focused incidents runtime and CLI tests covering parsed-but-not-promotable findings. Expected: the plan distinguishes empty findings from skipped candidates and the new output is asserted.
+2. Run eslint on the touched incidents and lifecycle command files. Expected: no lint errors in touched scope.
+3. Review lifecycle output for the new diagnostics path. Expected: commands explicitly report skipped structured findings instead of collapsing everything into the same no-op message.
+
+### Current Status
+
+- State: ok
+- Note: Focused incidents diagnostics coverage passed after worktree bootstrap: bun x vitest run packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts; bun x eslint packages/agentplane/src/runtime/incidents/types.ts packages/agentplane/src/runtime/incidents/index.ts packages/agentplane/src/runtime/incidents/resolve.ts packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/commands/incidents/shared.ts packages/agentplane/src/commands/incidents/collect.command.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts packages/agentplane/src/commands/task/hosted-close.command.ts. Result: pass. Evidence: empty incident findings now differ from skipped structured findings, and lifecycle diagnostics surface the distinction without changing promotion semantics.
+
+## Risks
+
+- Risk level: not recorded
+- Breaking change: no
+
+### Rollback
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-04-06T23:18:14.266Z
+- Branch: task/202604062309-ZBNXE7/incident-diagnostics
+- Head: 61ce80966f00
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202604062309-ZBNXE7/pr/github-body.md
+++ b/.agentplane/tasks/202604062309-ZBNXE7/pr/github-body.md
@@ -39,12 +39,32 @@ Differentiate no external incidents from structured findings that were parsed bu
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-06T23:18:53.185Z
+- Updated: 2026-04-06T23:21:15.275Z
 - Branch: task/202604062309-ZBNXE7/incident-diagnostics
-- Head: 232cf6eb02de
+- Head: 6ffddaf9f606
 
 ```text
-No changes detected.
+ .agentplane/tasks/202604062309-ZBNXE7/README.md    | 107 +++++++++++++++++++++
+ .../tasks/202604062309-ZBNXE7/pr/diffstat.txt      |   0
+ .../tasks/202604062309-ZBNXE7/pr/github-body.md    |  50 ++++++++++
+ .../tasks/202604062309-ZBNXE7/pr/github-title.txt  |   1 +
+ .agentplane/tasks/202604062309-ZBNXE7/pr/meta.json |  14 +++
+ .../tasks/202604062309-ZBNXE7/pr/notes.jsonl       |   0
+ .agentplane/tasks/202604062309-ZBNXE7/pr/review.md |  57 +++++++++++
+ .../tasks/202604062309-ZBNXE7/pr/verify.log        |   0
+ .../src/cli/run-cli.core.incidents.test.ts         |  95 ++++++++++++++++++
+ .../src/commands/incidents/collect.command.ts      |   6 +-
+ .../agentplane/src/commands/incidents/shared.ts    |  36 +++++++
+ .../pr/integrate/internal/finalize.test.ts         |  32 +++++-
+ .../src/commands/pr/integrate/internal/finalize.ts |   4 +-
+ packages/agentplane/src/commands/task/finish.ts    |  18 +++-
+ .../src/commands/task/finish.unit.test.ts          |  72 +++++++++++++-
+ .../src/commands/task/hosted-close.command.ts      |   4 +-
+ packages/agentplane/src/runtime/incidents/index.ts |   1 +
+ .../src/runtime/incidents/resolve.test.ts          |  28 ++++++
+ .../agentplane/src/runtime/incidents/resolve.ts    |  33 +++++--
+ packages/agentplane/src/runtime/incidents/types.ts |   8 ++
+ 20 files changed, 545 insertions(+), 21 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202604062309-ZBNXE7/pr/github-body.md
+++ b/.agentplane/tasks/202604062309-ZBNXE7/pr/github-body.md
@@ -39,9 +39,9 @@ Differentiate no external incidents from structured findings that were parsed bu
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-06T23:18:14.266Z
+- Updated: 2026-04-06T23:18:53.185Z
 - Branch: task/202604062309-ZBNXE7/incident-diagnostics
-- Head: 61ce80966f00
+- Head: 232cf6eb02de
 
 ```text
 No changes detected.

--- a/.agentplane/tasks/202604062309-ZBNXE7/pr/github-body.md
+++ b/.agentplane/tasks/202604062309-ZBNXE7/pr/github-body.md
@@ -39,32 +39,32 @@ Differentiate no external incidents from structured findings that were parsed bu
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-06T23:21:15.275Z
+- Updated: 2026-04-06T23:34:48.083Z
 - Branch: task/202604062309-ZBNXE7/incident-diagnostics
-- Head: 6ffddaf9f606
+- Head: 93d486f40a42
 
 ```text
  .agentplane/tasks/202604062309-ZBNXE7/README.md    | 107 +++++++++++++++++++++
- .../tasks/202604062309-ZBNXE7/pr/diffstat.txt      |   0
- .../tasks/202604062309-ZBNXE7/pr/github-body.md    |  50 ++++++++++
+ .../tasks/202604062309-ZBNXE7/pr/diffstat.txt      |  21 ++++
+ .../tasks/202604062309-ZBNXE7/pr/github-body.md    |  70 ++++++++++++++
  .../tasks/202604062309-ZBNXE7/pr/github-title.txt  |   1 +
  .agentplane/tasks/202604062309-ZBNXE7/pr/meta.json |  14 +++
  .../tasks/202604062309-ZBNXE7/pr/notes.jsonl       |   0
- .agentplane/tasks/202604062309-ZBNXE7/pr/review.md |  57 +++++++++++
+ .agentplane/tasks/202604062309-ZBNXE7/pr/review.md |  77 +++++++++++++++
  .../tasks/202604062309-ZBNXE7/pr/verify.log        |   0
  .../src/cli/run-cli.core.incidents.test.ts         |  95 ++++++++++++++++++
  .../src/commands/incidents/collect.command.ts      |   6 +-
  .../agentplane/src/commands/incidents/shared.ts    |  36 +++++++
- .../pr/integrate/internal/finalize.test.ts         |  32 +++++-
+ .../pr/integrate/internal/finalize.test.ts         |  39 +++++++-
  .../src/commands/pr/integrate/internal/finalize.ts |   4 +-
- packages/agentplane/src/commands/task/finish.ts    |  18 +++-
+ packages/agentplane/src/commands/task/finish.ts    |  15 ++-
  .../src/commands/task/finish.unit.test.ts          |  72 +++++++++++++-
  .../src/commands/task/hosted-close.command.ts      |   4 +-
  packages/agentplane/src/runtime/incidents/index.ts |   1 +
  .../src/runtime/incidents/resolve.test.ts          |  28 ++++++
  .../agentplane/src/runtime/incidents/resolve.ts    |  33 +++++--
  packages/agentplane/src/runtime/incidents/types.ts |   8 ++
- 20 files changed, 545 insertions(+), 21 deletions(-)
+ 20 files changed, 610 insertions(+), 21 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202604062309-ZBNXE7/pr/github-title.txt
+++ b/.agentplane/tasks/202604062309-ZBNXE7/pr/github-title.txt
@@ -1,0 +1,1 @@
+workflow: Expose skipped incident findings in lifecycle diagnostics (ZBNXE7)

--- a/.agentplane/tasks/202604062309-ZBNXE7/pr/meta.json
+++ b/.agentplane/tasks/202604062309-ZBNXE7/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202604062309-ZBNXE7/incident-diagnostics",
   "created_at": "2026-04-06T23:18:14.266Z",
-  "head_sha": "61ce80966f00a944df746940c98bee174c9de771",
+  "head_sha": "232cf6eb02de39128a79dd58e6d39bc7f51cc3b8",
   "last_verified_at": "2026-04-06T23:18:14.227Z",
   "last_verified_sha": "61ce80966f00a944df746940c98bee174c9de771",
   "schema_version": 1,
   "task_id": "202604062309-ZBNXE7",
-  "updated_at": "2026-04-06T23:18:14.266Z",
+  "updated_at": "2026-04-06T23:18:53.185Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202604062309-ZBNXE7/pr/meta.json
+++ b/.agentplane/tasks/202604062309-ZBNXE7/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202604062309-ZBNXE7/incident-diagnostics",
   "created_at": "2026-04-06T23:18:14.266Z",
-  "head_sha": "6ffddaf9f606caed02329fd814680c2193682a09",
+  "head_sha": "93d486f40a42b71724e84819c3bf1a45afed237f",
   "last_verified_at": "2026-04-06T23:18:14.227Z",
   "last_verified_sha": "61ce80966f00a944df746940c98bee174c9de771",
   "schema_version": 1,
   "task_id": "202604062309-ZBNXE7",
-  "updated_at": "2026-04-06T23:21:15.275Z",
+  "updated_at": "2026-04-06T23:34:48.083Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202604062309-ZBNXE7/pr/meta.json
+++ b/.agentplane/tasks/202604062309-ZBNXE7/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202604062309-ZBNXE7/incident-diagnostics",
   "created_at": "2026-04-06T23:18:14.266Z",
-  "head_sha": "232cf6eb02de39128a79dd58e6d39bc7f51cc3b8",
+  "head_sha": "6ffddaf9f606caed02329fd814680c2193682a09",
   "last_verified_at": "2026-04-06T23:18:14.227Z",
   "last_verified_sha": "61ce80966f00a944df746940c98bee174c9de771",
   "schema_version": 1,
   "task_id": "202604062309-ZBNXE7",
-  "updated_at": "2026-04-06T23:18:53.185Z",
+  "updated_at": "2026-04-06T23:21:15.275Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202604062309-ZBNXE7/pr/meta.json
+++ b/.agentplane/tasks/202604062309-ZBNXE7/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202604062309-ZBNXE7/incident-diagnostics",
+  "created_at": "2026-04-06T23:18:14.266Z",
+  "head_sha": "61ce80966f00a944df746940c98bee174c9de771",
+  "last_verified_at": "2026-04-06T23:18:14.227Z",
+  "last_verified_sha": "61ce80966f00a944df746940c98bee174c9de771",
+  "schema_version": 1,
+  "task_id": "202604062309-ZBNXE7",
+  "updated_at": "2026-04-06T23:18:14.266Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202604062309-ZBNXE7/pr/review.md
+++ b/.agentplane/tasks/202604062309-ZBNXE7/pr/review.md
@@ -45,12 +45,32 @@ Differentiate no external incidents from structured findings that were parsed bu
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-06T23:18:53.185Z
+- Updated: 2026-04-06T23:21:15.275Z
 - Branch: task/202604062309-ZBNXE7/incident-diagnostics
-- Head: 232cf6eb02de
+- Head: 6ffddaf9f606
 
 ```text
-No changes detected.
+ .agentplane/tasks/202604062309-ZBNXE7/README.md    | 107 +++++++++++++++++++++
+ .../tasks/202604062309-ZBNXE7/pr/diffstat.txt      |   0
+ .../tasks/202604062309-ZBNXE7/pr/github-body.md    |  50 ++++++++++
+ .../tasks/202604062309-ZBNXE7/pr/github-title.txt  |   1 +
+ .agentplane/tasks/202604062309-ZBNXE7/pr/meta.json |  14 +++
+ .../tasks/202604062309-ZBNXE7/pr/notes.jsonl       |   0
+ .agentplane/tasks/202604062309-ZBNXE7/pr/review.md |  57 +++++++++++
+ .../tasks/202604062309-ZBNXE7/pr/verify.log        |   0
+ .../src/cli/run-cli.core.incidents.test.ts         |  95 ++++++++++++++++++
+ .../src/commands/incidents/collect.command.ts      |   6 +-
+ .../agentplane/src/commands/incidents/shared.ts    |  36 +++++++
+ .../pr/integrate/internal/finalize.test.ts         |  32 +++++-
+ .../src/commands/pr/integrate/internal/finalize.ts |   4 +-
+ packages/agentplane/src/commands/task/finish.ts    |  18 +++-
+ .../src/commands/task/finish.unit.test.ts          |  72 +++++++++++++-
+ .../src/commands/task/hosted-close.command.ts      |   4 +-
+ packages/agentplane/src/runtime/incidents/index.ts |   1 +
+ .../src/runtime/incidents/resolve.test.ts          |  28 ++++++
+ .../agentplane/src/runtime/incidents/resolve.ts    |  33 +++++--
+ packages/agentplane/src/runtime/incidents/types.ts |   8 ++
+ 20 files changed, 545 insertions(+), 21 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202604062309-ZBNXE7/pr/review.md
+++ b/.agentplane/tasks/202604062309-ZBNXE7/pr/review.md
@@ -45,32 +45,32 @@ Differentiate no external incidents from structured findings that were parsed bu
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-06T23:21:15.275Z
+- Updated: 2026-04-06T23:34:48.083Z
 - Branch: task/202604062309-ZBNXE7/incident-diagnostics
-- Head: 6ffddaf9f606
+- Head: 93d486f40a42
 
 ```text
  .agentplane/tasks/202604062309-ZBNXE7/README.md    | 107 +++++++++++++++++++++
- .../tasks/202604062309-ZBNXE7/pr/diffstat.txt      |   0
- .../tasks/202604062309-ZBNXE7/pr/github-body.md    |  50 ++++++++++
+ .../tasks/202604062309-ZBNXE7/pr/diffstat.txt      |  21 ++++
+ .../tasks/202604062309-ZBNXE7/pr/github-body.md    |  70 ++++++++++++++
  .../tasks/202604062309-ZBNXE7/pr/github-title.txt  |   1 +
  .agentplane/tasks/202604062309-ZBNXE7/pr/meta.json |  14 +++
  .../tasks/202604062309-ZBNXE7/pr/notes.jsonl       |   0
- .agentplane/tasks/202604062309-ZBNXE7/pr/review.md |  57 +++++++++++
+ .agentplane/tasks/202604062309-ZBNXE7/pr/review.md |  77 +++++++++++++++
  .../tasks/202604062309-ZBNXE7/pr/verify.log        |   0
  .../src/cli/run-cli.core.incidents.test.ts         |  95 ++++++++++++++++++
  .../src/commands/incidents/collect.command.ts      |   6 +-
  .../agentplane/src/commands/incidents/shared.ts    |  36 +++++++
- .../pr/integrate/internal/finalize.test.ts         |  32 +++++-
+ .../pr/integrate/internal/finalize.test.ts         |  39 +++++++-
  .../src/commands/pr/integrate/internal/finalize.ts |   4 +-
- packages/agentplane/src/commands/task/finish.ts    |  18 +++-
+ packages/agentplane/src/commands/task/finish.ts    |  15 ++-
  .../src/commands/task/finish.unit.test.ts          |  72 +++++++++++++-
  .../src/commands/task/hosted-close.command.ts      |   4 +-
  packages/agentplane/src/runtime/incidents/index.ts |   1 +
  .../src/runtime/incidents/resolve.test.ts          |  28 ++++++
  .../agentplane/src/runtime/incidents/resolve.ts    |  33 +++++--
  packages/agentplane/src/runtime/incidents/types.ts |   8 ++
- 20 files changed, 545 insertions(+), 21 deletions(-)
+ 20 files changed, 610 insertions(+), 21 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202604062309-ZBNXE7/pr/review.md
+++ b/.agentplane/tasks/202604062309-ZBNXE7/pr/review.md
@@ -45,9 +45,9 @@ Differentiate no external incidents from structured findings that were parsed bu
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-06T23:18:14.266Z
+- Updated: 2026-04-06T23:18:53.185Z
 - Branch: task/202604062309-ZBNXE7/incident-diagnostics
-- Head: 61ce80966f00
+- Head: 232cf6eb02de
 
 ```text
 No changes detected.

--- a/.agentplane/tasks/202604062309-ZBNXE7/pr/review.md
+++ b/.agentplane/tasks/202604062309-ZBNXE7/pr/review.md
@@ -1,0 +1,57 @@
+# PR Review
+
+Created: 2026-04-06T23:18:14.266Z
+Branch: task/202604062309-ZBNXE7/incident-diagnostics
+
+## Summary
+
+Expose skipped incident findings in lifecycle diagnostics
+
+Differentiate no external incidents from structured findings that were parsed but not promotable, and surface that distinction in incidents collection and lifecycle output.
+
+## Scope
+
+- In scope: Differentiate no external incidents from structured findings that were parsed but not promotable, and surface that distinction in incidents collection and lifecycle output.
+- Out of scope: unrelated refactors not required for "Expose skipped incident findings in lifecycle diagnostics".
+
+## Verification
+
+### Plan
+
+1. Run focused incidents runtime and CLI tests covering parsed-but-not-promotable findings. Expected: the plan distinguishes empty findings from skipped candidates and the new output is asserted.
+2. Run eslint on the touched incidents and lifecycle command files. Expected: no lint errors in touched scope.
+3. Review lifecycle output for the new diagnostics path. Expected: commands explicitly report skipped structured findings instead of collapsing everything into the same no-op message.
+
+### Current Status
+
+- State: ok
+- Note: Focused incidents diagnostics coverage passed after worktree bootstrap: bun x vitest run packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts; bun x eslint packages/agentplane/src/runtime/incidents/types.ts packages/agentplane/src/runtime/incidents/index.ts packages/agentplane/src/runtime/incidents/resolve.ts packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/commands/incidents/shared.ts packages/agentplane/src/commands/incidents/collect.command.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts packages/agentplane/src/commands/task/hosted-close.command.ts. Result: pass. Evidence: empty incident findings now differ from skipped structured findings, and lifecycle diagnostics surface the distinction without changing promotion semantics.
+
+## Risks
+
+- Risk level: not recorded
+- Breaking change: no
+
+### Rollback
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-04-06T23:18:14.266Z
+- Branch: task/202604062309-ZBNXE7/incident-diagnostics
+- Head: 61ce80966f00
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/cli/run-cli.core.incidents.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.incidents.test.ts
@@ -168,4 +168,99 @@ describe("runCli incidents", () => {
     );
     expect(incidentsFile).toContain("INC-20260403-01");
   });
+
+  it("incidents collect reports skipped structured findings that are not marked external or promotable", async () => {
+    const root = await mkGitRepoRoot();
+    await configureGitUser(root);
+    const config = defaultConfig();
+    config.agents.approvals.require_plan = false;
+    await writeConfig(root, config);
+    await mkdir(path.join(root, ".agentplane", "policy"), { recursive: true });
+    await writeFile(
+      path.join(root, ".agentplane", "policy", "incidents.md"),
+      createIncidentRegistrySkeleton(),
+      "utf8",
+    );
+
+    let taskId = "";
+    {
+      const io = captureStdIO();
+      try {
+        const code = await runCli([
+          "task",
+          "new",
+          "--title",
+          "Report skipped structured findings",
+          "--description",
+          "Differentiate skipped findings from empty incident input",
+          "--priority",
+          "med",
+          "--owner",
+          "CODER",
+          "--tag",
+          "workflow",
+          "--root",
+          root,
+        ]);
+        expect(code).toBe(0);
+        taskId = io.stdout.trim();
+      } finally {
+        io.restore();
+      }
+    }
+
+    {
+      const io = captureStdIO();
+      try {
+        const code = await runCli([
+          "task",
+          "doc",
+          "set",
+          taskId,
+          "--section",
+          "Findings",
+          "--text",
+          [
+            "- Observation: transient GitHub transport failures forced manual retries.",
+            "  Impact: operators had to repeat the same reconcile loop.",
+            "  Resolution: move the flaky path onto resilient polling.",
+          ].join("\n"),
+          "--root",
+          root,
+        ]);
+        expect(code).toBe(0);
+      } finally {
+        io.restore();
+      }
+    }
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli([
+        "incidents",
+        "collect",
+        taskId,
+        "--check",
+        "--json",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(0);
+      const payload = JSON.parse(io.stdout) as {
+        task_id: string;
+        checked_only: boolean;
+        candidates: number;
+        skipped: { observation: string; reason: string }[];
+        promotable: unknown[];
+      };
+      expect(payload.task_id).toBe(taskId);
+      expect(payload.checked_only).toBe(true);
+      expect(payload.candidates).toBe(0);
+      expect(payload.skipped).toHaveLength(1);
+      expect(payload.skipped[0]?.reason).toBe("not_marked_external_or_promotable");
+      expect(payload.promotable).toHaveLength(0);
+    } finally {
+      io.restore();
+    }
+  });
 });

--- a/packages/agentplane/src/commands/incidents/collect.command.ts
+++ b/packages/agentplane/src/commands/incidents/collect.command.ts
@@ -1,7 +1,7 @@
 import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
 import { createCliEmitter } from "../../cli/output.js";
 import { loadCommandContext, type CommandContext } from "../shared/task-backend.js";
-import { collectTaskIncidents } from "./shared.js";
+import { collectTaskIncidents, renderIncidentCollectionPlanOutcome } from "./shared.js";
 
 type IncidentsCollectParsed = {
   taskId: string;
@@ -63,6 +63,7 @@ export function makeRunIncidentsCollectHandler(getCtx: (cmd: string) => Promise<
         task_id: p.taskId,
         checked_only: p.check,
         candidates: result.plan.candidates.length,
+        skipped: result.plan.skipped,
         promotable: result.plan.promotable.map((item) => item.entry),
         duplicates: result.plan.duplicates.map((item) => item.entry.id),
         wrote: result.wrote,
@@ -73,8 +74,9 @@ export function makeRunIncidentsCollectHandler(getCtx: (cmd: string) => Promise<
     output.success(
       p.check ? "checked" : "collected",
       p.taskId,
-      `candidates=${result.plan.candidates.length} promoted=${result.plan.promotable.length} duplicates=${result.plan.duplicates.length}`,
+      `candidates=${result.plan.candidates.length} skipped=${result.plan.skipped.length} promoted=${result.plan.promotable.length} duplicates=${result.plan.duplicates.length}`,
     );
+    output.info(renderIncidentCollectionPlanOutcome(result.plan));
     if (result.plan.promotable.length > 0 && !p.check) {
       output.info(`Incident registry updated: ${result.registryPath}`);
     }

--- a/packages/agentplane/src/commands/incidents/shared.ts
+++ b/packages/agentplane/src/commands/incidents/shared.ts
@@ -159,6 +159,42 @@ export function renderIncidentCollectionOutcome(promotedCount: number): string {
     : "incident registry unchanged (no promotable external findings)";
 }
 
+export function renderIncidentCollectionPlanOutcome(plan: {
+  candidates?: readonly unknown[];
+  skipped?: readonly unknown[];
+  promotable?: readonly unknown[];
+  duplicates?: readonly unknown[];
+}): string {
+  const candidates = Array.isArray(plan.candidates) ? plan.candidates.length : 0;
+  const skipped = Array.isArray(plan.skipped) ? plan.skipped.length : 0;
+  const promoted = Array.isArray(plan.promotable) ? plan.promotable.length : 0;
+  const duplicates = Array.isArray(plan.duplicates) ? plan.duplicates.length : 0;
+
+  if (promoted > 0) {
+    const suffix: string[] = [];
+    if (duplicates > 0) suffix.push(`${duplicates} duplicate${duplicates === 1 ? "" : "s"}`);
+    if (skipped > 0)
+      suffix.push(`${skipped} skipped structured finding${skipped === 1 ? "" : "s"}`);
+    return suffix.length > 0
+      ? `incident registry updated (${promoted} promoted; ${suffix.join("; ")})`
+      : renderIncidentCollectionOutcome(promoted);
+  }
+
+  if (skipped > 0) {
+    return `incident registry unchanged (${skipped} structured finding${skipped === 1 ? "" : "s"} skipped: add Promotion: incident-candidate or IncidentExternal/Fixability: external to promote reusable findings)`;
+  }
+
+  if (candidates === 0) {
+    return "incident registry unchanged (no structured incident findings)";
+  }
+
+  if (duplicates > 0 && duplicates === candidates) {
+    return `incident registry unchanged (${duplicates} duplicate incident${duplicates === 1 ? "" : "s"} already recorded)`;
+  }
+
+  return "incident registry unchanged (no promotable external findings)";
+}
+
 export async function adviseTaskIncidents(opts: {
   ctx: CommandContext;
   taskId: string;

--- a/packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts
+++ b/packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts
@@ -202,7 +202,14 @@ describe("pr/integrate/internal/finalize", () => {
       registry: null,
       plan: {
         candidates: [],
-        skipped: [{ observation: "transport drift", line: 1, reason: "not_marked_external_or_promotable", rawFields: {} }],
+        skipped: [
+          {
+            observation: "transport drift",
+            line: 1,
+            reason: "not_marked_external_or_promotable",
+            rawFields: {},
+          },
+        ],
         promotable: [],
         duplicates: [],
         issues: [],

--- a/packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts
+++ b/packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts
@@ -88,7 +88,7 @@ describe("pr/integrate/internal/finalize", () => {
       registryPath: "/repo/.agentplane/policy/incidents.md",
       registryText: "",
       registry: null,
-      plan: { promotable: [], issues: [] },
+      plan: { candidates: [], skipped: [], promotable: [], duplicates: [], issues: [] },
       wrote: false,
     });
   });
@@ -184,6 +184,36 @@ describe("pr/integrate/internal/finalize", () => {
         shouldRunVerify: false,
         alreadyVerifiedSha: null,
       }),
+    );
+  });
+
+  it("reports skipped structured findings when integrate does not promote incidents", async () => {
+    const { finalizeIntegrate } = await import("./finalize.js");
+    mocks.fileExists.mockResolvedValue(true);
+    mocks.readFile.mockResolvedValue("{}");
+    mocks.parsePrMeta.mockReturnValue({ schema_version: 1, task_id: "T-1" });
+    mocks.buildIntegratedPrMeta.mockReturnValue({ schema_version: 1, task_id: "T-1" });
+    mocks.gitDiffStat.mockResolvedValue("");
+    mocks.readCommitInfo.mockResolvedValue({ hash: "deadbeef", message: "merge" });
+    mocks.collectTaskIncidents.mockResolvedValue({
+      loaded: null,
+      registryPath: "/repo/.agentplane/policy/incidents.md",
+      registryText: "",
+      registry: null,
+      plan: {
+        candidates: [],
+        skipped: [{ observation: "transport drift", line: 1, reason: "not_marked_external_or_promotable", rawFields: {} }],
+        promotable: [],
+        duplicates: [],
+        issues: [],
+      },
+      wrote: false,
+    });
+
+    await finalizeIntegrate({ ...baseOpts(), quiet: false });
+
+    expect(emitter.info).toHaveBeenCalledWith(
+      expect.stringContaining("structured finding skipped"),
     );
   });
 });

--- a/packages/agentplane/src/commands/pr/integrate/internal/finalize.ts
+++ b/packages/agentplane/src/commands/pr/integrate/internal/finalize.ts
@@ -21,7 +21,7 @@ import { createTaskCloseCommit, writeFinishedTasks } from "../../../task/finish-
 import type { CommandContext } from "../../../shared/task-backend.js";
 import {
   collectTaskIncidents,
-  renderIncidentCollectionOutcome,
+  renderIncidentCollectionPlanOutcome,
 } from "../../../incidents/shared.js";
 
 function nowIso(): string {
@@ -128,7 +128,7 @@ export async function finalizeIntegrate(opts: {
     write: true,
   });
   if (!opts.quiet) {
-    output.info(renderIncidentCollectionOutcome(collectedIncidents.plan.promotable.length));
+    output.info(renderIncidentCollectionPlanOutcome(collectedIncidents.plan));
   }
   await createTaskCloseCommit({
     ctx: opts.ctx,

--- a/packages/agentplane/src/commands/task/finish.ts
+++ b/packages/agentplane/src/commands/task/finish.ts
@@ -361,10 +361,7 @@ export async function cmdFinish(opts: {
       });
       incidentPlans.push(collected.plan);
     }
-    const promotedIncidents = incidentPlans.reduce(
-      (sum, plan) => sum + plan.promotable.length,
-      0,
-    );
+    const promotedIncidents = incidentPlans.reduce((sum, plan) => sum + plan.promotable.length, 0);
 
     // tasks.json is export-only; generated via `agentplane task export`.
 

--- a/packages/agentplane/src/commands/task/finish.ts
+++ b/packages/agentplane/src/commands/task/finish.ts
@@ -8,7 +8,7 @@ import { ensureActionApproved } from "../shared/approval-requirements.js";
 import { ensureReconciledBeforeMutation } from "../shared/reconcile-check.js";
 import { loadCommandContext, type CommandContext } from "../shared/task-backend.js";
 import { backendIsLocalFileBackend, getTaskStore } from "../shared/task-store.js";
-import { collectTaskIncidents, renderIncidentCollectionOutcome } from "../incidents/shared.js";
+import { collectTaskIncidents, renderIncidentCollectionPlanOutcome } from "../incidents/shared.js";
 import {
   createTaskCloseCommit,
   existingCommitInfo,
@@ -350,7 +350,7 @@ export async function cmdFinish(opts: {
       taskCommitInfo,
     });
 
-    let promotedIncidents = 0;
+    const incidentPlans = [];
     for (const taskId of opts.taskIds) {
       const loadedTask = loadedTasks.find((candidate) => candidate.taskId === taskId) ?? null;
       const collected = await collectTaskIncidents({
@@ -359,8 +359,12 @@ export async function cmdFinish(opts: {
         task: loadedTask?.task ?? null,
         write: true,
       });
-      promotedIncidents += collected.plan.promotable.length;
+      incidentPlans.push(collected.plan);
     }
+    const promotedIncidents = incidentPlans.reduce(
+      (sum, plan) => sum + plan.promotable.length,
+      0,
+    );
 
     // tasks.json is export-only; generated via `agentplane task export`.
 
@@ -390,7 +394,13 @@ export async function cmdFinish(opts: {
     }
 
     if (!opts.quiet) {
-      process.stdout.write(`${infoMessage(renderIncidentCollectionOutcome(promotedIncidents))}\n`);
+      const incidentPlan = incidentPlans[0] ?? {
+        candidates: [],
+        skipped: [],
+        promotable: [],
+        duplicates: [],
+      };
+      process.stdout.write(`${infoMessage(renderIncidentCollectionPlanOutcome(incidentPlan))}\n`);
       process.stdout.write(`${successMessage("finished")}\n`);
     }
     return 0;

--- a/packages/agentplane/src/commands/task/finish.unit.test.ts
+++ b/packages/agentplane/src/commands/task/finish.unit.test.ts
@@ -993,9 +993,79 @@ describe("task finish (unit)", () => {
 
     expect(rc).toBe(0);
     expect(writes.join("")).toContain(
-      "incident registry unchanged (no promotable external findings)",
+      "incident registry unchanged (no structured incident findings)",
     );
     expect(writes.join("")).toContain("finished");
+
+    writeSpy.mockRestore();
+  });
+
+  it("prints skipped structured finding diagnostics when finish parses findings but does not promote them", async () => {
+    const writes: string[] = [];
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      writes.push(String(chunk));
+      return true;
+    });
+
+    const ctx = mkCtx();
+    ctx.config.workflow_mode = "branch_pr";
+    mocks.loadTaskFromContext.mockResolvedValue(
+      mkTask({
+        id: "T-2",
+        status: "DOING",
+        tags: ["workflow"],
+        commit: { hash: "def456", message: "feat: T-2" },
+        doc: [
+          "## Summary",
+          "Task summary",
+          "",
+          "## Scope",
+          "In-scope files",
+          "",
+          "## Plan",
+          "1. Implement",
+          "",
+          "## Verification",
+          "",
+          "## Rollback Plan",
+          "Revert commit",
+          "",
+          "## Findings",
+          "- Observation: transient GitHub transport failures forced manual retries.",
+          "  Impact: operators had to repeat the same reconcile loop.",
+          "  Resolution: move the flaky path onto resilient polling.",
+        ].join("\n"),
+      }),
+    );
+    mocks.readCommitInfo.mockResolvedValue({ hash: "def456", message: "feat: T-2" });
+
+    const { cmdFinish } = await import("./finish.js");
+    const rc = await cmdFinish({
+      ctx,
+      cwd: "/repo",
+      taskIds: ["T-2"],
+      author: "A",
+      body: "Verified: skipped structured findings should be reported.",
+      result: "incident diagnostics",
+      commit: "def456",
+      breaking: false,
+      force: false,
+      commitFromComment: false,
+      commitAllow: [],
+      commitAutoAllow: false,
+      commitAllowTasks: false,
+      commitRequireClean: false,
+      statusCommit: false,
+      statusCommitAllow: [],
+      statusCommitAutoAllow: false,
+      statusCommitRequireClean: false,
+      confirmStatusCommit: false,
+      quiet: false,
+    });
+
+    expect(rc).toBe(0);
+    expect(writes.join("")).toContain("structured finding skipped");
+    expect(writes.join("")).toContain("Promotion: incident-candidate");
 
     writeSpy.mockRestore();
   });

--- a/packages/agentplane/src/commands/task/hosted-close.command.ts
+++ b/packages/agentplane/src/commands/task/hosted-close.command.ts
@@ -14,7 +14,7 @@ import { loadTaskFromContext, type CommandContext } from "../shared/task-backend
 import { createTaskCloseCommit, writeFinishedTasks } from "./finish-shared.js";
 import { resolveHostedMergeTargetFromEvent } from "./hosted-merge-sync.js";
 import { readCommitInfo } from "./shared.js";
-import { collectTaskIncidents, renderIncidentCollectionOutcome } from "../incidents/shared.js";
+import { collectTaskIncidents, renderIncidentCollectionPlanOutcome } from "../incidents/shared.js";
 
 export type TaskHostedCloseParsed = {
   eventJson: string;
@@ -232,7 +232,7 @@ async function closeHostedTask(opts: {
   });
   if (!opts.quiet) {
     process.stdout.write(
-      `${infoMessage(renderIncidentCollectionOutcome(collectedIncidents.plan.promotable.length))}\n`,
+      `${infoMessage(renderIncidentCollectionPlanOutcome(collectedIncidents.plan))}\n`,
     );
   }
   await createTaskCloseCommit({

--- a/packages/agentplane/src/runtime/incidents/index.ts
+++ b/packages/agentplane/src/runtime/incidents/index.ts
@@ -3,6 +3,7 @@ export type {
   IncidentAdviceQuery,
   IncidentCollectionPlan,
   IncidentFindingCandidate,
+  IncidentSkippedFinding,
   IncidentPromotionDraft,
   IncidentPromotionIssue,
   IncidentPromotionTaskContext,

--- a/packages/agentplane/src/runtime/incidents/resolve.test.ts
+++ b/packages/agentplane/src/runtime/incidents/resolve.test.ts
@@ -94,12 +94,40 @@ describe("incidents runtime", () => {
     });
 
     expect(plan.candidates).toHaveLength(2);
+    expect(plan.skipped).toHaveLength(0);
     expect(plan.promotable).toHaveLength(0);
     expect(plan.duplicates).toHaveLength(1);
     expect(plan.issues).toHaveLength(1);
     expect(plan.issues[0]?.missingFields).toEqual([
       "Fixability: external or IncidentExternal: true",
     ]);
+  });
+
+  it("tracks structured findings that are skipped because they are not marked for promotion or external handling", () => {
+    const plan = planIncidentCollection({
+      task: {
+        id: "TASK-6",
+        title: "Document transport issue",
+        description: "Capture reusable workflow lesson without promoting it yet",
+        tags: ["workflow"],
+      },
+      findings: [
+        "- Observation: transient GitHub transport failures forced manual retries.",
+        "  Impact: operators had to repeat the same reconcile loop.",
+        "  Resolution: switch the flaky path to a resilient polling implementation.",
+      ].join("\n"),
+      registry: parseIncidentRegistry(createIncidentRegistrySkeleton()),
+      now: new Date("2026-04-06T10:00:00.000Z"),
+    });
+
+    expect(plan.candidates).toHaveLength(0);
+    expect(plan.skipped).toHaveLength(1);
+    expect(plan.skipped[0]).toMatchObject({
+      observation: "transient GitHub transport failures forced manual retries.",
+      reason: "not_marked_external_or_promotable",
+    });
+    expect(plan.promotable).toHaveLength(0);
+    expect(plan.issues).toHaveLength(0);
   });
 
   it("auto-promotes first external findings as open incidents and resolves advice by tags and scope", () => {

--- a/packages/agentplane/src/runtime/incidents/resolve.ts
+++ b/packages/agentplane/src/runtime/incidents/resolve.ts
@@ -3,6 +3,7 @@ import type {
   IncidentAdviceQuery,
   IncidentCollectionPlan,
   IncidentFindingCandidate,
+  IncidentSkippedFinding,
   IncidentPromotionDraft,
   IncidentPromotionIssue,
   IncidentPromotionTaskContext,
@@ -352,8 +353,16 @@ export function appendIncidentRegistryEntries(
 export function extractIncidentCandidatesFromFindings(
   findings: string,
 ): IncidentFindingCandidate[] {
+  return parseIncidentFindingBlocks(findings)
+    .filter((candidate) => candidate.shouldPromote)
+    .map(({ shouldPromote: _shouldPromote, ...candidate }) => candidate);
+}
+
+function parseIncidentFindingBlocks(
+  findings: string,
+): (IncidentFindingCandidate & { shouldPromote: boolean })[] {
   const lines = normalizeLines(findings);
-  const candidates: IncidentFindingCandidate[] = [];
+  const candidates: (IncidentFindingCandidate & { shouldPromote: boolean })[] = [];
   let currentFields: Record<string, string> | null = null;
   let currentLine = 0;
   let currentKey: string | null = null;
@@ -365,12 +374,6 @@ export function extractIncidentCandidatesFromFindings(
     const incidentExternal =
       parseBoolean(currentFields.incidentexternal) || fixability === "external";
     const shouldPromote = promotion?.toLowerCase() === "incident-candidate" || incidentExternal;
-    if (!shouldPromote) {
-      currentFields = null;
-      currentKey = null;
-      currentLine = 0;
-      return;
-    }
     const observation = currentFields.observation?.trim() ?? "";
     if (!observation) {
       currentFields = null;
@@ -390,6 +393,7 @@ export function extractIncidentCandidatesFromFindings(
       incidentMatch: parseCsvList(currentFields.incidentmatch),
       incidentExternal,
       fixability,
+      shouldPromote,
       line: currentLine,
       rawFields: { ...currentFields },
     });
@@ -527,7 +531,18 @@ export function planIncidentCollection(opts: {
   registry: IncidentRegistry;
   now?: Date;
 }): IncidentCollectionPlan {
-  const candidates = extractIncidentCandidatesFromFindings(opts.findings);
+  const parsed = parseIncidentFindingBlocks(opts.findings);
+  const candidates = parsed
+    .filter((candidate) => candidate.shouldPromote)
+    .map(({ shouldPromote: _shouldPromote, ...candidate }) => candidate);
+  const skipped: IncidentSkippedFinding[] = parsed
+    .filter((candidate) => !candidate.shouldPromote)
+    .map(({ observation, line, rawFields }) => ({
+      observation,
+      line,
+      reason: "not_marked_external_or_promotable",
+      rawFields,
+    }));
   const issues: IncidentPromotionIssue[] = [];
   const promotable: IncidentPromotionDraft[] = [];
   const duplicates: IncidentPromotionDraft[] = [];
@@ -563,7 +578,7 @@ export function planIncidentCollection(opts: {
     promotable.push(draft);
   }
 
-  return { candidates, promotable, duplicates, issues };
+  return { candidates, skipped, promotable, duplicates, issues };
 }
 
 export function buildIncidentAdviceQueryFromTask(opts: {

--- a/packages/agentplane/src/runtime/incidents/types.ts
+++ b/packages/agentplane/src/runtime/incidents/types.ts
@@ -38,6 +38,13 @@ export type IncidentFindingCandidate = {
   rawFields: Record<string, string>;
 };
 
+export type IncidentSkippedFinding = {
+  observation: string;
+  line: number;
+  reason: "not_marked_external_or_promotable";
+  rawFields: Record<string, string>;
+};
+
 export type IncidentPromotionTaskContext = {
   id: string;
   title: string;
@@ -60,6 +67,7 @@ export type IncidentPromotionIssue = {
 
 export type IncidentCollectionPlan = {
   candidates: IncidentFindingCandidate[];
+  skipped: IncidentSkippedFinding[];
   promotable: IncidentPromotionDraft[];
   duplicates: IncidentPromotionDraft[];
   issues: IncidentPromotionIssue[];


### PR DESCRIPTION
## Summary

Expose skipped incident findings in lifecycle diagnostics

Differentiate no external incidents from structured findings that were parsed but not promotable, and surface that distinction in incidents collection and lifecycle output.

## Scope

- In scope: Differentiate no external incidents from structured findings that were parsed but not promotable, and surface that distinction in incidents collection and lifecycle output.
- Out of scope: unrelated refactors not required for "Expose skipped incident findings in lifecycle diagnostics".

## Verification

### Plan

1. Run focused incidents runtime and CLI tests covering parsed-but-not-promotable findings. Expected: the plan distinguishes empty findings from skipped candidates and the new output is asserted.
2. Run eslint on the touched incidents and lifecycle command files. Expected: no lint errors in touched scope.
3. Review lifecycle output for the new diagnostics path. Expected: commands explicitly report skipped structured findings instead of collapsing everything into the same no-op message.

### Current Status

- State: ok
- Note: Focused incidents diagnostics coverage passed after worktree bootstrap: bun x vitest run packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts; bun x eslint packages/agentplane/src/runtime/incidents/types.ts packages/agentplane/src/runtime/incidents/index.ts packages/agentplane/src/runtime/incidents/resolve.ts packages/agentplane/src/runtime/incidents/resolve.test.ts packages/agentplane/src/commands/incidents/shared.ts packages/agentplane/src/commands/incidents/collect.command.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts packages/agentplane/src/commands/task/finish.ts packages/agentplane/src/commands/task/finish.unit.test.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.ts packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts packages/agentplane/src/commands/task/hosted-close.command.ts. Result: pass. Evidence: empty incident findings now differ from skipped structured findings, and lifecycle diagnostics surface the distinction without changing promotion semantics.

## Risks

- Risk level: not recorded
- Breaking change: no

### Rollback

- Revert task-related commit(s).
- Re-run required checks to confirm rollback safety.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-04-06T23:18:53.185Z
- Branch: task/202604062309-ZBNXE7/incident-diagnostics
- Head: 232cf6eb02de

```text
No changes detected.
```

</details>
