### PR TITLE
workflow: fetch hosted-close snapshot from PR head ref (TTYK1C)

### DIFF
--- a/.github/workflows/task-hosted-close.yml
+++ b/.github/workflows/task-hosted-close.yml
@@ -95,6 +95,15 @@ jobs:
           steps.prepare.outputs.actionable == 'true' &&
           steps.existing.outputs.pr_url == '' &&
           steps.existing.outputs.branch_exists != 'true'
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin \
+            "${{ steps.prepare.outputs.source_branch }}:${{ steps.prepare.outputs.source_branch }}"
+      - name: Apply hosted task closure on a local base checkout
+        if: |
+          steps.prepare.outputs.actionable == 'true' &&
+          steps.existing.outputs.pr_url == '' &&
+          steps.existing.outputs.branch_exists != 'true'
         id: close
         run: |
           set -euo pipefail

--- a/.github/workflows/task-hosted-close.yml
+++ b/.github/workflows/task-hosted-close.yml
@@ -98,7 +98,7 @@ jobs:
         run: |
           set -euo pipefail
           git fetch --no-tags origin \
-            "${{ steps.prepare.outputs.source_branch }}:${{ steps.prepare.outputs.source_branch }}"
+            "pull/${{ steps.prepare.outputs.pr_number }}/head:${{ steps.prepare.outputs.source_branch }}"
       - name: Apply hosted task closure on a local base checkout
         if: |
           steps.prepare.outputs.actionable == 'true' &&

--- a/packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
+++ b/packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
@@ -18,6 +18,8 @@ describe("Task hosted-close workflow contract", () => {
     expect(workflow).toContain("pull-requests: write");
     expect(workflow).toContain("fetch-depth: 0");
     expect(workflow).toContain("node scripts/prepare-hosted-task-closure.mjs");
+    expect(workflow).toContain("git fetch --no-tags origin");
+    expect(workflow).toContain('steps.prepare.outputs.source_branch }}:${{ steps.prepare.outputs.source_branch');
     expect(workflow).toContain("task hosted-close");
     expect(workflow).toContain("gh pr create");
     expect(workflow).toContain("gh pr merge --auto --squash --delete-branch");

--- a/packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
+++ b/packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
@@ -19,7 +19,9 @@ describe("Task hosted-close workflow contract", () => {
     expect(workflow).toContain("fetch-depth: 0");
     expect(workflow).toContain("node scripts/prepare-hosted-task-closure.mjs");
     expect(workflow).toContain("git fetch --no-tags origin");
-    expect(workflow).toContain('steps.prepare.outputs.source_branch }}:${{ steps.prepare.outputs.source_branch');
+    expect(workflow).toContain(
+      "steps.prepare.outputs.source_branch }}:${{ steps.prepare.outputs.source_branch",
+    );
     expect(workflow).toContain("task hosted-close");
     expect(workflow).toContain("gh pr create");
     expect(workflow).toContain("gh pr merge --auto --squash --delete-branch");

--- a/packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
+++ b/packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
@@ -20,7 +20,7 @@ describe("Task hosted-close workflow contract", () => {
     expect(workflow).toContain("node scripts/prepare-hosted-task-closure.mjs");
     expect(workflow).toContain("git fetch --no-tags origin");
     expect(workflow).toContain(
-      "steps.prepare.outputs.source_branch }}:${{ steps.prepare.outputs.source_branch",
+      "pull/${{ steps.prepare.outputs.pr_number }}/head:${{ steps.prepare.outputs.source_branch",
     );
     expect(workflow).toContain("task hosted-close");
     expect(workflow).toContain("gh pr create");


### PR DESCRIPTION
## Summary
- fetch hosted-close task snapshots from the merged PR head ref instead of the deletable source branch
- keep the workflow contract pinned to the PR-head refspec

## Verify
- bun x vitest run packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
- bun x eslint packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
- git push origin task/202604141003-TTYK1C/hosted-close-recovery
