### PR TITLE
architecture/backend: Introduce command-layer backend capability helpers (MV8SE2)

### DIFF
--- a/.agentplane/tasks/202604180617-8RSXN9/README.md
+++ b/.agentplane/tasks/202604180617-8RSXN9/README.md
@@ -1,0 +1,86 @@
+---
+id: "202604180617-8RSXN9"
+title: "Migrate task command paths onto backend capability facade"
+status: "TODO"
+priority: "med"
+owner: "CODER"
+revision: 2
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "backend"
+  - "code"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-04-18T06:18:07.927Z"
+doc_updated_by: "PLANNER"
+description: "Route task show and task mutation command helpers through capability-aware service helpers so command logic no longer special-cases the local backend directly."
+sections:
+  Summary: |-
+    Migrate task command paths onto backend capability facade
+    
+    Route task show and task mutation command helpers through capability-aware service helpers so command logic no longer special-cases the local backend directly.
+  Scope: |-
+    - In scope: Route task show and task mutation command helpers through capability-aware service helpers so command logic no longer special-cases the local backend directly.
+    - Out of scope: unrelated refactors not required for "Migrate task command paths onto backend capability facade".
+  Plan: "1. Replace task show and related command helpers with capability-aware service calls. 2. Remove remaining direct backendId/local-backend checks in migrated task command paths. 3. Verify with focused task command tests plus lint:core."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Migrate task command paths onto backend capability facade
+
+Route task show and task mutation command helpers through capability-aware service helpers so command logic no longer special-cases the local backend directly.
+
+## Scope
+
+- In scope: Route task show and task mutation command helpers through capability-aware service helpers so command logic no longer special-cases the local backend directly.
+- Out of scope: unrelated refactors not required for "Migrate task command paths onto backend capability facade".
+
+## Plan
+
+1. Replace task show and related command helpers with capability-aware service calls. 2. Remove remaining direct backendId/local-backend checks in migrated task command paths. 3. Verify with focused task command tests plus lint:core.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202604180617-MV8SE2/README.md
+++ b/.agentplane/tasks/202604180617-MV8SE2/README.md
@@ -1,0 +1,119 @@
+---
+id: "202604180617-MV8SE2"
+title: "Introduce command-layer backend capability helpers"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "architecture"
+  - "backend"
+  - "code"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-04-18T06:18:22.343Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-04-18T06:39:23.410Z"
+  updated_by: "CODER"
+  note: "Backend capability facade now drives local-task-store routing in shared task command paths; focused and full fast-suite verification passed."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: add a command/shared backend capability facade so task-store and task-mutation helpers stop branching directly on backendId and local backend type checks."
+events:
+  -
+    type: "status"
+    at: "2026-04-18T06:18:30.489Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: add a command/shared backend capability facade so task-store and task-mutation helpers stop branching directly on backendId and local backend type checks."
+  -
+    type: "verify"
+    at: "2026-04-18T06:39:23.410Z"
+    author: "CODER"
+    state: "ok"
+    note: "Backend capability facade now drives local-task-store routing in shared task command paths; focused and full fast-suite verification passed."
+doc_version: 3
+doc_updated_at: "2026-04-18T06:39:23.422Z"
+doc_updated_by: "CODER"
+description: "Add a command/shared capability facade over task backend traits so command services stop branching on backendId/local-backend checks directly."
+sections:
+  Summary: |-
+    Introduce command-layer backend capability helpers
+    
+    Add a command/shared capability facade over task backend traits so command services stop branching on backendId/local-backend checks directly.
+  Scope: |-
+    - In scope: Add a command/shared capability facade over task backend traits so command services stop branching on backendId/local-backend checks directly.
+    - Out of scope: unrelated refactors not required for "Introduce command-layer backend capability helpers".
+  Plan: "1. Introduce command/shared backend capability helpers that expose task-readme, local-store, projection-refresh, and snapshot-export decisions without direct backendId/local-backend checks. 2. Migrate the shared task storage and mutation helpers onto that facade while preserving behavior. 3. Verify with lint:core, test:fast, and focused backend/task command review for removed backendId branching."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-04-18T06:39:23.410Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Backend capability facade now drives local-task-store routing in shared task command paths; focused and full fast-suite verification passed.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-18T06:18:30.498Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Introduce command-layer backend capability helpers
+
+Add a command/shared capability facade over task backend traits so command services stop branching on backendId/local-backend checks directly.
+
+## Scope
+
+- In scope: Add a command/shared capability facade over task backend traits so command services stop branching on backendId/local-backend checks directly.
+- Out of scope: unrelated refactors not required for "Introduce command-layer backend capability helpers".
+
+## Plan
+
+1. Introduce command/shared backend capability helpers that expose task-readme, local-store, projection-refresh, and snapshot-export decisions without direct backendId/local-backend checks. 2. Migrate the shared task storage and mutation helpers onto that facade while preserving behavior. 3. Verify with lint:core, test:fast, and focused backend/task command review for removed backendId branching.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-04-18T06:39:23.410Z — VERIFY — ok
+
+By: CODER
+
+Note: Backend capability facade now drives local-task-store routing in shared task command paths; focused and full fast-suite verification passed.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-18T06:18:30.498Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202604180617-MV8SE2/pr/diffstat.txt
+++ b/.agentplane/tasks/202604180617-MV8SE2/pr/diffstat.txt
@@ -1,0 +1,19 @@
+ .agentplane/tasks/202604180617-8RSXN9/README.md    | 86 +++++++++++++++++++++
+ .agentplane/tasks/202604180617-SWBDDT/README.md    | 87 ++++++++++++++++++++++
+ .../agentplane/src/commands/shared/task-backend.ts | 24 +++++-
+ .../src/commands/shared/task-mutation.test.ts      | 25 ++++++-
+ .../src/commands/shared/task-mutation.ts           | 12 ++-
+ .../src/commands/shared/task-store/store.ts        |  5 +-
+ .../src/commands/task/block.unit.test.ts           |  1 +
+ .../agentplane/src/commands/task/doc.unit.test.ts  |  1 +
+ .../agentplane/src/commands/task/finish-shared.ts  | 10 ++-
+ packages/agentplane/src/commands/task/finish.ts    | 10 ++-
+ .../src/commands/task/finish.unit.test.ts          |  1 +
+ .../src/commands/task/mutation-parity.unit.test.ts | 11 +++
+ .../agentplane/src/commands/task/plan.unit.test.ts |  1 +
+ .../src/commands/task/set-status.unit.test.ts      |  1 +
+ packages/agentplane/src/commands/task/show.ts      |  5 +-
+ .../src/commands/task/start.unit.test.ts           |  1 +
+ .../src/commands/task/verify-record.unit.test.ts   |  1 +
+ .../src/commands/workflow.task-doc.test.ts         | 46 +++++++++++-
+ 18 files changed, 308 insertions(+), 20 deletions(-)

--- a/.agentplane/tasks/202604180617-MV8SE2/pr/github-body.md
+++ b/.agentplane/tasks/202604180617-MV8SE2/pr/github-body.md
@@ -1,0 +1,33 @@
+## Summary
+
+Introduce command-layer backend capability helpers
+
+Add a command/shared capability facade over task backend traits so command services stop branching on backendId/local-backend checks directly.
+
+## Scope
+
+- In scope: Add a command/shared capability facade over task backend traits so command services stop branching on backendId/local-backend checks directly.
+- Out of scope: unrelated refactors not required for "Introduce command-layer backend capability helpers".
+
+## Verification
+
+- State: ok
+- Note: Backend capability facade now drives local-task-store routing in shared task command paths; focused and full fast-suite verification passed.
+- Full verification checklist lives in local review.md.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-04-18T06:39:23.537Z
+- Branch: task/202604180617-MV8SE2/backend-capability-facade
+- Head: 6cfd5f685792
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202604180617-MV8SE2/pr/github-body.md
+++ b/.agentplane/tasks/202604180617-MV8SE2/pr/github-body.md
@@ -22,12 +22,30 @@ Add a command/shared capability facade over task backend traits so command servi
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-18T06:39:23.537Z
+- Updated: 2026-04-18T06:42:53.525Z
 - Branch: task/202604180617-MV8SE2/backend-capability-facade
-- Head: 6cfd5f685792
+- Head: e7d63f04c6d8
 
 ```text
-No changes detected.
+ .agentplane/tasks/202604180617-8RSXN9/README.md    | 86 +++++++++++++++++++++
+ .agentplane/tasks/202604180617-SWBDDT/README.md    | 87 ++++++++++++++++++++++
+ .../agentplane/src/commands/shared/task-backend.ts | 24 +++++-
+ .../src/commands/shared/task-mutation.test.ts      | 25 ++++++-
+ .../src/commands/shared/task-mutation.ts           | 12 ++-
+ .../src/commands/shared/task-store/store.ts        |  5 +-
+ .../src/commands/task/block.unit.test.ts           |  1 +
+ .../agentplane/src/commands/task/doc.unit.test.ts  |  1 +
+ .../agentplane/src/commands/task/finish-shared.ts  | 10 ++-
+ packages/agentplane/src/commands/task/finish.ts    | 10 ++-
+ .../src/commands/task/finish.unit.test.ts          |  1 +
+ .../src/commands/task/mutation-parity.unit.test.ts | 11 +++
+ .../agentplane/src/commands/task/plan.unit.test.ts |  1 +
+ .../src/commands/task/set-status.unit.test.ts      |  1 +
+ packages/agentplane/src/commands/task/show.ts      |  5 +-
+ .../src/commands/task/start.unit.test.ts           |  1 +
+ .../src/commands/task/verify-record.unit.test.ts   |  1 +
+ .../src/commands/workflow.task-doc.test.ts         | 46 +++++++++++-
+ 18 files changed, 308 insertions(+), 20 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202604180617-MV8SE2/pr/github-title.txt
+++ b/.agentplane/tasks/202604180617-MV8SE2/pr/github-title.txt
@@ -1,0 +1,1 @@
+architecture/backend: Introduce command-layer backend capability helpers (MV8SE2)

--- a/.agentplane/tasks/202604180617-MV8SE2/pr/meta.json
+++ b/.agentplane/tasks/202604180617-MV8SE2/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202604180617-MV8SE2/backend-capability-facade",
   "created_at": "2026-04-18T06:39:23.537Z",
-  "head_sha": "6cfd5f6857925b1b5ecdfd3594d80f81011bd3b6",
+  "head_sha": "e7d63f04c6d894177e7fee250fe9f36f25822100",
   "last_verified_at": "2026-04-18T06:39:23.410Z",
   "last_verified_sha": "6cfd5f6857925b1b5ecdfd3594d80f81011bd3b6",
   "schema_version": 1,
   "task_id": "202604180617-MV8SE2",
-  "updated_at": "2026-04-18T06:39:23.537Z",
+  "updated_at": "2026-04-18T06:42:53.525Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202604180617-MV8SE2/pr/meta.json
+++ b/.agentplane/tasks/202604180617-MV8SE2/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202604180617-MV8SE2/backend-capability-facade",
+  "created_at": "2026-04-18T06:39:23.537Z",
+  "head_sha": "6cfd5f6857925b1b5ecdfd3594d80f81011bd3b6",
+  "last_verified_at": "2026-04-18T06:39:23.410Z",
+  "last_verified_sha": "6cfd5f6857925b1b5ecdfd3594d80f81011bd3b6",
+  "schema_version": 1,
+  "task_id": "202604180617-MV8SE2",
+  "updated_at": "2026-04-18T06:39:23.537Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202604180617-MV8SE2/pr/review.md
+++ b/.agentplane/tasks/202604180617-MV8SE2/pr/review.md
@@ -1,0 +1,57 @@
+# PR Review
+
+Created: 2026-04-18T06:39:23.537Z
+Branch: task/202604180617-MV8SE2/backend-capability-facade
+
+## Summary
+
+Introduce command-layer backend capability helpers
+
+Add a command/shared capability facade over task backend traits so command services stop branching on backendId/local-backend checks directly.
+
+## Scope
+
+- In scope: Add a command/shared capability facade over task backend traits so command services stop branching on backendId/local-backend checks directly.
+- Out of scope: unrelated refactors not required for "Introduce command-layer backend capability helpers".
+
+## Verification
+
+### Plan
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+### Current Status
+
+- State: ok
+- Note: Backend capability facade now drives local-task-store routing in shared task command paths; focused and full fast-suite verification passed.
+
+## Risks
+
+- Risk level: not recorded
+- Breaking change: no
+
+### Rollback
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-04-18T06:39:23.537Z
+- Branch: task/202604180617-MV8SE2/backend-capability-facade
+- Head: 6cfd5f685792
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202604180617-MV8SE2/pr/review.md
+++ b/.agentplane/tasks/202604180617-MV8SE2/pr/review.md
@@ -45,12 +45,30 @@ Add a command/shared capability facade over task backend traits so command servi
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-04-18T06:39:23.537Z
+- Updated: 2026-04-18T06:42:53.525Z
 - Branch: task/202604180617-MV8SE2/backend-capability-facade
-- Head: 6cfd5f685792
+- Head: e7d63f04c6d8
 
 ```text
-No changes detected.
+ .agentplane/tasks/202604180617-8RSXN9/README.md    | 86 +++++++++++++++++++++
+ .agentplane/tasks/202604180617-SWBDDT/README.md    | 87 ++++++++++++++++++++++
+ .../agentplane/src/commands/shared/task-backend.ts | 24 +++++-
+ .../src/commands/shared/task-mutation.test.ts      | 25 ++++++-
+ .../src/commands/shared/task-mutation.ts           | 12 ++-
+ .../src/commands/shared/task-store/store.ts        |  5 +-
+ .../src/commands/task/block.unit.test.ts           |  1 +
+ .../agentplane/src/commands/task/doc.unit.test.ts  |  1 +
+ .../agentplane/src/commands/task/finish-shared.ts  | 10 ++-
+ packages/agentplane/src/commands/task/finish.ts    | 10 ++-
+ .../src/commands/task/finish.unit.test.ts          |  1 +
+ .../src/commands/task/mutation-parity.unit.test.ts | 11 +++
+ .../agentplane/src/commands/task/plan.unit.test.ts |  1 +
+ .../src/commands/task/set-status.unit.test.ts      |  1 +
+ packages/agentplane/src/commands/task/show.ts      |  5 +-
+ .../src/commands/task/start.unit.test.ts           |  1 +
+ .../src/commands/task/verify-record.unit.test.ts   |  1 +
+ .../src/commands/workflow.task-doc.test.ts         | 46 +++++++++++-
+ 18 files changed, 308 insertions(+), 20 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202604180617-SWBDDT/README.md
+++ b/.agentplane/tasks/202604180617-SWBDDT/README.md
@@ -1,0 +1,87 @@
+---
+id: "202604180617-SWBDDT"
+title: "Adopt CommandResult for release and task commands"
+status: "TODO"
+priority: "med"
+owner: "CODER"
+revision: 2
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "cli"
+  - "code"
+  - "output"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-04-18T06:18:07.921Z"
+doc_updated_by: "PLANNER"
+description: "Introduce a typed command result contract and route selected release/task commands through renderer-owned output so command handlers stop writing output ad hoc."
+sections:
+  Summary: |-
+    Adopt CommandResult for release and task commands
+    
+    Introduce a typed command result contract and route selected release/task commands through renderer-owned output so command handlers stop writing output ad hoc.
+  Scope: |-
+    - In scope: Introduce a typed command result contract and route selected release/task commands through renderer-owned output so command handlers stop writing output ad hoc.
+    - Out of scope: unrelated refactors not required for "Adopt CommandResult for release and task commands".
+  Plan: "1. Introduce a typed CommandResult contract and renderer-owned output helpers. 2. Migrate selected release/task commands from ad-hoc stdout writes to CommandResult. 3. Verify with command-level tests, lint:core, and test:fast."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Adopt CommandResult for release and task commands
+
+Introduce a typed command result contract and route selected release/task commands through renderer-owned output so command handlers stop writing output ad hoc.
+
+## Scope
+
+- In scope: Introduce a typed command result contract and route selected release/task commands through renderer-owned output so command handlers stop writing output ad hoc.
+- Out of scope: unrelated refactors not required for "Adopt CommandResult for release and task commands".
+
+## Plan
+
+1. Introduce a typed CommandResult contract and renderer-owned output helpers. 2. Migrate selected release/task commands from ad-hoc stdout writes to CommandResult. 3. Verify with command-level tests, lint:core, and test:fast.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/packages/agentplane/src/commands/shared/task-backend.ts
+++ b/packages/agentplane/src/commands/shared/task-backend.ts
@@ -113,6 +113,26 @@ export function taskDataToFrontmatter(task: TaskData): Record<string, unknown> {
   };
 }
 
+export function getTaskBackendCapabilities(ctx: CommandContext) {
+  return ctx.taskBackend.capabilities;
+}
+
+export function backendHasLocalCanonicalSource(ctx: CommandContext): boolean {
+  return getTaskBackendCapabilities(ctx).canonical_source === "local";
+}
+
+export function backendWritesTaskReadmes(ctx: CommandContext): boolean {
+  return getTaskBackendCapabilities(ctx).writes_task_readmes === true;
+}
+
+export function backendSupportsTaskBranchSnapshots(ctx: CommandContext): boolean {
+  return backendHasLocalCanonicalSource(ctx) && backendWritesTaskReadmes(ctx);
+}
+
+export function backendUsesLocalTaskStore(ctx: CommandContext): boolean {
+  return backendSupportsTaskBranchSnapshots(ctx);
+}
+
 export async function loadCommandContext(opts: {
   cwd: string;
   rootOverride?: string | null;
@@ -175,7 +195,7 @@ export async function resolveTaskBranchFromContext(opts: {
   ctx: CommandContext;
   taskId: string;
 }): Promise<string | null> {
-  if (opts.ctx.backendId !== "local") {
+  if (!backendSupportsTaskBranchSnapshots(opts.ctx)) {
     return null;
   }
 
@@ -201,7 +221,7 @@ export async function loadTaskFromBranchSnapshot(opts: {
   readmePath: string;
   branch?: string | null;
 }): Promise<TaskData | null> {
-  if (opts.ctx.backendId !== "local") {
+  if (!backendSupportsTaskBranchSnapshots(opts.ctx)) {
     return null;
   }
 

--- a/packages/agentplane/src/commands/shared/task-mutation.test.ts
+++ b/packages/agentplane/src/commands/shared/task-mutation.test.ts
@@ -66,7 +66,11 @@ describe("applyTaskMutation", () => {
 
     vi.doMock("./task-backend.js", async () => {
       const actual = await vi.importActual("./task-backend.js");
-      return { ...actual, loadTaskFromContext };
+      return {
+        ...actual,
+        backendUsesLocalTaskStore: () => true,
+        loadTaskFromContext,
+      };
     });
     vi.doMock("./task-store.js", async () => {
       const actual = await vi.importActual("./task-store.js");
@@ -114,6 +118,13 @@ describe("applyTaskMutation", () => {
         getTaskStore: () => store,
       };
     });
+    vi.doMock("./task-backend.js", async () => {
+      const actual = await vi.importActual("./task-backend.js");
+      return {
+        ...actual,
+        backendUsesLocalTaskStore: () => true,
+      };
+    });
 
     const { applyTaskMutation } = await import("./task-mutation.js");
     const result = await applyTaskMutation({
@@ -136,7 +147,11 @@ describe("applyTaskMutation", () => {
 
     vi.doMock("./task-backend.js", async () => {
       const actual = await vi.importActual("./task-backend.js");
-      return { ...actual, loadTaskFromContext };
+      return {
+        ...actual,
+        backendUsesLocalTaskStore: () => false,
+        loadTaskFromContext,
+      };
     });
     vi.doMock("./task-store.js", async () => {
       const actual = await vi.importActual("./task-store.js");
@@ -196,7 +211,11 @@ describe("applyTaskMutation", () => {
 
     vi.doMock("./task-backend.js", async () => {
       const actual = await vi.importActual("./task-backend.js");
-      return { ...actual, loadTaskFromContext };
+      return {
+        ...actual,
+        backendUsesLocalTaskStore: () => false,
+        loadTaskFromContext,
+      };
     });
     vi.doMock("./task-store.js", async () => {
       const actual = await vi.importActual("./task-store.js");

--- a/packages/agentplane/src/commands/shared/task-mutation.ts
+++ b/packages/agentplane/src/commands/shared/task-mutation.ts
@@ -1,10 +1,14 @@
 import type { TaskData, TaskWriteOptions } from "../../backends/task-backend.js";
 import { PolicyEngine } from "../../policy/engine.js";
 import type { PolicyActionId } from "../../policy/taxonomy.js";
-import { loadTaskFromContext, writeTasksOrFallback, type CommandContext } from "./task-backend.js";
+import {
+  backendUsesLocalTaskStore,
+  loadTaskFromContext,
+  writeTasksOrFallback,
+  type CommandContext,
+} from "./task-backend.js";
 import {
   applyTaskStoreIntentsToTask,
-  backendIsLocalFileBackend,
   getTaskStore,
   type TaskStoreIntentResult,
 } from "./task-store.js";
@@ -26,7 +30,7 @@ export async function withTaskMutationStorage<TResult>(opts: {
   local: (store: ReturnType<typeof getTaskStore>) => Promise<TResult> | TResult;
   remote: (backend: CommandContext["taskBackend"]) => Promise<TResult> | TResult;
 }): Promise<TResult> {
-  if (backendIsLocalFileBackend(opts.ctx)) {
+  if (backendUsesLocalTaskStore(opts.ctx)) {
     return await opts.local(getTaskStore(opts.ctx));
   }
   return await opts.remote(opts.ctx.taskBackend);
@@ -48,7 +52,7 @@ export async function applyTaskMutation(opts: {
     git: { stagedPaths: [] },
   });
 
-  if (backendIsLocalFileBackend(opts.ctx)) {
+  if (backendUsesLocalTaskStore(opts.ctx)) {
     const store = getTaskStore(opts.ctx);
     const result = await store.update(
       opts.taskId,

--- a/packages/agentplane/src/commands/shared/task-store/store.ts
+++ b/packages/agentplane/src/commands/shared/task-store/store.ts
@@ -1,6 +1,7 @@
-import { LocalBackend, type TaskData } from "../../../backends/task-backend.js";
+import type { TaskData } from "../../../backends/task-backend.js";
 import { exitCodeForError } from "../../../cli/exit-codes.js";
 import { CliError } from "../../../shared/errors.js";
+import { backendUsesLocalTaskStore } from "../task-backend.js";
 import {
   applyTaskStoreIntents,
   resolveTaskStoreIntents,
@@ -164,5 +165,5 @@ export function getTaskStore(ctx: TaskStoreContext): TaskStore {
 }
 
 export function backendIsLocalFileBackend(ctx: TaskStoreContext): boolean {
-  return ctx.taskBackend instanceof LocalBackend;
+  return backendUsesLocalTaskStore(ctx);
 }

--- a/packages/agentplane/src/commands/task/block.unit.test.ts
+++ b/packages/agentplane/src/commands/task/block.unit.test.ts
@@ -16,6 +16,7 @@ vi.mock("../guard/index.js", () => ({
   commitFromComment: mocks.commitFromComment,
 }));
 vi.mock("../shared/task-backend.js", () => ({
+  backendUsesLocalTaskStore: mocks.backendIsLocalFileBackend,
   loadCommandContext: mocks.loadCommandContext,
   loadTaskFromContext: mocks.loadTaskFromContext,
 }));

--- a/packages/agentplane/src/commands/task/doc.unit.test.ts
+++ b/packages/agentplane/src/commands/task/doc.unit.test.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../shared/task-backend.js", () => ({
+  backendUsesLocalTaskStore: mocks.backendIsLocalFileBackend,
   loadCommandContext: mocks.loadCommandContext,
   loadTaskFromContext: mocks.loadTaskFromContext,
 }));

--- a/packages/agentplane/src/commands/task/finish-shared.ts
+++ b/packages/agentplane/src/commands/task/finish-shared.ts
@@ -3,8 +3,12 @@ import { ensureDocSections } from "@agentplaneorg/core";
 import type { TaskData } from "../../backends/task-backend.js";
 import { CliError } from "../../shared/errors.js";
 import { cmdCommit } from "../guard/index.js";
-import { loadTaskFromContext, type CommandContext } from "../shared/task-backend.js";
-import { backendIsLocalFileBackend, getTaskStore, mutateTaskStore } from "../shared/task-store.js";
+import {
+  backendUsesLocalTaskStore,
+  loadTaskFromContext,
+  type CommandContext,
+} from "../shared/task-backend.js";
+import { getTaskStore, mutateTaskStore } from "../shared/task-store.js";
 
 import {
   ensureAgentFilledRequiredDocSections,
@@ -208,7 +212,7 @@ export async function writeFinishedTasks(opts: {
   breaking: boolean;
   taskCommitInfo: ResolvedCommitInfo | null;
 }): Promise<void> {
-  const useStore = backendIsLocalFileBackend(opts.ctx);
+  const useStore = backendUsesLocalTaskStore(opts.ctx);
   const store = useStore ? getTaskStore(opts.ctx) : null;
   const taskCount = opts.loadedTasks.length;
 

--- a/packages/agentplane/src/commands/task/finish.ts
+++ b/packages/agentplane/src/commands/task/finish.ts
@@ -10,8 +10,12 @@ import path from "node:path";
 import { ensureActionApproved } from "../shared/approval-requirements.js";
 import { ensureReconciledBeforeMutation } from "../shared/reconcile-check.js";
 import { gitCurrentBranch } from "../shared/git-ops.js";
-import { loadCommandContext, type CommandContext } from "../shared/task-backend.js";
-import { backendIsLocalFileBackend, getTaskStore } from "../shared/task-store.js";
+import {
+  backendUsesLocalTaskStore,
+  loadCommandContext,
+  type CommandContext,
+} from "../shared/task-backend.js";
+import { getTaskStore } from "../shared/task-store.js";
 import { applyTaskMutation } from "../shared/task-mutation.js";
 import { collectTaskIncidents, renderIncidentCollectionPlanOutcome } from "../incidents/shared.js";
 import {
@@ -266,7 +270,7 @@ export async function cmdFinish(opts: {
       });
     }
 
-    const useStore = backendIsLocalFileBackend(ctx);
+    const useStore = backendUsesLocalTaskStore(ctx);
     const store = useStore ? getTaskStore(ctx) : null;
     const backendWritesTaskReadmes = ctx.taskBackend.capabilities.writes_task_readmes === true;
     const defaultDirectCloseCommit =

--- a/packages/agentplane/src/commands/task/finish.unit.test.ts
+++ b/packages/agentplane/src/commands/task/finish.unit.test.ts
@@ -47,6 +47,7 @@ vi.mock("../shared/reconcile-check.js", () => ({
   ensureReconciledBeforeMutation: mocks.ensureReconciledBeforeMutation,
 }));
 vi.mock("../shared/task-backend.js", () => ({
+  backendUsesLocalTaskStore: mocks.backendIsLocalFileBackend,
   loadCommandContext: mocks.loadCommandContext,
   loadTaskFromContext: mocks.loadTaskFromContext,
 }));

--- a/packages/agentplane/src/commands/task/mutation-parity.unit.test.ts
+++ b/packages/agentplane/src/commands/task/mutation-parity.unit.test.ts
@@ -133,6 +133,7 @@ async function runCommentScenario(mode: BackendMode) {
   const ctx = mkCtx(backend);
 
   vi.doMock("../shared/task-backend.js", () => ({
+    backendUsesLocalTaskStore: () => mode === "local",
     loadCommandContext: vi.fn(),
     loadTaskFromContext,
   }));
@@ -180,6 +181,7 @@ async function runBlockScenario(mode: BackendMode) {
     commitFromComment: vi.fn(),
   }));
   vi.doMock("../shared/task-backend.js", () => ({
+    backendUsesLocalTaskStore: () => mode === "local",
     loadCommandContext: vi.fn(),
     loadTaskFromContext,
   }));
@@ -254,6 +256,7 @@ async function runStartScenario(mode: BackendMode) {
     commitFromComment: vi.fn(),
   }));
   vi.doMock("../shared/task-backend.js", () => ({
+    backendUsesLocalTaskStore: () => mode === "local",
     loadCommandContext: vi.fn(),
     loadTaskFromContext,
   }));
@@ -320,6 +323,7 @@ async function runSetStatusScenario(mode: BackendMode) {
     commitFromComment: vi.fn(),
   }));
   vi.doMock("../shared/task-backend.js", () => ({
+    backendUsesLocalTaskStore: () => mode === "local",
     loadCommandContext: vi.fn(),
     loadTaskFromContext,
     resolveDocUpdatedBy: (task: TaskData, author?: string) =>
@@ -412,6 +416,7 @@ async function runPlanSetScenario(mode: BackendMode) {
   const ctx = mkCtx(backend);
 
   vi.doMock("../shared/task-backend.js", () => ({
+    backendUsesLocalTaskStore: () => mode === "local",
     loadCommandContext: vi.fn(),
     loadTaskFromContext,
   }));
@@ -483,6 +488,7 @@ async function runVerifyRecordScenario(mode: BackendMode) {
     ensureReconciledBeforeMutation: vi.fn(() => Promise.resolve()),
   }));
   vi.doMock("../shared/task-backend.js", () => ({
+    backendUsesLocalTaskStore: () => mode === "local",
     loadCommandContext: vi.fn(),
     loadTaskFromContext,
   }));
@@ -555,6 +561,7 @@ async function runDocSetScenario(mode: BackendMode) {
   const loadTaskFromContext = vi.fn(() => Promise.resolve(cloneTask(currentTask)));
 
   vi.doMock("../shared/task-backend.js", () => ({
+    backendUsesLocalTaskStore: () => mode === "local",
     loadCommandContext: vi.fn(),
     loadTaskFromContext,
   }));
@@ -629,6 +636,10 @@ async function runDocShowScenario(mode: BackendMode) {
   });
   const ctx = mkCtx(backend);
 
+  vi.doMock("../shared/task-backend.js", () => ({
+    backendUsesLocalTaskStore: () => mode === "local",
+    loadCommandContext: vi.fn(),
+  }));
   vi.doMock("../shared/task-store.js", async () => {
     const actual = await vi.importActual("../shared/task-store.js");
     return {

--- a/packages/agentplane/src/commands/task/plan.unit.test.ts
+++ b/packages/agentplane/src/commands/task/plan.unit.test.ts
@@ -19,6 +19,7 @@ const mockBackendIsLocalFileBackend = vi.fn<(ctx: CommandContext) => boolean>();
 const mockGetTaskStore = vi.fn();
 
 vi.mock("../shared/task-backend.js", () => ({
+  backendUsesLocalTaskStore: mockBackendIsLocalFileBackend,
   loadCommandContext: mockLoadCommandContext,
   loadTaskFromContext: mockLoadTaskFromContext,
 }));

--- a/packages/agentplane/src/commands/task/set-status.unit.test.ts
+++ b/packages/agentplane/src/commands/task/set-status.unit.test.ts
@@ -19,6 +19,7 @@ vi.mock("../guard/index.js", () => ({
   commitFromComment: mocks.commitFromComment,
 }));
 vi.mock("../shared/task-backend.js", () => ({
+  backendUsesLocalTaskStore: mocks.backendIsLocalFileBackend,
   loadCommandContext: mocks.loadCommandContext,
   loadTaskFromContext: mocks.loadTaskFromContext,
   resolveDocUpdatedBy: (task: TaskData, author?: string) =>

--- a/packages/agentplane/src/commands/task/show.ts
+++ b/packages/agentplane/src/commands/task/show.ts
@@ -6,6 +6,7 @@ import { mapBackendError } from "../../cli/error-map.js";
 import { CliError } from "../../shared/errors.js";
 
 import {
+  backendSupportsTaskBranchSnapshots,
   loadCommandContext,
   loadTaskFromContext,
   taskDataToFrontmatter,
@@ -16,7 +17,7 @@ async function detectLocalTaskMetadataErrors(
   ctx: CommandContext,
   taskId: string,
 ): Promise<string[] | null> {
-  if (ctx.backendId !== "local") return null;
+  if (!backendSupportsTaskBranchSnapshots(ctx)) return null;
   const readmePath = taskReadmePath(
     path.join(ctx.resolvedProject.gitRoot, ctx.config.paths.workflow_dir),
     taskId,
@@ -51,7 +52,7 @@ export async function cmdTaskShow(opts: {
       (await loadCommandContext({ cwd: opts.cwd, rootOverride: opts.rootOverride ?? null }));
     const task = await loadTaskFromContext({ ctx, taskId: opts.taskId });
     const frontmatter = taskDataToFrontmatter(task);
-    if (ctx.backendId === "local") {
+    if (backendSupportsTaskBranchSnapshots(ctx)) {
       const metadataErrors = validateTaskDocMetadata(frontmatter);
       if (metadataErrors.length > 0) {
         throw new CliError({

--- a/packages/agentplane/src/commands/task/start.unit.test.ts
+++ b/packages/agentplane/src/commands/task/start.unit.test.ts
@@ -12,6 +12,7 @@ const mockBackendIsLocalFileBackend = vi.fn<(ctx: CommandContext) => boolean>();
 const mockGetTaskStore = vi.fn();
 
 vi.mock("../shared/task-backend.js", () => ({
+  backendUsesLocalTaskStore: mockBackendIsLocalFileBackend,
   loadCommandContext: mockLoadCommandContext,
   loadTaskFromContext: mockLoadTaskFromContext,
 }));

--- a/packages/agentplane/src/commands/task/verify-record.unit.test.ts
+++ b/packages/agentplane/src/commands/task/verify-record.unit.test.ts
@@ -34,6 +34,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 });
 
 vi.mock("../shared/task-backend.js", () => ({
+  backendUsesLocalTaskStore: mocks.backendIsLocalFileBackend,
   loadCommandContext: mocks.loadCommandContext,
   loadTaskFromContext: mocks.loadTaskFromContext,
 }));

--- a/packages/agentplane/src/commands/workflow.task-doc.test.ts
+++ b/packages/agentplane/src/commands/workflow.task-doc.test.ts
@@ -22,6 +22,20 @@ import {
 function baseTaskBackend(overrides: Partial<taskBackend.TaskBackend>): taskBackend.TaskBackend {
   return {
     id: "local",
+    capabilities: {
+      canonical_source: "local",
+      projection: "canonical",
+      projection_read_mode: "native",
+      reads_from_projection_by_default: true,
+      writes_task_readmes: true,
+      supports_task_revisions: true,
+      supports_revision_guarded_writes: true,
+      may_access_network_on_read: false,
+      may_access_network_on_write: false,
+      supports_projection_refresh: false,
+      supports_push_sync: false,
+      supports_snapshot_export: true,
+    },
     listTasks: vi.fn().mockResolvedValue([]),
     getTask: vi.fn().mockResolvedValue(null),
     writeTask: vi.fn().mockImplementation(() => Promise.resolve()),
@@ -248,6 +262,20 @@ describe("commands/workflow", () => {
     const spyEmptySection = vi.spyOn(taskBackend, "loadTaskBackend").mockResolvedValue({
       backendId: "local",
       backend: baseTaskBackend({
+        capabilities: {
+          canonical_source: "remote",
+          projection: "cache",
+          projection_read_mode: "native",
+          reads_from_projection_by_default: true,
+          writes_task_readmes: true,
+          supports_task_revisions: false,
+          supports_revision_guarded_writes: false,
+          may_access_network_on_read: false,
+          may_access_network_on_write: false,
+          supports_projection_refresh: true,
+          supports_push_sync: false,
+          supports_snapshot_export: true,
+        },
         getTaskDoc: vi.fn().mockResolvedValue("## Summary\n## Scope\n\ncontent"),
       }),
       resolved: { gitRoot: root, agentplaneDir: path.join(root, ".agentplane") },
@@ -271,7 +299,23 @@ describe("commands/workflow", () => {
 
     const spyEmpty = vi.spyOn(taskBackend, "loadTaskBackend").mockResolvedValue({
       backendId: "local",
-      backend: baseTaskBackend({ getTaskDoc: vi.fn().mockResolvedValue("") }),
+      backend: baseTaskBackend({
+        capabilities: {
+          canonical_source: "remote",
+          projection: "cache",
+          projection_read_mode: "native",
+          reads_from_projection_by_default: true,
+          writes_task_readmes: true,
+          supports_task_revisions: false,
+          supports_revision_guarded_writes: false,
+          may_access_network_on_read: false,
+          may_access_network_on_write: false,
+          supports_projection_refresh: true,
+          supports_push_sync: false,
+          supports_snapshot_export: true,
+        },
+        getTaskDoc: vi.fn().mockResolvedValue(""),
+      }),
       resolved: { gitRoot: root, agentplaneDir: path.join(root, ".agentplane") },
       config: defaultConfig(),
       backendConfigPath: path.join(root, ".agentplane", "backends", "local", "backend.json"),


### PR DESCRIPTION
## Summary

Introduce command-layer backend capability helpers

Add a command/shared capability facade over task backend traits so command services stop branching on backendId/local-backend checks directly.

## Scope

- In scope: Add a command/shared capability facade over task backend traits so command services stop branching on backendId/local-backend checks directly.
- Out of scope: unrelated refactors not required for "Introduce command-layer backend capability helpers".

## Verification

- State: ok
- Note: Backend capability facade now drives local-task-store routing in shared task command paths; focused and full fast-suite verification passed.
- Full verification checklist lives in local review.md.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-04-18T06:42:53.525Z
- Branch: task/202604180617-MV8SE2/backend-capability-facade
- Head: e7d63f04c6d8

```text
 .agentplane/tasks/202604180617-8RSXN9/README.md    | 86 +++++++++++++++++++++
 .agentplane/tasks/202604180617-SWBDDT/README.md    | 87 ++++++++++++++++++++++
 .../agentplane/src/commands/shared/task-backend.ts | 24 +++++-
 .../src/commands/shared/task-mutation.test.ts      | 25 ++++++-
 .../src/commands/shared/task-mutation.ts           | 12 ++-
 .../src/commands/shared/task-store/store.ts        |  5 +-
 .../src/commands/task/block.unit.test.ts           |  1 +
 .../agentplane/src/commands/task/doc.unit.test.ts  |  1 +
 .../agentplane/src/commands/task/finish-shared.ts  | 10 ++-
 packages/agentplane/src/commands/task/finish.ts    | 10 ++-
 .../src/commands/task/finish.unit.test.ts          |  1 +
 .../src/commands/task/mutation-parity.unit.test.ts | 11 +++
 .../agentplane/src/commands/task/plan.unit.test.ts |  1 +
 .../src/commands/task/set-status.unit.test.ts      |  1 +
 packages/agentplane/src/commands/task/show.ts      |  5 +-
 .../src/commands/task/start.unit.test.ts           |  1 +
 .../src/commands/task/verify-record.unit.test.ts   |  1 +
 .../src/commands/workflow.task-doc.test.ts         | 46 +++++++++++-
 18 files changed, 308 insertions(+), 20 deletions(-)
```

</details>
