### PR TITLE
Prune bootstrap guide exports

### DIFF
--- a/.agentplane/tasks/202604261618-HRKZVA/README.md
+++ b/.agentplane/tasks/202604261618-HRKZVA/README.md
@@ -1,0 +1,127 @@
+---
+id: "202604261618-HRKZVA"
+title: "Prune bootstrap guide exports"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "knip"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-04-26T16:19:02.979Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-04-26T16:22:19.380Z"
+  updated_by: "CODER"
+  note: "Command: bun run typecheck; Result: pass after bootstrap rerun; Evidence: tsc -b exited 0. Command: bun run lint:core; Result: pass; Evidence: eslint exited 0. Command: node scripts/check-knip-baseline.mjs; Result: pass; Evidence: baseline OK total=434. Command: node scripts/check-agent-bootstrap-fresh.mjs; Result: pass after framework bootstrap; Evidence: bootstrap docs and startup command blocks aligned. Command: focused command-guide vitest; Result: pass; Evidence: 2 files, 13 tests passed. Command: bun run format:check and git diff --check; Result: pass. Command: bun run framework:dev:bootstrap; Result: pass; Evidence: repo-local runtime ready."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Pruning unused bootstrap-guide exports while preserving generated bootstrap docs and command-guide runtime output, then refreshing Knip and validating docs freshness."
+events:
+  -
+    type: "status"
+    at: "2026-04-26T16:19:10.952Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Pruning unused bootstrap-guide exports while preserving generated bootstrap docs and command-guide runtime output, then refreshing Knip and validating docs freshness."
+  -
+    type: "verify"
+    at: "2026-04-26T16:22:19.380Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: bun run typecheck; Result: pass after bootstrap rerun; Evidence: tsc -b exited 0. Command: bun run lint:core; Result: pass; Evidence: eslint exited 0. Command: node scripts/check-knip-baseline.mjs; Result: pass; Evidence: baseline OK total=434. Command: node scripts/check-agent-bootstrap-fresh.mjs; Result: pass after framework bootstrap; Evidence: bootstrap docs and startup command blocks aligned. Command: focused command-guide vitest; Result: pass; Evidence: 2 files, 13 tests passed. Command: bun run format:check and git diff --check; Result: pass. Command: bun run framework:dev:bootstrap; Result: pass; Evidence: repo-local runtime ready."
+doc_version: 3
+doc_updated_at: "2026-04-26T16:22:19.383Z"
+doc_updated_by: "CODER"
+description: "Make unused bootstrap-guide constants, helper functions, and types module-local while preserving the generated docs renderer and quickstart imports, then refresh the Knip baseline."
+sections:
+  Summary: |-
+    Prune bootstrap guide exports
+    
+    Make unused bootstrap-guide constants, helper functions, and types module-local while preserving the generated docs renderer and quickstart imports, then refresh the Knip baseline.
+  Scope: |-
+    - In scope: Make unused bootstrap-guide constants, helper functions, and types module-local while preserving the generated docs renderer and quickstart imports, then refresh the Knip baseline.
+    - Out of scope: unrelated refactors not required for "Prune bootstrap guide exports".
+  Plan: |-
+    Plan:
+    1. Confirm bootstrap-guide.ts exports used by command-guide/scripts and identify unused export-only symbols.
+    2. Convert unused constants/helpers/types to module-local declarations without changing rendered quickstart/bootstrap output.
+    3. Refresh scripts/baselines/knip-baseline.json.
+    4. Verify with typecheck, lint:core, knip baseline check, command-guide/bootstrap docs tests, docs freshness check, format:check, git diff --check, and framework bootstrap if needed.
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-04-26T16:22:19.380Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Command: bun run typecheck; Result: pass after bootstrap rerun; Evidence: tsc -b exited 0. Command: bun run lint:core; Result: pass; Evidence: eslint exited 0. Command: node scripts/check-knip-baseline.mjs; Result: pass; Evidence: baseline OK total=434. Command: node scripts/check-agent-bootstrap-fresh.mjs; Result: pass after framework bootstrap; Evidence: bootstrap docs and startup command blocks aligned. Command: focused command-guide vitest; Result: pass; Evidence: 2 files, 13 tests passed. Command: bun run format:check and git diff --check; Result: pass. Command: bun run framework:dev:bootstrap; Result: pass; Evidence: repo-local runtime ready.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-26T16:19:10.957Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Prune bootstrap guide exports
+
+Make unused bootstrap-guide constants, helper functions, and types module-local while preserving the generated docs renderer and quickstart imports, then refresh the Knip baseline.
+
+## Scope
+
+- In scope: Make unused bootstrap-guide constants, helper functions, and types module-local while preserving the generated docs renderer and quickstart imports, then refresh the Knip baseline.
+- Out of scope: unrelated refactors not required for "Prune bootstrap guide exports".
+
+## Plan
+
+Plan:
+1. Confirm bootstrap-guide.ts exports used by command-guide/scripts and identify unused export-only symbols.
+2. Convert unused constants/helpers/types to module-local declarations without changing rendered quickstart/bootstrap output.
+3. Refresh scripts/baselines/knip-baseline.json.
+4. Verify with typecheck, lint:core, knip baseline check, command-guide/bootstrap docs tests, docs freshness check, format:check, git diff --check, and framework bootstrap if needed.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-04-26T16:22:19.380Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: bun run typecheck; Result: pass after bootstrap rerun; Evidence: tsc -b exited 0. Command: bun run lint:core; Result: pass; Evidence: eslint exited 0. Command: node scripts/check-knip-baseline.mjs; Result: pass; Evidence: baseline OK total=434. Command: node scripts/check-agent-bootstrap-fresh.mjs; Result: pass after framework bootstrap; Evidence: bootstrap docs and startup command blocks aligned. Command: focused command-guide vitest; Result: pass; Evidence: 2 files, 13 tests passed. Command: bun run format:check and git diff --check; Result: pass. Command: bun run framework:dev:bootstrap; Result: pass; Evidence: repo-local runtime ready.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-26T16:19:10.957Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202604261618-HRKZVA/README.md
+++ b/.agentplane/tasks/202604261618-HRKZVA/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202604261618-HRKZVA"
 title: "Prune bootstrap guide exports"
-status: "DOING"
+result_summary: "Pruned bootstrap guide export surface and reduced Knip baseline total to 434."
+status: "DONE"
 priority: "med"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -23,11 +24,16 @@ verification:
   updated_at: "2026-04-26T16:22:19.380Z"
   updated_by: "CODER"
   note: "Command: bun run typecheck; Result: pass after bootstrap rerun; Evidence: tsc -b exited 0. Command: bun run lint:core; Result: pass; Evidence: eslint exited 0. Command: node scripts/check-knip-baseline.mjs; Result: pass; Evidence: baseline OK total=434. Command: node scripts/check-agent-bootstrap-fresh.mjs; Result: pass after framework bootstrap; Evidence: bootstrap docs and startup command blocks aligned. Command: focused command-guide vitest; Result: pass; Evidence: 2 files, 13 tests passed. Command: bun run format:check and git diff --check; Result: pass. Command: bun run framework:dev:bootstrap; Result: pass; Evidence: repo-local runtime ready."
-commit: null
+commit:
+  hash: "ed51097d538f6bc9777a21c17ac5b260e09515b2"
+  message: "🚧 HRKZVA task: prune bootstrap guide exports"
 comments:
   -
     author: "CODER"
     body: "Start: Pruning unused bootstrap-guide exports while preserving generated bootstrap docs and command-guide runtime output, then refreshing Knip and validating docs freshness."
+  -
+    author: "CODER"
+    body: "Verified: Unused bootstrap-guide exports were made module-local while dynamic docs freshness exports stayed public, Knip baseline total reduced from 440 to 434, and local docs/code checks passed."
 events:
   -
     type: "status"
@@ -42,8 +48,15 @@ events:
     author: "CODER"
     state: "ok"
     note: "Command: bun run typecheck; Result: pass after bootstrap rerun; Evidence: tsc -b exited 0. Command: bun run lint:core; Result: pass; Evidence: eslint exited 0. Command: node scripts/check-knip-baseline.mjs; Result: pass; Evidence: baseline OK total=434. Command: node scripts/check-agent-bootstrap-fresh.mjs; Result: pass after framework bootstrap; Evidence: bootstrap docs and startup command blocks aligned. Command: focused command-guide vitest; Result: pass; Evidence: 2 files, 13 tests passed. Command: bun run format:check and git diff --check; Result: pass. Command: bun run framework:dev:bootstrap; Result: pass; Evidence: repo-local runtime ready."
+  -
+    type: "status"
+    at: "2026-04-26T16:22:30.933Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: Unused bootstrap-guide exports were made module-local while dynamic docs freshness exports stayed public, Knip baseline total reduced from 440 to 434, and local docs/code checks passed."
 doc_version: 3
-doc_updated_at: "2026-04-26T16:22:19.383Z"
+doc_updated_at: "2026-04-26T16:22:30.933Z"
 doc_updated_by: "CODER"
 description: "Make unused bootstrap-guide constants, helper functions, and types module-local while preserving the generated docs renderer and quickstart imports, then refresh the Knip baseline."
 sections:

--- a/packages/agentplane/src/cli/bootstrap-guide.ts
+++ b/packages/agentplane/src/cli/bootstrap-guide.ts
@@ -1,11 +1,10 @@
 import { COMMAND_SNIPPETS } from "./command-snippets.js";
 
 export const AGENT_BOOTSTRAP_DOC_PATH = "docs/user/agent-bootstrap.generated.mdx";
-export const AGENT_BOOTSTRAP_RUNTIME_SURFACE = "agentplane quickstart";
 export const BRANCH_PR_HOSTED_GATE_GUIDANCE =
   "confirm hosted required checks through the repository's configured CI/provider gate; optional framework-maintainer helper when present: `bun run workflow:wait-remote-checks`";
 
-export type BootstrapSection = {
+type BootstrapSection = {
   heading: string;
   summary: string;
   commands: readonly string[];
@@ -43,13 +42,13 @@ export const BOOTSTRAP_VERIFICATION_COMMANDS = [
   "node .agentplane/policy/check-routing.mjs",
 ] as const;
 
-export const BOOTSTRAP_RECOVERY_COMMANDS = [
+const BOOTSTRAP_RECOVERY_COMMANDS = [
   "agentplane doctor",
   "agentplane upgrade --dry-run",
   "agentplane upgrade",
 ] as const;
 
-export const BOOTSTRAP_SECTIONS: readonly BootstrapSection[] = [
+const BOOTSTRAP_SECTIONS: readonly BootstrapSection[] = [
   {
     heading: "1. Preflight",
     summary:
@@ -99,11 +98,7 @@ export const BOOTSTRAP_SECTIONS: readonly BootstrapSection[] = [
   },
 ] as const;
 
-export function renderBootstrapReferenceLine(): string {
-  return `Canonical installed startup surface: \`${AGENT_BOOTSTRAP_RUNTIME_SURFACE}\`.`;
-}
-
-export function renderBootstrapSectionLines(sections: readonly BootstrapSection[]): string[] {
+function renderBootstrapSectionLines(sections: readonly BootstrapSection[]): string[] {
   const lines: string[] = [];
   for (const section of sections) {
     lines.push(`## ${section.heading}`, "", section.summary, "");

--- a/scripts/baselines/knip-baseline.json
+++ b/scripts/baselines/knip-baseline.json
@@ -194,46 +194,14 @@
           "col": 14
         },
         {
-          "name": "AGENT_BOOTSTRAP_RUNTIME_SURFACE",
-          "line": 4,
-          "col": 14
-        },
-        {
           "name": "BOOTSTRAP_DIRECT_HAPPY_PATH_COMMANDS",
-          "line": 29,
-          "col": 14
-        },
-        {
-          "name": "BOOTSTRAP_RECOVERY_COMMANDS",
-          "line": 46,
-          "col": 14
-        },
-        {
-          "name": "BOOTSTRAP_SECTIONS",
-          "line": 52,
+          "line": 28,
           "col": 14
         },
         {
           "name": "BOOTSTRAP_VERIFICATION_COMMANDS",
-          "line": 37,
+          "line": 36,
           "col": 14
-        },
-        {
-          "name": "renderBootstrapReferenceLine",
-          "line": 102,
-          "col": 17
-        },
-        {
-          "name": "renderBootstrapSectionLines",
-          "line": 106,
-          "col": 17
-        }
-      ],
-      "types": [
-        {
-          "name": "BootstrapSection",
-          "line": 8,
-          "col": 13
         }
       ]
     },
@@ -3014,10 +2982,10 @@
   ],
   "counts": {
     "files": 5,
-    "exports": 164,
-    "types": 271,
+    "exports": 159,
+    "types": 270,
     "enumMembers": 0,
     "namespaceMembers": 0,
-    "total": 440
+    "total": 434
   }
 }


### PR DESCRIPTION
## Summary
- Make unused bootstrap-guide declarations module-local while preserving dynamic docs freshness exports
- Remove unused bootstrap helper/runtime constant
- Refresh Knip JSON baseline: total 440 -> 434
- Close task 202604261618-HRKZVA with verification evidence

## Verification
- bun run typecheck
- bun run lint:core
- node scripts/check-knip-baseline.mjs
- bunx vitest run packages/agentplane/src/cli/command-guide.test.ts packages/agentplane/src/cli/run-cli/commands/core.unit.test.ts
- node scripts/check-agent-bootstrap-fresh.mjs
- bun run format:check
- git diff --check
- bun run framework:dev:bootstrap
- pre-push full-fast suite passed before branch push