### PR TITLE
Close v0.3.18 release task

### DIFF
--- a/.agentplane/tasks/202604221009-0432YA/README.md
+++ b/.agentplane/tasks/202604221009-0432YA/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202604221009-0432YA"
 title: "Publish next patch release"
-status: "DOING"
+result_summary: "Published v0.3.18 patch release and merged release branch into main."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 4
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -18,15 +19,20 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
-commit: null
+  state: "ok"
+  updated_at: "2026-04-22T11:38:42.300Z"
+  updated_by: "CODER"
+  note: "Verified v0.3.18 release: PR #499 merged into main at 6ff1f4ac; tag v0.3.18 pushed at 2765b943; GitHub Publish to npm run 24776064562 passed; Docs CI/Core CI/Pages Deploy passed; npm versions agentplane, @agentplaneorg/core, @agentplaneorg/recipes all report 0.3.18."
+commit:
+  hash: "6ff1f4ac9d1801db88fc3b0fcb7cf7076fd59509"
+  message: "Merge pull request #499 from basilisk-labs/release/v0.3.18-publish"
 comments:
   -
     author: "CODER"
     body: "Start: generate the v0.3.18 patch release plan from current main, write release notes, run release gates, publish the release commit and tag, verify remote state, and clean stale merged branches after publication."
+  -
+    author: "CODER"
+    body: "Verified: PR #499 merged into main at 6ff1f4ac; tag v0.3.18 pushed at 2765b943; GitHub Release created; Publish to npm run 24776064562 passed; npm versions agentplane, @agentplaneorg/core, @agentplaneorg/recipes report 0.3.18."
 events:
   -
     type: "status"
@@ -35,8 +41,21 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: generate the v0.3.18 patch release plan from current main, write release notes, run release gates, publish the release commit and tag, verify remote state, and clean stale merged branches after publication."
+  -
+    type: "verify"
+    at: "2026-04-22T11:38:42.300Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified v0.3.18 release: PR #499 merged into main at 6ff1f4ac; tag v0.3.18 pushed at 2765b943; GitHub Publish to npm run 24776064562 passed; Docs CI/Core CI/Pages Deploy passed; npm versions agentplane, @agentplaneorg/core, @agentplaneorg/recipes all report 0.3.18."
+  -
+    type: "status"
+    at: "2026-04-22T11:38:50.557Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: PR #499 merged into main at 6ff1f4ac; tag v0.3.18 pushed at 2765b943; GitHub Release created; Publish to npm run 24776064562 passed; npm versions agentplane, @agentplaneorg/core, @agentplaneorg/recipes report 0.3.18."
 doc_version: 3
-doc_updated_at: "2026-04-22T10:11:00.973Z"
+doc_updated_at: "2026-04-22T11:38:50.558Z"
 doc_updated_by: "CODER"
 description: "Create and publish the next patch release from main after integrating all current branch work."
 sections:
@@ -54,6 +73,14 @@ sections:
     3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-04-22T11:38:42.300Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified v0.3.18 release: PR #499 merged into main at 6ff1f4ac; tag v0.3.18 pushed at 2765b943; GitHub Publish to npm run 24776064562 passed; Docs CI/Core CI/Pages Deploy passed; npm versions agentplane, @agentplaneorg/core, @agentplaneorg/recipes all report 0.3.18.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-22T10:11:00.973Z, excerpt_hash=sha256:2730c51d64e547dc593e41d92cce76a05e053612cd75bf1ccdce9d59c6b32c38
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -85,6 +112,14 @@ Release plan: publish v0.3.18 as the next patch release from current main. Steps
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-04-22T11:38:42.300Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified v0.3.18 release: PR #499 merged into main at 6ff1f4ac; tag v0.3.18 pushed at 2765b943; GitHub Publish to npm run 24776064562 passed; Docs CI/Core CI/Pages Deploy passed; npm versions agentplane, @agentplaneorg/core, @agentplaneorg/recipes all report 0.3.18.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-22T10:11:00.973Z, excerpt_hash=sha256:2730c51d64e547dc593e41d92cce76a05e053612cd75bf1ccdce9d59c6b32c38
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan


### PR DESCRIPTION
## Summary
- record AgentPlane verification and closeout evidence for release task 202604221009-0432YA

## Verification
- release PR #499 merged
- tag v0.3.18 pushed
- Publish to npm workflow 24776064562 passed
- npm packages report 0.3.18