### PR TITLE
incidents: Explain incident-registry no-op outcome explicitly in verify and finish (RF8TWW)

### DIFF
--- a/packages/agentplane/src/commands/incidents/shared.ts
+++ b/packages/agentplane/src/commands/incidents/shared.ts
@@ -222,7 +222,7 @@ export function renderIncidentCollectionPlanOutcome(
   },
   opts?: {
     wrote?: boolean;
-    context?: "collect" | "verify" | "generic";
+    context?: "collect" | "verify" | "finish" | "generic";
   },
 ): string {
   const candidates = Array.isArray(plan.candidates) ? plan.candidates.length : 0;
@@ -285,6 +285,12 @@ export function renderIncidentCollectionPlanOutcome(
   }
 
   if (candidates === 0) {
+    if (context === "verify") {
+      return "incident registry unchanged (plain verify note stayed task-local and did not update incidents.md: add --observation, --impact, and --resolution for a reusable incident, then rerun with --collect-incidents or collect later on the base branch)";
+    }
+    if (context === "finish") {
+      return "incident registry unchanged (plain finish body/result stayed task-local and did not update incidents.md: add --observation, --impact, and --resolution for a reusable incident before closeout)";
+    }
     return "incident registry unchanged (no structured incident findings)";
   }
 

--- a/packages/agentplane/src/commands/task/finish.ts
+++ b/packages/agentplane/src/commands/task/finish.ts
@@ -534,7 +534,7 @@ export async function cmdFinish(opts: {
         `${infoMessage(
           renderIncidentCollectionPlanOutcome(incidentPlan, {
             wrote: promotedIncidents > 0,
-            context: "generic",
+            context: "finish",
           }),
         )}\n`,
       );

--- a/packages/agentplane/src/commands/task/finish.unit.test.ts
+++ b/packages/agentplane/src/commands/task/finish.unit.test.ts
@@ -1014,8 +1014,10 @@ describe("task finish (unit)", () => {
 
     expect(rc).toBe(0);
     expect(writes.join("")).toContain(
-      "incident registry unchanged (no structured incident findings)",
+      "plain finish body/result stayed task-local",
     );
+    expect(writes.join("")).toContain("did not update incidents.md");
+    expect(writes.join("")).toContain("--observation, --impact, and --resolution");
     expect(writes.join("")).toContain("finished");
 
     writeSpy.mockRestore();

--- a/packages/agentplane/src/commands/task/finish.unit.test.ts
+++ b/packages/agentplane/src/commands/task/finish.unit.test.ts
@@ -1013,9 +1013,7 @@ describe("task finish (unit)", () => {
     });
 
     expect(rc).toBe(0);
-    expect(writes.join("")).toContain(
-      "plain finish body/result stayed task-local",
-    );
+    expect(writes.join("")).toContain("plain finish body/result stayed task-local");
     expect(writes.join("")).toContain("did not update incidents.md");
     expect(writes.join("")).toContain("--observation, --impact, and --resolution");
     expect(writes.join("")).toContain("finished");

--- a/packages/agentplane/src/commands/task/verify-record.unit.test.ts
+++ b/packages/agentplane/src/commands/task/verify-record.unit.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   collectTaskIncidents: vi.fn(),
   inspectTaskIncidents: vi.fn(),
   renderIncidentCollectionPlanOutcome: vi.fn(),
+  ensurePrArtifactsSynced: vi.fn(),
 }));
 
 vi.mock("node:fs/promises", async (importOriginal) => {
@@ -43,6 +44,9 @@ vi.mock("../incidents/shared.js", () => ({
   collectTaskIncidents: mocks.collectTaskIncidents,
   inspectTaskIncidents: mocks.inspectTaskIncidents,
   renderIncidentCollectionPlanOutcome: mocks.renderIncidentCollectionPlanOutcome,
+}));
+vi.mock("../pr/internal/sync.js", () => ({
+  ensurePrArtifactsSynced: mocks.ensurePrArtifactsSynced,
 }));
 vi.mock("../shared/task-store.js", async (importOriginal) => {
   const actualUnknown: unknown = await importOriginal();
@@ -93,6 +97,7 @@ describe("task verify record (unit)", () => {
     mocks.collectTaskIncidents.mockReset();
     mocks.inspectTaskIncidents.mockReset();
     mocks.renderIncidentCollectionPlanOutcome.mockReset();
+    mocks.ensurePrArtifactsSynced.mockReset();
 
     mocks.backendIsLocalFileBackend.mockReturnValue(false);
     mocks.ensureReconciledBeforeMutation.mockResolvedValue();
@@ -112,14 +117,75 @@ describe("task verify record (unit)", () => {
       plan: { promotable: [], skipped: [], duplicates: [], issues: [] },
     });
     mocks.renderIncidentCollectionPlanOutcome.mockReturnValue(
-      "incident registry unchanged (no structured incident findings)",
+      "incident registry unchanged (plain verify note stayed task-local and did not update incidents.md: add --observation, --impact, and --resolution for a reusable incident, then rerun with --collect-incidents or collect later on the base branch)",
     );
+    mocks.ensurePrArtifactsSynced.mockResolvedValue(false);
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-09T00:00:00.000Z"));
   });
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it("prints an explicit no-op explanation when verify records no structured incident finding", async () => {
+    const writes: string[] = [];
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      writes.push(String(chunk));
+      return true;
+    });
+    const backend: TaskBackend = {
+      id: "mock",
+      listTasks: () => Promise.resolve([]),
+      getTask: () => Promise.resolve(null),
+      writeTask: () => Promise.resolve(),
+      getTaskDoc: () =>
+        Promise.resolve(
+          [
+            "## Summary",
+            "x",
+            "",
+            "## Verify Steps",
+            "step",
+            "",
+            "## Verification",
+            "<!-- BEGIN VERIFICATION RESULTS -->",
+            "<!-- END VERIFICATION RESULTS -->",
+            "",
+            "## Findings",
+            "",
+          ].join("\n"),
+        ),
+    };
+    const ctx = mkCtx({ taskBackend: backend, backend });
+    ctx.config.workflow_mode = "branch_pr";
+    mocks.loadTaskFromContext.mockResolvedValue(
+      mkTask({
+        status: "DONE",
+        commit: { hash: "abc", message: "msg" },
+        doc: undefined,
+        doc_version: 3,
+        doc_updated_at: "2026-02-01T00:00:00Z",
+      }),
+    );
+
+    const { cmdTaskVerifyOk } = await import("./verify-record.js");
+    await expect(
+      cmdTaskVerifyOk({
+        ctx,
+        cwd: "/repo",
+        taskId: "T-1",
+        by: "A",
+        note: "Looks good",
+        quiet: false,
+      }),
+    ).resolves.toBe(0);
+
+    expect(writes.join("")).toContain("plain verify note stayed task-local");
+    expect(writes.join("")).toContain("did not update incidents.md");
+    expect(writes.join("")).toContain("--observation, --impact, and --resolution");
+
+    writeSpy.mockRestore();
   });
 
   it("cmdTaskVerifyOk validates note sources and mutually exclusive details/file", async () => {


### PR DESCRIPTION
## Summary

Explain incident-registry no-op outcome explicitly in verify and finish

Operators still misread 'incident registry unchanged' as a broken incidents pipeline when the real cause is that only a plain verify note/body was recorded without structured observation/impact/resolution fields. Make lifecycle output explain this distinction explicitly and point at the correct structured incident path.

## Scope

- In scope: Operators still misread 'incident registry unchanged' as a broken incidents pipeline when the real cause is that only a plain verify note/body was recorded without structured observation/impact/resolution fields. Make lifecycle output explain this distinction explicitly and point at the correct structured incident path.
- Out of scope: unrelated refactors not required for "Explain incident-registry no-op outcome explicitly in verify and finish".

## Verification

### Plan

1. Run verify/finish without structured incident fields. Expected: output explains that plain notes stay task-local and do not update incidents.md. 2. Run verify/finish with structured observation/impact/resolution fields. Expected: output still reports promotable incident handling correctly. 3. Run focused incidents/lifecycle output tests. Expected: both no-op and promotable paths stay covered.

### Current Status

- State: ok
- Note: Explicitly covered plain-note no-op and structured-incident paths for verify/finish, so operators now see why incidents.md stayed unchanged and what fields promote a reusable finding.

## Risks

- Risk level: not recorded
- Breaking change: no

### Rollback

- Revert task-related commit(s).
- Re-run required checks to confirm rollback safety.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-04-09T21:28:13.189Z
- Branch: task/202604092105-RF8TWW/incident-noop-explanation
- Head: 67b02d01b810

```text
 .../agentplane/src/commands/incidents/shared.ts    |  8 ++-
 packages/agentplane/src/commands/task/finish.ts    |  2 +-
 .../src/commands/task/finish.unit.test.ts          |  6 +-
 .../src/commands/task/verify-record.unit.test.ts   | 68 +++++++++++++++++++++-
 4 files changed, 78 insertions(+), 6 deletions(-)
```

</details>
