### PR TITLE
workflow: recover hosted-close branch snapshot for TTYK1C

### DIFF
--- a/.github/workflows/task-hosted-close.yml
+++ b/.github/workflows/task-hosted-close.yml
@@ -95,6 +95,15 @@ jobs:
           steps.prepare.outputs.actionable == 'true' &&
           steps.existing.outputs.pr_url == '' &&
           steps.existing.outputs.branch_exists != 'true'
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin \
+            "${{ steps.prepare.outputs.source_branch }}:${{ steps.prepare.outputs.source_branch }}"
+      - name: Apply hosted task closure on a local base checkout
+        if: |
+          steps.prepare.outputs.actionable == 'true' &&
+          steps.existing.outputs.pr_url == '' &&
+          steps.existing.outputs.branch_exists != 'true'
         id: close
         run: |
           set -euo pipefail

--- a/packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
+++ b/packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
@@ -18,6 +18,8 @@ describe("Task hosted-close workflow contract", () => {
     expect(workflow).toContain("pull-requests: write");
     expect(workflow).toContain("fetch-depth: 0");
     expect(workflow).toContain("node scripts/prepare-hosted-task-closure.mjs");
+    expect(workflow).toContain("git fetch --no-tags origin");
+    expect(workflow).toContain('steps.prepare.outputs.source_branch }}:${{ steps.prepare.outputs.source_branch');
     expect(workflow).toContain("task hosted-close");
     expect(workflow).toContain("gh pr create");
     expect(workflow).toContain("gh pr merge --auto --squash --delete-branch");

--- a/packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
+++ b/packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
@@ -19,7 +19,9 @@ describe("Task hosted-close workflow contract", () => {
     expect(workflow).toContain("fetch-depth: 0");
     expect(workflow).toContain("node scripts/prepare-hosted-task-closure.mjs");
     expect(workflow).toContain("git fetch --no-tags origin");
-    expect(workflow).toContain('steps.prepare.outputs.source_branch }}:${{ steps.prepare.outputs.source_branch');
+    expect(workflow).toContain(
+      "steps.prepare.outputs.source_branch }}:${{ steps.prepare.outputs.source_branch",
+    );
     expect(workflow).toContain("task hosted-close");
     expect(workflow).toContain("gh pr create");
     expect(workflow).toContain("gh pr merge --auto --squash --delete-branch");


### PR DESCRIPTION
## Summary
- fetch the source task branch in Task Hosted Close before running task hosted-close
- lock the workflow contract test to the explicit source-branch fetch

## Verify
- bun x vitest run packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
- bun x eslint packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
- git push -u origin task/202604141003-TTYK1C/hosted-close-recovery
