### PR TITLE
🧹 release: trim release task README whitespace

### DIFF
--- a/.agentplane/tasks/202605021914-ADH1EE/README.md
+++ b/.agentplane/tasks/202605021914-ADH1EE/README.md
@@ -62,7 +62,7 @@ description: "Add a dispatchable recovery path that can rerun selected distribut
 sections:
   Summary: |-
     Add release module recovery workflow
-    
+
     Add a dispatchable recovery path that can rerun selected distribution modules for an exact release tag and SHA without republishing npm.
   Scope: |-
     - In scope: Add a dispatchable recovery path that can rerun selected distribution modules for an exact release tag and SHA without republishing npm.
@@ -75,13 +75,13 @@ sections:
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
     ### 2026-05-02T19:36:11.293Z — VERIFY — ok
-    
+
     By: CODER
-    
+
     Note: Verified: publish-distribution-module.yml accepts exact tag/SHA/module inputs and excludes npm publish; workflow lint and contract tests passed.
-    
+
     VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-02T19:34:41.317Z, excerpt_hash=sha256:f2651ccc32b4b154044e08db43b0464efa701e68e1e7eb83e1fb4f5c66da6dae
-    
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).

--- a/.agentplane/tasks/202605021914-AMCDG4/README.md
+++ b/.agentplane/tasks/202605021914-AMCDG4/README.md
@@ -62,7 +62,7 @@ description: "Update release documentation and checks so the modular publish flo
 sections:
   Summary: |-
     Document modular release recovery
-    
+
     Update release documentation and checks so the modular publish flow, external PR handoffs, and recovery commands are clear and evidence-backed.
   Scope: |-
     - In scope: Update release documentation and checks so the modular publish flow, external PR handoffs, and recovery commands are clear and evidence-backed.
@@ -75,13 +75,13 @@ sections:
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
     ### 2026-05-02T19:36:12.112Z — VERIFY — ok
-    
+
     By: DOCS
-    
+
     Note: Verified: release publishing docs describe Publish release, standalone installers, distribution module recovery commands, and focused module retries.
-    
+
     VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-02T19:34:41.640Z, excerpt_hash=sha256:fca48445cee84c0e22951d987a470ec9ffb38cd19e62f7eae71d16893486e217
-    
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).

--- a/.agentplane/tasks/202605021914-N72MF3/README.md
+++ b/.agentplane/tasks/202605021914-N72MF3/README.md
@@ -62,7 +62,7 @@ description: "Split the release publish workflow into independently recoverable 
 sections:
   Summary: |-
     Modularize release publish jobs
-    
+
     Split the release publish workflow into independently recoverable jobs for distribution assets, npm, GitHub Release, GHCR, and credentials-gated external repositories.
   Scope: |-
     - In scope: Split the release publish workflow into independently recoverable jobs for distribution assets, npm, GitHub Release, GHCR, and credentials-gated external repositories.
@@ -75,13 +75,13 @@ sections:
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
     ### 2026-05-02T19:36:08.443Z — VERIFY — ok
-    
+
     By: CODER
-    
+
     Note: Verified: modular release pipeline checks passed: workflow lint, format, release:prepublish:fast, distribution/standalone/Homebrew/Scoop/setup-action/GHCR checks, targeted release contract tests, policy routing, docs scripts, and agentplane doctor.
-    
+
     VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-02T19:15:45.460Z, excerpt_hash=sha256:76c33aefe091b330e7fa0c28625b0abbc6b863a69b99616e49cf0ba286d243be
-    
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).

--- a/.agentplane/tasks/202605021914-Z2P2TS/README.md
+++ b/.agentplane/tasks/202605021914-Z2P2TS/README.md
@@ -62,7 +62,7 @@ description: "Make install.sh and install.ps1 consume standalone bundled-runtime
 sections:
   Summary: |-
     Add standalone installer distribution path
-    
+
     Make install.sh and install.ps1 consume standalone bundled-runtime release assets instead of requiring user-provided node/npm.
   Scope: |-
     - In scope: Make install.sh and install.ps1 consume standalone bundled-runtime release assets instead of requiring user-provided node/npm.
@@ -75,13 +75,13 @@ sections:
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
     ### 2026-05-02T19:36:10.313Z — VERIFY — ok
-    
+
     By: CODER
-    
+
     Note: Verified: install.sh and install.ps1 now consume standalone release archives with SHA256SUMS verification and no node/npm requirement; standalone production install test passes with local workspace tarballs.
-    
+
     VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-02T19:34:41.028Z, excerpt_hash=sha256:25fdb3b0d57c1c948df8c8d927f4b1492778b0e7e22aa7a3a27b776a967fbac3
-    
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).


### PR DESCRIPTION
## Summary
- Trim trailing whitespace in release task README metadata created during closeout.

## Verification
- git diff --check origin/main..HEAD

## Notes
- Task-state-only cleanup; no release code changes.