### PR TITLE
🚧 BHD4S4 task: Enforce English PR artifacts language [202605030733-BHD4S4]

### DIFF
--- a/.agentplane/config.json
+++ b/.agentplane/config.json
@@ -26,6 +26,7 @@
       "expected_version": "0.4.2"
     }
   },
+  "artifacts_language": "en",
   "tasks": {
     "id_suffix_length_default": 6,
     "verify": {

--- a/.agentplane/tasks/202605030733-BHD4S4/README.md
+++ b/.agentplane/tasks/202605030733-BHD4S4/README.md
@@ -4,7 +4,7 @@ title: "Enforce English PR artifacts language"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 4
+revision: 5
 origin:
   system: "manual"
 depends_on: []
@@ -19,10 +19,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-03T07:37:40.720Z"
+  updated_by: "CODER"
+  note: "Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts packages/core/src/config/config.test.ts --pool=forks --maxWorkers 1 --testTimeout 60000 --hookTimeout 60000; Result: pass; Evidence: 2 files, 22 tests passed. Command: node scripts/check-policy-routing.mjs && node scripts/check-recipes-inventory-fresh.mjs && git diff --check; Result: pass; Evidence: policy routing OK, recipes inventory up to date, no whitespace errors. Command: remote recipes raw fetch; Result: pass; Evidence: raw_recipes=1:code-map."
 commit: null
 comments:
   -
@@ -36,8 +36,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: porting the English PR artifact language validation from the stale cli-artifacts branch onto current main with current release state preserved."
+  -
+    type: "verify"
+    at: "2026-05-03T07:37:40.720Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts packages/core/src/config/config.test.ts --pool=forks --maxWorkers 1 --testTimeout 60000 --hookTimeout 60000; Result: pass; Evidence: 2 files, 22 tests passed. Command: node scripts/check-policy-routing.mjs && node scripts/check-recipes-inventory-fresh.mjs && git diff --check; Result: pass; Evidence: policy routing OK, recipes inventory up to date, no whitespace errors. Command: remote recipes raw fetch; Result: pass; Evidence: raw_recipes=1:code-map."
 doc_version: 3
-doc_updated_at: "2026-05-03T07:33:40.003Z"
+doc_updated_at: "2026-05-03T07:37:40.723Z"
 doc_updated_by: "CODER"
 description: "Port the artifacts_language configuration and PR artifact language validation from the stale cli-artifacts branch onto current main, preserving current v0.4.2 release state."
 sections:
@@ -55,11 +61,24 @@ sections:
     3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-03T07:37:40.720Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts packages/core/src/config/config.test.ts --pool=forks --maxWorkers 1 --testTimeout 60000 --hookTimeout 60000; Result: pass; Evidence: 2 files, 22 tests passed. Command: node scripts/check-policy-routing.mjs && node scripts/check-recipes-inventory-fresh.mjs && git diff --check; Result: pass; Evidence: policy routing OK, recipes inventory up to date, no whitespace errors. Command: remote recipes raw fetch; Result: pass; Evidence: raw_recipes=1:code-map.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-03T07:33:40.003Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
     - Re-run required checks to confirm rollback safety.
-  Findings: ""
+  Findings: |-
+    - Observation: Ported artifacts_language=en and PR artifact language validation onto current main; stale trust branch was not merged because it would reintroduce old task states.
+      Impact: PR artifacts for this repo now fail on Cyrillic text when artifacts_language is en; default schema remains any for other repos.
+      Resolution: No rework required before PR.
+      Promotion: incident-candidate
+      Fixability: external
 id_source: "generated"
 ---
 ## Summary
@@ -86,6 +105,14 @@ Plan: port only the useful artifacts_language=en configuration and PR artifact l
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-03T07:37:40.720Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts packages/core/src/config/config.test.ts --pool=forks --maxWorkers 1 --testTimeout 60000 --hookTimeout 60000; Result: pass; Evidence: 2 files, 22 tests passed. Command: node scripts/check-policy-routing.mjs && node scripts/check-recipes-inventory-fresh.mjs && git diff --check; Result: pass; Evidence: policy routing OK, recipes inventory up to date, no whitespace errors. Command: remote recipes raw fetch; Result: pass; Evidence: raw_recipes=1:code-map.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-03T07:33:40.003Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -94,3 +121,9 @@ Plan: port only the useful artifacts_language=en configuration and PR artifact l
 - Re-run required checks to confirm rollback safety.
 
 ## Findings
+
+- Observation: Ported artifacts_language=en and PR artifact language validation onto current main; stale trust branch was not merged because it would reintroduce old task states.
+  Impact: PR artifacts for this repo now fail on Cyrillic text when artifacts_language is en; default schema remains any for other repos.
+  Resolution: No rework required before PR.
+  Promotion: incident-candidate
+  Fixability: external

--- a/.agentplane/tasks/202605030733-BHD4S4/README.md
+++ b/.agentplane/tasks/202605030733-BHD4S4/README.md
@@ -1,0 +1,96 @@
+---
+id: "202605030733-BHD4S4"
+title: "Enforce English PR artifacts language"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "release"
+  - "workflow"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-03T07:33:30.552Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: porting the English PR artifact language validation from the stale cli-artifacts branch onto current main with current release state preserved."
+events:
+  -
+    type: "status"
+    at: "2026-05-03T07:33:40.003Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: porting the English PR artifact language validation from the stale cli-artifacts branch onto current main with current release state preserved."
+doc_version: 3
+doc_updated_at: "2026-05-03T07:33:40.003Z"
+doc_updated_by: "CODER"
+description: "Port the artifacts_language configuration and PR artifact language validation from the stale cli-artifacts branch onto current main, preserving current v0.4.2 release state."
+sections:
+  Summary: |-
+    Enforce English PR artifacts language
+    
+    Port the artifacts_language configuration and PR artifact language validation from the stale cli-artifacts branch onto current main, preserving current v0.4.2 release state.
+  Scope: |-
+    - In scope: Port the artifacts_language configuration and PR artifact language validation from the stale cli-artifacts branch onto current main, preserving current v0.4.2 release state.
+    - Out of scope: unrelated refactors not required for "Enforce English PR artifacts language".
+  Plan: "Plan: port only the useful artifacts_language=en configuration and PR artifact language validation from codex/cli-artifacts-language-validation onto current main; exclude stale release-format-only noise unless still required by conflicts; verify with targeted PR artifact tests, config schema checks, policy routing, recipes inventory, release candidate gate, hosted PR checks, and homepage/raw recipes spot check; merge via branch_pr; cleanup stale trust-recipes and cli-artifacts branches after merge."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Enforce English PR artifacts language
+
+Port the artifacts_language configuration and PR artifact language validation from the stale cli-artifacts branch onto current main, preserving current v0.4.2 release state.
+
+## Scope
+
+- In scope: Port the artifacts_language configuration and PR artifact language validation from the stale cli-artifacts branch onto current main, preserving current v0.4.2 release state.
+- Out of scope: unrelated refactors not required for "Enforce English PR artifacts language".
+
+## Plan
+
+Plan: port only the useful artifacts_language=en configuration and PR artifact language validation from codex/cli-artifacts-language-validation onto current main; exclude stale release-format-only noise unless still required by conflicts; verify with targeted PR artifact tests, config schema checks, policy routing, recipes inventory, release candidate gate, hosted PR checks, and homepage/raw recipes spot check; merge via branch_pr; cleanup stale trust-recipes and cli-artifacts branches after merge.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605030733-BHD4S4/pr/diffstat.txt
+++ b/.agentplane/tasks/202605030733-BHD4S4/pr/diffstat.txt
@@ -1,0 +1,18 @@
+ .agentplane/config.json                            |   1 +
+ docs/recipes-inventory.json                        |  76 +++++++++---
+ packages/agentplane/src/commands/pr/check.ts       |   2 +
+ .../src/commands/pr/integrate/artifacts.ts         |  75 +++++++++++-
+ .../src/commands/pr/integrate/internal/prepare.ts  |   3 +
+ .../pr/internal/pr-artifact-snapshot.test.ts       | 134 +++++++++++++++++++++
+ .../commands/pr/internal/pr-artifact-snapshot.ts   |  18 +++
+ .../src/commands/pr/internal/review-template.ts    |  29 +++++
+ .../src/commands/pr/internal/sync-model.ts         |   2 +
+ .../src/commands/pr/internal/sync-open-step.ts     |  25 ++++
+ .../src/commands/pr/internal/sync-update-step.ts   |  23 ++++
+ .../agentplane/src/commands/pr/internal/sync.ts    |   4 +
+ packages/core/schemas/config.schema.json           |   5 +
+ packages/core/src/config/config.test.ts            |   7 ++
+ packages/core/src/config/schema.impl.ts            |   3 +
+ packages/spec/examples/config.json                 |   1 +
+ packages/spec/schemas/config.schema.json           |   5 +
+ 17 files changed, 395 insertions(+), 18 deletions(-)

--- a/.agentplane/tasks/202605030733-BHD4S4/pr/github-body.md
+++ b/.agentplane/tasks/202605030733-BHD4S4/pr/github-body.md
@@ -1,0 +1,36 @@
+Task: `202605030733-BHD4S4`
+Title: Enforce English PR artifacts language
+
+## Summary
+
+Enforce English PR artifacts language
+
+Port the artifacts_language configuration and PR artifact language validation from the stale cli-artifacts branch onto current main, preserving current v0.4.2 release state.
+
+## Scope
+
+- In scope: Port the artifacts_language configuration and PR artifact language validation from the stale cli-artifacts branch onto current main, preserving current v0.4.2 release state.
+- Out of scope: unrelated refactors not required for "Enforce English PR artifacts language".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Full verification checklist lives in local review.md.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-03T07:33:40.046Z
+- Branch: task/202605030733-BHD4S4/artifacts-language-validation
+- Head: 988c7d2426d0
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605030733-BHD4S4/pr/github-body.md
+++ b/.agentplane/tasks/202605030733-BHD4S4/pr/github-body.md
@@ -14,8 +14,8 @@ Port the artifacts_language configuration and PR artifact language validation fr
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts packages/core/src/config/config.test.ts --pool=forks --maxWorkers 1 --testTimeout 60000 --hookTimeout 60000; Result: pass; Evidence: 2 files, 22 tests passed. Command: node scripts/check-policy-routing.mjs && node scripts/check-recipes-inventory-fresh.mjs && git diff --check; Result: pass; Evidence: policy routing OK, recipes inventory up to date, no whitespace errors. Command: remote recipes raw fetch; Result: pass; Evidence: raw_recipes=1:code-map.
 - Full verification checklist lives in local review.md.
 
 ## Handoff Notes
@@ -25,12 +25,29 @@ Port the artifacts_language configuration and PR artifact language validation fr
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-03T07:33:40.046Z
+- Updated: 2026-05-03T07:37:40.747Z
 - Branch: task/202605030733-BHD4S4/artifacts-language-validation
-- Head: 988c7d2426d0
+- Head: 17d0d8d2e220
 
 ```text
-No changes detected.
+ .agentplane/config.json                            |   1 +
+ docs/recipes-inventory.json                        |  76 +++++++++---
+ packages/agentplane/src/commands/pr/check.ts       |   2 +
+ .../src/commands/pr/integrate/artifacts.ts         |  75 +++++++++++-
+ .../src/commands/pr/integrate/internal/prepare.ts  |   3 +
+ .../pr/internal/pr-artifact-snapshot.test.ts       | 134 +++++++++++++++++++++
+ .../commands/pr/internal/pr-artifact-snapshot.ts   |  18 +++
+ .../src/commands/pr/internal/review-template.ts    |  29 +++++
+ .../src/commands/pr/internal/sync-model.ts         |   2 +
+ .../src/commands/pr/internal/sync-open-step.ts     |  25 ++++
+ .../src/commands/pr/internal/sync-update-step.ts   |  23 ++++
+ .../agentplane/src/commands/pr/internal/sync.ts    |   4 +
+ packages/core/schemas/config.schema.json           |   5 +
+ packages/core/src/config/config.test.ts            |   7 ++
+ packages/core/src/config/schema.impl.ts            |   3 +
+ packages/spec/examples/config.json                 |   1 +
+ packages/spec/schemas/config.schema.json           |   5 +
+ 17 files changed, 395 insertions(+), 18 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605030733-BHD4S4/pr/github-title.txt
+++ b/.agentplane/tasks/202605030733-BHD4S4/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 BHD4S4 task: Enforce English PR artifacts language [202605030733-BHD4S4]

--- a/.agentplane/tasks/202605030733-BHD4S4/pr/meta.json
+++ b/.agentplane/tasks/202605030733-BHD4S4/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605030733-BHD4S4/artifacts-language-validation",
+  "created_at": "2026-05-03T07:33:40.046Z",
+  "head_sha": "988c7d2426d0ef18d53c9aa95a121258eaa9d56f",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202605030733-BHD4S4",
+  "updated_at": "2026-05-03T07:33:40.046Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605030733-BHD4S4/pr/meta.json
+++ b/.agentplane/tasks/202605030733-BHD4S4/pr/meta.json
@@ -2,13 +2,13 @@
   "base": "main",
   "branch": "task/202605030733-BHD4S4/artifacts-language-validation",
   "created_at": "2026-05-03T07:33:40.046Z",
-  "head_sha": "988c7d2426d0ef18d53c9aa95a121258eaa9d56f",
-  "last_verified_at": null,
-  "last_verified_sha": null,
+  "head_sha": "17d0d8d2e2202f5da47e82f556b1cfabdb1f78d3",
+  "last_verified_at": "2026-05-03T07:37:40.720Z",
+  "last_verified_sha": "17d0d8d2e2202f5da47e82f556b1cfabdb1f78d3",
   "schema_version": 1,
   "task_id": "202605030733-BHD4S4",
-  "updated_at": "2026-05-03T07:33:40.046Z",
+  "updated_at": "2026-05-03T07:37:40.747Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605030733-BHD4S4/pr/review.md
+++ b/.agentplane/tasks/202605030733-BHD4S4/pr/review.md
@@ -24,8 +24,8 @@ Port the artifacts_language configuration and PR artifact language validation fr
 
 ### Current Status
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts packages/core/src/config/config.test.ts --pool=forks --maxWorkers 1 --testTimeout 60000 --hookTimeout 60000; Result: pass; Evidence: 2 files, 22 tests passed. Command: node scripts/check-policy-routing.mjs && node scripts/check-recipes-inventory-fresh.mjs && git diff --check; Result: pass; Evidence: policy routing OK, recipes inventory up to date, no whitespace errors. Command: remote recipes raw fetch; Result: pass; Evidence: raw_recipes=1:code-map.
 
 ## Risks
 
@@ -45,12 +45,29 @@ Port the artifacts_language configuration and PR artifact language validation fr
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-03T07:33:40.046Z
+- Updated: 2026-05-03T07:37:40.747Z
 - Branch: task/202605030733-BHD4S4/artifacts-language-validation
-- Head: 988c7d2426d0
+- Head: 17d0d8d2e220
 
 ```text
-No changes detected.
+ .agentplane/config.json                            |   1 +
+ docs/recipes-inventory.json                        |  76 +++++++++---
+ packages/agentplane/src/commands/pr/check.ts       |   2 +
+ .../src/commands/pr/integrate/artifacts.ts         |  75 +++++++++++-
+ .../src/commands/pr/integrate/internal/prepare.ts  |   3 +
+ .../pr/internal/pr-artifact-snapshot.test.ts       | 134 +++++++++++++++++++++
+ .../commands/pr/internal/pr-artifact-snapshot.ts   |  18 +++
+ .../src/commands/pr/internal/review-template.ts    |  29 +++++
+ .../src/commands/pr/internal/sync-model.ts         |   2 +
+ .../src/commands/pr/internal/sync-open-step.ts     |  25 ++++
+ .../src/commands/pr/internal/sync-update-step.ts   |  23 ++++
+ .../agentplane/src/commands/pr/internal/sync.ts    |   4 +
+ packages/core/schemas/config.schema.json           |   5 +
+ packages/core/src/config/config.test.ts            |   7 ++
+ packages/core/src/config/schema.impl.ts            |   3 +
+ packages/spec/examples/config.json                 |   1 +
+ packages/spec/schemas/config.schema.json           |   5 +
+ 17 files changed, 395 insertions(+), 18 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605030733-BHD4S4/pr/review.md
+++ b/.agentplane/tasks/202605030733-BHD4S4/pr/review.md
@@ -1,0 +1,57 @@
+# PR Review
+
+Created: 2026-05-03T07:33:40.046Z
+Branch: task/202605030733-BHD4S4/artifacts-language-validation
+
+## Summary
+
+Enforce English PR artifacts language
+
+Port the artifacts_language configuration and PR artifact language validation from the stale cli-artifacts branch onto current main, preserving current v0.4.2 release state.
+
+## Scope
+
+- In scope: Port the artifacts_language configuration and PR artifact language validation from the stale cli-artifacts branch onto current main, preserving current v0.4.2 release state.
+- Out of scope: unrelated refactors not required for "Enforce English PR artifacts language".
+
+## Verification
+
+### Plan
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+### Current Status
+
+- State: pending
+- Note: Not recorded yet.
+
+## Risks
+
+- Risk level: not recorded
+- Breaking change: no
+
+### Rollback
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-03T07:33:40.046Z
+- Branch: task/202605030733-BHD4S4/artifacts-language-validation
+- Head: 988c7d2426d0
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/docs/recipes-inventory.json
+++ b/docs/recipes-inventory.json
@@ -12,30 +12,72 @@
   },
   "recipes": [
     {
-      "id": "code-map",
-      "name": "Code Map",
-      "version": "0.1.1",
-      "summary": "Adds a lightweight code-map discipline to agent development work.",
-      "source": "agentplane-recipes/recipes/code-map",
+      "id": "dokploy",
+      "name": "Dokploy",
+      "version": "0.1.0",
+      "summary": "Dokploy API automation.",
+      "source": "agentplane-recipes/recipes/dokploy",
       "self_contained": true,
       "scenarios": [
         {
-          "id": "code-map",
-          "summary": "Create or refresh a compact project code map before implementation.",
+          "id": "deploy-application",
+          "summary": "Prepare a run plan for deploying an application through Dokploy.",
           "use_when": [
-            "A coding task spans multiple modules or ownership boundaries.",
-            "A new agent needs a quick map of the project's runtime surfaces.",
-            "A change depends on understanding entry points and verification commands."
+            "Need to deploy an application through Dokploy.",
+            "Need to review deployment permissions before execution."
           ],
-          "required_inputs": ["target_paths"],
-          "outputs": ["code_map_path", "mapped_surfaces", "verification_commands"],
-          "agents_involved": ["code-map-operator"],
-          "skills_used": ["code-map-discipline"],
-          "tools_used": [],
+          "required_inputs": ["application_id"],
+          "outputs": ["deployment_status"],
+          "agents_involved": ["dokploy-operator"],
+          "skills_used": ["dokploy-analysis"],
+          "tools_used": ["dokploy"],
+          "run_profile": {
+            "mode": "apply",
+            "sandbox": "workspace-write"
+          }
+        },
+        {
+          "id": "list-projects",
+          "summary": "Prepare a run plan for listing Dokploy projects.",
+          "use_when": [
+            "Need to validate Dokploy connectivity.",
+            "Need to inspect available projects before a deployment."
+          ],
+          "required_inputs": [],
+          "outputs": ["projects"],
+          "agents_involved": ["dokploy-operator"],
+          "skills_used": ["dokploy-analysis"],
+          "tools_used": ["dokploy"],
           "run_profile": {
             "mode": "analysis",
-            "sandbox": "workspace-write",
-            "writes_artifacts_to": ["docs/code-map.md"]
+            "sandbox": "workspace-write"
+          }
+        }
+      ]
+    },
+    {
+      "id": "viewer",
+      "name": "Viewer",
+      "version": "0.1.0",
+      "summary": "Local viewer for task artifacts.",
+      "source": "agentplane-recipes/recipes/viewer",
+      "self_contained": true,
+      "scenarios": [
+        {
+          "id": "viewer",
+          "summary": "Prepare the local task viewer run plan.",
+          "use_when": [
+            "Need to inspect task artifacts in a browser.",
+            "Need a local preview before editing task data."
+          ],
+          "required_inputs": ["port"],
+          "outputs": ["viewer_url"],
+          "agents_involved": ["viewer-operator"],
+          "skills_used": ["viewer-analysis"],
+          "tools_used": ["viewer-server"],
+          "run_profile": {
+            "mode": "analysis",
+            "sandbox": "workspace-write"
           }
         }
       ]

--- a/packages/agentplane/src/commands/pr/check.ts
+++ b/packages/agentplane/src/commands/pr/check.ts
@@ -89,6 +89,7 @@ export async function cmdPrCheck(opts: {
       relGithubTitlePath,
       relGithubBodyPath,
       taskId: task.id,
+      artifactsLanguage: config.artifacts_language,
     });
     const localSnapshot: PrArtifactSnapshot = {
       source: "local",
@@ -148,6 +149,7 @@ export async function cmdPrCheck(opts: {
         relGithubBodyPath,
         taskId: task.id,
         branchForFreshness,
+        artifactsLanguage: config.artifacts_language,
       });
       await evaluateSnapshotFreshness({
         snapshot: branchSnapshot,

--- a/packages/agentplane/src/commands/pr/integrate/artifacts.ts
+++ b/packages/agentplane/src/commands/pr/integrate/artifacts.ts
@@ -2,13 +2,14 @@ import path from "node:path";
 
 import { exitCodeForError } from "../../../cli/exit-codes.js";
 import { CliError } from "../../../shared/errors.js";
+import type { AgentplaneConfig } from "@agentplaneorg/core/config";
 
 import { readPrArtifact, readPrArtifactFromBranch } from "../internal/pr-paths.js";
 import { findWorktreeForBranch } from "@agentplaneorg/core/git";
 
 import type { CommandContext } from "../../shared/task-backend.js";
 
-import { validateReviewContents } from "../internal/review-template.js";
+import { validateArtifactsLanguage, validateReviewContents } from "../internal/review-template.js";
 
 type ReadPrArtifactOpts = {
   resolved: { gitRoot: string };
@@ -24,6 +25,7 @@ export async function readAndValidatePrArtifacts(opts: {
   prDir: string;
   metaPath: string;
   branch: string;
+  artifactsLanguage: AgentplaneConfig["artifacts_language"];
   taskId: string;
 }): Promise<{
   verifyLogText: string | null;
@@ -33,12 +35,16 @@ export async function readAndValidatePrArtifacts(opts: {
   const diffstatPath = path.join(prDir, "diffstat.txt");
   const verifyLogPath = path.join(prDir, "verify.log");
   const reviewPath = path.join(prDir, "review.md");
+  const githubTitlePath = path.join(prDir, "github-title.txt");
+  const githubBodyPath = path.join(prDir, "github-body.md");
   const worktreePath = await findWorktreeForBranch(opts.resolved.gitRoot, opts.branch);
 
   const errors: string[] = [];
   const relDiffstat = path.relative(opts.resolved.gitRoot, diffstatPath);
   const relVerifyLog = path.relative(opts.resolved.gitRoot, verifyLogPath);
   const relReview = path.relative(opts.resolved.gitRoot, reviewPath);
+  const relGithubTitle = path.relative(opts.resolved.gitRoot, githubTitlePath);
+  const relGithubBody = path.relative(opts.resolved.gitRoot, githubBodyPath);
 
   const diffstatText = await readPrArtifactTyped({
     resolved: opts.resolved,
@@ -67,6 +73,38 @@ export async function readAndValidatePrArtifacts(opts: {
   });
   if (reviewText === null) errors.push(`Missing ${relReview}`);
   if (reviewText) validateReviewContents(reviewText, errors);
+  const githubTitleText = await readPrArtifactTyped({
+    resolved: opts.resolved,
+    prDir,
+    fileName: "github-title.txt",
+    branch: opts.branch,
+    worktreePath,
+  });
+  if (githubTitleText === null) {
+    errors.push(`Missing ${relGithubTitle}`);
+  }
+  const githubBodyText = await readPrArtifactTyped({
+    resolved: opts.resolved,
+    prDir,
+    fileName: "github-body.md",
+    branch: opts.branch,
+    worktreePath,
+  });
+  if (githubBodyText === null) {
+    errors.push(`Missing ${relGithubBody}`);
+  }
+  validateArtifactsLanguage({
+    texts: {
+      reviewText,
+      githubTitleText,
+      githubBodyText,
+    },
+    relReviewPath: relReview,
+    relGithubTitlePath: relGithubTitle,
+    relGithubBodyPath: relGithubBody,
+    artifactsLanguage: opts.artifactsLanguage,
+    errors,
+  });
 
   if (errors.length > 0) {
     throw new CliError({
@@ -83,6 +121,7 @@ export async function ensureCommittedPrArtifactsOnBranch(opts: {
   resolved: { gitRoot: string };
   prDir: string;
   branch: string;
+  artifactsLanguage: AgentplaneConfig["artifacts_language"];
 }): Promise<void> {
   const readCommittedPrArtifact = readPrArtifactFromBranch as (
     o: ReadPrArtifactOpts,
@@ -92,12 +131,16 @@ export async function ensureCommittedPrArtifactsOnBranch(opts: {
   const verifyLogPath = path.join(prDir, "verify.log");
   const reviewPath = path.join(prDir, "review.md");
   const metaPath = path.join(prDir, "meta.json");
+  const githubTitlePath = path.join(prDir, "github-title.txt");
+  const githubBodyPath = path.join(prDir, "github-body.md");
 
   const errors: string[] = [];
   const relMeta = path.relative(opts.resolved.gitRoot, metaPath);
   const relDiffstat = path.relative(opts.resolved.gitRoot, diffstatPath);
   const relVerifyLog = path.relative(opts.resolved.gitRoot, verifyLogPath);
   const relReview = path.relative(opts.resolved.gitRoot, reviewPath);
+  const relGithubTitle = path.relative(opts.resolved.gitRoot, githubTitlePath);
+  const relGithubBody = path.relative(opts.resolved.gitRoot, githubBodyPath);
 
   const metaText = await readCommittedPrArtifact({
     resolved: opts.resolved,
@@ -138,6 +181,36 @@ export async function ensureCommittedPrArtifactsOnBranch(opts: {
   } else {
     validateReviewContents(reviewText, errors);
   }
+  const githubTitleText = await readCommittedPrArtifact({
+    resolved: opts.resolved,
+    prDir,
+    fileName: "github-title.txt",
+    branch: opts.branch,
+  });
+  if (githubTitleText === null) {
+    errors.push(`Missing committed ${relGithubTitle} on branch ${opts.branch}`);
+  }
+  const githubBodyText = await readCommittedPrArtifact({
+    resolved: opts.resolved,
+    prDir,
+    fileName: "github-body.md",
+    branch: opts.branch,
+  });
+  if (githubBodyText === null) {
+    errors.push(`Missing committed ${relGithubBody} on branch ${opts.branch}`);
+  }
+  validateArtifactsLanguage({
+    texts: {
+      reviewText,
+      githubTitleText,
+      githubBodyText,
+    },
+    relReviewPath: relReview,
+    relGithubTitlePath: relGithubTitle,
+    relGithubBodyPath: relGithubBody,
+    artifactsLanguage: opts.artifactsLanguage,
+    errors,
+  });
 
   if (errors.length > 0) {
     throw new CliError({

--- a/packages/agentplane/src/commands/pr/integrate/internal/prepare.ts
+++ b/packages/agentplane/src/commands/pr/integrate/internal/prepare.ts
@@ -145,6 +145,7 @@ export async function prepareIntegrate(opts: {
     resolved,
     prDir,
     branch,
+    artifactsLanguage: loadedConfig.artifacts_language,
   });
 
   const worktreePath = await findWorktreeForBranch(resolved.gitRoot, branch);
@@ -175,6 +176,7 @@ export async function prepareIntegrate(opts: {
     prDir,
     metaPath,
     branch,
+    artifactsLanguage: loadedConfig.artifacts_language,
     taskId: opts.taskId,
   });
   // readAndValidatePrArtifacts() throws if verify.log is missing; keep this non-null downstream.
@@ -236,6 +238,7 @@ export async function prepareIntegrate(opts: {
         prDir,
         metaPath,
         branch,
+        artifactsLanguage: loadedConfig.artifacts_language,
         taskId: opts.taskId,
       });
       verifyLogText = repairedArtifacts.verifyLogText ?? verifyLogText;

--- a/packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts
+++ b/packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts
@@ -131,4 +131,29 @@ describe("validateSnapshotContents", () => {
     expect(errors).toContain("Non-English text in .agentplane/tasks/T-1/pr/github-title.txt");
     expect(errors).toContain("Non-English text in .agentplane/tasks/T-1/pr/github-body.md");
   });
+
+  it("fails non-cyrillic non-English artifacts when language is en", () => {
+    const { errors } = validateSnapshotContents({
+      texts: makeTexts({
+        reviewText:
+          "## Summary\n- Este cambio valida artefactos\n## Scope\n- Test\n## Verification\n- State: pending\n## Risks\n- Risk level: low\n## Handoff Notes\n- No notes\n<!-- BEGIN AUTO SUMMARY -->\n<details><summary>Raw evidence</summary></details>\n<!-- END AUTO SUMMARY -->",
+        githubTitleText: "🧩 1 task: Résumé update [T-1]",
+        githubBodyText:
+          "Task: `T-1`\nTitle: Sample\n\n## Summary\n- Ceci est un exemple\n## Scope\n- Test\n## Verification\n- State: pending\n<details><summary>Raw evidence</summary></details>\n## Handoff Notes\n- No notes\n",
+      }),
+      relPrDir,
+      relMetaPath,
+      relDiffstatPath,
+      relVerifyLogPath,
+      relReviewPath,
+      relGithubTitlePath,
+      relGithubBodyPath,
+      taskId: "T-1",
+      artifactsLanguage: "en",
+    });
+
+    expect(errors).toContain("Non-English text in .agentplane/tasks/T-1/pr/review.md");
+    expect(errors).toContain("Non-English text in .agentplane/tasks/T-1/pr/github-title.txt");
+    expect(errors).toContain("Non-English text in .agentplane/tasks/T-1/pr/github-body.md");
+  });
 });

--- a/packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts
+++ b/packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import { validateSnapshotContents } from "./pr-artifact-snapshot.js";
+
+const relPrDir = ".agentplane/tasks/T-1/pr";
+const relMetaPath = ".agentplane/tasks/T-1/pr/meta.json";
+const relDiffstatPath = ".agentplane/tasks/T-1/pr/diffstat.txt";
+const relVerifyLogPath = ".agentplane/tasks/T-1/pr/verify.log";
+const relReviewPath = ".agentplane/tasks/T-1/pr/review.md";
+const relGithubTitlePath = ".agentplane/tasks/T-1/pr/github-title.txt";
+const relGithubBodyPath = ".agentplane/tasks/T-1/pr/github-body.md";
+
+function makeMetaText(): string {
+  const now = "2026-05-01T00:00:00.000Z";
+  const meta = {
+    schema_version: 1,
+    task_id: "T-1",
+    branch: "task/branch",
+    pr_number: null,
+    pr_url: null,
+    created_at: now,
+    updated_at: now,
+    status: null,
+    artifact_state: null,
+    artifact_state_reason: null,
+    artifact_state_updated_at: now,
+    merge_strategy: null,
+    merged_at: null,
+    merge_commit: null,
+    last_verified_sha: null,
+    last_verified_at: null,
+    verify: { status: "skipped" },
+    base: "main",
+    head_sha: "abc123",
+  };
+  return JSON.stringify(meta, null, 2);
+}
+
+function makeTexts(
+  overrides: {
+    reviewText?: string;
+    githubBodyText?: string;
+    githubTitleText?: string;
+  } = {},
+): {
+  metaText: string;
+  diffstatText: string;
+  verifyLogText: string;
+  reviewText: string;
+  githubTitleText: string;
+  githubBodyText: string;
+} {
+  const englishBody = [
+    "Task: `T-1`",
+    "Title: Sample task",
+    "",
+    "## Summary",
+    "- Sample summary.",
+    "## Scope",
+    "- Sample scope.",
+    "## Verification",
+    "- State: pending",
+    "<details><summary>Raw evidence</summary></details>",
+    "## Handoff Notes",
+    "- No notes",
+    "",
+  ].join("\n");
+
+  return {
+    metaText: makeMetaText(),
+    diffstatText: "A..B\n",
+    verifyLogText: "",
+    reviewText:
+      overrides.reviewText ??
+      [
+        "# PR Review",
+        "",
+        "Created: NOW",
+        "Branch: task/T-1",
+        "",
+        "## Summary",
+        "- Sample summary.",
+        "## Scope",
+        "- Sample scope.",
+        "## Verification",
+        "- Not recorded yet.",
+        "## Risks",
+        "- Risk level: low",
+        "## Handoff Notes",
+        "- No notes",
+      ].join("\n"),
+    githubTitleText: overrides.githubTitleText ?? "task: Sample task [T-1]",
+    githubBodyText: overrides.githubBodyText ?? englishBody,
+  };
+}
+
+describe("validateSnapshotContents", () => {
+  it("passes when artifacts language is not enforced", () => {
+    const { meta, errors } = validateSnapshotContents({
+      texts: makeTexts({
+        reviewText:
+          "## Summary\n- Пример без ограничения языка\n## Scope\n- Тест\n## Verification\n- State: pending\n## Risks\n- Risk level: low\n## Handoff Notes\n- No notes",
+      }),
+      relPrDir,
+      relMetaPath,
+      relDiffstatPath,
+      relVerifyLogPath,
+      relReviewPath,
+      relGithubTitlePath,
+      relGithubBodyPath,
+      taskId: "T-1",
+      artifactsLanguage: "any",
+    });
+
+    expect(meta).not.toBeNull();
+    expect(errors).toHaveLength(0);
+  });
+
+  it("fails russian artifacts when language is en", () => {
+    const { errors } = validateSnapshotContents({
+      texts: makeTexts({
+        reviewText:
+          "## Summary\n- Проверка\n## Scope\n- ...\n## Verification\n- ...\n## Risks\n- Risk level: low\n## Handoff Notes\n- ...",
+        githubTitleText: "task: Пример\n",
+        githubBodyText:
+          "Task: `T-1`\nTitle: Пример\n\n## Summary\n- ...\n## Scope\n- ...\n## Verification\n- ...\n<details><summary>Raw evidence</summary></details>\n## Handoff Notes\n- ...\n",
+      }),
+      relMetaPath,
+      relDiffstatPath,
+      relVerifyLogPath,
+      relPrDir,
+      relReviewPath,
+      relGithubTitlePath,
+      relGithubBodyPath,
+      taskId: "T-1",
+      artifactsLanguage: "en",
+    });
+
+    expect(errors).toContain("Non-English text in .agentplane/tasks/T-1/pr/review.md");
+    expect(errors).toContain("Non-English text in .agentplane/tasks/T-1/pr/github-title.txt");
+    expect(errors).toContain("Non-English text in .agentplane/tasks/T-1/pr/github-body.md");
+  });
+});

--- a/packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts
+++ b/packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { buildOpenedPrMeta, type PrMeta } from "../../shared/pr-meta.js";
 import { validateSnapshotContents } from "./pr-artifact-snapshot.js";
 
 const relPrDir = ".agentplane/tasks/T-1/pr";
@@ -12,27 +13,14 @@ const relGithubBodyPath = ".agentplane/tasks/T-1/pr/github-body.md";
 
 function makeMetaText(): string {
   const now = "2026-05-01T00:00:00.000Z";
-  const meta = {
-    schema_version: 1,
-    task_id: "T-1",
+  const meta: PrMeta = buildOpenedPrMeta({
+    taskId: "T-1",
     branch: "task/branch",
-    pr_number: null,
-    pr_url: null,
-    created_at: now,
-    updated_at: now,
-    status: null,
-    artifact_state: null,
-    artifact_state_reason: null,
-    artifact_state_updated_at: now,
-    merge_strategy: null,
-    merged_at: null,
-    merge_commit: null,
-    last_verified_sha: null,
-    last_verified_at: null,
-    verify: { status: "skipped" },
+    at: now,
+    previousMeta: null,
     base: "main",
-    head_sha: "abc123",
-  };
+    headSha: "abc123",
+  });
   return JSON.stringify(meta, null, 2);
 }
 
@@ -88,8 +76,11 @@ function makeTexts(
         "- Risk level: low",
         "## Handoff Notes",
         "- No notes",
+        "<!-- BEGIN AUTO SUMMARY -->",
+        "<details><summary>Raw evidence</summary></details>",
+        "<!-- END AUTO SUMMARY -->",
       ].join("\n"),
-    githubTitleText: overrides.githubTitleText ?? "task: Sample task [T-1]",
+    githubTitleText: overrides.githubTitleText ?? "🧩 1 task: Sample task [T-1]",
     githubBodyText: overrides.githubBodyText ?? englishBody,
   };
 }
@@ -99,7 +90,7 @@ describe("validateSnapshotContents", () => {
     const { meta, errors } = validateSnapshotContents({
       texts: makeTexts({
         reviewText:
-          "## Summary\n- Пример без ограничения языка\n## Scope\n- Тест\n## Verification\n- State: pending\n## Risks\n- Risk level: low\n## Handoff Notes\n- No notes",
+          "## Summary\n- Пример без ограничения языка\n## Scope\n- Тест\n## Verification\n- State: pending\n## Risks\n- Risk level: low\n## Handoff Notes\n- No notes\n<!-- BEGIN AUTO SUMMARY -->\n<details><summary>Raw evidence</summary></details>\n<!-- END AUTO SUMMARY -->",
       }),
       relPrDir,
       relMetaPath,

--- a/packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.ts
+++ b/packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.ts
@@ -10,10 +10,12 @@ import { assessPrArtifactFreshness } from "./freshness.js";
 import { readPrArtifactFromBranch } from "./pr-paths.js";
 import { parsePrMeta, type PrMeta } from "../../shared/pr-meta.js";
 import {
+  validateArtifactsLanguage,
   validateGithubPrBodyContents,
   validateGithubPrTitleContents,
   validateReviewContents,
 } from "./review-template.js";
+import type { AgentplaneConfig } from "@agentplaneorg/core/config";
 import {
   findWorktreeForBranch,
   gitListTaskBranches,
@@ -86,6 +88,7 @@ export function validateSnapshotContents(opts: {
   relGithubTitlePath: string;
   relGithubBodyPath: string;
   taskId: string;
+  artifactsLanguage: AgentplaneConfig["artifacts_language"];
 }): { meta: PrMeta | null; errors: string[] } {
   const errors: string[] = [];
   let meta: PrMeta | null = null;
@@ -117,6 +120,19 @@ export function validateSnapshotContents(opts: {
   } else {
     errors.push(`Missing ${opts.relGithubBodyPath}`);
   }
+
+  validateArtifactsLanguage({
+    texts: {
+      reviewText: opts.texts.reviewText,
+      githubTitleText: opts.texts.githubTitleText,
+      githubBodyText: opts.texts.githubBodyText,
+    },
+    relReviewPath: opts.relReviewPath,
+    relGithubTitlePath: opts.relGithubTitlePath,
+    relGithubBodyPath: opts.relGithubBodyPath,
+    artifactsLanguage: opts.artifactsLanguage,
+    errors,
+  });
   return { meta, errors };
 }
 
@@ -219,6 +235,7 @@ export async function buildBranchSnapshot(opts: {
   relGithubBodyPath: string;
   taskId: string;
   branchForFreshness: string;
+  artifactsLanguage: AgentplaneConfig["artifacts_language"];
 }): Promise<PrArtifactSnapshot> {
   const worktreePath = await findWorktreeForBranch(opts.resolved.gitRoot, opts.branchForFreshness);
   const texts: PrArtifactTexts = {
@@ -275,6 +292,7 @@ export async function buildBranchSnapshot(opts: {
     relGithubTitlePath: opts.relGithubTitlePath,
     relGithubBodyPath: opts.relGithubBodyPath,
     taskId: opts.taskId,
+    artifactsLanguage: opts.artifactsLanguage,
   });
   return {
     source: "branch",

--- a/packages/agentplane/src/commands/pr/internal/review-template.ts
+++ b/packages/agentplane/src/commands/pr/internal/review-template.ts
@@ -12,7 +12,8 @@ const VERIFICATION_SECTION = "## Verification";
 const RISKS_SECTION = "## Risks";
 const HANDOFF_NOTES_MARKER = "## Handoff Notes";
 const TASK_ID_SUFFIX_PATTERN = /\s*\[[^\]]+\]\s*$/u;
-const CYRILLIC_CHARACTERS = /[\u0400-\u04FF]/u;
+const COMMON_NON_ENGLISH_LATIN_MARKERS =
+  /\b(?:avec|dans|des|est|este|esta|las|les|los|para|pero|por|que|sans|sont|una|une)\b/iu;
 
 function sectionText(task: TaskData, name: string, fallback: string): string {
   const value = typeof task.sections?.[name] === "string" ? task.sections[name].trim() : "";
@@ -371,13 +372,20 @@ export function validateArtifactsLanguage(opts: {
 }): void {
   if (opts.artifactsLanguage !== "en") return;
 
-  if (opts.texts.reviewText && CYRILLIC_CHARACTERS.test(opts.texts.reviewText)) {
+  if (opts.texts.reviewText && containsLikelyNonEnglishText(opts.texts.reviewText)) {
     opts.errors.push(`Non-English text in ${opts.relReviewPath}`);
   }
-  if (opts.texts.githubTitleText && CYRILLIC_CHARACTERS.test(opts.texts.githubTitleText)) {
+  if (opts.texts.githubTitleText && containsLikelyNonEnglishText(opts.texts.githubTitleText)) {
     opts.errors.push(`Non-English text in ${opts.relGithubTitlePath}`);
   }
-  if (opts.texts.githubBodyText && CYRILLIC_CHARACTERS.test(opts.texts.githubBodyText)) {
+  if (opts.texts.githubBodyText && containsLikelyNonEnglishText(opts.texts.githubBodyText)) {
     opts.errors.push(`Non-English text in ${opts.relGithubBodyPath}`);
   }
+}
+
+function containsLikelyNonEnglishText(text: string): boolean {
+  for (const char of text) {
+    if (/\p{Letter}/u.test(char) && !/[A-Za-z]/u.test(char)) return true;
+  }
+  return COMMON_NON_ENGLISH_LATIN_MARKERS.test(text);
 }

--- a/packages/agentplane/src/commands/pr/internal/review-template.ts
+++ b/packages/agentplane/src/commands/pr/internal/review-template.ts
@@ -1,4 +1,5 @@
 import type { TaskData } from "../../../backends/task-backend.js";
+import type { AgentplaneConfig } from "@agentplaneorg/core/config";
 import type { PrHandoffNote } from "./note-store.js";
 import { extractTaskSuffix, parseTaskSubjectTemplate } from "@agentplaneorg/core/commit";
 import { normalizeTaskStatus } from "@agentplaneorg/core/tasks";
@@ -11,6 +12,7 @@ const VERIFICATION_SECTION = "## Verification";
 const RISKS_SECTION = "## Risks";
 const HANDOFF_NOTES_MARKER = "## Handoff Notes";
 const TASK_ID_SUFFIX_PATTERN = /\s*\[[^\]]+\]\s*$/u;
+const CYRILLIC_CHARACTERS = /[\u0400-\u04FF]/u;
 
 function sectionText(task: TaskData, name: string, fallback: string): string {
   const value = typeof task.sections?.[name] === "string" ? task.sections[name].trim() : "";
@@ -350,5 +352,32 @@ export function validateGithubPrTitleContents(
   const expectedSuffix = extractTaskSuffix(taskId);
   if (expectedSuffix && parsed.suffix.toLowerCase() !== expectedSuffix.toLowerCase()) {
     errors.push("GitHub PR title suffix does not match task id");
+  }
+}
+
+type PrArtifactTexts = {
+  reviewText: string | null;
+  githubTitleText: string | null;
+  githubBodyText: string | null;
+};
+
+export function validateArtifactsLanguage(opts: {
+  texts: PrArtifactTexts;
+  relReviewPath: string;
+  relGithubTitlePath: string;
+  relGithubBodyPath: string;
+  artifactsLanguage: AgentplaneConfig["artifacts_language"];
+  errors: string[];
+}): void {
+  if (opts.artifactsLanguage !== "en") return;
+
+  if (opts.texts.reviewText && CYRILLIC_CHARACTERS.test(opts.texts.reviewText)) {
+    opts.errors.push(`Non-English text in ${opts.relReviewPath}`);
+  }
+  if (opts.texts.githubTitleText && CYRILLIC_CHARACTERS.test(opts.texts.githubTitleText)) {
+    opts.errors.push(`Non-English text in ${opts.relGithubTitlePath}`);
+  }
+  if (opts.texts.githubBodyText && CYRILLIC_CHARACTERS.test(opts.texts.githubBodyText)) {
+    opts.errors.push(`Non-English text in ${opts.relGithubBodyPath}`);
   }
 }

--- a/packages/agentplane/src/commands/pr/internal/sync-model.ts
+++ b/packages/agentplane/src/commands/pr/internal/sync-model.ts
@@ -1,6 +1,7 @@
 import type { TaskData } from "../../../backends/task-backend.js";
 import type { PrMeta } from "../../shared/pr-meta.js";
 import type { readPrHandoffNotes } from "./note-store.js";
+import type { AgentplaneConfig } from "@agentplaneorg/core/config";
 
 export type PrRemoteMode = "auto" | "sync-only";
 
@@ -25,6 +26,7 @@ export type PrSyncCommonState = {
   reviewPath: string;
   githubTitlePath: string;
   githubBodyPath: string;
+  artifactsLanguage: AgentplaneConfig["artifacts_language"];
   existingMeta: PrMeta | null;
   relatedTaskIds: string[];
   handoffNotes: Awaited<ReturnType<typeof readPrHandoffNotes>>;

--- a/packages/agentplane/src/commands/pr/internal/sync-open-step.ts
+++ b/packages/agentplane/src/commands/pr/internal/sync-open-step.ts
@@ -1,5 +1,9 @@
+import path from "node:path";
+
 import { fileExists } from "../../../cli/fs-utils.js";
+import { exitCodeForError } from "../../../cli/exit-codes.js";
 import { writeJsonStableIfChanged, writeTextIfChanged } from "../../../shared/write-if-changed.js";
+import { CliError } from "../../../shared/errors.js";
 import {
   buildObservedGithubPrMeta,
   buildOpenedPrMeta,
@@ -11,6 +15,7 @@ import {
   renderGithubPrBody,
   renderPrAutoSummary,
   renderPrReviewDocument,
+  validateArtifactsLanguage,
 } from "./review-template.js";
 import { computePrDiffstat } from "./sync-branch.js";
 import {
@@ -158,6 +163,26 @@ export async function runPrOpenSync(
     handoffNotes: common.handoffNotes,
     autoSummary: nextAutoSummary,
   });
+  const errors: string[] = [];
+  validateArtifactsLanguage({
+    texts: {
+      reviewText: nextReview,
+      githubTitleText: githubTitle,
+      githubBodyText: nextGithubBody,
+    },
+    relReviewPath: path.relative(common.resolved.gitRoot, common.reviewPath),
+    relGithubTitlePath: path.relative(common.resolved.gitRoot, common.githubTitlePath),
+    relGithubBodyPath: path.relative(common.resolved.gitRoot, common.githubBodyPath),
+    artifactsLanguage: common.artifactsLanguage,
+    errors,
+  });
+  if (errors.length > 0) {
+    throw new CliError({
+      exitCode: exitCodeForError("E_VALIDATION"),
+      code: "E_VALIDATION",
+      message: errors.join("\n"),
+    });
+  }
   await writeJsonStableIfChanged(common.metaPath, nextMeta);
   await writeTextIfChanged(common.diffstatPath, diffstat ? `${diffstat}\n` : "");
   if (!(await fileExists(common.notesPath))) {

--- a/packages/agentplane/src/commands/pr/internal/sync-update-step.ts
+++ b/packages/agentplane/src/commands/pr/internal/sync-update-step.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import { CliError } from "../../../shared/errors.js";
 import { exitCodeForError } from "../../../cli/exit-codes.js";
 import { writeJsonStableIfChanged, writeTextIfChanged } from "../../../shared/write-if-changed.js";
@@ -11,6 +13,7 @@ import {
   renderGithubPrBody,
   renderPrAutoSummary,
   renderPrReviewDocument,
+  validateArtifactsLanguage,
 } from "./review-template.js";
 import { computePrDiffstat } from "./sync-branch.js";
 import {
@@ -76,6 +79,26 @@ export async function runPrUpdateSync(common: PrSyncCommonState): Promise<{ meta
     handoffNotes: common.handoffNotes,
     autoSummary: nextAutoSummary,
   });
+  const errors: string[] = [];
+  validateArtifactsLanguage({
+    texts: {
+      reviewText: nextReview,
+      githubTitleText: githubTitle,
+      githubBodyText: githubBody,
+    },
+    relReviewPath: path.relative(common.resolved.gitRoot, common.reviewPath),
+    relGithubTitlePath: path.relative(common.resolved.gitRoot, common.githubTitlePath),
+    relGithubBodyPath: path.relative(common.resolved.gitRoot, common.githubBodyPath),
+    artifactsLanguage: common.artifactsLanguage,
+    errors,
+  });
+  if (errors.length > 0) {
+    throw new CliError({
+      exitCode: exitCodeForError("E_VALIDATION"),
+      code: "E_VALIDATION",
+      message: errors.join("\n"),
+    });
+  }
 
   await writeTextIfChanged(common.diffstatPath, diffstat ? `${diffstat}\n` : "");
   await writeTextIfChanged(common.reviewPath, nextReview);

--- a/packages/agentplane/src/commands/pr/internal/sync.ts
+++ b/packages/agentplane/src/commands/pr/internal/sync.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { resolveBaseBranch } from "@agentplaneorg/core/git";
+import type { AgentplaneConfig } from "@agentplaneorg/core/config";
 
 import { mapBackendError } from "../../../cli/error-map.js";
 import { exitCodeForError } from "../../../cli/exit-codes.js";
@@ -48,6 +49,7 @@ async function buildPrSyncCommonState(opts: {
   reviewPath: string;
   githubTitlePath: string;
   githubBodyPath: string;
+  artifactsLanguage: AgentplaneConfig["artifacts_language"];
   existingMeta: PrMeta | null;
   relatedTaskIds?: string[];
   branch: string;
@@ -102,6 +104,7 @@ async function buildPrSyncCommonState(opts: {
     reviewPath: opts.reviewPath,
     githubTitlePath: opts.githubTitlePath,
     githubBodyPath: opts.githubBodyPath,
+    artifactsLanguage: opts.artifactsLanguage,
     existingMeta: opts.existingMeta,
     relatedTaskIds: normalizeRelatedTaskIds(opts.relatedTaskIds, opts.task.id),
     handoffNotes,
@@ -289,6 +292,7 @@ export async function syncPrArtifacts(opts: {
         reviewPath,
         githubTitlePath,
         githubBodyPath,
+        artifactsLanguage: config.artifacts_language,
         existingMeta,
         relatedTaskIds: opts.includeTaskIds,
         branch,

--- a/packages/core/schemas/config.schema.json
+++ b/packages/core/schemas/config.schema.json
@@ -726,6 +726,11 @@
         "config_path": ".agentplane/backends/local/backend.json"
       }
     },
+    "artifacts_language": {
+      "type": "string",
+      "enum": ["any", "en"],
+      "default": "any"
+    },
     "closure_commit_requires_approval": {
       "type": "boolean",
       "default": false

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -163,12 +163,14 @@ describe("config", () => {
     setByDottedKey(cfg, "close_commit.direct_dirty_policy", "strict");
     setByDottedKey(cfg, "tasks.id_suffix_length_default", "12");
     setByDottedKey(cfg, "tasks.verify.required_tags", '["code","backend"]');
+    setByDottedKey(cfg, "artifacts_language", "en");
 
     const validated = validateConfig(cfg);
     expect(validated.finish_auto_status_commit).toBe(false);
     expect(validated.close_commit.direct_dirty_policy).toBe("strict");
     expect(validated.tasks.id_suffix_length_default).toBe(12);
     expect(validated.tasks.verify.required_tags).toEqual(["code", "backend"]);
+    expect(validated.artifacts_language).toBe("en");
   });
 
   it("default execution profile values are present", () => {
@@ -492,6 +494,11 @@ describe("config", () => {
         "closure_commit_requires_approval",
         (raw) => (raw.closure_commit_requires_approval = "nope"),
         /closure_commit_requires_approval/,
+      ],
+      [
+        "artifacts_language",
+        (raw) => (raw.artifacts_language = "de"),
+        schemaPath("artifacts_language"),
       ],
       [
         "paths.agents_dir",

--- a/packages/core/src/config/schema.impl.ts
+++ b/packages/core/src/config/schema.impl.ts
@@ -95,6 +95,8 @@ const TASK_DOC_REQUIRED_SECTIONS_DEFAULT = [
   "Rollback Plan",
 ] as string[];
 
+const ARTIFACTS_LANGUAGE = z.enum(["any", "en"]).default("any");
+
 const COMMENT_POLICY_SCHEMA = z
   .object({
     prefix: nonEmptyString(),
@@ -393,6 +395,7 @@ export const AgentplaneConfigSchema = z
       })
       .passthrough()
       .default({ config_path: ".agentplane/backends/local/backend.json" }),
+    artifacts_language: ARTIFACTS_LANGUAGE,
     closure_commit_requires_approval: z.boolean().default(false),
   })
   .passthrough();

--- a/packages/spec/examples/config.json
+++ b/packages/spec/examples/config.json
@@ -30,6 +30,7 @@
       "expected_version": null
     }
   },
+  "artifacts_language": "any",
   "tasks": {
     "id_suffix_length_default": 6,
     "verify": {

--- a/packages/spec/schemas/config.schema.json
+++ b/packages/spec/schemas/config.schema.json
@@ -726,6 +726,11 @@
         "config_path": ".agentplane/backends/local/backend.json"
       }
     },
+    "artifacts_language": {
+      "type": "string",
+      "enum": ["any", "en"],
+      "default": "any"
+    },
     "closure_commit_requires_approval": {
       "type": "boolean",
       "default": false


### PR DESCRIPTION
Task: `202605030733-BHD4S4`
Title: Enforce English PR artifacts language

## Summary

Enforce English PR artifacts language

Port the artifacts_language configuration and PR artifact language validation from the stale cli-artifacts branch onto current main, preserving current v0.4.2 release state.

## Scope

- In scope: Port the artifacts_language configuration and PR artifact language validation from the stale cli-artifacts branch onto current main, preserving current v0.4.2 release state.
- Out of scope: unrelated refactors not required for "Enforce English PR artifacts language".

## Verification

- State: ok
- Note: Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts packages/core/src/config/config.test.ts --pool=forks --maxWorkers 1 --testTimeout 60000 --hookTimeout 60000; Result: pass; Evidence: 2 files, 22 tests passed. Command: node scripts/check-policy-routing.mjs && node scripts/check-recipes-inventory-fresh.mjs && git diff --check; Result: pass; Evidence: policy routing OK, recipes inventory up to date, no whitespace errors. Command: remote recipes raw fetch; Result: pass; Evidence: raw_recipes=1:code-map.
- Full verification checklist lives in local review.md.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-03T07:37:40.747Z
- Branch: task/202605030733-BHD4S4/artifacts-language-validation
- Head: 17d0d8d2e220

```text
 .agentplane/config.json                            |   1 +
 docs/recipes-inventory.json                        |  76 +++++++++---
 packages/agentplane/src/commands/pr/check.ts       |   2 +
 .../src/commands/pr/integrate/artifacts.ts         |  75 +++++++++++-
 .../src/commands/pr/integrate/internal/prepare.ts  |   3 +
 .../pr/internal/pr-artifact-snapshot.test.ts       | 134 +++++++++++++++++++++
 .../commands/pr/internal/pr-artifact-snapshot.ts   |  18 +++
 .../src/commands/pr/internal/review-template.ts    |  29 +++++
 .../src/commands/pr/internal/sync-model.ts         |   2 +
 .../src/commands/pr/internal/sync-open-step.ts     |  25 ++++
 .../src/commands/pr/internal/sync-update-step.ts   |  23 ++++
 .../agentplane/src/commands/pr/internal/sync.ts    |   4 +
 packages/core/schemas/config.schema.json           |   5 +
 packages/core/src/config/config.test.ts            |   7 ++
 packages/core/src/config/schema.impl.ts            |   3 +
 packages/spec/examples/config.json                 |   1 +
 packages/spec/schemas/config.schema.json           |   5 +
 17 files changed, 395 insertions(+), 18 deletions(-)
```

</details>
