### PR TITLE
Fix init legacy recipe cache migration

### DIFF
--- a/.agentplane/tasks/202604221751-WBAAD1/README.md
+++ b/.agentplane/tasks/202604221751-WBAAD1/README.md
@@ -1,0 +1,135 @@
+---
+id: "202604221751-WBAAD1"
+title: "Migrate legacy recipe cache scenarios during init"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "cli"
+  - "init"
+  - "recipes"
+  - "release"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-04-22T17:51:09.740Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-04-22T17:56:26.116Z"
+  updated_by: "CODER"
+  note: "Verified legacy cached recipe migration during init."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: fixing init recipe cache migration for legacy cached scenario descriptors that omit file metadata, with persistence and release-path regression coverage."
+events:
+  -
+    type: "status"
+    at: "2026-04-22T17:51:10.139Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: fixing init recipe cache migration for legacy cached scenario descriptors that omit file metadata, with persistence and release-path regression coverage."
+  -
+    type: "verify"
+    at: "2026-04-22T17:56:26.116Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified legacy cached recipe migration during init."
+doc_version: 3
+doc_updated_at: "2026-04-22T17:56:26.123Z"
+doc_updated_by: "CODER"
+description: "Fix agentplane init for legacy cached recipe scenarios that omit file metadata by normalizing and persisting old recipe cache entries instead of aborting init."
+sections:
+  Summary: |-
+    Migrate legacy recipe cache scenarios during init
+    
+    Fix agentplane init for legacy cached recipe scenarios that omit file metadata by normalizing and persisting old recipe cache entries instead of aborting init.
+  Scope: |-
+    - In scope: Fix agentplane init for legacy cached recipe scenarios that omit file metadata by normalizing and persisting old recipe cache entries instead of aborting init.
+    - Out of scope: unrelated refactors not required for "Migrate legacy recipe cache scenarios during init".
+  Plan: |-
+    1. Inspect recipe cache read/write flow and current manifest v1 normalization.
+    2. Add legacy v1 scenario file fallback using a deterministic scenario path derived from the normalized scenario id.
+    3. Persist migrated cached recipe manifests back to recipes.json when old cache entries are normalized.
+    4. Add regression coverage for a minimal legacy scenario with no file field and for cache rewrite behavior.
+    5. Run targeted recipes/init/critical tests and release parity before commit.
+  Verify Steps: |-
+    1. Review the requested outcome for "Migrate legacy recipe cache scenarios during init". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-04-22T17:56:26.116Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified legacy cached recipe migration during init.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-22T17:51:10.145Z, excerpt_hash=sha256:ce1ebdcedf07b116a673f860cb91f6ca4e0c7daa010556f752078c300044ea2f
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Legacy schema_version=1 cached recipe scenarios without file now normalize to scenarios/<scenario-id>.json and init read path persists the normalized recipes.json.
+      Impact: agentplane init no longer aborts on old cached recipe scenario descriptors missing modern fields.
+      Resolution: Covered by recipes manifest unit test, init cache persistence test, full interactive init v2 test, critical init exit-code test, package typechecks, agentplane build, release parity, doctor, and policy routing.
+id_source: "generated"
+---
+## Summary
+
+Migrate legacy recipe cache scenarios during init
+
+Fix agentplane init for legacy cached recipe scenarios that omit file metadata by normalizing and persisting old recipe cache entries instead of aborting init.
+
+## Scope
+
+- In scope: Fix agentplane init for legacy cached recipe scenarios that omit file metadata by normalizing and persisting old recipe cache entries instead of aborting init.
+- Out of scope: unrelated refactors not required for "Migrate legacy recipe cache scenarios during init".
+
+## Plan
+
+1. Inspect recipe cache read/write flow and current manifest v1 normalization.
+2. Add legacy v1 scenario file fallback using a deterministic scenario path derived from the normalized scenario id.
+3. Persist migrated cached recipe manifests back to recipes.json when old cache entries are normalized.
+4. Add regression coverage for a minimal legacy scenario with no file field and for cache rewrite behavior.
+5. Run targeted recipes/init/critical tests and release parity before commit.
+
+## Verify Steps
+
+1. Review the requested outcome for "Migrate legacy recipe cache scenarios during init". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-04-22T17:56:26.116Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified legacy cached recipe migration during init.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-22T17:51:10.145Z, excerpt_hash=sha256:ce1ebdcedf07b116a673f860cb91f6ca4e0c7daa010556f752078c300044ea2f
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Legacy schema_version=1 cached recipe scenarios without file now normalize to scenarios/<scenario-id>.json and init read path persists the normalized recipes.json.
+  Impact: agentplane init no longer aborts on old cached recipe scenario descriptors missing modern fields.
+  Resolution: Covered by recipes manifest unit test, init cache persistence test, full interactive init v2 test, critical init exit-code test, package typechecks, agentplane build, release parity, doctor, and policy routing.

--- a/.agentplane/tasks/202604221751-WBAAD1/README.md
+++ b/.agentplane/tasks/202604221751-WBAAD1/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202604221751-WBAAD1"
 title: "Migrate legacy recipe cache scenarios during init"
-status: "DOING"
+result_summary: "Implemented legacy scenario file fallback, init cache migration writeback, and regression coverage for full interactive init."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -24,11 +25,16 @@ verification:
   updated_at: "2026-04-22T17:56:26.116Z"
   updated_by: "CODER"
   note: "Verified legacy cached recipe migration during init."
-commit: null
+commit:
+  hash: "a9338d82b23c7a34d6515abe6e456ee41dd2e8ee"
+  message: "🚧 WBAAD1 task: migrate legacy recipe cache scenarios"
 comments:
   -
     author: "CODER"
     body: "Start: fixing init recipe cache migration for legacy cached scenario descriptors that omit file metadata, with persistence and release-path regression coverage."
+  -
+    author: "CODER"
+    body: "Verified: legacy cached recipe scenarios without file now normalize and persist during init read path."
 events:
   -
     type: "status"
@@ -43,8 +49,15 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified legacy cached recipe migration during init."
+  -
+    type: "status"
+    at: "2026-04-22T17:56:57.673Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: legacy cached recipe scenarios without file now normalize and persist during init read path."
 doc_version: 3
-doc_updated_at: "2026-04-22T17:56:26.123Z"
+doc_updated_at: "2026-04-22T17:56:57.673Z"
 doc_updated_by: "CODER"
 description: "Fix agentplane init for legacy cached recipe scenarios that omit file metadata by normalizing and persisting old recipe cache entries instead of aborting init."
 sections:

--- a/packages/agentplane/src/cli/init-recipes-cache.test.ts
+++ b/packages/agentplane/src/cli/init-recipes-cache.test.ts
@@ -50,9 +50,7 @@ describe("init cached recipes", () => {
     ) as {
       recipes: [{ manifest: { scenarios: [{ file: string; use_when: string[] }] } }];
     };
-    expect(migrated.recipes[0]?.manifest.scenarios[0]?.file).toBe(
-      `scenarios/${scenario.id}.json`,
-    );
+    expect(migrated.recipes[0]?.manifest.scenarios[0]?.file).toBe(`scenarios/${scenario.id}.json`);
     expect(migrated.recipes[0]?.manifest.scenarios[0]?.use_when).toEqual([scenario.summary]);
   });
 });

--- a/packages/agentplane/src/cli/init-recipes-cache.test.ts
+++ b/packages/agentplane/src/cli/init-recipes-cache.test.ts
@@ -1,4 +1,4 @@
-import { writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -24,6 +24,7 @@ describe("init cached recipes", () => {
       outputs: undefined,
       agents_involved: undefined,
       run_profile: undefined,
+      file: undefined,
     };
     const manifest = baseRecipeManifest({ scenarios: [scenario] });
     await writeFile(
@@ -43,5 +44,15 @@ describe("init cached recipes", () => {
     await expect(listCachedRecipes()).resolves.toEqual([
       { id: "viewer", summary: "Preview tasks", version: "1.2.3" },
     ]);
+
+    const migrated = JSON.parse(
+      await readFile(path.join(requireRecipesTempHome(), "recipes.json"), "utf8"),
+    ) as {
+      recipes: [{ manifest: { scenarios: [{ file: string; use_when: string[] }] } }];
+    };
+    expect(migrated.recipes[0]?.manifest.scenarios[0]?.file).toBe(
+      `scenarios/${scenario.id}.json`,
+    );
+    expect(migrated.recipes[0]?.manifest.scenarios[0]?.use_when).toEqual([scenario.summary]);
   });
 });

--- a/packages/agentplane/src/cli/run-cli.core.init.v2.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.init.v2.test.ts
@@ -296,9 +296,7 @@ describe("runCli interactive init UI", () => {
     ) as {
       recipes: [{ manifest: { scenarios: [{ file: string; use_when: string[] }] } }];
     };
-    expect(migrated.recipes[0]?.manifest.scenarios[0]?.file).toBe(
-      "scenarios/RECIPE_SCENARIO.json",
-    );
+    expect(migrated.recipes[0]?.manifest.scenarios[0]?.file).toBe("scenarios/RECIPE_SCENARIO.json");
     expect(migrated.recipes[0]?.manifest.scenarios[0]?.use_when).toEqual(["Recipe scenario"]);
   });
 

--- a/packages/agentplane/src/cli/run-cli.core.init.v2.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.init.v2.test.ts
@@ -113,6 +113,7 @@ async function writeLegacyRecipeCache(): Promise<void> {
     outputs: undefined,
     agents_involved: undefined,
     run_profile: undefined,
+    file: undefined,
   };
   const manifest = baseRecipeManifest({ scenarios: [scenario] });
   await writeFile(
@@ -290,6 +291,15 @@ describe("runCli interactive init UI", () => {
     });
     expect(mocks.outroMock).toHaveBeenCalledWith(`AgentPlane initialized in ${root}.`);
     await expect(pathExists(path.join(root, ".agentplane", "config.json"))).resolves.toBe(true);
+    const migrated = JSON.parse(
+      await readFile(path.join(process.env.AGENTPLANE_HOME ?? "", "recipes.json"), "utf8"),
+    ) as {
+      recipes: [{ manifest: { scenarios: [{ file: string; use_when: string[] }] } }];
+    };
+    expect(migrated.recipes[0]?.manifest.scenarios[0]?.file).toBe(
+      "scenarios/RECIPE_SCENARIO.json",
+    );
+    expect(migrated.recipes[0]?.manifest.scenarios[0]?.use_when).toEqual(["Recipe scenario"]);
   });
 
   it("keeps --experimental-ui as a compatibility alias", async () => {

--- a/packages/agentplane/src/cli/run-cli.critical.exit-codes.test.ts
+++ b/packages/agentplane/src/cli/run-cli.critical.exit-codes.test.ts
@@ -71,7 +71,6 @@ describeCritical("critical: exit codes contract", () => {
                     {
                       id: "viewer",
                       summary: "Launch the viewer",
-                      file: "scenarios/viewer.json",
                     },
                   ],
                 },

--- a/packages/agentplane/src/cli/run-cli/commands/init/recipes.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/recipes.ts
@@ -1,5 +1,5 @@
 import { cmdRecipeAddParsed } from "../../../../commands/recipes/impl/commands/add.js";
-import { readInstalledRecipesFile } from "../../../../commands/recipes/impl/installed-recipes.js";
+import { readAndMigrateInstalledRecipesFile } from "../../../../commands/recipes/impl/installed-recipes.js";
 import { resolveInstalledRecipesPath } from "../../../../commands/recipes/impl/paths.js";
 import { CliError } from "../../../../shared/errors.js";
 
@@ -10,7 +10,7 @@ type CachedRecipeInfo = {
 };
 
 export async function listCachedRecipes(): Promise<CachedRecipeInfo[]> {
-  const cached = await readInstalledRecipesFile(resolveInstalledRecipesPath());
+  const cached = await readAndMigrateInstalledRecipesFile(resolveInstalledRecipesPath());
   return cached.recipes.map((recipe) => ({
     id: recipe.id,
     summary: recipe.manifest.summary,

--- a/packages/agentplane/src/commands/recipes/impl/installed-recipes.ts
+++ b/packages/agentplane/src/commands/recipes/impl/installed-recipes.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
+import { canonicalizeJson } from "@agentplaneorg/core/tasks";
 import {
   normalizeRecipeTags,
   validateRecipeManifest,
@@ -45,10 +46,36 @@ function sortInstalledRecipes(file: InstalledRecipesFile): InstalledRecipesFile 
   return { schema_version: 1, updated_at: file.updated_at, recipes };
 }
 
+function canonicalJsonText(value: unknown): string {
+  return JSON.stringify(canonicalizeJson(value));
+}
+
+function installedRecipesNeedMigration(raw: unknown, normalized: InstalledRecipesFile): boolean {
+  return canonicalJsonText(raw) !== canonicalJsonText(normalized);
+}
+
 export async function readInstalledRecipesFile(filePath: string): Promise<InstalledRecipesFile> {
   try {
     const raw = JSON.parse(await readFile(filePath, "utf8")) as unknown;
     return sortInstalledRecipes(validateInstalledRecipesFile(raw));
+  } catch (err) {
+    const code = (err as { code?: string } | null)?.code;
+    if (code === "ENOENT") return { schema_version: 1, updated_at: "", recipes: [] };
+    throw err;
+  }
+}
+
+export async function readAndMigrateInstalledRecipesFile(
+  filePath: string,
+): Promise<InstalledRecipesFile> {
+  try {
+    const raw = JSON.parse(await readFile(filePath, "utf8")) as unknown;
+    const normalized = sortInstalledRecipes(validateInstalledRecipesFile(raw));
+    if (installedRecipesNeedMigration(raw, normalized)) {
+      await mkdir(path.dirname(filePath), { recursive: true });
+      await writeJsonStableIfChanged(filePath, normalized);
+    }
+    return normalized;
   } catch (err) {
     const code = (err as { code?: string } | null)?.code;
     if (code === "ENOENT") return { schema_version: 1, updated_at: "", recipes: [] };

--- a/packages/recipes/src/index.test.ts
+++ b/packages/recipes/src/index.test.ts
@@ -38,7 +38,6 @@ describe("@agentplaneorg/recipes", () => {
         {
           id: "viewer",
           summary: "Launch the viewer",
-          file: "scenarios/viewer.json",
         },
       ],
     });
@@ -49,6 +48,7 @@ describe("@agentplaneorg/recipes", () => {
     expect(manifest.scenarios?.[0]?.outputs).toEqual([]);
     expect(manifest.scenarios?.[0]?.agents_involved).toEqual([]);
     expect(manifest.scenarios?.[0]?.run_profile).toEqual({ mode: "analysis" });
+    expect(manifest.scenarios?.[0]?.file).toBe("scenarios/viewer.json");
   });
 
   it("keeps v2 scenario descriptors strict", () => {
@@ -78,5 +78,39 @@ describe("@agentplaneorg/recipes", () => {
         ],
       }),
     ).toThrow("Invalid field manifest.scenarios[0].use_when: expected string[]");
+  });
+
+  it("keeps v2 scenario files strict", () => {
+    expect(() =>
+      validateRecipeManifest({
+        schema_version: "2",
+        kind: "project_overlay",
+        id: "viewer",
+        version: "1.0.0",
+        name: "Viewer",
+        summary: "Preview tasks",
+        agents: [
+          {
+            id: "viewer",
+            display_name: "Viewer",
+            role: "viewer",
+            summary: "Preview tasks",
+            file: "agents/viewer.md",
+          },
+        ],
+        scenarios: [
+          {
+            id: "viewer",
+            name: "Launch the viewer",
+            summary: "Launch the viewer",
+            use_when: ["Preview tasks"],
+            required_inputs: [],
+            outputs: [],
+            agents_involved: ["viewer"],
+            run_profile: { mode: "analysis" },
+          },
+        ],
+      }),
+    ).toThrow("Invalid field manifest.scenarios[0].file: expected string");
   });
 });

--- a/packages/recipes/src/manifest.ts
+++ b/packages/recipes/src/manifest.ts
@@ -150,6 +150,12 @@ function normalizeLegacyRunProfile(raw: unknown, field: string): RecipeRunProfil
   return raw === undefined ? { mode: "analysis" } : normalizeRunProfile(raw, field);
 }
 
+function normalizeLegacyScenarioFile(raw: unknown, field: string, scenarioId: string): string {
+  const value =
+    raw === undefined ? `scenarios/${scenarioId}.json` : normalizeRequiredString(raw, field);
+  return normalizeRecipeRelativePath(field, value);
+}
+
 function normalizeScenarios(
   raw: unknown,
   opts?: { legacyScenarioDefaults?: boolean },
@@ -230,10 +236,12 @@ function normalizeScenarios(
       run_profile: legacyDefaults
         ? normalizeLegacyRunProfile(entry.run_profile, `manifest.scenarios[${index}].run_profile`)
         : normalizeRunProfile(entry.run_profile, `manifest.scenarios[${index}].run_profile`),
-      file: normalizeRecipeRelativePath(
-        `manifest.scenarios[${index}].file`,
-        normalizeRequiredString(entry.file, `manifest.scenarios[${index}].file`),
-      ),
+      file: legacyDefaults
+        ? normalizeLegacyScenarioFile(entry.file, `manifest.scenarios[${index}].file`, id)
+        : normalizeRecipeRelativePath(
+            `manifest.scenarios[${index}].file`,
+            normalizeRequiredString(entry.file, `manifest.scenarios[${index}].file`),
+          ),
     };
   });
 }


### PR DESCRIPTION
## Summary
- migrate legacy cached recipe scenario descriptors that omit modern fields, including scenario file
- persist normalized recipes.json during init cached-recipes read path
- add regression coverage for cache persistence, full interactive init, critical init, and recipes manifest strictness

## Verification
- bun run test:project -- recipes packages/recipes/src/index.test.ts
- bun run test:project -- agentplane packages/agentplane/src/cli/init-recipes-cache.test.ts
- bun run test:project -- cli-core packages/agentplane/src/cli/run-cli.core.init.v2.test.ts
- bun run test:project -- critical packages/agentplane/src/cli/run-cli.critical.exit-codes.test.ts
- bun run test:project -- agentplane packages/agentplane/src/cli/run-cli/commands/init/ui-v2.test.ts
- bun run --filter=@agentplaneorg/recipes typecheck
- bun run --filter=agentplane typecheck
- bun run --filter=@agentplaneorg/recipes build
- bun run --filter=agentplane build
- bun run release:parity
- agentplane doctor
- node .agentplane/policy/check-routing.mjs
- pre-push fast CI: 236 test files, 1371 passed, 2 skipped; critical E2E: 5 files, 14 passed