### PR TITLE
Close v0.3.26 release task

### DIFF
--- a/.agentplane/tasks/202604241538-EGVKSE/README.md
+++ b/.agentplane/tasks/202604241538-EGVKSE/README.md
@@ -1,0 +1,132 @@
+---
+id: "202604241538-EGVKSE"
+title: "Publish next v0.3 patch release after freeze cleanup"
+result_summary: "Published v0.3.26: npm packages agentplane, @agentplaneorg/core, and @agentplaneorg/recipes are available at 0.3.26; GitHub Release v0.3.26 is public."
+status: "DONE"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "release"
+  - "v0.3"
+verify:
+  - "agentplane release apply --push --yes"
+  - "bun run release:ci-check"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-04-24T15:38:48.225Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-04-24T17:40:45.251Z"
+  updated_by: "CODER"
+  note: "release v0.3.26 verified: release:ci-check passed locally, release apply pushed v0.3.26, PR #520 merged to main, Publish to npm run 24903280575 succeeded, npm registry exposes agentplane/core/recipes 0.3.26, GitHub Release v0.3.26 published"
+commit:
+  hash: "1f9f716ac68d6e54d82b258bbf6108401925233a"
+  message: "✨ release: publish v0.3.26"
+comments:
+  -
+    author: "CODER"
+    body: "Start: remove the requested audit artifact, prepare v0.3.26 release metadata, run the full release gate, and publish through the direct-mode release route."
+  -
+    author: "CODER"
+    body: "Verified: v0.3.26 is published to npm and GitHub after PR #520 merged to main. AUDIT_0.3.24.md was removed from the workspace before release and was not part of the published tree."
+events:
+  -
+    type: "status"
+    at: "2026-04-24T15:38:58.832Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: remove the requested audit artifact, prepare v0.3.26 release metadata, run the full release gate, and publish through the direct-mode release route."
+  -
+    type: "verify"
+    at: "2026-04-24T17:40:45.251Z"
+    author: "CODER"
+    state: "ok"
+    note: "release v0.3.26 verified: release:ci-check passed locally, release apply pushed v0.3.26, PR #520 merged to main, Publish to npm run 24903280575 succeeded, npm registry exposes agentplane/core/recipes 0.3.26, GitHub Release v0.3.26 published"
+  -
+    type: "status"
+    at: "2026-04-24T17:40:52.368Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: v0.3.26 is published to npm and GitHub after PR #520 merged to main. AUDIT_0.3.24.md was removed from the workspace before release and was not part of the published tree."
+doc_version: 3
+doc_updated_at: "2026-04-24T17:40:52.370Z"
+doc_updated_by: "CODER"
+description: "Remove AUDIT_0.3.24.md, verify the v0.3 freeze branch, bump to the next patch version, run release gates, and publish the next patch release."
+sections:
+  Summary: |-
+    Publish next v0.3 patch release after freeze cleanup
+    
+    Remove AUDIT_0.3.24.md, verify the v0.3 freeze branch, bump to the next patch version, run release gates, and publish the next patch release.
+  Scope: |-
+    - In scope: Remove AUDIT_0.3.24.md, verify the v0.3 freeze branch, bump to the next patch version, run release gates, and publish the next patch release.
+    - Out of scope: unrelated refactors not required for "Publish next v0.3 patch release after freeze cleanup".
+  Plan: "Release plan: version=0.3.26, tag=v0.3.26, scope=remove root AUDIT_0.3.24.md artifact; publish the completed v0.3 freeze and hygiene work as the next patch release. Steps: 1. Delete the requested untracked audit markdown. 2. Inspect release plan output and generated release-note requirements. 3. Apply the patch version/release-note changes needed for v0.3.26. 4. Run required release gates, including bun run release:ci-check and release parity/version checks. 5. Publish using direct-mode route agentplane release apply --push --yes. 6. Record version/tag/package evidence and finish with traceable commit metadata."
+  Verify Steps: |-
+    1. Review the requested outcome for "Publish next v0.3 patch release after freeze cleanup". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-04-24T17:40:45.251Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: release v0.3.26 verified: release:ci-check passed locally, release apply pushed v0.3.26, PR #520 merged to main, Publish to npm run 24903280575 succeeded, npm registry exposes agentplane/core/recipes 0.3.26, GitHub Release v0.3.26 published
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-24T15:38:58.845Z, excerpt_hash=sha256:1aa6b5f96909934f242301e6741a13604e79d04cc1ecd3c0a75ae5a556239433
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Publish next v0.3 patch release after freeze cleanup
+
+Remove AUDIT_0.3.24.md, verify the v0.3 freeze branch, bump to the next patch version, run release gates, and publish the next patch release.
+
+## Scope
+
+- In scope: Remove AUDIT_0.3.24.md, verify the v0.3 freeze branch, bump to the next patch version, run release gates, and publish the next patch release.
+- Out of scope: unrelated refactors not required for "Publish next v0.3 patch release after freeze cleanup".
+
+## Plan
+
+Release plan: version=0.3.26, tag=v0.3.26, scope=remove root AUDIT_0.3.24.md artifact; publish the completed v0.3 freeze and hygiene work as the next patch release. Steps: 1. Delete the requested untracked audit markdown. 2. Inspect release plan output and generated release-note requirements. 3. Apply the patch version/release-note changes needed for v0.3.26. 4. Run required release gates, including bun run release:ci-check and release parity/version checks. 5. Publish using direct-mode route agentplane release apply --push --yes. 6. Record version/tag/package evidence and finish with traceable commit metadata.
+
+## Verify Steps
+
+1. Review the requested outcome for "Publish next v0.3 patch release after freeze cleanup". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-04-24T17:40:45.251Z — VERIFY — ok
+
+By: CODER
+
+Note: release v0.3.26 verified: release:ci-check passed locally, release apply pushed v0.3.26, PR #520 merged to main, Publish to npm run 24903280575 succeeded, npm registry exposes agentplane/core/recipes 0.3.26, GitHub Release v0.3.26 published
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-24T15:38:58.845Z, excerpt_hash=sha256:1aa6b5f96909934f242301e6741a13604e79d04cc1ecd3c0a75ae5a556239433
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings


### PR DESCRIPTION
Close task 202604241538-EGVKSE after publishing v0.3.26.\n\nEvidence:\n- release commit: 1f9f716ac68d6e54d82b258bbf6108401925233a\n- release PR: #520 merged to main\n- npm packages published: agentplane@0.3.26, @agentplaneorg/core@0.3.26, @agentplaneorg/recipes@0.3.26\n- GitHub Release: https://github.com/basilisk-labs/agentplane/releases/tag/v0.3.26\n- local release:ci-check passed before release apply\n- publish workflow completed successfully\n- agentplane doctor and release parity passed after publication\n\nThis PR contains only the AgentPlane task close README generated by finish.