### PR TITLE
fix: scope integrate stale-dist bypass to integrate-owned commits

### DIFF
--- a/packages/agentplane/src/commands/pr/integrate/internal/merge.test.ts
+++ b/packages/agentplane/src/commands/pr/integrate/internal/merge.test.ts
@@ -68,6 +68,7 @@ describe("pr/integrate/internal/merge", () => {
         AGENTPLANE_TASK_ID: "202602111653-X32XPT",
         AGENTPLANE_ALLOW_BASE: "1",
         AGENTPLANE_ALLOW_TASKS: "1",
+        AGENTPLANE_DEV_ALLOW_STALE_DIST: "1",
       },
     });
   });
@@ -114,6 +115,7 @@ describe("pr/integrate/internal/merge", () => {
         AGENTPLANE_TASK_ID: "202602111653-X32XPT",
         AGENTPLANE_ALLOW_BASE: "1",
         AGENTPLANE_ALLOW_TASKS: "1",
+        AGENTPLANE_DEV_ALLOW_STALE_DIST: "1",
       },
     });
   });
@@ -203,6 +205,7 @@ describe("pr/integrate/internal/merge", () => {
         AGENTPLANE_TASK_ID: "202602111653-X32XPT",
         AGENTPLANE_ALLOW_BASE: "1",
         AGENTPLANE_ALLOW_TASKS: "1",
+        AGENTPLANE_DEV_ALLOW_STALE_DIST: "1",
       },
     });
   });

--- a/packages/agentplane/src/commands/pr/integrate/internal/merge.ts
+++ b/packages/agentplane/src/commands/pr/integrate/internal/merge.ts
@@ -19,6 +19,16 @@ type MovedTaskArtifact = {
 
 const noopPromise = (): Promise<void> => Promise.resolve();
 
+function integrateCommitEnv(taskId: string): NodeJS.ProcessEnv {
+  return {
+    ...gitEnv(),
+    AGENTPLANE_TASK_ID: taskId,
+    AGENTPLANE_ALLOW_BASE: "1",
+    AGENTPLANE_ALLOW_TASKS: "1",
+    AGENTPLANE_DEV_ALLOW_STALE_DIST: "1",
+  };
+}
+
 function isTaskArtifactPath(filePath: string): boolean {
   const normalized = filePath.replaceAll("\\", "/");
   return normalized.startsWith(".agentplane/tasks/") || normalized.startsWith("tasks/");
@@ -233,12 +243,7 @@ export async function runSquashMerge(opts: {
     subject = `🧩 ${suffix} integrate: ${fallbackIntegrateSummary(opts)}`;
   }
 
-  const env = {
-    ...process.env,
-    AGENTPLANE_TASK_ID: opts.taskId,
-    AGENTPLANE_ALLOW_BASE: "1",
-    AGENTPLANE_ALLOW_TASKS: "1",
-  };
+  const env = integrateCommitEnv(opts.taskId);
   try {
     await execFileAsync("git", ["commit", "-m", subject], {
       cwd: opts.gitRoot,
@@ -274,12 +279,7 @@ export async function runMergeCommit(opts: {
     taskId: opts.taskId,
     changedPaths: opts.changedPaths,
   });
-  const env = {
-    ...process.env,
-    AGENTPLANE_TASK_ID: opts.taskId,
-    AGENTPLANE_ALLOW_BASE: "1",
-    AGENTPLANE_ALLOW_TASKS: "1",
-  };
+  const env = integrateCommitEnv(opts.taskId);
   try {
     await execFileAsync(
       "git",


### PR DESCRIPTION
# PR Review

Created: 2026-04-09T21:10:10.992Z
Branch: task/202604092105-DBE1JB/integrate-stale-dist

## Summary

Make integrate commit path tolerate expected stale-dist during base-side squash

agentplane integrate on base main currently fails when its own squash-commit path touches watched runtime files and the stale-dist guard blocks the internal git commit. Make the integrate-owned commit path deterministic without weakening normal stale-dist enforcement for regular commands.

## Scope

- In scope: agentplane integrate on base main currently fails when its own squash-commit path touches watched runtime files and the stale-dist guard blocks the internal git commit. Make the integrate-owned commit path deterministic without weakening normal stale-dist enforcement for regular commands.
- Out of scope: unrelated refactors not required for "Make integrate commit path tolerate expected stale-dist during base-side squash".

## Verification

### Plan

1. Reproduce the base-side integrate path on a fixture where watched runtime files are part of the task diff. Expected: integrate no longer fails only because its own squash commit temporarily makes the checkout look stale. 2. Verify ordinary stale-dist enforcement still blocks unrelated strict mutating commands outside the integrate-owned commit path. Expected: no broad weakening of the guard. 3. Run focused integrate and stale-dist regression tests. Expected: the new path is covered and existing stale-dist contracts stay green.

### Current Status

- State: pending
- Note: Not recorded yet.

## Risks

- Risk level: not recorded
- Breaking change: no

### Rollback

- Revert task-related commit(s).
- Re-run required checks to confirm rollback safety.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<!-- BEGIN AUTO SUMMARY -->
<details>
<summary>Raw evidence</summary>

- Updated: 2026-04-09T21:10:10.992Z
- Branch: task/202604092105-DBE1JB/integrate-stale-dist
- Head: bf6d7d28e026

```text
No changes detected.
```

</details>
<!-- END AUTO SUMMARY -->
