### PR TITLE
task: Modularize release publish jobs [202605021914-N72MF3]

### DIFF
--- a/.agentplane/tasks/202605021914-ADH1EE/README.md
+++ b/.agentplane/tasks/202605021914-ADH1EE/README.md
@@ -1,0 +1,118 @@
+---
+id: "202605021914-ADH1EE"
+title: "Add release module recovery workflow"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "ci"
+  - "recovery"
+  - "release"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-02T19:15:20.373Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-02T19:36:11.293Z"
+  updated_by: "CODER"
+  note: "Verified: publish-distribution-module.yml accepts exact tag/SHA/module inputs and excludes npm publish; workflow lint and contract tests passed."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Implement exact-SHA distribution module recovery workflow as part of the approved modular release pipeline worktree; do not republish npm in this path."
+events:
+  -
+    type: "status"
+    at: "2026-05-02T19:34:41.317Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Implement exact-SHA distribution module recovery workflow as part of the approved modular release pipeline worktree; do not republish npm in this path."
+  -
+    type: "verify"
+    at: "2026-05-02T19:36:11.293Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: publish-distribution-module.yml accepts exact tag/SHA/module inputs and excludes npm publish; workflow lint and contract tests passed."
+doc_version: 3
+doc_updated_at: "2026-05-02T19:36:11.300Z"
+doc_updated_by: "CODER"
+description: "Add a dispatchable recovery path that can rerun selected distribution modules for an exact release tag and SHA without republishing npm."
+sections:
+  Summary: |-
+    Add release module recovery workflow
+    
+    Add a dispatchable recovery path that can rerun selected distribution modules for an exact release tag and SHA without republishing npm.
+  Scope: |-
+    - In scope: Add a dispatchable recovery path that can rerun selected distribution modules for an exact release tag and SHA without republishing npm.
+    - Out of scope: unrelated refactors not required for "Add release module recovery workflow".
+  Plan: "Plan: after publish modules and standalone installers are deterministic, add a workflow_dispatch recovery surface that reruns selected distribution modules for an exact tag/SHA from release-distribution.json without republishing npm; include result artifacts and duplicate-PR handling."
+  Verify Steps: |-
+    1. Review the requested outcome for "Add release module recovery workflow". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-02T19:36:11.293Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: publish-distribution-module.yml accepts exact tag/SHA/module inputs and excludes npm publish; workflow lint and contract tests passed.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-02T19:34:41.317Z, excerpt_hash=sha256:f2651ccc32b4b154044e08db43b0464efa701e68e1e7eb83e1fb4f5c66da6dae
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add release module recovery workflow
+
+Add a dispatchable recovery path that can rerun selected distribution modules for an exact release tag and SHA without republishing npm.
+
+## Scope
+
+- In scope: Add a dispatchable recovery path that can rerun selected distribution modules for an exact release tag and SHA without republishing npm.
+- Out of scope: unrelated refactors not required for "Add release module recovery workflow".
+
+## Plan
+
+Plan: after publish modules and standalone installers are deterministic, add a workflow_dispatch recovery surface that reruns selected distribution modules for an exact tag/SHA from release-distribution.json without republishing npm; include result artifacts and duplicate-PR handling.
+
+## Verify Steps
+
+1. Review the requested outcome for "Add release module recovery workflow". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-02T19:36:11.293Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: publish-distribution-module.yml accepts exact tag/SHA/module inputs and excludes npm publish; workflow lint and contract tests passed.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-02T19:34:41.317Z, excerpt_hash=sha256:f2651ccc32b4b154044e08db43b0464efa701e68e1e7eb83e1fb4f5c66da6dae
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605021914-AMCDG4/README.md
+++ b/.agentplane/tasks/202605021914-AMCDG4/README.md
@@ -1,0 +1,118 @@
+---
+id: "202605021914-AMCDG4"
+title: "Document modular release recovery"
+status: "DOING"
+priority: "med"
+owner: "DOCS"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "docs"
+  - "recovery"
+  - "release"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-02T19:15:25.137Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-02T19:36:12.112Z"
+  updated_by: "DOCS"
+  note: "Verified: release publishing docs describe Publish release, standalone installers, distribution module recovery commands, and focused module retries."
+commit: null
+comments:
+  -
+    author: "DOCS"
+    body: "Start: Document the modular release recovery workflow and evidence model after automation changes are in place."
+events:
+  -
+    type: "status"
+    at: "2026-05-02T19:34:41.640Z"
+    author: "DOCS"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Document the modular release recovery workflow and evidence model after automation changes are in place."
+  -
+    type: "verify"
+    at: "2026-05-02T19:36:12.112Z"
+    author: "DOCS"
+    state: "ok"
+    note: "Verified: release publishing docs describe Publish release, standalone installers, distribution module recovery commands, and focused module retries."
+doc_version: 3
+doc_updated_at: "2026-05-02T19:36:12.118Z"
+doc_updated_by: "DOCS"
+description: "Update release documentation and checks so the modular publish flow, external PR handoffs, and recovery commands are clear and evidence-backed."
+sections:
+  Summary: |-
+    Document modular release recovery
+    
+    Update release documentation and checks so the modular publish flow, external PR handoffs, and recovery commands are clear and evidence-backed.
+  Scope: |-
+    - In scope: Update release documentation and checks so the modular publish flow, external PR handoffs, and recovery commands are clear and evidence-backed.
+    - Out of scope: unrelated refactors not required for "Document modular release recovery".
+  Plan: "Plan: document the modular release flow, required vs credentials-gated channels, recovery commands, and post-release evidence model; update workflow contract tests or docs checks so the published guidance matches automation."
+  Verify Steps: |-
+    1. Review the requested outcome for "Document modular release recovery". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-02T19:36:12.112Z — VERIFY — ok
+    
+    By: DOCS
+    
+    Note: Verified: release publishing docs describe Publish release, standalone installers, distribution module recovery commands, and focused module retries.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-02T19:34:41.640Z, excerpt_hash=sha256:fca48445cee84c0e22951d987a470ec9ffb38cd19e62f7eae71d16893486e217
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Document modular release recovery
+
+Update release documentation and checks so the modular publish flow, external PR handoffs, and recovery commands are clear and evidence-backed.
+
+## Scope
+
+- In scope: Update release documentation and checks so the modular publish flow, external PR handoffs, and recovery commands are clear and evidence-backed.
+- Out of scope: unrelated refactors not required for "Document modular release recovery".
+
+## Plan
+
+Plan: document the modular release flow, required vs credentials-gated channels, recovery commands, and post-release evidence model; update workflow contract tests or docs checks so the published guidance matches automation.
+
+## Verify Steps
+
+1. Review the requested outcome for "Document modular release recovery". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-02T19:36:12.112Z — VERIFY — ok
+
+By: DOCS
+
+Note: Verified: release publishing docs describe Publish release, standalone installers, distribution module recovery commands, and focused module retries.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-02T19:34:41.640Z, excerpt_hash=sha256:fca48445cee84c0e22951d987a470ec9ffb38cd19e62f7eae71d16893486e217
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605021914-N72MF3/README.md
+++ b/.agentplane/tasks/202605021914-N72MF3/README.md
@@ -1,0 +1,129 @@
+---
+id: "202605021914-N72MF3"
+title: "Modularize release publish jobs"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "ci"
+  - "distribution"
+  - "release"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-02T19:15:07.283Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-02T19:36:08.443Z"
+  updated_by: "CODER"
+  note: "Verified: modular release pipeline checks passed: workflow lint, format, release:prepublish:fast, distribution/standalone/Homebrew/Scoop/setup-action/GHCR checks, targeted release contract tests, policy routing, docs scripts, and agentplane doctor."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Implement the approved modular release pipeline task chain in this dedicated worktree, preserving exact-SHA release readiness and stopping if publish scope changes."
+events:
+  -
+    type: "status"
+    at: "2026-05-02T19:15:45.460Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Implement the approved modular release pipeline task chain in this dedicated worktree, preserving exact-SHA release readiness and stopping if publish scope changes."
+  -
+    type: "verify"
+    at: "2026-05-02T19:36:08.443Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: modular release pipeline checks passed: workflow lint, format, release:prepublish:fast, distribution/standalone/Homebrew/Scoop/setup-action/GHCR checks, targeted release contract tests, policy routing, docs scripts, and agentplane doctor."
+doc_version: 3
+doc_updated_at: "2026-05-02T19:36:08.457Z"
+doc_updated_by: "CODER"
+description: "Split the release publish workflow into independently recoverable jobs for distribution assets, npm, GitHub Release, GHCR, and credentials-gated external repositories."
+sections:
+  Summary: |-
+    Modularize release publish jobs
+    
+    Split the release publish workflow into independently recoverable jobs for distribution assets, npm, GitHub Release, GHCR, and credentials-gated external repositories.
+  Scope: |-
+    - In scope: Split the release publish workflow into independently recoverable jobs for distribution assets, npm, GitHub Release, GHCR, and credentials-gated external repositories.
+    - Out of scope: unrelated refactors not required for "Modularize release publish jobs".
+  Plan: "Plan: 1) split .github/workflows/publish.yml into independent publish jobs that share release-distribution artifacts; 2) preserve exact-SHA release-ready gating and npm idempotency; 3) make required and credentials-gated modules produce separate evidence artifacts; 4) verify with workflow contract tests and release checks."
+  Verify Steps: |-
+    1. Review the requested outcome for "Modularize release publish jobs". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-02T19:36:08.443Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: modular release pipeline checks passed: workflow lint, format, release:prepublish:fast, distribution/standalone/Homebrew/Scoop/setup-action/GHCR checks, targeted release contract tests, policy routing, docs scripts, and agentplane doctor.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-02T19:15:45.460Z, excerpt_hash=sha256:76c33aefe091b330e7fa0c28625b0abbc6b863a69b99616e49cf0ba286d243be
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Primary publish workflow now treats credentials-gated external handoffs as non-blocking and a separate exact-SHA distribution module workflow can recover GitHub Release assets, GHCR, Homebrew, Scoop, and setup-action without npm republish.
+      Impact: Partial release recovery is more granular; npm/GitHub/GHCR remain required release channels while external handoffs can be retried independently.
+      Resolution: Added workflow and contract coverage for the modular recovery path.
+      Promotion: incident-candidate
+      Fixability: external
+id_source: "generated"
+---
+## Summary
+
+Modularize release publish jobs
+
+Split the release publish workflow into independently recoverable jobs for distribution assets, npm, GitHub Release, GHCR, and credentials-gated external repositories.
+
+## Scope
+
+- In scope: Split the release publish workflow into independently recoverable jobs for distribution assets, npm, GitHub Release, GHCR, and credentials-gated external repositories.
+- Out of scope: unrelated refactors not required for "Modularize release publish jobs".
+
+## Plan
+
+Plan: 1) split .github/workflows/publish.yml into independent publish jobs that share release-distribution artifacts; 2) preserve exact-SHA release-ready gating and npm idempotency; 3) make required and credentials-gated modules produce separate evidence artifacts; 4) verify with workflow contract tests and release checks.
+
+## Verify Steps
+
+1. Review the requested outcome for "Modularize release publish jobs". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-02T19:36:08.443Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: modular release pipeline checks passed: workflow lint, format, release:prepublish:fast, distribution/standalone/Homebrew/Scoop/setup-action/GHCR checks, targeted release contract tests, policy routing, docs scripts, and agentplane doctor.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-02T19:15:45.460Z, excerpt_hash=sha256:76c33aefe091b330e7fa0c28625b0abbc6b863a69b99616e49cf0ba286d243be
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Primary publish workflow now treats credentials-gated external handoffs as non-blocking and a separate exact-SHA distribution module workflow can recover GitHub Release assets, GHCR, Homebrew, Scoop, and setup-action without npm republish.
+  Impact: Partial release recovery is more granular; npm/GitHub/GHCR remain required release channels while external handoffs can be retried independently.
+  Resolution: Added workflow and contract coverage for the modular recovery path.
+  Promotion: incident-candidate
+  Fixability: external

--- a/.agentplane/tasks/202605021914-N72MF3/pr/diffstat.txt
+++ b/.agentplane/tasks/202605021914-N72MF3/pr/diffstat.txt
@@ -1,0 +1,13 @@
+ .agentplane/tasks/202605021914-ADH1EE/README.md    | 118 +++++++++++++
+ .agentplane/tasks/202605021914-AMCDG4/README.md    | 118 +++++++++++++
+ .agentplane/tasks/202605021914-Z2P2TS/README.md    | 118 +++++++++++++
+ .github/workflows/publish-distribution-module.yml  | 196 +++++++++++++++++++++
+ .github/workflows/publish.yml                      |   5 +-
+ docs/developer/release-and-publishing.mdx          |  39 ++--
+ .../generate-release-distribution-script.test.ts   |  12 ++
+ .../generate-standalone-cli-assets-script.test.ts  |  49 +++++-
+ .../release/publish-workflow-contract.test.ts      |  31 ++++
+ scripts/generate-release-distribution.mjs          |  99 ++++++++---
+ scripts/generate-standalone-cli-assets.mjs         |  54 ++++--
+ scripts/render-ghcr-image-metadata.mjs             |  26 ++-
+ 12 files changed, 805 insertions(+), 60 deletions(-)

--- a/.agentplane/tasks/202605021914-N72MF3/pr/github-body.md
+++ b/.agentplane/tasks/202605021914-N72MF3/pr/github-body.md
@@ -1,0 +1,48 @@
+Task: `202605021914-N72MF3`
+Title: Modularize release publish jobs
+
+## Summary
+
+Modularize release publish jobs
+
+Split the release publish workflow into independently recoverable jobs for distribution assets, npm, GitHub Release, GHCR, and credentials-gated external repositories.
+
+## Scope
+
+- In scope: Split the release publish workflow into independently recoverable jobs for distribution assets, npm, GitHub Release, GHCR, and credentials-gated external repositories.
+- Out of scope: unrelated refactors not required for "Modularize release publish jobs".
+
+## Verification
+
+- State: ok
+- Note: Verified: modular release pipeline checks passed: workflow lint, format, release:prepublish:fast, distribution/standalone/Homebrew/Scoop/setup-action/GHCR checks, targeted release contract tests, policy routing, docs scripts, and agentplane doctor.
+- Full verification checklist lives in local review.md.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-02T19:37:06.619Z
+- Branch: task/202605021914-N72MF3/release-pipeline-modules
+- Head: 42ac5f1c4588
+
+```text
+ .agentplane/tasks/202605021914-ADH1EE/README.md    | 118 +++++++++++++
+ .agentplane/tasks/202605021914-AMCDG4/README.md    | 118 +++++++++++++
+ .agentplane/tasks/202605021914-Z2P2TS/README.md    | 118 +++++++++++++
+ .github/workflows/publish-distribution-module.yml  | 196 +++++++++++++++++++++
+ .github/workflows/publish.yml                      |   5 +-
+ docs/developer/release-and-publishing.mdx          |  39 ++--
+ .../generate-release-distribution-script.test.ts   |  12 ++
+ .../generate-standalone-cli-assets-script.test.ts  |  49 +++++-
+ .../release/publish-workflow-contract.test.ts      |  31 ++++
+ scripts/generate-release-distribution.mjs          |  99 ++++++++---
+ scripts/generate-standalone-cli-assets.mjs         |  54 ++++--
+ scripts/render-ghcr-image-metadata.mjs             |  26 ++-
+ 12 files changed, 805 insertions(+), 60 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605021914-N72MF3/pr/github-title.txt
+++ b/.agentplane/tasks/202605021914-N72MF3/pr/github-title.txt
@@ -1,0 +1,1 @@
+task: Modularize release publish jobs [202605021914-N72MF3]

--- a/.agentplane/tasks/202605021914-N72MF3/pr/meta.json
+++ b/.agentplane/tasks/202605021914-N72MF3/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605021914-N72MF3/release-pipeline-modules",
+  "created_at": "2026-05-02T19:15:45.534Z",
+  "head_sha": "42ac5f1c45885fb308f0119816efa9671982cef7",
+  "last_verified_at": "2026-05-02T19:36:08.443Z",
+  "last_verified_sha": "b73d17fb596422b25012a5f44f8f216e19b73301",
+  "schema_version": 1,
+  "task_id": "202605021914-N72MF3",
+  "updated_at": "2026-05-02T19:37:06.619Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605021914-N72MF3/pr/review.md
+++ b/.agentplane/tasks/202605021914-N72MF3/pr/review.md
@@ -1,0 +1,69 @@
+# PR Review
+
+Created: 2026-05-02T19:15:45.534Z
+Branch: task/202605021914-N72MF3/release-pipeline-modules
+
+## Summary
+
+Modularize release publish jobs
+
+Split the release publish workflow into independently recoverable jobs for distribution assets, npm, GitHub Release, GHCR, and credentials-gated external repositories.
+
+## Scope
+
+- In scope: Split the release publish workflow into independently recoverable jobs for distribution assets, npm, GitHub Release, GHCR, and credentials-gated external repositories.
+- Out of scope: unrelated refactors not required for "Modularize release publish jobs".
+
+## Verification
+
+### Plan
+
+1. Review the requested outcome for "Modularize release publish jobs". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+### Current Status
+
+- State: ok
+- Note: Verified: modular release pipeline checks passed: workflow lint, format, release:prepublish:fast, distribution/standalone/Homebrew/Scoop/setup-action/GHCR checks, targeted release contract tests, policy routing, docs scripts, and agentplane doctor.
+
+## Risks
+
+- Risk level: not recorded
+- Breaking change: no
+
+### Rollback
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-02T19:37:06.619Z
+- Branch: task/202605021914-N72MF3/release-pipeline-modules
+- Head: 42ac5f1c4588
+
+```text
+ .agentplane/tasks/202605021914-ADH1EE/README.md    | 118 +++++++++++++
+ .agentplane/tasks/202605021914-AMCDG4/README.md    | 118 +++++++++++++
+ .agentplane/tasks/202605021914-Z2P2TS/README.md    | 118 +++++++++++++
+ .github/workflows/publish-distribution-module.yml  | 196 +++++++++++++++++++++
+ .github/workflows/publish.yml                      |   5 +-
+ docs/developer/release-and-publishing.mdx          |  39 ++--
+ .../generate-release-distribution-script.test.ts   |  12 ++
+ .../generate-standalone-cli-assets-script.test.ts  |  49 +++++-
+ .../release/publish-workflow-contract.test.ts      |  31 ++++
+ scripts/generate-release-distribution.mjs          |  99 ++++++++---
+ scripts/generate-standalone-cli-assets.mjs         |  54 ++++--
+ scripts/render-ghcr-image-metadata.mjs             |  26 ++-
+ 12 files changed, 805 insertions(+), 60 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605021914-Z2P2TS/README.md
+++ b/.agentplane/tasks/202605021914-Z2P2TS/README.md
@@ -1,0 +1,118 @@
+---
+id: "202605021914-Z2P2TS"
+title: "Add standalone installer distribution path"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "distribution"
+  - "installer"
+  - "release"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-02T19:15:14.203Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-02T19:36:10.313Z"
+  updated_by: "CODER"
+  note: "Verified: install.sh and install.ps1 now consume standalone release archives with SHA256SUMS verification and no node/npm requirement; standalone production install test passes with local workspace tarballs."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Implement standalone installer distribution path as part of the approved modular release pipeline worktree; stop if installer scope expands beyond release assets."
+events:
+  -
+    type: "status"
+    at: "2026-05-02T19:34:41.028Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Implement standalone installer distribution path as part of the approved modular release pipeline worktree; stop if installer scope expands beyond release assets."
+  -
+    type: "verify"
+    at: "2026-05-02T19:36:10.313Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: install.sh and install.ps1 now consume standalone release archives with SHA256SUMS verification and no node/npm requirement; standalone production install test passes with local workspace tarballs."
+doc_version: 3
+doc_updated_at: "2026-05-02T19:36:10.321Z"
+doc_updated_by: "CODER"
+description: "Make install.sh and install.ps1 consume standalone bundled-runtime release assets instead of requiring user-provided node/npm."
+sections:
+  Summary: |-
+    Add standalone installer distribution path
+    
+    Make install.sh and install.ps1 consume standalone bundled-runtime release assets instead of requiring user-provided node/npm.
+  Scope: |-
+    - In scope: Make install.sh and install.ps1 consume standalone bundled-runtime release assets instead of requiring user-provided node/npm.
+    - Out of scope: unrelated refactors not required for "Add standalone installer distribution path".
+  Plan: "Plan: after N72MF3 design is in place, update release distribution generation so install.sh and install.ps1 install standalone bundled-runtime assets, not npm tarballs; add/adjust tests for OS/arch selection, checksum validation, and no external node/npm requirement."
+  Verify Steps: |-
+    1. Review the requested outcome for "Add standalone installer distribution path". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-02T19:36:10.313Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: install.sh and install.ps1 now consume standalone release archives with SHA256SUMS verification and no node/npm requirement; standalone production install test passes with local workspace tarballs.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-02T19:34:41.028Z, excerpt_hash=sha256:25fdb3b0d57c1c948df8c8d927f4b1492778b0e7e22aa7a3a27b776a967fbac3
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add standalone installer distribution path
+
+Make install.sh and install.ps1 consume standalone bundled-runtime release assets instead of requiring user-provided node/npm.
+
+## Scope
+
+- In scope: Make install.sh and install.ps1 consume standalone bundled-runtime release assets instead of requiring user-provided node/npm.
+- Out of scope: unrelated refactors not required for "Add standalone installer distribution path".
+
+## Plan
+
+Plan: after N72MF3 design is in place, update release distribution generation so install.sh and install.ps1 install standalone bundled-runtime assets, not npm tarballs; add/adjust tests for OS/arch selection, checksum validation, and no external node/npm requirement.
+
+## Verify Steps
+
+1. Review the requested outcome for "Add standalone installer distribution path". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-02T19:36:10.313Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: install.sh and install.ps1 now consume standalone release archives with SHA256SUMS verification and no node/npm requirement; standalone production install test passes with local workspace tarballs.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-02T19:34:41.028Z, excerpt_hash=sha256:25fdb3b0d57c1c948df8c8d927f4b1492778b0e7e22aa7a3a27b776a967fbac3
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.github/workflows/publish-distribution-module.yml
+++ b/.github/workflows/publish-distribution-module.yml
@@ -1,0 +1,196 @@
+name: Publish distribution module
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to recover (vX.Y.Z)"
+        required: true
+      sha:
+        description: "Exact release commit SHA"
+        required: true
+      module:
+        description: "Module to run: github-release, ghcr, homebrew, scoop, setup-agentplane, external, all"
+        required: true
+        default: "all"
+
+permissions:
+  contents: write
+  packages: write
+  pull-requests: write
+
+concurrency:
+  group: distribution-module-${{ github.event.inputs.tag }}-${{ github.event.inputs.module }}
+  cancel-in-progress: false
+
+jobs:
+  publish-module:
+    name: Publish ${{ github.event.inputs.module }} for ${{ github.event.inputs.tag }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    env:
+      MODULE: ${{ github.event.inputs.module }}
+      RELEASE_TAG: ${{ github.event.inputs.tag }}
+      RELEASE_SHA: ${{ github.event.inputs.sha }}
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.sha }}
+          fetch-depth: 0
+          submodules: recursive
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.6"
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - name: Validate module input
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$MODULE" in
+            github-release|ghcr|homebrew|scoop|setup-agentplane|external|all) ;;
+            *) echo "Unsupported module: $MODULE" >&2; exit 2 ;;
+          esac
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+      - name: Resolve release version
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${RELEASE_TAG#v}"
+          if [ "$VERSION" = "$RELEASE_TAG" ] || [ -z "$VERSION" ]; then
+            echo "tag must be v-prefixed: $RELEASE_TAG" >&2
+            exit 2
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Validate release payload
+        run: |
+          node scripts/check-release-notes.mjs --tag "$RELEASE_TAG"
+          node scripts/check-release-version.mjs --tag "$RELEASE_TAG"
+          bun run release:check
+      - name: Generate release distribution assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/generate-release-distribution.mjs \
+            --out .agentplane/.release/publish/distribution \
+            --version "${{ steps.release.outputs.version }}" \
+            --tag "$RELEASE_TAG" \
+            --sha "$RELEASE_SHA" \
+            --repo "${{ github.repository }}"
+      - name: Render module artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/render-homebrew-formula.mjs \
+            --manifest .agentplane/.release/publish/distribution/release-distribution.json \
+            --out .agentplane/.release/publish/homebrew
+          node scripts/render-scoop-manifest.mjs \
+            --manifest .agentplane/.release/publish/distribution/release-distribution.json \
+            --out .agentplane/.release/publish/scoop
+          node scripts/render-setup-agentplane-action.mjs \
+            --manifest .agentplane/.release/publish/distribution/release-distribution.json \
+            --out .agentplane/.release/publish/setup-agentplane
+      - name: Publish GitHub Release assets
+        if: contains(fromJSON('["github-release","all"]'), github.event.inputs.module)
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.event.inputs.tag }}
+          body_path: docs/releases/${{ github.event.inputs.tag }}.md
+          files: |
+            .agentplane/.release/publish/distribution/agentplane-v${{ steps.release.outputs.version }}-darwin-arm64.tar.gz
+            .agentplane/.release/publish/distribution/agentplane-v${{ steps.release.outputs.version }}-darwin-x64.tar.gz
+            .agentplane/.release/publish/distribution/agentplane-v${{ steps.release.outputs.version }}-linux-arm64.tar.gz
+            .agentplane/.release/publish/distribution/agentplane-v${{ steps.release.outputs.version }}-linux-x64.tar.gz
+            .agentplane/.release/publish/distribution/agentplane-v${{ steps.release.outputs.version }}-win32-x64.zip
+            .agentplane/.release/publish/distribution/agentplane-upgrade.tar.gz
+            .agentplane/.release/publish/distribution/agentplane-upgrade.tar.gz.sha256
+            .agentplane/.release/publish/distribution/install.sh
+            .agentplane/.release/publish/distribution/install.ps1
+            .agentplane/.release/publish/distribution/SHA256SUMS
+            .agentplane/.release/publish/distribution/release-distribution.json
+            .agentplane/.release/publish/distribution/standalone-assets.json
+      - name: Publish GHCR image
+        if: contains(fromJSON('["ghcr","all"]'), github.event.inputs.module)
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/render-ghcr-image-metadata.mjs \
+            --manifest .agentplane/.release/publish/distribution/release-distribution.json \
+            --out .agentplane/.release/publish/ghcr
+          set -a
+          . .agentplane/.release/publish/ghcr/docker-build-args.env
+          set +a
+          echo "$GITHUB_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          docker build \
+            -f packages/agentplane/Dockerfile \
+            --build-arg "AGENTPLANE_VERSION=${AGENTPLANE_VERSION}" \
+            --build-arg "AGENTPLANE_TARBALL_FILE=${AGENTPLANE_TARBALL_FILE}" \
+            --build-arg "AGENTPLANE_TARBALL_SHA256_FILE=${AGENTPLANE_TARBALL_SHA256_FILE}" \
+            -t "${GHCR_VERSION_TAG}" \
+            -t "${GHCR_RELEASE_TAG}" \
+            -t "${GHCR_LATEST_TAG}" \
+            .
+          docker push "${GHCR_VERSION_TAG}"
+          docker push "${GHCR_RELEASE_TAG}"
+          docker push "${GHCR_LATEST_TAG}"
+          node scripts/render-ghcr-image-metadata.mjs \
+            --manifest .agentplane/.release/publish/distribution/release-distribution.json \
+            --out .agentplane/.release/publish/ghcr \
+            --status published
+      - name: Publish Homebrew tap PR
+        if: contains(fromJSON('["homebrew","external","all"]'), github.event.inputs.module)
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN || '' }}
+        run: |
+          node scripts/publish-external-distribution.mjs \
+            --module homebrew \
+            --repo basilisk-labs/homebrew-tap \
+            --source .agentplane/.release/publish/homebrew \
+            --copy Formula/agentplane.rb:Formula/agentplane.rb \
+            --version "${{ steps.release.outputs.version }}" \
+            --tag "$RELEASE_TAG" \
+            --sha "$RELEASE_SHA" \
+            --token-env HOMEBREW_TAP_TOKEN \
+            --out .agentplane/.release/publish/homebrew/homebrew-publish-result.json
+      - name: Publish Scoop bucket PR
+        if: contains(fromJSON('["scoop","external","all"]'), github.event.inputs.module)
+        env:
+          SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN || '' }}
+        run: |
+          node scripts/publish-external-distribution.mjs \
+            --module scoop \
+            --repo basilisk-labs/scoop-bucket \
+            --source .agentplane/.release/publish/scoop \
+            --copy agentplane.json:bucket/agentplane.json \
+            --version "${{ steps.release.outputs.version }}" \
+            --tag "$RELEASE_TAG" \
+            --sha "$RELEASE_SHA" \
+            --token-env SCOOP_BUCKET_TOKEN \
+            --out .agentplane/.release/publish/scoop/scoop-publish-result.json
+      - name: Publish setup-agentplane PR
+        if: contains(fromJSON('["setup-agentplane","external","all"]'), github.event.inputs.module)
+        env:
+          SETUP_AGENTPLANE_TOKEN: ${{ secrets.SETUP_AGENTPLANE_TOKEN || '' }}
+        run: |
+          node scripts/publish-external-distribution.mjs \
+            --module setup-agentplane \
+            --repo basilisk-labs/setup-agentplane \
+            --source .agentplane/.release/publish/setup-agentplane \
+            --copy action.yml:action.yml \
+            --copy README.md:README.md \
+            --version "${{ steps.release.outputs.version }}" \
+            --tag "$RELEASE_TAG" \
+            --sha "$RELEASE_SHA" \
+            --token-env SETUP_AGENTPLANE_TOKEN \
+            --out .agentplane/.release/publish/setup-agentplane/setup-agentplane-publish-result.json
+      - name: Upload distribution module artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: distribution-module-${{ github.event.inputs.module }}-${{ github.event.inputs.tag }}
+          path: .agentplane/.release/publish/
+          if-no-files-found: warn

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to npm
+name: Publish release
 
 on:
   workflow_run:
@@ -420,6 +420,7 @@ jobs:
             .agentplane/.release/publish/distribution/release-distribution.json
             .agentplane/.release/publish/distribution/standalone-assets.json
       - name: Publish Homebrew tap PR
+        continue-on-error: true
         shell: bash
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN || '' }}
@@ -436,6 +437,7 @@ jobs:
             --token-env HOMEBREW_TAP_TOKEN \
             --out .agentplane/.release/publish/homebrew/homebrew-publish-result.json
       - name: Publish Scoop bucket PR
+        continue-on-error: true
         shell: bash
         env:
           SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN || '' }}
@@ -452,6 +454,7 @@ jobs:
             --token-env SCOOP_BUCKET_TOKEN \
             --out .agentplane/.release/publish/scoop/scoop-publish-result.json
       - name: Publish setup-agentplane PR
+        continue-on-error: true
         shell: bash
         env:
           SETUP_AGENTPLANE_TOKEN: ${{ secrets.SETUP_AGENTPLANE_TOKEN || '' }}

--- a/docs/developer/release-and-publishing.mdx
+++ b/docs/developer/release-and-publishing.mdx
@@ -103,7 +103,7 @@ release-relevant Linux gate that can block or invalidate a publishable SHA.
 npm publish is GitHub-only.
 Local `npm publish` is blocked by `prepublishOnly` through `scripts/enforce-github-publish.mjs`.
 
-GitHub workflow `Publish to npm`:
+GitHub workflow `Publish release`:
 
 - observes successful `Core CI` `workflow_run` events on `main` to detect release readiness, but does not publish from automatic events
 - publishes only from explicit `workflow_dispatch`
@@ -144,9 +144,9 @@ Required release distribution artifacts:
 - `agentplane-vX.Y.Z-<platform>-<arch>.tar.gz` or `.zip`: bundled-runtime CLI archives for
   package managers and no-Node installer paths.
 
-The install scripts are convenience entrypoints, not update sources of truth. Package managers and
-scripts must install an exact release version and must not implement self-update behavior that
-bypasses the hosted release pipeline.
+The install scripts are convenience entrypoints over the same standalone release assets used by
+package managers and setup actions. They install an exact release version, verify `SHA256SUMS`, and
+must not require external `node`, `npm`, `bun`, or global packages.
 
 ## Standalone CLI artifact contract
 
@@ -293,6 +293,22 @@ If a credential is absent, the channel must record `skipped_missing_credentials`
 secret name and a recovery command. It must not fail an otherwise valid npm/GitHub/GHCR release
 unless that channel was explicitly marked required for the run.
 
+External handoff channels are also recoverable through `Publish distribution module`, a
+`workflow_dispatch` workflow that accepts:
+
+- `tag`: release tag, for example `v0.4.2`
+- `sha`: exact release commit SHA
+- `module`: `github-release`, `ghcr`, `homebrew`, `scoop`, `setup-agentplane`, `external`, or `all`
+
+Use it when npm is already published and a distribution channel needs a focused retry:
+
+```bash
+gh workflow run publish-distribution-module.yml \
+  -f tag=vX.Y.Z \
+  -f sha=<release-sha> \
+  -f module=homebrew
+```
+
 External moderated registries such as `homebrew/core`, winget, Chocolatey, AUR, and nixpkgs are
 follow-up publication targets. They should be opened as PR jobs or manual recovery tasks after the
 release is already published, because their review queues are outside the AgentPlane release SLA.
@@ -325,7 +341,7 @@ GitHub workflow `Core CI` also supports `workflow_dispatch` recovery:
 - prefer `sha=<release commit>` to validate the exact historical release candidate
 - use `ref` only when `sha` is omitted
 - the dispatched run checks out that exact target and can mint the canonical `release-ready` artifact
-  for the same commit, which `Publish to npm` then consumes
+  for the same commit, which `Publish release` then consumes
 
 ## Provenance requirements
 
@@ -353,7 +369,7 @@ workflow can publish it without forking the release route.
   artifact source instead of following a moving branch ref
 - If the exact release SHA never produced `release-ready` historically:
 - first dispatch `Core CI` for that same `sha`
-- then dispatch `Publish to npm` for that same `sha`
+- then dispatch `Publish release` for that same `sha`
 - If only some packages are trusted publishers:
 - keep OIDC enabled and supply `NPM_TOKEN` as fallback for the remaining packages until npm-side
   trusted publishing is enabled for them too
@@ -388,11 +404,12 @@ only on workflow status inference.
 
 For distribution recovery, use the manifest first:
 
-- if npm succeeded but a package-manager channel was skipped, rerun only that channel with the same
-  `release-distribution.json`
-- if GitHub Release assets are missing, regenerate and upload assets for the same tag before running
-  package-manager modules
-- if GHCR publish failed after npm succeeded, rerun the GHCR module against the exact release SHA
+- if npm succeeded but a package-manager channel was skipped, dispatch `Publish distribution module`
+  with `module=homebrew`, `module=scoop`, `module=setup-agentplane`, or `module=external`
+- if GitHub Release assets are missing, dispatch `Publish distribution module` with
+  `module=github-release` for the same tag and SHA
+- if GHCR publish failed after npm succeeded, dispatch `Publish distribution module` with
+  `module=ghcr` against the exact release SHA
 - if a tap, bucket, or setup-action repository PR already exists, update that PR rather than creating
   a duplicate
 - if credentials were missing, add the secret and rerun the credentials-gated module; do not bump the

--- a/packages/agentplane/src/commands/release/generate-release-distribution-script.test.ts
+++ b/packages/agentplane/src/commands/release/generate-release-distribution-script.test.ts
@@ -60,6 +60,8 @@ describe("generate-release-distribution script", () => {
       releaseAssets: { name: string; kind: string }[];
     };
     const checksums = await readFile(path.join(outDir, "SHA256SUMS"), "utf8");
+    const installSh = await readFile(path.join(outDir, "install.sh"), "utf8");
+    const installPs1 = await readFile(path.join(outDir, "install.ps1"), "utf8");
 
     expect(manifest.platformAssets).toHaveLength(5);
     expect(manifest.platformAssets).toContainEqual(
@@ -88,6 +90,16 @@ describe("generate-release-distribution script", () => {
       expect(checksums).toContain(asset.name);
       expect(existsSync(path.join(outDir, asset.name))).toBe(true);
     }
+    expect(installSh).toContain("SHA256SUMS");
+    expect(installSh).toContain('asset="agentplane-v$VERSION-$platform-$arch.tar.gz"');
+    expect(installSh).toContain('"$INSTALL_DIR/bin/agentplane" --version');
+    expect(installSh).not.toContain("npm install");
+    expect(installSh).not.toContain("need node");
+    expect(installPs1).toContain("SHA256SUMS");
+    expect(installPs1).toContain('"agentplane-v$Version-win32-x64.zip"');
+    expect(installPs1).toContain('"bin\\agentplane.cmd"');
+    expect(installPs1).not.toContain("npm install");
+    expect(installPs1).not.toContain('Require-Command "node"');
   }, 90_000);
 
   it("validates standalone assets during release distribution check", async () => {

--- a/packages/agentplane/src/commands/release/generate-release-distribution-script.test.ts
+++ b/packages/agentplane/src/commands/release/generate-release-distribution-script.test.ts
@@ -97,6 +97,7 @@ describe("generate-release-distribution script", () => {
     expect(installSh).not.toContain("need node");
     expect(installPs1).toContain("SHA256SUMS");
     expect(installPs1).toContain('"agentplane-v$Version-win32-x64.zip"');
+    expect(installPs1).toContain("-split '\\s+'");
     expect(installPs1).toContain('"bin\\agentplane.cmd"');
     expect(installPs1).not.toContain("npm install");
     expect(installPs1).not.toContain('Require-Command "node"');

--- a/packages/agentplane/src/commands/release/generate-standalone-cli-assets-script.test.ts
+++ b/packages/agentplane/src/commands/release/generate-standalone-cli-assets-script.test.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -170,6 +170,53 @@ describe("generate-standalone-cli-assets script", () => {
 
     expect(stdout).toContain("standalone CLI assets check");
     expect(existsSync(outDir)).toBe(false);
+  }, 90_000);
+
+  it("installs production dependencies from a sanitized package payload", async () => {
+    const root = await makeTempRoot();
+    const outDir = path.join(root, "out");
+    const extractDir = path.join(root, "extract");
+
+    await execFileAsync(
+      "node",
+      [
+        SCRIPT_PATH,
+        "--out",
+        outDir,
+        "--target",
+        "linux-x64",
+        "--version",
+        "1.2.3",
+        "--tag",
+        "v1.2.3",
+        "--sha",
+        "abc123",
+        "--synthetic-node",
+      ],
+      { cwd: process.cwd() },
+    );
+
+    const archivePath = path.join(outDir, "agentplane-v1.2.3-linux-x64.tar.gz");
+    await mkdir(extractDir, { recursive: true });
+    await execFileAsync("tar", ["-xzf", archivePath, "-C", extractDir], { cwd: process.cwd() });
+    const manifest = JSON.parse(
+      await readFile(path.join(outDir, "standalone-assets.json"), "utf8"),
+    ) as { assets: { dependencyStatus: string }[] };
+    const packageJson = JSON.parse(
+      await readFile(path.join(extractDir, "lib", "agentplane", "package", "package.json"), "utf8"),
+    ) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+      scripts?: Record<string, string>;
+    };
+
+    expect(manifest.assets[0]?.dependencyStatus).toBe(
+      "installed_npm_omit_dev_local_workspace_tarballs",
+    );
+    expect(packageJson.dependencies?.["@agentplaneorg/core"]).toBe("1.2.3");
+    expect(packageJson.dependencies?.["@agentplaneorg/recipes"]).toBe("1.2.3");
+    expect(packageJson.devDependencies).toBeUndefined();
+    expect(packageJson.scripts).toBeUndefined();
   }, 90_000);
 
   it("smoke-tests a standalone archive fixture without a PATH node dependency", async () => {

--- a/packages/agentplane/src/commands/release/generate-standalone-cli-assets-script.test.ts
+++ b/packages/agentplane/src/commands/release/generate-standalone-cli-assets-script.test.ts
@@ -210,9 +210,7 @@ describe("generate-standalone-cli-assets script", () => {
       scripts?: Record<string, string>;
     };
 
-    expect(manifest.assets[0]?.dependencyStatus).toBe(
-      "installed_npm_omit_dev_local_workspace_tarballs",
-    );
+    expect(manifest.assets[0]?.dependencyStatus).toBe("installed_npm_ci_local_workspace_tarballs");
     expect(packageJson.dependencies?.["@agentplaneorg/core"]).toBe("1.2.3");
     expect(packageJson.dependencies?.["@agentplaneorg/recipes"]).toBe("1.2.3");
     expect(packageJson.devDependencies).toBeUndefined();

--- a/packages/agentplane/src/commands/release/publish-workflow-contract.test.ts
+++ b/packages/agentplane/src/commands/release/publish-workflow-contract.test.ts
@@ -4,8 +4,18 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const PUBLISH_WORKFLOW_PATH = path.resolve(process.cwd(), ".github/workflows/publish.yml");
+const DISTRIBUTION_MODULE_WORKFLOW_PATH = path.resolve(
+  process.cwd(),
+  ".github/workflows/publish-distribution-module.yml",
+);
 
 describe("publish workflow contract", () => {
+  it("names the primary workflow as a full release publisher", async () => {
+    const workflow = await readFile(PUBLISH_WORKFLOW_PATH, "utf8");
+
+    expect(workflow).toContain("name: Publish release");
+  });
+
   it("uses workflow_run from Core CI and downloads the exact detected release-ready artifact by run id", async () => {
     const workflow = await readFile(PUBLISH_WORKFLOW_PATH, "utf8");
 
@@ -47,6 +57,7 @@ describe("publish workflow contract", () => {
     expect(workflow).toContain("Render setup-agentplane action");
     expect(workflow).toContain("node scripts/render-setup-agentplane-action.mjs");
     expect(workflow).toContain("Publish Homebrew tap PR");
+    expect(workflow).toContain("continue-on-error: true");
     expect(workflow).toContain("Publish Scoop bucket PR");
     expect(workflow).toContain("Publish setup-agentplane PR");
     expect(workflow).toContain("node scripts/publish-external-distribution.mjs");
@@ -213,5 +224,25 @@ describe("publish workflow contract", () => {
     expect(workflow).toContain(
       "SHA=\"$(node -e \"const fs=require('node:fs'); const payload=JSON.parse(fs.readFileSync('.agentplane/.release/ready/canonical.json','utf8')); process.stdout.write(String(payload.sha || ''));\")\"",
     );
+  });
+
+  it("adds an exact-SHA distribution module recovery workflow without npm publication", async () => {
+    const workflow = await readFile(DISTRIBUTION_MODULE_WORKFLOW_PATH, "utf8");
+
+    expect(workflow).toContain("name: Publish distribution module");
+    expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).toContain("tag:");
+    expect(workflow).toContain("sha:");
+    expect(workflow).toContain("module:");
+    expect(workflow).toContain("ref: ${{ github.event.inputs.sha }}");
+    expect(workflow).toContain("node scripts/generate-release-distribution.mjs");
+    expect(workflow).toContain("Publish GitHub Release assets");
+    expect(workflow).toContain("Publish GHCR image");
+    expect(workflow).toContain("Publish Homebrew tap PR");
+    expect(workflow).toContain("Publish Scoop bucket PR");
+    expect(workflow).toContain("Publish setup-agentplane PR");
+    expect(workflow).toContain("distribution-module-${{ github.event.inputs.module }}");
+    expect(workflow).not.toContain("npm publish");
+    expect(workflow).not.toContain("Write npm auth config");
   });
 });

--- a/scripts/generate-release-distribution.mjs
+++ b/scripts/generate-release-distribution.mjs
@@ -161,13 +161,15 @@ function packCliPackage(repoRoot, outDir) {
   };
 }
 
-function renderInstallSh({ version, tarballUrl, tarballSha256 }) {
+function renderInstallSh({ version, repo, tag }) {
   return `#!/usr/bin/env sh
 set -eu
 
 VERSION="${version}"
-TARBALL_URL="${tarballUrl}"
-TARBALL_SHA256="${tarballSha256}"
+REPO="${repo}"
+TAG="${tag}"
+BASE_URL="https://github.com/$REPO/releases/download/$TAG"
+INSTALL_DIR="\${AGENTPLANE_INSTALL_DIR:-$HOME/.agentplane/standalone/$VERSION}"
 
 need() {
   command -v "$1" >/dev/null 2>&1 || {
@@ -176,40 +178,67 @@ need() {
   }
 }
 
-need node
-need npm
 need curl
+need tar
 
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT INT TERM
-tarball="$tmp_dir/agentplane-$VERSION.tgz"
 
-curl -fsSL "$TARBALL_URL" -o "$tarball"
-if command -v sha256sum >/dev/null 2>&1; then
-  actual="$(sha256sum "$tarball" | awk '{print $1}')"
-else
-  need shasum
-  actual="$(shasum -a 256 "$tarball" | awk '{print $1}')"
+case "$(uname -s)" in
+  Darwin) platform="darwin" ;;
+  Linux) platform="linux" ;;
+  *) echo "agentplane install: unsupported OS: $(uname -s)" >&2; exit 1 ;;
+esac
+
+case "$(uname -m)" in
+  arm64|aarch64) arch="arm64" ;;
+  x86_64|amd64) arch="x64" ;;
+  *) echo "agentplane install: unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+asset="agentplane-v$VERSION-$platform-$arch.tar.gz"
+archive="$tmp_dir/$asset"
+checksums="$tmp_dir/SHA256SUMS"
+
+curl -fsSL "$BASE_URL/SHA256SUMS" -o "$checksums"
+curl -fsSL "$BASE_URL/$asset" -o "$archive"
+
+expected="$(awk -v asset="$asset" '$2 == asset {print $1}' "$checksums")"
+if [ -z "$expected" ]; then
+  echo "agentplane install: checksum entry missing for $asset" >&2
+  exit 1
 fi
 
-if [ "$actual" != "$TARBALL_SHA256" ]; then
-  echo "agentplane install: checksum mismatch for $TARBALL_URL" >&2
-  echo "expected: $TARBALL_SHA256" >&2
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "$archive" | awk '{print $1}')"
+else
+  need shasum
+  actual="$(shasum -a 256 "$archive" | awk '{print $1}')"
+fi
+
+if [ "$actual" != "$expected" ]; then
+  echo "agentplane install: checksum mismatch for $asset" >&2
+  echo "expected: $expected" >&2
   echo "actual:   $actual" >&2
   exit 1
 fi
 
-npm install -g "$tarball"
-agentplane --version
+rm -rf "$INSTALL_DIR"
+mkdir -p "$INSTALL_DIR"
+tar -xzf "$archive" -C "$INSTALL_DIR"
+"$INSTALL_DIR/bin/agentplane" --version
+printf '%s\\n' "$INSTALL_DIR/bin"
 `;
 }
 
-function renderInstallPs1({ version, tarballUrl, tarballSha256 }) {
+function renderInstallPs1({ version, repo, tag }) {
   return `$ErrorActionPreference = "Stop"
 
 $Version = "${version}"
-$TarballUrl = "${tarballUrl}"
-$TarballSha256 = "${tarballSha256}"
+$Repo = "${repo}"
+$Tag = "${tag}"
+$BaseUrl = "https://github.com/$Repo/releases/download/$Tag"
+$InstallDir = if ($env:AGENTPLANE_INSTALL_DIR) { $env:AGENTPLANE_INSTALL_DIR } else { Join-Path $HOME ".agentplane\\standalone\\$Version" }
 
 function Require-Command($Name) {
   if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
@@ -217,20 +246,32 @@ function Require-Command($Name) {
   }
 }
 
-Require-Command "node"
-Require-Command "npm"
-
 $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("agentplane-install-" + [System.Guid]::NewGuid().ToString("N"))
 New-Item -ItemType Directory -Path $TempDir | Out-Null
 try {
-  $Tarball = Join-Path $TempDir "agentplane-$Version.tgz"
-  Invoke-WebRequest -Uri $TarballUrl -OutFile $Tarball
-  $Actual = (Get-FileHash -Algorithm SHA256 -Path $Tarball).Hash.ToLowerInvariant()
-  if ($Actual -ne $TarballSha256) {
-    throw "agentplane install: checksum mismatch for $TarballUrl; expected $TarballSha256, actual $Actual"
+  $Asset = "agentplane-v$Version-win32-x64.zip"
+  $Archive = Join-Path $TempDir $Asset
+  $Checksums = Join-Path $TempDir "SHA256SUMS"
+  Invoke-WebRequest -Uri "$BaseUrl/SHA256SUMS" -OutFile $Checksums
+  Invoke-WebRequest -Uri "$BaseUrl/$Asset" -OutFile $Archive
+  $Expected = (Get-Content $Checksums | ForEach-Object {
+    $Parts = ($_ -split "\\s+")
+    if ($Parts.Count -ge 2 -and $Parts[1] -eq $Asset) { $Parts[0] }
+  } | Select-Object -First 1)
+  if (-not $Expected) {
+    throw "agentplane install: checksum entry missing for $Asset"
   }
-  npm install -g $Tarball
-  agentplane --version
+  $Actual = (Get-FileHash -Algorithm SHA256 -Path $Archive).Hash.ToLowerInvariant()
+  if ($Actual -ne $Expected.ToLowerInvariant()) {
+    throw "agentplane install: checksum mismatch for $Asset; expected $Expected, actual $Actual"
+  }
+  if (Test-Path $InstallDir) {
+    Remove-Item -Recurse -Force $InstallDir
+  }
+  New-Item -ItemType Directory -Path $InstallDir | Out-Null
+  Expand-Archive -Path $Archive -DestinationPath $InstallDir -Force
+  & (Join-Path $InstallDir "bin\\agentplane.cmd") --version
+  Write-Output (Join-Path $InstallDir "bin")
 }
 finally {
   Remove-Item -Recurse -Force $TempDir -ErrorAction SilentlyContinue
@@ -327,8 +368,8 @@ async function buildDistribution(repoRoot, args) {
   const upgradeBundle = await createUpgradeBundle(repoRoot, outDir);
   const installerAssets = await writeInstallers(outDir, {
     version,
-    tarballUrl: cliTarballUrl,
-    tarballSha256: cliTarball.sha256,
+    repo: args.repo,
+    tag,
   });
   const standaloneManifest = generateStandaloneAssets(repoRoot, outDir, {
     version,

--- a/scripts/generate-release-distribution.mjs
+++ b/scripts/generate-release-distribution.mjs
@@ -255,7 +255,7 @@ try {
   Invoke-WebRequest -Uri "$BaseUrl/SHA256SUMS" -OutFile $Checksums
   Invoke-WebRequest -Uri "$BaseUrl/$Asset" -OutFile $Archive
   $Expected = (Get-Content $Checksums | ForEach-Object {
-    $Parts = ($_ -split "\\s+")
+    $Parts = ($_ -split '\\s+')
     if ($Parts.Count -ge 2 -and $Parts[1] -eq $Asset) { $Parts[0] }
   } | Select-Object -First 1)
   if (-not $Expected) {

--- a/scripts/generate-standalone-cli-assets.mjs
+++ b/scripts/generate-standalone-cli-assets.mjs
@@ -338,11 +338,23 @@ function createArchive(rootDir, outPath, target) {
 
 async function installProductionDependencies(repoRoot, packageRoot, skipInstall) {
   if (skipInstall) return "skipped_check_mode";
-  run("npm", ["install", "--omit=dev", "--ignore-scripts", "--no-audit", "--no-fund"], {
+  const env = {
+    ...process.env,
+    NPM_CONFIG_CACHE: path.join(repoRoot, ".agentplane", ".npm-cache"),
+  };
+  run(
+    "npm",
+    ["install", "--package-lock-only", "--omit=dev", "--ignore-scripts", "--no-audit", "--no-fund"],
+    {
+      cwd: packageRoot,
+      env,
+    },
+  );
+  run("npm", ["ci", "--omit=dev", "--ignore-scripts", "--no-audit", "--no-fund"], {
     cwd: packageRoot,
-    env: { ...process.env, NPM_CONFIG_CACHE: path.join(repoRoot, ".agentplane", ".npm-cache") },
+    env,
   });
-  return "installed_npm_omit_dev_local_workspace_tarballs";
+  return "installed_npm_ci_local_workspace_tarballs";
 }
 
 function publicStandaloneAsset(asset) {

--- a/scripts/generate-standalone-cli-assets.mjs
+++ b/scripts/generate-standalone-cli-assets.mjs
@@ -12,6 +12,8 @@ const DEFAULT_REPO = "basilisk-labs/agentplane";
 const DEFAULT_OUT_DIR = ".agentplane/.release/publish/standalone";
 const DEFAULT_NODE_VERSION = "v24.15.0";
 const CLI_PACKAGE_DIR = "packages/agentplane";
+const CORE_PACKAGE_DIR = "packages/core";
+const RECIPES_PACKAGE_DIR = "packages/recipes";
 const NODE_DIST_BASE_URL = "https://nodejs.org/download/release";
 const TARGETS = [
   { platform: "darwin", arch: "arm64", node: "darwin-arm64", archive: "tar.gz" },
@@ -216,17 +218,17 @@ async function materializeOfficialNode({ target, nodeVersion, cacheDir, nodeRoot
   }
 }
 
-function packCliPackage(repoRoot, outDir) {
+function packWorkspacePackage(repoRoot, packageDir, outDir) {
   const cacheDir = path.join(repoRoot, ".agentplane", ".npm-cache");
   const stdout = run("npm", ["pack", "--json", "--ignore-scripts", "--pack-destination", outDir], {
-    cwd: path.join(repoRoot, CLI_PACKAGE_DIR),
+    cwd: path.join(repoRoot, packageDir),
     env: { ...process.env, NPM_CONFIG_CACHE: cacheDir },
   });
   const jsonMatch = /(^|\n)(\[\s*\{[\s\S]*\]\s*)$/u.exec(stdout);
-  if (!jsonMatch) throw new Error("npm pack did not emit JSON for the agentplane package");
+  if (!jsonMatch) throw new Error(`npm pack did not emit JSON for ${packageDir}`);
   const [entry] = JSON.parse(jsonMatch[2]);
   const filename = String(entry?.filename ?? "");
-  if (!filename) throw new Error("npm pack did not report a filename for agentplane");
+  if (!filename) throw new Error(`npm pack did not report a filename for ${packageDir}`);
   return path.join(outDir, filename);
 }
 
@@ -238,6 +240,30 @@ async function extractCliPackage(tarballPath, packageRoot) {
   } finally {
     rmSync(extractDir, { recursive: true, force: true });
   }
+}
+
+async function sanitizeStandalonePackageJson(packageRoot, localPackages) {
+  const packageJsonPath = path.join(packageRoot, "package.json");
+  const packageJson = await readJson(packageJsonPath);
+  delete packageJson.devDependencies;
+  delete packageJson.scripts;
+  packageJson.dependencies = {
+    ...(packageJson.dependencies ?? {}),
+    "@agentplaneorg/core": `file:${localPackages.coreTarball}`,
+    "@agentplaneorg/recipes": `file:${localPackages.recipesTarball}`,
+  };
+  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
+}
+
+async function restoreStandalonePackageJson(packageRoot, version) {
+  const packageJsonPath = path.join(packageRoot, "package.json");
+  const packageJson = await readJson(packageJsonPath);
+  packageJson.dependencies = {
+    ...(packageJson.dependencies ?? {}),
+    "@agentplaneorg/core": version,
+    "@agentplaneorg/recipes": version,
+  };
+  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
 }
 
 async function writeWrapper(target, rootDir) {
@@ -312,15 +338,11 @@ function createArchive(rootDir, outPath, target) {
 
 async function installProductionDependencies(repoRoot, packageRoot, skipInstall) {
   if (skipInstall) return "skipped_check_mode";
-  const lockPath = path.join(repoRoot, "bun.lock");
-  if (!existsSync(lockPath)) {
-    throw new Error("Standalone dependency installation requires repository bun.lock");
-  }
-  await writeFile(path.join(packageRoot, "bun.lock"), await readFile(lockPath));
-  run("bun", ["install", "--production", "--frozen-lockfile", "--ignore-scripts"], {
+  run("npm", ["install", "--omit=dev", "--ignore-scripts", "--no-audit", "--no-fund"], {
     cwd: packageRoot,
+    env: { ...process.env, NPM_CONFIG_CACHE: path.join(repoRoot, ".agentplane", ".npm-cache") },
   });
-  return "installed_bun_frozen_lockfile";
+  return "installed_npm_omit_dev_local_workspace_tarballs";
 }
 
 function publicStandaloneAsset(asset) {
@@ -342,6 +364,8 @@ async function buildTarget({
   target,
   syntheticNode,
   skipInstall,
+  coreTarball,
+  recipesTarball,
 }) {
   const rootDir = path.join(workRoot, `${target.platform}-${target.arch}`);
   const packageRoot = path.join(rootDir, "lib", "agentplane", "package");
@@ -350,7 +374,9 @@ async function buildTarget({
   await mkdir(nodeRoot, { recursive: true });
 
   await extractCliPackage(cliTarball, packageRoot);
+  await sanitizeStandalonePackageJson(packageRoot, { coreTarball, recipesTarball });
   const dependencyStatus = await installProductionDependencies(repoRoot, packageRoot, skipInstall);
+  await restoreStandalonePackageJson(packageRoot, version);
   await (syntheticNode
     ? materializeSyntheticNode(target, nodeRoot)
     : materializeOfficialNode({
@@ -435,7 +461,9 @@ async function buildStandaloneAssets(repoRoot, args) {
     const targets = selectTargets(args.targets);
     const packDir = path.join(workRoot, ".npm-pack");
     await mkdir(packDir, { recursive: true });
-    const cliTarball = packCliPackage(repoRoot, packDir);
+    const cliTarball = packWorkspacePackage(repoRoot, CLI_PACKAGE_DIR, packDir);
+    const coreTarball = packWorkspacePackage(repoRoot, CORE_PACKAGE_DIR, packDir);
+    const recipesTarball = packWorkspacePackage(repoRoot, RECIPES_PACKAGE_DIR, packDir);
     const assets = [];
     for (const target of targets) {
       assets.push(
@@ -452,6 +480,8 @@ async function buildStandaloneAssets(repoRoot, args) {
           target,
           syntheticNode: args.check || args.syntheticNode,
           skipInstall: args.check || args.skipInstall,
+          coreTarball,
+          recipesTarball,
         }),
       );
     }

--- a/scripts/render-ghcr-image-metadata.mjs
+++ b/scripts/render-ghcr-image-metadata.mjs
@@ -64,11 +64,15 @@ function sha256File(filePath) {
 }
 
 function runDistributionGenerator(repoRoot, outDir) {
-  execFileSync("node", ["scripts/generate-release-distribution.mjs", "--out", outDir], {
-    cwd: repoRoot,
-    stdio: "ignore",
-    env: process.env,
-  });
+  execFileSync(
+    "node",
+    ["scripts/generate-release-distribution.mjs", "--out", outDir, "--standalone-check-mode"],
+    {
+      cwd: repoRoot,
+      stdio: "ignore",
+      env: process.env,
+    },
+  );
   return path.join(outDir, "release-distribution.json");
 }
 
@@ -90,6 +94,15 @@ function packCliPackage(repoRoot, outDir) {
   const filename = String(entry?.filename ?? "");
   if (!filename) throw new Error("npm pack did not report a filename for agentplane");
   return path.join(outDir, filename);
+}
+
+function findDistributionTarball(manifestPath, version) {
+  const tarballPath = path.join(
+    path.dirname(manifestPath),
+    ".npm-pack",
+    `agentplane-${version}.tgz`,
+  );
+  return existsSync(tarballPath) ? tarballPath : null;
 }
 
 function buildImageMetadata(manifest) {
@@ -123,7 +136,8 @@ async function renderGhcr(repoRoot, args) {
   const channel = manifest.channels?.ghcr ?? {};
   const status = args.status || channel.status || "unknown";
   await mkdir(outDir, { recursive: true });
-  const packedTarballPath = packCliPackage(repoRoot, outDir);
+  const packedTarballPath =
+    findDistributionTarball(manifestPath, metadata.version) ?? packCliPackage(repoRoot, outDir);
   const packedTarballSha256 = sha256File(packedTarballPath);
   if (packedTarballSha256 !== metadata.tarballSha256) {
     throw new Error(


### PR DESCRIPTION
Task: `202605021914-N72MF3`
Title: Modularize release publish jobs

## Summary

Modularize release publish jobs

Split the release publish workflow into independently recoverable jobs for distribution assets, npm, GitHub Release, GHCR, and credentials-gated external repositories.

## Scope

- In scope: Split the release publish workflow into independently recoverable jobs for distribution assets, npm, GitHub Release, GHCR, and credentials-gated external repositories.
- Out of scope: unrelated refactors not required for "Modularize release publish jobs".

## Verification

- State: ok
- Note: Verified: modular release pipeline checks passed: workflow lint, format, release:prepublish:fast, distribution/standalone/Homebrew/Scoop/setup-action/GHCR checks, targeted release contract tests, policy routing, docs scripts, and agentplane doctor.
- Full verification checklist lives in local review.md.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-02T19:37:06.619Z
- Branch: task/202605021914-N72MF3/release-pipeline-modules
- Head: 42ac5f1c4588

```text
 .agentplane/tasks/202605021914-ADH1EE/README.md    | 118 +++++++++++++
 .agentplane/tasks/202605021914-AMCDG4/README.md    | 118 +++++++++++++
 .agentplane/tasks/202605021914-Z2P2TS/README.md    | 118 +++++++++++++
 .github/workflows/publish-distribution-module.yml  | 196 +++++++++++++++++++++
 .github/workflows/publish.yml                      |   5 +-
 docs/developer/release-and-publishing.mdx          |  39 ++--
 .../generate-release-distribution-script.test.ts   |  12 ++
 .../generate-standalone-cli-assets-script.test.ts  |  49 +++++-
 .../release/publish-workflow-contract.test.ts      |  31 ++++
 scripts/generate-release-distribution.mjs          |  99 ++++++++---
 scripts/generate-standalone-cli-assets.mjs         |  54 ++++--
 scripts/render-ghcr-image-metadata.mjs             |  26 ++-
 12 files changed, 805 insertions(+), 60 deletions(-)
```

</details>
