### PR TITLE
Reduce Knip baseline by removing internal-only exports

### DIFF
--- a/.agentplane/tasks/202604261411-44NSJW/README.md
+++ b/.agentplane/tasks/202604261411-44NSJW/README.md
@@ -1,0 +1,131 @@
+---
+id: "202604261411-44NSJW"
+title: "Remove obvious unused public exports"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "cleanup"
+  - "knip"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-04-26T14:11:35.757Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-04-26T14:14:30.956Z"
+  updated_by: "CODER"
+  note: "Removed four obvious internal-only exports from Knip baseline."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: remove obvious internal-only exports from the Knip baseline."
+events:
+  -
+    type: "status"
+    at: "2026-04-26T14:11:36.538Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: remove obvious internal-only exports from the Knip baseline."
+  -
+    type: "verify"
+    at: "2026-04-26T14:14:30.956Z"
+    author: "CODER"
+    state: "ok"
+    note: "Removed four obvious internal-only exports from Knip baseline."
+doc_version: 3
+doc_updated_at: "2026-04-26T14:14:30.967Z"
+doc_updated_by: "CODER"
+description: "Reduce Knip baseline by unexporting internal-only types/functions that are currently listed as unused public surface."
+sections:
+  Summary: |-
+    Remove obvious unused public exports
+    
+    Reduce Knip baseline by unexporting internal-only types/functions that are currently listed as unused public surface.
+  Scope: |-
+    - In scope: Reduce Knip baseline by unexporting internal-only types/functions that are currently listed as unused public surface.
+    - Out of scope: unrelated refactors not required for "Remove obvious unused public exports".
+  Plan: |-
+    1. Unexport internal-only symbols currently listed in the Knip baseline: PolicyTemplate, toTaskDocMutationComments, RedmineCacheDocContext, RedmineReportContext.
+    2. Refresh the Knip JSON baseline to remove the resolved entries.
+    3. Verify typecheck, lint, knip baseline, and focused affected tests.
+  Verify Steps: |-
+    1. Review the requested outcome for "Remove obvious unused public exports". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-04-26T14:14:30.956Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Removed four obvious internal-only exports from Knip baseline.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-26T14:11:36.558Z, excerpt_hash=sha256:676123a5964c64ad2ea46c03d122684d270e205cd4bed8b98476009d6f320c74
+    
+    Details:
+    
+    Checks passed: bun run typecheck; bun run lint:core; node scripts/check-knip-baseline.mjs; bun run format:check; git diff --check; focused vitest redmine/agents/task-backend batch passed 55/55.
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Remove obvious unused public exports
+
+Reduce Knip baseline by unexporting internal-only types/functions that are currently listed as unused public surface.
+
+## Scope
+
+- In scope: Reduce Knip baseline by unexporting internal-only types/functions that are currently listed as unused public surface.
+- Out of scope: unrelated refactors not required for "Remove obvious unused public exports".
+
+## Plan
+
+1. Unexport internal-only symbols currently listed in the Knip baseline: PolicyTemplate, toTaskDocMutationComments, RedmineCacheDocContext, RedmineReportContext.
+2. Refresh the Knip JSON baseline to remove the resolved entries.
+3. Verify typecheck, lint, knip baseline, and focused affected tests.
+
+## Verify Steps
+
+1. Review the requested outcome for "Remove obvious unused public exports". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-04-26T14:14:30.956Z — VERIFY — ok
+
+By: CODER
+
+Note: Removed four obvious internal-only exports from Knip baseline.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-26T14:11:36.558Z, excerpt_hash=sha256:676123a5964c64ad2ea46c03d122684d270e205cd4bed8b98476009d6f320c74
+
+Details:
+
+Checks passed: bun run typecheck; bun run lint:core; node scripts/check-knip-baseline.mjs; bun run format:check; git diff --check; focused vitest redmine/agents/task-backend batch passed 55/55.
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202604261411-44NSJW/README.md
+++ b/.agentplane/tasks/202604261411-44NSJW/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202604261411-44NSJW"
 title: "Remove obvious unused public exports"
-status: "DOING"
+result_summary: "Knip baseline reduced from total 527 to 523."
+status: "DONE"
 priority: "med"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -23,11 +24,16 @@ verification:
   updated_at: "2026-04-26T14:14:30.956Z"
   updated_by: "CODER"
   note: "Removed four obvious internal-only exports from Knip baseline."
-commit: null
+commit:
+  hash: "5e3d48ff68d2b6c8331b215b64b0baec26b7d682"
+  message: "✅ 44NSJW meta: done"
 comments:
   -
     author: "CODER"
     body: "Start: remove obvious internal-only exports from the Knip baseline."
+  -
+    author: "CODER"
+    body: "Verified: four internal-only exports removed and Knip baseline lowered."
 events:
   -
     type: "status"
@@ -42,8 +48,15 @@ events:
     author: "CODER"
     state: "ok"
     note: "Removed four obvious internal-only exports from Knip baseline."
+  -
+    type: "status"
+    at: "2026-04-26T14:15:19.123Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: four internal-only exports removed and Knip baseline lowered."
 doc_version: 3
-doc_updated_at: "2026-04-26T14:14:30.967Z"
+doc_updated_at: "2026-04-26T14:15:19.125Z"
 doc_updated_by: "CODER"
 description: "Reduce Knip baseline by unexporting internal-only types/functions that are currently listed as unused public surface."
 sections:

--- a/packages/agentplane/src/agents/agents-template.ts
+++ b/packages/agentplane/src/agents/agents-template.ts
@@ -19,7 +19,7 @@ type Heading = { index: number; level: number; title: string };
 export type WorkflowMode = "direct" | "branch_pr";
 
 type AgentTemplate = { fileName: string; contents: string };
-export type PolicyTemplate = { relativePath: string; contents: string };
+type PolicyTemplate = { relativePath: string; contents: string };
 
 let agentTemplatesCache: Promise<AgentTemplate[]> | null = null;
 const policyGatewayTemplateCache = new Map<PolicyGatewayFlavor, Promise<string>>();

--- a/packages/agentplane/src/backends/task-backend/local-backend-state.ts
+++ b/packages/agentplane/src/backends/task-backend/local-backend-state.ts
@@ -36,7 +36,7 @@ export function assertExpectedRevision(opts: {
   );
 }
 
-export function toTaskDocMutationComments(comments: unknown): TaskDocMutationState["comments"] {
+function toTaskDocMutationComments(comments: unknown): TaskDocMutationState["comments"] {
   if (!Array.isArray(comments)) return null;
   const normalized = comments.flatMap((entry) => {
     if (!isRecord(entry)) return [];

--- a/packages/agentplane/src/backends/task-backend/redmine/backend-cache-doc.ts
+++ b/packages/agentplane/src/backends/task-backend/redmine/backend-cache-doc.ts
@@ -26,7 +26,7 @@ type RedmineCachePort = {
   writeTask: (task: TaskData, opts?: TaskWriteOptions) => Promise<void>;
 };
 
-export type RedmineCacheDocContext = {
+type RedmineCacheDocContext = {
   cache: RedmineCachePort | null;
   customFields: Record<string, unknown>;
   ownerAgent: string;

--- a/packages/agentplane/src/backends/task-backend/redmine/backend-report.ts
+++ b/packages/agentplane/src/backends/task-backend/redmine/backend-report.ts
@@ -7,7 +7,7 @@ import {
 } from "./inspect.js";
 import { type TaskBackendInspectionResult, type TaskData } from "../shared.js";
 
-export type RedmineReportContext = {
+type RedmineReportContext = {
   projectId: string;
   customFields: Record<string, unknown>;
   requestJson: (

--- a/scripts/baselines/knip-baseline.json
+++ b/scripts/baselines/knip-baseline.json
@@ -35,46 +35,6 @@
       ]
     },
     {
-      "file": "packages/agentplane/src/agents/agents-template.ts",
-      "types": [
-        {
-          "name": "PolicyTemplate",
-          "line": 22,
-          "col": 13
-        }
-      ]
-    },
-    {
-      "file": "packages/agentplane/src/backends/task-backend/local-backend-state.ts",
-      "exports": [
-        {
-          "name": "toTaskDocMutationComments",
-          "line": 39,
-          "col": 17
-        }
-      ]
-    },
-    {
-      "file": "packages/agentplane/src/backends/task-backend/redmine/backend-cache-doc.ts",
-      "types": [
-        {
-          "name": "RedmineCacheDocContext",
-          "line": 29,
-          "col": 13
-        }
-      ]
-    },
-    {
-      "file": "packages/agentplane/src/backends/task-backend/redmine/backend-report.ts",
-      "types": [
-        {
-          "name": "RedmineReportContext",
-          "line": 10,
-          "col": 13
-        }
-      ]
-    },
-    {
       "file": "packages/agentplane/src/backends/task-backend/redmine/backend-runtime.ts",
       "exports": [
         {
@@ -3491,10 +3451,10 @@
   ],
   "counts": {
     "files": 5,
-    "exports": 231,
-    "types": 291,
+    "exports": 230,
+    "types": 288,
     "enumMembers": 0,
     "namespaceMembers": 0,
-    "total": 527
+    "total": 523
   }
 }


### PR DESCRIPTION
## Summary
- Remove four internal-only exports/types that are not part of the public surface
- Refresh the Knip JSON baseline after the cleanup
- Close task 202604261411-44NSJW with verification evidence

## Verification
- bun run typecheck
- bun run lint:core
- node scripts/check-knip-baseline.mjs
- bun run format:check
- git diff --check
- bun run framework:dev:bootstrap
- focused vitest suite: agents template, Redmine backend cache/docs/mapping/write, task backend shared
- pre-push full-fast suite passed before branch push
