### PR TITLE
Fix v0.3.17 Knip release gate

### DIFF
--- a/packages/agentplane/src/commands/hooks/index.ts
+++ b/packages/agentplane/src/commands/hooks/index.ts
@@ -1,4 +1,4 @@
-export { HOOK_NAMES, type HookName } from "./shared.js";
+export { HOOK_NAMES } from "./shared.js";
 export { cmdHooksInstall, cmdHooksUninstall } from "./install.js";
 export { cmdHooksRun } from "./run.js";
 export { resolvePrePushHookScriptPath } from "./run.pre-push.js";


### PR DESCRIPTION
## Summary
- remove unused hooks type re-export introduced during the release refactor
- restore Knip baseline to 301 types / 563 total without changing the debt ceiling

## Verification
- bun run knip:check
- bun run typecheck
- bun run framework:dev:bootstrap
- pre-push full-fast + critical E2E passed while pushing the branch

Task: 202604201745-RD18WW