### PR TITLE
workflow: fetch hosted-close snapshot from PR head ref (TTYK1C)

### DIFF
--- a/.github/workflows/task-hosted-close.yml
+++ b/.github/workflows/task-hosted-close.yml
@@ -98,7 +98,7 @@ jobs:
         run: |
           set -euo pipefail
           git fetch --no-tags origin \
-            "${{ steps.prepare.outputs.source_branch }}:${{ steps.prepare.outputs.source_branch }}"
+            "pull/${{ steps.prepare.outputs.pr_number }}/head:${{ steps.prepare.outputs.source_branch }}"
       - name: Apply hosted task closure on a local base checkout
         if: |
           steps.prepare.outputs.actionable == 'true' &&

--- a/packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
+++ b/packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
@@ -20,7 +20,7 @@ describe("Task hosted-close workflow contract", () => {
     expect(workflow).toContain("node scripts/prepare-hosted-task-closure.mjs");
     expect(workflow).toContain("git fetch --no-tags origin");
     expect(workflow).toContain(
-      "steps.prepare.outputs.source_branch }}:${{ steps.prepare.outputs.source_branch",
+      "pull/${{ steps.prepare.outputs.pr_number }}/head:${{ steps.prepare.outputs.source_branch",
     );
     expect(workflow).toContain("task hosted-close");
     expect(workflow).toContain("gh pr create");


### PR DESCRIPTION
## Summary
- fetch hosted-close task snapshots from the merged PR head ref instead of the deletable source branch
- keep the workflow contract pinned to the PR-head refspec

## Verify
- bun x vitest run packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
- bun x eslint packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
- git push -u origin task/202604141003-TTYK1C/pr-head-ref-recovery
