### PR TITLE
Harden CLI cold-start guard retries

### DIFF
--- a/.agentplane/tasks/202604261742-XBVYMY/README.md
+++ b/.agentplane/tasks/202604261742-XBVYMY/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202604261742-XBVYMY"
 title: "Harden CLI cold-start guard retries"
-status: "DOING"
+result_summary: "Updated bench:cli:cold:check to use warmups=2 and attempts=5, refreshed scripts docs, and recorded verification evidence."
+status: "DONE"
 priority: "med"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -23,11 +24,16 @@ verification:
   updated_at: "2026-04-26T17:45:23.144Z"
   updated_by: "CODER"
   note: "Validated cold-start guard retry budget update: focused script tests passed, updated bench:cli:cold:check passed with existing thresholds, docs script check passed, format/typecheck/diff checks passed."
-commit: null
+commit:
+  hash: "bd20eb499bd9df57f6c02e0c7aeed95b344b16a3"
+  message: "🚧 XBVYMY task: harden cold-start guard retries"
 comments:
   -
     author: "CODER"
     body: "Start: Harden the default CLI cold-start guard retry settings without changing latency thresholds, then refresh scripts docs and verify the guard."
+  -
+    author: "CODER"
+    body: "Verified: cold-start guard retry budget hardened with unchanged latency thresholds; focused script tests, standalone guard, docs script check, format, typecheck, and diff checks passed."
 events:
   -
     type: "status"
@@ -42,8 +48,15 @@ events:
     author: "CODER"
     state: "ok"
     note: "Validated cold-start guard retry budget update: focused script tests passed, updated bench:cli:cold:check passed with existing thresholds, docs script check passed, format/typecheck/diff checks passed."
+  -
+    type: "status"
+    at: "2026-04-26T17:45:52.995Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: cold-start guard retry budget hardened with unchanged latency thresholds; focused script tests, standalone guard, docs script check, format, typecheck, and diff checks passed."
 doc_version: 3
-doc_updated_at: "2026-04-26T17:45:23.186Z"
+doc_updated_at: "2026-04-26T17:45:52.996Z"
 doc_updated_by: "CODER"
 description: "Make the default bench:cli:cold:check script less flaky in pre-push by increasing warmups and retry attempts without raising latency thresholds."
 sections:

--- a/.agentplane/tasks/202604261742-XBVYMY/README.md
+++ b/.agentplane/tasks/202604261742-XBVYMY/README.md
@@ -1,0 +1,123 @@
+---
+id: "202604261742-XBVYMY"
+title: "Harden CLI cold-start guard retries"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "performance"
+  - "tooling"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-04-26T17:42:16.155Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-04-26T17:45:23.144Z"
+  updated_by: "CODER"
+  note: "Validated cold-start guard retry budget update: focused script tests passed, updated bench:cli:cold:check passed with existing thresholds, docs script check passed, format/typecheck/diff checks passed."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Harden the default CLI cold-start guard retry settings without changing latency thresholds, then refresh scripts docs and verify the guard."
+events:
+  -
+    type: "status"
+    at: "2026-04-26T17:42:25.119Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Harden the default CLI cold-start guard retry settings without changing latency thresholds, then refresh scripts docs and verify the guard."
+  -
+    type: "verify"
+    at: "2026-04-26T17:45:23.144Z"
+    author: "CODER"
+    state: "ok"
+    note: "Validated cold-start guard retry budget update: focused script tests passed, updated bench:cli:cold:check passed with existing thresholds, docs script check passed, format/typecheck/diff checks passed."
+doc_version: 3
+doc_updated_at: "2026-04-26T17:45:23.186Z"
+doc_updated_by: "CODER"
+description: "Make the default bench:cli:cold:check script less flaky in pre-push by increasing warmups and retry attempts without raising latency thresholds."
+sections:
+  Summary: |-
+    Harden CLI cold-start guard retries
+    
+    Make the default bench:cli:cold:check script less flaky in pre-push by increasing warmups and retry attempts without raising latency thresholds.
+  Scope: |-
+    - In scope: Make the default bench:cli:cold:check script less flaky in pre-push by increasing warmups and retry attempts without raising latency thresholds.
+    - Out of scope: unrelated refactors not required for "Harden CLI cold-start guard retries".
+  Plan: |-
+    1. Update the default bench:cli:cold:check script to keep the same latency thresholds but use more warmup/retry budget for pre-push stability.
+    2. Refresh generated scripts documentation so the npm-script contract stays visible.
+    3. Verify with the cold guard script test, standalone cold guard, format/diff checks, and task verification.
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-04-26T17:45:23.144Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Validated cold-start guard retry budget update: focused script tests passed, updated bench:cli:cold:check passed with existing thresholds, docs script check passed, format/typecheck/diff checks passed.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-26T17:42:25.146Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Harden CLI cold-start guard retries
+
+Make the default bench:cli:cold:check script less flaky in pre-push by increasing warmups and retry attempts without raising latency thresholds.
+
+## Scope
+
+- In scope: Make the default bench:cli:cold:check script less flaky in pre-push by increasing warmups and retry attempts without raising latency thresholds.
+- Out of scope: unrelated refactors not required for "Harden CLI cold-start guard retries".
+
+## Plan
+
+1. Update the default bench:cli:cold:check script to keep the same latency thresholds but use more warmup/retry budget for pre-push stability.
+2. Refresh generated scripts documentation so the npm-script contract stays visible.
+3. Verify with the cold guard script test, standalone cold guard, format/diff checks, and task verification.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-04-26T17:45:23.144Z — VERIFY — ok
+
+By: CODER
+
+Note: Validated cold-start guard retry budget update: focused script tests passed, updated bench:cli:cold:check passed with existing thresholds, docs script check passed, format/typecheck/diff checks passed.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-04-26T17:42:25.146Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "workflow:github-protection:check": "node scripts/check-github-protection-contract.mjs",
     "framework:dev:bootstrap": "node scripts/bootstrap-framework-dev.mjs",
     "bench:cli:cold": "node scripts/measure-cli-cold-path.mjs",
-    "bench:cli:cold:check": "node scripts/check-cli-cold-baseline.mjs --warmups 1 --attempts 2",
+    "bench:cli:cold:check": "node scripts/check-cli-cold-baseline.mjs --warmups 2 --attempts 5",
     "runner:codex:approval-probe": "bun scripts/run-runner-codex-approval-probe.mjs",
     "runner:codex:smoke": "bun scripts/run-runner-codex-smoke.mjs",
     "docs:cli:generate": "node packages/agentplane/dist/cli.js docs cli --out docs/user/cli-reference.generated.mdx",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -91,7 +91,7 @@ Grouping policy: `ci`, `release`, `docs`, `test`, `coverage`, `arch`, `bench`, `
 | Script                 | Command                                                             | Purpose                             |
 | ---------------------- | ------------------------------------------------------------------- | ----------------------------------- |
 | `bench:cli:cold`       | `node scripts/measure-cli-cold-path.mjs`                            | Run bench workflow: cli cold.       |
-| `bench:cli:cold:check` | `node scripts/check-cli-cold-baseline.mjs --warmups 1 --attempts 2` | Run bench workflow: cli cold check. |
+| `bench:cli:cold:check` | `node scripts/check-cli-cold-baseline.mjs --warmups 2 --attempts 5` | Run bench workflow: cli cold check. |
 
 ## Misc
 


### PR DESCRIPTION
## Summary
- Increase the default cold-start guard warmup/retry budget without changing latency thresholds
- Refresh generated scripts README
- Record AgentPlane task verification for 202604261742-XBVYMY

## Verification
- bunx vitest run packages/agentplane/src/cli/check-cli-cold-baseline-script.test.ts packages/agentplane/src/cli/measure-cli-cold-path-script.test.ts
- bun run bench:cli:cold:check
- bun run docs:scripts:check
- bun run format:check
- bun run typecheck
- git diff --check
- pre-push fast CI via git push (passed, including cold guard retry 2/5, fast unit suite, critical E2E)