### PR TITLE
docs: Prepare AgentPlane listing submission profile (51FA6Z)

### DIFF
--- a/.agentplane/tasks/202605011515-H09565/README.md
+++ b/.agentplane/tasks/202605011515-H09565/README.md
@@ -1,0 +1,89 @@
+---
+id: "202605011515-H09565"
+title: "Add AgentPlane to bradAGI awesome-cli-coding-agents"
+status: "TODO"
+priority: "med"
+owner: "DOCS"
+revision: 1
+origin:
+  system: "manual"
+depends_on:
+  - "202605011515-SS66H4"
+tags:
+  - "docs"
+verify: []
+plan_approval:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-01T15:15:23.671Z"
+doc_updated_by: "DOCS"
+description: "Submit a GitHub PR adding AgentPlane to bradAGI/awesome-cli-coding-agents under Harnesses and orchestration after verifying the current category names and formatting conventions."
+sections:
+  Summary: |-
+    Add AgentPlane to bradAGI awesome-cli-coding-agents
+    
+    Submit a GitHub PR adding AgentPlane to bradAGI/awesome-cli-coding-agents under Harnesses and orchestration after verifying the current category names and formatting conventions.
+  Scope: |-
+    - In scope: Submit a GitHub PR adding AgentPlane to bradAGI/awesome-cli-coding-agents under Harnesses and orchestration after verifying the current category names and formatting conventions.
+    - Out of scope: unrelated refactors not required for "Add AgentPlane to bradAGI awesome-cli-coding-agents".
+  Plan: |-
+    1. Implement the change for "Add AgentPlane to bradAGI awesome-cli-coding-agents".
+    2. Run required checks and capture verification evidence.
+    3. Finalize task findings and finish with traceable commit metadata.
+  Verify Steps: |-
+    1. Review the requested outcome for "Add AgentPlane to bradAGI awesome-cli-coding-agents". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add AgentPlane to bradAGI awesome-cli-coding-agents
+
+Submit a GitHub PR adding AgentPlane to bradAGI/awesome-cli-coding-agents under Harnesses and orchestration after verifying the current category names and formatting conventions.
+
+## Scope
+
+- In scope: Submit a GitHub PR adding AgentPlane to bradAGI/awesome-cli-coding-agents under Harnesses and orchestration after verifying the current category names and formatting conventions.
+- Out of scope: unrelated refactors not required for "Add AgentPlane to bradAGI awesome-cli-coding-agents".
+
+## Plan
+
+1. Implement the change for "Add AgentPlane to bradAGI awesome-cli-coding-agents".
+2. Run required checks and capture verification evidence.
+3. Finalize task findings and finish with traceable commit metadata.
+
+## Verify Steps
+
+1. Review the requested outcome for "Add AgentPlane to bradAGI awesome-cli-coding-agents". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605011515-NKWCVZ/README.md
+++ b/.agentplane/tasks/202605011515-NKWCVZ/README.md
@@ -1,0 +1,89 @@
+---
+id: "202605011515-NKWCVZ"
+title: "Add AgentPlane to ai-boost awesome-harness-engineering"
+status: "TODO"
+priority: "med"
+owner: "DOCS"
+revision: 1
+origin:
+  system: "manual"
+depends_on:
+  - "202605011515-H09565"
+tags:
+  - "docs"
+verify: []
+plan_approval:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-01T15:15:46.452Z"
+doc_updated_by: "DOCS"
+description: "Submit a GitHub PR adding AgentPlane to ai-boost/awesome-harness-engineering in Task Runners and Orchestration or the closest workflow-control section after checking current scope and ordering."
+sections:
+  Summary: |-
+    Add AgentPlane to ai-boost awesome-harness-engineering
+    
+    Submit a GitHub PR adding AgentPlane to ai-boost/awesome-harness-engineering in Task Runners and Orchestration or the closest workflow-control section after checking current scope and ordering.
+  Scope: |-
+    - In scope: Submit a GitHub PR adding AgentPlane to ai-boost/awesome-harness-engineering in Task Runners and Orchestration or the closest workflow-control section after checking current scope and ordering.
+    - Out of scope: unrelated refactors not required for "Add AgentPlane to ai-boost awesome-harness-engineering".
+  Plan: |-
+    1. Implement the change for "Add AgentPlane to ai-boost awesome-harness-engineering".
+    2. Run required checks and capture verification evidence.
+    3. Finalize task findings and finish with traceable commit metadata.
+  Verify Steps: |-
+    1. Review the requested outcome for "Add AgentPlane to ai-boost awesome-harness-engineering". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add AgentPlane to ai-boost awesome-harness-engineering
+
+Submit a GitHub PR adding AgentPlane to ai-boost/awesome-harness-engineering in Task Runners and Orchestration or the closest workflow-control section after checking current scope and ordering.
+
+## Scope
+
+- In scope: Submit a GitHub PR adding AgentPlane to ai-boost/awesome-harness-engineering in Task Runners and Orchestration or the closest workflow-control section after checking current scope and ordering.
+- Out of scope: unrelated refactors not required for "Add AgentPlane to ai-boost awesome-harness-engineering".
+
+## Plan
+
+1. Implement the change for "Add AgentPlane to ai-boost awesome-harness-engineering".
+2. Run required checks and capture verification evidence.
+3. Finalize task findings and finish with traceable commit metadata.
+
+## Verify Steps
+
+1. Review the requested outcome for "Add AgentPlane to ai-boost awesome-harness-engineering". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605011515-SS66H4/README.md
+++ b/.agentplane/tasks/202605011515-SS66H4/README.md
@@ -1,0 +1,90 @@
+---
+id: "202605011515-SS66H4"
+title: "Add AgentPlane to Picrew awesome-agent-harness"
+status: "TODO"
+priority: "med"
+owner: "DOCS"
+revision: 1
+origin:
+  system: "manual"
+depends_on:
+  - "202605011517-51FA6Z"
+tags:
+  - "docs"
+verify: []
+plan_approval:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-01T15:15:09.839Z"
+doc_updated_by: "DOCS"
+description: "Submit a focused GitHub PR adding AgentPlane to Picrew/awesome-agent-harness in the most fitting harness implementation, guardrails, governance, or orchestration section after verifying the current README structure."
+sections:
+  Summary: |-
+    Add AgentPlane to Picrew awesome-agent-harness
+    
+    Submit a focused GitHub PR adding AgentPlane to Picrew/awesome-agent-harness in the most fitting harness implementation, guardrails, governance, or orchestration section after verifying the current README structure.
+  Scope: |-
+    - In scope: Submit a focused GitHub PR adding AgentPlane to Picrew/awesome-agent-harness in the most fitting harness implementation, guardrails, governance, or orchestration section after verifying the current README structure.
+    - Out of scope: unrelated refactors not required for "Add AgentPlane to Picrew awesome-agent-harness".
+  Plan: |-
+    1. Implement the change for "Add AgentPlane to Picrew awesome-agent-harness".
+    2. Run required checks and capture verification evidence.
+    3. Finalize task findings and finish with traceable commit metadata.
+  Verify Steps: |-
+    1. Review the requested outcome for "Add AgentPlane to Picrew awesome-agent-harness". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add AgentPlane to Picrew awesome-agent-harness
+
+Submit a focused GitHub PR adding AgentPlane to Picrew/awesome-agent-harness in the most fitting harness implementation, guardrails, governance, or orchestration section after verifying the current README structure.
+
+## Scope
+
+- In scope: Submit a focused GitHub PR adding AgentPlane to Picrew/awesome-agent-harness in the most fitting harness implementation, guardrails, governance, or orchestration section after verifying the current README structure.
+- Out of scope: unrelated refactors not required for "Add AgentPlane to Picrew awesome-agent-harness".
+
+## Plan
+
+1. Implement the change for "Add AgentPlane to Picrew awesome-agent-harness".
+2. Run required checks and capture verification evidence.
+3. Finalize task findings and finish with traceable commit metadata.
+
+## Verify Steps
+
+1. Review the requested outcome for "Add AgentPlane to Picrew awesome-agent-harness". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605011516-SWJJK0/README.md
+++ b/.agentplane/tasks/202605011516-SWJJK0/README.md
@@ -1,0 +1,90 @@
+---
+id: "202605011516-SWJJK0"
+title: "Add AgentPlane to walkinglabs awesome-harness-engineering"
+status: "TODO"
+priority: "med"
+owner: "DOCS"
+revision: 1
+origin:
+  system: "manual"
+depends_on:
+  - "202605011518-ZJQZMT"
+tags:
+  - "docs"
+verify: []
+plan_approval:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-01T15:16:05.441Z"
+doc_updated_by: "DOCS"
+description: "Submit a GitHub PR adding AgentPlane to walkinglabs/awesome-harness-engineering as a reliability and workflow-control primitive after verifying the stricter inclusion scope and current section structure."
+sections:
+  Summary: |-
+    Add AgentPlane to walkinglabs awesome-harness-engineering
+    
+    Submit a GitHub PR adding AgentPlane to walkinglabs/awesome-harness-engineering as a reliability and workflow-control primitive after verifying the stricter inclusion scope and current section structure.
+  Scope: |-
+    - In scope: Submit a GitHub PR adding AgentPlane to walkinglabs/awesome-harness-engineering as a reliability and workflow-control primitive after verifying the stricter inclusion scope and current section structure.
+    - Out of scope: unrelated refactors not required for "Add AgentPlane to walkinglabs awesome-harness-engineering".
+  Plan: |-
+    1. Implement the change for "Add AgentPlane to walkinglabs awesome-harness-engineering".
+    2. Run required checks and capture verification evidence.
+    3. Finalize task findings and finish with traceable commit metadata.
+  Verify Steps: |-
+    1. Review the requested outcome for "Add AgentPlane to walkinglabs awesome-harness-engineering". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add AgentPlane to walkinglabs awesome-harness-engineering
+
+Submit a GitHub PR adding AgentPlane to walkinglabs/awesome-harness-engineering as a reliability and workflow-control primitive after verifying the stricter inclusion scope and current section structure.
+
+## Scope
+
+- In scope: Submit a GitHub PR adding AgentPlane to walkinglabs/awesome-harness-engineering as a reliability and workflow-control primitive after verifying the stricter inclusion scope and current section structure.
+- Out of scope: unrelated refactors not required for "Add AgentPlane to walkinglabs awesome-harness-engineering".
+
+## Plan
+
+1. Implement the change for "Add AgentPlane to walkinglabs awesome-harness-engineering".
+2. Run required checks and capture verification evidence.
+3. Finalize task findings and finish with traceable commit metadata.
+
+## Verify Steps
+
+1. Review the requested outcome for "Add AgentPlane to walkinglabs awesome-harness-engineering". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605011517-51FA6Z/README.md
+++ b/.agentplane/tasks/202605011517-51FA6Z/README.md
@@ -1,0 +1,98 @@
+---
+id: "202605011517-51FA6Z"
+title: "Prepare AgentPlane listing submission profile"
+status: "DOING"
+priority: "med"
+owner: "DOCS"
+revision: 7
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "docs"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-01T15:21:31.638Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+commit: null
+comments:
+  -
+    author: "DOCS"
+    body: "Start: preparing listing-only discoverability profile in a dedicated branch_pr worktree; skill artifacts remain excluded by user request."
+events:
+  -
+    type: "status"
+    at: "2026-05-01T15:22:53.833Z"
+    author: "DOCS"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: preparing listing-only discoverability profile in a dedicated branch_pr worktree; skill artifacts remain excluded by user request."
+doc_version: 3
+doc_updated_at: "2026-05-01T15:22:53.833Z"
+doc_updated_by: "DOCS"
+description: "Prepare AgentPlane for curated-list submissions by updating GitHub topics and adding docs/listing.md snippets. Excludes agent-skill directory work by user request."
+sections:
+  Summary: "Prepare AgentPlane for curated-list submissions by tightening repository discovery metadata and adding reusable listing snippets. Agent-skill directory work is explicitly out of scope by user request."
+  Scope: |-
+    - In scope: update GitHub repository topics for harness/coding-agent discovery; add docs/listing.md with short, medium, tag, category, and PR-body snippets for curated-list submissions.
+    - Out of scope: skills/agentplane-workflow, agent skill directories, MCP lists, runtime/code changes, unrelated launch content.
+  Plan: |-
+    1. Verify current repository topics and README positioning.
+    2. Add only listing-oriented metadata/docs: GitHub topics and docs/listing.md.
+    3. Do not create skills/agentplane-workflow or submit to agent-skill directories in this task.
+    4. Run docs/policy checks and record verification evidence before PR/listing work continues.
+  Verify Steps: |-
+    1. Confirm GitHub topics include the listing/discoverability terms and do not remove existing useful topics.
+    2. Confirm docs/listing.md exists and contains short, medium, tags, best categories, suggested entries, and PR-body snippets for curated-list submissions.
+    3. Confirm no skills/agentplane-workflow directory or agent-skill submission artifact was created.
+    4. Run node .agentplane/policy/check-routing.mjs and agentplane doctor.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Prepare AgentPlane for curated-list submissions by tightening repository discovery metadata and adding reusable listing snippets. Agent-skill directory work is explicitly out of scope by user request.
+
+## Scope
+
+- In scope: update GitHub repository topics for harness/coding-agent discovery; add docs/listing.md with short, medium, tag, category, and PR-body snippets for curated-list submissions.
+- Out of scope: skills/agentplane-workflow, agent skill directories, MCP lists, runtime/code changes, unrelated launch content.
+
+## Plan
+
+1. Verify current repository topics and README positioning.
+2. Add only listing-oriented metadata/docs: GitHub topics and docs/listing.md.
+3. Do not create skills/agentplane-workflow or submit to agent-skill directories in this task.
+4. Run docs/policy checks and record verification evidence before PR/listing work continues.
+
+## Verify Steps
+
+1. Confirm GitHub topics include the listing/discoverability terms and do not remove existing useful topics.
+2. Confirm docs/listing.md exists and contains short, medium, tags, best categories, suggested entries, and PR-body snippets for curated-list submissions.
+3. Confirm no skills/agentplane-workflow directory or agent-skill submission artifact was created.
+4. Run node .agentplane/policy/check-routing.mjs and agentplane doctor.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605011517-51FA6Z/README.md
+++ b/.agentplane/tasks/202605011517-51FA6Z/README.md
@@ -4,7 +4,7 @@ title: "Prepare AgentPlane listing submission profile"
 status: "DOING"
 priority: "med"
 owner: "DOCS"
-revision: 7
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -17,10 +17,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-01T15:45:46.547Z"
+  updated_by: "DOCS"
+  note: "docs listing profile verified; doctor passed after longer runtime"
 commit: null
 comments:
   -
@@ -34,8 +34,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: preparing listing-only discoverability profile in a dedicated branch_pr worktree; skill artifacts remain excluded by user request."
+  -
+    type: "verify"
+    at: "2026-05-01T15:45:46.547Z"
+    author: "DOCS"
+    state: "ok"
+    note: "docs listing profile verified; doctor passed after longer runtime"
 doc_version: 3
-doc_updated_at: "2026-05-01T15:22:53.833Z"
+doc_updated_at: "2026-05-01T15:45:46.580Z"
 doc_updated_by: "DOCS"
 description: "Prepare AgentPlane for curated-list submissions by updating GitHub topics and adding docs/listing.md snippets. Excludes agent-skill directory work by user request."
 sections:
@@ -55,6 +61,40 @@ sections:
     4. Run node .agentplane/policy/check-routing.mjs and agentplane doctor.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-01T15:45:46.547Z — VERIFY — ok
+    
+    By: DOCS
+    
+    Note: docs listing profile verified; doctor passed after longer runtime
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-01T15:22:53.833Z, excerpt_hash=sha256:00680cd1dc15eebd3fa79df676f868eae71453126aaee46f34ffcaaef5ce823b
+    
+    Details:
+    
+    Command: git diff --check
+    Result: pass
+    Evidence: no whitespace errors.
+    Scope: docs/listing.md, docs navigation, task artifacts.
+    Links: docs/listing.md.
+    
+    Command: bun run docs:ia:check
+    Result: pass
+    Evidence: ok: docs IA, sidebar coverage, and current path references are aligned.
+    Scope: docs/index.mdx, docs/README.md, website/sidebars.ts, docs/listing.md.
+    Links: docs/listing.md.
+    
+    Command: node .agentplane/policy/check-routing.mjs
+    Result: pass
+    Evidence: policy routing OK.
+    Scope: policy routing after docs-only task setup.
+    Links: loaded branch_pr/docs policy modules.
+    
+    Command: node packages/agentplane/dist/cli.js doctor
+    Result: pass
+    Evidence: doctor OK; runtime repo-local; elapsed 1:27.68; info-only historical archive findings.
+    Scope: AgentPlane worktree health after docs/listing submission profile changes.
+    Links: docs/listing.md.
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -88,6 +128,40 @@ Prepare AgentPlane for curated-list submissions by tightening repository discove
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-01T15:45:46.547Z — VERIFY — ok
+
+By: DOCS
+
+Note: docs listing profile verified; doctor passed after longer runtime
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-01T15:22:53.833Z, excerpt_hash=sha256:00680cd1dc15eebd3fa79df676f868eae71453126aaee46f34ffcaaef5ce823b
+
+Details:
+
+Command: git diff --check
+Result: pass
+Evidence: no whitespace errors.
+Scope: docs/listing.md, docs navigation, task artifacts.
+Links: docs/listing.md.
+
+Command: bun run docs:ia:check
+Result: pass
+Evidence: ok: docs IA, sidebar coverage, and current path references are aligned.
+Scope: docs/index.mdx, docs/README.md, website/sidebars.ts, docs/listing.md.
+Links: docs/listing.md.
+
+Command: node .agentplane/policy/check-routing.mjs
+Result: pass
+Evidence: policy routing OK.
+Scope: policy routing after docs-only task setup.
+Links: loaded branch_pr/docs policy modules.
+
+Command: node packages/agentplane/dist/cli.js doctor
+Result: pass
+Evidence: doctor OK; runtime repo-local; elapsed 1:27.68; info-only historical archive findings.
+Scope: AgentPlane worktree health after docs/listing submission profile changes.
+Links: docs/listing.md.
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605011517-51FA6Z/pr/diffstat.txt
+++ b/.agentplane/tasks/202605011517-51FA6Z/pr/diffstat.txt
@@ -1,0 +1,14 @@
+ .agentplane/tasks/202605011515-H09565/README.md |  89 +++++++++++++++++
+ .agentplane/tasks/202605011515-NKWCVZ/README.md |  89 +++++++++++++++++
+ .agentplane/tasks/202605011515-SS66H4/README.md |  90 +++++++++++++++++
+ .agentplane/tasks/202605011516-SWJJK0/README.md |  90 +++++++++++++++++
+ .agentplane/tasks/202605011518-97HPR5/README.md |  89 +++++++++++++++++
+ .agentplane/tasks/202605011518-PH7024/README.md |  89 +++++++++++++++++
+ .agentplane/tasks/202605011518-ZJQZMT/README.md |  89 +++++++++++++++++
+ .agentplane/tasks/202605011519-653853/README.md |  89 +++++++++++++++++
+ .agentplane/tasks/202605011519-EF3RKQ/README.md |  89 +++++++++++++++++
+ docs/README.md                                  |   3 +
+ docs/index.mdx                                  |   5 +-
+ docs/listing.md                                 | 126 ++++++++++++++++++++++++
+ website/sidebars.ts                             |   1 +
+ 13 files changed, 936 insertions(+), 2 deletions(-)

--- a/.agentplane/tasks/202605011517-51FA6Z/pr/github-body.md
+++ b/.agentplane/tasks/202605011517-51FA6Z/pr/github-body.md
@@ -9,8 +9,8 @@ Prepare AgentPlane for curated-list submissions by tightening repository discove
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: docs listing profile verified; doctor passed after longer runtime
 - Full verification checklist lives in local review.md.
 
 ## Handoff Notes

--- a/.agentplane/tasks/202605011517-51FA6Z/pr/github-body.md
+++ b/.agentplane/tasks/202605011517-51FA6Z/pr/github-body.md
@@ -20,12 +20,25 @@ Prepare AgentPlane for curated-list submissions by tightening repository discove
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-01T15:22:58.600Z
+- Updated: 2026-05-01T15:36:46.140Z
 - Branch: task/202605011517-51FA6Z/listing-submission-profile
-- Head: ffeacc948b22
+- Head: e7403edb6f14
 
 ```text
-No changes detected.
+ .agentplane/tasks/202605011515-H09565/README.md |  89 +++++++++++++++++
+ .agentplane/tasks/202605011515-NKWCVZ/README.md |  89 +++++++++++++++++
+ .agentplane/tasks/202605011515-SS66H4/README.md |  90 +++++++++++++++++
+ .agentplane/tasks/202605011516-SWJJK0/README.md |  90 +++++++++++++++++
+ .agentplane/tasks/202605011518-97HPR5/README.md |  89 +++++++++++++++++
+ .agentplane/tasks/202605011518-PH7024/README.md |  89 +++++++++++++++++
+ .agentplane/tasks/202605011518-ZJQZMT/README.md |  89 +++++++++++++++++
+ .agentplane/tasks/202605011519-653853/README.md |  89 +++++++++++++++++
+ .agentplane/tasks/202605011519-EF3RKQ/README.md |  89 +++++++++++++++++
+ docs/README.md                                  |   3 +
+ docs/index.mdx                                  |   5 +-
+ docs/listing.md                                 | 126 ++++++++++++++++++++++++
+ website/sidebars.ts                             |   1 +
+ 13 files changed, 936 insertions(+), 2 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605011517-51FA6Z/pr/github-body.md
+++ b/.agentplane/tasks/202605011517-51FA6Z/pr/github-body.md
@@ -1,0 +1,31 @@
+## Summary
+
+Prepare AgentPlane for curated-list submissions by tightening repository discovery metadata and adding reusable listing snippets. Agent-skill directory work is explicitly out of scope by user request.
+
+## Scope
+
+- In scope: update GitHub repository topics for harness/coding-agent discovery; add docs/listing.md with short, medium, tag, category, and PR-body snippets for curated-list submissions.
+- Out of scope: skills/agentplane-workflow, agent skill directories, MCP lists, runtime/code changes, unrelated launch content.
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Full verification checklist lives in local review.md.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-01T15:22:58.600Z
+- Branch: task/202605011517-51FA6Z/listing-submission-profile
+- Head: ffeacc948b22
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605011517-51FA6Z/pr/github-title.txt
+++ b/.agentplane/tasks/202605011517-51FA6Z/pr/github-title.txt
@@ -1,0 +1,1 @@
+docs: Prepare AgentPlane listing submission profile (51FA6Z)

--- a/.agentplane/tasks/202605011517-51FA6Z/pr/meta.json
+++ b/.agentplane/tasks/202605011517-51FA6Z/pr/meta.json
@@ -3,12 +3,12 @@
   "branch": "task/202605011517-51FA6Z/listing-submission-profile",
   "created_at": "2026-05-01T15:22:58.600Z",
   "head_sha": "e7403edb6f14a8332fdcd85b96d663116e38e033",
-  "last_verified_at": null,
-  "last_verified_sha": null,
+  "last_verified_at": "2026-05-01T15:45:46.547Z",
+  "last_verified_sha": "e7403edb6f14a8332fdcd85b96d663116e38e033",
   "schema_version": 1,
   "task_id": "202605011517-51FA6Z",
   "updated_at": "2026-05-01T15:36:46.140Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605011517-51FA6Z/pr/meta.json
+++ b/.agentplane/tasks/202605011517-51FA6Z/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605011517-51FA6Z/listing-submission-profile",
   "created_at": "2026-05-01T15:22:58.600Z",
-  "head_sha": "ffeacc948b226395c05fcbbda28c73fbd4c3d61b",
+  "head_sha": "e7403edb6f14a8332fdcd85b96d663116e38e033",
   "last_verified_at": null,
   "last_verified_sha": null,
   "schema_version": 1,
   "task_id": "202605011517-51FA6Z",
-  "updated_at": "2026-05-01T15:22:58.600Z",
+  "updated_at": "2026-05-01T15:36:46.140Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202605011517-51FA6Z/pr/meta.json
+++ b/.agentplane/tasks/202605011517-51FA6Z/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605011517-51FA6Z/listing-submission-profile",
+  "created_at": "2026-05-01T15:22:58.600Z",
+  "head_sha": "ffeacc948b226395c05fcbbda28c73fbd4c3d61b",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202605011517-51FA6Z",
+  "updated_at": "2026-05-01T15:22:58.600Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605011517-51FA6Z/pr/review.md
+++ b/.agentplane/tasks/202605011517-51FA6Z/pr/review.md
@@ -23,8 +23,8 @@ Prepare AgentPlane for curated-list submissions by tightening repository discove
 
 ### Current Status
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: docs listing profile verified; doctor passed after longer runtime
 
 ## Risks
 

--- a/.agentplane/tasks/202605011517-51FA6Z/pr/review.md
+++ b/.agentplane/tasks/202605011517-51FA6Z/pr/review.md
@@ -1,0 +1,56 @@
+# PR Review
+
+Created: 2026-05-01T15:22:58.600Z
+Branch: task/202605011517-51FA6Z/listing-submission-profile
+
+## Summary
+
+Prepare AgentPlane for curated-list submissions by tightening repository discovery metadata and adding reusable listing snippets. Agent-skill directory work is explicitly out of scope by user request.
+
+## Scope
+
+- In scope: update GitHub repository topics for harness/coding-agent discovery; add docs/listing.md with short, medium, tag, category, and PR-body snippets for curated-list submissions.
+- Out of scope: skills/agentplane-workflow, agent skill directories, MCP lists, runtime/code changes, unrelated launch content.
+
+## Verification
+
+### Plan
+
+1. Confirm GitHub topics include the listing/discoverability terms and do not remove existing useful topics.
+2. Confirm docs/listing.md exists and contains short, medium, tags, best categories, suggested entries, and PR-body snippets for curated-list submissions.
+3. Confirm no skills/agentplane-workflow directory or agent-skill submission artifact was created.
+4. Run node .agentplane/policy/check-routing.mjs and agentplane doctor.
+
+### Current Status
+
+- State: pending
+- Note: Not recorded yet.
+
+## Risks
+
+- Risk level: not recorded
+- Breaking change: no
+
+### Rollback
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-01T15:22:58.600Z
+- Branch: task/202605011517-51FA6Z/listing-submission-profile
+- Head: ffeacc948b22
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605011517-51FA6Z/pr/review.md
+++ b/.agentplane/tasks/202605011517-51FA6Z/pr/review.md
@@ -44,12 +44,25 @@ Prepare AgentPlane for curated-list submissions by tightening repository discove
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-01T15:22:58.600Z
+- Updated: 2026-05-01T15:36:46.140Z
 - Branch: task/202605011517-51FA6Z/listing-submission-profile
-- Head: ffeacc948b22
+- Head: e7403edb6f14
 
 ```text
-No changes detected.
+ .agentplane/tasks/202605011515-H09565/README.md |  89 +++++++++++++++++
+ .agentplane/tasks/202605011515-NKWCVZ/README.md |  89 +++++++++++++++++
+ .agentplane/tasks/202605011515-SS66H4/README.md |  90 +++++++++++++++++
+ .agentplane/tasks/202605011516-SWJJK0/README.md |  90 +++++++++++++++++
+ .agentplane/tasks/202605011518-97HPR5/README.md |  89 +++++++++++++++++
+ .agentplane/tasks/202605011518-PH7024/README.md |  89 +++++++++++++++++
+ .agentplane/tasks/202605011518-ZJQZMT/README.md |  89 +++++++++++++++++
+ .agentplane/tasks/202605011519-653853/README.md |  89 +++++++++++++++++
+ .agentplane/tasks/202605011519-EF3RKQ/README.md |  89 +++++++++++++++++
+ docs/README.md                                  |   3 +
+ docs/index.mdx                                  |   5 +-
+ docs/listing.md                                 | 126 ++++++++++++++++++++++++
+ website/sidebars.ts                             |   1 +
+ 13 files changed, 936 insertions(+), 2 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605011518-97HPR5/README.md
+++ b/.agentplane/tasks/202605011518-97HPR5/README.md
@@ -1,0 +1,89 @@
+---
+id: "202605011518-97HPR5"
+title: "Add AgentPlane to ai-for-developers awesome-ai-coding-tools"
+status: "TODO"
+priority: "med"
+owner: "DOCS"
+revision: 1
+origin:
+  system: "manual"
+depends_on:
+  - "202605011516-SWJJK0"
+tags:
+  - "docs"
+verify: []
+plan_approval:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-01T15:18:35.730Z"
+doc_updated_by: "DOCS"
+description: "Submit a GitHub PR adding AgentPlane to ai-for-developers/awesome-ai-coding-tools as workflow infrastructure for AI coding tools after verifying the current contribution format."
+sections:
+  Summary: |-
+    Add AgentPlane to ai-for-developers awesome-ai-coding-tools
+    
+    Submit a GitHub PR adding AgentPlane to ai-for-developers/awesome-ai-coding-tools as workflow infrastructure for AI coding tools after verifying the current contribution format.
+  Scope: |-
+    - In scope: Submit a GitHub PR adding AgentPlane to ai-for-developers/awesome-ai-coding-tools as workflow infrastructure for AI coding tools after verifying the current contribution format.
+    - Out of scope: unrelated refactors not required for "Add AgentPlane to ai-for-developers awesome-ai-coding-tools".
+  Plan: |-
+    1. Implement the change for "Add AgentPlane to ai-for-developers awesome-ai-coding-tools".
+    2. Run required checks and capture verification evidence.
+    3. Finalize task findings and finish with traceable commit metadata.
+  Verify Steps: |-
+    1. Review the requested outcome for "Add AgentPlane to ai-for-developers awesome-ai-coding-tools". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add AgentPlane to ai-for-developers awesome-ai-coding-tools
+
+Submit a GitHub PR adding AgentPlane to ai-for-developers/awesome-ai-coding-tools as workflow infrastructure for AI coding tools after verifying the current contribution format.
+
+## Scope
+
+- In scope: Submit a GitHub PR adding AgentPlane to ai-for-developers/awesome-ai-coding-tools as workflow infrastructure for AI coding tools after verifying the current contribution format.
+- Out of scope: unrelated refactors not required for "Add AgentPlane to ai-for-developers awesome-ai-coding-tools".
+
+## Plan
+
+1. Implement the change for "Add AgentPlane to ai-for-developers awesome-ai-coding-tools".
+2. Run required checks and capture verification evidence.
+3. Finalize task findings and finish with traceable commit metadata.
+
+## Verify Steps
+
+1. Review the requested outcome for "Add AgentPlane to ai-for-developers awesome-ai-coding-tools". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605011518-PH7024/README.md
+++ b/.agentplane/tasks/202605011518-PH7024/README.md
@@ -1,0 +1,89 @@
+---
+id: "202605011518-PH7024"
+title: "Add AgentPlane to brandonhimpfen awesome-ai-coding-agents"
+status: "TODO"
+priority: "med"
+owner: "DOCS"
+revision: 1
+origin:
+  system: "manual"
+depends_on:
+  - "202605011518-97HPR5"
+tags:
+  - "docs"
+verify: []
+plan_approval:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-01T15:18:51.518Z"
+doc_updated_by: "DOCS"
+description: "Submit a GitHub PR adding AgentPlane to brandonhimpfen/awesome-ai-coding-agents as workflow infrastructure for AI coding agents after checking scope alignment, formatting, and category placement."
+sections:
+  Summary: |-
+    Add AgentPlane to brandonhimpfen awesome-ai-coding-agents
+    
+    Submit a GitHub PR adding AgentPlane to brandonhimpfen/awesome-ai-coding-agents as workflow infrastructure for AI coding agents after checking scope alignment, formatting, and category placement.
+  Scope: |-
+    - In scope: Submit a GitHub PR adding AgentPlane to brandonhimpfen/awesome-ai-coding-agents as workflow infrastructure for AI coding agents after checking scope alignment, formatting, and category placement.
+    - Out of scope: unrelated refactors not required for "Add AgentPlane to brandonhimpfen awesome-ai-coding-agents".
+  Plan: |-
+    1. Implement the change for "Add AgentPlane to brandonhimpfen awesome-ai-coding-agents".
+    2. Run required checks and capture verification evidence.
+    3. Finalize task findings and finish with traceable commit metadata.
+  Verify Steps: |-
+    1. Review the requested outcome for "Add AgentPlane to brandonhimpfen awesome-ai-coding-agents". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add AgentPlane to brandonhimpfen awesome-ai-coding-agents
+
+Submit a GitHub PR adding AgentPlane to brandonhimpfen/awesome-ai-coding-agents as workflow infrastructure for AI coding agents after checking scope alignment, formatting, and category placement.
+
+## Scope
+
+- In scope: Submit a GitHub PR adding AgentPlane to brandonhimpfen/awesome-ai-coding-agents as workflow infrastructure for AI coding agents after checking scope alignment, formatting, and category placement.
+- Out of scope: unrelated refactors not required for "Add AgentPlane to brandonhimpfen awesome-ai-coding-agents".
+
+## Plan
+
+1. Implement the change for "Add AgentPlane to brandonhimpfen awesome-ai-coding-agents".
+2. Run required checks and capture verification evidence.
+3. Finalize task findings and finish with traceable commit metadata.
+
+## Verify Steps
+
+1. Review the requested outcome for "Add AgentPlane to brandonhimpfen awesome-ai-coding-agents". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605011518-ZJQZMT/README.md
+++ b/.agentplane/tasks/202605011518-ZJQZMT/README.md
@@ -1,0 +1,89 @@
+---
+id: "202605011518-ZJQZMT"
+title: "Add AgentPlane to AutoJunjie awesome-agent-harness"
+status: "TODO"
+priority: "med"
+owner: "DOCS"
+revision: 1
+origin:
+  system: "manual"
+depends_on:
+  - "202605011515-NKWCVZ"
+tags:
+  - "docs"
+verify: []
+plan_approval:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-01T15:18:09.457Z"
+doc_updated_by: "DOCS"
+description: "Submit a GitHub PR adding AgentPlane to AutoJunjie/awesome-agent-harness as a Git-native coding-agent harness after verifying the current repository structure and list formatting."
+sections:
+  Summary: |-
+    Add AgentPlane to AutoJunjie awesome-agent-harness
+    
+    Submit a GitHub PR adding AgentPlane to AutoJunjie/awesome-agent-harness as a Git-native coding-agent harness after verifying the current repository structure and list formatting.
+  Scope: |-
+    - In scope: Submit a GitHub PR adding AgentPlane to AutoJunjie/awesome-agent-harness as a Git-native coding-agent harness after verifying the current repository structure and list formatting.
+    - Out of scope: unrelated refactors not required for "Add AgentPlane to AutoJunjie awesome-agent-harness".
+  Plan: |-
+    1. Implement the change for "Add AgentPlane to AutoJunjie awesome-agent-harness".
+    2. Run required checks and capture verification evidence.
+    3. Finalize task findings and finish with traceable commit metadata.
+  Verify Steps: |-
+    1. Review the requested outcome for "Add AgentPlane to AutoJunjie awesome-agent-harness". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add AgentPlane to AutoJunjie awesome-agent-harness
+
+Submit a GitHub PR adding AgentPlane to AutoJunjie/awesome-agent-harness as a Git-native coding-agent harness after verifying the current repository structure and list formatting.
+
+## Scope
+
+- In scope: Submit a GitHub PR adding AgentPlane to AutoJunjie/awesome-agent-harness as a Git-native coding-agent harness after verifying the current repository structure and list formatting.
+- Out of scope: unrelated refactors not required for "Add AgentPlane to AutoJunjie awesome-agent-harness".
+
+## Plan
+
+1. Implement the change for "Add AgentPlane to AutoJunjie awesome-agent-harness".
+2. Run required checks and capture verification evidence.
+3. Finalize task findings and finish with traceable commit metadata.
+
+## Verify Steps
+
+1. Review the requested outcome for "Add AgentPlane to AutoJunjie awesome-agent-harness". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605011519-653853/README.md
+++ b/.agentplane/tasks/202605011519-653853/README.md
@@ -1,0 +1,89 @@
+---
+id: "202605011519-653853"
+title: "Add AgentPlane to sorrycc awesome-code-agents"
+status: "TODO"
+priority: "med"
+owner: "DOCS"
+revision: 1
+origin:
+  system: "manual"
+depends_on:
+  - "202605011518-PH7024"
+tags:
+  - "docs"
+verify: []
+plan_approval:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-01T15:19:13.702Z"
+doc_updated_by: "DOCS"
+description: "Submit a GitHub PR adding AgentPlane to sorrycc/awesome-code-agents under workflow, orchestration, or infrastructure rather than agent sections after checking current structure."
+sections:
+  Summary: |-
+    Add AgentPlane to sorrycc awesome-code-agents
+    
+    Submit a GitHub PR adding AgentPlane to sorrycc/awesome-code-agents under workflow, orchestration, or infrastructure rather than agent sections after checking current structure.
+  Scope: |-
+    - In scope: Submit a GitHub PR adding AgentPlane to sorrycc/awesome-code-agents under workflow, orchestration, or infrastructure rather than agent sections after checking current structure.
+    - Out of scope: unrelated refactors not required for "Add AgentPlane to sorrycc awesome-code-agents".
+  Plan: |-
+    1. Implement the change for "Add AgentPlane to sorrycc awesome-code-agents".
+    2. Run required checks and capture verification evidence.
+    3. Finalize task findings and finish with traceable commit metadata.
+  Verify Steps: |-
+    1. Review the requested outcome for "Add AgentPlane to sorrycc awesome-code-agents". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add AgentPlane to sorrycc awesome-code-agents
+
+Submit a GitHub PR adding AgentPlane to sorrycc/awesome-code-agents under workflow, orchestration, or infrastructure rather than agent sections after checking current structure.
+
+## Scope
+
+- In scope: Submit a GitHub PR adding AgentPlane to sorrycc/awesome-code-agents under workflow, orchestration, or infrastructure rather than agent sections after checking current structure.
+- Out of scope: unrelated refactors not required for "Add AgentPlane to sorrycc awesome-code-agents".
+
+## Plan
+
+1. Implement the change for "Add AgentPlane to sorrycc awesome-code-agents".
+2. Run required checks and capture verification evidence.
+3. Finalize task findings and finish with traceable commit metadata.
+
+## Verify Steps
+
+1. Review the requested outcome for "Add AgentPlane to sorrycc awesome-code-agents". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605011519-EF3RKQ/README.md
+++ b/.agentplane/tasks/202605011519-EF3RKQ/README.md
@@ -1,0 +1,89 @@
+---
+id: "202605011519-EF3RKQ"
+title: "Add AgentPlane to filipecalegario awesome-vibe-coding"
+status: "TODO"
+priority: "med"
+owner: "DOCS"
+revision: 1
+origin:
+  system: "manual"
+depends_on:
+  - "202605011519-653853"
+tags:
+  - "docs"
+verify: []
+plan_approval:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-01T15:19:34.329Z"
+doc_updated_by: "DOCS"
+description: "Submit a GitHub PR adding AgentPlane to filipecalegario/awesome-vibe-coding as workflow governance or task-lifecycle infrastructure for vibe-coded repositories after verifying fit and format."
+sections:
+  Summary: |-
+    Add AgentPlane to filipecalegario awesome-vibe-coding
+    
+    Submit a GitHub PR adding AgentPlane to filipecalegario/awesome-vibe-coding as workflow governance or task-lifecycle infrastructure for vibe-coded repositories after verifying fit and format.
+  Scope: |-
+    - In scope: Submit a GitHub PR adding AgentPlane to filipecalegario/awesome-vibe-coding as workflow governance or task-lifecycle infrastructure for vibe-coded repositories after verifying fit and format.
+    - Out of scope: unrelated refactors not required for "Add AgentPlane to filipecalegario awesome-vibe-coding".
+  Plan: |-
+    1. Implement the change for "Add AgentPlane to filipecalegario awesome-vibe-coding".
+    2. Run required checks and capture verification evidence.
+    3. Finalize task findings and finish with traceable commit metadata.
+  Verify Steps: |-
+    1. Review the requested outcome for "Add AgentPlane to filipecalegario awesome-vibe-coding". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add AgentPlane to filipecalegario awesome-vibe-coding
+
+Submit a GitHub PR adding AgentPlane to filipecalegario/awesome-vibe-coding as workflow governance or task-lifecycle infrastructure for vibe-coded repositories after verifying fit and format.
+
+## Scope
+
+- In scope: Submit a GitHub PR adding AgentPlane to filipecalegario/awesome-vibe-coding as workflow governance or task-lifecycle infrastructure for vibe-coded repositories after verifying fit and format.
+- Out of scope: unrelated refactors not required for "Add AgentPlane to filipecalegario awesome-vibe-coding".
+
+## Plan
+
+1. Implement the change for "Add AgentPlane to filipecalegario awesome-vibe-coding".
+2. Run required checks and capture verification evidence.
+3. Finalize task findings and finish with traceable commit metadata.
+
+## Verify Steps
+
+1. Review the requested outcome for "Add AgentPlane to filipecalegario awesome-vibe-coding". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,9 @@ Page text lives in the Markdown and MDX files under this directory.
 
 `website/sidebars.ts` is the active navigation manifest for the public docs site.
 
+`docs/listing.md` is the reusable listing/submission profile for curated harness,
+CLI coding-agent, and AI coding-tool directories.
+
 Docs are organized into an agent-first navigation model on top of `docs/user/`, `docs/developer/`, and `docs/help/`:
 
 - `Start`

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -68,8 +68,9 @@ This documentation follows an agent-first structure:
 7. [Agent discovery](user/agent-discovery)
 8. [Indexing and webmaster operations](user/indexing-and-webmaster-operations)
 9. [Website IA](user/website-ia)
-10. [CLI reference (generated)](user/cli-reference.generated)
-11. [Generated reference](reference/generated-reference)
+10. [Listing submission profile](listing)
+11. [CLI reference (generated)](user/cli-reference.generated)
+12. [Generated reference](reference/generated-reference)
 
 ## Developer Guide
 

--- a/docs/listing.md
+++ b/docs/listing.md
@@ -1,0 +1,126 @@
+---
+title: "Listing submission profile"
+description: "Reusable positioning, snippets, and PR copy for submitting AgentPlane to curated coding-agent and harness-engineering lists."
+---
+
+# AgentPlane listing submission profile
+
+Use this page when submitting AgentPlane to curated GitHub lists. The goal is to make each submission improve the target list rather than read like bulk promotion.
+
+## Positioning
+
+AgentPlane should be listed as:
+
+```text
+Git-native workflow control / harness layer for coding agents.
+```
+
+Shorter form:
+
+```text
+Local-first CLI harness for auditable coding-agent work in Git.
+```
+
+Do not position AgentPlane as another AI coding agent, hosted agent platform, MCP server, or agent skill directory entry.
+
+## Snippets
+
+### Short
+
+AgentPlane - Git-native workflow control for auditable coding-agent work.
+
+### Medium
+
+AgentPlane is a local-first CLI harness for Claude Code, Codex, Cursor, Aider, and similar coding agents. It records task state, plan approval, verification evidence, and finish closure inside the Git repository.
+
+### Tags
+
+`git-native`, `local-first`, `coding-agents`, `agent-harness`, `harness-engineering`, `workflow-control`, `verification`, `governance`
+
+### Best categories
+
+- Harness engineering
+- Coding-agent workflow control
+- Agent infrastructure
+- Guardrails / governance
+- CLI agent orchestration
+
+## Suggested entries
+
+### Harness-focused lists
+
+```markdown
+- [AgentPlane](https://github.com/basilisk-labs/agentplane) - Local-first, Git-native CLI harness for auditable coding-agent work. Records task state, plan approval, verification evidence, and finish closure in repo-local artifacts.
+```
+
+### CLI coding-agent lists
+
+```markdown
+- [AgentPlane](https://github.com/basilisk-labs/agentplane) - Git-native workflow control layer for Claude Code, Codex, Cursor, Aider, and other CLI coding-agent workflows. Adds task, plan, approval, verification, and finish records inside the repository.
+```
+
+### Harness-engineering lists
+
+```markdown
+- [AgentPlane](https://github.com/basilisk-labs/agentplane) - Repo-local workflow control for coding agents. Makes task state, accepted plans, verification notes, and closure evidence explicit inside Git rather than hidden in chat/session context.
+```
+
+### Strict reliability lists
+
+```markdown
+- [AgentPlane](https://github.com/basilisk-labs/agentplane) - Local Git-native control layer for coding-agent reliability: explicit task state, plan approval, verification evidence, and deterministic task closure.
+```
+
+### Repository-as-system-of-record lists
+
+```markdown
+- [AgentPlane](https://github.com/basilisk-labs/agentplane) - Git-native coding-agent harness that treats repository-local task records, workflow policy, verification, and closure as the system of record.
+```
+
+## Submission order
+
+1. `Picrew/awesome-agent-harness`
+2. `bradAGI/awesome-cli-coding-agents`
+3. `ai-boost/awesome-harness-engineering`
+4. `AutoJunjie/awesome-agent-harness`
+5. `walkinglabs/awesome-harness-engineering`
+6. `ai-for-developers/awesome-ai-coding-tools`
+7. `brandonhimpfen/awesome-ai-coding-agents`
+8. `sorrycc/awesome-code-agents`
+9. `filipecalegario/awesome-vibe-coding`
+
+## PR body template
+
+```text
+Hi - I would like to add AgentPlane to this list.
+
+Disclosure: I maintain AgentPlane.
+
+Why it fits:
+AgentPlane is not another coding agent and not a hosted agent platform. It is a local-first, Git-native workflow control layer for Claude Code, Codex, Cursor, Aider, and similar coding-agent workflows.
+
+It records:
+- task state
+- accepted plan
+- approval state
+- verification evidence
+- finish / closure record
+- Git revision link
+
+Suggested category:
+[Harness Architecture & Orchestration / Agent Infrastructure / Guardrails & Governance / Reference Harness Implementations]
+
+Suggested entry:
+[AgentPlane](https://github.com/basilisk-labs/agentplane) - Local-first, Git-native CLI harness for auditable coding-agent work. Records task state, plan approval, verification evidence, and finish closure in repo-local artifacts.
+
+Happy to adjust category, wording, or remove if this is outside scope.
+```
+
+## Maintainer guidance
+
+- Fit the target list's structure first; do not force AgentPlane into a top section.
+- Follow `CONTRIBUTING.md` and generated-data files when the list uses them.
+- Keep wording concrete: task state, plan approval, verification evidence, finish closure, Git revision.
+- Avoid claims like "best", "production-grade", "first", or "revolutionary".
+- Skip MCP server lists unless AgentPlane ships an MCP server.
+- Skip agent-skill lists unless a real skill artifact is created in a separate approved task.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -98,6 +98,7 @@ const sidebars: SidebarsConfig = {
         "user/agent-discovery",
         "user/indexing-and-webmaster-operations",
         "user/website-ia",
+        "listing",
         "user/cli-reference.generated",
         "reference/generated-reference",
       ],


### PR DESCRIPTION
## Summary

Prepare AgentPlane for curated-list submissions by tightening repository discovery metadata and adding reusable listing snippets. Agent-skill directory work is explicitly out of scope by user request.

## Scope

- In scope: update GitHub repository topics for harness/coding-agent discovery; add docs/listing.md with short, medium, tag, category, and PR-body snippets for curated-list submissions.
- Out of scope: skills/agentplane-workflow, agent skill directories, MCP lists, runtime/code changes, unrelated launch content.

## Verification

- State: ok
- Note: docs listing profile verified; doctor passed after longer runtime
- Full verification checklist lives in local review.md.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-01T15:36:46.140Z
- Branch: task/202605011517-51FA6Z/listing-submission-profile
- Head: e7403edb6f14

```text
 .agentplane/tasks/202605011515-H09565/README.md |  89 +++++++++++++++++
 .agentplane/tasks/202605011515-NKWCVZ/README.md |  89 +++++++++++++++++
 .agentplane/tasks/202605011515-SS66H4/README.md |  90 +++++++++++++++++
 .agentplane/tasks/202605011516-SWJJK0/README.md |  90 +++++++++++++++++
 .agentplane/tasks/202605011518-97HPR5/README.md |  89 +++++++++++++++++
 .agentplane/tasks/202605011518-PH7024/README.md |  89 +++++++++++++++++
 .agentplane/tasks/202605011518-ZJQZMT/README.md |  89 +++++++++++++++++
 .agentplane/tasks/202605011519-653853/README.md |  89 +++++++++++++++++
 .agentplane/tasks/202605011519-EF3RKQ/README.md |  89 +++++++++++++++++
 docs/README.md                                  |   3 +
 docs/index.mdx                                  |   5 +-
 docs/listing.md                                 | 126 ++++++++++++++++++++++++
 website/sidebars.ts                             |   1 +
 13 files changed, 936 insertions(+), 2 deletions(-)
```

</details>
