### PR TITLE
Fix local release E2E missing-auth regression under repo-slug validation order (6M267V)

### DIFF
--- a/packages/agentplane/src/commands/release/local-release-e2e-script.test.ts
+++ b/packages/agentplane/src/commands/release/local-release-e2e-script.test.ts
@@ -272,8 +272,10 @@ describe("local release E2E script", () => {
     async () => {
       const { root, binDir } = await initWorkspace();
 
-      const result = await runScript(root, ["--skip-prepublish"], {
+      const result = await runScript(root, ["--skip-prepublish", "--repo", "basilisk-labs/agentplane"], {
         PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        GITHUB_TOKEN: "",
+        GH_TOKEN: "",
       }).then(
         () => ({ ok: true as const, stderr: "" }),
         (error: unknown) => {

--- a/packages/agentplane/src/commands/release/local-release-e2e-script.test.ts
+++ b/packages/agentplane/src/commands/release/local-release-e2e-script.test.ts
@@ -272,11 +272,15 @@ describe("local release E2E script", () => {
     async () => {
       const { root, binDir } = await initWorkspace();
 
-      const result = await runScript(root, ["--skip-prepublish", "--repo", "basilisk-labs/agentplane"], {
-        PATH: `${binDir}:${process.env.PATH ?? ""}`,
-        GITHUB_TOKEN: "",
-        GH_TOKEN: "",
-      }).then(
+      const result = await runScript(
+        root,
+        ["--skip-prepublish", "--repo", "basilisk-labs/agentplane"],
+        {
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          GITHUB_TOKEN: "",
+          GH_TOKEN: "",
+        },
+      ).then(
         () => ({ ok: true as const, stderr: "" }),
         (error: unknown) => {
           const stderr =


### PR DESCRIPTION
## Summary

Fix local release E2E missing-auth regression under repo-slug validation order

pre-push is currently blocked by local-release-e2e-script.test.ts expecting a missing GITHUB_TOKEN error even though the script now validates repository slug earlier. Align the test or command contract so the missing-auth path is exercised deterministically again.

## Scope

- In scope: pre-push is currently blocked by local-release-e2e-script.test.ts expecting a missing GITHUB_TOKEN error even though the script now validates repository slug earlier. Align the test or command contract so the missing-auth path is exercised deterministically again.
- Out of scope: unrelated refactors not required for "Fix local release E2E missing-auth regression under repo-slug validation order".

## Verification

### Plan

1. Reproduce the missing-auth path in the local release E2E harness under the current repository-slug validation order. Expected: the test reaches the intended auth failure deterministically. 2. Verify the fix does not weaken release input validation for other arguments. Expected: repository-slug and exact-checkout guards still behave as before. 3. Run the focused local release E2E test and the pre-push path that was blocked. Expected: the regression is covered and closure-wave push can proceed.

### Current Status

- State: ok
- Note: The missing-auth release E2E path is deterministic again: the test now passes an explicit repo slug and clears inherited GH token env so it reliably exercises the auth failure branch.

## Risks

- Risk level: not recorded
- Breaking change: no

### Rollback

- Revert task-related commit(s).
- Re-run required checks to confirm rollback safety.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-04-09T21:43:19.629Z
- Branch: task/202604092141-6M267V/release-auth-order
- Head: e93dc0954744

```text
No changes detected.
```

</details>
