### PR TITLE
🧪 HTD2WC task: speed up standalone check assets

### DIFF
--- a/.agentplane/tasks/202605022156-9SXTNH/README.md
+++ b/.agentplane/tasks/202605022156-9SXTNH/README.md
@@ -1,0 +1,118 @@
+---
+id: "202605022156-9SXTNH"
+title: "Fix standalone release scripts under Node 24"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "release"
+  - "testing"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-02T21:56:58.534Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-02T21:57:02.130Z"
+  updated_by: "CODER"
+  note: "Targeted release standalone checks passed: bunx vitest run packages/agentplane/src/commands/release/generate-release-distribution-script.test.ts packages/agentplane/src/commands/release/render-scoop-and-setup-standalone-script.test.ts (4 tests passed)."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Fix Node 24 standalone release pre-push blocker by reducing synthetic check-mode archive generation cost only."
+events:
+  -
+    type: "status"
+    at: "2026-05-02T21:57:00.201Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Fix Node 24 standalone release pre-push blocker by reducing synthetic check-mode archive generation cost only."
+  -
+    type: "verify"
+    at: "2026-05-02T21:57:02.130Z"
+    author: "CODER"
+    state: "ok"
+    note: "Targeted release standalone checks passed: bunx vitest run packages/agentplane/src/commands/release/generate-release-distribution-script.test.ts packages/agentplane/src/commands/release/render-scoop-and-setup-standalone-script.test.ts (4 tests passed)."
+doc_version: 3
+doc_updated_at: "2026-05-02T21:57:02.135Z"
+doc_updated_by: "CODER"
+description: "Repair the standalone release distribution check path that blocks pre-push under Node 24."
+sections:
+  Summary: |-
+    Fix standalone release scripts under Node 24
+    
+    Repair the standalone release distribution check path that blocks pre-push under Node 24.
+  Scope: |-
+    - In scope: Repair the standalone release distribution check path that blocks pre-push under Node 24.
+    - Out of scope: unrelated refactors not required for "Fix standalone release scripts under Node 24".
+  Plan: "1. Keep production standalone asset generation unchanged. 2. Speed up synthetic/check-mode standalone generation by materializing a minimal synthetic agentplane package when synthetic Node and skip-install are active. 3. Verify the release distribution and setup-agentplane renderer tests."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-02T21:57:02.130Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Targeted release standalone checks passed: bunx vitest run packages/agentplane/src/commands/release/generate-release-distribution-script.test.ts packages/agentplane/src/commands/release/render-scoop-and-setup-standalone-script.test.ts (4 tests passed).
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-02T21:57:00.201Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Fix standalone release scripts under Node 24
+
+Repair the standalone release distribution check path that blocks pre-push under Node 24.
+
+## Scope
+
+- In scope: Repair the standalone release distribution check path that blocks pre-push under Node 24.
+- Out of scope: unrelated refactors not required for "Fix standalone release scripts under Node 24".
+
+## Plan
+
+1. Keep production standalone asset generation unchanged. 2. Speed up synthetic/check-mode standalone generation by materializing a minimal synthetic agentplane package when synthetic Node and skip-install are active. 3. Verify the release distribution and setup-agentplane renderer tests.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-02T21:57:02.130Z — VERIFY — ok
+
+By: CODER
+
+Note: Targeted release standalone checks passed: bunx vitest run packages/agentplane/src/commands/release/generate-release-distribution-script.test.ts packages/agentplane/src/commands/release/render-scoop-and-setup-standalone-script.test.ts (4 tests passed).
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-02T21:57:00.201Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/scripts/generate-standalone-cli-assets.mjs
+++ b/scripts/generate-standalone-cli-assets.mjs
@@ -266,6 +266,34 @@ async function restoreStandalonePackageJson(packageRoot, version) {
   await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
 }
 
+async function materializeSyntheticAgentplanePackage(packageRoot, version) {
+  const binDir = path.join(packageRoot, "bin");
+  await mkdir(binDir, { recursive: true });
+  await writeFile(
+    path.join(packageRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "agentplane",
+        version,
+        type: "module",
+        bin: {
+          agentplane: "bin/agentplane.js",
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+  const binPath = path.join(binDir, "agentplane.js");
+  await writeFile(
+    binPath,
+    "#!/usr/bin/env node\nconsole.log(process.argv.includes('--version') ? process.env.AGENTPLANE_SYNTHETIC_VERSION || '0.0.0' : 'synthetic-agentplane')\n",
+    "utf8",
+  );
+  chmodSync(binPath, 0o755);
+}
+
 async function writeWrapper(target, rootDir) {
   const binDir = path.join(rootDir, "bin");
   await mkdir(binDir, { recursive: true });
@@ -385,10 +413,15 @@ async function buildTarget({
   await mkdir(packageRoot, { recursive: true });
   await mkdir(nodeRoot, { recursive: true });
 
-  await extractCliPackage(cliTarball, packageRoot);
-  await sanitizeStandalonePackageJson(packageRoot, { coreTarball, recipesTarball });
-  const dependencyStatus = await installProductionDependencies(repoRoot, packageRoot, skipInstall);
-  await restoreStandalonePackageJson(packageRoot, version);
+  let dependencyStatus = "skipped_check_mode";
+  if (syntheticNode && skipInstall) {
+    await materializeSyntheticAgentplanePackage(packageRoot, version);
+  } else {
+    await extractCliPackage(cliTarball, packageRoot);
+    await sanitizeStandalonePackageJson(packageRoot, { coreTarball, recipesTarball });
+    dependencyStatus = await installProductionDependencies(repoRoot, packageRoot, skipInstall);
+    await restoreStandalonePackageJson(packageRoot, version);
+  }
   await (syntheticNode
     ? materializeSyntheticNode(target, nodeRoot)
     : materializeOfficialNode({


### PR DESCRIPTION
## Summary
- Speed up standalone release check-mode by materializing a minimal synthetic agentplane package when synthetic Node and skip-install are active.
- Keep production standalone archive generation unchanged.
- Preserve release distribution contract coverage for platform assets, checksums, wrappers, and manifests.

## Verification
- Targeted: bunx vitest run packages/agentplane/src/commands/release/generate-release-distribution-script.test.ts packages/agentplane/src/commands/release/render-scoop-and-setup-standalone-script.test.ts
- Pre-push full-fast: 261 unit test files passed, 1484 tests passed, 2 skipped; critical E2E 5 files passed, 14 tests passed.