### PR TITLE
task: Standardize release PR titles and messages [202605011918-JW3M0Z]

### DIFF
--- a/.agentplane/tasks/202605011918-JW3M0Z/README.md
+++ b/.agentplane/tasks/202605011918-JW3M0Z/README.md
@@ -1,0 +1,138 @@
+---
+id: "202605011918-JW3M0Z"
+title: "Standardize release PR titles and messages"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "release"
+  - "workflow"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-01T19:18:27.774Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-01T19:24:48.053Z"
+  updated_by: "CODER"
+  note: "Passed targeted PR-title, hosted-close, release-evidence, workflow-contract, lint, routing, bootstrap, and doctor checks."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: standardize branch_pr, hosted-close, and release-evidence PR titles with one readable task format."
+events:
+  -
+    type: "status"
+    at: "2026-05-01T19:18:47.792Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: standardize branch_pr, hosted-close, and release-evidence PR titles with one readable task format."
+  -
+    type: "verify"
+    at: "2026-05-01T19:24:48.053Z"
+    author: "CODER"
+    state: "ok"
+    note: "Passed targeted PR-title, hosted-close, release-evidence, workflow-contract, lint, routing, bootstrap, and doctor checks."
+doc_version: 3
+doc_updated_at: "2026-05-01T19:24:48.060Z"
+doc_updated_by: "CODER"
+description: "Make branch_pr and hosted-close PR titles/messages use one readable canonical format before publishing v0.4.1."
+sections:
+  Summary: |-
+    Standardize release PR titles and messages
+    
+    Make branch_pr and hosted-close PR titles/messages use one readable canonical format before publishing v0.4.1.
+  Scope: |-
+    - In scope: Make branch_pr and hosted-close PR titles/messages use one readable canonical format before publishing v0.4.1.
+    - Out of scope: unrelated refactors not required for "Standardize release PR titles and messages".
+  Plan: |-
+    1. Inspect PR title generation for branch_pr PRs, hosted-close PRs, and release evidence PRs.
+    2. Add a shared readable PR title/message formatter that produces one canonical shape for task PRs and close PRs.
+    3. Update command scripts/workflow helpers and tests/contracts that assert titles.
+    4. Run targeted PR/hosted-close tests plus workflow checks, lint, policy routing, and doctor.
+    5. Open/merge this task via branch_pr, then reassess release readiness before publishing v0.4.1.
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-01T19:24:48.053Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Passed targeted PR-title, hosted-close, release-evidence, workflow-contract, lint, routing, bootstrap, and doctor checks.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-01T19:18:47.792Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: PR titles now use canonical task/task-close/task-evidence prefixes with full task ids, and generated PR bodies use Source/Scope sections.
+      Impact: Release and closure PRs are easier to scan and no longer mix suffix-only, emoji-only, and scoped-title formats.
+      Resolution: Updated task PR, hosted close PR, hosted workflow closure, and release evidence PR generators plus regression tests.
+      Promotion: incident-candidate
+      Fixability: external
+id_source: "generated"
+---
+## Summary
+
+Standardize release PR titles and messages
+
+Make branch_pr and hosted-close PR titles/messages use one readable canonical format before publishing v0.4.1.
+
+## Scope
+
+- In scope: Make branch_pr and hosted-close PR titles/messages use one readable canonical format before publishing v0.4.1.
+- Out of scope: unrelated refactors not required for "Standardize release PR titles and messages".
+
+## Plan
+
+1. Inspect PR title generation for branch_pr PRs, hosted-close PRs, and release evidence PRs.
+2. Add a shared readable PR title/message formatter that produces one canonical shape for task PRs and close PRs.
+3. Update command scripts/workflow helpers and tests/contracts that assert titles.
+4. Run targeted PR/hosted-close tests plus workflow checks, lint, policy routing, and doctor.
+5. Open/merge this task via branch_pr, then reassess release readiness before publishing v0.4.1.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-01T19:24:48.053Z — VERIFY — ok
+
+By: CODER
+
+Note: Passed targeted PR-title, hosted-close, release-evidence, workflow-contract, lint, routing, bootstrap, and doctor checks.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-01T19:18:47.792Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: PR titles now use canonical task/task-close/task-evidence prefixes with full task ids, and generated PR bodies use Source/Scope sections.
+  Impact: Release and closure PRs are easier to scan and no longer mix suffix-only, emoji-only, and scoped-title formats.
+  Resolution: Updated task PR, hosted close PR, hosted workflow closure, and release evidence PR generators plus regression tests.
+  Promotion: incident-candidate
+  Fixability: external

--- a/.agentplane/tasks/202605011918-JW3M0Z/pr/diffstat.txt
+++ b/.agentplane/tasks/202605011918-JW3M0Z/pr/diffstat.txt
@@ -1,0 +1,13 @@
+ .github/workflows/publish.yml                      |  4 +--
+ .../cli/prepare-hosted-task-closure-script.test.ts |  7 +++-
+ .../cli/run-cli.core.pr-flow.pr-lifecycle.test.ts  |  2 +-
+ .../run-cli.core.pr-flow.pr-open.artifacts.test.ts |  4 +--
+ .../cli/run-cli.core.task-hosted-close-pr.test.ts  |  4 +++
+ .../src/commands/pr/internal/review-template.ts    | 23 +++----------
+ .../release/release-task-evidence-script.test.ts   |  4 ++-
+ .../src/commands/task/hosted-close-pr.execute.ts   | 30 ++++++++++++-----
+ .../src/commands/task/hosted-close-pr.precheck.ts  |  1 +
+ .../src/commands/task/hosted-close-pr.types.ts     |  1 +
+ scripts/prepare-hosted-task-closure.mjs            | 39 +++++++++++++++++++---
+ scripts/release-task-evidence.mjs                  | 22 ++++++++----
+ 12 files changed, 94 insertions(+), 47 deletions(-)

--- a/.agentplane/tasks/202605011918-JW3M0Z/pr/github-body.md
+++ b/.agentplane/tasks/202605011918-JW3M0Z/pr/github-body.md
@@ -1,0 +1,48 @@
+Task: `202605011918-JW3M0Z`
+Title: Standardize release PR titles and messages
+
+## Summary
+
+Standardize release PR titles and messages
+
+Make branch_pr and hosted-close PR titles/messages use one readable canonical format before publishing v0.4.1.
+
+## Scope
+
+- In scope: Make branch_pr and hosted-close PR titles/messages use one readable canonical format before publishing v0.4.1.
+- Out of scope: unrelated refactors not required for "Standardize release PR titles and messages".
+
+## Verification
+
+- State: ok
+- Note: Passed targeted PR-title, hosted-close, release-evidence, workflow-contract, lint, routing, bootstrap, and doctor checks.
+- Full verification checklist lives in local review.md.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-01T19:25:13.455Z
+- Branch: task/202605011918-JW3M0Z/standardize-pr-titles
+- Head: 4952e94907c1
+
+```text
+ .github/workflows/publish.yml                      |  4 +--
+ .../cli/prepare-hosted-task-closure-script.test.ts |  7 +++-
+ .../cli/run-cli.core.pr-flow.pr-lifecycle.test.ts  |  2 +-
+ .../run-cli.core.pr-flow.pr-open.artifacts.test.ts |  4 +--
+ .../cli/run-cli.core.task-hosted-close-pr.test.ts  |  4 +++
+ .../src/commands/pr/internal/review-template.ts    | 23 +++----------
+ .../release/release-task-evidence-script.test.ts   |  4 ++-
+ .../src/commands/task/hosted-close-pr.execute.ts   | 30 ++++++++++++-----
+ .../src/commands/task/hosted-close-pr.precheck.ts  |  1 +
+ .../src/commands/task/hosted-close-pr.types.ts     |  1 +
+ scripts/prepare-hosted-task-closure.mjs            | 39 +++++++++++++++++++---
+ scripts/release-task-evidence.mjs                  | 22 ++++++++----
+ 12 files changed, 94 insertions(+), 47 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605011918-JW3M0Z/pr/github-title.txt
+++ b/.agentplane/tasks/202605011918-JW3M0Z/pr/github-title.txt
@@ -1,0 +1,1 @@
+task: Standardize release PR titles and messages [202605011918-JW3M0Z]

--- a/.agentplane/tasks/202605011918-JW3M0Z/pr/meta.json
+++ b/.agentplane/tasks/202605011918-JW3M0Z/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605011918-JW3M0Z/standardize-pr-titles",
+  "created_at": "2026-05-01T19:18:47.834Z",
+  "head_sha": "4952e94907c181febfbb5c2268b2d1b5617a5629",
+  "last_verified_at": "2026-05-01T19:24:48.053Z",
+  "last_verified_sha": "abc47697882b1cbb9bf7883ffb2f962c6eaa9e2c",
+  "schema_version": 1,
+  "task_id": "202605011918-JW3M0Z",
+  "updated_at": "2026-05-01T19:25:13.455Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605011918-JW3M0Z/pr/review.md
+++ b/.agentplane/tasks/202605011918-JW3M0Z/pr/review.md
@@ -1,0 +1,69 @@
+# PR Review
+
+Created: 2026-05-01T19:18:47.834Z
+Branch: task/202605011918-JW3M0Z/standardize-pr-titles
+
+## Summary
+
+Standardize release PR titles and messages
+
+Make branch_pr and hosted-close PR titles/messages use one readable canonical format before publishing v0.4.1.
+
+## Scope
+
+- In scope: Make branch_pr and hosted-close PR titles/messages use one readable canonical format before publishing v0.4.1.
+- Out of scope: unrelated refactors not required for "Standardize release PR titles and messages".
+
+## Verification
+
+### Plan
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+### Current Status
+
+- State: ok
+- Note: Passed targeted PR-title, hosted-close, release-evidence, workflow-contract, lint, routing, bootstrap, and doctor checks.
+
+## Risks
+
+- Risk level: not recorded
+- Breaking change: no
+
+### Rollback
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-01T19:25:13.455Z
+- Branch: task/202605011918-JW3M0Z/standardize-pr-titles
+- Head: 4952e94907c1
+
+```text
+ .github/workflows/publish.yml                      |  4 +--
+ .../cli/prepare-hosted-task-closure-script.test.ts |  7 +++-
+ .../cli/run-cli.core.pr-flow.pr-lifecycle.test.ts  |  2 +-
+ .../run-cli.core.pr-flow.pr-open.artifacts.test.ts |  4 +--
+ .../cli/run-cli.core.task-hosted-close-pr.test.ts  |  4 +++
+ .../src/commands/pr/internal/review-template.ts    | 23 +++----------
+ .../release/release-task-evidence-script.test.ts   |  4 ++-
+ .../src/commands/task/hosted-close-pr.execute.ts   | 30 ++++++++++++-----
+ .../src/commands/task/hosted-close-pr.precheck.ts  |  1 +
+ .../src/commands/task/hosted-close-pr.types.ts     |  1 +
+ scripts/prepare-hosted-task-closure.mjs            | 39 +++++++++++++++++++---
+ scripts/release-task-evidence.mjs                  | 22 ++++++++----
+ 12 files changed, 94 insertions(+), 47 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -548,12 +548,10 @@ jobs:
             echo "closure_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          suffix="${{ steps.release_evidence.outputs.task_id }}"
-          suffix="${suffix##*-}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add "${{ steps.release_evidence.outputs.readme_path }}"
-          git commit --no-verify -m "📝 ${suffix} task: record hosted publish evidence"
+          git commit --no-verify -m "📝 ${{ steps.release_evidence.outputs.task_id }} task: record hosted publish evidence"
           echo "created_commit=true" >> "$GITHUB_OUTPUT"
           echo "closure_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Push release evidence branch

--- a/packages/agentplane/src/cli/prepare-hosted-task-closure-script.test.ts
+++ b/packages/agentplane/src/cli/prepare-hosted-task-closure-script.test.ts
@@ -85,12 +85,17 @@ describe("prepare-hosted-task-closure script", () => {
       closure_branch?: string;
       merge_sha?: string;
       pr_title?: string;
+      pr_body?: string;
     };
     expect(parsed.actionable).toBe(true);
     expect(parsed.task_id).toBe("202603271940-EG3B0C");
     expect(parsed.merge_sha).toBe("1234567890abcdef1234567890abcdef12345678");
     expect(parsed.closure_branch).toBe("task-close/202603271940-EG3B0C/1234567890ab");
-    expect(parsed.pr_title).toContain("202603271940-EG3B0C");
+    expect(parsed.pr_title).toBe(
+      "task-close: Runner repository refactor [202603271940-EG3B0C]",
+    );
+    expect(parsed.pr_body).toContain("## Source");
+    expect(parsed.pr_body).toContain("## Scope");
   });
 
   it("returns a no-op payload for non-task PR branches", async () => {

--- a/packages/agentplane/src/cli/run-cli.core.pr-flow.pr-lifecycle.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.pr-flow.pr-lifecycle.test.ts
@@ -523,7 +523,7 @@ describe("runCli branch_pr lifecycle flow", { timeout: PR_FLOW_INTEGRATION_TIMEO
       expect(review).toContain("change.txt");
       const githubTitle = await readFile(path.join(prDir, "github-title.txt"), "utf8");
       const githubBody = await readFile(path.join(prDir, "github-body.md"), "utf8");
-      expect(githubTitle.trim()).toContain(`(${extractTaskSuffix(taskId)})`);
+      expect(githubTitle.trim()).toContain(`[${taskId}]`);
       expect(githubTitle).not.toContain(`task/${taskId}/pr-update`);
       expect(githubBody).toContain("## Summary");
       expect(githubBody).toContain("## Scope");

--- a/packages/agentplane/src/cli/run-cli.core.pr-flow.pr-open.artifacts.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.pr-flow.pr-open.artifacts.test.ts
@@ -128,9 +128,7 @@ describe("runCli pr open flow artifacts", { timeout: PR_FLOW_INTEGRATION_TIMEOUT
     await readFile(prArtifacts.diffstatPath, "utf8");
     expect(await readFile(prArtifacts.notesPath, "utf8")).toBe("");
     await readFile(prArtifacts.verifyLogPath, "utf8");
-    expect(await readFile(prArtifacts.githubTitlePath, "utf8")).toContain(
-      `(${extractTaskSuffix(taskId)})`,
-    );
+    expect(await readFile(prArtifacts.githubTitlePath, "utf8")).toContain(`[${taskId}]`);
     expect(await prArtifacts.readGithubBody()).toContain("## Verification");
     expect(await prArtifacts.readGithubBody()).not.toContain("## Risks");
   });

--- a/packages/agentplane/src/cli/run-cli.core.task-hosted-close-pr.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.task-hosted-close-pr.test.ts
@@ -718,6 +718,10 @@ describe("runCli", { timeout: HOSTED_CLOSE_INTEGRATION_TIMEOUT_MS }, () => {
     expect(log).toContain(
       '"repos/example/repo/pulls?state=closed&head=example%3Atask%2F202604091600-348SVA%2Fhosted-close-pr-fallback&base=main"',
     );
+    expect(log).toContain(
+      "title=task-close: Hosted close PR fallback [202604091600-348SVA]",
+    );
+    expect(log).toContain("## Source");
     expect(log).toContain('"POST"');
   }, 240_000);
 

--- a/packages/agentplane/src/commands/pr/internal/review-template.ts
+++ b/packages/agentplane/src/commands/pr/internal/review-template.ts
@@ -1,5 +1,3 @@
-import { extractTaskSuffix } from "@agentplaneorg/core/commit";
-
 import type { TaskData } from "../../../backends/task-backend.js";
 import type { PrHandoffNote } from "./note-store.js";
 
@@ -20,18 +18,6 @@ function normalizeOneLine(value: string, maxChars: number): string {
   const trimmed = value.trim().replaceAll(/\s+/g, " ");
   if (!trimmed) return "";
   return trimmed.length > maxChars ? `${trimmed.slice(0, Math.max(1, maxChars - 3))}...` : trimmed;
-}
-
-function informativeTags(task: TaskData): string[] {
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const rawTag of Array.isArray(task.tags) ? task.tags : []) {
-    const tag = rawTag.trim().toLowerCase();
-    if (!tag || tag === "code" || seen.has(tag)) continue;
-    seen.add(tag);
-    out.push(tag);
-  }
-  return out;
 }
 
 function renderVerificationSummary(task: TaskData): string {
@@ -150,10 +136,8 @@ function renderGithubBodySections(opts: {
 }
 
 export function buildGithubPrTitle(task: TaskData): string {
-  const suffix = extractTaskSuffix(task.id);
-  const scope = informativeTags(task).slice(0, 2).join("/");
-  const title = normalizeOneLine(task.title, scope ? 72 : 84);
-  return scope ? `${scope}: ${title} (${suffix})` : `${title} (${suffix})`;
+  const title = normalizeOneLine(task.title, 96) || "Untitled task";
+  return `task: ${title} [${task.id}]`;
 }
 
 export function renderPrAutoSummary(opts: {
@@ -258,6 +242,9 @@ export function renderGithubPrBody(opts: {
   autoSummary: string;
 }): string {
   return [
+    `Task: \`${opts.task.id}\``,
+    `Title: ${normalizeOneLine(opts.task.title, 120) || "Untitled task"}`,
+    "",
     ...renderGithubBodySections({
       task: opts.task,
       handoffNotes: opts.handoffNotes ?? [],

--- a/packages/agentplane/src/commands/release/release-task-evidence-script.test.ts
+++ b/packages/agentplane/src/commands/release/release-task-evidence-script.test.ts
@@ -222,8 +222,10 @@ describe("release-task-evidence script", () => {
     expect(payload.actionable).toBe(true);
     expect(payload.task_id).toBe(taskId);
     expect(payload.closure_branch).toBe(`task-close/${taskId}/${releaseSha.slice(0, 12)}-publish`);
-    expect(payload.pr_title).toContain(taskId);
+    expect(payload.pr_title).toBe(`task-evidence: Record hosted publish evidence [${taskId}]`);
     expect(payload.pr_body).toContain("v0.3.15");
+    expect(payload.pr_body).toContain("## Source");
+    expect(payload.pr_body).toContain("## Scope");
   });
 
   it("marks prepare as non-actionable when publish-result is incomplete", async () => {

--- a/packages/agentplane/src/commands/task/hosted-close-pr.execute.ts
+++ b/packages/agentplane/src/commands/task/hosted-close-pr.execute.ts
@@ -9,8 +9,15 @@ import type {
   HostedClosePrPlan,
 } from "./hosted-close-pr.types.js";
 
-function buildHostedClosePrTitle(taskId: string): string {
-  return `📝 ${taskId} task: close after hosted merge`;
+function normalizeOneLine(value: string, maxChars: number): string {
+  const trimmed = value.trim().replaceAll(/\s+/g, " ");
+  if (!trimmed) return "";
+  return trimmed.length > maxChars ? `${trimmed.slice(0, Math.max(1, maxChars - 3))}...` : trimmed;
+}
+
+function buildHostedClosePrTitle(opts: { taskId: string; taskTitle: string }): string {
+  const title = normalizeOneLine(opts.taskTitle, 96) || "Hosted task closure";
+  return `task-close: ${title} [${opts.taskId}]`;
 }
 
 function buildHostedClosePrBody(opts: {
@@ -21,14 +28,21 @@ function buildHostedClosePrBody(opts: {
 }): string {
   const prLine =
     typeof opts.prNumber === "number" && opts.prNumber > 0
-      ? `Automated closure for merged task PR #${opts.prNumber}.`
-      : "Automated closure for merged task PR.";
+      ? `Closes task \`${opts.taskId}\` after merged task PR #${opts.prNumber}.`
+      : `Closes task \`${opts.taskId}\` after a merged task PR.`;
   return [
     prLine,
     "",
-    `- task_id: \`${opts.taskId}\``,
-    `- source_branch: \`${opts.sourceBranch}\``,
-    `- merge_sha: \`${opts.mergeSha}\``,
+    "## Source",
+    "",
+    `- Task: \`${opts.taskId}\``,
+    typeof opts.prNumber === "number" && opts.prNumber > 0
+      ? `- Source PR: #${opts.prNumber}`
+      : "- Source PR: not recorded",
+    `- Source branch: \`${opts.sourceBranch}\``,
+    `- Merge SHA: \`${opts.mergeSha}\``,
+    "",
+    "## Scope",
     "",
     "This PR contains only tracked task artifacts produced by the hosted branch_pr closure flow.",
   ].join("\n");
@@ -163,7 +177,7 @@ export async function executeHostedClosePrPlan(
     "-X",
     "POST",
     "-f",
-    `title=${buildHostedClosePrTitle(plan.taskId)}`,
+    `title=${buildHostedClosePrTitle({ taskId: plan.taskId, taskTitle: plan.taskTitle })}`,
     "-f",
     `body=${buildHostedClosePrBody({
       taskId: plan.taskId,

--- a/packages/agentplane/src/commands/task/hosted-close-pr.precheck.ts
+++ b/packages/agentplane/src/commands/task/hosted-close-pr.precheck.ts
@@ -327,6 +327,7 @@ export async function precheckHostedClosePr(
     kind: "ready",
     plan: {
       taskId: opts.taskId,
+      taskTitle: task.title,
       gitRoot,
       workflowDir: opts.ctx.config.paths.workflow_dir,
       repo,

--- a/packages/agentplane/src/commands/task/hosted-close-pr.types.ts
+++ b/packages/agentplane/src/commands/task/hosted-close-pr.types.ts
@@ -31,6 +31,7 @@ export type HostedClosePrPrecheckOptions = {
 
 export type HostedClosePrPlan = {
   taskId: string;
+  taskTitle: string;
   gitRoot: string;
   workflowDir: string;
   repo: string;

--- a/scripts/prepare-hosted-task-closure.mjs
+++ b/scripts/prepare-hosted-task-closure.mjs
@@ -63,6 +63,29 @@ function shortSha(value) {
     .slice(0, 12);
 }
 
+function normalizeOneLine(value, maxChars) {
+  const trimmed = String(value ?? "")
+    .trim()
+    .replaceAll(/\s+/g, " ");
+  if (!trimmed) return "";
+  return trimmed.length > maxChars ? `${trimmed.slice(0, Math.max(1, maxChars - 3))}...` : trimmed;
+}
+
+function titleFromSourcePullTitle(value, taskId) {
+  const title = normalizeOneLine(value, 140);
+  if (!title) return "Merged task";
+  const patterns = [
+    /^task:\s*(.+?)\s*\[[^\]]+\]$/iu,
+    /^[^:]+:\s*(.+?)\s*\([A-Z0-9]{4,8}\)$/iu,
+    /^[\p{Emoji_Presentation}\p{Extended_Pictographic}\s]*[A-Z0-9-]+\s+task:\s*(.+)$/iu,
+  ];
+  for (const pattern of patterns) {
+    const match = pattern.exec(title);
+    if (match?.[1]) return normalizeOneLine(match[1], 96);
+  }
+  return normalizeOneLine(title.replace(`[${taskId}]`, "").replace(`(${taskId})`, ""), 96);
+}
+
 function buildClosureMetadata(payload, prefix) {
   const pull = payload && typeof payload === "object" ? payload.pull_request : null;
   if (!pull || typeof pull !== "object") return noAction("event does not contain pull_request");
@@ -85,13 +108,19 @@ function buildClosureMetadata(payload, prefix) {
 
   const mergeShort = shortSha(mergeSha);
   const closureBranch = `task-close/${taskId}/${mergeShort}`;
-  const prTitle = `📝 ${taskId} task: close after hosted merge`;
+  const sourceTitle = titleFromSourcePullTitle(pull.title, taskId);
+  const prTitle = `task-close: ${sourceTitle} [${taskId}]`;
   const prBody = [
-    `Automated closure for merged task PR #${number}.`,
+    `Closes task \`${taskId}\` after merged task PR #${number}.`,
     "",
-    `- task_id: \`${taskId}\``,
-    `- source_branch: \`${sourceBranch}\``,
-    `- merge_sha: \`${mergeSha}\``,
+    "## Source",
+    "",
+    `- Task: \`${taskId}\``,
+    `- Source PR: #${number}`,
+    `- Source branch: \`${sourceBranch}\``,
+    `- Merge SHA: \`${mergeSha}\``,
+    "",
+    "## Scope",
     "",
     "This PR contains only tracked task artifacts produced by the hosted branch_pr closure flow.",
   ].join("\n");

--- a/scripts/release-task-evidence.mjs
+++ b/scripts/release-task-evidence.mjs
@@ -72,6 +72,10 @@ function shortSha(value) {
   return value.trim().slice(0, 12);
 }
 
+function buildReleaseEvidencePrTitle(taskId) {
+  return `task-evidence: Record hosted publish evidence [${taskId}]`;
+}
+
 async function git(args) {
   const result = await execFileAsync("git", args, {
     cwd: process.cwd(),
@@ -127,17 +131,21 @@ function buildPrepareOutcome({ actionable, reason, manifest, releaseSha, baseRef
     ? `https://github.com/${repo}/actions/runs/${manifest.job.runId}`
     : null;
   const prBodyLines = [
-    `Automated hosted publish evidence for ${manifest.tag}.`,
+    `Records hosted publish evidence for \`${manifest.tag}\`.`,
     "",
-    `- task_id: \`${taskId}\``,
-    `- release_sha: \`${releaseSha}\``,
-    `- tag: \`${manifest.tag}\``,
-    `- release_url: ${releaseUrl}`,
+    "## Source",
+    "",
+    `- Task: \`${taskId}\``,
+    `- Release SHA: \`${releaseSha}\``,
+    `- Tag: \`${manifest.tag}\``,
+    `- Release: ${releaseUrl}`,
   ];
   if (publishRunUrl) {
-    prBodyLines.push(`- publish_run: ${publishRunUrl}`);
+    prBodyLines.push(`- Publish run: ${publishRunUrl}`);
   }
   prBodyLines.push(
+    "",
+    "## Scope",
     "",
     "This PR updates only the tracked release task README so canonical task closure includes hosted publish evidence.",
   );
@@ -149,7 +157,7 @@ function buildPrepareOutcome({ actionable, reason, manifest, releaseSha, baseRef
     base_ref: baseRef,
     release_sha: releaseSha,
     closure_branch: closureBranch,
-    pr_title: `📝 ${taskId} task: record hosted publish evidence`,
+    pr_title: buildReleaseEvidencePrTitle(taskId),
     pr_body: prBodyLines.join("\n"),
     readme_path: `.agentplane/tasks/${taskId}/README.md`,
   };


### PR DESCRIPTION
Task: `202605011918-JW3M0Z`
Title: Standardize release PR titles and messages

## Summary

Standardize release PR titles and messages

Make branch_pr and hosted-close PR titles/messages use one readable canonical format before publishing v0.4.1.

## Scope

- In scope: Make branch_pr and hosted-close PR titles/messages use one readable canonical format before publishing v0.4.1.
- Out of scope: unrelated refactors not required for "Standardize release PR titles and messages".

## Verification

- State: ok
- Note: Passed targeted PR-title, hosted-close, release-evidence, workflow-contract, lint, routing, bootstrap, and doctor checks.
- Full verification checklist lives in local review.md.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-01T19:25:13.455Z
- Branch: task/202605011918-JW3M0Z/standardize-pr-titles
- Head: 4952e94907c1

```text
 .github/workflows/publish.yml                      |  4 +--
 .../cli/prepare-hosted-task-closure-script.test.ts |  7 +++-
 .../cli/run-cli.core.pr-flow.pr-lifecycle.test.ts  |  2 +-
 .../run-cli.core.pr-flow.pr-open.artifacts.test.ts |  4 +--
 .../cli/run-cli.core.task-hosted-close-pr.test.ts  |  4 +++
 .../src/commands/pr/internal/review-template.ts    | 23 +++----------
 .../release/release-task-evidence-script.test.ts   |  4 ++-
 .../src/commands/task/hosted-close-pr.execute.ts   | 30 ++++++++++++-----
 .../src/commands/task/hosted-close-pr.precheck.ts  |  1 +
 .../src/commands/task/hosted-close-pr.types.ts     |  1 +
 scripts/prepare-hosted-task-closure.mjs            | 39 +++++++++++++++++++---
 scripts/release-task-evidence.mjs                  | 22 ++++++++----
 12 files changed, 94 insertions(+), 47 deletions(-)
```

</details>
