### PR TITLE
incidents/ux: Let verify append promotable incident findings in one command (DCDXVB)

### DIFF
--- a/.agentplane/tasks/202604081816-DCDXVB/README.md
+++ b/.agentplane/tasks/202604081816-DCDXVB/README.md
@@ -1,0 +1,113 @@
+---
+id: "202604081816-DCDXVB"
+title: "Let verify append promotable incident findings in one command"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "incidents"
+  - "ux"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-04-08T18:17:42.963Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-04-08T18:50:24.765Z"
+  updated_by: "CODER"
+  note: "Command: bun x vitest run packages/agentplane/src/commands/task/verify-record.unit.test.ts packages/agentplane/src/commands/workflow.verify-hooks.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts; bun x eslint packages/agentplane/src/cli/command-invocations.ts packages/agentplane/src/commands/task/findings.ts packages/agentplane/src/commands/task/shared/transitions.ts packages/agentplane/src/commands/task/verify-command-shared.ts packages/agentplane/src/commands/task/verify-ok.command.ts packages/agentplane/src/commands/task/verify-record.ts packages/agentplane/src/commands/task/verify-rework.command.ts packages/agentplane/src/commands/verify.run.ts packages/agentplane/src/commands/verify.spec.ts packages/agentplane/src/commands/workflow.verify-hooks.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts; bun run framework:dev:bootstrap. Result: pass. Evidence: verify now accepts structured finding flags, records incident-candidate vs task-local findings in the same mutation path, and incidents collect sees verify-appended promotable findings while local-only entries stay skipped. Scope: verify-to-findings incident flow."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: trace verify and findings flows, then add the smallest verify-side structured finding append path so incident candidates can be recorded without a second command."
+events:
+  -
+    type: "status"
+    at: "2026-04-08T18:26:53.837Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: trace verify and findings flows, then add the smallest verify-side structured finding append path so incident candidates can be recorded without a second command."
+  -
+    type: "verify"
+    at: "2026-04-08T18:50:24.765Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: bun x vitest run packages/agentplane/src/commands/task/verify-record.unit.test.ts packages/agentplane/src/commands/workflow.verify-hooks.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts; bun x eslint packages/agentplane/src/cli/command-invocations.ts packages/agentplane/src/commands/task/findings.ts packages/agentplane/src/commands/task/shared/transitions.ts packages/agentplane/src/commands/task/verify-command-shared.ts packages/agentplane/src/commands/task/verify-ok.command.ts packages/agentplane/src/commands/task/verify-record.ts packages/agentplane/src/commands/task/verify-rework.command.ts packages/agentplane/src/commands/verify.run.ts packages/agentplane/src/commands/verify.spec.ts packages/agentplane/src/commands/workflow.verify-hooks.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts; bun run framework:dev:bootstrap. Result: pass. Evidence: verify now accepts structured finding flags, records incident-candidate vs task-local findings in the same mutation path, and incidents collect sees verify-appended promotable findings while local-only entries stay skipped. Scope: verify-to-findings incident flow."
+doc_version: 3
+doc_updated_at: "2026-04-08T18:50:24.776Z"
+doc_updated_by: "CODER"
+description: "The incident registry path exists, but real operator flow almost never leaves structured incident candidates because verify and findings are separate steps. Extend verify so a verifier can append a structured finding/incident candidate in the same command, preserving task-local opt-out and existing promotion semantics."
+sections:
+  Summary: |-
+    Let verify append promotable incident findings in one command
+    
+    The incident registry path exists, but real operator flow almost never leaves structured incident candidates because verify and findings are separate steps. Extend verify so a verifier can append a structured finding/incident candidate in the same command, preserving task-local opt-out and existing promotion semantics.
+  Scope: |-
+    - In scope: The incident registry path exists, but real operator flow almost never leaves structured incident candidates because verify and findings are separate steps. Extend verify so a verifier can append a structured finding/incident candidate in the same command, preserving task-local opt-out and existing promotion semantics.
+    - Out of scope: unrelated refactors not required for "Let verify append promotable incident findings in one command".
+  Plan: "1. Trace verify and findings flows to find the smallest way to let a verifier append a structured finding/incident candidate without a second command. 2. Extend verify CLI parsing and record logic with optional finding fields that append the same structured block as task findings add, preserving local-only opt-out and existing note/file behavior. 3. Add targeted tests for verify plus finding append, local-only behavior, and incident-ready default semantics. 4. Verify that finish or incidents collect can promote the appended finding under the existing rules."
+  Verify Steps: "1. Run the focused verify/findings/incident tests. Expected: verify can append a structured finding in the same command and preserves existing verification behavior. 2. Validate local-only vs default-promotable semantics. Expected: default verify-added findings carry incident-candidate metadata, while explicit local-only entries stay task-local. 3. Run incidents collect on a representative task fixture. Expected: a verify-appended promotable finding can be promoted under the existing incidents rules."
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-04-08T18:50:24.765Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Command: bun x vitest run packages/agentplane/src/commands/task/verify-record.unit.test.ts packages/agentplane/src/commands/workflow.verify-hooks.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts; bun x eslint packages/agentplane/src/cli/command-invocations.ts packages/agentplane/src/commands/task/findings.ts packages/agentplane/src/commands/task/shared/transitions.ts packages/agentplane/src/commands/task/verify-command-shared.ts packages/agentplane/src/commands/task/verify-ok.command.ts packages/agentplane/src/commands/task/verify-record.ts packages/agentplane/src/commands/task/verify-rework.command.ts packages/agentplane/src/commands/verify.run.ts packages/agentplane/src/commands/verify.spec.ts packages/agentplane/src/commands/workflow.verify-hooks.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts; bun run framework:dev:bootstrap. Result: pass. Evidence: verify now accepts structured finding flags, records incident-candidate vs task-local findings in the same mutation path, and incidents collect sees verify-appended promotable findings while local-only entries stay skipped. Scope: verify-to-findings incident flow.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-08T18:26:53.852Z, excerpt_hash=sha256:1bb20b0c5a296606ae8641fe595c4679af4b17c3ae788a4e0cad851b32f7f7e4
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Let verify append promotable incident findings in one command
+
+The incident registry path exists, but real operator flow almost never leaves structured incident candidates because verify and findings are separate steps. Extend verify so a verifier can append a structured finding/incident candidate in the same command, preserving task-local opt-out and existing promotion semantics.
+
+## Scope
+
+- In scope: The incident registry path exists, but real operator flow almost never leaves structured incident candidates because verify and findings are separate steps. Extend verify so a verifier can append a structured finding/incident candidate in the same command, preserving task-local opt-out and existing promotion semantics.
+- Out of scope: unrelated refactors not required for "Let verify append promotable incident findings in one command".
+
+## Plan
+
+1. Trace verify and findings flows to find the smallest way to let a verifier append a structured finding/incident candidate without a second command. 2. Extend verify CLI parsing and record logic with optional finding fields that append the same structured block as task findings add, preserving local-only opt-out and existing note/file behavior. 3. Add targeted tests for verify plus finding append, local-only behavior, and incident-ready default semantics. 4. Verify that finish or incidents collect can promote the appended finding under the existing rules.
+
+## Verify Steps
+
+1. Run the focused verify/findings/incident tests. Expected: verify can append a structured finding in the same command and preserves existing verification behavior. 2. Validate local-only vs default-promotable semantics. Expected: default verify-added findings carry incident-candidate metadata, while explicit local-only entries stay task-local. 3. Run incidents collect on a representative task fixture. Expected: a verify-appended promotable finding can be promoted under the existing incidents rules.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-04-08T18:50:24.765Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: bun x vitest run packages/agentplane/src/commands/task/verify-record.unit.test.ts packages/agentplane/src/commands/workflow.verify-hooks.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts; bun x eslint packages/agentplane/src/cli/command-invocations.ts packages/agentplane/src/commands/task/findings.ts packages/agentplane/src/commands/task/shared/transitions.ts packages/agentplane/src/commands/task/verify-command-shared.ts packages/agentplane/src/commands/task/verify-ok.command.ts packages/agentplane/src/commands/task/verify-record.ts packages/agentplane/src/commands/task/verify-rework.command.ts packages/agentplane/src/commands/verify.run.ts packages/agentplane/src/commands/verify.spec.ts packages/agentplane/src/commands/workflow.verify-hooks.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts; bun run framework:dev:bootstrap. Result: pass. Evidence: verify now accepts structured finding flags, records incident-candidate vs task-local findings in the same mutation path, and incidents collect sees verify-appended promotable findings while local-only entries stay skipped. Scope: verify-to-findings incident flow.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-08T18:26:53.852Z, excerpt_hash=sha256:1bb20b0c5a296606ae8641fe595c4679af4b17c3ae788a4e0cad851b32f7f7e4
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202604081816-DCDXVB/pr/diffstat.txt
+++ b/.agentplane/tasks/202604081816-DCDXVB/pr/diffstat.txt
@@ -1,0 +1,21 @@
+ .agentplane/tasks/202604081816-DCDXVB/README.md    | 113 +++++++++++++
+ .../tasks/202604081816-DCDXVB/pr/diffstat.txt      |   0
+ .../tasks/202604081816-DCDXVB/pr/github-body.md    |  48 ++++++
+ .../tasks/202604081816-DCDXVB/pr/github-title.txt  |   1 +
+ .agentplane/tasks/202604081816-DCDXVB/pr/meta.json |  14 ++
+ .../tasks/202604081816-DCDXVB/pr/notes.jsonl       |   0
+ .agentplane/tasks/202604081816-DCDXVB/pr/review.md |  55 +++++++
+ .../tasks/202604081816-DCDXVB/pr/verify.log        |   0
+ docs/user/cli-reference.generated.mdx              |  33 ++++
+ packages/agentplane/src/cli/command-invocations.ts |   5 +-
+ .../src/cli/run-cli.core.incidents.test.ts         | 178 +++++++++++++++++++++
+ packages/agentplane/src/commands/task/findings.ts  | 138 +++++++++++-----
+ .../src/commands/task/shared/transitions.ts        |   1 +
+ .../src/commands/task/verify-command-shared.ts     | 121 ++++++++++++++
+ .../src/commands/task/verify-ok.command.ts         |  11 ++
+ .../agentplane/src/commands/task/verify-record.ts  | 133 ++++++++++++++-
+ .../src/commands/task/verify-rework.command.ts     |  11 ++
+ packages/agentplane/src/commands/verify.run.ts     |   9 ++
+ packages/agentplane/src/commands/verify.spec.ts    |  17 +-
+ .../src/commands/workflow.verify-hooks.test.ts     |  35 ++++
+ 20 files changed, 867 insertions(+), 56 deletions(-)

--- a/.agentplane/tasks/202604081816-DCDXVB/pr/github-body.md
+++ b/.agentplane/tasks/202604081816-DCDXVB/pr/github-body.md
@@ -1,0 +1,48 @@
+## Summary
+
+Let verify append promotable incident findings in one command
+
+The incident registry path exists, but real operator flow almost never leaves structured incident candidates because verify and findings are separate steps. Extend verify so a verifier can append a structured finding/incident candidate in the same command, preserving task-local opt-out and existing promotion semantics.
+
+## Scope
+
+- In scope: The incident registry path exists, but real operator flow almost never leaves structured incident candidates because verify and findings are separate steps. Extend verify so a verifier can append a structured finding/incident candidate in the same command, preserving task-local opt-out and existing promotion semantics.
+- Out of scope: unrelated refactors not required for "Let verify append promotable incident findings in one command".
+
+## Verification
+
+### Plan
+
+1. Run the focused verify/findings/incident tests. Expected: verify can append a structured finding in the same command and preserves existing verification behavior. 2. Validate local-only vs default-promotable semantics. Expected: default verify-added findings carry incident-candidate metadata, while explicit local-only entries stay task-local. 3. Run incidents collect on a representative task fixture. Expected: a verify-appended promotable finding can be promoted under the existing incidents rules.
+
+### Current Status
+
+- State: ok
+- Note: Command: bun x vitest run packages/agentplane/src/commands/task/verify-record.unit.test.ts packages/agentplane/src/commands/workflow.verify-hooks.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts; bun x eslint packages/agentplane/src/cli/command-invocations.ts packages/agentplane/src/commands/task/findings.ts packages/agentplane/src/commands/task/shared/transitions.ts packages/agentplane/src/commands/task/verify-command-shared.ts packages/agentplane/src/commands/task/verify-ok.command.ts packages/agentplane/src/commands/task/verify-record.ts packages/agentplane/src/commands/task/verify-rework.command.ts packages/agentplane/src/commands/verify.run.ts packages/agentplane/src/commands/verify.spec.ts packages/agentplane/src/commands/workflow.verify-hooks.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts; bun run framework:dev:bootstrap. Result: pass. Evidence: verify now accepts structured finding flags, records incident-candidate vs task-local findings in the same mutation path, and incidents collect sees verify-appended promotable findings while local-only entries stay skipped. Scope: verify-to-findings incident flow.
+
+## Risks
+
+- Risk level: not recorded
+- Breaking change: no
+
+### Rollback
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-04-08T18:50:24.855Z
+- Branch: task/202604081816-DCDXVB/verify-incident-finding
+- Head: 70c479c09c78
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202604081816-DCDXVB/pr/github-body.md
+++ b/.agentplane/tasks/202604081816-DCDXVB/pr/github-body.md
@@ -37,12 +37,32 @@ The incident registry path exists, but real operator flow almost never leaves st
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-08T18:50:24.855Z
+- Updated: 2026-04-08T18:57:12.941Z
 - Branch: task/202604081816-DCDXVB/verify-incident-finding
-- Head: 70c479c09c78
+- Head: f276e8731274
 
 ```text
-No changes detected.
+ .agentplane/tasks/202604081816-DCDXVB/README.md    | 113 +++++++++++++
+ .../tasks/202604081816-DCDXVB/pr/diffstat.txt      |   0
+ .../tasks/202604081816-DCDXVB/pr/github-body.md    |  48 ++++++
+ .../tasks/202604081816-DCDXVB/pr/github-title.txt  |   1 +
+ .agentplane/tasks/202604081816-DCDXVB/pr/meta.json |  14 ++
+ .../tasks/202604081816-DCDXVB/pr/notes.jsonl       |   0
+ .agentplane/tasks/202604081816-DCDXVB/pr/review.md |  55 +++++++
+ .../tasks/202604081816-DCDXVB/pr/verify.log        |   0
+ docs/user/cli-reference.generated.mdx              |  33 ++++
+ packages/agentplane/src/cli/command-invocations.ts |   5 +-
+ .../src/cli/run-cli.core.incidents.test.ts         | 178 +++++++++++++++++++++
+ packages/agentplane/src/commands/task/findings.ts  | 138 +++++++++++-----
+ .../src/commands/task/shared/transitions.ts        |   1 +
+ .../src/commands/task/verify-command-shared.ts     | 121 ++++++++++++++
+ .../src/commands/task/verify-ok.command.ts         |  11 ++
+ .../agentplane/src/commands/task/verify-record.ts  | 133 ++++++++++++++-
+ .../src/commands/task/verify-rework.command.ts     |  11 ++
+ packages/agentplane/src/commands/verify.run.ts     |   9 ++
+ packages/agentplane/src/commands/verify.spec.ts    |  17 +-
+ .../src/commands/workflow.verify-hooks.test.ts     |  35 ++++
+ 20 files changed, 867 insertions(+), 56 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202604081816-DCDXVB/pr/github-title.txt
+++ b/.agentplane/tasks/202604081816-DCDXVB/pr/github-title.txt
@@ -1,0 +1,1 @@
+incidents/ux: Let verify append promotable incident findings in one command (DCDXVB)

--- a/.agentplane/tasks/202604081816-DCDXVB/pr/meta.json
+++ b/.agentplane/tasks/202604081816-DCDXVB/pr/meta.json
@@ -2,12 +2,15 @@
   "base": "main",
   "branch": "task/202604081816-DCDXVB/verify-incident-finding",
   "created_at": "2026-04-08T18:50:24.855Z",
-  "head_sha": "70c479c09c783a817bd2ad4b9971a9a84bbc74fb",
+  "head_sha": "f276e87312749a6d0076011c8fcdd933d39736ad",
   "last_verified_at": "2026-04-08T18:50:24.765Z",
   "last_verified_sha": "70c479c09c783a817bd2ad4b9971a9a84bbc74fb",
+  "pr_number": 154,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/154",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202604081816-DCDXVB",
-  "updated_at": "2026-04-08T18:50:24.855Z",
+  "updated_at": "2026-04-08T18:57:12.941Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202604081816-DCDXVB/pr/meta.json
+++ b/.agentplane/tasks/202604081816-DCDXVB/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202604081816-DCDXVB/verify-incident-finding",
+  "created_at": "2026-04-08T18:50:24.855Z",
+  "head_sha": "70c479c09c783a817bd2ad4b9971a9a84bbc74fb",
+  "last_verified_at": "2026-04-08T18:50:24.765Z",
+  "last_verified_sha": "70c479c09c783a817bd2ad4b9971a9a84bbc74fb",
+  "schema_version": 1,
+  "task_id": "202604081816-DCDXVB",
+  "updated_at": "2026-04-08T18:50:24.855Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202604081816-DCDXVB/pr/review.md
+++ b/.agentplane/tasks/202604081816-DCDXVB/pr/review.md
@@ -43,12 +43,32 @@ The incident registry path exists, but real operator flow almost never leaves st
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-08T18:50:24.855Z
+- Updated: 2026-04-08T18:57:12.941Z
 - Branch: task/202604081816-DCDXVB/verify-incident-finding
-- Head: 70c479c09c78
+- Head: f276e8731274
 
 ```text
-No changes detected.
+ .agentplane/tasks/202604081816-DCDXVB/README.md    | 113 +++++++++++++
+ .../tasks/202604081816-DCDXVB/pr/diffstat.txt      |   0
+ .../tasks/202604081816-DCDXVB/pr/github-body.md    |  48 ++++++
+ .../tasks/202604081816-DCDXVB/pr/github-title.txt  |   1 +
+ .agentplane/tasks/202604081816-DCDXVB/pr/meta.json |  14 ++
+ .../tasks/202604081816-DCDXVB/pr/notes.jsonl       |   0
+ .agentplane/tasks/202604081816-DCDXVB/pr/review.md |  55 +++++++
+ .../tasks/202604081816-DCDXVB/pr/verify.log        |   0
+ docs/user/cli-reference.generated.mdx              |  33 ++++
+ packages/agentplane/src/cli/command-invocations.ts |   5 +-
+ .../src/cli/run-cli.core.incidents.test.ts         | 178 +++++++++++++++++++++
+ packages/agentplane/src/commands/task/findings.ts  | 138 +++++++++++-----
+ .../src/commands/task/shared/transitions.ts        |   1 +
+ .../src/commands/task/verify-command-shared.ts     | 121 ++++++++++++++
+ .../src/commands/task/verify-ok.command.ts         |  11 ++
+ .../agentplane/src/commands/task/verify-record.ts  | 133 ++++++++++++++-
+ .../src/commands/task/verify-rework.command.ts     |  11 ++
+ packages/agentplane/src/commands/verify.run.ts     |   9 ++
+ packages/agentplane/src/commands/verify.spec.ts    |  17 +-
+ .../src/commands/workflow.verify-hooks.test.ts     |  35 ++++
+ 20 files changed, 867 insertions(+), 56 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202604081816-DCDXVB/pr/review.md
+++ b/.agentplane/tasks/202604081816-DCDXVB/pr/review.md
@@ -1,0 +1,55 @@
+# PR Review
+
+Created: 2026-04-08T18:50:24.855Z
+Branch: task/202604081816-DCDXVB/verify-incident-finding
+
+## Summary
+
+Let verify append promotable incident findings in one command
+
+The incident registry path exists, but real operator flow almost never leaves structured incident candidates because verify and findings are separate steps. Extend verify so a verifier can append a structured finding/incident candidate in the same command, preserving task-local opt-out and existing promotion semantics.
+
+## Scope
+
+- In scope: The incident registry path exists, but real operator flow almost never leaves structured incident candidates because verify and findings are separate steps. Extend verify so a verifier can append a structured finding/incident candidate in the same command, preserving task-local opt-out and existing promotion semantics.
+- Out of scope: unrelated refactors not required for "Let verify append promotable incident findings in one command".
+
+## Verification
+
+### Plan
+
+1. Run the focused verify/findings/incident tests. Expected: verify can append a structured finding in the same command and preserves existing verification behavior. 2. Validate local-only vs default-promotable semantics. Expected: default verify-added findings carry incident-candidate metadata, while explicit local-only entries stay task-local. 3. Run incidents collect on a representative task fixture. Expected: a verify-appended promotable finding can be promoted under the existing incidents rules.
+
+### Current Status
+
+- State: ok
+- Note: Command: bun x vitest run packages/agentplane/src/commands/task/verify-record.unit.test.ts packages/agentplane/src/commands/workflow.verify-hooks.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts; bun x eslint packages/agentplane/src/cli/command-invocations.ts packages/agentplane/src/commands/task/findings.ts packages/agentplane/src/commands/task/shared/transitions.ts packages/agentplane/src/commands/task/verify-command-shared.ts packages/agentplane/src/commands/task/verify-ok.command.ts packages/agentplane/src/commands/task/verify-record.ts packages/agentplane/src/commands/task/verify-rework.command.ts packages/agentplane/src/commands/verify.run.ts packages/agentplane/src/commands/verify.spec.ts packages/agentplane/src/commands/workflow.verify-hooks.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts; bun run framework:dev:bootstrap. Result: pass. Evidence: verify now accepts structured finding flags, records incident-candidate vs task-local findings in the same mutation path, and incidents collect sees verify-appended promotable findings while local-only entries stay skipped. Scope: verify-to-findings incident flow.
+
+## Risks
+
+- Risk level: not recorded
+- Breaking change: no
+
+### Rollback
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-04-08T18:50:24.855Z
+- Branch: task/202604081816-DCDXVB/verify-incident-finding
+- Head: 70c479c09c78
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -1226,6 +1226,15 @@ Options:
 - `--details <text>`: Optional free-form details (mutually exclusive with --file).
 - `--file <path>`: Read details from a file path (mutually exclusive with --details).
 - `--quiet`: Suppress output. (default=false)
+- `--observation <text>`: Structured finding observation to append with the verification.
+- `--impact <text>`: Structured finding impact to append with the verification.
+- `--resolution <text>`: Structured finding resolution to append with the verification.
+- `--local-only`: Keep the finding task-local; omit incident-candidate promotion. (default=false)
+- `--incident-scope <text>`: Optional incident scope for the appended finding.
+- `--incident-tag <tag>`: Repeatable incident tag for the appended finding. (repeatable)
+- `--incident-match <term>`: Repeatable incident match term for the appended finding. (repeatable)
+- `--incident-advice <text>`: Optional operator advice for the appended finding.
+- `--incident-rule <text>`: Optional incident rule for the appended finding.
 
 Examples:
 
@@ -1246,6 +1255,12 @@ agentplane verify 202602030608-F1Q8AB --rework --by REVIEWER --note "Needs chang
 ```
 
 - Record a needs-rework outcome with details.
+
+```sh
+agentplane verify 202602030608-F1Q8AB --ok --by REVIEWER --note "Looks good" --observation "Repeated recovery was manual." --impact "Operators needed a second command." --resolution "Append structured findings during verify."
+```
+
+- Record verification and append a promotable structured finding in one command.
 
 ## Policy
 
@@ -3341,6 +3356,15 @@ Options:
 - `--details <text>`: Optional details text (mutually exclusive with --file).
 - `--file <path>`: Optional details file path (mutually exclusive with --details).
 - `--quiet`: Suppress normal output (still prints errors). (default=false)
+- `--observation <text>`: Structured finding observation to append with the verification.
+- `--impact <text>`: Structured finding impact to append with the verification.
+- `--resolution <text>`: Structured finding resolution to append with the verification.
+- `--local-only`: Keep the finding task-local; omit incident-candidate promotion. (default=false)
+- `--incident-scope <text>`: Optional incident scope for the appended finding.
+- `--incident-tag <tag>`: Repeatable incident tag for the appended finding. (repeatable)
+- `--incident-match <term>`: Repeatable incident match term for the appended finding. (repeatable)
+- `--incident-advice <text>`: Optional operator advice for the appended finding.
+- `--incident-rule <text>`: Optional incident rule for the appended finding.
 
 Examples:
 
@@ -3368,6 +3392,15 @@ Options:
 - `--details <text>`: Optional details text (mutually exclusive with --file).
 - `--file <path>`: Optional details file path (mutually exclusive with --details).
 - `--quiet`: Suppress normal output (still prints errors). (default=false)
+- `--observation <text>`: Structured finding observation to append with the verification.
+- `--impact <text>`: Structured finding impact to append with the verification.
+- `--resolution <text>`: Structured finding resolution to append with the verification.
+- `--local-only`: Keep the finding task-local; omit incident-candidate promotion. (default=false)
+- `--incident-scope <text>`: Optional incident scope for the appended finding.
+- `--incident-tag <tag>`: Repeatable incident tag for the appended finding. (repeatable)
+- `--incident-match <term>`: Repeatable incident match term for the appended finding. (repeatable)
+- `--incident-advice <text>`: Optional operator advice for the appended finding.
+- `--incident-rule <text>`: Optional incident rule for the appended finding.
 
 Examples:
 

--- a/packages/agentplane/src/cli/command-invocations.ts
+++ b/packages/agentplane/src/cli/command-invocations.ts
@@ -22,7 +22,10 @@ const COMMAND_INVOCATIONS = new Map<string, string>([
   ["task show", "agentplane task show <task-id>"],
   ["task start-ready", 'agentplane task start-ready <task-id> --author <ROLE> --body "Start: ..."'],
   ["task verify-show", "agentplane task verify-show <task-id>"],
-  ["verify", 'agentplane verify <task-id> --ok|--rework --by <ROLE> --note "..."'],
+  [
+    "verify",
+    'agentplane verify <task-id> --ok|--rework --by <ROLE> --note "..." [--observation "..." --impact "..." --resolution "..."] [--local-only]',
+  ],
 ]);
 
 function formatCommandId(id: CommandId): string {

--- a/packages/agentplane/src/cli/run-cli.core.incidents.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.incidents.test.ts
@@ -138,6 +138,184 @@ describe("runCli incidents", () => {
     }
   });
 
+  it("verify can append promotable findings and local-only findings stay skipped in incidents collect", async () => {
+    const root = await mkGitRepoRoot();
+    await configureGitUser(root);
+    const config = defaultConfig();
+    config.agents.approvals.require_plan = false;
+    await writeConfig(root, config);
+    await mkdir(path.join(root, ".agentplane", "policy"), { recursive: true });
+    await writeFile(
+      path.join(root, ".agentplane", "policy", "incidents.md"),
+      createIncidentRegistrySkeleton(),
+      "utf8",
+    );
+
+    let promotableTaskId = "";
+    {
+      const io = captureStdIO();
+      try {
+        const code = await runCli([
+          "task",
+          "new",
+          "--title",
+          "Verify appends promotable finding",
+          "--description",
+          "Exercise verify to incidents collect flow",
+          "--priority",
+          "med",
+          "--owner",
+          "CODER",
+          "--tag",
+          "workflow",
+          "--root",
+          root,
+        ]);
+        expect(code).toBe(0);
+        promotableTaskId = io.stdout.trim();
+      } finally {
+        io.restore();
+      }
+    }
+
+    {
+      const io = captureStdIO();
+      try {
+        const code = await runCli([
+          "verify",
+          promotableTaskId,
+          "--ok",
+          "--by",
+          "REVIEWER",
+          "--note",
+          "Looks good",
+          "--observation",
+          "Repeated recovery was still manual.",
+          "--impact",
+          "Operators had to remember a second command to preserve findings.",
+          "--resolution",
+          "Append incident-ready findings during verify.",
+          "--root",
+          root,
+        ]);
+        expect(code).toBe(0);
+        expect(io.stdout).toContain("finding=incident-candidate");
+      } finally {
+        io.restore();
+      }
+    }
+
+    {
+      const io = captureStdIO();
+      try {
+        const code = await runCli([
+          "incidents",
+          "collect",
+          promotableTaskId,
+          "--check",
+          "--json",
+          "--root",
+          root,
+        ]);
+        expect(code).toBe(0);
+        const payload = JSON.parse(io.stdout) as {
+          task_id: string;
+          promotable: { observation: string; fixability: string | null; state: string }[];
+          skipped: unknown[];
+        };
+        expect(payload.task_id).toBe(promotableTaskId);
+        expect(payload.promotable).toHaveLength(1);
+        expect(payload.promotable[0]?.fixability).toBe("external");
+        expect(payload.promotable[0]?.state).toBe("open");
+        expect(payload.skipped).toHaveLength(0);
+      } finally {
+        io.restore();
+      }
+    }
+
+    let localOnlyTaskId = "";
+    {
+      const io = captureStdIO();
+      try {
+        const code = await runCli([
+          "task",
+          "new",
+          "--title",
+          "Verify appends local-only finding",
+          "--description",
+          "Keep finding task-local",
+          "--priority",
+          "med",
+          "--owner",
+          "CODER",
+          "--tag",
+          "workflow",
+          "--root",
+          root,
+        ]);
+        expect(code).toBe(0);
+        localOnlyTaskId = io.stdout.trim();
+      } finally {
+        io.restore();
+      }
+    }
+
+    {
+      const io = captureStdIO();
+      try {
+        const code = await runCli([
+          "verify",
+          localOnlyTaskId,
+          "--ok",
+          "--by",
+          "REVIEWER",
+          "--note",
+          "Looks good",
+          "--observation",
+          "The issue is already local to this task.",
+          "--impact",
+          "No registry promotion is needed.",
+          "--resolution",
+          "Keep this finding task-local.",
+          "--local-only",
+          "--root",
+          root,
+        ]);
+        expect(code).toBe(0);
+        expect(io.stdout).toContain("finding=task-local");
+      } finally {
+        io.restore();
+      }
+    }
+
+    {
+      const io = captureStdIO();
+      try {
+        const code = await runCli([
+          "incidents",
+          "collect",
+          localOnlyTaskId,
+          "--check",
+          "--json",
+          "--root",
+          root,
+        ]);
+        expect(code).toBe(0);
+        const payload = JSON.parse(io.stdout) as {
+          task_id: string;
+          promotable: unknown[];
+          skipped: { observation: string; reason: string }[];
+        };
+        expect(payload.task_id).toBe(localOnlyTaskId);
+        expect(payload.promotable).toHaveLength(0);
+        expect(payload.skipped).toHaveLength(1);
+        expect(payload.skipped[0]?.reason).toBe("not_marked_external_or_promotable");
+      } finally {
+        io.restore();
+      }
+    }
+  });
+
   it("incidents advise resolves matches for ad hoc scope and tags", async () => {
     const root = await mkGitRepoRoot();
     const config = defaultConfig();

--- a/packages/agentplane/src/commands/task/findings.ts
+++ b/packages/agentplane/src/commands/task/findings.ts
@@ -1,11 +1,21 @@
-import { ensureDocSections, normalizeTaskDoc, setMarkdownSection } from "@agentplaneorg/core";
+import {
+  ensureDocSections,
+  normalizeTaskDoc,
+  setMarkdownSection,
+  type AgentplaneConfig,
+} from "@agentplaneorg/core";
 
+import type { TaskData } from "../../backends/task-backend.js";
 import { mapBackendError } from "../../cli/error-map.js";
 import { infoMessage } from "../../cli/output.js";
 import { CliError } from "../../shared/errors.js";
 import { loadCommandContext, type CommandContext } from "../shared/task-backend.js";
 import { applyTaskMutation } from "../shared/task-mutation.js";
-import { setTaskSectionIntent, touchTaskDocMetaIntent } from "../shared/task-store.js";
+import {
+  setTaskSectionIntent,
+  touchTaskDocMetaIntent,
+  type TaskStoreIntent,
+} from "../shared/task-store.js";
 
 import { resolveWritableDocSections } from "./shared.js";
 import {
@@ -76,6 +86,69 @@ function appendFindingBlock(existingSection: string | null, block: string): stri
   return `${current}\n\n${block}`;
 }
 
+export type StructuredFindingMutationPlan = {
+  targetSection: string;
+  expectedCurrentText: string | null;
+  intents: readonly TaskStoreIntent[];
+};
+
+export function buildStructuredFindingMutationPlan(opts: {
+  current: TaskData;
+  config: AgentplaneConfig;
+  observation: string;
+  impact: string;
+  resolution: string;
+  promote: boolean;
+  external: boolean;
+  incidentScope?: string;
+  incidentTags: readonly string[];
+  incidentMatch: readonly string[];
+  incidentAdvice?: string;
+  incidentRule?: string;
+  updatedBy?: string;
+}): StructuredFindingMutationPlan | null {
+  const currentDocRaw = typeof opts.current.doc === "string" ? opts.current.doc : "";
+  const docVersion = normalizeTaskDocVersion(opts.current.doc_version);
+  const targetSection = taskObservationSectionName(docVersion);
+  const sectionOrder = resolveWritableDocSections({
+    allowedSections: opts.config.tasks.doc.sections,
+    requiredSections: opts.config.tasks.doc.required_sections,
+    targetSection,
+  });
+  const existingSection = extractTaskObservationSection(currentDocRaw, docVersion);
+  const block = renderStructuredFindingBlock({
+    observation: opts.observation,
+    impact: opts.impact,
+    resolution: opts.resolution,
+    promote: opts.promote,
+    external: opts.external,
+    incidentScope: opts.incidentScope,
+    incidentTags: opts.incidentTags,
+    incidentMatch: opts.incidentMatch,
+    incidentAdvice: opts.incidentAdvice,
+    incidentRule: opts.incidentRule,
+  });
+  const nextSectionText = appendFindingBlock(existingSection, block);
+  const nextDoc = ensureDocSections(
+    setMarkdownSection(currentDocRaw, targetSection, nextSectionText),
+    sectionOrder,
+  );
+  if (normalizeTaskDoc(currentDocRaw) === normalizeTaskDoc(nextDoc) && !opts.updatedBy) {
+    return null;
+  }
+  const expectedCurrentText = extractDocSection(currentDocRaw, targetSection);
+  const intents: TaskStoreIntent[] = [
+    setTaskSectionIntent({
+      section: targetSection,
+      text: nextSectionText,
+      requiredSections: sectionOrder,
+      expectedCurrentText,
+    }),
+    ...(opts.updatedBy ? [touchTaskDocMetaIntent({ updatedBy: opts.updatedBy })] : []),
+  ];
+  return { targetSection, expectedCurrentText, intents };
+}
+
 export function renderFindingsAddRegistryNote(opts: {
   promote: boolean;
   external: boolean;
@@ -112,19 +185,6 @@ export async function cmdTaskFindingsAdd(opts: {
     updatedBy = ensureNonEmptyFlag("updated-by", opts.updatedBy);
   }
 
-  const block = renderStructuredFindingBlock({
-    observation: opts.observation,
-    impact: opts.impact,
-    resolution: opts.resolution,
-    promote: opts.promote,
-    external: opts.external,
-    incidentScope: opts.incidentScope,
-    incidentTags: opts.incidentTags,
-    incidentMatch: opts.incidentMatch,
-    incidentAdvice: opts.incidentAdvice,
-    incidentRule: opts.incidentRule,
-  });
-
   try {
     const ctx =
       opts.ctx ??
@@ -144,40 +204,30 @@ export async function cmdTaskFindingsAdd(opts: {
     await applyTaskMutation({
       ctx,
       taskId: opts.taskId,
-      build: async (current) => {
-        const currentDocRaw =
-          typeof current.doc === "string"
-            ? current.doc
-            : ((await backend.getTaskDoc!(opts.taskId)) ?? "");
-        const docVersion = normalizeTaskDocVersion(current.doc_version);
-        targetSection = taskObservationSectionName(docVersion);
-        const sectionOrder = resolveWritableDocSections({
-          allowedSections: config.tasks.doc.sections,
-          requiredSections: config.tasks.doc.required_sections,
-          targetSection,
+      build: (current) => {
+        const plan = buildStructuredFindingMutationPlan({
+          current,
+          config,
+          observation: opts.observation,
+          impact: opts.impact,
+          resolution: opts.resolution,
+          promote: opts.promote,
+          external: opts.external,
+          incidentScope: opts.incidentScope,
+          incidentTags: opts.incidentTags,
+          incidentMatch: opts.incidentMatch,
+          incidentAdvice: opts.incidentAdvice,
+          incidentRule: opts.incidentRule,
+          updatedBy,
         });
-        const existingSection = extractTaskObservationSection(currentDocRaw, docVersion);
-        const nextSectionText = appendFindingBlock(existingSection, block);
-        const nextDoc = ensureDocSections(
-          setMarkdownSection(currentDocRaw, targetSection, nextSectionText),
-          sectionOrder,
-        );
-        if (normalizeTaskDoc(currentDocRaw) === normalizeTaskDoc(nextDoc) && !updatedBy) {
+        if (!plan) {
           return null;
         }
-        const expectedCurrentText = extractDocSection(currentDocRaw, targetSection);
+        targetSection = plan.targetSection;
         return {
-          intents: [
-            setTaskSectionIntent({
-              section: targetSection,
-              text: nextSectionText,
-              requiredSections: sectionOrder,
-              expectedCurrentText,
-            }),
-            ...(updatedBy ? [touchTaskDocMetaIntent({ updatedBy })] : []),
-          ],
+          intents: plan.intents,
           writeOptions: {
-            expectedCurrentText,
+            expectedCurrentText: plan.expectedCurrentText,
             expectedSection: targetSection,
           },
         };

--- a/packages/agentplane/src/commands/task/shared/transitions.ts
+++ b/packages/agentplane/src/commands/task/shared/transitions.ts
@@ -56,6 +56,7 @@ export function ensureVerificationSatisfiedIfRequired(
 
   const hint =
     `use \`agentplane verify ${task.id} --ok|--rework --by <ID> --note <TEXT>\` ` +
+    `and add \`--observation <TEXT> --impact <TEXT> --resolution <TEXT>\` when you want a structured finding ` +
     `or \`agentplane task verify ok|rework ${task.id} --by <ID> --note <TEXT>\``;
 
   throw new CliError({

--- a/packages/agentplane/src/commands/task/verify-command-shared.ts
+++ b/packages/agentplane/src/commands/task/verify-command-shared.ts
@@ -8,7 +8,75 @@ export type VerifyCommonParsed = {
   details?: string;
   file?: string;
   quiet: boolean;
+  observation?: string;
+  impact?: string;
+  resolution?: string;
+  localOnly: boolean;
+  incidentScope?: string;
+  incidentTags: string[];
+  incidentMatch: string[];
+  incidentAdvice?: string;
+  incidentRule?: string;
 };
+
+export const verifyFindingOptions: readonly OptionSpec[] = [
+  {
+    kind: "string",
+    name: "observation",
+    valueHint: "<text>",
+    description: "Structured finding observation to append with the verification.",
+  },
+  {
+    kind: "string",
+    name: "impact",
+    valueHint: "<text>",
+    description: "Structured finding impact to append with the verification.",
+  },
+  {
+    kind: "string",
+    name: "resolution",
+    valueHint: "<text>",
+    description: "Structured finding resolution to append with the verification.",
+  },
+  {
+    kind: "boolean",
+    name: "local-only",
+    default: false,
+    description: "Keep the finding task-local; omit incident-candidate promotion.",
+  },
+  {
+    kind: "string",
+    name: "incident-scope",
+    valueHint: "<text>",
+    description: "Optional incident scope for the appended finding.",
+  },
+  {
+    kind: "string",
+    name: "incident-tag",
+    valueHint: "<tag>",
+    repeatable: true,
+    description: "Repeatable incident tag for the appended finding.",
+  },
+  {
+    kind: "string",
+    name: "incident-match",
+    valueHint: "<term>",
+    repeatable: true,
+    description: "Repeatable incident match term for the appended finding.",
+  },
+  {
+    kind: "string",
+    name: "incident-advice",
+    valueHint: "<text>",
+    description: "Optional operator advice for the appended finding.",
+  },
+  {
+    kind: "string",
+    name: "incident-rule",
+    valueHint: "<text>",
+    description: "Optional incident rule for the appended finding.",
+  },
+] as const;
 
 export const verifyCommonOptions: readonly OptionSpec[] = [
   { kind: "string", name: "by", valueHint: "<id>", required: true, description: "Verifier id." },
@@ -42,6 +110,7 @@ export const verifyCommonOptions: readonly OptionSpec[] = [
     default: false,
     description: "Suppress normal output (still prints errors).",
   },
+  ...verifyFindingOptions,
 ] as const;
 
 export function validateVerifyDetailsFileExclusive<TParsed>(
@@ -106,6 +175,46 @@ export function validateVerifyNoteSource<TParsed>(
   }
 }
 
+export function validateVerifyFindingSource<TParsed>(
+  raw: ParsedRaw,
+  spec: CommandSpec<TParsed>,
+  opts?: { command?: string },
+): void {
+  const hasFindingField = [
+    raw.opts.observation,
+    raw.opts.impact,
+    raw.opts.resolution,
+    raw.opts["incident-scope"],
+    raw.opts["incident-advice"],
+    raw.opts["incident-rule"],
+  ].some((value) => typeof value === "string" && value.trim().length > 0);
+  const hasFindingCollections =
+    Array.isArray(raw.opts["incident-tag"]) && raw.opts["incident-tag"].length > 0
+      ? true
+      : Array.isArray(raw.opts["incident-match"]) && raw.opts["incident-match"].length > 0;
+  const hasFindingToggle = raw.opts["local-only"] === true;
+  if (!hasFindingField && !hasFindingCollections && !hasFindingToggle) return;
+
+  const observation = raw.opts.observation;
+  const impact = raw.opts.impact;
+  const resolution = raw.opts.resolution;
+  if (
+    typeof observation !== "string" ||
+    observation.trim().length === 0 ||
+    typeof impact !== "string" ||
+    impact.trim().length === 0 ||
+    typeof resolution !== "string" ||
+    resolution.trim().length === 0
+  ) {
+    throw usageError({
+      spec,
+      command: opts?.command,
+      message:
+        "Provide --observation, --impact, and --resolution together when appending a structured finding.",
+    });
+  }
+}
+
 export function parseVerifyCommonOptions(raw: ParsedRaw): VerifyCommonParsed {
   return {
     by: typeof raw.opts.by === "string" ? raw.opts.by : "",
@@ -114,5 +223,17 @@ export function parseVerifyCommonOptions(raw: ParsedRaw): VerifyCommonParsed {
     details: typeof raw.opts.details === "string" ? raw.opts.details : undefined,
     file: typeof raw.opts.file === "string" ? raw.opts.file : undefined,
     quiet: raw.opts.quiet === true,
+    observation: typeof raw.opts.observation === "string" ? raw.opts.observation : undefined,
+    impact: typeof raw.opts.impact === "string" ? raw.opts.impact : undefined,
+    resolution: typeof raw.opts.resolution === "string" ? raw.opts.resolution : undefined,
+    localOnly: raw.opts["local-only"] === true,
+    incidentScope:
+      typeof raw.opts["incident-scope"] === "string" ? raw.opts["incident-scope"] : undefined,
+    incidentTags: (raw.opts["incident-tag"] as string[] | undefined) ?? [],
+    incidentMatch: (raw.opts["incident-match"] as string[] | undefined) ?? [],
+    incidentAdvice:
+      typeof raw.opts["incident-advice"] === "string" ? raw.opts["incident-advice"] : undefined,
+    incidentRule:
+      typeof raw.opts["incident-rule"] === "string" ? raw.opts["incident-rule"] : undefined,
   };
 }

--- a/packages/agentplane/src/commands/task/verify-ok.command.ts
+++ b/packages/agentplane/src/commands/task/verify-ok.command.ts
@@ -5,6 +5,7 @@ import { cmdTaskVerifyOk } from "./verify-record.js";
 import {
   parseVerifyCommonOptions,
   validateVerifyDetailsFileExclusive,
+  validateVerifyFindingSource,
   validateVerifyNonEmptyInput,
   validateVerifyNoteSource,
   verifyCommonOptions,
@@ -33,6 +34,7 @@ export const taskVerifyOkSpec: CommandSpec<TaskVerifyOkParsed> = {
     });
     validateVerifyNonEmptyInput(raw, taskVerifyOkSpec, "by");
     validateVerifyNoteSource(raw, taskVerifyOkSpec);
+    validateVerifyFindingSource(raw, taskVerifyOkSpec);
   },
   parse: (raw) => ({
     taskId: String(raw.args["task-id"]),
@@ -53,6 +55,15 @@ export function makeRunTaskVerifyOkHandler(getCtx: (cmd: string) => Promise<Comm
       details: p.details,
       file: p.file,
       quiet: p.quiet,
+      observation: p.observation,
+      impact: p.impact,
+      resolution: p.resolution,
+      localOnly: p.localOnly,
+      incidentScope: p.incidentScope,
+      incidentTags: p.incidentTags,
+      incidentMatch: p.incidentMatch,
+      incidentAdvice: p.incidentAdvice,
+      incidentRule: p.incidentRule,
     });
   };
 }

--- a/packages/agentplane/src/commands/task/verify-record.ts
+++ b/packages/agentplane/src/commands/task/verify-record.ts
@@ -11,6 +11,7 @@ import { applyTaskMutation } from "../shared/task-mutation.js";
 import { ensurePrArtifactsSynced } from "../pr/internal/sync.js";
 import { resolvePrPaths } from "../pr/internal/pr-paths.js";
 import { buildVerifiedPrMeta, parsePrMeta } from "../shared/pr-meta.js";
+import { buildStructuredFindingMutationPlan } from "./findings.js";
 
 import {
   decodeEscapedTaskTextNewlines,
@@ -20,6 +21,17 @@ import {
 
 type VerifyState = "ok" | "needs_rework";
 type VerifyCommandName = "task verify ok" | "task verify rework" | "verify";
+type VerifyStructuredFindingInput = {
+  observation: string;
+  impact: string;
+  resolution: string;
+  localOnly?: boolean;
+  incidentScope?: string;
+  incidentTags?: string[];
+  incidentMatch?: string[];
+  incidentAdvice?: string;
+  incidentRule?: string;
+};
 type ResolvedVerifyRecordInput = {
   by: string;
   note: string;
@@ -39,6 +51,7 @@ async function recordVerificationResult(opts: {
   by: string;
   note: string;
   details?: string | null;
+  finding?: VerifyStructuredFindingInput | null;
   quiet: boolean;
 }): Promise<void> {
   const ctx =
@@ -73,7 +86,25 @@ async function recordVerificationResult(opts: {
           (await backend.getTaskDoc!(current.id)),
         requiredSections: config.tasks.doc.required_sections,
       });
-      return { intents: execution.intents };
+      const intents = [...execution.intents];
+      if (opts.finding) {
+        const findingPlan = buildStructuredFindingMutationPlan({
+          current,
+          config,
+          observation: opts.finding.observation,
+          impact: opts.finding.impact,
+          resolution: opts.finding.resolution,
+          promote: !opts.finding.localOnly,
+          external: !opts.finding.localOnly,
+          incidentScope: opts.finding.incidentScope,
+          incidentTags: opts.finding.incidentTags ?? [],
+          incidentMatch: opts.finding.incidentMatch ?? [],
+          incidentAdvice: opts.finding.incidentAdvice,
+          incidentRule: opts.finding.incidentRule,
+        });
+        if (findingPlan) intents.push(...findingPlan.intents);
+      }
+      return { intents };
     },
   });
 
@@ -105,6 +136,11 @@ async function recordVerificationResult(opts: {
   }
 
   if (!opts.quiet) {
+    const findingState = opts.finding
+      ? opts.finding.localOnly
+        ? "task-local"
+        : "incident-candidate"
+      : null;
     const readmePath = path.join(
       resolved.gitRoot,
       config.paths.workflow_dir,
@@ -112,8 +148,13 @@ async function recordVerificationResult(opts: {
       "README.md",
     );
     const relReadmePath = path.relative(resolved.gitRoot, readmePath);
+    const extra = findingState ? ` finding=${findingState}` : "";
     process.stdout.write(
-      `${successMessage("verified", opts.taskId, `state=${opts.state} readme=${relReadmePath}`)}\n`,
+      `${successMessage(
+        "verified",
+        opts.taskId,
+        `state=${opts.state} readme=${relReadmePath}${extra}`,
+      )}\n`,
     );
   }
 }
@@ -203,6 +244,7 @@ async function executeVerifyRecordCommand(opts: {
   noteFile?: string;
   details?: string;
   file?: string;
+  finding?: VerifyStructuredFindingInput | null;
   quiet: boolean;
   command: VerifyCommandName;
 }): Promise<number> {
@@ -218,6 +260,7 @@ async function executeVerifyRecordCommand(opts: {
       by: input.by,
       note: input.note,
       details: input.details,
+      finding: opts.finding,
       quiet: opts.quiet,
     });
     return 0;
@@ -237,9 +280,38 @@ export async function cmdTaskVerifyOk(opts: {
   noteFile?: string;
   details?: string;
   file?: string;
+  observation?: string;
+  impact?: string;
+  resolution?: string;
+  localOnly: boolean;
+  incidentScope?: string;
+  incidentTags: string[];
+  incidentMatch: string[];
+  incidentAdvice?: string;
+  incidentRule?: string;
   quiet: boolean;
 }): Promise<number> {
-  return await executeVerifyRecordCommand({ ...opts, state: "ok", command: "task verify ok" });
+  return await executeVerifyRecordCommand({
+    ...opts,
+    state: "ok",
+    command: "task verify ok",
+    finding:
+      typeof opts.observation === "string" &&
+      typeof opts.impact === "string" &&
+      typeof opts.resolution === "string"
+        ? {
+            observation: opts.observation,
+            impact: opts.impact,
+            resolution: opts.resolution,
+            localOnly: opts.localOnly === true,
+            incidentScope: opts.incidentScope,
+            incidentTags: opts.incidentTags ?? [],
+            incidentMatch: opts.incidentMatch ?? [],
+            incidentAdvice: opts.incidentAdvice,
+            incidentRule: opts.incidentRule,
+          }
+        : null,
+  });
 }
 
 export async function cmdTaskVerifyRework(opts: {
@@ -252,12 +324,37 @@ export async function cmdTaskVerifyRework(opts: {
   noteFile?: string;
   details?: string;
   file?: string;
+  observation?: string;
+  impact?: string;
+  resolution?: string;
+  localOnly?: boolean;
+  incidentScope?: string;
+  incidentTags?: string[];
+  incidentMatch?: string[];
+  incidentAdvice?: string;
+  incidentRule?: string;
   quiet: boolean;
 }): Promise<number> {
   return await executeVerifyRecordCommand({
     ...opts,
     state: "needs_rework",
     command: "task verify rework",
+    finding:
+      typeof opts.observation === "string" &&
+      typeof opts.impact === "string" &&
+      typeof opts.resolution === "string"
+        ? {
+            observation: opts.observation,
+            impact: opts.impact,
+            resolution: opts.resolution,
+            localOnly: opts.localOnly === true,
+            incidentScope: opts.incidentScope,
+            incidentTags: opts.incidentTags ?? [],
+            incidentMatch: opts.incidentMatch ?? [],
+            incidentAdvice: opts.incidentAdvice,
+            incidentRule: opts.incidentRule,
+          }
+        : null,
   });
 }
 
@@ -272,7 +369,35 @@ export async function cmdVerifyParsed(opts: {
   noteFile?: string;
   details?: string;
   file?: string;
+  observation?: string;
+  impact?: string;
+  resolution?: string;
+  localOnly?: boolean;
+  incidentScope?: string;
+  incidentTags?: string[];
+  incidentMatch?: string[];
+  incidentAdvice?: string;
+  incidentRule?: string;
   quiet: boolean;
 }): Promise<number> {
-  return await executeVerifyRecordCommand({ ...opts, command: "verify" });
+  return await executeVerifyRecordCommand({
+    ...opts,
+    command: "verify",
+    finding:
+      typeof opts.observation === "string" &&
+      typeof opts.impact === "string" &&
+      typeof opts.resolution === "string"
+        ? {
+            observation: opts.observation,
+            impact: opts.impact,
+            resolution: opts.resolution,
+            localOnly: opts.localOnly === true,
+            incidentScope: opts.incidentScope,
+            incidentTags: opts.incidentTags ?? [],
+            incidentMatch: opts.incidentMatch ?? [],
+            incidentAdvice: opts.incidentAdvice,
+            incidentRule: opts.incidentRule,
+          }
+        : null,
+  });
 }

--- a/packages/agentplane/src/commands/task/verify-rework.command.ts
+++ b/packages/agentplane/src/commands/task/verify-rework.command.ts
@@ -5,6 +5,7 @@ import { cmdTaskVerifyRework } from "./verify-record.js";
 import {
   parseVerifyCommonOptions,
   validateVerifyDetailsFileExclusive,
+  validateVerifyFindingSource,
   validateVerifyNonEmptyInput,
   validateVerifyNoteSource,
   verifyCommonOptions,
@@ -34,6 +35,7 @@ export const taskVerifyReworkSpec: CommandSpec<TaskVerifyReworkParsed> = {
     });
     validateVerifyNonEmptyInput(raw, taskVerifyReworkSpec, "by");
     validateVerifyNoteSource(raw, taskVerifyReworkSpec);
+    validateVerifyFindingSource(raw, taskVerifyReworkSpec);
   },
   parse: (raw) => ({
     taskId: String(raw.args["task-id"]),
@@ -54,6 +56,15 @@ export function makeRunTaskVerifyReworkHandler(getCtx: (cmd: string) => Promise<
       details: p.details,
       file: p.file,
       quiet: p.quiet,
+      observation: p.observation,
+      impact: p.impact,
+      resolution: p.resolution,
+      localOnly: p.localOnly,
+      incidentScope: p.incidentScope,
+      incidentTags: p.incidentTags,
+      incidentMatch: p.incidentMatch,
+      incidentAdvice: p.incidentAdvice,
+      incidentRule: p.incidentRule,
     });
   };
 }

--- a/packages/agentplane/src/commands/verify.run.ts
+++ b/packages/agentplane/src/commands/verify.run.ts
@@ -17,6 +17,15 @@ export function makeRunVerifyHandler(getCtx: (cmd: string) => Promise<CommandCon
       noteFile: p.noteFile,
       details: p.details,
       file: p.file,
+      observation: p.observation,
+      impact: p.impact,
+      resolution: p.resolution,
+      localOnly: p.localOnly,
+      incidentScope: p.incidentScope,
+      incidentTags: p.incidentTags,
+      incidentMatch: p.incidentMatch,
+      incidentAdvice: p.incidentAdvice,
+      incidentRule: p.incidentRule,
       quiet: p.quiet,
     });
   };

--- a/packages/agentplane/src/commands/verify.spec.ts
+++ b/packages/agentplane/src/commands/verify.spec.ts
@@ -1,23 +1,20 @@
 import type { CommandSpec } from "../cli/spec/spec.js";
 import { usageError } from "../cli/spec/errors.js";
 import {
+  type VerifyCommonParsed,
   parseVerifyCommonOptions,
   validateVerifyDetailsFileExclusive,
+  validateVerifyFindingSource,
   validateVerifyNonEmptyInput,
   validateVerifyNoteSource,
+  verifyFindingOptions,
 } from "./task/verify-command-shared.js";
 
 type VerifyState = "ok" | "needs_rework";
 
-export type VerifyParsed = {
+export type VerifyParsed = VerifyCommonParsed & {
   taskId: string;
   state: VerifyState;
-  by: string;
-  note: string;
-  noteFile?: string;
-  details?: string;
-  file?: string;
-  quiet: boolean;
 };
 
 export const verifySpec: CommandSpec<VerifyParsed> = {
@@ -77,6 +74,7 @@ export const verifySpec: CommandSpec<VerifyParsed> = {
       description: "Read details from a file path (mutually exclusive with --details).",
     },
     { kind: "boolean", name: "quiet", default: false, description: "Suppress output." },
+    ...verifyFindingOptions,
   ],
   examples: [
     {
@@ -90,6 +88,10 @@ export const verifySpec: CommandSpec<VerifyParsed> = {
     {
       cmd: 'agentplane verify 202602030608-F1Q8AB --rework --by REVIEWER --note "Needs changes" --details "Missing tests"',
       why: "Record a needs-rework outcome with details.",
+    },
+    {
+      cmd: 'agentplane verify 202602030608-F1Q8AB --ok --by REVIEWER --note "Looks good" --observation "Repeated recovery was manual." --impact "Operators needed a second command." --resolution "Append structured findings during verify."',
+      why: "Record verification and append a promotable structured finding in one command.",
     },
   ],
   validateRaw: (raw) => {
@@ -105,6 +107,7 @@ export const verifySpec: CommandSpec<VerifyParsed> = {
     validateVerifyDetailsFileExclusive(raw, verifySpec, { command: "verify" });
     validateVerifyNonEmptyInput(raw, verifySpec, "by");
     validateVerifyNoteSource(raw, verifySpec, { command: "verify" });
+    validateVerifyFindingSource(raw, verifySpec, { command: "verify" });
   },
   parse: (raw) => {
     const ok = raw.opts.ok === true;

--- a/packages/agentplane/src/commands/workflow.verify-hooks.test.ts
+++ b/packages/agentplane/src/commands/workflow.verify-hooks.test.ts
@@ -101,6 +101,41 @@ describe("commands/workflow", () => {
     ).not.toThrow();
   });
 
+  it("verify requires a complete structured finding tuple when finding flags are present", () => {
+    const taskId = "202602050900-V1F3";
+
+    expect(() =>
+      parseCommandArgv(verifySpec, [
+        taskId,
+        "--ok",
+        "--by",
+        "REVIEWER",
+        "--note",
+        "x",
+        "--observation",
+        "Manual recovery repeated.",
+      ]),
+    ).toThrow();
+
+    expect(() =>
+      parseCommandArgv(verifySpec, [
+        taskId,
+        "--ok",
+        "--by",
+        "REVIEWER",
+        "--note",
+        "x",
+        "--observation",
+        "Manual recovery repeated.",
+        "--impact",
+        "Operators needed an extra command.",
+        "--resolution",
+        "Append a structured finding during verify.",
+        "--local-only",
+      ]),
+    ).not.toThrow();
+  });
+
   it("verify appends a result entry and updates task.verification state", async () => {
     const root = await makeRepo();
     const taskId = "202602050900-V1F4B";


### PR DESCRIPTION
## Summary

Let verify append promotable incident findings in one command

The incident registry path exists, but real operator flow almost never leaves structured incident candidates because verify and findings are separate steps. Extend verify so a verifier can append a structured finding/incident candidate in the same command, preserving task-local opt-out and existing promotion semantics.

## Scope

- In scope: The incident registry path exists, but real operator flow almost never leaves structured incident candidates because verify and findings are separate steps. Extend verify so a verifier can append a structured finding/incident candidate in the same command, preserving task-local opt-out and existing promotion semantics.
- Out of scope: unrelated refactors not required for "Let verify append promotable incident findings in one command".

## Verification

### Plan

1. Run the focused verify/findings/incident tests. Expected: verify can append a structured finding in the same command and preserves existing verification behavior. 2. Validate local-only vs default-promotable semantics. Expected: default verify-added findings carry incident-candidate metadata, while explicit local-only entries stay task-local. 3. Run incidents collect on a representative task fixture. Expected: a verify-appended promotable finding can be promoted under the existing incidents rules.

### Current Status

- State: ok
- Note: Command: bun x vitest run packages/agentplane/src/commands/task/verify-record.unit.test.ts packages/agentplane/src/commands/workflow.verify-hooks.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts; bun x eslint packages/agentplane/src/cli/command-invocations.ts packages/agentplane/src/commands/task/findings.ts packages/agentplane/src/commands/task/shared/transitions.ts packages/agentplane/src/commands/task/verify-command-shared.ts packages/agentplane/src/commands/task/verify-ok.command.ts packages/agentplane/src/commands/task/verify-record.ts packages/agentplane/src/commands/task/verify-rework.command.ts packages/agentplane/src/commands/verify.run.ts packages/agentplane/src/commands/verify.spec.ts packages/agentplane/src/commands/workflow.verify-hooks.test.ts packages/agentplane/src/cli/run-cli.core.incidents.test.ts; bun run framework:dev:bootstrap. Result: pass. Evidence: verify now accepts structured finding flags, records incident-candidate vs task-local findings in the same mutation path, and incidents collect sees verify-appended promotable findings while local-only entries stay skipped. Scope: verify-to-findings incident flow.

## Risks

- Risk level: not recorded
- Breaking change: no

### Rollback

- Revert task-related commit(s).
- Re-run required checks to confirm rollback safety.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-04-08T18:57:12.941Z
- Branch: task/202604081816-DCDXVB/verify-incident-finding
- Head: f276e8731274

```text
No changes detected.
```

</details>
