### PR TITLE
workflow: Isolate framework core runtime resolution inside framework checkouts (PEV6JS)

### DIFF
--- a/.agentplane/tasks/202604160802-PEV6JS/README.md
+++ b/.agentplane/tasks/202604160802-PEV6JS/README.md
@@ -1,0 +1,121 @@
+---
+id: "202604160802-PEV6JS"
+title: "Isolate framework core runtime resolution inside framework checkouts"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "workflow"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-04-16T08:03:13.970Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-04-16T08:06:04.497Z"
+  updated_by: "CODER"
+  note: "Verified framework runtime core isolation with focused checks: bun vitest run packages/agentplane/src/shared/runtime-source.test.ts packages/agentplane/src/commands/runtime.command.test.ts packages/agentplane/src/commands/doctor.command.test.ts -t runtime && bun run framework:dev:bootstrap && node packages/agentplane/bin/agentplane.js runtime explain && node packages/agentplane/bin/agentplane.js doctor"
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: isolating framework runtime core resolution so framework checkouts resolve @agentplaneorg/core from their own packages/core instead of the shared repo root."
+events:
+  -
+    type: "status"
+    at: "2026-04-16T08:03:41.445Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: isolating framework runtime core resolution so framework checkouts resolve @agentplaneorg/core from their own packages/core instead of the shared repo root."
+  -
+    type: "verify"
+    at: "2026-04-16T08:06:04.497Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified framework runtime core isolation with focused checks: bun vitest run packages/agentplane/src/shared/runtime-source.test.ts packages/agentplane/src/commands/runtime.command.test.ts packages/agentplane/src/commands/doctor.command.test.ts -t runtime && bun run framework:dev:bootstrap && node packages/agentplane/bin/agentplane.js runtime explain && node packages/agentplane/bin/agentplane.js doctor"
+doc_version: 3
+doc_updated_at: "2026-04-16T08:06:04.512Z"
+doc_updated_by: "CODER"
+description: "Ensure runtime source reporting and framework-mode package resolution prefer the framework checkout's packages/core instead of falling back to the shared repo root when running inside a framework checkout."
+sections:
+  Summary: |-
+    Isolate framework core runtime resolution inside framework checkouts
+    
+    Ensure runtime source reporting and framework-mode package resolution prefer the framework checkout's packages/core instead of falling back to the shared repo root when running inside a framework checkout.
+  Scope: |-
+    - In scope: Ensure runtime source reporting and framework-mode package resolution prefer the framework checkout's packages/core instead of falling back to the shared repo root when running inside a framework checkout.
+    - Out of scope: unrelated refactors not required for "Isolate framework core runtime resolution inside framework checkouts".
+  Plan: |-
+    1. Inspect framework runtime resolution and identify the smallest change that makes @agentplaneorg/core resolve from the framework checkout when available. -> verify: source of mismatch is mapped in code and tests
+    2. Implement the framework-checkout-aware core resolution path without changing non-framework runtime modes. -> verify: runtime explain and doctor-facing facts point to the framework checkout core root in framework mode
+    3. Add focused regression coverage, then publish the branch_pr task through PR and hosted close. -> verify: targeted tests pass and the branch lands on main cleanly
+  Verify Steps: |-
+    1. Review the requested outcome for "Isolate framework core runtime resolution inside framework checkouts". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-04-16T08:06:04.497Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified framework runtime core isolation with focused checks: bun vitest run packages/agentplane/src/shared/runtime-source.test.ts packages/agentplane/src/commands/runtime.command.test.ts packages/agentplane/src/commands/doctor.command.test.ts -t runtime && bun run framework:dev:bootstrap && node packages/agentplane/bin/agentplane.js runtime explain && node packages/agentplane/bin/agentplane.js doctor
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-16T08:03:41.456Z, excerpt_hash=sha256:ce41e9e563cc49aca5f55f6f7c5ab00fe0a205d29d53e207003545161dbf422a
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Isolate framework core runtime resolution inside framework checkouts
+
+Ensure runtime source reporting and framework-mode package resolution prefer the framework checkout's packages/core instead of falling back to the shared repo root when running inside a framework checkout.
+
+## Scope
+
+- In scope: Ensure runtime source reporting and framework-mode package resolution prefer the framework checkout's packages/core instead of falling back to the shared repo root when running inside a framework checkout.
+- Out of scope: unrelated refactors not required for "Isolate framework core runtime resolution inside framework checkouts".
+
+## Plan
+
+1. Inspect framework runtime resolution and identify the smallest change that makes @agentplaneorg/core resolve from the framework checkout when available. -> verify: source of mismatch is mapped in code and tests
+2. Implement the framework-checkout-aware core resolution path without changing non-framework runtime modes. -> verify: runtime explain and doctor-facing facts point to the framework checkout core root in framework mode
+3. Add focused regression coverage, then publish the branch_pr task through PR and hosted close. -> verify: targeted tests pass and the branch lands on main cleanly
+
+## Verify Steps
+
+1. Review the requested outcome for "Isolate framework core runtime resolution inside framework checkouts". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-04-16T08:06:04.497Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified framework runtime core isolation with focused checks: bun vitest run packages/agentplane/src/shared/runtime-source.test.ts packages/agentplane/src/commands/runtime.command.test.ts packages/agentplane/src/commands/doctor.command.test.ts -t runtime && bun run framework:dev:bootstrap && node packages/agentplane/bin/agentplane.js runtime explain && node packages/agentplane/bin/agentplane.js doctor
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-16T08:03:41.456Z, excerpt_hash=sha256:ce41e9e563cc49aca5f55f6f7c5ab00fe0a205d29d53e207003545161dbf422a
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/packages/agentplane/src/shared/runtime-source.test.ts
+++ b/packages/agentplane/src/shared/runtime-source.test.ts
@@ -104,6 +104,24 @@ describe("runtime-source", () => {
     expect(report.frameworkSources.agentplaneRoot).toBe(fixture.agentplaneRoot);
   });
 
+  it("prefers the framework checkout core root for repo-local runtime when no explicit core path is provided", async () => {
+    const fixture = await createFrameworkFixture();
+
+    const report = resolveRuntimeSourceInfo({
+      cwd: fixture.nestedCwd,
+      activeBinaryPath: fixture.agentplaneBin,
+      env: { ...process.env },
+      agentplanePackageRoot: fixture.agentplaneRoot,
+    });
+
+    expect(report.mode).toBe("repo-local");
+    expect(report.framework.inFrameworkCheckout).toBe(true);
+    expect(report.framework.isRepoLocalRuntime).toBe(true);
+    expect(report.frameworkSources.coreRoot).toBe(path.join(fixture.repoRoot, "packages", "core"));
+    expect(report.core.packageRoot).toBe(path.join(fixture.repoRoot, "packages", "core"));
+    expect(report.core.version).toBe("0.3.3-beta.0");
+  });
+
   it("reports a normal global install outside the framework checkout", async () => {
     const fixture = await createFrameworkFixture();
     const outsideRoot = await mkdtemp(path.join(os.tmpdir(), "agentplane-runtime-source-outside-"));

--- a/packages/agentplane/src/shared/runtime-source.ts
+++ b/packages/agentplane/src/shared/runtime-source.ts
@@ -125,9 +125,15 @@ function resolveAgentplanePackageInfo(
   return resolvePackageInfo(path.join(inferredRoot, "package.json"));
 }
 
-function resolveCorePackageInfo(options: ResolveRuntimeSourceInfoOptions): ResolvedPackageInfo {
+function resolveCorePackageInfo(
+  options: ResolveRuntimeSourceInfoOptions,
+  frameworkCoreRoot: string | null,
+): ResolvedPackageInfo {
   if (options.corePackageJsonPath) {
     return resolvePackageInfo(path.resolve(options.corePackageJsonPath));
+  }
+  if (frameworkCoreRoot) {
+    return resolvePackageInfo(path.join(frameworkCoreRoot, "package.json"));
   }
   try {
     const req = createRequire(options.entryModuleUrl ?? import.meta.url);
@@ -184,7 +190,6 @@ export function resolveRuntimeSourceInfo(
   const cwd = path.resolve(options.cwd ?? process.cwd());
   const env = options.env ?? process.env;
   const agentplane = resolveAgentplanePackageInfo(options);
-  const core = resolveCorePackageInfo(options);
   const fallbackBin =
     agentplane.packageRoot === null
       ? null
@@ -198,6 +203,10 @@ export function resolveRuntimeSourceInfo(
     cwd,
     thisBin: activeBinaryPath ?? fallbackBin ?? cwd,
   });
+  const frameworkCoreRoot = resolveFrameworkCoreRoot(framework.checkout?.repoRoot ?? null);
+  const preferredFrameworkCoreRoot =
+    framework.inFrameworkCheckout && framework.isRepoLocalRuntime ? frameworkCoreRoot : null;
+  const core = resolveCorePackageInfo(options, preferredFrameworkCoreRoot);
 
   return {
     cwd,
@@ -208,7 +217,7 @@ export function resolveRuntimeSourceInfo(
     frameworkSources: {
       repoRoot: framework.checkout?.repoRoot ?? null,
       agentplaneRoot: framework.checkout?.packageRoot ?? agentplane.packageRoot,
-      coreRoot: resolveFrameworkCoreRoot(framework.checkout?.repoRoot ?? null),
+      coreRoot: frameworkCoreRoot,
     },
     agentplane,
     core,


### PR DESCRIPTION
## Summary

Isolate framework core runtime resolution inside framework checkouts

Ensure runtime source reporting and framework-mode package resolution prefer the framework checkout's packages/core instead of falling back to the shared repo root when running inside a framework checkout.

## Scope

- In scope: Ensure runtime source reporting and framework-mode package resolution prefer the framework checkout's packages/core instead of falling back to the shared repo root when running inside a framework checkout.
- Out of scope: unrelated refactors not required for "Isolate framework core runtime resolution inside framework checkouts".

## Verification

- State: ok
- Note: Verified framework runtime core isolation with focused checks: bun vitest run packages/agentplane/src/shared/runtime-source.test.ts packages/agentplane/src/commands/runtime.command.test.ts packages/agentplane/src/commands/doctor.command.test.ts -t runtime && bun run framework:dev:bootstrap && node packages/agentplane/bin/agentplane.js runtime explain && node packages/agentplane/bin/agentplane.js doctor
- Full verification checklist lives in local review.md.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-04-16T08:09:16.063Z
- Branch: task/202604160802-PEV6JS/isolate-framework-core-resolution
- Head: f87d2e703f91

```text
 packages/agentplane/src/shared/runtime-source.test.ts | 18 ++++++++++++++++++
 packages/agentplane/src/shared/runtime-source.ts      | 15 ++++++++++++---
 2 files changed, 30 insertions(+), 3 deletions(-)
```

</details>
