### PR TITLE
Close v0.3.27 release task

### DIFF
--- a/.agentplane/tasks/202604250806-56MG2S/README.md
+++ b/.agentplane/tasks/202604250806-56MG2S/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202604250806-56MG2S"
 title: "Publish v0.3.27 patch release"
-status: "DOING"
+result_summary: "Published v0.3.27 for agentplane, @agentplaneorg/core, and @agentplaneorg/recipes; release tag and GitHub Release are live."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 5
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -19,15 +20,20 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
-commit: null
+  state: "ok"
+  updated_at: "2026-04-25T08:51:47.220Z"
+  updated_by: "CODER"
+  note: "Published v0.3.27 after PR #522 merged into protected main. Evidence: release plan targeted v0.3.27; release apply prepublish gates passed locally before protected-branch rejection; PR checks passed and PR #522 merged at 0dc40cf0; publish workflow 24927099253 succeeded; npm shows agentplane/core/recipes 0.3.27; origin tag v0.3.27 points to 0dc40cf0; GitHub Release v0.3.27 is published; agentplane doctor OK."
+commit:
+  hash: "0dc40cf03ff7c267d1a34eae37c4b39bc69d1ac9"
+  message: "Merge pull request #522 from basilisk-labs/codex/release-v0.3.27"
 comments:
   -
     author: "CODER"
     body: "Start: publishing v0.3.27 from direct main after the release hygiene gates and docs cleanup landed cleanly."
+  -
+    author: "CODER"
+    body: "Verified: v0.3.27 is published on npm and GitHub after PR #522 merged into main. Publish workflow 24927099253 succeeded, origin/v0.3.27 points at 0dc40cf0, npm reports 0.3.27 for all three public packages, and doctor is OK."
 events:
   -
     type: "status"
@@ -36,8 +42,21 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: publishing v0.3.27 from direct main after the release hygiene gates and docs cleanup landed cleanly."
+  -
+    type: "verify"
+    at: "2026-04-25T08:51:47.220Z"
+    author: "CODER"
+    state: "ok"
+    note: "Published v0.3.27 after PR #522 merged into protected main. Evidence: release plan targeted v0.3.27; release apply prepublish gates passed locally before protected-branch rejection; PR checks passed and PR #522 merged at 0dc40cf0; publish workflow 24927099253 succeeded; npm shows agentplane/core/recipes 0.3.27; origin tag v0.3.27 points to 0dc40cf0; GitHub Release v0.3.27 is published; agentplane doctor OK."
+  -
+    type: "status"
+    at: "2026-04-25T08:51:53.392Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: v0.3.27 is published on npm and GitHub after PR #522 merged into main. Publish workflow 24927099253 succeeded, origin/v0.3.27 points at 0dc40cf0, npm reports 0.3.27 for all three public packages, and doctor is OK."
 doc_version: 3
-doc_updated_at: "2026-04-25T08:07:16.014Z"
+doc_updated_at: "2026-04-25T08:51:53.393Z"
 doc_updated_by: "CODER"
 description: "Publish the next patch release containing release hygiene gates, repo-neutral workflow scope, sanitized package manifests, init recipe install commit capture, roadmap 0.6, and docs cleanup."
 sections:
@@ -58,6 +77,14 @@ sections:
     6. Run agentplane doctor. Expected: OK after release.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-04-25T08:51:47.220Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Published v0.3.27 after PR #522 merged into protected main. Evidence: release plan targeted v0.3.27; release apply prepublish gates passed locally before protected-branch rejection; PR checks passed and PR #522 merged at 0dc40cf0; publish workflow 24927099253 succeeded; npm shows agentplane/core/recipes 0.3.27; origin tag v0.3.27 points to 0dc40cf0; GitHub Release v0.3.27 is published; agentplane doctor OK.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-25T08:07:16.014Z, excerpt_hash=sha256:fecfa06bc46d5ac715c3fb625ee8e3f25b022858e1a578051be51f204878f511
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -92,6 +119,14 @@ Release plan: version=v0.3.27, tag=v0.3.27, scope=publish the release hygiene/wo
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-04-25T08:51:47.220Z — VERIFY — ok
+
+By: CODER
+
+Note: Published v0.3.27 after PR #522 merged into protected main. Evidence: release plan targeted v0.3.27; release apply prepublish gates passed locally before protected-branch rejection; PR checks passed and PR #522 merged at 0dc40cf0; publish workflow 24927099253 succeeded; npm shows agentplane/core/recipes 0.3.27; origin tag v0.3.27 points to 0dc40cf0; GitHub Release v0.3.27 is published; agentplane doctor OK.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-25T08:07:16.014Z, excerpt_hash=sha256:fecfa06bc46d5ac715c3fb625ee8e3f25b022858e1a578051be51f204878f511
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan


### PR DESCRIPTION
## Summary
- Record verification and close task 202604250806-56MG2S after v0.3.27 publication.

## Verification
- npm view agentplane/@agentplaneorg/core/@agentplaneorg/recipes -> 0.3.27
- origin tag v0.3.27 -> 0dc40cf0
- GitHub Release v0.3.27 published
- agentplane doctor OK
- pre-push docs-only path passed for this close branch