### PR TITLE
incidents/workflow: Explain internal Findings vs incidents registry promotion (R3SG76)

### DIFF
--- a/.agentplane/policy/workflow.branch_pr.md
+++ b/.agentplane/policy/workflow.branch_pr.md
@@ -30,7 +30,7 @@ agentplane finish <task-id> --author INTEGRATOR --body "Verified: ..." --result 
 - Task documentation updates MAY be batched within one turn before approval.
 - MUST run `task plan approve` then `task start-ready` as `Step 1 -> wait -> Step 2` (never parallel).
 - `task start-ready` MAY surface targeted incident advice for analogous scope/tags; follow it before widening scope.
-- Keep structured resolved external findings in the task README; mark reusable ones with `Fixability: external` (or `IncidentExternal: true`) and let base-branch `finish` or `agentplane incidents collect <task-id>` promote them into `.agentplane/policy/incidents.md`, using optional `Incident*` fields only when the inferred scope/advice needs refinement.
+- Keep structured resolved external findings in the task README; mark reusable ones with `Fixability: external` (or `IncidentExternal: true`) and let base-branch `finish` or `agentplane incidents collect <task-id>` promote them into `.agentplane/policy/incidents.md`, using optional `Incident*` fields only when the inferred scope/advice needs refinement. Plain `Findings` text remains task-local and does not update the shared incident registry.
 - MUST stop and request re-approval on material drift.
 - Planning and closure happen on base checkout.
 - Do not export task snapshots from task branches.

--- a/.agentplane/policy/workflow.direct.md
+++ b/.agentplane/policy/workflow.direct.md
@@ -38,7 +38,7 @@ If any step fails:
    - `doc_version=3`: task `Findings`
 3. Mark task blocked: `agentplane block <task-id> --author <ROLE> --body "Blocked: ..."`.
 4. Request re-approval before scope/risk changes.
-5. If failure is external/process-related and should become reusable advice, record a structured `Observation` / `Impact` / `Resolution` block in `Findings` and mark it with `Fixability: external` (or `IncidentExternal: true`); optional `Incident*` fields refine the promoted registry entry.
+5. If failure is external/process-related and should become reusable advice, record a structured `Observation` / `Impact` / `Resolution` block in `Findings` and mark it with `Fixability: external` (or `IncidentExternal: true`); plain prose in `Findings` stays task-local and does not update `.agentplane/policy/incidents.md`.
 
 ## Constraints
 
@@ -47,7 +47,7 @@ If any step fails:
 - MUST run `task plan approve` then `task start-ready` as `Step 1 -> wait -> Step 2` (never parallel).
 - `task start-ready` MAY surface targeted incident advice for analogous scope/tags; follow it before widening scope.
 - In direct mode, `finish` auto-creates the deterministic close commit by default; use `--no-close-commit` only for explicit manual handling.
-- `finish` evaluates structured resolved external findings, auto-derives incident advice when only `Observation` / `Impact` / `Resolution` plus `Fixability: external` are present, and appends valid entries to `.agentplane/policy/incidents.md`.
+- `finish` evaluates structured resolved external findings, auto-derives incident advice when only `Observation` / `Impact` / `Resolution` plus `Fixability: external` are present, and appends valid entries to `.agentplane/policy/incidents.md`; plain `Findings` text remains task-local.
 - MUST stop and request re-approval on material drift.
 - Do not use worktrees in direct mode.
 - Do not perform `branch_pr`-only operations.

--- a/.agentplane/tasks/202604072309-R3SG76/README.md
+++ b/.agentplane/tasks/202604072309-R3SG76/README.md
@@ -4,7 +4,7 @@ title: "Explain internal Findings vs incidents registry promotion"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -20,9 +20,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-04-08T00:57:13.792Z"
+  updated_at: "2026-04-08T01:08:26.576Z"
   updated_by: "CODER"
-  note: "Verified targeted incidents and command-guide coverage; messaging now distinguishes plain task-local Findings from structured external incident promotion without changing promotion semantics."
+  note: "Re-verified after syncing canonical policy assets; incidents/finish/integrate diagnostics, bootstrap docs, routing, and agent-template sync remain aligned on the current head."
 commit: null
 comments:
   -
@@ -42,8 +42,14 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified targeted incidents and command-guide coverage; messaging now distinguishes plain task-local Findings from structured external incident promotion without changing promotion semantics."
+  -
+    type: "verify"
+    at: "2026-04-08T01:08:26.576Z"
+    author: "CODER"
+    state: "ok"
+    note: "Re-verified after syncing canonical policy assets; incidents/finish/integrate diagnostics, bootstrap docs, routing, and agent-template sync remain aligned on the current head."
 doc_version: 3
-doc_updated_at: "2026-04-08T00:57:13.796Z"
+doc_updated_at: "2026-04-08T01:08:26.586Z"
 doc_updated_by: "CODER"
 description: "When Findings contains plain text, incidents collect and close-path diagnostics should explicitly distinguish internal follow-up defects from reusable external incident candidates so operators do not expect incidents.md updates from task-local code bugs."
 sections:
@@ -68,6 +74,14 @@ sections:
     Note: Verified targeted incidents and command-guide coverage; messaging now distinguishes plain task-local Findings from structured external incident promotion without changing promotion semantics.
     
     VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-08T00:44:20.068Z, excerpt_hash=sha256:97786aa004558cc1c6ef29cdb1ee926f4b4735b67de3ed304137441ae54c4931
+    
+    ### 2026-04-08T01:08:26.576Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Re-verified after syncing canonical policy assets; incidents/finish/integrate diagnostics, bootstrap docs, routing, and agent-template sync remain aligned on the current head.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-08T00:57:13.796Z, excerpt_hash=sha256:97786aa004558cc1c6ef29cdb1ee926f4b4735b67de3ed304137441ae54c4931
     
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
@@ -107,6 +121,14 @@ By: CODER
 Note: Verified targeted incidents and command-guide coverage; messaging now distinguishes plain task-local Findings from structured external incident promotion without changing promotion semantics.
 
 VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-08T00:44:20.068Z, excerpt_hash=sha256:97786aa004558cc1c6ef29cdb1ee926f4b4735b67de3ed304137441ae54c4931
+
+### 2026-04-08T01:08:26.576Z — VERIFY — ok
+
+By: CODER
+
+Note: Re-verified after syncing canonical policy assets; incidents/finish/integrate diagnostics, bootstrap docs, routing, and agent-template sync remain aligned on the current head.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-08T00:57:13.796Z, excerpt_hash=sha256:97786aa004558cc1c6ef29cdb1ee926f4b4735b67de3ed304137441ae54c4931
 
 <!-- END VERIFICATION RESULTS -->
 

--- a/.agentplane/tasks/202604072309-R3SG76/README.md
+++ b/.agentplane/tasks/202604072309-R3SG76/README.md
@@ -1,0 +1,118 @@
+---
+id: "202604072309-R3SG76"
+title: "Explain internal Findings vs incidents registry promotion"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "incidents"
+  - "workflow"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-04-08T00:44:19.616Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-04-08T00:57:13.792Z"
+  updated_by: "CODER"
+  note: "Verified targeted incidents and command-guide coverage; messaging now distinguishes plain task-local Findings from structured external incident promotion without changing promotion semantics."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: clarify Findings versus incidents registry promotion without changing incident collection semantics."
+events:
+  -
+    type: "status"
+    at: "2026-04-08T00:44:20.058Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: clarify Findings versus incidents registry promotion without changing incident collection semantics."
+  -
+    type: "verify"
+    at: "2026-04-08T00:57:13.792Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified targeted incidents and command-guide coverage; messaging now distinguishes plain task-local Findings from structured external incident promotion without changing promotion semantics."
+doc_version: 3
+doc_updated_at: "2026-04-08T00:57:13.796Z"
+doc_updated_by: "CODER"
+description: "When Findings contains plain text, incidents collect and close-path diagnostics should explicitly distinguish internal follow-up defects from reusable external incident candidates so operators do not expect incidents.md updates from task-local code bugs."
+sections:
+  Summary: |-
+    Explain internal Findings vs incidents registry promotion
+    
+    When Findings contains plain text, incidents collect and close-path diagnostics should explicitly distinguish internal follow-up defects from reusable external incident candidates so operators do not expect incidents.md updates from task-local code bugs.
+  Scope: |-
+    - In scope: When Findings contains plain text, incidents collect and close-path diagnostics should explicitly distinguish internal follow-up defects from reusable external incident candidates so operators do not expect incidents.md updates from task-local code bugs.
+    - Out of scope: unrelated refactors not required for "Explain internal Findings vs incidents registry promotion".
+  Plan: |-
+    1. Implement the change for "Explain internal Findings vs incidents registry promotion".
+    2. Run required checks and capture verification evidence.
+    3. Finalize task findings and finish with traceable commit metadata.
+  Verify Steps: "1. Run the targeted incidents and findings vitest coverage for resolve, finish, and run-cli incidents/findings flows; expected: all pass. 2. Review the changed CLI and guide messages; expected: they explicitly distinguish task-local Findings from reusable incidents registry promotion. 3. Confirm no behavior change in incidents promotion semantics; expected: incidents.md is updated only by structured reusable incident candidates, not by plain Findings text."
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-04-08T00:57:13.792Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified targeted incidents and command-guide coverage; messaging now distinguishes plain task-local Findings from structured external incident promotion without changing promotion semantics.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-08T00:44:20.068Z, excerpt_hash=sha256:97786aa004558cc1c6ef29cdb1ee926f4b4735b67de3ed304137441ae54c4931
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Explain internal Findings vs incidents registry promotion
+
+When Findings contains plain text, incidents collect and close-path diagnostics should explicitly distinguish internal follow-up defects from reusable external incident candidates so operators do not expect incidents.md updates from task-local code bugs.
+
+## Scope
+
+- In scope: When Findings contains plain text, incidents collect and close-path diagnostics should explicitly distinguish internal follow-up defects from reusable external incident candidates so operators do not expect incidents.md updates from task-local code bugs.
+- Out of scope: unrelated refactors not required for "Explain internal Findings vs incidents registry promotion".
+
+## Plan
+
+1. Implement the change for "Explain internal Findings vs incidents registry promotion".
+2. Run required checks and capture verification evidence.
+3. Finalize task findings and finish with traceable commit metadata.
+
+## Verify Steps
+
+1. Run the targeted incidents and findings vitest coverage for resolve, finish, and run-cli incidents/findings flows; expected: all pass. 2. Review the changed CLI and guide messages; expected: they explicitly distinguish task-local Findings from reusable incidents registry promotion. 3. Confirm no behavior change in incidents promotion semantics; expected: incidents.md is updated only by structured reusable incident candidates, not by plain Findings text.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-04-08T00:57:13.792Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified targeted incidents and command-guide coverage; messaging now distinguishes plain task-local Findings from structured external incident promotion without changing promotion semantics.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-08T00:44:20.068Z, excerpt_hash=sha256:97786aa004558cc1c6ef29cdb1ee926f4b4735b67de3ed304137441ae54c4931
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202604072309-R3SG76/pr/diffstat.txt
+++ b/.agentplane/tasks/202604072309-R3SG76/pr/diffstat.txt
@@ -1,0 +1,22 @@
+ .agentplane/policy/workflow.branch_pr.md           |   2 +-
+ .agentplane/policy/workflow.direct.md              |   4 +-
+ .agentplane/tasks/202604072309-R3SG76/README.md    | 118 +++++++++++++++++++++
+ .../tasks/202604072309-R3SG76/pr/diffstat.txt      |   0
+ .../tasks/202604072309-R3SG76/pr/github-body.md    |  48 +++++++++
+ .../tasks/202604072309-R3SG76/pr/github-title.txt  |   1 +
+ .agentplane/tasks/202604072309-R3SG76/pr/meta.json |  14 +++
+ .../tasks/202604072309-R3SG76/pr/notes.jsonl       |   0
+ .agentplane/tasks/202604072309-R3SG76/pr/review.md |  55 ++++++++++
+ .../tasks/202604072309-R3SG76/pr/verify.log        |   0
+ docs/user/agent-bootstrap.generated.mdx            |   3 +-
+ docs/user/tasks-and-backends.mdx                   |   3 +-
+ .../agentplane/assets/policy/workflow.branch_pr.md |   2 +-
+ .../agentplane/assets/policy/workflow.direct.md    |   4 +-
+ packages/agentplane/src/cli/bootstrap-guide.ts     |   4 +-
+ packages/agentplane/src/cli/command-guide.test.ts  |   8 ++
+ packages/agentplane/src/cli/command-guide.ts       |   2 +-
+ .../src/cli/run-cli.core.incidents.test.ts         |   3 +-
+ .../agentplane/src/commands/incidents/shared.ts    |   4 +-
+ .../pr/integrate/internal/finalize.test.ts         |   4 +-
+ .../src/commands/task/finish.unit.test.ts          |   7 +-
+ 21 files changed, 267 insertions(+), 19 deletions(-)

--- a/.agentplane/tasks/202604072309-R3SG76/pr/github-body.md
+++ b/.agentplane/tasks/202604072309-R3SG76/pr/github-body.md
@@ -18,7 +18,7 @@ When Findings contains plain text, incidents collect and close-path diagnostics 
 ### Current Status
 
 - State: ok
-- Note: Verified targeted incidents and command-guide coverage; messaging now distinguishes plain task-local Findings from structured external incident promotion without changing promotion semantics.
+- Note: Re-verified after syncing canonical policy assets; incidents/finish/integrate diagnostics, bootstrap docs, routing, and agent-template sync remain aligned on the current head.
 
 ## Risks
 
@@ -37,12 +37,33 @@ When Findings contains plain text, incidents collect and close-path diagnostics 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-08T01:00:59.289Z
+- Updated: 2026-04-08T01:07:42.241Z
 - Branch: task/202604072309-R3SG76/incidents-findings-boundary
-- Head: f40d5aa39527
+- Head: dba269e19c27
 
 ```text
-No changes detected.
+ .agentplane/policy/workflow.branch_pr.md           |   2 +-
+ .agentplane/policy/workflow.direct.md              |   4 +-
+ .agentplane/tasks/202604072309-R3SG76/README.md    | 118 +++++++++++++++++++++
+ .../tasks/202604072309-R3SG76/pr/diffstat.txt      |   0
+ .../tasks/202604072309-R3SG76/pr/github-body.md    |  48 +++++++++
+ .../tasks/202604072309-R3SG76/pr/github-title.txt  |   1 +
+ .agentplane/tasks/202604072309-R3SG76/pr/meta.json |  14 +++
+ .../tasks/202604072309-R3SG76/pr/notes.jsonl       |   0
+ .agentplane/tasks/202604072309-R3SG76/pr/review.md |  55 ++++++++++
+ .../tasks/202604072309-R3SG76/pr/verify.log        |   0
+ docs/user/agent-bootstrap.generated.mdx            |   3 +-
+ docs/user/tasks-and-backends.mdx                   |   3 +-
+ .../agentplane/assets/policy/workflow.branch_pr.md |   2 +-
+ .../agentplane/assets/policy/workflow.direct.md    |   4 +-
+ packages/agentplane/src/cli/bootstrap-guide.ts     |   4 +-
+ packages/agentplane/src/cli/command-guide.test.ts  |   8 ++
+ packages/agentplane/src/cli/command-guide.ts       |   2 +-
+ .../src/cli/run-cli.core.incidents.test.ts         |   3 +-
+ .../agentplane/src/commands/incidents/shared.ts    |   4 +-
+ .../pr/integrate/internal/finalize.test.ts         |   4 +-
+ .../src/commands/task/finish.unit.test.ts          |   7 +-
+ 21 files changed, 267 insertions(+), 19 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202604072309-R3SG76/pr/github-body.md
+++ b/.agentplane/tasks/202604072309-R3SG76/pr/github-body.md
@@ -1,0 +1,48 @@
+## Summary
+
+Explain internal Findings vs incidents registry promotion
+
+When Findings contains plain text, incidents collect and close-path diagnostics should explicitly distinguish internal follow-up defects from reusable external incident candidates so operators do not expect incidents.md updates from task-local code bugs.
+
+## Scope
+
+- In scope: When Findings contains plain text, incidents collect and close-path diagnostics should explicitly distinguish internal follow-up defects from reusable external incident candidates so operators do not expect incidents.md updates from task-local code bugs.
+- Out of scope: unrelated refactors not required for "Explain internal Findings vs incidents registry promotion".
+
+## Verification
+
+### Plan
+
+1. Run the targeted incidents and findings vitest coverage for resolve, finish, and run-cli incidents/findings flows; expected: all pass. 2. Review the changed CLI and guide messages; expected: they explicitly distinguish task-local Findings from reusable incidents registry promotion. 3. Confirm no behavior change in incidents promotion semantics; expected: incidents.md is updated only by structured reusable incident candidates, not by plain Findings text.
+
+### Current Status
+
+- State: ok
+- Note: Verified targeted incidents and command-guide coverage; messaging now distinguishes plain task-local Findings from structured external incident promotion without changing promotion semantics.
+
+## Risks
+
+- Risk level: not recorded
+- Breaking change: no
+
+### Rollback
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-04-08T01:00:59.289Z
+- Branch: task/202604072309-R3SG76/incidents-findings-boundary
+- Head: f40d5aa39527
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202604072309-R3SG76/pr/github-title.txt
+++ b/.agentplane/tasks/202604072309-R3SG76/pr/github-title.txt
@@ -1,0 +1,1 @@
+incidents/workflow: Explain internal Findings vs incidents registry promotion (R3SG76)

--- a/.agentplane/tasks/202604072309-R3SG76/pr/meta.json
+++ b/.agentplane/tasks/202604072309-R3SG76/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202604072309-R3SG76/incidents-findings-boundary",
+  "created_at": "2026-04-08T00:57:13.825Z",
+  "head_sha": "f40d5aa395279f3bd3ea1e4c3c44961a6df147c0",
+  "last_verified_at": "2026-04-08T00:57:13.792Z",
+  "last_verified_sha": "c1ef3608ba82310ba70e9f7294e0c7b7df5270f3",
+  "schema_version": 1,
+  "task_id": "202604072309-R3SG76",
+  "updated_at": "2026-04-08T01:00:59.289Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202604072309-R3SG76/pr/meta.json
+++ b/.agentplane/tasks/202604072309-R3SG76/pr/meta.json
@@ -2,12 +2,15 @@
   "base": "main",
   "branch": "task/202604072309-R3SG76/incidents-findings-boundary",
   "created_at": "2026-04-08T00:57:13.825Z",
-  "head_sha": "f40d5aa395279f3bd3ea1e4c3c44961a6df147c0",
-  "last_verified_at": "2026-04-08T00:57:13.792Z",
-  "last_verified_sha": "c1ef3608ba82310ba70e9f7294e0c7b7df5270f3",
+  "head_sha": "dba269e19c27b919b7551e758660f5bfc9899dfd",
+  "last_verified_at": "2026-04-08T01:08:26.576Z",
+  "last_verified_sha": "dba269e19c27b919b7551e758660f5bfc9899dfd",
+  "pr_number": 144,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/144",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202604072309-R3SG76",
-  "updated_at": "2026-04-08T01:00:59.289Z",
+  "updated_at": "2026-04-08T01:07:42.241Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202604072309-R3SG76/pr/review.md
+++ b/.agentplane/tasks/202604072309-R3SG76/pr/review.md
@@ -23,7 +23,7 @@ When Findings contains plain text, incidents collect and close-path diagnostics 
 ### Current Status
 
 - State: ok
-- Note: Verified targeted incidents and command-guide coverage; messaging now distinguishes plain task-local Findings from structured external incident promotion without changing promotion semantics.
+- Note: Re-verified after syncing canonical policy assets; incidents/finish/integrate diagnostics, bootstrap docs, routing, and agent-template sync remain aligned on the current head.
 
 ## Risks
 
@@ -43,12 +43,33 @@ When Findings contains plain text, incidents collect and close-path diagnostics 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-08T01:00:59.289Z
+- Updated: 2026-04-08T01:07:42.241Z
 - Branch: task/202604072309-R3SG76/incidents-findings-boundary
-- Head: f40d5aa39527
+- Head: dba269e19c27
 
 ```text
-No changes detected.
+ .agentplane/policy/workflow.branch_pr.md           |   2 +-
+ .agentplane/policy/workflow.direct.md              |   4 +-
+ .agentplane/tasks/202604072309-R3SG76/README.md    | 118 +++++++++++++++++++++
+ .../tasks/202604072309-R3SG76/pr/diffstat.txt      |   0
+ .../tasks/202604072309-R3SG76/pr/github-body.md    |  48 +++++++++
+ .../tasks/202604072309-R3SG76/pr/github-title.txt  |   1 +
+ .agentplane/tasks/202604072309-R3SG76/pr/meta.json |  14 +++
+ .../tasks/202604072309-R3SG76/pr/notes.jsonl       |   0
+ .agentplane/tasks/202604072309-R3SG76/pr/review.md |  55 ++++++++++
+ .../tasks/202604072309-R3SG76/pr/verify.log        |   0
+ docs/user/agent-bootstrap.generated.mdx            |   3 +-
+ docs/user/tasks-and-backends.mdx                   |   3 +-
+ .../agentplane/assets/policy/workflow.branch_pr.md |   2 +-
+ .../agentplane/assets/policy/workflow.direct.md    |   4 +-
+ packages/agentplane/src/cli/bootstrap-guide.ts     |   4 +-
+ packages/agentplane/src/cli/command-guide.test.ts  |   8 ++
+ packages/agentplane/src/cli/command-guide.ts       |   2 +-
+ .../src/cli/run-cli.core.incidents.test.ts         |   3 +-
+ .../agentplane/src/commands/incidents/shared.ts    |   4 +-
+ .../pr/integrate/internal/finalize.test.ts         |   4 +-
+ .../src/commands/task/finish.unit.test.ts          |   7 +-
+ 21 files changed, 267 insertions(+), 19 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202604072309-R3SG76/pr/review.md
+++ b/.agentplane/tasks/202604072309-R3SG76/pr/review.md
@@ -1,0 +1,55 @@
+# PR Review
+
+Created: 2026-04-08T00:57:13.825Z
+Branch: task/202604072309-R3SG76/incidents-findings-boundary
+
+## Summary
+
+Explain internal Findings vs incidents registry promotion
+
+When Findings contains plain text, incidents collect and close-path diagnostics should explicitly distinguish internal follow-up defects from reusable external incident candidates so operators do not expect incidents.md updates from task-local code bugs.
+
+## Scope
+
+- In scope: When Findings contains plain text, incidents collect and close-path diagnostics should explicitly distinguish internal follow-up defects from reusable external incident candidates so operators do not expect incidents.md updates from task-local code bugs.
+- Out of scope: unrelated refactors not required for "Explain internal Findings vs incidents registry promotion".
+
+## Verification
+
+### Plan
+
+1. Run the targeted incidents and findings vitest coverage for resolve, finish, and run-cli incidents/findings flows; expected: all pass. 2. Review the changed CLI and guide messages; expected: they explicitly distinguish task-local Findings from reusable incidents registry promotion. 3. Confirm no behavior change in incidents promotion semantics; expected: incidents.md is updated only by structured reusable incident candidates, not by plain Findings text.
+
+### Current Status
+
+- State: ok
+- Note: Verified targeted incidents and command-guide coverage; messaging now distinguishes plain task-local Findings from structured external incident promotion without changing promotion semantics.
+
+## Risks
+
+- Risk level: not recorded
+- Breaking change: no
+
+### Rollback
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-04-08T01:00:59.289Z
+- Branch: task/202604072309-R3SG76/incidents-findings-boundary
+- Head: f40d5aa39527
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/docs/user/agent-bootstrap.generated.mdx
+++ b/docs/user/agent-bootstrap.generated.mdx
@@ -63,7 +63,8 @@ Reuse historical incident advice only through targeted lookup, and validate prom
 - `node .agentplane/policy/check-routing.mjs`
 
 - Use `agentplane incidents advise <task-id>` after `start-ready` when analogous scope or tags might have prior external failure modes.
-- Use `agentplane incidents collect <task-id> --check` before `finish` when task `Findings` contains reusable external `Observation` / `Impact` / `Resolution` blocks marked with `Fixability: external` (or `IncidentExternal: true`).
+- Use `agentplane task findings add <task-id> --observation "..." --impact "..." --resolution "..."` to append reusable structured Findings blocks without replacing the whole README; promotion is the default unless you pass `--local-only`.
+- Use `agentplane incidents collect <task-id> --check` before `finish` when task `Findings` contains reusable external `Observation` / `Impact` / `Resolution` blocks. Plain prose in `Findings` stays task-local and does not update `.agentplane/policy/incidents.md`.
 - Keep repository-fixable defects task-local; only external or process incidents belong in `.agentplane/policy/incidents.md`.
 
 ## 4. Fallbacks and recovery

--- a/docs/user/tasks-and-backends.mdx
+++ b/docs/user/tasks-and-backends.mdx
@@ -64,7 +64,8 @@ Section semantics:
 
 - `## Findings` is task-local and may contain raw incident candidates.
 - `.agentplane/policy/incidents.md` stores only curated strong incidents with repository-wide value.
-- Promotion from `Findings` to policy incidents is explicit, not automatic.
+- Plain prose in `## Findings` stays task-local and never updates `.agentplane/policy/incidents.md` by itself.
+- Structured reusable external findings are promoted during `agentplane finish` or `agentplane incidents collect <task-id>`.
 
 ### Frontmatter boundaries
 

--- a/packages/agentplane/assets/policy/workflow.branch_pr.md
+++ b/packages/agentplane/assets/policy/workflow.branch_pr.md
@@ -30,7 +30,7 @@ agentplane finish <task-id> --author INTEGRATOR --body "Verified: ..." --result 
 - Task documentation updates MAY be batched within one turn before approval.
 - MUST run `task plan approve` then `task start-ready` as `Step 1 -> wait -> Step 2` (never parallel).
 - `task start-ready` MAY surface targeted incident advice for analogous scope/tags; follow it before widening scope.
-- Keep structured resolved external findings in the task README; mark reusable ones with `Fixability: external` (or `IncidentExternal: true`) and let base-branch `finish` or `agentplane incidents collect <task-id>` promote them into `.agentplane/policy/incidents.md`, using optional `Incident*` fields only when the inferred scope/advice needs refinement.
+- Keep structured resolved external findings in the task README; mark reusable ones with `Fixability: external` (or `IncidentExternal: true`) and let base-branch `finish` or `agentplane incidents collect <task-id>` promote them into `.agentplane/policy/incidents.md`, using optional `Incident*` fields only when the inferred scope/advice needs refinement. Plain `Findings` text remains task-local and does not update the shared incident registry.
 - MUST stop and request re-approval on material drift.
 - Planning and closure happen on base checkout.
 - Do not export task snapshots from task branches.

--- a/packages/agentplane/assets/policy/workflow.direct.md
+++ b/packages/agentplane/assets/policy/workflow.direct.md
@@ -38,7 +38,7 @@ If any step fails:
    - `doc_version=3`: task `Findings`
 3. Mark task blocked: `agentplane block <task-id> --author <ROLE> --body "Blocked: ..."`.
 4. Request re-approval before scope/risk changes.
-5. If failure is external/process-related and should become reusable advice, record a structured `Observation` / `Impact` / `Resolution` block in `Findings` and mark it with `Fixability: external` (or `IncidentExternal: true`); optional `Incident*` fields refine the promoted registry entry.
+5. If failure is external/process-related and should become reusable advice, record a structured `Observation` / `Impact` / `Resolution` block in `Findings` and mark it with `Fixability: external` (or `IncidentExternal: true`); plain prose in `Findings` stays task-local and does not update `.agentplane/policy/incidents.md`.
 
 ## Constraints
 
@@ -47,7 +47,7 @@ If any step fails:
 - MUST run `task plan approve` then `task start-ready` as `Step 1 -> wait -> Step 2` (never parallel).
 - `task start-ready` MAY surface targeted incident advice for analogous scope/tags; follow it before widening scope.
 - In direct mode, `finish` auto-creates the deterministic close commit by default; use `--no-close-commit` only for explicit manual handling.
-- `finish` evaluates structured resolved external findings, auto-derives incident advice when only `Observation` / `Impact` / `Resolution` plus `Fixability: external` are present, and appends valid entries to `.agentplane/policy/incidents.md`.
+- `finish` evaluates structured resolved external findings, auto-derives incident advice when only `Observation` / `Impact` / `Resolution` plus `Fixability: external` are present, and appends valid entries to `.agentplane/policy/incidents.md`; plain `Findings` text remains task-local.
 - MUST stop and request re-approval on material drift.
 - Do not use worktrees in direct mode.
 - Do not perform `branch_pr`-only operations.

--- a/packages/agentplane/src/cli/bootstrap-guide.ts
+++ b/packages/agentplane/src/cli/bootstrap-guide.ts
@@ -79,8 +79,8 @@ export const BOOTSTRAP_SECTIONS: readonly BootstrapSection[] = [
     commands: BOOTSTRAP_VERIFICATION_COMMANDS,
     notes: [
       "Use `agentplane incidents advise <task-id>` after `start-ready` when analogous scope or tags might have prior external failure modes.",
-      "Use `agentplane task findings add <task-id> ... --promote --external` to append reusable structured Findings blocks without replacing the whole README.",
-      "Use `agentplane incidents collect <task-id> --check` before `finish` when task `Findings` contains reusable external `Observation` / `Impact` / `Resolution` blocks marked with `Fixability: external` (or `IncidentExternal: true`).",
+      'Use `agentplane task findings add <task-id> --observation "..." --impact "..." --resolution "..."` to append reusable structured Findings blocks without replacing the whole README; promotion is the default unless you pass `--local-only`.',
+      "Use `agentplane incidents collect <task-id> --check` before `finish` when task `Findings` contains reusable external `Observation` / `Impact` / `Resolution` blocks. Plain prose in `Findings` stays task-local and does not update `.agentplane/policy/incidents.md`.",
       "Keep repository-fixable defects task-local; only external or process incidents belong in `.agentplane/policy/incidents.md`.",
     ],
   },

--- a/packages/agentplane/src/cli/command-guide.test.ts
+++ b/packages/agentplane/src/cli/command-guide.test.ts
@@ -77,6 +77,14 @@ describe("command-guide", () => {
     expect(text).toContain("Use `agentplane role ORCHESTRATOR` during planning");
     expect(text).toContain("agentplane incidents advise <task-id>");
     expect(text).toContain("agentplane incidents collect <task-id> --check");
+    expect(text).toContain("promotion is the default unless you pass `--local-only`");
+    expect(text).toContain("Plain prose in `Findings` stays task-local");
     expect(text).toContain("workflow:wait-remote-checks");
+  });
+
+  it("updates the planner role guidance to the promotion-by-default findings flow", () => {
+    const text = renderRoleTyped("planner");
+    expect(text).toContain("promotion is the default unless `--local-only` is set");
+    expect(text).not.toContain("[--promote] [--external]");
   });
 });

--- a/packages/agentplane/src/cli/command-guide.ts
+++ b/packages/agentplane/src/cli/command-guide.ts
@@ -39,7 +39,7 @@ const ROLE_GUIDES: RoleGuide[] = [
       SHARED_STARTUP_NOTE,
       '- Create executable tasks with `agentplane task new --title "..." --description "..." --priority med --owner <ROLE> --tag <tag>`.',
       '- Fill docs with `agentplane task doc set <task-id> --section <name> --text "..."` and set plan text with `agentplane task plan set <task-id> --text "..." --updated-by <ROLE>`.',
-      '- Append reusable incident-ready Findings via `agentplane task findings add <task-id> --observation "..." --impact "..." --resolution "..." [--promote] [--external]` instead of replacing the full Findings section by hand.',
+      '- Append reusable incident-ready Findings via `agentplane task findings add <task-id> --observation "..." --impact "..." --resolution "..."`; promotion is the default unless `--local-only` is set.',
       "- Approve plan only after required sections and Verify Steps are ready.",
     ],
   },

--- a/packages/agentplane/src/cli/run-cli.core.incidents.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.incidents.test.ts
@@ -356,7 +356,8 @@ describe("runCli incidents", () => {
     try {
       const code = await runCli(["incidents", "collect", taskId, "--check", "--root", root]);
       expect(code).toBe(0);
-      expect(io.stdout).toContain("Findings has text but no structured incident blocks");
+      expect(io.stdout).toContain("plain Findings text stays task-local");
+      expect(io.stdout).toContain("does not update incidents.md");
       expect(io.stdout).toContain("Observation/Impact/Resolution");
     } finally {
       io.restore();

--- a/packages/agentplane/src/commands/incidents/shared.ts
+++ b/packages/agentplane/src/commands/incidents/shared.ts
@@ -220,11 +220,11 @@ export function renderIncidentCollectionPlanOutcome(plan: {
   }
 
   if (skipped > 0) {
-    return `incident registry unchanged (${skipped} structured finding${skipped === 1 ? "" : "s"} skipped: add Promotion: incident-candidate or IncidentExternal/Fixability: external to promote reusable findings)`;
+    return `incident registry unchanged (${skipped} structured finding${skipped === 1 ? "" : "s"} stayed task-local: mark reusable external findings with Promotion: incident-candidate plus Fixability: external, or use task findings add without --local-only)`;
   }
 
   if (candidates === 0 && structuredFindingCount === 0 && findingsTextPresent) {
-    return "incident registry unchanged (Findings has text but no structured incident blocks: add Observation/Impact/Resolution fields before Promotion: incident-candidate or IncidentExternal/Fixability: external)";
+    return "incident registry unchanged (plain Findings text stays task-local and does not update incidents.md: add a structured Observation/Impact/Resolution block for reusable external incidents, or use task findings add without --local-only)";
   }
 
   if (candidates === 0) {

--- a/packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts
+++ b/packages/agentplane/src/commands/pr/integrate/internal/finalize.test.ts
@@ -223,7 +223,7 @@ describe("pr/integrate/internal/finalize", () => {
     await finalizeIntegrate({ ...baseOpts(), quiet: false });
 
     expect(emitter.info).toHaveBeenCalledWith(
-      expect.stringContaining("structured finding skipped"),
+      expect.stringContaining("structured finding stayed task-local"),
     );
   });
 
@@ -255,7 +255,7 @@ describe("pr/integrate/internal/finalize", () => {
     await finalizeIntegrate({ ...baseOpts(), quiet: false });
 
     expect(emitter.info).toHaveBeenCalledWith(
-      expect.stringContaining("Findings has text but no structured incident blocks"),
+      expect.stringContaining("plain Findings text stays task-local"),
     );
   });
 });

--- a/packages/agentplane/src/commands/task/finish.unit.test.ts
+++ b/packages/agentplane/src/commands/task/finish.unit.test.ts
@@ -1062,7 +1062,8 @@ describe("task finish (unit)", () => {
     });
 
     expect(rc).toBe(0);
-    expect(writes.join("")).toContain("Findings has text but no structured incident blocks");
+    expect(writes.join("")).toContain("plain Findings text stays task-local");
+    expect(writes.join("")).toContain("does not update incidents.md");
     expect(writes.join("")).toContain("Observation/Impact/Resolution");
 
     writeSpy.mockRestore();
@@ -1132,8 +1133,8 @@ describe("task finish (unit)", () => {
     });
 
     expect(rc).toBe(0);
-    expect(writes.join("")).toContain("structured finding skipped");
-    expect(writes.join("")).toContain("Promotion: incident-candidate");
+    expect(writes.join("")).toContain("structured finding stayed task-local");
+    expect(writes.join("")).toContain("use task findings add without --local-only");
 
     writeSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary

Explain internal Findings vs incidents registry promotion

When Findings contains plain text, incidents collect and close-path diagnostics should explicitly distinguish internal follow-up defects from reusable external incident candidates so operators do not expect incidents.md updates from task-local code bugs.

## Scope

- In scope: When Findings contains plain text, incidents collect and close-path diagnostics should explicitly distinguish internal follow-up defects from reusable external incident candidates so operators do not expect incidents.md updates from task-local code bugs.
- Out of scope: unrelated refactors not required for "Explain internal Findings vs incidents registry promotion".

## Verification

### Plan

1. Run the targeted incidents and findings vitest coverage for resolve, finish, and run-cli incidents/findings flows; expected: all pass. 2. Review the changed CLI and guide messages; expected: they explicitly distinguish task-local Findings from reusable incidents registry promotion. 3. Confirm no behavior change in incidents promotion semantics; expected: incidents.md is updated only by structured reusable incident candidates, not by plain Findings text.

### Current Status

- State: ok
- Note: Verified targeted incidents and command-guide coverage; messaging now distinguishes plain task-local Findings from structured external incident promotion without changing promotion semantics.

## Risks

- Risk level: not recorded
- Breaking change: no

### Rollback

- Revert task-related commit(s).
- Re-run required checks to confirm rollback safety.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-04-08T01:00:59.289Z
- Branch: task/202604072309-R3SG76/incidents-findings-boundary
- Head: f40d5aa39527

```text
No changes detected.
```

</details>
