### PR TITLE
workflow/worktree: Clean base task README after branch_pr work start (77V6J5)

### DIFF
--- a/.agentplane/tasks/202604081931-77V6J5/README.md
+++ b/.agentplane/tasks/202604081931-77V6J5/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202604081931-77V6J5"
 title: "Clean base task README after branch_pr work start"
-status: "DOING"
+result_summary: "Merged via local task branch commit e820c9f93593."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 4
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -19,15 +20,20 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
-commit: null
+  state: "ok"
+  updated_at: "2026-04-08T19:54:41.280Z"
+  updated_by: "REVIEWER"
+  note: "The fresh branch_pr worktree still seeds local-backend task READMEs; the base checkout no longer retains untracked task README copies after work start; targeted lint and the seeded-worktree integration test passed in the task worktree after bootstrap."
+commit:
+  hash: "e820c9f935932fb1f09dfd88f502a684379f6cbf"
+  message: "🧩 77V6J5 task: prune base-side task README duplicates after worktree seeding"
 comments:
   -
     author: "CODER"
     body: "Start: remove base-checkout task README duplicates after worktree seeding so future upstream task README tracking does not block git pull."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: branch_pr worktree seeding keeps README copies in the task worktree and removes the base-side untracked duplicates so later pulls do not fail."
 events:
   -
     type: "status"
@@ -36,9 +42,22 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: remove base-checkout task README duplicates after worktree seeding so future upstream task README tracking does not block git pull."
+  -
+    type: "verify"
+    at: "2026-04-08T19:54:41.280Z"
+    author: "REVIEWER"
+    state: "ok"
+    note: "The fresh branch_pr worktree still seeds local-backend task READMEs; the base checkout no longer retains untracked task README copies after work start; targeted lint and the seeded-worktree integration test passed in the task worktree after bootstrap."
+  -
+    type: "status"
+    at: "2026-04-08T19:54:48.146Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: branch_pr worktree seeding keeps README copies in the task worktree and removes the base-side untracked duplicates so later pulls do not fail."
 doc_version: 3
-doc_updated_at: "2026-04-08T19:48:41.431Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-04-08T19:54:48.147Z"
+doc_updated_by: "INTEGRATOR"
 description: "When branch_pr work start seeds task artifacts into a new worktree, remove the duplicate untracked base-checkout task README for that task so later pulls do not fail when the task README becomes tracked upstream."
 sections:
   Summary: |-
@@ -58,6 +77,14 @@ sections:
     3. Run the targeted lint and test coverage for the touched `work-start` path. Expected: no regressions in the branch_pr work start flow or its CLI integration test.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-04-08T19:54:41.280Z — VERIFY — ok
+    
+    By: REVIEWER
+    
+    Note: The fresh branch_pr worktree still seeds local-backend task READMEs; the base checkout no longer retains untracked task README copies after work start; targeted lint and the seeded-worktree integration test passed in the task worktree after bootstrap.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-08T19:48:41.431Z, excerpt_hash=sha256:7ef955b9c1ea7d4ff27d2d15939b542f995717614a08e276dc6c1b43f2526244
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -91,6 +118,14 @@ When branch_pr work start seeds task artifacts into a new worktree, remove the d
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-04-08T19:54:41.280Z — VERIFY — ok
+
+By: REVIEWER
+
+Note: The fresh branch_pr worktree still seeds local-backend task READMEs; the base checkout no longer retains untracked task README copies after work start; targeted lint and the seeded-worktree integration test passed in the task worktree after bootstrap.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-08T19:48:41.431Z, excerpt_hash=sha256:7ef955b9c1ea7d4ff27d2d15939b542f995717614a08e276dc6c1b43f2526244
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202604081931-77V6J5/README.md
+++ b/.agentplane/tasks/202604081931-77V6J5/README.md
@@ -1,0 +1,101 @@
+---
+id: "202604081931-77V6J5"
+title: "Clean base task README after branch_pr work start"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "workflow"
+  - "worktree"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-04-08T19:48:37.296Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: remove base-checkout task README duplicates after worktree seeding so future upstream task README tracking does not block git pull."
+events:
+  -
+    type: "status"
+    at: "2026-04-08T19:48:41.420Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: remove base-checkout task README duplicates after worktree seeding so future upstream task README tracking does not block git pull."
+doc_version: 3
+doc_updated_at: "2026-04-08T19:48:41.431Z"
+doc_updated_by: "CODER"
+description: "When branch_pr work start seeds task artifacts into a new worktree, remove the duplicate untracked base-checkout task README for that task so later pulls do not fail when the task README becomes tracked upstream."
+sections:
+  Summary: |-
+    Clean base task README after branch_pr work start
+    
+    When branch_pr work start seeds task artifacts into a new worktree, remove the duplicate untracked base-checkout task README for that task so later pulls do not fail when the task README becomes tracked upstream.
+  Scope: |-
+    - In scope: When branch_pr work start seeds task artifacts into a new worktree, remove the duplicate untracked base-checkout task README for that task so later pulls do not fail when the task README becomes tracked upstream.
+    - Out of scope: unrelated refactors not required for "Clean base task README after branch_pr work start".
+  Plan: |-
+    1. Implement the change for "Clean base task README after branch_pr work start".
+    2. Run required checks and capture verification evidence.
+    3. Finalize task findings and finish with traceable commit metadata.
+  Verify Steps: |-
+    1. Run the `work start` branch_pr integration scenario for seeded local-backend READMEs. Expected: the fresh worktree still receives the task README files it needs.
+    2. Confirm the base checkout no longer retains untracked `.agentplane/tasks/<task-id>/README.md` copies after `work start`. Expected: `git status --short --untracked-files=all` does not list those task README paths on the base checkout.
+    3. Run the targeted lint and test coverage for the touched `work-start` path. Expected: no regressions in the branch_pr work start flow or its CLI integration test.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Clean base task README after branch_pr work start
+
+When branch_pr work start seeds task artifacts into a new worktree, remove the duplicate untracked base-checkout task README for that task so later pulls do not fail when the task README becomes tracked upstream.
+
+## Scope
+
+- In scope: When branch_pr work start seeds task artifacts into a new worktree, remove the duplicate untracked base-checkout task README for that task so later pulls do not fail when the task README becomes tracked upstream.
+- Out of scope: unrelated refactors not required for "Clean base task README after branch_pr work start".
+
+## Plan
+
+1. Implement the change for "Clean base task README after branch_pr work start".
+2. Run required checks and capture verification evidence.
+3. Finalize task findings and finish with traceable commit metadata.
+
+## Verify Steps
+
+1. Run the `work start` branch_pr integration scenario for seeded local-backend READMEs. Expected: the fresh worktree still receives the task README files it needs.
+2. Confirm the base checkout no longer retains untracked `.agentplane/tasks/<task-id>/README.md` copies after `work start`. Expected: `git status --short --untracked-files=all` does not list those task README paths on the base checkout.
+3. Run the targeted lint and test coverage for the touched `work-start` path. Expected: no regressions in the branch_pr work start flow or its CLI integration test.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/packages/agentplane/src/cli/run-cli.core.pr-flow.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.pr-flow.test.ts
@@ -543,6 +543,22 @@ describe("runCli", () => {
       );
       expect(await pathExists(taskReadmePath)).toBe(true);
       expect(await pathExists(siblingReadmePath)).toBe(true);
+      expect(await pathExists(path.join(root, ".agentplane", "tasks", taskId, "README.md"))).toBe(
+        false,
+      );
+      expect(
+        await pathExists(path.join(root, ".agentplane", "tasks", siblingTaskId, "README.md")),
+      ).toBe(false);
+
+      const { stdout: baseStatus } = await execFileAsync("git", [
+        "status",
+        "--short",
+        "--untracked-files=all",
+      ], {
+        cwd: root,
+      });
+      expect(baseStatus).not.toContain(`?? .agentplane/tasks/${taskId}/README.md`);
+      expect(baseStatus).not.toContain(`?? .agentplane/tasks/${siblingTaskId}/README.md`);
 
       const showIo = captureStdIO();
       try {
@@ -573,12 +589,7 @@ describe("runCli", () => {
       }
 
       const seededReadme = await readFile(taskReadmePath, "utf8");
-      const baseReadme = await readFile(
-        path.join(root, ".agentplane", "tasks", taskId, "README.md"),
-        "utf8",
-      );
       expect(seededReadme).toContain('status: "DOING"');
-      expect(baseReadme).toContain('status: "TODO"');
     },
     WORK_START_BRANCH_AND_WORKTREE_TIMEOUT_MS,
   );

--- a/packages/agentplane/src/commands/branch/work-start.ts
+++ b/packages/agentplane/src/commands/branch/work-start.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { resolveBaseBranch } from "@agentplaneorg/core";
@@ -84,6 +84,26 @@ async function materializeLocalBackendReadmesForWorktree(opts: {
     const targetReadme = path.join(targetRoot, entry.name, "README.md");
     await mkdir(path.dirname(targetReadme), { recursive: true });
     await copyFile(sourceReadme, targetReadme);
+
+    const relativeReadme = path.relative(opts.repoRoot, sourceReadme);
+    const tracked = await isGitTracked(opts.repoRoot, relativeReadme);
+    if (!tracked) {
+      await rm(sourceReadme, { force: true });
+    }
+  }
+}
+
+async function isGitTracked(gitRoot: string, relativePath: string): Promise<boolean> {
+  try {
+    await execFileAsync("git", ["ls-files", "--error-unmatch", "--", relativePath], {
+      cwd: gitRoot,
+      env: gitEnv(),
+    });
+    return true;
+  } catch (err) {
+    const code = (err as { code?: number | string } | null)?.code;
+    if (code === 1) return false;
+    throw err;
   }
 }
 


### PR DESCRIPTION
## Summary

Clean base task README after branch_pr work start

When branch_pr work start seeds task artifacts into a new worktree, remove the duplicate untracked base-checkout task README for that task so later pulls do not fail when the task README becomes tracked upstream.

## Scope

- In scope: When branch_pr work start seeds task artifacts into a new worktree, remove the duplicate untracked base-checkout task README for that task so later pulls do not fail when the task README becomes tracked upstream.
- Out of scope: unrelated refactors not required for "Clean base task README after branch_pr work start".

## Verification

### Plan

1. Run the `work start` branch_pr integration scenario for seeded local-backend READMEs. Expected: the fresh worktree still receives the task README files it needs.
2. Confirm the base checkout no longer retains untracked `.agentplane/tasks/<task-id>/README.md` copies after `work start`. Expected: `git status --short --untracked-files=all` does not list those task README paths on the base checkout.
3. Run the targeted lint and test coverage for the touched `work-start` path. Expected: no regressions in the branch_pr work start flow or its CLI integration test.

### Current Status

- State: ok
- Note: The fresh branch_pr worktree still seeds local-backend task READMEs; the base checkout no longer retains untracked task README copies after work start; targeted lint and the seeded-worktree integration test passed in the task worktree after bootstrap.

## Risks

- Risk level: not recorded
- Breaking change: no

### Rollback

- Revert task-related commit(s).
- Re-run required checks to confirm rollback safety.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-04-08T19:54:41.370Z
- Branch: task/202604081931-77V6J5/cleanup-base-readme
- Head: e820c9f93593

```text
 .agentplane/tasks/202604081931-77V6J5/README.md    | 101 +++++++++++++++++++++
 .../src/cli/run-cli.core.pr-flow.test.ts           |  21 ++++-
 .../agentplane/src/commands/branch/work-start.ts   |  22 ++++-
 3 files changed, 138 insertions(+), 6 deletions(-)
```

</details>
