### PR TITLE
🧭 RPMEKK bun: fix Windows Bun installer executable [202605031118-RPMEKK]

### DIFF
--- a/packages/agentplane/src/commands/release/generate-release-distribution-script.test.ts
+++ b/packages/agentplane/src/commands/release/generate-release-distribution-script.test.ts
@@ -138,6 +138,8 @@ describe("generate-release-distribution script", () => {
     expect(installPs1).toContain('"agentplane-bun-v$Version-win32-x64.zip"');
     expect(installPs1).toContain(String.raw`-split '\s+'`);
     expect(installPs1).toContain(String.raw`"bin\agentplane.cmd"`);
+    expect(installPs1).toContain(String.raw`"bin\agentplane.exe"`);
+    expect(installPs1).toContain("Join-Path $InstallDir $AgentplaneBin");
     expect(installPs1).not.toContain("npm install");
     expect(installPs1).not.toContain('Require-Command "node"');
   }, 90_000);

--- a/scripts/generate-release-distribution.mjs
+++ b/scripts/generate-release-distribution.mjs
@@ -241,6 +241,7 @@ function renderInstallPs1({ version, repo, tag }) {
   const defaultInstallDir = String.raw`".agentplane\standalone\$Version"`;
   const checksumSplitPattern = String.raw`'\s+'`;
   const agentplaneCmd = String.raw`"bin\agentplane.cmd"`;
+  const agentplaneExe = String.raw`"bin\agentplane.exe"`;
   return `$ErrorActionPreference = "Stop"
 
 $Version = "${version}"
@@ -261,9 +262,11 @@ New-Item -ItemType Directory -Path $TempDir | Out-Null
 try {
   if ($Channel -eq "standalone") {
     $Asset = "agentplane-v$Version-win32-x64.zip"
+    $AgentplaneBin = ${agentplaneCmd}
   }
   elseif ($Channel -eq "bun") {
     $Asset = "agentplane-bun-v$Version-win32-x64.zip"
+    $AgentplaneBin = ${agentplaneExe}
   }
   else {
     throw "agentplane install: unsupported channel: $Channel (expected standalone or bun)"
@@ -288,7 +291,7 @@ try {
   }
   New-Item -ItemType Directory -Path $InstallDir | Out-Null
   Expand-Archive -Path $Archive -DestinationPath $InstallDir -Force
-  & (Join-Path $InstallDir ${agentplaneCmd}) --version
+  & (Join-Path $InstallDir $AgentplaneBin) --version
   Write-Output (Join-Path $InstallDir "bin")
 }
 finally {


### PR DESCRIPTION
Follow-up to PR #809 review feedback.\n\nFixes the Windows installer smoke command for AGENTPLANE_INSTALL_CHANNEL=bun to run bin\\agentplane.exe instead of the standalone bin\\agentplane.cmd shim.\n\nVerification:\n- bun test packages/agentplane/src/commands/release/generate-release-distribution-script.test.ts\n- node scripts/generate-release-distribution.mjs --check