### PR TITLE
Prevent post-close PR artifact dirt after finish --close-commit (BGDQEG)

### DIFF
--- a/packages/agentplane/src/cli/run-cli.core.lifecycle.block-finish.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.lifecycle.block-finish.test.ts
@@ -474,6 +474,124 @@ describe("runCli", () => {
   });
 
   it(
+    "finish --close-commit leaves branch_pr PR artifacts clean and verified on the base checkout",
+    { timeout: 120_000 },
+    async () => {
+      const root = await mkGitRepoRoot();
+      const config = defaultConfig();
+      config.workflow_mode = "branch_pr";
+      await writeConfig(root, config);
+      await configureGitUser(root);
+
+      const execFileAsync = promisify(execFile);
+      await execFileAsync("git", ["checkout", "-b", "main"], { cwd: root });
+      await writeFile(path.join(root, "file.txt"), "content", "utf8");
+      await execFileAsync("git", ["add", "file.txt"], { cwd: root });
+      await execFileAsync("git", ["commit", "-m", "feat: seed commit"], { cwd: root });
+      const { stdout: implHash } = await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: root });
+
+      const ioNew = captureStdIO();
+      let taskId = "";
+      try {
+        const code = await runCli([
+          "task",
+          "new",
+          "--title",
+          "Finish branch_pr close commit refreshes PR artifacts",
+          "--description",
+          "Finish should not leave refreshed pr artifacts dirty after the close commit.",
+          "--priority",
+          "med",
+          "--owner",
+          "CODER",
+          "--tag",
+          "docs",
+          "--root",
+          root,
+        ]);
+        expect(code).toBe(0);
+        taskId = ioNew.stdout.trim();
+      } finally {
+        ioNew.restore();
+      }
+
+      await runCliSilent(["branch", "base", "set", "main", "--root", root]);
+      await runCliSilent([
+        "pr",
+        "open",
+        taskId,
+        "--author",
+        "CODER",
+        "--branch",
+        `task/${taskId}/close-artifacts`,
+        "--root",
+        root,
+      ]);
+      await runCliSilent([
+        "verify",
+        taskId,
+        "--ok",
+        "--by",
+        "REVIEWER",
+        "--note",
+        "Ok to finish after PR artifacts reflect pass state.",
+        "--quiet",
+        "--root",
+        root,
+      ]);
+
+      const io = captureStdIO();
+      try {
+        const code = await runCli([
+          "finish",
+          taskId,
+          "--author",
+          "INTEGRATOR",
+          "--body",
+          "Verified: branch_pr close commit should commit the refreshed pr artifacts and leave the base checkout clean.",
+          "--result",
+          "branch_pr close commit refreshes PR artifacts",
+          "--commit",
+          implHash.trim(),
+          "--close-commit",
+          "--root",
+          root,
+        ]);
+        expect(code).toBe(0);
+        expect(io.stdout).toContain("creating deterministic close commit");
+        expect(io.stdout).toContain("✅ finished");
+      } finally {
+        io.restore();
+      }
+
+      const { stdout: status } = await execFileAsync(
+        "git",
+        ["status", "--short", "--untracked-files=no"],
+        { cwd: root },
+      );
+      expect(status.trim()).toBe("");
+
+      const prDir = path.join(root, ".agentplane", "tasks", taskId, "pr");
+      const meta = JSON.parse(await readFile(path.join(prDir, "meta.json"), "utf8")) as {
+        last_verified_at?: string | null;
+        verify?: { status?: string | null };
+      };
+      expect(meta.last_verified_at).toBeTruthy();
+      expect(meta.verify?.status).toBe("pass");
+      expect(await readFile(path.join(prDir, "review.md"), "utf8")).toContain("- State: ok");
+      expect(await readFile(path.join(prDir, "github-body.md"), "utf8")).toContain(
+        "- State: ok",
+      );
+      expect(await readFile(path.join(prDir, "review.md"), "utf8")).not.toContain(
+        "Not recorded yet.",
+      );
+      expect(await readFile(path.join(prDir, "github-body.md"), "utf8")).not.toContain(
+        "Not recorded yet.",
+      );
+    },
+  );
+
+  it(
     "finish --close-commit succeeds on main in branch_pr mode without a pinned base when origin HEAD resolves main",
     { timeout: 120_000 },
     async () => {

--- a/packages/agentplane/src/cli/run-cli.core.lifecycle.block-finish.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.lifecycle.block-finish.test.ts
@@ -579,9 +579,7 @@ describe("runCli", () => {
       expect(meta.last_verified_at).toBeTruthy();
       expect(meta.verify?.status).toBe("pass");
       expect(await readFile(path.join(prDir, "review.md"), "utf8")).toContain("- State: ok");
-      expect(await readFile(path.join(prDir, "github-body.md"), "utf8")).toContain(
-        "- State: ok",
-      );
+      expect(await readFile(path.join(prDir, "github-body.md"), "utf8")).toContain("- State: ok");
       expect(await readFile(path.join(prDir, "review.md"), "utf8")).not.toContain(
         "Not recorded yet.",
       );

--- a/packages/agentplane/src/commands/guard/impl/commands.ts
+++ b/packages/agentplane/src/commands/guard/impl/commands.ts
@@ -409,6 +409,15 @@ export async function cmdCommit(opts: {
         }
         return 0;
       }
+      if (opts.closeStageTaskArtifacts === true) {
+        await refreshBranchPrArtifactsAfterTaskCommit({
+          ctx,
+          cwd: opts.cwd,
+          rootOverride: opts.rootOverride,
+          taskId: opts.taskId,
+          quiet: opts.quiet,
+        });
+      }
       await (opts.closeStageTaskArtifacts === true
         ? stageAllowlist({
             ctx,

--- a/packages/agentplane/src/commands/guard/impl/commands.unit.test.ts
+++ b/packages/agentplane/src/commands/guard/impl/commands.unit.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   ensureReconciledBeforeMutation: vi.fn(),
   execFileAsync: vi.fn(),
   gitEnv: vi.fn(),
+  refreshBranchPrArtifactsAfterTaskCommit: vi.fn(),
   loadCommandContext: vi.fn(),
   loadTaskFromContext: vi.fn(),
   buildCloseCommitMessage: vi.fn(),
@@ -28,6 +29,9 @@ vi.mock("../../shared/reconcile-check.js", () => ({
 vi.mock("../../shared/git.js", () => ({
   execFileAsync: mocks.execFileAsync,
   gitEnv: mocks.gitEnv,
+}));
+vi.mock("../../shared/post-commit-pr-artifacts.js", () => ({
+  refreshBranchPrArtifactsAfterTaskCommit: mocks.refreshBranchPrArtifactsAfterTaskCommit,
 }));
 vi.mock("./close-message.js", () => ({
   buildCloseCommitMessage: mocks.buildCloseCommitMessage,
@@ -396,6 +400,57 @@ describe("guard/impl/commands", () => {
     } finally {
       stdout.mockRestore();
     }
+  });
+
+  it("cmdCommit close refreshes PR artifacts before staging task artifact scope", async () => {
+    const { cmdCommit } = await import("./commands.js");
+    const ctx = mkCtx();
+    ctx.git.statusChangedPaths.mockResolvedValue([
+      ".agentplane/tasks/T-12/pr/meta.json",
+      ".agentplane/tasks/T-12/pr/review.md",
+    ]);
+    mocks.loadTaskFromContext.mockResolvedValue({ id: "T-12" });
+    mocks.buildCloseCommitMessage.mockResolvedValue({
+      subject: "✅ ABC123 close: done",
+      body: "body",
+    });
+    mocks.taskReadmePathForTask.mockReturnValue("/repo/.agentplane/tasks/T-12/README.md");
+    mocks.buildGitCommitEnv.mockReturnValue({ AGENTPLANE_TASK_ID: "T-12" });
+
+    const rc = await cmdCommit({
+      ctx: ctx as never,
+      cwd: "/repo",
+      taskId: "T-12",
+      message: "",
+      close: true,
+      allow: [],
+      autoAllow: false,
+      allowTasks: false,
+      allowBase: false,
+      allowPolicy: false,
+      allowConfig: false,
+      allowHooks: false,
+      allowCI: false,
+      requireClean: false,
+      quiet: true,
+      closeStageTaskArtifacts: true,
+    });
+
+    expect(rc).toBe(0);
+    expect(mocks.refreshBranchPrArtifactsAfterTaskCommit).toHaveBeenCalledWith({
+      ctx,
+      cwd: "/repo",
+      rootOverride: undefined,
+      taskId: "T-12",
+      quiet: true,
+    });
+    expect(ctx.git.stage).toHaveBeenCalledWith([
+      ".agentplane/tasks/T-12/pr/meta.json",
+      ".agentplane/tasks/T-12/pr/review.md",
+    ]);
+    expect(
+      mocks.refreshBranchPrArtifactsAfterTaskCommit.mock.invocationCallOrder[0],
+    ).toBeLessThan(ctx.git.stage.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY);
   });
 
   it("cmdCommit rejects auto-allow mode", async () => {

--- a/packages/agentplane/src/commands/guard/impl/commands.unit.test.ts
+++ b/packages/agentplane/src/commands/guard/impl/commands.unit.test.ts
@@ -448,9 +448,9 @@ describe("guard/impl/commands", () => {
       ".agentplane/tasks/T-12/pr/meta.json",
       ".agentplane/tasks/T-12/pr/review.md",
     ]);
-    expect(
-      mocks.refreshBranchPrArtifactsAfterTaskCommit.mock.invocationCallOrder[0],
-    ).toBeLessThan(ctx.git.stage.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY);
+    expect(mocks.refreshBranchPrArtifactsAfterTaskCommit.mock.invocationCallOrder[0]).toBeLessThan(
+      ctx.git.stage.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
   });
 
   it("cmdCommit rejects auto-allow mode", async () => {


### PR DESCRIPTION
## Summary

Prevent post-close PR artifact dirt after finish --close-commit

Fix branch_pr finish so deterministic close commits do not leave .agentplane/tasks/<task-id>/pr/* tracked changes dirty after the commit completes.

## Scope

- In scope: Fix branch_pr finish so deterministic close commits do not leave .agentplane/tasks/<task-id>/pr/* tracked changes dirty after the commit completes.
- Out of scope: unrelated refactors not required for "Prevent post-close PR artifact dirt after finish --close-commit".

## Verification

### Plan

1. Reproduce the branch_pr finish path that previously left `.agentplane/tasks/<task-id>/pr/*` dirty after `finish --close-commit`. Expected: the regression test fails before the fix and passes after it.
2. Run the touched finish/commit lifecycle tests. Expected: finish still records DONE metadata and deterministic close commits without regressing existing branch_pr or direct-mode close behavior.
3. Re-run the real reconcile flow for `202604091956-BKQG36`. Expected: `BKQG36` can be verified and finished without leaving tracked `pr/*` dirt on `main`.

### Current Status

- State: pending
- Note: Not recorded yet.

## Risks

- Risk level: not recorded
- Breaking change: no

### Rollback

- Revert task-related commit(s).
- Re-run required checks to confirm rollback safety.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-04-09T20:21:06.727Z
- Branch: task/202604092006-BGDQEG/close-commit-pr-artifacts
- Head: e1c83a480e8a

```text
No changes detected.
```

</details>
