### PR TITLE
NXZF00 close: fix prompt compiler duplicate helper

### DIFF
--- a/packages/agentplane/src/runtime/prompt-modules/compiler.ts
+++ b/packages/agentplane/src/runtime/prompt-modules/compiler.ts
@@ -75,14 +75,6 @@ const PROMPT_MODULE_WORKFLOW_MODE_VALUES = ["direct", "branch_pr"] as const;
 const PROMPT_MODULE_POLICY_GATEWAY_VALUES = ["codex", "claude"] as const;
 const PROMPT_MODULE_VALIDATOR_PHASE_VALUES = ["resolve", "compile", "emit", "doctor"] as const;
 
-function hasControlCharacter(value: string): boolean {
-  for (const character of value) {
-    const code = character.codePointAt(0) ?? -1;
-    if (code <= 0x1f || code === 0x7f) return true;
-  }
-  return false;
-}
-
 function hasAllowedValue<TValue extends string>(
   value: string,
   allowedValues: readonly TValue[],


### PR DESCRIPTION
Fixes the hosted close build failure after #657 by removing the duplicate hasControlCharacter implementation introduced by branch merge overlap.\n\nVerification:\n- bun run --filter=@agentplaneorg/core build && bun run --filter=agentplane build\n- bunx eslint packages/agentplane/src/runtime/prompt-modules/compiler.ts\n- pre-push standard gate passed on task/202605010748-NXZF00/close-fix