### PR TITLE
Prune runner adapter re-exports

### DIFF
--- a/.agentplane/tasks/202604261637-7VVX7E/README.md
+++ b/.agentplane/tasks/202604261637-7VVX7E/README.md
@@ -1,0 +1,257 @@
+---
+id: "202604261637-7VVX7E"
+title: "Prune runner adapter re-exports"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "knip"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-04-26T16:37:36.654Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-04-26T16:38:52.143Z"
+  updated_by: "CODER"
+  note: |-
+    Command: bunx vitest run packages/agentplane/src/runner/adapters/codex.test.ts packages/agentplane/src/runner/adapters/custom.test.ts packages/agentplane/src/runner/usecases/task-run-lifecycle.test.ts packages/agentplane/src/runner/config.test.ts
+    Result: pass
+    Evidence: 4 files, 33 tests passed.
+    Scope: runner adapter factory, codex/custom adapter behavior, and lifecycle consumers.
+    
+    Command: bun run typecheck
+    Result: pass
+    Evidence: tsc -b exited 0.
+    Scope: repository TypeScript after pruning adapter index exports.
+    
+    Command: bun run lint:core
+    Result: pass
+    Evidence: eslint exited 0.
+    Scope: packages, scripts, and root lint config.
+    
+    Command: node scripts/check-knip-baseline.mjs
+    Result: pass
+    Evidence: baseline OK total=423/423.
+    Scope: unused-code baseline after removing runner adapter re-exports.
+    
+    Command: bun run format:check
+    Result: pass
+    Evidence: All matched files use Prettier code style.
+    Scope: repository formatting.
+    
+    Command: git diff --check
+    Result: pass
+    Evidence: no whitespace errors.
+    Scope: changed diff.
+    
+    Command: bun run framework:dev:bootstrap
+    Result: pass
+    Evidence: Framework dev runtime is ready.
+    Scope: repo-local CLI/runtime after runner source change.
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Prune unused runner adapter re-exports from the adapters index while keeping createRunnerAdapter behavior intact, then refresh Knip and run runner-focused verification."
+events:
+  -
+    type: "status"
+    at: "2026-04-26T16:37:40.429Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Prune unused runner adapter re-exports from the adapters index while keeping createRunnerAdapter behavior intact, then refresh Knip and run runner-focused verification."
+  -
+    type: "verify"
+    at: "2026-04-26T16:38:52.143Z"
+    author: "CODER"
+    state: "ok"
+    note: |-
+      Command: bunx vitest run packages/agentplane/src/runner/adapters/codex.test.ts packages/agentplane/src/runner/adapters/custom.test.ts packages/agentplane/src/runner/usecases/task-run-lifecycle.test.ts packages/agentplane/src/runner/config.test.ts
+      Result: pass
+      Evidence: 4 files, 33 tests passed.
+      Scope: runner adapter factory, codex/custom adapter behavior, and lifecycle consumers.
+      
+      Command: bun run typecheck
+      Result: pass
+      Evidence: tsc -b exited 0.
+      Scope: repository TypeScript after pruning adapter index exports.
+      
+      Command: bun run lint:core
+      Result: pass
+      Evidence: eslint exited 0.
+      Scope: packages, scripts, and root lint config.
+      
+      Command: node scripts/check-knip-baseline.mjs
+      Result: pass
+      Evidence: baseline OK total=423/423.
+      Scope: unused-code baseline after removing runner adapter re-exports.
+      
+      Command: bun run format:check
+      Result: pass
+      Evidence: All matched files use Prettier code style.
+      Scope: repository formatting.
+      
+      Command: git diff --check
+      Result: pass
+      Evidence: no whitespace errors.
+      Scope: changed diff.
+      
+      Command: bun run framework:dev:bootstrap
+      Result: pass
+      Evidence: Framework dev runtime is ready.
+      Scope: repo-local CLI/runtime after runner source change.
+doc_version: 3
+doc_updated_at: "2026-04-26T16:38:52.146Z"
+doc_updated_by: "CODER"
+description: "Remove unused class/helper/type re-exports from runner/adapters/index.ts while keeping createRunnerAdapter as the internal factory, then refresh the Knip baseline."
+sections:
+  Summary: |-
+    Prune runner adapter re-exports
+    
+    Remove unused class/helper/type re-exports from runner/adapters/index.ts while keeping createRunnerAdapter as the internal factory, then refresh the Knip baseline.
+  Scope: |-
+    - In scope: Remove unused class/helper/type re-exports from runner/adapters/index.ts while keeping createRunnerAdapter as the internal factory, then refresh the Knip baseline.
+    - Out of scope: unrelated refactors not required for "Prune runner adapter re-exports".
+  Plan: |-
+    1. Remove unused re-exports from packages/agentplane/src/runner/adapters/index.ts while preserving createRunnerAdapter.
+    2. Refresh scripts/baselines/knip-baseline.json and confirm the total decreases.
+    3. Run focused runner adapter tests plus typecheck, lint, Knip check, format, diff check, framework bootstrap, and task verification.
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-04-26T16:38:52.143Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Command: bunx vitest run packages/agentplane/src/runner/adapters/codex.test.ts packages/agentplane/src/runner/adapters/custom.test.ts packages/agentplane/src/runner/usecases/task-run-lifecycle.test.ts packages/agentplane/src/runner/config.test.ts
+    Result: pass
+    Evidence: 4 files, 33 tests passed.
+    Scope: runner adapter factory, codex/custom adapter behavior, and lifecycle consumers.
+    
+    Command: bun run typecheck
+    Result: pass
+    Evidence: tsc -b exited 0.
+    Scope: repository TypeScript after pruning adapter index exports.
+    
+    Command: bun run lint:core
+    Result: pass
+    Evidence: eslint exited 0.
+    Scope: packages, scripts, and root lint config.
+    
+    Command: node scripts/check-knip-baseline.mjs
+    Result: pass
+    Evidence: baseline OK total=423/423.
+    Scope: unused-code baseline after removing runner adapter re-exports.
+    
+    Command: bun run format:check
+    Result: pass
+    Evidence: All matched files use Prettier code style.
+    Scope: repository formatting.
+    
+    Command: git diff --check
+    Result: pass
+    Evidence: no whitespace errors.
+    Scope: changed diff.
+    
+    Command: bun run framework:dev:bootstrap
+    Result: pass
+    Evidence: Framework dev runtime is ready.
+    Scope: repo-local CLI/runtime after runner source change.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-26T16:37:40.435Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Prune runner adapter re-exports
+
+Remove unused class/helper/type re-exports from runner/adapters/index.ts while keeping createRunnerAdapter as the internal factory, then refresh the Knip baseline.
+
+## Scope
+
+- In scope: Remove unused class/helper/type re-exports from runner/adapters/index.ts while keeping createRunnerAdapter as the internal factory, then refresh the Knip baseline.
+- Out of scope: unrelated refactors not required for "Prune runner adapter re-exports".
+
+## Plan
+
+1. Remove unused re-exports from packages/agentplane/src/runner/adapters/index.ts while preserving createRunnerAdapter.
+2. Refresh scripts/baselines/knip-baseline.json and confirm the total decreases.
+3. Run focused runner adapter tests plus typecheck, lint, Knip check, format, diff check, framework bootstrap, and task verification.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-04-26T16:38:52.143Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: bunx vitest run packages/agentplane/src/runner/adapters/codex.test.ts packages/agentplane/src/runner/adapters/custom.test.ts packages/agentplane/src/runner/usecases/task-run-lifecycle.test.ts packages/agentplane/src/runner/config.test.ts
+Result: pass
+Evidence: 4 files, 33 tests passed.
+Scope: runner adapter factory, codex/custom adapter behavior, and lifecycle consumers.
+
+Command: bun run typecheck
+Result: pass
+Evidence: tsc -b exited 0.
+Scope: repository TypeScript after pruning adapter index exports.
+
+Command: bun run lint:core
+Result: pass
+Evidence: eslint exited 0.
+Scope: packages, scripts, and root lint config.
+
+Command: node scripts/check-knip-baseline.mjs
+Result: pass
+Evidence: baseline OK total=423/423.
+Scope: unused-code baseline after removing runner adapter re-exports.
+
+Command: bun run format:check
+Result: pass
+Evidence: All matched files use Prettier code style.
+Scope: repository formatting.
+
+Command: git diff --check
+Result: pass
+Evidence: no whitespace errors.
+Scope: changed diff.
+
+Command: bun run framework:dev:bootstrap
+Result: pass
+Evidence: Framework dev runtime is ready.
+Scope: repo-local CLI/runtime after runner source change.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-26T16:37:40.435Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202604261637-7VVX7E/README.md
+++ b/.agentplane/tasks/202604261637-7VVX7E/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202604261637-7VVX7E"
 title: "Prune runner adapter re-exports"
-status: "DOING"
+result_summary: "Pruned runner adapter re-exports and reduced Knip baseline total from 428 to 423."
+status: "DONE"
 priority: "med"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -57,11 +58,16 @@ verification:
     Result: pass
     Evidence: Framework dev runtime is ready.
     Scope: repo-local CLI/runtime after runner source change.
-commit: null
+commit:
+  hash: "2479ffa6eade3dcde8b08f7921fe7d3bcfe2fb4d"
+  message: "🚧 7VVX7E task: prune runner adapter re-exports"
 comments:
   -
     author: "CODER"
     body: "Start: Prune unused runner adapter re-exports from the adapters index while keeping createRunnerAdapter behavior intact, then refresh Knip and run runner-focused verification."
+  -
+    author: "CODER"
+    body: "Verified: Removed unused runner adapter re-exports while preserving createRunnerAdapter, refreshed Knip baseline to total 423, and passed runner-focused tests plus typecheck, lint, Knip, format, diff check, and framework bootstrap."
 events:
   -
     type: "status"
@@ -110,8 +116,15 @@ events:
       Result: pass
       Evidence: Framework dev runtime is ready.
       Scope: repo-local CLI/runtime after runner source change.
+  -
+    type: "status"
+    at: "2026-04-26T16:39:07.059Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: Removed unused runner adapter re-exports while preserving createRunnerAdapter, refreshed Knip baseline to total 423, and passed runner-focused tests plus typecheck, lint, Knip, format, diff check, and framework bootstrap."
 doc_version: 3
-doc_updated_at: "2026-04-26T16:38:52.146Z"
+doc_updated_at: "2026-04-26T16:39:07.059Z"
 doc_updated_by: "CODER"
 description: "Remove unused class/helper/type re-exports from runner/adapters/index.ts while keeping createRunnerAdapter as the internal factory, then refresh the Knip baseline."
 sections:

--- a/packages/agentplane/src/runner/adapters/index.ts
+++ b/packages/agentplane/src/runner/adapters/index.ts
@@ -14,8 +14,3 @@ export function createRunnerAdapter(config: Pick<AgentplaneConfig, "runner">): R
     }
   }
 }
-
-export { CodexRunnerAdapter } from "./codex.js";
-export { CustomRunnerAdapter } from "./custom.js";
-export type { RunnerAdapter } from "./shared.js";
-export { runnerAdapterFailureResult, runnerAdapterSuccessResult } from "./shared.js";

--- a/scripts/baselines/knip-baseline.json
+++ b/scripts/baselines/knip-baseline.json
@@ -1067,12 +1067,12 @@
       "exports": [
         {
           "name": "assertReleaseBumpApproved",
-          "line": 75,
+          "line": 72,
           "col": 17
         },
         {
           "name": "runPushPreflight",
-          "line": 23,
+          "line": 20,
           "col": 23
         }
       ]
@@ -2002,38 +2002,6 @@
       ]
     },
     {
-      "file": "packages/agentplane/src/runner/adapters/index.ts",
-      "exports": [
-        {
-          "name": "CodexRunnerAdapter",
-          "line": 18,
-          "col": 10
-        },
-        {
-          "name": "CustomRunnerAdapter",
-          "line": 19,
-          "col": 10
-        },
-        {
-          "name": "runnerAdapterFailureResult",
-          "line": 21,
-          "col": 10
-        },
-        {
-          "name": "runnerAdapterSuccessResult",
-          "line": 21,
-          "col": 38
-        }
-      ],
-      "types": [
-        {
-          "name": "RunnerAdapter",
-          "line": 20,
-          "col": 15
-        }
-      ]
-    },
-    {
       "file": "packages/agentplane/src/runner/adapters/recipe-run-profile.ts",
       "types": [
         {
@@ -2945,10 +2913,10 @@
   ],
   "counts": {
     "files": 5,
-    "exports": 154,
-    "types": 269,
+    "exports": 150,
+    "types": 268,
     "enumMembers": 0,
     "namespaceMembers": 0,
-    "total": 428
+    "total": 423
   }
 }


### PR DESCRIPTION
## Summary
- Keep createRunnerAdapter as the runner adapter factory
- Remove unused class/helper/type re-exports from runner/adapters/index.ts
- Refresh Knip JSON baseline: total 428 -> 423
- Close task 202604261637-7VVX7E with verification evidence

## Verification
- bunx vitest run packages/agentplane/src/runner/adapters/codex.test.ts packages/agentplane/src/runner/adapters/custom.test.ts packages/agentplane/src/runner/usecases/task-run-lifecycle.test.ts packages/agentplane/src/runner/config.test.ts
- bun run typecheck
- bun run lint:core
- node scripts/check-knip-baseline.mjs
- bun run format:check
- git diff --check
- bun run framework:dev:bootstrap
- pre-push full-fast suite passed before branch push