### PR TITLE
release: Preserve current runtime checkout in publish recovery (9H8FF8)

### DIFF
--- a/.agentplane/tasks/202604151513-9H8FF8/README.md
+++ b/.agentplane/tasks/202604151513-9H8FF8/README.md
@@ -1,0 +1,121 @@
+---
+id: "202604151513-9H8FF8"
+title: "Preserve current runtime checkout in publish recovery"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "release"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-04-15T15:13:47.805Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-04-15T15:14:58.611Z"
+  updated_by: "CODER"
+  note: "Verified: publish workflow exact-SHA recovery now preserves the current-runtime resolver checkout by ordering checkouts safely; publish-workflow-contract.test.ts passes locally."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: reorder publish recovery checkouts so the current-runtime resolver survives exact-SHA workflow_dispatch, then rerun the 0.3.11 publish recovery."
+events:
+  -
+    type: "status"
+    at: "2026-04-15T15:13:47.812Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: reorder publish recovery checkouts so the current-runtime resolver survives exact-SHA workflow_dispatch, then rerun the 0.3.11 publish recovery."
+  -
+    type: "verify"
+    at: "2026-04-15T15:14:58.611Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: publish workflow exact-SHA recovery now preserves the current-runtime resolver checkout by ordering checkouts safely; publish-workflow-contract.test.ts passes locally."
+doc_version: 3
+doc_updated_at: "2026-04-15T15:14:58.615Z"
+doc_updated_by: "CODER"
+description: "Keep the current-workflow runtime checkout alive for workflow_dispatch publish recovery by ordering checkouts safely, then publish v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee."
+sections:
+  Summary: |-
+    Preserve current runtime checkout in publish recovery
+    
+    Keep the current-workflow runtime checkout alive for workflow_dispatch publish recovery by ordering checkouts safely, then publish v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee.
+  Scope: |-
+    - In scope: Keep the current-workflow runtime checkout alive for workflow_dispatch publish recovery by ordering checkouts safely, then publish v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee.
+    - Out of scope: unrelated refactors not required for "Preserve current runtime checkout in publish recovery".
+  Plan: |-
+    1. Implement the change for "Preserve current runtime checkout in publish recovery".
+    2. Run required checks and capture verification evidence.
+    3. Finalize task findings and finish with traceable commit metadata.
+  Verify Steps: |-
+    1. Review the requested outcome for "Preserve current runtime checkout in publish recovery". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-04-15T15:14:58.611Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: publish workflow exact-SHA recovery now preserves the current-runtime resolver checkout by ordering checkouts safely; publish-workflow-contract.test.ts passes locally.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-15T15:13:47.834Z, excerpt_hash=sha256:853240d89e1862a42e29d042f332c88e66585a6f4f77caaeb28d860c3625c760
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Preserve current runtime checkout in publish recovery
+
+Keep the current-workflow runtime checkout alive for workflow_dispatch publish recovery by ordering checkouts safely, then publish v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee.
+
+## Scope
+
+- In scope: Keep the current-workflow runtime checkout alive for workflow_dispatch publish recovery by ordering checkouts safely, then publish v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee.
+- Out of scope: unrelated refactors not required for "Preserve current runtime checkout in publish recovery".
+
+## Plan
+
+1. Implement the change for "Preserve current runtime checkout in publish recovery".
+2. Run required checks and capture verification evidence.
+3. Finalize task findings and finish with traceable commit metadata.
+
+## Verify Steps
+
+1. Review the requested outcome for "Preserve current runtime checkout in publish recovery". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-04-15T15:14:58.611Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: publish workflow exact-SHA recovery now preserves the current-runtime resolver checkout by ordering checkouts safely; publish-workflow-contract.test.ts passes locally.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-15T15:13:47.834Z, excerpt_hash=sha256:853240d89e1862a42e29d042f332c88e66585a6f4f77caaeb28d860c3625c760
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,14 +56,14 @@ jobs:
           else
             echo "ref=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
           fi
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.ref.outputs.ref }}
       - name: Checkout current workflow runtime
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.sha != ''
         uses: actions/checkout@v4
         with:
           path: .agentplane/.release/runtime
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.ref.outputs.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: "24"


### PR DESCRIPTION
## Summary

Preserve current runtime checkout in publish recovery

Keep the current-workflow runtime checkout alive for workflow_dispatch publish recovery by ordering checkouts safely, then publish v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee.

## Scope

- In scope: Keep the current-workflow runtime checkout alive for workflow_dispatch publish recovery by ordering checkouts safely, then publish v0.3.11 from d95b2762f78815b60407a62f2227136c85cae5ee.
- Out of scope: unrelated refactors not required for "Preserve current runtime checkout in publish recovery".

## Verification

- State: ok
- Note: Verified: publish workflow exact-SHA recovery now preserves the current-runtime resolver checkout by ordering checkouts safely; publish-workflow-contract.test.ts passes locally.
- Full verification checklist lives in local review.md.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-04-15T15:16:51.061Z
- Branch: task/202604151513-9H8FF8/publish-runtime-checkout-order
- Head: 5c711c117712

```text
 .agentplane/tasks/202604151513-9H8FF8/README.md | 121 ++++++++++++++++++++++++
 .github/workflows/publish.yml                   |   6 +-
 2 files changed, 124 insertions(+), 3 deletions(-)
```

</details>
