### PR TITLE
close: reconcile April 9 branch_pr task state

### DIFF
--- a/.agentplane/tasks/202604092201-9CPEMF/README.md
+++ b/.agentplane/tasks/202604092201-9CPEMF/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202604092201-9CPEMF"
 title: "Show incident IDs and registry paths after successful promotion"
-status: "DOING"
+result_summary: "Merged via PR #234."
+status: "DONE"
 priority: "med"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -22,11 +23,16 @@ verification:
   updated_at: "2026-04-09T22:20:12.342Z"
   updated_by: "CODER"
   note: "Verification refreshed on final branch head after success-output cleanup; targeted incidents/task CLI tests and eslint remain green."
-commit: null
+commit:
+  hash: "62448ed52a3f5ec110233702308a19d07b3f3c90"
+  message: "incidents/ux: Show incident IDs and registry paths after successful promotion (9CPEMF) (#234)"
 comments:
   -
     author: "CODER"
     body: "Start: enrich incident promotion success output with IDs and registry paths."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: PR #234 merged and the promoted incident success-output change is present on main after runtime bootstrap."
 events:
   -
     type: "status"
@@ -47,9 +53,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verification refreshed on final branch head after success-output cleanup; targeted incidents/task CLI tests and eslint remain green."
+  -
+    type: "status"
+    at: "2026-04-09T22:58:21.740Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: PR #234 merged and the promoted incident success-output change is present on main after runtime bootstrap."
 doc_version: 3
-doc_updated_at: "2026-04-09T22:20:12.345Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-04-09T22:58:21.740Z"
+doc_updated_by: "INTEGRATOR"
 description: "Make incident collection success output name promoted incident IDs and the registry files that changed so operators can immediately verify incidents.md updates."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202604092201-9CPEMF/pr/diffstat.txt
+++ b/.agentplane/tasks/202604092201-9CPEMF/pr/diffstat.txt
@@ -1,17 +1,17 @@
- .agentplane/tasks/202604092201-9CPEMF/README.md    | 121 +++++++++++++++++++++
- .../tasks/202604092201-9CPEMF/pr/diffstat.txt      |   9 ++
- .../tasks/202604092201-9CPEMF/pr/github-body.md    |  52 +++++++++
+ .agentplane/tasks/202604092201-9CPEMF/README.md    | 143 +++++++++++++++++++++
+ .../tasks/202604092201-9CPEMF/pr/diffstat.txt      |  17 +++
+ .../tasks/202604092201-9CPEMF/pr/github-body.md    |  68 ++++++++++
  .../tasks/202604092201-9CPEMF/pr/github-title.txt  |   1 +
- .agentplane/tasks/202604092201-9CPEMF/pr/meta.json |  14 +++
+ .agentplane/tasks/202604092201-9CPEMF/pr/meta.json |  17 +++
  .../tasks/202604092201-9CPEMF/pr/notes.jsonl       |   0
- .agentplane/tasks/202604092201-9CPEMF/pr/review.md |  59 ++++++++++
+ .agentplane/tasks/202604092201-9CPEMF/pr/review.md |  75 +++++++++++
  .../tasks/202604092201-9CPEMF/pr/verify.log        |   0
- .../src/cli/run-cli.core.incidents.test.ts         |  84 ++++++++++++++
+ .../src/cli/run-cli.core.incidents.test.ts         |  84 ++++++++++++
  .../agentplane/src/cli/run-cli.core.tasks.test.ts  |   2 +
  .../src/commands/incidents/collect.command.ts      |   6 +-
- .../agentplane/src/commands/incidents/shared.ts    |  51 ++++++++-
+ .../agentplane/src/commands/incidents/shared.ts    |  51 +++++++-
  .../src/commands/pr/integrate/internal/finalize.ts |   2 +
  packages/agentplane/src/commands/task/finish.ts    |   4 +
  .../src/commands/task/hosted-close.command.ts      |   2 +
  .../agentplane/src/commands/task/verify-record.ts  |   2 +
- 16 files changed, 400 insertions(+), 9 deletions(-)
+ 16 files changed, 465 insertions(+), 9 deletions(-)

--- a/.agentplane/tasks/202604092201-9CPEMF/pr/github-body.md
+++ b/.agentplane/tasks/202604092201-9CPEMF/pr/github-body.md
@@ -41,28 +41,28 @@ Make incident collection success output name promoted incident IDs and the regis
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-09T22:20:12.357Z
+- Updated: 2026-04-09T22:58:21.814Z
 - Branch: task/202604092201-9CPEMF/incidents-promotion-success
-- Head: 731125fdbb0d
+- Head: 425c0b4b208f
 
 ```text
- .agentplane/tasks/202604092201-9CPEMF/README.md    | 121 +++++++++++++++++++++
- .../tasks/202604092201-9CPEMF/pr/diffstat.txt      |   9 ++
- .../tasks/202604092201-9CPEMF/pr/github-body.md    |  52 +++++++++
+ .agentplane/tasks/202604092201-9CPEMF/README.md    | 143 +++++++++++++++++++++
+ .../tasks/202604092201-9CPEMF/pr/diffstat.txt      |  17 +++
+ .../tasks/202604092201-9CPEMF/pr/github-body.md    |  68 ++++++++++
  .../tasks/202604092201-9CPEMF/pr/github-title.txt  |   1 +
- .agentplane/tasks/202604092201-9CPEMF/pr/meta.json |  14 +++
+ .agentplane/tasks/202604092201-9CPEMF/pr/meta.json |  17 +++
  .../tasks/202604092201-9CPEMF/pr/notes.jsonl       |   0
- .agentplane/tasks/202604092201-9CPEMF/pr/review.md |  59 ++++++++++
+ .agentplane/tasks/202604092201-9CPEMF/pr/review.md |  75 +++++++++++
  .../tasks/202604092201-9CPEMF/pr/verify.log        |   0
- .../src/cli/run-cli.core.incidents.test.ts         |  84 ++++++++++++++
+ .../src/cli/run-cli.core.incidents.test.ts         |  84 ++++++++++++
  .../agentplane/src/cli/run-cli.core.tasks.test.ts  |   2 +
  .../src/commands/incidents/collect.command.ts      |   6 +-
- .../agentplane/src/commands/incidents/shared.ts    |  51 ++++++++-
+ .../agentplane/src/commands/incidents/shared.ts    |  51 +++++++-
  .../src/commands/pr/integrate/internal/finalize.ts |   2 +
  packages/agentplane/src/commands/task/finish.ts    |   4 +
  .../src/commands/task/hosted-close.command.ts      |   2 +
  .../agentplane/src/commands/task/verify-record.ts  |   2 +
- 16 files changed, 400 insertions(+), 9 deletions(-)
+ 16 files changed, 465 insertions(+), 9 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202604092201-9CPEMF/pr/meta.json
+++ b/.agentplane/tasks/202604092201-9CPEMF/pr/meta.json
@@ -2,15 +2,17 @@
   "base": "main",
   "branch": "task/202604092201-9CPEMF/incidents-promotion-success",
   "created_at": "2026-04-09T22:06:35.842Z",
-  "head_sha": "731125fdbb0d0007f8b4f622f3a379b90f452c7b",
+  "head_sha": "425c0b4b208f861abca3fbbf0a3ee0dbc419fcf2",
   "last_verified_at": "2026-04-09T22:20:12.342Z",
   "last_verified_sha": "731125fdbb0d0007f8b4f622f3a379b90f452c7b",
+  "merge_commit": "62448ed52a3f5ec110233702308a19d07b3f3c90",
+  "merged_at": "2026-04-09T22:45:41Z",
   "pr_number": 234,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/234",
   "schema_version": 1,
-  "status": "OPEN",
+  "status": "MERGED",
   "task_id": "202604092201-9CPEMF",
-  "updated_at": "2026-04-09T22:20:12.357Z",
+  "updated_at": "2026-04-09T22:58:21.814Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202604092201-9CPEMF/pr/review.md
+++ b/.agentplane/tasks/202604092201-9CPEMF/pr/review.md
@@ -47,28 +47,28 @@ Make incident collection success output name promoted incident IDs and the regis
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-09T22:20:12.357Z
+- Updated: 2026-04-09T22:58:21.814Z
 - Branch: task/202604092201-9CPEMF/incidents-promotion-success
-- Head: 731125fdbb0d
+- Head: 425c0b4b208f
 
 ```text
- .agentplane/tasks/202604092201-9CPEMF/README.md    | 121 +++++++++++++++++++++
- .../tasks/202604092201-9CPEMF/pr/diffstat.txt      |   9 ++
- .../tasks/202604092201-9CPEMF/pr/github-body.md    |  52 +++++++++
+ .agentplane/tasks/202604092201-9CPEMF/README.md    | 143 +++++++++++++++++++++
+ .../tasks/202604092201-9CPEMF/pr/diffstat.txt      |  17 +++
+ .../tasks/202604092201-9CPEMF/pr/github-body.md    |  68 ++++++++++
  .../tasks/202604092201-9CPEMF/pr/github-title.txt  |   1 +
- .agentplane/tasks/202604092201-9CPEMF/pr/meta.json |  14 +++
+ .agentplane/tasks/202604092201-9CPEMF/pr/meta.json |  17 +++
  .../tasks/202604092201-9CPEMF/pr/notes.jsonl       |   0
- .agentplane/tasks/202604092201-9CPEMF/pr/review.md |  59 ++++++++++
+ .agentplane/tasks/202604092201-9CPEMF/pr/review.md |  75 +++++++++++
  .../tasks/202604092201-9CPEMF/pr/verify.log        |   0
- .../src/cli/run-cli.core.incidents.test.ts         |  84 ++++++++++++++
+ .../src/cli/run-cli.core.incidents.test.ts         |  84 ++++++++++++
  .../agentplane/src/cli/run-cli.core.tasks.test.ts  |   2 +
  .../src/commands/incidents/collect.command.ts      |   6 +-
- .../agentplane/src/commands/incidents/shared.ts    |  51 ++++++++-
+ .../agentplane/src/commands/incidents/shared.ts    |  51 +++++++-
  .../src/commands/pr/integrate/internal/finalize.ts |   2 +
  packages/agentplane/src/commands/task/finish.ts    |   4 +
  .../src/commands/task/hosted-close.command.ts      |   2 +
  .../agentplane/src/commands/task/verify-record.ts  |   2 +
- 16 files changed, 400 insertions(+), 9 deletions(-)
+ 16 files changed, 465 insertions(+), 9 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202604092201-C3ZHCX/README.md
+++ b/.agentplane/tasks/202604092201-C3ZHCX/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202604092201-C3ZHCX"
 title: "Allow cleanup merged to fetch origin before candidate resolution"
-status: "DOING"
+result_summary: "Merged via PR #236."
+status: "DONE"
 priority: "med"
 owner: "CODER"
-revision: 7
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -22,11 +23,16 @@ verification:
   updated_at: "2026-04-09T22:53:55.569Z"
   updated_by: "CODER"
   note: "Rebased cleanup merged fetch mode on top of remote-delete support; targeted cleanup merged vitest suite and eslint passed on the final branch head."
-commit: null
+commit:
+  hash: "120e619ec23a579a9ac9000079fab9df2c7f60da"
+  message: "git/workflow: Allow cleanup merged to fetch origin before candidate resolution (C3ZHCX) (#236)"
 comments:
   -
     author: "CODER"
     body: "Start: add explicit fetch/prune mode to cleanup merged."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: PR #236 merged on main after rebasing fetch mode on top of remote-delete support; targeted cleanup merged tests and eslint passed on the final branch head."
 events:
   -
     type: "status"
@@ -53,9 +59,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Rebased cleanup merged fetch mode on top of remote-delete support; targeted cleanup merged vitest suite and eslint passed on the final branch head."
+  -
+    type: "status"
+    at: "2026-04-09T22:59:55.883Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: PR #236 merged on main after rebasing fetch mode on top of remote-delete support; targeted cleanup merged tests and eslint passed on the final branch head."
 doc_version: 3
-doc_updated_at: "2026-04-09T22:53:55.572Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-04-09T22:59:55.884Z"
+doc_updated_by: "INTEGRATOR"
 description: "Add an explicit fetch/prune option to cleanup merged so operators can refresh origin state before local and remote cleanup decisions."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202604092201-C3ZHCX/pr/diffstat.txt
+++ b/.agentplane/tasks/202604092201-C3ZHCX/pr/diffstat.txt
@@ -1,13 +1,13 @@
- .agentplane/tasks/202604092201-C3ZHCX/README.md    | 143 +++++++++++++
- .../tasks/202604092201-C3ZHCX/pr/diffstat.txt      |   5 +
- .../tasks/202604092201-C3ZHCX/pr/github-body.md    |  52 +++++
+ .agentplane/tasks/202604092201-C3ZHCX/README.md    | 165 +++++++++++++++++++++
+ .../tasks/202604092201-C3ZHCX/pr/diffstat.txt      |  13 ++
+ .../tasks/202604092201-C3ZHCX/pr/github-body.md    |  64 ++++++++
  .../tasks/202604092201-C3ZHCX/pr/github-title.txt  |   1 +
- .agentplane/tasks/202604092201-C3ZHCX/pr/meta.json |  17 ++
+ .agentplane/tasks/202604092201-C3ZHCX/pr/meta.json |  17 +++
  .../tasks/202604092201-C3ZHCX/pr/notes.jsonl       |   0
- .agentplane/tasks/202604092201-C3ZHCX/pr/review.md |  59 ++++++
+ .agentplane/tasks/202604092201-C3ZHCX/pr/review.md |  71 +++++++++
  .../tasks/202604092201-C3ZHCX/pr/verify.log        |   0
  docs/user/cli-reference.generated.mdx              |   7 +
- .../run-cli.core.pr-flow.cleanup-merged.test.ts    | 234 ++++++++++++++-------
+ .../run-cli.core.pr-flow.cleanup-merged.test.ts    |  99 ++++++++++++-
  .../src/commands/branch/cleanup-merged.ts          |  11 +-
  .../src/commands/cleanup/merged.command.ts         |  13 ++
- 12 files changed, 464 insertions(+), 78 deletions(-)
+ 12 files changed, 459 insertions(+), 2 deletions(-)

--- a/.agentplane/tasks/202604092201-C3ZHCX/pr/github-body.md
+++ b/.agentplane/tasks/202604092201-C3ZHCX/pr/github-body.md
@@ -41,24 +41,24 @@ Add an explicit fetch/prune option to cleanup merged so operators can refresh or
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-09T22:53:56.616Z
+- Updated: 2026-04-09T22:59:55.970Z
 - Branch: task/202604092201-C3ZHCX/cleanup-fetch-origin
-- Head: dd1c7f4b0d45
+- Head: 90fa5ac7a195
 
 ```text
- .agentplane/tasks/202604092201-C3ZHCX/README.md    | 143 +++++++++++++
- .../tasks/202604092201-C3ZHCX/pr/diffstat.txt      |   5 +
- .../tasks/202604092201-C3ZHCX/pr/github-body.md    |  52 +++++
+ .agentplane/tasks/202604092201-C3ZHCX/README.md    | 165 +++++++++++++++++++++
+ .../tasks/202604092201-C3ZHCX/pr/diffstat.txt      |  13 ++
+ .../tasks/202604092201-C3ZHCX/pr/github-body.md    |  64 ++++++++
  .../tasks/202604092201-C3ZHCX/pr/github-title.txt  |   1 +
- .agentplane/tasks/202604092201-C3ZHCX/pr/meta.json |  17 ++
+ .agentplane/tasks/202604092201-C3ZHCX/pr/meta.json |  17 +++
  .../tasks/202604092201-C3ZHCX/pr/notes.jsonl       |   0
- .agentplane/tasks/202604092201-C3ZHCX/pr/review.md |  59 ++++++
+ .agentplane/tasks/202604092201-C3ZHCX/pr/review.md |  71 +++++++++
  .../tasks/202604092201-C3ZHCX/pr/verify.log        |   0
  docs/user/cli-reference.generated.mdx              |   7 +
- .../run-cli.core.pr-flow.cleanup-merged.test.ts    | 234 ++++++++++++++-------
+ .../run-cli.core.pr-flow.cleanup-merged.test.ts    |  99 ++++++++++++-
  .../src/commands/branch/cleanup-merged.ts          |  11 +-
  .../src/commands/cleanup/merged.command.ts         |  13 ++
- 12 files changed, 464 insertions(+), 78 deletions(-)
+ 12 files changed, 459 insertions(+), 2 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202604092201-C3ZHCX/pr/meta.json
+++ b/.agentplane/tasks/202604092201-C3ZHCX/pr/meta.json
@@ -2,15 +2,17 @@
   "base": "main",
   "branch": "task/202604092201-C3ZHCX/cleanup-fetch-origin",
   "created_at": "2026-04-09T22:14:04.887Z",
-  "head_sha": "551e1c95c466ad56e43e32bfacee098446f23b14",
+  "head_sha": "90fa5ac7a195d1490468942b74dd0e3cdcebae8a",
   "last_verified_at": "2026-04-09T22:53:55.569Z",
   "last_verified_sha": "551e1c95c466ad56e43e32bfacee098446f23b14",
+  "merge_commit": "120e619ec23a579a9ac9000079fab9df2c7f60da",
+  "merged_at": "2026-04-09T22:59:12Z",
   "pr_number": 236,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/236",
   "schema_version": 1,
-  "status": "OPEN",
+  "status": "MERGED",
   "task_id": "202604092201-C3ZHCX",
-  "updated_at": "2026-04-09T22:53:56.616Z",
+  "updated_at": "2026-04-09T22:59:55.970Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202604092201-C3ZHCX/pr/review.md
+++ b/.agentplane/tasks/202604092201-C3ZHCX/pr/review.md
@@ -47,24 +47,24 @@ Add an explicit fetch/prune option to cleanup merged so operators can refresh or
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-09T22:53:56.616Z
+- Updated: 2026-04-09T22:59:55.970Z
 - Branch: task/202604092201-C3ZHCX/cleanup-fetch-origin
-- Head: dd1c7f4b0d45
+- Head: 90fa5ac7a195
 
 ```text
- .agentplane/tasks/202604092201-C3ZHCX/README.md    | 143 +++++++++++++
- .../tasks/202604092201-C3ZHCX/pr/diffstat.txt      |   5 +
- .../tasks/202604092201-C3ZHCX/pr/github-body.md    |  52 +++++
+ .agentplane/tasks/202604092201-C3ZHCX/README.md    | 165 +++++++++++++++++++++
+ .../tasks/202604092201-C3ZHCX/pr/diffstat.txt      |  13 ++
+ .../tasks/202604092201-C3ZHCX/pr/github-body.md    |  64 ++++++++
  .../tasks/202604092201-C3ZHCX/pr/github-title.txt  |   1 +
- .agentplane/tasks/202604092201-C3ZHCX/pr/meta.json |  17 ++
+ .agentplane/tasks/202604092201-C3ZHCX/pr/meta.json |  17 +++
  .../tasks/202604092201-C3ZHCX/pr/notes.jsonl       |   0
- .agentplane/tasks/202604092201-C3ZHCX/pr/review.md |  59 ++++++
+ .agentplane/tasks/202604092201-C3ZHCX/pr/review.md |  71 +++++++++
  .../tasks/202604092201-C3ZHCX/pr/verify.log        |   0
  docs/user/cli-reference.generated.mdx              |   7 +
- .../run-cli.core.pr-flow.cleanup-merged.test.ts    | 234 ++++++++++++++-------
+ .../run-cli.core.pr-flow.cleanup-merged.test.ts    |  99 ++++++++++++-
  .../src/commands/branch/cleanup-merged.ts          |  11 +-
  .../src/commands/cleanup/merged.command.ts         |  13 ++
- 12 files changed, 464 insertions(+), 78 deletions(-)
+ 12 files changed, 459 insertions(+), 2 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202604092201-RM6TDD/README.md
+++ b/.agentplane/tasks/202604092201-RM6TDD/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202604092201-RM6TDD"
 title: "Allow cleanup merged to delete remote task branches"
-status: "DOING"
+result_summary: "Merged via PR #235."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -22,11 +23,16 @@ verification:
   updated_at: "2026-04-09T22:16:51.053Z"
   updated_by: "CODER"
   note: "Refreshed CLI reference after adding cleanup merged remote delete mode; targeted cleanup merged parser and remote deletion tests remain green."
-commit: null
+commit:
+  hash: "3b19584f87e1a30dcb34816fd3b3128fd381ff05"
+  message: "github/workflow: Allow cleanup merged to delete remote task branches (RM6TDD) (#235)"
 comments:
   -
     author: "CODER"
     body: "Start: extend cleanup merged with opt-in remote branch deletion."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: PR #235 merged on main and cleanup merged now supports opt-in remote branch deletion with tracked PR artifacts."
 events:
   -
     type: "status"
@@ -47,9 +53,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Refreshed CLI reference after adding cleanup merged remote delete mode; targeted cleanup merged parser and remote deletion tests remain green."
+  -
+    type: "status"
+    at: "2026-04-09T22:58:24.501Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: PR #235 merged on main and cleanup merged now supports opt-in remote branch deletion with tracked PR artifacts."
 doc_version: 3
-doc_updated_at: "2026-04-09T22:16:51.057Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-04-09T22:58:24.501Z"
+doc_updated_by: "INTEGRATOR"
 description: "Extend cleanup merged with an opt-in remote-branch deletion mode for merged DONE task branches so operators do not need manual git push --delete cleanup."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202604092201-RM6TDD/pr/diffstat.txt
+++ b/.agentplane/tasks/202604092201-RM6TDD/pr/diffstat.txt
@@ -1,13 +1,13 @@
- .agentplane/tasks/202604092201-RM6TDD/README.md    | 121 ++++++++++++++++++++
- .../tasks/202604092201-RM6TDD/pr/diffstat.txt      |   4 +
- .../tasks/202604092201-RM6TDD/pr/github-body.md    |  52 +++++++++
+ .agentplane/tasks/202604092201-RM6TDD/README.md    | 143 +++++++++++++++++++++
+ .../tasks/202604092201-RM6TDD/pr/diffstat.txt      |  13 ++
+ .../tasks/202604092201-RM6TDD/pr/github-body.md    |  52 ++++++++
  .../tasks/202604092201-RM6TDD/pr/github-title.txt  |   1 +
- .agentplane/tasks/202604092201-RM6TDD/pr/meta.json |  14 +++
+ .agentplane/tasks/202604092201-RM6TDD/pr/meta.json |  17 +++
  .../tasks/202604092201-RM6TDD/pr/notes.jsonl       |   0
- .agentplane/tasks/202604092201-RM6TDD/pr/review.md |  59 ++++++++++
+ .agentplane/tasks/202604092201-RM6TDD/pr/review.md |  59 +++++++++
  .../tasks/202604092201-RM6TDD/pr/verify.log        |   0
- docs/user/cli-reference.generated.mdx              |   7 ++
- .../run-cli.core.pr-flow.cleanup-merged.test.ts    | 125 ++++++++++++++++++++-
- .../src/commands/branch/cleanup-merged.ts          |  48 +++++++-
- .../src/commands/cleanup/merged.command.ts         |  13 +++
- 12 files changed, 441 insertions(+), 3 deletions(-)
+ docs/user/cli-reference.generated.mdx              |   7 +
+ .../run-cli.core.pr-flow.cleanup-merged.test.ts    | 125 +++++++++++++++++-
+ .../src/commands/branch/cleanup-merged.ts          |  48 ++++++-
+ .../src/commands/cleanup/merged.command.ts         |  13 ++
+ 12 files changed, 475 insertions(+), 3 deletions(-)

--- a/.agentplane/tasks/202604092201-RM6TDD/pr/github-body.md
+++ b/.agentplane/tasks/202604092201-RM6TDD/pr/github-body.md
@@ -41,12 +41,24 @@ Extend cleanup merged with an opt-in remote-branch deletion mode for merged DONE
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-09T22:22:23.980Z
+- Updated: 2026-04-09T22:58:24.580Z
 - Branch: task/202604092201-RM6TDD/cleanup-remote-delete
-- Head: 50ac0ec65b26
+- Head: 324e3c1ba65a
 
 ```text
-No changes detected.
+ .agentplane/tasks/202604092201-RM6TDD/README.md    | 143 +++++++++++++++++++++
+ .../tasks/202604092201-RM6TDD/pr/diffstat.txt      |  13 ++
+ .../tasks/202604092201-RM6TDD/pr/github-body.md    |  52 ++++++++
+ .../tasks/202604092201-RM6TDD/pr/github-title.txt  |   1 +
+ .agentplane/tasks/202604092201-RM6TDD/pr/meta.json |  17 +++
+ .../tasks/202604092201-RM6TDD/pr/notes.jsonl       |   0
+ .agentplane/tasks/202604092201-RM6TDD/pr/review.md |  59 +++++++++
+ .../tasks/202604092201-RM6TDD/pr/verify.log        |   0
+ docs/user/cli-reference.generated.mdx              |   7 +
+ .../run-cli.core.pr-flow.cleanup-merged.test.ts    | 125 +++++++++++++++++-
+ .../src/commands/branch/cleanup-merged.ts          |  48 ++++++-
+ .../src/commands/cleanup/merged.command.ts         |  13 ++
+ 12 files changed, 475 insertions(+), 3 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202604092201-RM6TDD/pr/meta.json
+++ b/.agentplane/tasks/202604092201-RM6TDD/pr/meta.json
@@ -2,15 +2,17 @@
   "base": "main",
   "branch": "task/202604092201-RM6TDD/cleanup-remote-delete",
   "created_at": "2026-04-09T22:12:00.653Z",
-  "head_sha": "50ac0ec65b261cf7f08d6c548a73fad09962b360",
+  "head_sha": "324e3c1ba65a300740cc2b585736befea2cfc845",
   "last_verified_at": "2026-04-09T22:16:51.053Z",
   "last_verified_sha": "8401e016e721756c93b8ac2e9247ec6cc78f5116",
+  "merge_commit": "3b19584f87e1a30dcb34816fd3b3128fd381ff05",
+  "merged_at": "2026-04-09T22:46:05Z",
   "pr_number": 235,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/235",
   "schema_version": 1,
-  "status": "OPEN",
+  "status": "MERGED",
   "task_id": "202604092201-RM6TDD",
-  "updated_at": "2026-04-09T22:22:23.980Z",
+  "updated_at": "2026-04-09T22:58:24.580Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202604092201-RM6TDD/pr/review.md
+++ b/.agentplane/tasks/202604092201-RM6TDD/pr/review.md
@@ -47,12 +47,24 @@ Extend cleanup merged with an opt-in remote-branch deletion mode for merged DONE
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-09T22:22:23.980Z
+- Updated: 2026-04-09T22:58:24.580Z
 - Branch: task/202604092201-RM6TDD/cleanup-remote-delete
-- Head: 50ac0ec65b26
+- Head: 324e3c1ba65a
 
 ```text
-No changes detected.
+ .agentplane/tasks/202604092201-RM6TDD/README.md    | 143 +++++++++++++++++++++
+ .../tasks/202604092201-RM6TDD/pr/diffstat.txt      |  13 ++
+ .../tasks/202604092201-RM6TDD/pr/github-body.md    |  52 ++++++++
+ .../tasks/202604092201-RM6TDD/pr/github-title.txt  |   1 +
+ .agentplane/tasks/202604092201-RM6TDD/pr/meta.json |  17 +++
+ .../tasks/202604092201-RM6TDD/pr/notes.jsonl       |   0
+ .agentplane/tasks/202604092201-RM6TDD/pr/review.md |  59 +++++++++
+ .../tasks/202604092201-RM6TDD/pr/verify.log        |   0
+ docs/user/cli-reference.generated.mdx              |   7 +
+ .../run-cli.core.pr-flow.cleanup-merged.test.ts    | 125 +++++++++++++++++-
+ .../src/commands/branch/cleanup-merged.ts          |  48 ++++++-
+ .../src/commands/cleanup/merged.command.ts         |  13 ++
+ 12 files changed, 475 insertions(+), 3 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202604092232-YJ4245/README.md
+++ b/.agentplane/tasks/202604092232-YJ4245/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202604092232-YJ4245"
 title: "Let branch_pr finish close committed task artifacts without self-dirty failure"
-status: "DOING"
+result_summary: "Merged via PR #237."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -22,11 +23,16 @@ verification:
   updated_at: "2026-04-09T22:37:33.526Z"
   updated_by: "CODER"
   note: "Invalidated memoized git status after branch_pr PR artifact refresh so deterministic close commits see fresh task artifact changes; verified targeted guard/finish unit tests and eslint."
-commit: null
+commit:
+  hash: "375362976d8ab0a8b4ca2a85d7320917b5159ea6"
+  message: "workflow: Let branch_pr finish close committed task artifacts without self-dirt... (YJ4245) (#237)"
 comments:
   -
     author: "CODER"
     body: "Start: repair branch_pr finish closeout so deterministic close commits can stage the finish-generated task README and PR artifacts without self-dirty failure."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: PR #237 merged on main and branch_pr close commits now invalidate memoized git status after artifact refresh."
 events:
   -
     type: "status"
@@ -41,9 +47,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Invalidated memoized git status after branch_pr PR artifact refresh so deterministic close commits see fresh task artifact changes; verified targeted guard/finish unit tests and eslint."
+  -
+    type: "status"
+    at: "2026-04-09T22:58:26.838Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: PR #237 merged on main and branch_pr close commits now invalidate memoized git status after artifact refresh."
 doc_version: 3
-doc_updated_at: "2026-04-09T22:37:33.527Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-04-09T22:58:26.839Z"
+doc_updated_by: "INTEGRATOR"
 description: "Fix finish --close-commit so branch_pr closeout can commit the task README and task PR artifacts that finish itself just updated, instead of failing on a self-generated dirty working tree."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202604092232-YJ4245/pr/diffstat.txt
+++ b/.agentplane/tasks/202604092232-YJ4245/pr/diffstat.txt
@@ -1,0 +1,27 @@
+ .agentplane/tasks/202604092201-9CPEMF/README.md    | 143 +++++++++++++++++++++
+ .../tasks/202604092201-9CPEMF/pr/diffstat.txt      |  17 +++
+ .../tasks/202604092201-9CPEMF/pr/github-body.md    |  68 ++++++++++
+ .../tasks/202604092201-9CPEMF/pr/github-title.txt  |   1 +
+ .agentplane/tasks/202604092201-9CPEMF/pr/meta.json |  17 +++
+ .../tasks/202604092201-9CPEMF/pr/notes.jsonl       |   0
+ .agentplane/tasks/202604092201-9CPEMF/pr/review.md |  75 +++++++++++
+ .../tasks/202604092201-9CPEMF/pr/verify.log        |   0
+ .agentplane/tasks/202604092232-YJ4245/README.md    | 117 +++++++++++++++++
+ .../tasks/202604092232-YJ4245/pr/diffstat.txt      |   0
+ .../tasks/202604092232-YJ4245/pr/github-body.md    |  50 +++++++
+ .../tasks/202604092232-YJ4245/pr/github-title.txt  |   1 +
+ .agentplane/tasks/202604092232-YJ4245/pr/meta.json |  17 +++
+ .../tasks/202604092232-YJ4245/pr/notes.jsonl       |   0
+ .agentplane/tasks/202604092232-YJ4245/pr/review.md |  57 ++++++++
+ .../tasks/202604092232-YJ4245/pr/verify.log        |   0
+ .../src/cli/run-cli.core.incidents.test.ts         |  84 ++++++++++++
+ .../agentplane/src/cli/run-cli.core.tasks.test.ts  |   2 +
+ .../agentplane/src/commands/guard/impl/commands.ts |   3 +
+ .../src/commands/guard/impl/commands.unit.test.ts  |   9 ++
+ .../src/commands/incidents/collect.command.ts      |   6 +-
+ .../agentplane/src/commands/incidents/shared.ts    |  51 +++++++-
+ .../src/commands/pr/integrate/internal/finalize.ts |   2 +
+ packages/agentplane/src/commands/task/finish.ts    |   4 +
+ .../src/commands/task/hosted-close.command.ts      |   2 +
+ .../agentplane/src/commands/task/verify-record.ts  |   2 +
+ 26 files changed, 719 insertions(+), 9 deletions(-)

--- a/.agentplane/tasks/202604092232-YJ4245/pr/github-body.md
+++ b/.agentplane/tasks/202604092232-YJ4245/pr/github-body.md
@@ -39,12 +39,38 @@ Fix finish --close-commit so branch_pr closeout can commit the task README and t
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-09T22:38:59.152Z
+- Updated: 2026-04-09T22:58:26.918Z
 - Branch: task/202604092232-YJ4245/finish-close-dirty-fix
-- Head: 0f7ebe698302
+- Head: 46ab715bc0be
 
 ```text
-No changes detected.
+ .agentplane/tasks/202604092201-9CPEMF/README.md    | 143 +++++++++++++++++++++
+ .../tasks/202604092201-9CPEMF/pr/diffstat.txt      |  17 +++
+ .../tasks/202604092201-9CPEMF/pr/github-body.md    |  68 ++++++++++
+ .../tasks/202604092201-9CPEMF/pr/github-title.txt  |   1 +
+ .agentplane/tasks/202604092201-9CPEMF/pr/meta.json |  17 +++
+ .../tasks/202604092201-9CPEMF/pr/notes.jsonl       |   0
+ .agentplane/tasks/202604092201-9CPEMF/pr/review.md |  75 +++++++++++
+ .../tasks/202604092201-9CPEMF/pr/verify.log        |   0
+ .agentplane/tasks/202604092232-YJ4245/README.md    | 117 +++++++++++++++++
+ .../tasks/202604092232-YJ4245/pr/diffstat.txt      |   0
+ .../tasks/202604092232-YJ4245/pr/github-body.md    |  50 +++++++
+ .../tasks/202604092232-YJ4245/pr/github-title.txt  |   1 +
+ .agentplane/tasks/202604092232-YJ4245/pr/meta.json |  17 +++
+ .../tasks/202604092232-YJ4245/pr/notes.jsonl       |   0
+ .agentplane/tasks/202604092232-YJ4245/pr/review.md |  57 ++++++++
+ .../tasks/202604092232-YJ4245/pr/verify.log        |   0
+ .../src/cli/run-cli.core.incidents.test.ts         |  84 ++++++++++++
+ .../agentplane/src/cli/run-cli.core.tasks.test.ts  |   2 +
+ .../agentplane/src/commands/guard/impl/commands.ts |   3 +
+ .../src/commands/guard/impl/commands.unit.test.ts  |   9 ++
+ .../src/commands/incidents/collect.command.ts      |   6 +-
+ .../agentplane/src/commands/incidents/shared.ts    |  51 +++++++-
+ .../src/commands/pr/integrate/internal/finalize.ts |   2 +
+ packages/agentplane/src/commands/task/finish.ts    |   4 +
+ .../src/commands/task/hosted-close.command.ts      |   2 +
+ .../agentplane/src/commands/task/verify-record.ts  |   2 +
+ 26 files changed, 719 insertions(+), 9 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202604092232-YJ4245/pr/meta.json
+++ b/.agentplane/tasks/202604092232-YJ4245/pr/meta.json
@@ -2,15 +2,17 @@
   "base": "main",
   "branch": "task/202604092232-YJ4245/finish-close-dirty-fix",
   "created_at": "2026-04-09T22:37:33.545Z",
-  "head_sha": "0f7ebe698302597012949f09cba26986f14ef7b2",
+  "head_sha": "46ab715bc0bebb0c13b8ea14209643c40e269537",
   "last_verified_at": "2026-04-09T22:37:33.526Z",
   "last_verified_sha": "cf5b0d473eda8ace830fa94bd4fdf5a6281f28f8",
+  "merge_commit": "375362976d8ab0a8b4ca2a85d7320917b5159ea6",
+  "merged_at": "2026-04-09T22:43:55Z",
   "pr_number": 237,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/237",
   "schema_version": 1,
-  "status": "OPEN",
+  "status": "MERGED",
   "task_id": "202604092232-YJ4245",
-  "updated_at": "2026-04-09T22:38:59.152Z",
+  "updated_at": "2026-04-09T22:58:26.918Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202604092232-YJ4245/pr/review.md
+++ b/.agentplane/tasks/202604092232-YJ4245/pr/review.md
@@ -45,12 +45,38 @@ Fix finish --close-commit so branch_pr closeout can commit the task README and t
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-09T22:38:59.152Z
+- Updated: 2026-04-09T22:58:26.918Z
 - Branch: task/202604092232-YJ4245/finish-close-dirty-fix
-- Head: 0f7ebe698302
+- Head: 46ab715bc0be
 
 ```text
-No changes detected.
+ .agentplane/tasks/202604092201-9CPEMF/README.md    | 143 +++++++++++++++++++++
+ .../tasks/202604092201-9CPEMF/pr/diffstat.txt      |  17 +++
+ .../tasks/202604092201-9CPEMF/pr/github-body.md    |  68 ++++++++++
+ .../tasks/202604092201-9CPEMF/pr/github-title.txt  |   1 +
+ .agentplane/tasks/202604092201-9CPEMF/pr/meta.json |  17 +++
+ .../tasks/202604092201-9CPEMF/pr/notes.jsonl       |   0
+ .agentplane/tasks/202604092201-9CPEMF/pr/review.md |  75 +++++++++++
+ .../tasks/202604092201-9CPEMF/pr/verify.log        |   0
+ .agentplane/tasks/202604092232-YJ4245/README.md    | 117 +++++++++++++++++
+ .../tasks/202604092232-YJ4245/pr/diffstat.txt      |   0
+ .../tasks/202604092232-YJ4245/pr/github-body.md    |  50 +++++++
+ .../tasks/202604092232-YJ4245/pr/github-title.txt  |   1 +
+ .agentplane/tasks/202604092232-YJ4245/pr/meta.json |  17 +++
+ .../tasks/202604092232-YJ4245/pr/notes.jsonl       |   0
+ .agentplane/tasks/202604092232-YJ4245/pr/review.md |  57 ++++++++
+ .../tasks/202604092232-YJ4245/pr/verify.log        |   0
+ .../src/cli/run-cli.core.incidents.test.ts         |  84 ++++++++++++
+ .../agentplane/src/cli/run-cli.core.tasks.test.ts  |   2 +
+ .../agentplane/src/commands/guard/impl/commands.ts |   3 +
+ .../src/commands/guard/impl/commands.unit.test.ts  |   9 ++
+ .../src/commands/incidents/collect.command.ts      |   6 +-
+ .../agentplane/src/commands/incidents/shared.ts    |  51 +++++++-
+ .../src/commands/pr/integrate/internal/finalize.ts |   2 +
+ packages/agentplane/src/commands/task/finish.ts    |   4 +
+ .../src/commands/task/hosted-close.command.ts      |   2 +
+ .../agentplane/src/commands/task/verify-record.ts  |   2 +
+ 26 files changed, 719 insertions(+), 9 deletions(-)
 ```
 
 </details>


### PR DESCRIPTION
## Summary
- persist deterministic close commits for 9CPEMF, RM6TDD, YJ4245, and C3ZHCX onto protected main
- reconcile local branch_pr task state with the already merged implementation PRs #234, #235, #237, and #236
- leave code unchanged outside task lifecycle artifacts

## Verification
- agentplane task list
- task-specific verification evidence already recorded before closeout
- bun run framework:dev:bootstrap on base before finish wave
