### PR TITLE
🧪 E011A7 test: keep doctor memo coverage focused

### DIFF
--- a/packages/agentplane/src/commands/doctor.branch-pr.memo.test.ts
+++ b/packages/agentplane/src/commands/doctor.branch-pr.memo.test.ts
@@ -1,0 +1,54 @@
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  checkBranchPrBatchIncludedTaskDrift,
+  checkBranchPrDoneTaskOpenPrDrift,
+  checkBranchPrShippedTaskDrift,
+} from "./doctor/branch-pr.js";
+
+const workspaces: string[] = [];
+
+async function mkWorkspace(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "agentplane-doctor-branch-pr-memo-"));
+  workspaces.push(root);
+  await mkdir(path.join(root, ".agentplane", "tasks"), { recursive: true });
+  return root;
+}
+
+afterEach(async () => {
+  while (workspaces.length > 0) {
+    const root = workspaces.pop();
+    if (!root) continue;
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+describe("doctor branch_pr memoization", () => {
+  it("reuses the local task scan across branch_pr doctor checks", async () => {
+    const root = await mkWorkspace();
+    const listTasks = vi.fn().mockResolvedValue([
+      { id: "202605041200-ABC123", status: "TODO", commit: null },
+      { id: "202605041201-DEF456", status: "DONE", commit: null },
+    ]);
+    const ctx = {
+      backendId: "local",
+      config: {
+        workflow_mode: "branch_pr",
+        paths: { workflow_dir: ".agentplane/tasks" },
+      },
+      memo: {},
+      resolvedProject: { agentplaneDir: path.join(root, ".agentplane"), gitRoot: root },
+      taskBackend: { listTasks },
+    } as unknown as Parameters<typeof checkBranchPrShippedTaskDrift>[0];
+
+    await checkBranchPrShippedTaskDrift(ctx);
+    await checkBranchPrDoneTaskOpenPrDrift(ctx);
+    await checkBranchPrBatchIncludedTaskDrift(ctx);
+
+    expect(listTasks).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/agentplane/src/commands/doctor.command.open-pr.test.ts
+++ b/packages/agentplane/src/commands/doctor.command.open-pr.test.ts
@@ -12,7 +12,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   checkBranchPrBatchIncludedTaskDrift,
   checkBranchPrDoneTaskOpenPrDrift,
-  checkBranchPrShippedTaskDrift,
 } from "./doctor/branch-pr.js";
 import { runDoctor } from "./doctor.run.js";
 
@@ -1114,30 +1113,6 @@ describe(
 
       const findings = await checkBranchPrDoneTaskOpenPrDrift(ctx);
       expect(findings).toHaveLength(0);
-    });
-
-    it("reuses the local task scan across branch_pr doctor checks", async () => {
-      const ws = await mkWorkspace();
-      const listTasks = vi.fn().mockResolvedValue([
-        { id: "202605041200-ABC123", status: "TODO", commit: null },
-        { id: "202605041201-DEF456", status: "DONE", commit: null },
-      ]);
-      const ctx = {
-        backendId: "local",
-        config: {
-          workflow_mode: "branch_pr",
-          paths: { workflow_dir: ".agentplane/tasks" },
-        },
-        memo: {},
-        resolvedProject: { agentplaneDir: path.join(ws.root, ".agentplane"), gitRoot: ws.root },
-        taskBackend: { listTasks },
-      } as unknown as Parameters<typeof checkBranchPrShippedTaskDrift>[0];
-
-      await checkBranchPrShippedTaskDrift(ctx);
-      await checkBranchPrDoneTaskOpenPrDrift(ctx);
-      await checkBranchPrBatchIncludedTaskDrift(ctx);
-
-      expect(listTasks).toHaveBeenCalledTimes(1);
     });
 
     it("warns when a Redmine backend is configured without canonical_state readiness", async () => {


### PR DESCRIPTION
Follow-up after PR #866 and hosted close landed on main.\n\nThis PR only moves the new doctor memoization regression coverage out of the already-oversized doctor.command.open-pr.test.ts file, after the local pre-push hotspot guard caught the test baseline growth.\n\nVerification run locally:\n- bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/doctor.branch-pr.memo.test.ts packages/agentplane/src/commands/doctor.command.open-pr.test.ts\n- bunx prettier --check packages/agentplane/src/commands/doctor.branch-pr.memo.test.ts packages/agentplane/src/commands/doctor.command.open-pr.test.ts\n- bun run hotspots:check