### PR TITLE
task: Fix repo-local handoff dependency detection [202605022114-F0DGQ6]

### DIFF
--- a/.agentplane/tasks/202605022114-F0DGQ6/README.md
+++ b/.agentplane/tasks/202605022114-F0DGQ6/README.md
@@ -1,0 +1,118 @@
+---
+id: "202605022114-F0DGQ6"
+title: "Fix repo-local handoff dependency detection"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "cli"
+  - "code"
+  - "release"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-02T21:14:58.598Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-02T21:25:48.137Z"
+  updated_by: "CODER"
+  note: "Verified: repo-local handoff dependency detection now accepts workspace-local @agentplaneorg/core resolution and rejects missing package-local installs when resolution escapes the framework checkout. Evidence: bun test packages/agentplane/src/cli/repo-local-handoff.test.ts passed 7/7; combined affected suite passed 14/14; prettier check passed; git diff --check passed; agentplane doctor passed."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Apply the repo-local handoff dependency detection fix from a fresh worktree and verify the wrapper behavior before the next patch release."
+events:
+  -
+    type: "status"
+    at: "2026-05-02T21:15:28.101Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Apply the repo-local handoff dependency detection fix from a fresh worktree and verify the wrapper behavior before the next patch release."
+  -
+    type: "verify"
+    at: "2026-05-02T21:25:48.137Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: repo-local handoff dependency detection now accepts workspace-local @agentplaneorg/core resolution and rejects missing package-local installs when resolution escapes the framework checkout. Evidence: bun test packages/agentplane/src/cli/repo-local-handoff.test.ts passed 7/7; combined affected suite passed 14/14; prettier check passed; git diff --check passed; agentplane doctor passed."
+doc_version: 3
+doc_updated_at: "2026-05-02T21:25:48.158Z"
+doc_updated_by: "CODER"
+description: "Avoid false missing-dependency reports when the repo-local wrapper resolves @agentplaneorg/core through workspace conditional exports instead of package-local node_modules."
+sections:
+  Summary: |-
+    Fix repo-local handoff dependency detection
+
+    Avoid false missing-dependency reports when the repo-local wrapper resolves @agentplaneorg/core through workspace conditional exports instead of package-local node_modules.
+  Scope: |-
+    - In scope: Avoid false missing-dependency reports when the repo-local wrapper resolves @agentplaneorg/core through workspace conditional exports instead of package-local node_modules.
+    - Out of scope: unrelated refactors not required for "Fix repo-local handoff dependency detection".
+  Plan: "1. Reproduce the stale worktree patch on a fresh branch_pr worktree from current main. 2. Update repo-local dependency readiness so workspace-resolved @agentplaneorg/core inside the framework checkout counts as available, while external/global resolution still requires package-local node_modules. 3. Keep the repo-local handoff test compatible with dist and source conditional-export resolution. 4. Run the task Verify Steps plus targeted repo-local handoff test and diff hygiene checks. 5. Open, merge, finish, and clean the obsolete v0.4.2 worktree/branch."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-02T21:25:48.137Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified: repo-local handoff dependency detection now accepts workspace-local @agentplaneorg/core resolution and rejects missing package-local installs when resolution escapes the framework checkout. Evidence: bun test packages/agentplane/src/cli/repo-local-handoff.test.ts passed 7/7; combined affected suite passed 14/14; prettier check passed; git diff --check passed; agentplane doctor passed.
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-02T21:15:28.101Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Fix repo-local handoff dependency detection
+
+Avoid false missing-dependency reports when the repo-local wrapper resolves @agentplaneorg/core through workspace conditional exports instead of package-local node_modules.
+
+## Scope
+
+- In scope: Avoid false missing-dependency reports when the repo-local wrapper resolves @agentplaneorg/core through workspace conditional exports instead of package-local node_modules.
+- Out of scope: unrelated refactors not required for "Fix repo-local handoff dependency detection".
+
+## Plan
+
+1. Reproduce the stale worktree patch on a fresh branch_pr worktree from current main. 2. Update repo-local dependency readiness so workspace-resolved @agentplaneorg/core inside the framework checkout counts as available, while external/global resolution still requires package-local node_modules. 3. Keep the repo-local handoff test compatible with dist and source conditional-export resolution. 4. Run the task Verify Steps plus targeted repo-local handoff test and diff hygiene checks. 5. Open, merge, finish, and clean the obsolete v0.4.2 worktree/branch.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-02T21:25:48.137Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: repo-local handoff dependency detection now accepts workspace-local @agentplaneorg/core resolution and rejects missing package-local installs when resolution escapes the framework checkout. Evidence: bun test packages/agentplane/src/cli/repo-local-handoff.test.ts passed 7/7; combined affected suite passed 14/14; prettier check passed; git diff --check passed; agentplane doctor passed.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-02T21:15:28.101Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605022114-F0DGQ6/pr/diffstat.txt
+++ b/.agentplane/tasks/202605022114-F0DGQ6/pr/diffstat.txt
@@ -1,0 +1,7 @@
+ .agentplane/tasks/202605022118-M0GKG8/README.md    | 118 +++++++++++++++++++++
+ packages/agentplane/bin/agentplane.js              |   7 +-
+ .../agentplane/src/cli/repo-local-handoff.test.ts  |   9 +-
+ .../generate-release-distribution-script.test.ts   |   4 +-
+ scripts/generate-release-distribution.mjs          |   9 +-
+ scripts/generate-standalone-cli-assets.mjs         |   4 +-
+ 6 files changed, 139 insertions(+), 12 deletions(-)

--- a/.agentplane/tasks/202605022114-F0DGQ6/pr/github-body.md
+++ b/.agentplane/tasks/202605022114-F0DGQ6/pr/github-body.md
@@ -20,7 +20,7 @@ Avoid false missing-dependency reports when the repo-local wrapper resolves @age
 
 ## Handoff Notes
 
-- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+- 2026-05-02T21:26:55Z CODER: Related task included: 202605022118-M0GKG8 fixes current release lint drift discovered during patch-release readiness checks. Verification: lint:core passed, generate-release-distribution-script.test.ts passed 2/2, combined affected suite passed 14/14.
 
 <details>
 <summary>Raw evidence</summary>

--- a/.agentplane/tasks/202605022114-F0DGQ6/pr/github-body.md
+++ b/.agentplane/tasks/202605022114-F0DGQ6/pr/github-body.md
@@ -1,0 +1,42 @@
+Task: `202605022114-F0DGQ6`
+Title: Fix repo-local handoff dependency detection
+
+## Summary
+
+Fix repo-local handoff dependency detection
+
+Avoid false missing-dependency reports when the repo-local wrapper resolves @agentplaneorg/core through workspace conditional exports instead of package-local node_modules.
+
+## Scope
+
+- In scope: Avoid false missing-dependency reports when the repo-local wrapper resolves @agentplaneorg/core through workspace conditional exports instead of package-local node_modules.
+- Out of scope: unrelated refactors not required for "Fix repo-local handoff dependency detection".
+
+## Verification
+
+- State: ok
+- Note: Verified: repo-local handoff dependency detection now accepts workspace-local @agentplaneorg/core resolution and rejects missing package-local installs when resolution escapes the framework checkout. Evidence: bun test packages/agentplane/src/cli/repo-local-handoff.test.ts passed 7/7; combined affected suite passed 14/14; prettier check passed; git diff --check passed; agentplane doctor passed.
+- Full verification checklist lives in local review.md.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-02T21:26:26.141Z
+- Branch: task/202605022114-F0DGQ6/repo-local-handoff-deps
+- Head: e0736895b5e9
+
+```text
+ .agentplane/tasks/202605022118-M0GKG8/README.md    | 118 +++++++++++++++++++++
+ packages/agentplane/bin/agentplane.js              |   7 +-
+ .../agentplane/src/cli/repo-local-handoff.test.ts  |   9 +-
+ .../generate-release-distribution-script.test.ts   |   4 +-
+ scripts/generate-release-distribution.mjs          |   9 +-
+ scripts/generate-standalone-cli-assets.mjs         |   4 +-
+ 6 files changed, 139 insertions(+), 12 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605022114-F0DGQ6/pr/github-title.txt
+++ b/.agentplane/tasks/202605022114-F0DGQ6/pr/github-title.txt
@@ -1,0 +1,1 @@
+task: Fix repo-local handoff dependency detection [202605022114-F0DGQ6]

--- a/.agentplane/tasks/202605022114-F0DGQ6/pr/meta.json
+++ b/.agentplane/tasks/202605022114-F0DGQ6/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605022114-F0DGQ6/repo-local-handoff-deps",
+  "created_at": "2026-05-02T21:15:28.144Z",
+  "head_sha": "e0736895b5e9fe9c2794957ef972def94cd600fa",
+  "last_verified_at": "2026-05-02T21:25:48.137Z",
+  "last_verified_sha": "04699e5c12c179ef255724a52286cf3cb5ac8c0f",
+  "schema_version": 1,
+  "task_id": "202605022114-F0DGQ6",
+  "updated_at": "2026-05-02T21:26:26.141Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605022114-F0DGQ6/pr/notes.jsonl
+++ b/.agentplane/tasks/202605022114-F0DGQ6/pr/notes.jsonl
@@ -1,0 +1,1 @@
+{"schema_version":1,"created_at":"2026-05-02T21:26:55.411Z","author":"CODER","body":"Related task included: 202605022118-M0GKG8 fixes current release lint drift discovered during patch-release readiness checks. Verification: lint:core passed, generate-release-distribution-script.test.ts passed 2/2, combined affected suite passed 14/14."}

--- a/.agentplane/tasks/202605022114-F0DGQ6/pr/review.md
+++ b/.agentplane/tasks/202605022114-F0DGQ6/pr/review.md
@@ -39,7 +39,7 @@ Avoid false missing-dependency reports when the repo-local wrapper resolves @age
 
 ## Handoff Notes
 
-- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+- 2026-05-02T21:26:55Z CODER: Related task included: 202605022118-M0GKG8 fixes current release lint drift discovered during patch-release readiness checks. Verification: lint:core passed, generate-release-distribution-script.test.ts passed 2/2, combined affected suite passed 14/14.
 
 <!-- BEGIN AUTO SUMMARY -->
 <details>

--- a/.agentplane/tasks/202605022114-F0DGQ6/pr/review.md
+++ b/.agentplane/tasks/202605022114-F0DGQ6/pr/review.md
@@ -1,0 +1,63 @@
+# PR Review
+
+Created: 2026-05-02T21:15:28.144Z
+Branch: task/202605022114-F0DGQ6/repo-local-handoff-deps
+
+## Summary
+
+Fix repo-local handoff dependency detection
+
+Avoid false missing-dependency reports when the repo-local wrapper resolves @agentplaneorg/core through workspace conditional exports instead of package-local node_modules.
+
+## Scope
+
+- In scope: Avoid false missing-dependency reports when the repo-local wrapper resolves @agentplaneorg/core through workspace conditional exports instead of package-local node_modules.
+- Out of scope: unrelated refactors not required for "Fix repo-local handoff dependency detection".
+
+## Verification
+
+### Plan
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+### Current Status
+
+- State: ok
+- Note: Verified: repo-local handoff dependency detection now accepts workspace-local @agentplaneorg/core resolution and rejects missing package-local installs when resolution escapes the framework checkout. Evidence: bun test packages/agentplane/src/cli/repo-local-handoff.test.ts passed 7/7; combined affected suite passed 14/14; prettier check passed; git diff --check passed; agentplane doctor passed.
+
+## Risks
+
+- Risk level: not recorded
+- Breaking change: no
+
+### Rollback
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-02T21:26:26.141Z
+- Branch: task/202605022114-F0DGQ6/repo-local-handoff-deps
+- Head: e0736895b5e9
+
+```text
+ .agentplane/tasks/202605022118-M0GKG8/README.md    | 118 +++++++++++++++++++++
+ packages/agentplane/bin/agentplane.js              |   7 +-
+ .../agentplane/src/cli/repo-local-handoff.test.ts  |   9 +-
+ .../generate-release-distribution-script.test.ts   |   4 +-
+ scripts/generate-release-distribution.mjs          |   9 +-
+ scripts/generate-standalone-cli-assets.mjs         |   4 +-
+ 6 files changed, 139 insertions(+), 12 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605022118-M0GKG8/README.md
+++ b/.agentplane/tasks/202605022118-M0GKG8/README.md
@@ -1,0 +1,118 @@
+---
+id: "202605022118-M0GKG8"
+title: "Fix release lint drift before patch release"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "lint"
+  - "release"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-02T21:18:15.521Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-02T21:25:58.359Z"
+  updated_by: "CODER"
+  note: "Verified: current release lint drift is fixed without behavior changes. Evidence: bun run lint:core passed after String.raw and dependency-spread cleanup; bun test packages/agentplane/src/commands/release/generate-release-distribution-script.test.ts passed 2/2; combined affected suite passed 14/14; prettier check passed; git diff --check passed."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Fix the release-distribution lint drift found during patch-release readiness checks and include it in the current release-readiness PR."
+events:
+  -
+    type: "status"
+    at: "2026-05-02T21:18:59.916Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Fix the release-distribution lint drift found during patch-release readiness checks and include it in the current release-readiness PR."
+  -
+    type: "verify"
+    at: "2026-05-02T21:25:58.359Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: current release lint drift is fixed without behavior changes. Evidence: bun run lint:core passed after String.raw and dependency-spread cleanup; bun test packages/agentplane/src/commands/release/generate-release-distribution-script.test.ts passed 2/2; combined affected suite passed 14/14; prettier check passed; git diff --check passed."
+doc_version: 3
+doc_updated_at: "2026-05-02T21:25:58.368Z"
+doc_updated_by: "CODER"
+description: "Repair current release-distribution and standalone asset lint errors so release-readiness checks can run cleanly before the next patch release."
+sections:
+  Summary: |-
+    Fix release lint drift before patch release
+
+    Repair current release-distribution and standalone asset lint errors so release-readiness checks can run cleanly before the next patch release.
+  Scope: |-
+    - In scope: Repair current release-distribution and standalone asset lint errors so release-readiness checks can run cleanly before the next patch release.
+    - Out of scope: unrelated refactors not required for "Fix release lint drift before patch release".
+  Plan: "1. Fix the current release lint errors reported by bun run lint:core without changing release behavior. 2. Use String.raw for PowerShell checksum regex snippets. 3. Remove useless empty-object fallbacks in standalone package dependency spreads. 4. Rerun lint, targeted release distribution tests if needed, and diff hygiene. 5. Include this task as a related release-readiness batch in the F0DGQ6 PR."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-02T21:25:58.359Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified: current release lint drift is fixed without behavior changes. Evidence: bun run lint:core passed after String.raw and dependency-spread cleanup; bun test packages/agentplane/src/commands/release/generate-release-distribution-script.test.ts passed 2/2; combined affected suite passed 14/14; prettier check passed; git diff --check passed.
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-02T21:18:59.916Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Fix release lint drift before patch release
+
+Repair current release-distribution and standalone asset lint errors so release-readiness checks can run cleanly before the next patch release.
+
+## Scope
+
+- In scope: Repair current release-distribution and standalone asset lint errors so release-readiness checks can run cleanly before the next patch release.
+- Out of scope: unrelated refactors not required for "Fix release lint drift before patch release".
+
+## Plan
+
+1. Fix the current release lint errors reported by bun run lint:core without changing release behavior. 2. Use String.raw for PowerShell checksum regex snippets. 3. Remove useless empty-object fallbacks in standalone package dependency spreads. 4. Rerun lint, targeted release distribution tests if needed, and diff hygiene. 5. Include this task as a related release-readiness batch in the F0DGQ6 PR.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-02T21:25:58.359Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: current release lint drift is fixed without behavior changes. Evidence: bun run lint:core passed after String.raw and dependency-spread cleanup; bun test packages/agentplane/src/commands/release/generate-release-distribution-script.test.ts passed 2/2; combined affected suite passed 14/14; prettier check passed; git diff --check passed.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-02T21:18:59.916Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/packages/agentplane/bin/agentplane.js
+++ b/packages/agentplane/bin/agentplane.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { stat } from "node:fs/promises";
 import { createRequire } from "node:module";
@@ -187,6 +188,7 @@ function renderStalePolicyWarning(reason) {
 
 function missingRepoRuntimeDependencies(agentplaneRoot) {
   const requireFromAgentplane = createRequire(path.join(agentplaneRoot, "package.json"));
+  const frameworkRoot = path.resolve(agentplaneRoot, "..", "..");
   let packageJson = null;
   try {
     packageJson = requireFromAgentplane("./package.json");
@@ -206,8 +208,9 @@ function missingRepoRuntimeDependencies(agentplaneRoot) {
   const requiredSpecifiers = ["@agentplaneorg/core"];
   return requiredSpecifiers.filter((specifier) => {
     try {
-      requireFromAgentplane.resolve(specifier);
-      return false;
+      const resolved = requireFromAgentplane.resolve(specifier);
+      if (isPathInside(frameworkRoot, resolved)) return false;
+      return !existsSync(path.join(agentplaneRoot, "node_modules", ...specifier.split("/")));
     } catch {
       return true;
     }

--- a/packages/agentplane/src/cli/repo-local-handoff.test.ts
+++ b/packages/agentplane/src/cli/repo-local-handoff.test.ts
@@ -238,9 +238,12 @@ describe("repo-local handoff wrapper", () => {
     const requireFromAgentplane = createRequire(
       path.join(workspaceRoot, "packages", "agentplane", "package.json"),
     );
-    expect(requireFromAgentplane.resolve("@agentplaneorg/core")).toBe(
-      path.join(workspaceRoot, "packages", "core", "dist", "index.js"),
-    );
+    const resolvedCore = requireFromAgentplane.resolve("@agentplaneorg/core");
+    const relativeCore = path.relative(path.join(workspaceRoot, "packages", "core"), resolvedCore);
+    expect(
+      relativeCore === path.join("dist", "index.js") ||
+        relativeCore === path.join("src", "index.ts"),
+    ).toBe(true);
   });
 
   it("delegates to the repo-local binary from a nested framework cwd", async () => {

--- a/packages/agentplane/src/commands/release/generate-release-distribution-script.test.ts
+++ b/packages/agentplane/src/commands/release/generate-release-distribution-script.test.ts
@@ -97,8 +97,8 @@ describe("generate-release-distribution script", () => {
     expect(installSh).not.toContain("need node");
     expect(installPs1).toContain("SHA256SUMS");
     expect(installPs1).toContain('"agentplane-v$Version-win32-x64.zip"');
-    expect(installPs1).toContain("-split '\\s+'");
-    expect(installPs1).toContain('"bin\\agentplane.cmd"');
+    expect(installPs1).toContain(String.raw`-split '\s+'`);
+    expect(installPs1).toContain(String.raw`"bin\agentplane.cmd"`);
     expect(installPs1).not.toContain("npm install");
     expect(installPs1).not.toContain('Require-Command "node"');
   }, 90_000);

--- a/scripts/generate-release-distribution.mjs
+++ b/scripts/generate-release-distribution.mjs
@@ -232,13 +232,16 @@ printf '%s\\n' "$INSTALL_DIR/bin"
 }
 
 function renderInstallPs1({ version, repo, tag }) {
+  const defaultInstallDir = String.raw`".agentplane\standalone\$Version"`;
+  const checksumSplitPattern = String.raw`'\s+'`;
+  const agentplaneCmd = String.raw`"bin\agentplane.cmd"`;
   return `$ErrorActionPreference = "Stop"
 
 $Version = "${version}"
 $Repo = "${repo}"
 $Tag = "${tag}"
 $BaseUrl = "https://github.com/$Repo/releases/download/$Tag"
-$InstallDir = if ($env:AGENTPLANE_INSTALL_DIR) { $env:AGENTPLANE_INSTALL_DIR } else { Join-Path $HOME ".agentplane\\standalone\\$Version" }
+$InstallDir = if ($env:AGENTPLANE_INSTALL_DIR) { $env:AGENTPLANE_INSTALL_DIR } else { Join-Path $HOME ${defaultInstallDir} }
 
 function Require-Command($Name) {
   if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
@@ -255,7 +258,7 @@ try {
   Invoke-WebRequest -Uri "$BaseUrl/SHA256SUMS" -OutFile $Checksums
   Invoke-WebRequest -Uri "$BaseUrl/$Asset" -OutFile $Archive
   $Expected = (Get-Content $Checksums | ForEach-Object {
-    $Parts = ($_ -split '\\s+')
+    $Parts = ($_ -split ${checksumSplitPattern})
     if ($Parts.Count -ge 2 -and $Parts[1] -eq $Asset) { $Parts[0] }
   } | Select-Object -First 1)
   if (-not $Expected) {
@@ -270,7 +273,7 @@ try {
   }
   New-Item -ItemType Directory -Path $InstallDir | Out-Null
   Expand-Archive -Path $Archive -DestinationPath $InstallDir -Force
-  & (Join-Path $InstallDir "bin\\agentplane.cmd") --version
+  & (Join-Path $InstallDir ${agentplaneCmd}) --version
   Write-Output (Join-Path $InstallDir "bin")
 }
 finally {

--- a/scripts/generate-standalone-cli-assets.mjs
+++ b/scripts/generate-standalone-cli-assets.mjs
@@ -248,7 +248,7 @@ async function sanitizeStandalonePackageJson(packageRoot, localPackages) {
   delete packageJson.devDependencies;
   delete packageJson.scripts;
   packageJson.dependencies = {
-    ...(packageJson.dependencies ?? {}),
+    ...packageJson.dependencies,
     "@agentplaneorg/core": `file:${localPackages.coreTarball}`,
     "@agentplaneorg/recipes": `file:${localPackages.recipesTarball}`,
   };
@@ -259,7 +259,7 @@ async function restoreStandalonePackageJson(packageRoot, version) {
   const packageJsonPath = path.join(packageRoot, "package.json");
   const packageJson = await readJson(packageJsonPath);
   packageJson.dependencies = {
-    ...(packageJson.dependencies ?? {}),
+    ...packageJson.dependencies,
     "@agentplaneorg/core": version,
     "@agentplaneorg/recipes": version,
   };


### PR DESCRIPTION
Task: `202605022114-F0DGQ6`
Title: Fix repo-local handoff dependency detection

## Summary

Fix repo-local handoff dependency detection

Avoid false missing-dependency reports when the repo-local wrapper resolves @agentplaneorg/core through workspace conditional exports instead of package-local node_modules.

## Scope

- In scope: Avoid false missing-dependency reports when the repo-local wrapper resolves @agentplaneorg/core through workspace conditional exports instead of package-local node_modules.
- Out of scope: unrelated refactors not required for "Fix repo-local handoff dependency detection".

## Verification

- State: ok
- Note: Verified: repo-local handoff dependency detection now accepts workspace-local @agentplaneorg/core resolution and rejects missing package-local installs when resolution escapes the framework checkout. Evidence: bun test packages/agentplane/src/cli/repo-local-handoff.test.ts passed 7/7; combined affected suite passed 14/14; prettier check passed; git diff --check passed; agentplane doctor passed.
- Full verification checklist lives in local review.md.

## Handoff Notes

- 2026-05-02T21:26:55Z CODER: Related task included: 202605022118-M0GKG8 fixes current release lint drift discovered during patch-release readiness checks. Verification: lint:core passed, generate-release-distribution-script.test.ts passed 2/2, combined affected suite passed 14/14.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-02T21:26:26.141Z
- Branch: task/202605022114-F0DGQ6/repo-local-handoff-deps
- Head: e0736895b5e9

```text
 .agentplane/tasks/202605022118-M0GKG8/README.md    | 118 +++++++++++++++++++++
 packages/agentplane/bin/agentplane.js              |   7 +-
 .../agentplane/src/cli/repo-local-handoff.test.ts  |   9 +-
 .../generate-release-distribution-script.test.ts   |   4 +-
 scripts/generate-release-distribution.mjs          |   9 +-
 scripts/generate-standalone-cli-assets.mjs         |   4 +-
 6 files changed, 139 insertions(+), 12 deletions(-)
```

</details>
