### PR TITLE
fix: make remote-check waits progress-aware

### DIFF
--- a/packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts
+++ b/packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts
@@ -47,6 +47,7 @@ async function writeGhMock(root: string) {
         prViewCallsByTarget: {},
         statusCallsByHead: {},
         checkRunCalls: 0,
+        jobCallsById: {},
         protectionCalls: 0,
         repoViewCalls: 0,
       },
@@ -72,7 +73,7 @@ async function writeGhMock(root: string) {
     "function readCounter(key, subkey) { const file = counterPath(key, subkey); if (!file || !fs.existsSync(file)) { if (typeof subkey === 'string') { const map = stateSeed[key] && typeof stateSeed[key] === 'object' ? stateSeed[key] : {}; return Number(map[subkey] || 0); } return Number(stateSeed[key] || 0); } const raw = fs.readFileSync(file, 'utf8').trim(); return raw.length > 0 ? Number(raw) : 0; }",
     "function writeCounter(key, subkey, value) { const file = counterPath(key, subkey); if (!file) return; fs.writeFileSync(file, String(value)); }",
     "function mapFromCounters(key) { if (!stateDir || !fs.existsSync(stateDir)) return stateSeed[key] && typeof stateSeed[key] === 'object' ? { ...stateSeed[key] } : {}; const result = stateSeed[key] && typeof stateSeed[key] === 'object' ? { ...stateSeed[key] } : {}; for (const entry of fs.readdirSync(stateDir)) { const prefix = `${key}__`; if (!entry.startsWith(prefix) || !entry.endsWith('.txt')) continue; const subkey = decodeURIComponent(entry.slice(prefix.length, -4)); if (subkey === '__root__') continue; const raw = fs.readFileSync(path.join(stateDir, entry), 'utf8').trim(); result[subkey] = raw.length > 0 ? Number(raw) : 0; } return result; }",
-    "function snapshotState() { return { ...stateSeed, prViewCalls: readCounter('prViewCalls'), prViewCallsByTarget: mapFromCounters('prViewCallsByTarget'), statusCallsByHead: mapFromCounters('statusCallsByHead'), checkRunCalls: readCounter('checkRunCalls'), protectionCalls: readCounter('protectionCalls'), repoViewCalls: readCounter('repoViewCalls') }; }",
+    "function snapshotState() { return { ...stateSeed, prViewCalls: readCounter('prViewCalls'), prViewCallsByTarget: mapFromCounters('prViewCallsByTarget'), statusCallsByHead: mapFromCounters('statusCallsByHead'), checkRunCalls: readCounter('checkRunCalls'), jobCallsById: mapFromCounters('jobCallsById'), protectionCalls: readCounter('protectionCalls'), repoViewCalls: readCounter('repoViewCalls') }; }",
     "function saveSnapshot() { if (!statePath) return; fs.writeFileSync(statePath, JSON.stringify(snapshotState(), null, 2)); }",
     "function readState() { return snapshotState(); }",
     "function ok(payload) { process.stdout.write(`${JSON.stringify(payload)}\\n`); process.exit(0); }",
@@ -90,9 +91,28 @@ async function writeGhMock(root: string) {
     "  const failure = { state: 'failure', statuses: [ { context: 'Core CI / test', state: 'failure', description: 'failed' }, { context: 'Docs CI / docs', state: 'success', description: 'done' } ] };",
     "  if (headSha === 'head-sha-2' && scenario === 'multi-second-failure') return failure;",
     "  if (scenario === 'timeout') return pending;",
+    "  if (scenario === 'progressing-in-progress') return attempt < 2 ? pending : success;",
+    "  if (scenario === 'stuck-in-progress') return pending;",
     "  return attempt === 0 ? pending : success;",
     "}",
-    "function checkRunsPayload() { return { total_count: 0, check_runs: [] }; }",
+    "function checkRunsPayload(headSha) {",
+    "  const attempt = Number(readState().checkRunCalls || 0);",
+    "  if (scenario === 'progressing-in-progress' && headSha === 'head-sha-1' && attempt < 2) {",
+    "    return { total_count: 1, check_runs: [ { name: 'Core CI / test', status: 'in_progress', conclusion: null, details_url: 'https://github.com/basilisk-labs/agentplane/actions/runs/1/job/99', started_at: '2026-01-01T00:00:00Z', completed_at: null } ] };",
+    "  }",
+    "  if (scenario === 'stuck-in-progress' && headSha === 'head-sha-1') {",
+    "    return { total_count: 1, check_runs: [ { name: 'Core CI / test', status: 'in_progress', conclusion: null, details_url: 'https://github.com/basilisk-labs/agentplane/actions/runs/1/job/99', started_at: '2026-01-01T00:00:00Z', completed_at: null } ] };",
+    "  }",
+    "  return { total_count: 0, check_runs: [] };",
+    "}",
+    "function actionsJobPayload(jobId) {",
+    "  const attempt = Number((readState().jobCallsById || {})[jobId] || 0);",
+    "  if (scenario === 'progressing-in-progress') {",
+    "    if (attempt === 0) return { status: 'in_progress', conclusion: null, started_at: '2026-01-01T00:00:00Z', completed_at: null, steps: [ { number: 1, name: 'Set up job', status: 'completed', conclusion: 'success', completed_at: '2026-01-01T00:00:05Z' }, { number: 2, name: 'Run tests', status: 'in_progress', conclusion: null, completed_at: null } ] };",
+    "    return { status: 'in_progress', conclusion: null, started_at: '2026-01-01T00:00:00Z', completed_at: null, steps: [ { number: 1, name: 'Set up job', status: 'completed', conclusion: 'success', completed_at: '2026-01-01T00:00:05Z' }, { number: 2, name: 'Run tests', status: 'completed', conclusion: 'success', completed_at: '2026-01-01T00:00:20Z' }, { number: 3, name: 'Upload artifacts', status: 'in_progress', conclusion: null, completed_at: null } ] };",
+    "  }",
+    "  return { status: 'in_progress', conclusion: null, started_at: '2026-01-01T00:00:00Z', completed_at: null, steps: [ { number: 1, name: 'Set up job', status: 'completed', conclusion: 'success', completed_at: '2026-01-01T00:00:05Z' }, { number: 2, name: 'Run tests', status: 'in_progress', conclusion: null, completed_at: null } ] };",
+    "}",
     "function transientFailureOnce() {",
     "  const attempt = Number(readState().prViewCalls || 0);",
     "  if (scenario === 'retry-transient' && attempt === 0) {",
@@ -116,8 +136,9 @@ async function writeGhMock(root: string) {
     "}",
     String.raw`if (args[0] === 'api' && /\/commits\/head-sha-1\/status$/.test(args[1])) { const payload = statusPayload('head-sha-1'); nextCount('statusCallsByHead', 'head-sha-1'); ok(payload); }`,
     String.raw`if (args[0] === 'api' && /\/commits\/head-sha-2\/status$/.test(args[1])) { const payload = statusPayload('head-sha-2'); nextCount('statusCallsByHead', 'head-sha-2'); ok(payload); }`,
-    String.raw`if (args[0] === 'api' && /\/commits\/head-sha-1\/check-runs$/.test(args[1])) { nextCount('checkRunCalls'); ok(checkRunsPayload()); }`,
-    String.raw`if (args[0] === 'api' && /\/commits\/head-sha-2\/check-runs$/.test(args[1])) { nextCount('checkRunCalls'); ok(checkRunsPayload()); }`,
+    String.raw`if (args[0] === 'api' && /\/commits\/head-sha-1\/check-runs$/.test(args[1])) { nextCount('checkRunCalls'); ok(checkRunsPayload('head-sha-1')); }`,
+    String.raw`if (args[0] === 'api' && /\/commits\/head-sha-2\/check-runs$/.test(args[1])) { nextCount('checkRunCalls'); ok(checkRunsPayload('head-sha-2')); }`,
+    String.raw`if (args[0] === 'api' && /\/actions\/jobs\/99$/.test(args[1])) { nextCount('jobCallsById', '99'); ok(actionsJobPayload('99')); }`,
     "fail(`unexpected gh invocation: ${args.join(' ')}`);",
   ].join("\n");
 
@@ -184,8 +205,8 @@ describe("wait-remote-pr-checks script", () => {
     });
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("attempt 1/3");
-    expect(result.stdout).toContain("attempt 2/3");
+    expect(result.stdout).toContain("poll 1 (idle 1/3)");
+    expect(result.stdout).toContain("poll 2 (idle 0/3)");
     expect(result.stdout).toContain("required checks passed for PR #123");
 
     const callLogText = await readFile(callLog, "utf8");
@@ -325,8 +346,49 @@ describe("wait-remote-pr-checks script", () => {
     });
 
     expect(result.exitCode).toBe(1);
-    expect(result.stdout).toContain("attempt 1/2");
-    expect(result.stdout).toContain("attempt 2/2");
-    expect(result.stderr).toContain("timed out waiting for required checks");
+    expect(result.stdout).toContain("poll 1 (idle 1/2)");
+    expect(result.stdout).toContain("poll 2 (idle 2/2)");
+    expect(result.stderr).toContain("timed out waiting for required checks after 2 idle polls");
+  });
+
+  it("keeps waiting while an in-progress required check keeps advancing", async () => {
+    const root = await makeTempRoot();
+    const { stateFile } = await writeGhMock(root);
+
+    const result = await runScript([], {
+      env: {
+        PATH: `${path.join(root, "bin")}:${process.env.PATH ?? ""}`,
+        GH_STATE_FILE: stateFile,
+        GH_SCENARIO: "progressing-in-progress",
+        AGENTPLANE_REMOTE_CHECK_INTERVAL_MS: "0",
+        AGENTPLANE_REMOTE_CHECK_MAX_ATTEMPTS: "2",
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("poll 1 (idle 1/2): Core CI / test=in_progress");
+    expect(result.stdout).toContain("poll 2 (idle 1/2)");
+    expect(result.stdout).toContain("poll 3 (idle 0/2)");
+    expect(result.stdout).toContain("required checks passed for PR #123");
+  });
+
+  it("still times out when an in-progress required check stops changing", async () => {
+    const root = await makeTempRoot();
+    const { stateFile } = await writeGhMock(root);
+
+    const result = await runScript([], {
+      env: {
+        PATH: `${path.join(root, "bin")}:${process.env.PATH ?? ""}`,
+        GH_STATE_FILE: stateFile,
+        GH_SCENARIO: "stuck-in-progress",
+        AGENTPLANE_REMOTE_CHECK_INTERVAL_MS: "0",
+        AGENTPLANE_REMOTE_CHECK_MAX_ATTEMPTS: "2",
+      },
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain("poll 1 (idle 1/2): Core CI / test=in_progress");
+    expect(result.stdout).toContain("poll 2 (idle 2/2): Core CI / test=in_progress");
+    expect(result.stderr).toContain("timed out waiting for required checks after 2 idle polls");
   });
 });

--- a/scripts/wait-remote-pr-checks.mjs
+++ b/scripts/wait-remote-pr-checks.mjs
@@ -121,6 +121,10 @@ function normalizeErrorText(err) {
   return String(err);
 }
 
+function compactText(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
 function isTransientGhTransportError(err) {
   const text = normalizeErrorText(err);
   if (GH_PERMANENT_ERROR_PATTERNS.some((pattern) => pattern.test(text))) return false;
@@ -274,9 +278,11 @@ async function loadCurrentCheckState(repoSlug, headSha) {
   const normalized = [];
 
   for (const status of statuses) {
-    const context = typeof status?.context === "string" ? status.context.trim() : "";
+    const context = compactText(status?.context);
     if (!context) continue;
-    const state = typeof status?.state === "string" ? status.state.trim().toLowerCase() : "";
+    const state = compactText(status?.state).toLowerCase();
+    const details = compactText(status?.description);
+    const updatedAt = compactText(status?.updated_at);
     let outcome = "pending";
     switch (state) {
       case "success": {
@@ -300,16 +306,24 @@ async function loadCurrentCheckState(repoSlug, headSha) {
     normalized.push({
       name: context,
       outcome,
-      details: typeof status?.description === "string" ? status.description.trim() : "",
+      details,
+      progressKey: `status|${state}|${details}|${updatedAt}`,
     });
   }
 
-  for (const checkRun of checkRuns) {
-    const name = typeof checkRun?.name === "string" ? checkRun.name.trim() : "";
+  const checkRunProgress = await Promise.all(
+    checkRuns.map(async (checkRun) => ({
+      checkRun,
+      progressKey: await loadCheckRunProgressKey(repoSlug, checkRun),
+    })),
+  );
+
+  for (const { checkRun, progressKey } of checkRunProgress) {
+    const name = compactText(checkRun?.name);
     if (!name) continue;
-    const status = typeof checkRun?.status === "string" ? checkRun.status.trim().toLowerCase() : "";
-    const conclusion =
-      typeof checkRun?.conclusion === "string" ? checkRun.conclusion.trim().toLowerCase() : "";
+    const status = compactText(checkRun?.status).toLowerCase();
+    const conclusion = compactText(checkRun?.conclusion).toLowerCase();
+    const details = compactText(checkRun?.details_url);
     let outcome = "pending";
     switch (true) {
       case status !== "completed": {
@@ -332,11 +346,44 @@ async function loadCurrentCheckState(repoSlug, headSha) {
     normalized.push({
       name,
       outcome,
-      details: typeof checkRun?.details_url === "string" ? checkRun.details_url.trim() : "",
+      details,
+      progressKey:
+        progressKey ||
+        `check-run|${status}|${conclusion}|${compactText(checkRun?.started_at)}|${compactText(checkRun?.completed_at)}|${details}`,
     });
   }
 
   return normalized;
+}
+
+function extractGithubActionsJobId(detailsUrl) {
+  const match = compactText(detailsUrl).match(/\/actions\/runs\/\d+\/job\/(\d+)/u);
+  return match?.[1] ?? null;
+}
+
+async function loadCheckRunProgressKey(repoSlug, checkRun) {
+  const jobId = extractGithubActionsJobId(checkRun?.details_url);
+  if (!jobId) return "";
+
+  const payload = await runGhJsonWithRetry(["api", `repos/${repoSlug}/actions/jobs/${jobId}`]);
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return "";
+
+  const steps = Array.isArray(payload.steps) ? payload.steps : [];
+  const normalizedSteps = steps.map((step) => ({
+    number: Number.isInteger(step?.number) ? step.number : null,
+    name: compactText(step?.name),
+    status: compactText(step?.status).toLowerCase(),
+    conclusion: compactText(step?.conclusion).toLowerCase(),
+    completed_at: compactText(step?.completed_at),
+  }));
+
+  return JSON.stringify({
+    status: compactText(payload.status).toLowerCase(),
+    conclusion: compactText(payload.conclusion).toLowerCase(),
+    started_at: compactText(payload.started_at),
+    completed_at: compactText(payload.completed_at),
+    steps: normalizedSteps,
+  });
 }
 
 function summarizeChecks(checks, requiredContexts) {
@@ -351,15 +398,34 @@ function summarizeChecks(checks, requiredContexts) {
   const items = contexts.map((name) => {
     const states = byName.get(name) ?? [];
     if (states.some((entry) => entry.outcome === "failure")) {
-      return { name, outcome: "failure" };
+      return { name, outcome: "failure", progressKey: "" };
     }
-    if (states.some((entry) => entry.outcome === "in_progress" || entry.outcome === "pending")) {
-      return { name, outcome: "pending" };
+    if (states.some((entry) => entry.outcome === "in_progress")) {
+      return {
+        name,
+        outcome: "in_progress",
+        progressKey: states
+          .filter((entry) => entry.outcome === "in_progress" || entry.outcome === "pending")
+          .map((entry) => compactText(entry.progressKey))
+          .toSorted()
+          .join("||"),
+      };
+    }
+    if (states.some((entry) => entry.outcome === "pending")) {
+      return {
+        name,
+        outcome: "pending",
+        progressKey: states
+          .filter((entry) => entry.outcome === "pending")
+          .map((entry) => compactText(entry.progressKey))
+          .toSorted()
+          .join("||"),
+      };
     }
     if (states.some((entry) => entry.outcome === "success")) {
-      return { name, outcome: "success" };
+      return { name, outcome: "success", progressKey: "" };
     }
-    return { name, outcome: "pending" };
+    return { name, outcome: "pending", progressKey: "" };
   });
 
   const failures = items.filter((item) => item.outcome === "failure");
@@ -379,6 +445,14 @@ function formatSummary(items) {
   return items.map((item) => `${item.name}=${item.outcome}`).join(", ");
 }
 
+function pendingFingerprint(items) {
+  return items
+    .filter((item) => item.outcome === "pending" || item.outcome === "in_progress")
+    .map((item) => `${item.name}:${item.outcome}:${compactText(item.progressKey)}`)
+    .toSorted()
+    .join("##");
+}
+
 function formatPullRequestPrefix(pr, index, total) {
   const title = pr.title ? ` (${pr.title})` : "";
   const position = total > 1 ? ` [${index}/${total}]` : "";
@@ -386,11 +460,19 @@ function formatPullRequestPrefix(pr, index, total) {
 }
 
 async function waitForPullRequestChecks(repoSlug, pr, requiredContexts, options, prefix) {
-  for (let attempt = 1; attempt <= options.maxAttempts; attempt += 1) {
+  let poll = 0;
+  let idleAttempts = 0;
+  let lastFingerprint = "";
+
+  while (idleAttempts < options.maxAttempts) {
+    poll += 1;
     const checks = await loadCurrentCheckState(repoSlug, pr.headRefOid);
     const summary = summarizeChecks(checks, requiredContexts);
+    const fingerprint = pendingFingerprint(summary.items);
+    const progressObserved = fingerprint.length > 0 && fingerprint !== lastFingerprint;
+    idleAttempts = fingerprint.length === 0 ? 0 : progressObserved ? 1 : idleAttempts + 1;
     process.stdout.write(
-      `${prefix} attempt ${attempt}/${options.maxAttempts}: ${formatSummary(summary.items)}\n`,
+      `${prefix} poll ${poll} (idle ${idleAttempts}/${options.maxAttempts}): ${formatSummary(summary.items)}\n`,
     );
 
     if (summary.failures.length > 0) {
@@ -405,13 +487,12 @@ async function waitForPullRequestChecks(repoSlug, pr, requiredContexts, options,
       return { ok: true };
     }
 
-    if (attempt < options.maxAttempts) {
-      await sleep(options.intervalMs);
-    }
+    lastFingerprint = fingerprint;
+    if (idleAttempts < options.maxAttempts) await sleep(options.intervalMs);
   }
 
   process.stderr.write(
-    `error: timed out waiting for required checks after ${options.maxAttempts} attempts for ${prefix}\n`,
+    `error: timed out waiting for required checks after ${options.maxAttempts} idle polls for ${prefix}\n`,
   );
   return { ok: false };
 }


### PR DESCRIPTION
# PR Review

Created: 2026-04-09T21:18:36.553Z
Branch: task/202604092105-B4S9NE/progress-aware-waiter

## Summary

Make wait-remote-checks progress-aware for long-running required checks

workflow:wait-remote-checks currently times out after a fixed attempt budget even when the remaining required check is still actively progressing, which causes false failures on long Windows jobs. Make the waiter extend or reset its deadline when in-progress required checks continue to advance.

## Scope

- In scope: workflow:wait-remote-checks currently times out after a fixed attempt budget even when the remaining required check is still actively progressing, which causes false failures on long Windows jobs. Make the waiter extend or reset its deadline when in-progress required checks continue to advance.
- Out of scope: unrelated refactors not required for "Make wait-remote-checks progress-aware for long-running required checks".

## Verification

### Plan

1. Reproduce a required-check workflow where one check is still actively progressing beyond the old fixed attempt window. Expected: wait-remote-checks stays alive while progress continues. 2. Verify idle pending checks still time out deterministically. Expected: the command does not wait forever when nothing advances. 3. Run focused waiter tests. Expected: progress-aware extension and failure paths are covered.

### Current Status

- State: pending
- Note: Not recorded yet.

## Risks

- Risk level: not recorded
- Breaking change: no

### Rollback

- Revert task-related commit(s).
- Re-run required checks to confirm rollback safety.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<!-- BEGIN AUTO SUMMARY -->
<details>
<summary>Raw evidence</summary>

- Updated: 2026-04-09T21:18:36.553Z
- Branch: task/202604092105-B4S9NE/progress-aware-waiter
- Head: fe9cca884c7b

```text
No changes detected.
```

</details>
<!-- END AUTO SUMMARY -->
