### PR TITLE
release: Fix publish workflow exact-sha identity for release recovery (X154XQ)

### DIFF
--- a/.agentplane/tasks/202604151451-X154XQ/README.md
+++ b/.agentplane/tasks/202604151451-X154XQ/README.md
@@ -1,0 +1,121 @@
+---
+id: "202604151451-X154XQ"
+title: "Fix publish workflow exact-sha identity for release recovery"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "release"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-04-15T14:52:45.065Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-04-15T14:54:29.059Z"
+  updated_by: "CODER"
+  note: "Verified: publish workflow_dispatch now keeps an explicit input sha when resolving release-ready source; publish-workflow-contract.test.ts passes locally."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: fix publish workflow_dispatch exact-SHA identity, then rerun publish recovery for d95b2762f78815b60407a62f2227136c85cae5ee."
+events:
+  -
+    type: "status"
+    at: "2026-04-15T14:52:53.099Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: fix publish workflow_dispatch exact-SHA identity, then rerun publish recovery for d95b2762f78815b60407a62f2227136c85cae5ee."
+  -
+    type: "verify"
+    at: "2026-04-15T14:54:29.059Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: publish workflow_dispatch now keeps an explicit input sha when resolving release-ready source; publish-workflow-contract.test.ts passes locally."
+doc_version: 3
+doc_updated_at: "2026-04-15T14:54:29.063Z"
+doc_updated_by: "CODER"
+description: "Keep workflow_dispatch publish recovery bound to the requested exact SHA instead of mutable main HEAD, then verify by publishing v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee."
+sections:
+  Summary: |-
+    Fix publish workflow exact-sha identity for release recovery
+    
+    Keep workflow_dispatch publish recovery bound to the requested exact SHA instead of mutable main HEAD, then verify by publishing v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee.
+  Scope: |-
+    - In scope: Keep workflow_dispatch publish recovery bound to the requested exact SHA instead of mutable main HEAD, then verify by publishing v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee.
+    - Out of scope: unrelated refactors not required for "Fix publish workflow exact-sha identity for release recovery".
+  Plan: |-
+    1. Fix publish workflow_dispatch exact-SHA identity in publish.yml and extend the publish workflow contract test.
+    2. Land the fix through the protected-main PR + hosted-close path.
+    3. Re-run publish recovery for d95b2762f78815b60407a62f2227136c85cae5ee and verify tag/npm state for 0.3.11.
+  Verify Steps: |-
+    1. Review the requested outcome for "Fix publish workflow exact-sha identity for release recovery". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-04-15T14:54:29.059Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: publish workflow_dispatch now keeps an explicit input sha when resolving release-ready source; publish-workflow-contract.test.ts passes locally.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-15T14:52:53.110Z, excerpt_hash=sha256:73c723f49eee6c69729789d1c09a95d001c67668eb0b8bf31989b3ba320a481d
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Fix publish workflow exact-sha identity for release recovery
+
+Keep workflow_dispatch publish recovery bound to the requested exact SHA instead of mutable main HEAD, then verify by publishing v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee.
+
+## Scope
+
+- In scope: Keep workflow_dispatch publish recovery bound to the requested exact SHA instead of mutable main HEAD, then verify by publishing v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee.
+- Out of scope: unrelated refactors not required for "Fix publish workflow exact-sha identity for release recovery".
+
+## Plan
+
+1. Fix publish workflow_dispatch exact-SHA identity in publish.yml and extend the publish workflow contract test.
+2. Land the fix through the protected-main PR + hosted-close path.
+3. Re-run publish recovery for d95b2762f78815b60407a62f2227136c85cae5ee and verify tag/npm state for 0.3.11.
+
+## Verify Steps
+
+1. Review the requested outcome for "Fix publish workflow exact-sha identity for release recovery". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-04-15T14:54:29.059Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: publish workflow_dispatch now keeps an explicit input sha when resolving release-ready source; publish-workflow-contract.test.ts passes locally.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-15T14:52:53.110Z, excerpt_hash=sha256:73c723f49eee6c69729789d1c09a95d001c67668eb0b8bf31989b3ba320a481d
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,7 +71,11 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .agentplane/.release/ready
-          SHA="$(git rev-parse HEAD)"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.sha }}" ]; then
+            SHA="${{ github.event.inputs.sha }}"
+          else
+            SHA="$(git rev-parse HEAD)"
+          fi
           SOURCE_STATUS=0
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
             if node scripts/resolve-release-ready-source.mjs \

--- a/packages/agentplane/src/commands/release/publish-workflow-contract.test.ts
+++ b/packages/agentplane/src/commands/release/publish-workflow-contract.test.ts
@@ -41,6 +41,11 @@ describe("publish workflow contract", () => {
     expect(workflow).toContain('if [ -n "${{ github.event.inputs.sha }}" ]; then');
     expect(workflow).toContain('echo "ref=${{ github.event.inputs.sha }}" >> "$GITHUB_OUTPUT"');
     expect(workflow).toContain(
+      'if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.sha }}" ]; then',
+    );
+    expect(workflow).toContain('SHA="${{ github.event.inputs.sha }}"');
+    expect(workflow).toContain('SHA="$(git rev-parse HEAD)"');
+    expect(workflow).toContain(
       'description: "Git ref to evaluate only when sha is omitted (default: main)"',
     );
   });


### PR DESCRIPTION
## Summary

Fix publish workflow exact-sha identity for release recovery

Keep workflow_dispatch publish recovery bound to the requested exact SHA instead of mutable main HEAD, then verify by publishing v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee.

## Scope

- In scope: Keep workflow_dispatch publish recovery bound to the requested exact SHA instead of mutable main HEAD, then verify by publishing v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee.
- Out of scope: unrelated refactors not required for "Fix publish workflow exact-sha identity for release recovery".

## Verification

- State: ok
- Note: Verified: publish workflow_dispatch now keeps an explicit input sha when resolving release-ready source; publish-workflow-contract.test.ts passes locally.
- Full verification checklist lives in local review.md.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-04-15T14:57:15.858Z
- Branch: task/202604151451-X154XQ/publish-exact-sha-identity
- Head: 2f254fc33460

```text
 .agentplane/tasks/202604151451-X154XQ/README.md    | 121 +++++++++++++++++++++
 .github/workflows/publish.yml                      |   6 +-
 .../release/publish-workflow-contract.test.ts      |   5 +
 3 files changed, 131 insertions(+), 1 deletion(-)
```

</details>
