### PR TITLE
release: Decouple publish recovery resolver from historical checkout (PWKS2Q)

### DIFF
--- a/.agentplane/tasks/202604151503-PWKS2Q/README.md
+++ b/.agentplane/tasks/202604151503-PWKS2Q/README.md
@@ -1,0 +1,121 @@
+---
+id: "202604151503-PWKS2Q"
+title: "Decouple publish recovery resolver from historical checkout"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "release"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-04-15T15:04:01.917Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-04-15T15:06:31.304Z"
+  updated_by: "CODER"
+  note: "Verified: publish workflow_dispatch now resolves release-ready source via the current workflow runtime while preserving the requested historical publish target; publish-workflow-contract.test.ts passes locally."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: decouple publish recovery resolver from the historical checkout, then rerun the d95b2762 publish recovery."
+events:
+  -
+    type: "status"
+    at: "2026-04-15T15:04:01.919Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: decouple publish recovery resolver from the historical checkout, then rerun the d95b2762 publish recovery."
+  -
+    type: "verify"
+    at: "2026-04-15T15:06:31.304Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: publish workflow_dispatch now resolves release-ready source via the current workflow runtime while preserving the requested historical publish target; publish-workflow-contract.test.ts passes locally."
+doc_version: 3
+doc_updated_at: "2026-04-15T15:06:31.308Z"
+doc_updated_by: "CODER"
+description: "Run publish workflow_dispatch recovery using the current resolver/runtime while keeping the requested historical SHA only as the publish target, then publish v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee."
+sections:
+  Summary: |-
+    Decouple publish recovery resolver from historical checkout
+    
+    Run publish workflow_dispatch recovery using the current resolver/runtime while keeping the requested historical SHA only as the publish target, then publish v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee.
+  Scope: |-
+    - In scope: Run publish workflow_dispatch recovery using the current resolver/runtime while keeping the requested historical SHA only as the publish target, then publish v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee.
+    - Out of scope: unrelated refactors not required for "Decouple publish recovery resolver from historical checkout".
+  Plan: |-
+    1. Decouple publish workflow_dispatch release-ready resolution from the historical checkout while keeping the requested exact SHA as the publish target, and extend contract coverage.
+    2. Land the fix through the protected-main PR + hosted-close path.
+    3. Re-run publish recovery for d95b2762f78815b60407a62f2227136c85cae5ee and verify v0.3.11 tag/npm state.
+  Verify Steps: |-
+    1. Review the requested outcome for "Decouple publish recovery resolver from historical checkout". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-04-15T15:06:31.304Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: publish workflow_dispatch now resolves release-ready source via the current workflow runtime while preserving the requested historical publish target; publish-workflow-contract.test.ts passes locally.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-15T15:04:01.942Z, excerpt_hash=sha256:e764377f7f69a64404a9522b36684ddf6715b338fa87a4dfe1a75b6f1b694c1d
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Decouple publish recovery resolver from historical checkout
+
+Run publish workflow_dispatch recovery using the current resolver/runtime while keeping the requested historical SHA only as the publish target, then publish v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee.
+
+## Scope
+
+- In scope: Run publish workflow_dispatch recovery using the current resolver/runtime while keeping the requested historical SHA only as the publish target, then publish v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee.
+- Out of scope: unrelated refactors not required for "Decouple publish recovery resolver from historical checkout".
+
+## Plan
+
+1. Decouple publish workflow_dispatch release-ready resolution from the historical checkout while keeping the requested exact SHA as the publish target, and extend contract coverage.
+2. Land the fix through the protected-main PR + hosted-close path.
+3. Re-run publish recovery for d95b2762f78815b60407a62f2227136c85cae5ee and verify v0.3.11 tag/npm state.
+
+## Verify Steps
+
+1. Review the requested outcome for "Decouple publish recovery resolver from historical checkout". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-04-15T15:06:31.304Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: publish workflow_dispatch now resolves release-ready source via the current workflow runtime while preserving the requested historical publish target; publish-workflow-contract.test.ts passes locally.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-15T15:04:01.942Z, excerpt_hash=sha256:e764377f7f69a64404a9522b36684ddf6715b338fa87a4dfe1a75b6f1b694c1d
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,11 @@ jobs:
           else
             echo "ref=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
           fi
+      - name: Checkout current workflow runtime
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.sha != ''
+        uses: actions/checkout@v4
+        with:
+          path: .agentplane/.release/runtime
       - uses: actions/checkout@v4
         with:
           ref: ${{ steps.ref.outputs.ref }}
@@ -71,14 +76,16 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .agentplane/.release/ready
+          RUNTIME_SCRIPT="scripts/resolve-release-ready-source.mjs"
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.sha }}" ]; then
             SHA="${{ github.event.inputs.sha }}"
+            RUNTIME_SCRIPT=".agentplane/.release/runtime/scripts/resolve-release-ready-source.mjs"
           else
             SHA="$(git rev-parse HEAD)"
           fi
           SOURCE_STATUS=0
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            if node scripts/resolve-release-ready-source.mjs \
+            if node "${RUNTIME_SCRIPT}" \
               --workflow ci.yml \
               --sha "${SHA}" \
               --run-id "${{ github.event.workflow_run.id }}" \
@@ -88,7 +95,7 @@ jobs:
               SOURCE_STATUS=$?
             fi
           else
-            node scripts/resolve-release-ready-source.mjs \
+            node "${RUNTIME_SCRIPT}" \
               --workflow ci.yml \
               --sha "${SHA}" \
               --json > .agentplane/.release/ready/source.json

--- a/packages/agentplane/src/commands/release/publish-workflow-contract.test.ts
+++ b/packages/agentplane/src/commands/release/publish-workflow-contract.test.ts
@@ -15,7 +15,13 @@ describe("publish workflow contract", () => {
     expect(workflow).toContain("actions/download-artifact@v4");
     expect(workflow).toContain("name: release-ready");
     expect(workflow).toContain("run-id: ${{ needs.detect.outputs.release_ready_run_id }}");
-    expect(workflow).toContain("node scripts/resolve-release-ready-source.mjs");
+    expect(workflow).toContain("name: Checkout current workflow runtime");
+    expect(workflow).toContain("path: .agentplane/.release/runtime");
+    expect(workflow).toContain('RUNTIME_SCRIPT="scripts/resolve-release-ready-source.mjs"');
+    expect(workflow).toContain(
+      'RUNTIME_SCRIPT=".agentplane/.release/runtime/scripts/resolve-release-ready-source.mjs"',
+    );
+    expect(workflow).toContain('node "${RUNTIME_SCRIPT}" \\');
     expect(workflow).toContain("node scripts/write-publish-result-manifest.mjs");
     expect(workflow).toContain("name: publish-result");
     expect(workflow).toContain("path: .agentplane/.release/publish/publish-result.json");


### PR DESCRIPTION
## Summary

Decouple publish recovery resolver from historical checkout

Run publish workflow_dispatch recovery using the current resolver/runtime while keeping the requested historical SHA only as the publish target, then publish v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee.

## Scope

- In scope: Run publish workflow_dispatch recovery using the current resolver/runtime while keeping the requested historical SHA only as the publish target, then publish v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee.
- Out of scope: unrelated refactors not required for "Decouple publish recovery resolver from historical checkout".

## Verification

- State: ok
- Note: Verified: publish workflow_dispatch now resolves release-ready source via the current workflow runtime while preserving the requested historical publish target; publish-workflow-contract.test.ts passes locally.
- Full verification checklist lives in local review.md.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-04-15T15:09:09.623Z
- Branch: task/202604151503-PWKS2Q/publish-recovery-current-runtime
- Head: e7ec2de706e9

```text
 .agentplane/tasks/202604151503-PWKS2Q/README.md    | 121 +++++++++++++++++++++
 .github/workflows/publish.yml                      |  11 +-
 .../release/publish-workflow-contract.test.ts      |   8 +-
 3 files changed, 137 insertions(+), 3 deletions(-)
```

</details>
