### PR TITLE
workflow: Auto-refresh branch_pr PR artifacts after task-scoped commits (V5N3P8)

### DIFF
--- a/packages/agentplane/src/cli/run-cli.core.pr-flow.pr.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.pr-flow.pr.test.ts
@@ -509,6 +509,188 @@ describe("runCli", () => {
     await readFile(path.join(prDir, "github-body.md"), "utf8");
   });
 
+  it("task set-status --commit-from-comment refreshes branch_pr PR head_sha after the commit", async () => {
+    const root = await mkGitRepoRootWithBranch("main");
+    const config = defaultConfig();
+    config.workflow_mode = "branch_pr";
+    config.agents.approvals.require_plan = false;
+    await writeConfig(root, config);
+    await configureGitUser(root);
+    const execFileAsync = promisify(execFile);
+    await writeFile(path.join(root, "seed.txt"), "seed\n", "utf8");
+    await execFileAsync("git", ["add", "seed.txt"], { cwd: root });
+    await execFileAsync("git", ["commit", "-m", "seed"], { cwd: root });
+
+    let taskId = "";
+    const ioTask = captureStdIO();
+    try {
+      const code = await runCli([
+        "task",
+        "new",
+        "--title",
+        "Branch PR meta head sync",
+        "--description",
+        "Comment-driven task commits should keep pr/meta head_sha current",
+        "--priority",
+        "med",
+        "--owner",
+        "CODER",
+        "--tag",
+        "workflow",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(0);
+      taskId = ioTask.stdout.trim();
+    } finally {
+      ioTask.restore();
+    }
+
+    await runCliSilent(["branch", "base", "set", "main", "--root", root]);
+    await execFileAsync("git", ["checkout", "-b", `task/${taskId}/status-sync`], { cwd: root });
+
+    await runCliSilent([
+      "pr",
+      "open",
+      taskId,
+      "--author",
+      "CODER",
+      "--branch",
+      `task/${taskId}/status-sync`,
+      "--root",
+      root,
+    ]);
+
+    await runCliSilent([
+      "task",
+      "start-ready",
+      taskId,
+      "--author",
+      "CODER",
+      "--body",
+      "Start: move the task into DOING before the comment-driven status commit sync regression.",
+      "--root",
+      root,
+    ]);
+
+    const metaPath = path.join(root, ".agentplane", "tasks", taskId, "pr", "meta.json");
+    const before = JSON.parse(await readFile(metaPath, "utf8")) as { head_sha?: string | null };
+    expect(before.head_sha).toMatch(/^[0-9a-f]{40}$/u);
+
+    await writeFile(path.join(root, "blocker.txt"), "blocked\n", "utf8");
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli([
+        "task",
+        "set-status",
+        taskId,
+        "BLOCKED",
+        "--author",
+        "CODER",
+        "--body",
+        "Blocked: waiting on a dependency while the branch_pr PR artifact refresh regression is under test.",
+        "--commit-from-comment",
+        "--commit-allow",
+        "blocker.txt",
+        "--confirm-status-commit",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(0);
+    } finally {
+      io.restore();
+    }
+
+    const after = JSON.parse(await readFile(metaPath, "utf8")) as { head_sha?: string | null };
+    const { stdout: headStdout } = await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: root });
+    const headSha = headStdout.trim();
+    expect(after.head_sha).toBe(headSha);
+    expect(after.head_sha).not.toBe(before.head_sha);
+  });
+
+  it("commit refreshes branch_pr PR head_sha after a task-scoped commit", async () => {
+    const root = await mkGitRepoRootWithBranch("main");
+    const config = defaultConfig();
+    config.workflow_mode = "branch_pr";
+    await writeConfig(root, config);
+    await configureGitUser(root);
+    const execFileAsync = promisify(execFile);
+    await writeFile(path.join(root, "seed.txt"), "seed\n", "utf8");
+    await execFileAsync("git", ["add", "seed.txt"], { cwd: root });
+    await execFileAsync("git", ["commit", "-m", "seed"], { cwd: root });
+
+    let taskId = "";
+    const ioTask = captureStdIO();
+    try {
+      const code = await runCli([
+        "task",
+        "new",
+        "--title",
+        "Branch PR guard commit sync",
+        "--description",
+        "Commit should keep pr/meta head_sha current on task branches",
+        "--priority",
+        "med",
+        "--owner",
+        "CODER",
+        "--tag",
+        "workflow",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(0);
+      taskId = ioTask.stdout.trim();
+    } finally {
+      ioTask.restore();
+    }
+
+    await runCliSilent(["branch", "base", "set", "main", "--root", root]);
+    await execFileAsync("git", ["checkout", "-b", `task/${taskId}/guard-sync`], { cwd: root });
+    await runCliSilent([
+      "pr",
+      "open",
+      taskId,
+      "--author",
+      "CODER",
+      "--branch",
+      `task/${taskId}/guard-sync`,
+      "--root",
+      root,
+    ]);
+
+    const metaPath = path.join(root, ".agentplane", "tasks", taskId, "pr", "meta.json");
+    const before = JSON.parse(await readFile(metaPath, "utf8")) as { head_sha?: string | null };
+    expect(before.head_sha).toMatch(/^[0-9a-f]{40}$/u);
+    const suffix = extractTaskSuffix(taskId);
+
+    await writeFile(path.join(root, "src.ts"), "export const value = 1;\n", "utf8");
+    await execFileAsync("git", ["add", "src.ts"], { cwd: root });
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli([
+        "commit",
+        taskId,
+        "-m",
+        `🧩 ${suffix} workflow: refresh branch_pr artifacts after guard commit`,
+        "--allow",
+        "src.ts",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(0);
+    } finally {
+      io.restore();
+    }
+
+    const after = JSON.parse(await readFile(metaPath, "utf8")) as { head_sha?: string | null };
+    const { stdout: headStdout } = await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: root });
+    const headSha = headStdout.trim();
+    expect(after.head_sha).toBe(headSha);
+    expect(after.head_sha).not.toBe(before.head_sha);
+  });
+
   it("pr update refreshes diffstat and auto summary", { timeout: 60_000 }, async () => {
     const root = await mkGitRepoRootWithBranch("main");
     const config = defaultConfig();

--- a/packages/agentplane/src/commands/guard/impl/commands.ts
+++ b/packages/agentplane/src/commands/guard/impl/commands.ts
@@ -7,6 +7,7 @@ import { infoMessage, successMessage } from "../../../cli/output.js";
 import { stripAnsi } from "../../../cli/shared/ansi.js";
 import { withDiagnosticContext } from "../../../shared/diagnostics.js";
 import { CliError } from "../../../shared/errors.js";
+import { refreshBranchPrArtifactsAfterTaskCommit } from "../../shared/post-commit-pr-artifacts.js";
 import { loadCommandContext, type CommandContext } from "../../shared/task-backend.js";
 import { loadTaskFromContext } from "../../shared/task-backend.js";
 import { execFileAsync, gitEnv } from "../../shared/git.js";
@@ -538,6 +539,13 @@ export async function cmdCommit(opts: {
       allowCI: opts.allowCI,
     });
     await ctx.git.commit({ message: opts.message, env });
+    await refreshBranchPrArtifactsAfterTaskCommit({
+      ctx,
+      cwd: opts.cwd,
+      rootOverride: opts.rootOverride,
+      taskId: opts.taskId,
+      quiet: opts.quiet,
+    });
 
     if (!opts.quiet) {
       const { hash, subject } = await ctx.git.headHashSubject();

--- a/packages/agentplane/src/commands/shared/post-commit-pr-artifacts.ts
+++ b/packages/agentplane/src/commands/shared/post-commit-pr-artifacts.ts
@@ -1,0 +1,32 @@
+import { warnMessage } from "../../cli/output.js";
+import { normalizeGhTransportError } from "../shared/gh-transport.js";
+import type { CommandContext } from "../shared/task-backend.js";
+import { ensurePrArtifactsSynced } from "../pr/internal/sync.js";
+
+export async function refreshBranchPrArtifactsAfterTaskCommit(opts: {
+  ctx: CommandContext;
+  cwd: string;
+  rootOverride?: string;
+  taskId: string;
+  quiet: boolean;
+}): Promise<void> {
+  if (opts.ctx.config.workflow_mode !== "branch_pr") return;
+
+  try {
+    await ensurePrArtifactsSynced({
+      ctx: opts.ctx,
+      cwd: opts.cwd,
+      rootOverride: opts.rootOverride,
+      taskId: opts.taskId,
+    });
+  } catch (err) {
+    if (opts.quiet) return;
+    const detail = normalizeGhTransportError(err).trim();
+    const suffix = detail ? ` (${detail})` : "";
+    process.stderr.write(
+      `${warnMessage(
+        `task commit succeeded but PR artifacts refresh failed for ${opts.taskId}; run \`agentplane pr update ${opts.taskId}\`${suffix}`,
+      )}\n`,
+    );
+  }
+}

--- a/packages/agentplane/src/commands/task/shared/transitions.ts
+++ b/packages/agentplane/src/commands/task/shared/transitions.ts
@@ -10,6 +10,7 @@ import { CliError } from "../../../shared/errors.js";
 import { parseGitLogHashSubject } from "../../../shared/git-log.js";
 import type { TaskData, TaskEvent } from "../../../backends/task-backend.js";
 import { commitFromComment } from "../../guard/index.js";
+import { refreshBranchPrArtifactsAfterTaskCommit } from "../../shared/post-commit-pr-artifacts.js";
 import type { CommandContext } from "../../shared/task-backend.js";
 import { requiresVerificationByPrimary, toStringArray } from "./tags.js";
 
@@ -224,7 +225,7 @@ export async function runTaskTransitionCommentCommit(opts: {
         author: opts.author,
       })
     : undefined;
-  return await commitFromComment({
+  const result = await commitFromComment({
     ctx: opts.ctx,
     cwd: opts.cwd,
     rootOverride: opts.rootOverride,
@@ -244,6 +245,14 @@ export async function runTaskTransitionCommentCommit(opts: {
     quiet: opts.quiet,
     config: opts.ctx.config,
   });
+  await refreshBranchPrArtifactsAfterTaskCommit({
+    ctx: opts.ctx,
+    cwd: opts.cwd,
+    rootOverride: opts.rootOverride,
+    taskId: opts.taskId,
+    quiet: opts.quiet,
+  });
+  return result;
 }
 
 export async function readHeadCommit(cwd: string): Promise<{ hash: string; message: string }> {


### PR DESCRIPTION
## Summary

Auto-refresh branch_pr PR artifacts after task-scoped commits

Keep pr/meta head_sha and related branch_pr artifacts in sync after task-scoped local commits so integrate and pr check do not fail on avoidable stale artifact drift.

## Scope

- In scope: Keep pr/meta head_sha and related branch_pr artifacts in sync after task-scoped local commits so integrate and pr check do not fail on avoidable stale artifact drift.
- Out of scope: unrelated refactors not required for "Auto-refresh branch_pr PR artifacts after task-scoped commits".

## Verification

### Plan

<!-- TODO: REPLACE WITH TASK-SPECIFIC ACCEPTANCE STEPS -->

1. <Action>. Expected: <observable result>.
2. <Action>. Expected: <observable result>.
3. <Action>. Expected: <observable result>.

### Current Status

- State: ok
- Note: Command: targeted branch_pr commit-path regressions + eslint. Result: pass. Evidence: both commit and comment-driven status transitions now refresh pr/meta head_sha without a manual pr update; scoped lint is clean. Scope: post-commit PR artifact sync for branch_pr task commits.

## Risks

- Risk level: not recorded
- Breaking change: no

### Rollback

- Revert task-related commit(s).
- Re-run required checks to confirm rollback safety.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-04-09T11:48:55.764Z
- Branch: task/202604091136-V5N3P8/pr-artifact-auto-refresh
- Head: e71db4080e38

```text
No changes detected.
```

</details>
