### PR TITLE
hooks: Make fresh-worktree hook runner degrade cleanly before bootstrap (NK7RVS)

### DIFF
--- a/packages/agentplane/bin/agentplane.js
+++ b/packages/agentplane/bin/agentplane.js
@@ -2,6 +2,7 @@
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { stat } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { distExists, isPackageBuildFresh } from "./dist-guard.js";
 import {
@@ -129,6 +130,19 @@ function renderStalePolicyWarning(reason) {
   return "warning: allowing read-only diagnostic command to run with a stale repo build inside the framework checkout.\n";
 }
 
+function missingRepoRuntimeDependencies(agentplaneRoot) {
+  const requireFromAgentplane = createRequire(path.join(agentplaneRoot, "package.json"));
+  const requiredSpecifiers = ["@agentplaneorg/core"];
+  return requiredSpecifiers.filter((specifier) => {
+    try {
+      requireFromAgentplane.resolve(specifier);
+      return false;
+    } catch {
+      return true;
+    }
+  });
+}
+
 async function assertDistUpToDate() {
   const here = path.dirname(fileURLToPath(import.meta.url));
   const agentplaneRoot = path.resolve(here, "..");
@@ -140,6 +154,24 @@ async function assertDistUpToDate() {
     process.stderr.write(
       "error: agentplane dist is missing for this framework checkout.\n" +
         "This worktree is not bootstrapped yet.\n" +
+        "Fix:\n" +
+        `  ${FRAMEWORK_DEV_BOOTSTRAP_COMMAND}\n` +
+        "Manual fallback:\n" +
+        FRAMEWORK_DEV_MANUAL_REPAIR_COMMANDS.map((command) => `  ${command}\n`).join("") +
+        "Supported global override when you intentionally want the installed binary:\n" +
+        `  ${FRAMEWORK_DEV_FORCE_GLOBAL_EXAMPLE}\n`,
+    );
+    process.exitCode = 2;
+    return false;
+  }
+
+  const missingDeps = missingRepoRuntimeDependencies(agentplaneRoot);
+  if (missingDeps.length > 0) {
+    process.stderr.write(
+      "error: repo-local runtime dependencies are missing for this framework checkout.\n" +
+        "This worktree is not bootstrapped yet.\n" +
+        "Missing module resolution:\n" +
+        missingDeps.map((specifier) => `  ${specifier}\n`).join("") +
         "Fix:\n" +
         `  ${FRAMEWORK_DEV_BOOTSTRAP_COMMAND}\n` +
         "Manual fallback:\n" +

--- a/packages/agentplane/bin/agentplane.js
+++ b/packages/agentplane/bin/agentplane.js
@@ -132,6 +132,22 @@ function renderStalePolicyWarning(reason) {
 
 function missingRepoRuntimeDependencies(agentplaneRoot) {
   const requireFromAgentplane = createRequire(path.join(agentplaneRoot, "package.json"));
+  let packageJson = null;
+  try {
+    packageJson = requireFromAgentplane("./package.json");
+  } catch {
+    return [];
+  }
+  const declaredDeps = {};
+  if (packageJson?.dependencies && typeof packageJson.dependencies === "object") {
+    Object.assign(declaredDeps, packageJson.dependencies);
+  }
+  if (packageJson?.optionalDependencies && typeof packageJson.optionalDependencies === "object") {
+    Object.assign(declaredDeps, packageJson.optionalDependencies);
+  }
+  if (!("@agentplaneorg/core" in declaredDeps)) {
+    return [];
+  }
   const requiredSpecifiers = ["@agentplaneorg/core"];
   return requiredSpecifiers.filter((specifier) => {
     try {

--- a/packages/agentplane/src/cli/repo-local-handoff.test.ts
+++ b/packages/agentplane/src/cli/repo-local-handoff.test.ts
@@ -166,11 +166,7 @@ async function setupFrameworkCheckoutWithoutInstallLayout() {
   );
   await writeFile(
     path.join(distDir, "cli.js"),
-    [
-      "#!/usr/bin/env node",
-      String.raw`process.stdout.write("SHOULD_NOT_RUN\n");`,
-      "",
-    ].join("\n"),
+    ["#!/usr/bin/env node", String.raw`process.stdout.write("SHOULD_NOT_RUN\n");`, ""].join("\n"),
     "utf8",
   );
   await execFileAsync("git", ["init", "-q", "-b", "main"], { cwd: repoRoot });

--- a/packages/agentplane/src/cli/repo-local-handoff.test.ts
+++ b/packages/agentplane/src/cli/repo-local-handoff.test.ts
@@ -138,6 +138,50 @@ async function setupFrameworkCheckoutWithoutDist() {
   };
 }
 
+async function setupFrameworkCheckoutWithoutInstallLayout() {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "agentplane-framework-checkout-"));
+  tempRoots.push(repoRoot);
+  const binDir = path.join(repoRoot, "packages", "agentplane", "bin");
+  const distDir = path.join(repoRoot, "packages", "agentplane", "dist");
+  const srcDir = path.join(repoRoot, "packages", "agentplane", "src", "nested");
+  await mkdir(binDir, { recursive: true });
+  await mkdir(distDir, { recursive: true });
+  await mkdir(srcDir, { recursive: true });
+  for (const entry of await readdir(path.join(workspaceRoot, "packages", "agentplane", "bin"))) {
+    if (!entry.endsWith(".js")) continue;
+    await copyFile(
+      path.join(workspaceRoot, "packages", "agentplane", "bin", entry),
+      path.join(binDir, entry),
+    );
+  }
+  await writeFile(
+    path.join(repoRoot, "packages", "agentplane", "src", "cli.ts"),
+    "export const cli = true;\n",
+    "utf8",
+  );
+  await writeFile(
+    path.join(repoRoot, "packages", "agentplane", "package.json"),
+    '{\n  "name": "agentplane",\n  "type": "module"\n}\n',
+    "utf8",
+  );
+  await writeFile(
+    path.join(distDir, ".build-manifest.json"),
+    JSON.stringify({
+      schema_version: 1,
+      git_head: null,
+      watched_runtime_paths: ["src"],
+      watched_runtime_files: [{ path: "src/cli.ts", sha256: "stub", size_bytes: 24 }],
+      watched_runtime_snapshot_hash: "stub",
+    }),
+    "utf8",
+  );
+
+  return {
+    repoRoot,
+    nestedCwd: srcDir,
+  };
+}
+
 afterEach(async () => {
   while (tempRoots.length > 0) {
     const root = tempRoots.pop();
@@ -252,6 +296,33 @@ describe("repo-local handoff wrapper", () => {
       expect(err.stderr ?? "").toContain(
         "AGENTPLANE_USE_GLOBAL_IN_FRAMEWORK=1 agentplane <command>",
       );
+      expect(err.stdout ?? "").toBe("");
+    }
+  });
+
+  it("reports bootstrap guidance when repo-local install layout is missing", async () => {
+    const globalInstall = await setupGlobalInstall();
+    const framework = await setupFrameworkCheckoutWithoutInstallLayout();
+
+    try {
+      await execFileAsync(process.execPath, [globalInstall.binPath, "help"], {
+        cwd: framework.nestedCwd,
+        encoding: "utf8",
+        env: buildChildEnv(),
+      });
+      throw new Error("expected command to fail");
+    } catch (error) {
+      const err = error as { stderr?: string; stdout?: string };
+      expect(err.stderr ?? "").toContain(
+        "repo-local runtime dependencies are missing for this framework checkout",
+      );
+      expect(err.stderr ?? "").toContain("This worktree is not bootstrapped yet.");
+      expect(err.stderr ?? "").toContain("@agentplaneorg/core");
+      expect(err.stderr ?? "").toContain("bun run framework:dev:bootstrap");
+      expect(err.stderr ?? "").toContain(
+        "AGENTPLANE_USE_GLOBAL_IN_FRAMEWORK=1 agentplane <command>",
+      );
+      expect(err.stderr ?? "").not.toContain("ERR_MODULE_NOT_FOUND");
       expect(err.stdout ?? "").toBe("");
     }
   });

--- a/packages/agentplane/src/cli/repo-local-handoff.test.ts
+++ b/packages/agentplane/src/cli/repo-local-handoff.test.ts
@@ -161,14 +161,37 @@ async function setupFrameworkCheckoutWithoutInstallLayout() {
   );
   await writeFile(
     path.join(repoRoot, "packages", "agentplane", "package.json"),
-    '{\n  "name": "agentplane",\n  "type": "module"\n}\n',
+    '{\n  "name": "agentplane",\n  "type": "module",\n  "dependencies": {\n    "@agentplaneorg/core": "0.0.0-test"\n  }\n}\n',
     "utf8",
   );
+  await writeFile(
+    path.join(distDir, "cli.js"),
+    [
+      "#!/usr/bin/env node",
+      String.raw`process.stdout.write("SHOULD_NOT_RUN\n");`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await execFileAsync("git", ["init", "-q", "-b", "main"], { cwd: repoRoot });
+  await execFileAsync("git", ["config", "user.name", "Repo Local Handoff Test"], { cwd: repoRoot });
+  await execFileAsync("git", ["config", "user.email", "repo-local-handoff@example.com"], {
+    cwd: repoRoot,
+  });
+  await execFileAsync("git", ["add", "."], { cwd: repoRoot });
+  await execFileAsync("git", ["commit", "-m", "feat: install-layout harness"], {
+    cwd: repoRoot,
+  });
+  const headResult = await execFileAsync("git", ["rev-parse", "HEAD"], {
+    cwd: path.join(repoRoot, "packages", "agentplane"),
+    encoding: "utf8",
+  });
+  const head = headResult.stdout.trim();
   await writeFile(
     path.join(distDir, ".build-manifest.json"),
     JSON.stringify({
       schema_version: 1,
-      git_head: null,
+      git_head: head,
       watched_runtime_paths: ["src"],
       watched_runtime_files: [{ path: "src/cli.ts", sha256: "stub", size_bytes: 24 }],
       watched_runtime_snapshot_hash: "stub",
@@ -323,6 +346,7 @@ describe("repo-local handoff wrapper", () => {
         "AGENTPLANE_USE_GLOBAL_IN_FRAMEWORK=1 agentplane <command>",
       );
       expect(err.stderr ?? "").not.toContain("ERR_MODULE_NOT_FOUND");
+      expect(err.stdout ?? "").not.toContain("SHOULD_NOT_RUN");
       expect(err.stdout ?? "").toBe("");
     }
   });


### PR DESCRIPTION
## Summary

Make fresh-worktree hook runner degrade cleanly before bootstrap

Fix the hook/runtime path in a fresh framework worktree so commit hooks do not crash with ERR_MODULE_NOT_FOUND before bootstrap; either detect unbootstrapped repo-local runtime and fall back cleanly or emit deterministic guidance without a Node stack trace.

## Scope

- In scope: Fix the hook/runtime path in a fresh framework worktree so commit hooks do not crash with ERR_MODULE_NOT_FOUND before bootstrap; either detect unbootstrapped repo-local runtime and fall back cleanly or emit deterministic guidance without a Node stack trace.
- Out of scope: unrelated refactors not required for "Make fresh-worktree hook runner degrade cleanly before bootstrap".

## Verification

### Plan

1. Reproduce the fresh framework-worktree hook path before bootstrap. Expected: hooks no longer crash with raw `ERR_MODULE_NOT_FOUND`; they emit deterministic bootstrap guidance or a clean fallback.
2. Run targeted hook/runtime tests. Expected: the fresh-worktree path degrades cleanly before bootstrap and the bootstrapped path still passes.
3. Validate the real workflow in a fresh worktree. Expected: commit hooks fail cleanly before `bun run framework:dev:bootstrap` and succeed after bootstrap without manual environment hacks.

### Current Status

- State: pending
- Note: Not recorded yet.

## Risks

- Risk level: not recorded
- Breaking change: no

### Rollback

- Revert task-related commit(s).
- Re-run required checks to confirm rollback safety.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-04-09T20:51:56.335Z
- Branch: task/202604092006-NK7RVS/fresh-worktree-hooks
- Head: 430a0a99d8e4

```text
No changes detected.
```

</details>
