### PR TITLE
Fix init legacy recipe manifests and restore logo

### DIFF
--- a/.agentplane/tasks/202604221556-W3HD3Y/README.md
+++ b/.agentplane/tasks/202604221556-W3HD3Y/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202604221556-W3HD3Y"
 title: "Fix init recipe manifest validation and ASCII logo"
-status: "DOING"
+result_summary: "Fixed init cached recipe manifest compatibility and restored the interactive init ASCII logo."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -23,11 +24,16 @@ verification:
   updated_at: "2026-04-22T15:59:54.205Z"
   updated_by: "CODER"
   note: "Verified: legacy cached recipe manifests without manifest.scenarios[].name no longer fail init recipe cache reads; ASCII logo rendering is covered; targeted recipe/init tests, typechecks, prettier, bootstrap, and temp AGENTPLANE_HOME init smoke passed."
-commit: null
+commit:
+  hash: "86fb6c8af95663b8559e94b0d94c058e5a5d75cb"
+  message: "🐛 W3HD3Y init: tolerate legacy recipe scenarios"
 comments:
   -
     author: "CODER"
     body: "Start: fix the v0.3.18 init cached recipe manifest regression, restore ASCII logo rendering in interactive init, and verify both paths with focused tests and smoke coverage."
+  -
+    author: "CODER"
+    body: "Verified: legacy cached recipe manifests without manifest.scenarios[].name no longer break init recipe cache reads; ASCII logo rendering is restored in interactive init; targeted tests, typechecks, prettier, bootstrap, and temp AGENTPLANE_HOME init smoke passed."
 events:
   -
     type: "status"
@@ -42,8 +48,15 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified: legacy cached recipe manifests without manifest.scenarios[].name no longer fail init recipe cache reads; ASCII logo rendering is covered; targeted recipe/init tests, typechecks, prettier, bootstrap, and temp AGENTPLANE_HOME init smoke passed."
+  -
+    type: "status"
+    at: "2026-04-22T16:00:17.107Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: legacy cached recipe manifests without manifest.scenarios[].name no longer break init recipe cache reads; ASCII logo rendering is restored in interactive init; targeted tests, typechecks, prettier, bootstrap, and temp AGENTPLANE_HOME init smoke passed."
 doc_version: 3
-doc_updated_at: "2026-04-22T15:59:54.208Z"
+doc_updated_at: "2026-04-22T16:00:17.108Z"
 doc_updated_by: "CODER"
 description: "Fix the v0.3.18 init regression that rejects cached recipe manifests with 'manifest.scenarios[0].name: expected string', restore the ASCII logo in the interactive init UI, and add regression coverage for both behaviors."
 sections:

--- a/.agentplane/tasks/202604221556-W3HD3Y/README.md
+++ b/.agentplane/tasks/202604221556-W3HD3Y/README.md
@@ -1,0 +1,139 @@
+---
+id: "202604221556-W3HD3Y"
+title: "Fix init recipe manifest validation and ASCII logo"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "cli"
+  - "init"
+  - "release"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-04-22T15:56:55.320Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-04-22T15:59:54.205Z"
+  updated_by: "CODER"
+  note: "Verified: legacy cached recipe manifests without manifest.scenarios[].name no longer fail init recipe cache reads; ASCII logo rendering is covered; targeted recipe/init tests, typechecks, prettier, bootstrap, and temp AGENTPLANE_HOME init smoke passed."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: fix the v0.3.18 init cached recipe manifest regression, restore ASCII logo rendering in interactive init, and verify both paths with focused tests and smoke coverage."
+events:
+  -
+    type: "status"
+    at: "2026-04-22T15:56:59.543Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: fix the v0.3.18 init cached recipe manifest regression, restore ASCII logo rendering in interactive init, and verify both paths with focused tests and smoke coverage."
+  -
+    type: "verify"
+    at: "2026-04-22T15:59:54.205Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: legacy cached recipe manifests without manifest.scenarios[].name no longer fail init recipe cache reads; ASCII logo rendering is covered; targeted recipe/init tests, typechecks, prettier, bootstrap, and temp AGENTPLANE_HOME init smoke passed."
+doc_version: 3
+doc_updated_at: "2026-04-22T15:59:54.208Z"
+doc_updated_by: "CODER"
+description: "Fix the v0.3.18 init regression that rejects cached recipe manifests with 'manifest.scenarios[0].name: expected string', restore the ASCII logo in the interactive init UI, and add regression coverage for both behaviors."
+sections:
+  Summary: |-
+    Fix init recipe manifest validation and ASCII logo
+    
+    Fix the v0.3.18 init regression that rejects cached recipe manifests with 'manifest.scenarios[0].name: expected string', restore the ASCII logo in the interactive init UI, and add regression coverage for both behaviors.
+  Scope: |-
+    - In scope: Fix the v0.3.18 init regression that rejects cached recipe manifests with 'manifest.scenarios[0].name: expected string', restore the ASCII logo in the interactive init UI, and add regression coverage for both behaviors.
+    - Out of scope: unrelated refactors not required for "Fix init recipe manifest validation and ASCII logo".
+  Plan: |-
+    Goal: fix the interactive init regression reported against v0.3.18 and restore the ASCII init logo.
+    
+    Plan:
+    1. Add a regression test for cached legacy recipe manifests where manifest.scenarios[].name is absent.
+    2. Normalize legacy scenario names from summary so init can list cached recipes without requiring users to clear ~/.agentplane/recipes.json.
+    3. Restore ASCII logo rendering in init v2 before the Setup section.
+    4. Add a focused UI regression test for the logo.
+    5. Run targeted unit tests, typecheck, formatting, and an init smoke with a legacy cached recipe file.
+  Verify Steps: |-
+    - bun run test:project -- recipes packages/recipes/src/index.test.ts
+    - bun run test:project -- agentplane packages/agentplane/src/cli/init-recipes-cache.test.ts packages/agentplane/src/cli/run-cli/commands/init/ui-v2.test.ts packages/agentplane/src/cli/run-cli/commands/init/prompts-v2.test.ts
+    - bun run --filter=@agentplaneorg/recipes typecheck
+    - bun run --filter=agentplane typecheck
+    - bunx prettier --check packages/recipes/src/manifest.ts packages/recipes/src/index.test.ts packages/agentplane/src/cli/init-recipes-cache.test.ts packages/agentplane/src/cli/run-cli/commands/init/ui-v2.ts packages/agentplane/src/cli/run-cli/commands/init/ui-v2.test.ts packages/agentplane/src/cli/run-cli/commands/init/orchestrate-v2.ts
+    - Init smoke with a temp AGENTPLANE_HOME containing a legacy cached recipe manifest without scenarios[].name
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-04-22T15:59:54.205Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: legacy cached recipe manifests without manifest.scenarios[].name no longer fail init recipe cache reads; ASCII logo rendering is covered; targeted recipe/init tests, typechecks, prettier, bootstrap, and temp AGENTPLANE_HOME init smoke passed.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-22T15:56:59.548Z, excerpt_hash=sha256:a7750058c01adf268b9764e75ae65b507b4edfccb650c8dc9a9f2cd4c2cf4e80
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Fix init recipe manifest validation and ASCII logo
+
+Fix the v0.3.18 init regression that rejects cached recipe manifests with 'manifest.scenarios[0].name: expected string', restore the ASCII logo in the interactive init UI, and add regression coverage for both behaviors.
+
+## Scope
+
+- In scope: Fix the v0.3.18 init regression that rejects cached recipe manifests with 'manifest.scenarios[0].name: expected string', restore the ASCII logo in the interactive init UI, and add regression coverage for both behaviors.
+- Out of scope: unrelated refactors not required for "Fix init recipe manifest validation and ASCII logo".
+
+## Plan
+
+Goal: fix the interactive init regression reported against v0.3.18 and restore the ASCII init logo.
+
+Plan:
+1. Add a regression test for cached legacy recipe manifests where manifest.scenarios[].name is absent.
+2. Normalize legacy scenario names from summary so init can list cached recipes without requiring users to clear ~/.agentplane/recipes.json.
+3. Restore ASCII logo rendering in init v2 before the Setup section.
+4. Add a focused UI regression test for the logo.
+5. Run targeted unit tests, typecheck, formatting, and an init smoke with a legacy cached recipe file.
+
+## Verify Steps
+
+- bun run test:project -- recipes packages/recipes/src/index.test.ts
+- bun run test:project -- agentplane packages/agentplane/src/cli/init-recipes-cache.test.ts packages/agentplane/src/cli/run-cli/commands/init/ui-v2.test.ts packages/agentplane/src/cli/run-cli/commands/init/prompts-v2.test.ts
+- bun run --filter=@agentplaneorg/recipes typecheck
+- bun run --filter=agentplane typecheck
+- bunx prettier --check packages/recipes/src/manifest.ts packages/recipes/src/index.test.ts packages/agentplane/src/cli/init-recipes-cache.test.ts packages/agentplane/src/cli/run-cli/commands/init/ui-v2.ts packages/agentplane/src/cli/run-cli/commands/init/ui-v2.test.ts packages/agentplane/src/cli/run-cli/commands/init/orchestrate-v2.ts
+- Init smoke with a temp AGENTPLANE_HOME containing a legacy cached recipe manifest without scenarios[].name
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-04-22T15:59:54.205Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: legacy cached recipe manifests without manifest.scenarios[].name no longer fail init recipe cache reads; ASCII logo rendering is covered; targeted recipe/init tests, typechecks, prettier, bootstrap, and temp AGENTPLANE_HOME init smoke passed.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-22T15:56:59.548Z, excerpt_hash=sha256:a7750058c01adf268b9764e75ae65b507b4edfccb650c8dc9a9f2cd4c2cf4e80
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/packages/agentplane/src/cli/init-recipes-cache.test.ts
+++ b/packages/agentplane/src/cli/init-recipes-cache.test.ts
@@ -1,0 +1,39 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  baseRecipeEntry,
+  baseRecipeManifest,
+  installRecipesCommandHarness,
+  requireRecipesTempHome,
+  scenarioDescriptor,
+} from "@agentplane/testkit/recipes";
+
+import { listCachedRecipes } from "./run-cli/commands/init/recipes.js";
+
+installRecipesCommandHarness();
+
+describe("init cached recipes", () => {
+  it("lists cached legacy scenario manifests that omit scenario name", async () => {
+    const scenario = { ...scenarioDescriptor(), name: undefined };
+    const manifest = baseRecipeManifest({ scenarios: [scenario] });
+    await writeFile(
+      path.join(requireRecipesTempHome(), "recipes.json"),
+      JSON.stringify(
+        {
+          schema_version: 1,
+          updated_at: "2026-04-22T00:00:00.000Z",
+          recipes: [baseRecipeEntry({ manifest })],
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    await expect(listCachedRecipes()).resolves.toEqual([
+      { id: "viewer", summary: "Preview tasks", version: "1.2.3" },
+    ]);
+  });
+});

--- a/packages/agentplane/src/cli/run-cli/commands/init/orchestrate-v2.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/orchestrate-v2.ts
@@ -36,7 +36,7 @@ import {
   promptWorkflowStep,
 } from "./steps/index.js";
 import type { InitV2PromptClack } from "./steps/contracts.js";
-import { outroError, outroSuccess, previewInstall, section } from "./ui-v2.js";
+import { introLogo, outroError, outroSuccess, previewInstall, section } from "./ui-v2.js";
 import { ensureAgentsFiles } from "./write-agents.js";
 import { ensureAgentplaneDirs, writeBackendStubs, writeInitConfig } from "./write-config.js";
 import { ensureInitRedmineEnvTemplate } from "./write-env.js";
@@ -86,6 +86,7 @@ export async function cmdInitV2(opts: {
   try {
     const promptClack = clack as InitV2PromptClack & Pick<InitV2ClackPrompts, "note">;
     clack.intro("AgentPlane init");
+    introLogo(clack);
     section(clack, "Setup", "Choose the project defaults before AgentPlane writes files.");
     const setup = await promptSetupProfileStep({
       clack: promptClack,

--- a/packages/agentplane/src/cli/run-cli/commands/init/ui-v2.test.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/ui-v2.test.ts
@@ -48,7 +48,7 @@ describe("init ui v2", () => {
     introLogo(clack);
 
     expect(clack.note).toHaveBeenCalledWith(expect.stringContaining("_   ____"));
-    expect(clack.note).toHaveBeenCalledWith(expect.stringContaining("\\___"));
+    expect(clack.note).toHaveBeenCalledWith(expect.stringContaining(String.raw`\___`));
   });
 
   it("emits preview output through Clack note", () => {

--- a/packages/agentplane/src/cli/run-cli/commands/init/ui-v2.test.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/ui-v2.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  introLogo,
   outroError,
   outroSuccess,
   previewConflicts,
@@ -39,6 +40,15 @@ describe("init ui v2", () => {
 
     expect(clack.log.step).toHaveBeenCalledWith("Setup Profile");
     expect(clack.note).toHaveBeenCalledWith("Pick a profile.");
+  });
+
+  it("emits the ASCII logo through a Clack note", () => {
+    const clack = clackMock();
+
+    introLogo(clack);
+
+    expect(clack.note).toHaveBeenCalledWith(expect.stringContaining("_   ____"));
+    expect(clack.note).toHaveBeenCalledWith(expect.stringContaining("\\___"));
   });
 
   it("emits preview output through Clack note", () => {

--- a/packages/agentplane/src/cli/run-cli/commands/init/ui-v2.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/ui-v2.ts
@@ -7,6 +7,15 @@ type InitV2PreviewItem = {
   value: string | number | boolean | null | undefined;
 };
 
+const INIT_ASCII_LOGO = String.raw`
+    _                    _   ____  _
+   / \   __ _  ___ _ __ | |_|  _ \| | __ _ _ __   ___
+  / _ \ / _\` |/ _ \ '_ \| __| |_) | |/ _\` | '_ \ / _ \
+ / ___ \ (_| |  __/ | | | |_|  __/| | (_| | | | |  __/
+/_/   \_\__, |\___|_| |_|\__|_|   |_|\__,_|_| |_|\___|
+        |___/
+`.trim();
+
 function stringifyPreviewValue(value: InitV2PreviewItem["value"]): string {
   if (value === true) return "yes";
   if (value === false) return "no";
@@ -30,6 +39,10 @@ export function section(
   if (message?.trim()) {
     clack.note(message.trim());
   }
+}
+
+export function introLogo(clack: Pick<InitV2ClackPrompts, "note">): void {
+  clack.note(INIT_ASCII_LOGO);
 }
 
 export function previewInstall(

--- a/packages/recipes/src/index.test.ts
+++ b/packages/recipes/src/index.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { RECIPES_SCENARIOS_DIR_NAME, RECIPES_VERSION, normalizeRecipeId } from "./index.js";
+import {
+  RECIPES_SCENARIOS_DIR_NAME,
+  RECIPES_VERSION,
+  normalizeRecipeId,
+  validateRecipeManifest,
+} from "./index.js";
 
 describe("@agentplaneorg/recipes", () => {
   it("exports version", () => {
@@ -10,5 +15,39 @@ describe("@agentplaneorg/recipes", () => {
   it("exports recipe domain helpers", () => {
     expect(RECIPES_SCENARIOS_DIR_NAME).toBe("scenarios");
     expect(normalizeRecipeId("demo")).toBe("demo");
+  });
+
+  it("normalizes legacy scenario descriptors that omit name", () => {
+    const manifest = validateRecipeManifest({
+      schema_version: "1",
+      kind: "project_overlay",
+      id: "viewer",
+      version: "1.0.0",
+      name: "Viewer",
+      summary: "Preview tasks",
+      agents: [
+        {
+          id: "viewer",
+          display_name: "Viewer",
+          role: "viewer",
+          summary: "Preview tasks",
+          file: "agents/viewer.md",
+        },
+      ],
+      scenarios: [
+        {
+          id: "viewer",
+          summary: "Launch the viewer",
+          use_when: ["Need a browser preview"],
+          required_inputs: [],
+          outputs: [],
+          agents_involved: ["viewer"],
+          run_profile: { mode: "analysis" },
+          file: "scenarios/viewer.json",
+        },
+      ],
+    });
+
+    expect(manifest.scenarios?.[0]?.name).toBe("Launch the viewer");
   });
 });

--- a/packages/recipes/src/manifest.ts
+++ b/packages/recipes/src/manifest.ts
@@ -150,10 +150,14 @@ function normalizeScenarios(raw: unknown): RecipeScenarioDescriptor[] {
     if (!isRecord(entry)) {
       throw new Error(invalidFieldMessage(`manifest.scenarios[${index}]`, "object"));
     }
+    const id = normalizeScenarioId(
+      normalizeRequiredString(entry.id, `manifest.scenarios[${index}].id`),
+    );
+    const summary = normalizeRequiredString(entry.summary, `manifest.scenarios[${index}].summary`);
     return {
-      id: normalizeScenarioId(normalizeRequiredString(entry.id, `manifest.scenarios[${index}].id`)),
-      name: normalizeRequiredString(entry.name, `manifest.scenarios[${index}].name`),
-      summary: normalizeRequiredString(entry.summary, `manifest.scenarios[${index}].summary`),
+      id,
+      name: normalizeOptionalString(entry.name, `manifest.scenarios[${index}].name`) ?? summary,
+      summary,
       description: normalizeOptionalString(
         entry.description,
         `manifest.scenarios[${index}].description`,


### PR DESCRIPTION
## Summary
- tolerate cached legacy recipe manifests where scenarios omit name and use summary as the display fallback
- restore ASCII logo rendering in interactive init v2
- add regression coverage for recipe manifest normalization, init cached recipe listing, and init logo output

## Verification
- bun run test:project -- recipes packages/recipes/src/index.test.ts
- bun run test:project -- agentplane packages/agentplane/src/cli/init-recipes-cache.test.ts packages/agentplane/src/cli/run-cli/commands/init/ui-v2.test.ts packages/agentplane/src/cli/run-cli/commands/init/prompts-v2.test.ts
- bun run --filter=@agentplaneorg/recipes typecheck
- bun run --filter=agentplane typecheck
- bunx prettier --check targeted files
- temp AGENTPLANE_HOME init smoke with legacy cached recipe manifest without scenarios[].name
- pre-push standard fast gate