### PR TITLE
Close v0.3.24 release task

### DIFF
--- a/.agentplane/tasks/202604231823-3425P4/README.md
+++ b/.agentplane/tasks/202604231823-3425P4/README.md
@@ -1,10 +1,12 @@
 ---
 id: "202604231823-3425P4"
 title: "Publish v0.3.24 patch release"
-status: "DOING"
+result_summary: "Release v0.3.24 is published: release commit 62f379389fd7f36a591a20384287b08ca17ce5f7 was merged into main via PR #517 as merge commit bcfcfab7bfccc7532fe43a64b68d879c715f0c7e, tag v0.3.24 is on the remote, and Publish to npm run 24880065158 completed successfully."
+risk_level: "low"
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 8
+revision: 9
 origin:
   system: "manual"
 depends_on: []
@@ -28,7 +30,9 @@ verification:
     Command: AGENTPLANE_RELEASE_DRY_RUN=1 agentplane release apply; Result: pass; Evidence: prepared release commit 62f379389fd7f36a591a20384287b08ca17ce5f7 and local tag v0.3.24 with report .agentplane/.release/apply/2026-04-23T18-25-27-747Z.json. Scope: direct-mode release mutation path before protected-main recovery.
     Command: gh pr create/merge for #517; Result: pass; Evidence: PR https://github.com/basilisk-labs/agentplane/pull/517 merged into main as bcfcfab7bfccc7532fe43a64b68d879c715f0c7e while preserving the tagged release commit in main history. Scope: protected-main recovery for the release commit.
     Command: gh run watch 24880065158 --exit-status; Result: pass; Evidence: Publish to npm completed successfully for merge SHA bcfcfab7bfccc7532fe43a64b68d879c715f0c7e. Scope: hosted publication evidence for v0.3.24.
-commit: null
+commit:
+  hash: "e9c30e71aff43a854fa3f0b5834ce3430d903823"
+  message: "✅ 3425P4 meta: done"
 comments:
   -
     author: "CODER"
@@ -39,6 +43,9 @@ comments:
   -
     author: "CODER"
     body: "Start: continue the blocked v0.3.24 release through the protected-main recovery route by opening a PR from codex/release-v0.3.24, merging it without squash so the tagged release commit stays in main history, and then recording final publication evidence."
+  -
+    author: "CODER"
+    body: "Verified: published v0.3.24 through the protected-main recovery path, preserved the tagged release commit in main history, and confirmed the hosted Publish to npm workflow succeeded for the merged release SHA."
 events:
   -
     type: "status"
@@ -72,8 +79,15 @@ events:
       Command: AGENTPLANE_RELEASE_DRY_RUN=1 agentplane release apply; Result: pass; Evidence: prepared release commit 62f379389fd7f36a591a20384287b08ca17ce5f7 and local tag v0.3.24 with report .agentplane/.release/apply/2026-04-23T18-25-27-747Z.json. Scope: direct-mode release mutation path before protected-main recovery.
       Command: gh pr create/merge for #517; Result: pass; Evidence: PR https://github.com/basilisk-labs/agentplane/pull/517 merged into main as bcfcfab7bfccc7532fe43a64b68d879c715f0c7e while preserving the tagged release commit in main history. Scope: protected-main recovery for the release commit.
       Command: gh run watch 24880065158 --exit-status; Result: pass; Evidence: Publish to npm completed successfully for merge SHA bcfcfab7bfccc7532fe43a64b68d879c715f0c7e. Scope: hosted publication evidence for v0.3.24.
+  -
+    type: "status"
+    at: "2026-04-24T08:33:31.499Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: published v0.3.24 through the protected-main recovery path, preserved the tagged release commit in main history, and confirmed the hosted Publish to npm workflow succeeded for the merged release SHA."
 doc_version: 3
-doc_updated_at: "2026-04-24T08:33:23.012Z"
+doc_updated_at: "2026-04-24T08:33:31.499Z"
 doc_updated_by: "CODER"
 description: "Cut the next patch release for the completed 0.3 foundation stabilization work after all open tasks are closed, the release notes are updated, and the direct-mode release flow verifies cleanly."
 sections:

--- a/.agentplane/tasks/202604231823-3425P4/README.md
+++ b/.agentplane/tasks/202604231823-3425P4/README.md
@@ -1,0 +1,156 @@
+---
+id: "202604231823-3425P4"
+title: "Publish v0.3.24 patch release"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 8
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "ci"
+  - "release"
+  - "v0.3"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-04-23T18:23:55.658Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-04-24T08:33:23.003Z"
+  updated_by: "CODER"
+  note: |-
+    Command: agentplane release plan --patch; Result: pass; Evidence: release plan .agentplane/.release/plan/2026-04-23T18-24-15-266Z targeted v0.3.24 from v0.3.23. Scope: release target freeze for the patch line.
+    Command: ./node_modules/.bin/prettier docs/releases/v0.3.24.md --check; Result: pass; Evidence: release notes formatting is clean. Scope: authored release notes for v0.3.24.
+    Command: AGENTPLANE_RELEASE_DRY_RUN=1 agentplane release apply; Result: pass; Evidence: prepared release commit 62f379389fd7f36a591a20384287b08ca17ce5f7 and local tag v0.3.24 with report .agentplane/.release/apply/2026-04-23T18-25-27-747Z.json. Scope: direct-mode release mutation path before protected-main recovery.
+    Command: gh pr create/merge for #517; Result: pass; Evidence: PR https://github.com/basilisk-labs/agentplane/pull/517 merged into main as bcfcfab7bfccc7532fe43a64b68d879c715f0c7e while preserving the tagged release commit in main history. Scope: protected-main recovery for the release commit.
+    Command: gh run watch 24880065158 --exit-status; Result: pass; Evidence: Publish to npm completed successfully for merge SHA bcfcfab7bfccc7532fe43a64b68d879c715f0c7e. Scope: hosted publication evidence for v0.3.24.
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: freeze the v0.3.24 release target from the current clean main state, author the release notes from the landed foundation work, rerun the release verification path, and only then execute release apply --push --yes."
+  -
+    author: "CODER"
+    body: "Blocked: release apply prepared local commit 62f379389fd7f36a591a20384287b08ca17ce5f7 and remote tag v0.3.24, but protected-main push was rejected with GH006 and the available GitHub integration cannot create the required recovery PR (403 Resource not accessible by integration); remaining work is to open and merge a PR from codex/release-v0.3.24 into main so the tagged release commit lands on the publication branch."
+  -
+    author: "CODER"
+    body: "Start: continue the blocked v0.3.24 release through the protected-main recovery route by opening a PR from codex/release-v0.3.24, merging it without squash so the tagged release commit stays in main history, and then recording final publication evidence."
+events:
+  -
+    type: "status"
+    at: "2026-04-23T18:24:07.472Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: freeze the v0.3.24 release target from the current clean main state, author the release notes from the landed foundation work, rerun the release verification path, and only then execute release apply --push --yes."
+  -
+    type: "status"
+    at: "2026-04-23T18:27:20.238Z"
+    author: "CODER"
+    from: "DOING"
+    to: "BLOCKED"
+    note: "Blocked: release apply prepared local commit 62f379389fd7f36a591a20384287b08ca17ce5f7 and remote tag v0.3.24, but protected-main push was rejected with GH006 and the available GitHub integration cannot create the required recovery PR (403 Resource not accessible by integration); remaining work is to open and merge a PR from codex/release-v0.3.24 into main so the tagged release commit lands on the publication branch."
+  -
+    type: "status"
+    at: "2026-04-24T08:28:04.389Z"
+    author: "CODER"
+    from: "BLOCKED"
+    to: "DOING"
+    note: "Start: continue the blocked v0.3.24 release through the protected-main recovery route by opening a PR from codex/release-v0.3.24, merging it without squash so the tagged release commit stays in main history, and then recording final publication evidence."
+  -
+    type: "verify"
+    at: "2026-04-24T08:33:23.003Z"
+    author: "CODER"
+    state: "ok"
+    note: |-
+      Command: agentplane release plan --patch; Result: pass; Evidence: release plan .agentplane/.release/plan/2026-04-23T18-24-15-266Z targeted v0.3.24 from v0.3.23. Scope: release target freeze for the patch line.
+      Command: ./node_modules/.bin/prettier docs/releases/v0.3.24.md --check; Result: pass; Evidence: release notes formatting is clean. Scope: authored release notes for v0.3.24.
+      Command: AGENTPLANE_RELEASE_DRY_RUN=1 agentplane release apply; Result: pass; Evidence: prepared release commit 62f379389fd7f36a591a20384287b08ca17ce5f7 and local tag v0.3.24 with report .agentplane/.release/apply/2026-04-23T18-25-27-747Z.json. Scope: direct-mode release mutation path before protected-main recovery.
+      Command: gh pr create/merge for #517; Result: pass; Evidence: PR https://github.com/basilisk-labs/agentplane/pull/517 merged into main as bcfcfab7bfccc7532fe43a64b68d879c715f0c7e while preserving the tagged release commit in main history. Scope: protected-main recovery for the release commit.
+      Command: gh run watch 24880065158 --exit-status; Result: pass; Evidence: Publish to npm completed successfully for merge SHA bcfcfab7bfccc7532fe43a64b68d879c715f0c7e. Scope: hosted publication evidence for v0.3.24.
+doc_version: 3
+doc_updated_at: "2026-04-24T08:33:23.012Z"
+doc_updated_by: "CODER"
+description: "Cut the next patch release for the completed 0.3 foundation stabilization work after all open tasks are closed, the release notes are updated, and the direct-mode release flow verifies cleanly."
+sections:
+  Summary: |-
+    Publish v0.3.24 patch release
+    
+    Cut the next patch release for the completed 0.3 foundation stabilization work after all open tasks are closed, the release notes are updated, and the direct-mode release flow verifies cleanly.
+  Scope: |-
+    - In scope: Cut the next patch release for the completed 0.3 foundation stabilization work after all open tasks are closed, the release notes are updated, and the direct-mode release flow verifies cleanly.
+    - Out of scope: unrelated refactors not required for "Publish v0.3.24 patch release".
+  Plan: "Release plan: version=0.3.24, tag=v0.3.24, scope=publish the completed 0.3 foundation stabilization work from main; update release notes, run the direct-mode release verification path, and publish via release apply --push --yes once all gates pass."
+  Verify Steps: |-
+    1. Confirm the requested release outcome for v0.3.24 and the authored notes file. Expected: the release task scope and docs/releases/v0.3.24.md match the shipped changes.
+    2. Run the release verification path before publication. Expected: release plan and required checks pass without unexpected regressions.
+    3. Run the direct-mode publication route. Expected: release apply publishes the version bump commit and v0.3.24 tag, and any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-04-24T08:33:23.003Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Command: agentplane release plan --patch; Result: pass; Evidence: release plan .agentplane/.release/plan/2026-04-23T18-24-15-266Z targeted v0.3.24 from v0.3.23. Scope: release target freeze for the patch line.
+    Command: ./node_modules/.bin/prettier docs/releases/v0.3.24.md --check; Result: pass; Evidence: release notes formatting is clean. Scope: authored release notes for v0.3.24.
+    Command: AGENTPLANE_RELEASE_DRY_RUN=1 agentplane release apply; Result: pass; Evidence: prepared release commit 62f379389fd7f36a591a20384287b08ca17ce5f7 and local tag v0.3.24 with report .agentplane/.release/apply/2026-04-23T18-25-27-747Z.json. Scope: direct-mode release mutation path before protected-main recovery.
+    Command: gh pr create/merge for #517; Result: pass; Evidence: PR https://github.com/basilisk-labs/agentplane/pull/517 merged into main as bcfcfab7bfccc7532fe43a64b68d879c715f0c7e while preserving the tagged release commit in main history. Scope: protected-main recovery for the release commit.
+    Command: gh run watch 24880065158 --exit-status; Result: pass; Evidence: Publish to npm completed successfully for merge SHA bcfcfab7bfccc7532fe43a64b68d879c715f0c7e. Scope: hosted publication evidence for v0.3.24.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-24T08:28:04.401Z, excerpt_hash=sha256:5354ecfcde17d71775959e0e3b8224b487d87b2c8b7c71dfeced70a9d6e8d9b3
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Publish v0.3.24 patch release
+
+Cut the next patch release for the completed 0.3 foundation stabilization work after all open tasks are closed, the release notes are updated, and the direct-mode release flow verifies cleanly.
+
+## Scope
+
+- In scope: Cut the next patch release for the completed 0.3 foundation stabilization work after all open tasks are closed, the release notes are updated, and the direct-mode release flow verifies cleanly.
+- Out of scope: unrelated refactors not required for "Publish v0.3.24 patch release".
+
+## Plan
+
+Release plan: version=0.3.24, tag=v0.3.24, scope=publish the completed 0.3 foundation stabilization work from main; update release notes, run the direct-mode release verification path, and publish via release apply --push --yes once all gates pass.
+
+## Verify Steps
+
+1. Confirm the requested release outcome for v0.3.24 and the authored notes file. Expected: the release task scope and docs/releases/v0.3.24.md match the shipped changes.
+2. Run the release verification path before publication. Expected: release plan and required checks pass without unexpected regressions.
+3. Run the direct-mode publication route. Expected: release apply publishes the version bump commit and v0.3.24 tag, and any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-04-24T08:33:23.003Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: agentplane release plan --patch; Result: pass; Evidence: release plan .agentplane/.release/plan/2026-04-23T18-24-15-266Z targeted v0.3.24 from v0.3.23. Scope: release target freeze for the patch line.
+Command: ./node_modules/.bin/prettier docs/releases/v0.3.24.md --check; Result: pass; Evidence: release notes formatting is clean. Scope: authored release notes for v0.3.24.
+Command: AGENTPLANE_RELEASE_DRY_RUN=1 agentplane release apply; Result: pass; Evidence: prepared release commit 62f379389fd7f36a591a20384287b08ca17ce5f7 and local tag v0.3.24 with report .agentplane/.release/apply/2026-04-23T18-25-27-747Z.json. Scope: direct-mode release mutation path before protected-main recovery.
+Command: gh pr create/merge for #517; Result: pass; Evidence: PR https://github.com/basilisk-labs/agentplane/pull/517 merged into main as bcfcfab7bfccc7532fe43a64b68d879c715f0c7e while preserving the tagged release commit in main history. Scope: protected-main recovery for the release commit.
+Command: gh run watch 24880065158 --exit-status; Result: pass; Evidence: Publish to npm completed successfully for merge SHA bcfcfab7bfccc7532fe43a64b68d879c715f0c7e. Scope: hosted publication evidence for v0.3.24.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-24T08:28:04.401Z, excerpt_hash=sha256:5354ecfcde17d71775959e0e3b8224b487d87b2c8b7c71dfeced70a9d6e8d9b3
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings


### PR DESCRIPTION
## Summary

Close the `202604231823-3425P4` release task after `v0.3.24` publication completed.

## Included

- task artifact updates for `202604231823-3425P4`
- verification evidence covering release plan, protected-main recovery PR #517, and successful `Publish to npm`
- deterministic task close commit after release publication

## Evidence

- release PR merged: https://github.com/basilisk-labs/agentplane/pull/517
- merge commit on main: `bcfcfab7bfccc7532fe43a64b68d879c715f0c7e`
- publish workflow succeeded: https://github.com/basilisk-labs/agentplane/actions/runs/24880065158
- task close commits on this branch: `e9c30e71aff4e6f7fa9304bf0d046dfeea0d6b8c`, `880e145eac87f1044a8bb1e27dfb1cfc9c9eca4c`
