### PR TITLE
✅ release: close dependent release pipeline tasks

### DIFF
--- a/.agentplane/tasks/202605021914-ADH1EE/README.md
+++ b/.agentplane/tasks/202605021914-ADH1EE/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202605021914-ADH1EE"
 title: "Add release module recovery workflow"
-status: "DOING"
+result_summary: "Release module recovery workflow merged via PR #766."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -23,11 +24,16 @@ verification:
   updated_at: "2026-05-02T19:36:11.293Z"
   updated_by: "CODER"
   note: "Verified: publish-distribution-module.yml accepts exact tag/SHA/module inputs and excludes npm publish; workflow lint and contract tests passed."
-commit: null
+commit:
+  hash: "93db085a628f25e32e4bbb669c8d0132f5f61c5a"
+  message: "✅ N72MF3 close: Merged via PR #766. (202605021914-N72MF3) [ci,distribution,release] (#767)"
 comments:
   -
     author: "CODER"
     body: "Start: Implement exact-SHA distribution module recovery workflow as part of the approved modular release pipeline worktree; do not republish npm in this path."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: release module recovery workflow merged via PR #766 and post-merge checks passed."
 events:
   -
     type: "status"
@@ -42,9 +48,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified: publish-distribution-module.yml accepts exact tag/SHA/module inputs and excludes npm publish; workflow lint and contract tests passed."
+  -
+    type: "status"
+    at: "2026-05-02T20:03:23.946Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: release module recovery workflow merged via PR #766 and post-merge checks passed."
 doc_version: 3
-doc_updated_at: "2026-05-02T19:36:11.300Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-02T20:03:23.947Z"
+doc_updated_by: "INTEGRATOR"
 description: "Add a dispatchable recovery path that can rerun selected distribution modules for an exact release tag and SHA without republishing npm."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605021914-AMCDG4/README.md
+++ b/.agentplane/tasks/202605021914-AMCDG4/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202605021914-AMCDG4"
 title: "Document modular release recovery"
-status: "DOING"
+result_summary: "Modular release recovery documentation merged via PR #766."
+status: "DONE"
 priority: "med"
 owner: "DOCS"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -23,11 +24,16 @@ verification:
   updated_at: "2026-05-02T19:36:12.112Z"
   updated_by: "DOCS"
   note: "Verified: release publishing docs describe Publish release, standalone installers, distribution module recovery commands, and focused module retries."
-commit: null
+commit:
+  hash: "93db085a628f25e32e4bbb669c8d0132f5f61c5a"
+  message: "✅ N72MF3 close: Merged via PR #766. (202605021914-N72MF3) [ci,distribution,release] (#767)"
 comments:
   -
     author: "DOCS"
     body: "Start: Document the modular release recovery workflow and evidence model after automation changes are in place."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: modular release recovery documentation merged via PR #766 and post-merge checks passed."
 events:
   -
     type: "status"
@@ -42,9 +48,16 @@ events:
     author: "DOCS"
     state: "ok"
     note: "Verified: release publishing docs describe Publish release, standalone installers, distribution module recovery commands, and focused module retries."
+  -
+    type: "status"
+    at: "2026-05-02T20:03:41.924Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: modular release recovery documentation merged via PR #766 and post-merge checks passed."
 doc_version: 3
-doc_updated_at: "2026-05-02T19:36:12.118Z"
-doc_updated_by: "DOCS"
+doc_updated_at: "2026-05-02T20:03:41.926Z"
+doc_updated_by: "INTEGRATOR"
 description: "Update release documentation and checks so the modular publish flow, external PR handoffs, and recovery commands are clear and evidence-backed."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605021914-Z2P2TS/README.md
+++ b/.agentplane/tasks/202605021914-Z2P2TS/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202605021914-Z2P2TS"
 title: "Add standalone installer distribution path"
-status: "DOING"
+result_summary: "Standalone installer distribution path merged via PR #766."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -23,11 +24,16 @@ verification:
   updated_at: "2026-05-02T19:36:10.313Z"
   updated_by: "CODER"
   note: "Verified: install.sh and install.ps1 now consume standalone release archives with SHA256SUMS verification and no node/npm requirement; standalone production install test passes with local workspace tarballs."
-commit: null
+commit:
+  hash: "93db085a628f25e32e4bbb669c8d0132f5f61c5a"
+  message: "✅ N72MF3 close: Merged via PR #766. (202605021914-N72MF3) [ci,distribution,release] (#767)"
 comments:
   -
     author: "CODER"
     body: "Start: Implement standalone installer distribution path as part of the approved modular release pipeline worktree; stop if installer scope expands beyond release assets."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: standalone installer distribution path merged via PR #766 and post-merge checks passed."
 events:
   -
     type: "status"
@@ -42,9 +48,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified: install.sh and install.ps1 now consume standalone release archives with SHA256SUMS verification and no node/npm requirement; standalone production install test passes with local workspace tarballs."
+  -
+    type: "status"
+    at: "2026-05-02T20:02:52.566Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: standalone installer distribution path merged via PR #766 and post-merge checks passed."
 doc_version: 3
-doc_updated_at: "2026-05-02T19:36:10.321Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-02T20:02:52.568Z"
+doc_updated_by: "INTEGRATOR"
 description: "Make install.sh and install.ps1 consume standalone bundled-runtime release assets instead of requiring user-provided node/npm."
 sections:
   Summary: |-


### PR DESCRIPTION
## Summary
- Close the three dependent release pipeline task READMEs that were implemented and verified in PR #766.
- Keep the hosted-close N72MF3 result intact and add task-local close evidence for Z2P2TS, ADH1EE, and AMCDG4.

## Verification
- git diff --check origin/main..HEAD
- agentplane task list | rg '202605021914-(Z2P2TS|ADH1EE|AMCDG4|N72MF3)'

## Notes
- Code and workflow changes already merged in PR #766.
- This PR is task-state-only closure metadata.