### PR TITLE
🚧 WF1Q77 task: Make diagnostics teach remediation [202605041849-WF1Q77]

### DIFF
--- a/.agentplane/tasks/202605041849-WF1Q77/README.md
+++ b/.agentplane/tasks/202605041849-WF1Q77/README.md
@@ -1,0 +1,140 @@
+---
+id: "202605041849-WF1Q77"
+title: "Make diagnostics teach remediation"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-04T18:54:46.669Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-04T19:04:15.599Z"
+  updated_by: "CODER"
+  note: "Focused remediation diagnostics implementation verified: ACR, workflow doctor, policy routing, and framework runtime dependency surfaces now emit or preserve actionable code, why, fix, safe command, and stop condition guidance with regression coverage."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implementing shared agent-facing remediation diagnostics in the task worktree, with focused tests for doctor/workflow, ACR, and policy routing surfaces."
+events:
+  -
+    type: "status"
+    at: "2026-05-04T18:55:13.702Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implementing shared agent-facing remediation diagnostics in the task worktree, with focused tests for doctor/workflow, ACR, and policy routing surfaces."
+  -
+    type: "verify"
+    at: "2026-05-04T19:04:15.599Z"
+    author: "CODER"
+    state: "ok"
+    note: "Focused remediation diagnostics implementation verified: ACR, workflow doctor, policy routing, and framework runtime dependency surfaces now emit or preserve actionable code, why, fix, safe command, and stop condition guidance with regression coverage."
+doc_version: 3
+doc_updated_at: "2026-05-04T19:04:15.604Z"
+doc_updated_by: "CODER"
+description: "Introduce a shared agent-facing remediation contract for diagnostic failures and apply it to high-value doctor, workflow, ACR, and policy routing surfaces."
+sections:
+  Summary: |-
+    Make diagnostics teach remediation
+    
+    Introduce a shared agent-facing remediation contract for diagnostic failures and apply it to high-value doctor, workflow, ACR, and policy routing surfaces.
+  Scope: |-
+    - In scope: Introduce a shared agent-facing remediation contract for diagnostic failures and apply it to high-value doctor, workflow, ACR, and policy routing surfaces.
+    - Out of scope: unrelated refactors not required for "Make diagnostics teach remediation".
+  Plan: |-
+    1. Add a shared diagnostic remediation contract that can render agent-facing guidance with code, why, fix, safe command, and stop condition.
+    2. Apply the contract to the highest-value diagnostic surfaces in scope: doctor/workflow diagnostics, ACR validation or check failures, and policy routing/check failures where they currently emit bare errors.
+    3. Keep output backward-compatible for existing callers while enriching human/agent text output and preserving machine-readable codes.
+    4. Add focused regression tests for the new rendering and at least one integration point per touched surface.
+    5. Verify with focused tests, typecheck, git diff checks, framework bootstrap or documented bootstrap blocker, agentplane doctor, and policy routing.
+  Verify Steps: |-
+    1. Run focused tests for the shared diagnostic remediation contract and each touched integration point. Expected: tests assert code, why, fix, safe command, and stop condition render in agent-facing output without dropping existing diagnostic codes.
+    2. Run bun run typecheck. Expected: TypeScript passes for changed diagnostic surfaces.
+    3. Run git diff --check. Expected: no whitespace or patch-format issues.
+    4. Run bun run framework:dev:bootstrap, or record a concrete pre-existing bootstrap blocker if the local dependency layout remains outside this task's fix. Expected: repo-local runtime can rebuild and explain itself.
+    5. Run agentplane doctor and node .agentplane/policy/check-routing.mjs. Expected: both complete, and any diagnostic failure includes actionable remediation fields.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-04T19:04:15.599Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Focused remediation diagnostics implementation verified: ACR, workflow doctor, policy routing, and framework runtime dependency surfaces now emit or preserve actionable code, why, fix, safe command, and stop condition guidance with regression coverage.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-04T18:55:13.702Z, excerpt_hash=sha256:1d4f09691609a686197d1b20cf2224208a4941cc95b9ac1e8485b8bc5e7bb6b0
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Commands passed: focused bun tests for workflow/ACR/policy routing plus targeted stale-dist workspace dependency test; bun run typecheck; Prettier check on touched files; ESLint on touched files; bun run arch:check; git diff --check; bun run framework:dev:bootstrap; agentplane doctor; node .agentplane/policy/check-routing.mjs.
+      Impact: Diagnostic failures now teach agents the likely cause and safe recovery path instead of only emitting bare failure text; existing diagnostic codes remain stable for tests and automation.
+      Resolution: No mandatory check remains skipped. The full stale-dist-readonly file still contains an unrelated pre-existing auto-bootstrap timeout when run under this ad hoc focused bundle; the new workspace dependency test passes independently.
+      Promotion: incident-candidate
+      Fixability: external
+id_source: "generated"
+---
+## Summary
+
+Make diagnostics teach remediation
+
+Introduce a shared agent-facing remediation contract for diagnostic failures and apply it to high-value doctor, workflow, ACR, and policy routing surfaces.
+
+## Scope
+
+- In scope: Introduce a shared agent-facing remediation contract for diagnostic failures and apply it to high-value doctor, workflow, ACR, and policy routing surfaces.
+- Out of scope: unrelated refactors not required for "Make diagnostics teach remediation".
+
+## Plan
+
+1. Add a shared diagnostic remediation contract that can render agent-facing guidance with code, why, fix, safe command, and stop condition.
+2. Apply the contract to the highest-value diagnostic surfaces in scope: doctor/workflow diagnostics, ACR validation or check failures, and policy routing/check failures where they currently emit bare errors.
+3. Keep output backward-compatible for existing callers while enriching human/agent text output and preserving machine-readable codes.
+4. Add focused regression tests for the new rendering and at least one integration point per touched surface.
+5. Verify with focused tests, typecheck, git diff checks, framework bootstrap or documented bootstrap blocker, agentplane doctor, and policy routing.
+
+## Verify Steps
+
+1. Run focused tests for the shared diagnostic remediation contract and each touched integration point. Expected: tests assert code, why, fix, safe command, and stop condition render in agent-facing output without dropping existing diagnostic codes.
+2. Run bun run typecheck. Expected: TypeScript passes for changed diagnostic surfaces.
+3. Run git diff --check. Expected: no whitespace or patch-format issues.
+4. Run bun run framework:dev:bootstrap, or record a concrete pre-existing bootstrap blocker if the local dependency layout remains outside this task's fix. Expected: repo-local runtime can rebuild and explain itself.
+5. Run agentplane doctor and node .agentplane/policy/check-routing.mjs. Expected: both complete, and any diagnostic failure includes actionable remediation fields.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-04T19:04:15.599Z — VERIFY — ok
+
+By: CODER
+
+Note: Focused remediation diagnostics implementation verified: ACR, workflow doctor, policy routing, and framework runtime dependency surfaces now emit or preserve actionable code, why, fix, safe command, and stop condition guidance with regression coverage.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-04T18:55:13.702Z, excerpt_hash=sha256:1d4f09691609a686197d1b20cf2224208a4941cc95b9ac1e8485b8bc5e7bb6b0
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Commands passed: focused bun tests for workflow/ACR/policy routing plus targeted stale-dist workspace dependency test; bun run typecheck; Prettier check on touched files; ESLint on touched files; bun run arch:check; git diff --check; bun run framework:dev:bootstrap; agentplane doctor; node .agentplane/policy/check-routing.mjs.
+  Impact: Diagnostic failures now teach agents the likely cause and safe recovery path instead of only emitting bare failure text; existing diagnostic codes remain stable for tests and automation.
+  Resolution: No mandatory check remains skipped. The full stale-dist-readonly file still contains an unrelated pre-existing auto-bootstrap timeout when run under this ad hoc focused bundle; the new workspace dependency test passes independently.
+  Promotion: incident-candidate
+  Fixability: external

--- a/.agentplane/tasks/202605041849-WF1Q77/pr/diffstat.txt
+++ b/.agentplane/tasks/202605041849-WF1Q77/pr/diffstat.txt
@@ -1,0 +1,15 @@
+ .../agentplane/assets/policy/check-routing.mjs     | 46 ++++++++++-
+ packages/agentplane/bin/agentplane.js              |  7 +-
+ .../src/agents/policy-routing-check.test.ts        | 50 ++++++++++++
+ packages/agentplane/src/cli/error-map.ts           | 15 ++++
+ .../agentplane/src/cli/stale-dist-readonly.test.ts | 66 +++++++++++++++-
+ .../src/commands/acr/acr.command.test.ts           | 13 ++++
+ .../agentplane/src/commands/acr/acr.command.ts     | 77 +++++++++++++++++++
+ .../agentplane/src/commands/doctor/workflow.ts     |  5 +-
+ .../agentplane/src/commands/shared/diagnostics.ts  | 35 +++++++++
+ .../src/shared/diagnostic-remediation.ts           | 17 +++++
+ packages/agentplane/src/shared/errors.ts           | 16 ++++
+ packages/agentplane/src/workflow-runtime/types.ts  |  7 ++
+ .../src/workflow-runtime/validate.test.ts          |  7 ++
+ .../src/workflow-runtime/validation-helpers.ts     | 88 +++++++++++++++++++++-
+ 14 files changed, 442 insertions(+), 7 deletions(-)

--- a/.agentplane/tasks/202605041849-WF1Q77/pr/github-body.md
+++ b/.agentplane/tasks/202605041849-WF1Q77/pr/github-body.md
@@ -1,0 +1,36 @@
+Task: `202605041849-WF1Q77`
+Title: Make diagnostics teach remediation
+
+## Summary
+
+Make diagnostics teach remediation
+
+Introduce a shared agent-facing remediation contract for diagnostic failures and apply it to high-value doctor, workflow, ACR, and policy routing surfaces.
+
+## Scope
+
+- In scope: Introduce a shared agent-facing remediation contract for diagnostic failures and apply it to high-value doctor, workflow, ACR, and policy routing surfaces.
+- Out of scope: unrelated refactors not required for "Make diagnostics teach remediation".
+
+## Verification
+
+- State: ok
+- Note: Focused remediation diagnostics implementation verified: ACR, workflow doctor, policy routing, and framework runtime dependency surfaces now emit or preserve actionable code, why, fix, safe command, and stop condition guidance with regression coverage.
+- Full verification checklist lives in local review.md.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-04T18:55:16.828Z
+- Branch: task/202605041849-WF1Q77/teaching-diagnostics
+- Head: 45a242eec857
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605041849-WF1Q77/pr/github-body.md
+++ b/.agentplane/tasks/202605041849-WF1Q77/pr/github-body.md
@@ -25,12 +25,26 @@ Introduce a shared agent-facing remediation contract for diagnostic failures and
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-04T18:55:16.828Z
+- Updated: 2026-05-04T19:05:07.465Z
 - Branch: task/202605041849-WF1Q77/teaching-diagnostics
-- Head: 45a242eec857
+- Head: 50405bd32810
 
 ```text
-No changes detected.
+ .../agentplane/assets/policy/check-routing.mjs     | 46 ++++++++++-
+ packages/agentplane/bin/agentplane.js              |  7 +-
+ .../src/agents/policy-routing-check.test.ts        | 50 ++++++++++++
+ packages/agentplane/src/cli/error-map.ts           | 15 ++++
+ .../agentplane/src/cli/stale-dist-readonly.test.ts | 66 +++++++++++++++-
+ .../src/commands/acr/acr.command.test.ts           | 13 ++++
+ .../agentplane/src/commands/acr/acr.command.ts     | 77 +++++++++++++++++++
+ .../agentplane/src/commands/doctor/workflow.ts     |  5 +-
+ .../agentplane/src/commands/shared/diagnostics.ts  | 35 +++++++++
+ .../src/shared/diagnostic-remediation.ts           | 17 +++++
+ packages/agentplane/src/shared/errors.ts           | 16 ++++
+ packages/agentplane/src/workflow-runtime/types.ts  |  7 ++
+ .../src/workflow-runtime/validate.test.ts          |  7 ++
+ .../src/workflow-runtime/validation-helpers.ts     | 88 +++++++++++++++++++++-
+ 14 files changed, 442 insertions(+), 7 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605041849-WF1Q77/pr/github-title.txt
+++ b/.agentplane/tasks/202605041849-WF1Q77/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 WF1Q77 task: Make diagnostics teach remediation [202605041849-WF1Q77]

--- a/.agentplane/tasks/202605041849-WF1Q77/pr/meta.json
+++ b/.agentplane/tasks/202605041849-WF1Q77/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605041849-WF1Q77/teaching-diagnostics",
   "created_at": "2026-05-04T18:55:16.828Z",
-  "head_sha": "45a242eec857f4ff5c4c8849f8e0c3d378a598fd",
+  "head_sha": "50405bd328105fe093b04ddcd9b4326d082aa91a",
   "last_verified_at": "2026-05-04T19:04:15.599Z",
   "last_verified_sha": "45a242eec857f4ff5c4c8849f8e0c3d378a598fd",
   "schema_version": 1,
   "task_id": "202605041849-WF1Q77",
-  "updated_at": "2026-05-04T18:55:16.828Z",
+  "updated_at": "2026-05-04T19:05:07.465Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605041849-WF1Q77/pr/meta.json
+++ b/.agentplane/tasks/202605041849-WF1Q77/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605041849-WF1Q77/teaching-diagnostics",
+  "created_at": "2026-05-04T18:55:16.828Z",
+  "head_sha": "45a242eec857f4ff5c4c8849f8e0c3d378a598fd",
+  "last_verified_at": "2026-05-04T19:04:15.599Z",
+  "last_verified_sha": "45a242eec857f4ff5c4c8849f8e0c3d378a598fd",
+  "schema_version": 1,
+  "task_id": "202605041849-WF1Q77",
+  "updated_at": "2026-05-04T18:55:16.828Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605041849-WF1Q77/pr/review.md
+++ b/.agentplane/tasks/202605041849-WF1Q77/pr/review.md
@@ -1,0 +1,59 @@
+# PR Review
+
+Created: 2026-05-04T18:55:16.828Z
+Branch: task/202605041849-WF1Q77/teaching-diagnostics
+
+## Summary
+
+Make diagnostics teach remediation
+
+Introduce a shared agent-facing remediation contract for diagnostic failures and apply it to high-value doctor, workflow, ACR, and policy routing surfaces.
+
+## Scope
+
+- In scope: Introduce a shared agent-facing remediation contract for diagnostic failures and apply it to high-value doctor, workflow, ACR, and policy routing surfaces.
+- Out of scope: unrelated refactors not required for "Make diagnostics teach remediation".
+
+## Verification
+
+### Plan
+
+1. Run focused tests for the shared diagnostic remediation contract and each touched integration point. Expected: tests assert code, why, fix, safe command, and stop condition render in agent-facing output without dropping existing diagnostic codes.
+2. Run bun run typecheck. Expected: TypeScript passes for changed diagnostic surfaces.
+3. Run git diff --check. Expected: no whitespace or patch-format issues.
+4. Run bun run framework:dev:bootstrap, or record a concrete pre-existing bootstrap blocker if the local dependency layout remains outside this task's fix. Expected: repo-local runtime can rebuild and explain itself.
+5. Run agentplane doctor and node .agentplane/policy/check-routing.mjs. Expected: both complete, and any diagnostic failure includes actionable remediation fields.
+
+### Current Status
+
+- State: ok
+- Note: Focused remediation diagnostics implementation verified: ACR, workflow doctor, policy routing, and framework runtime dependency surfaces now emit or preserve actionable code, why, fix, safe command, and stop condition guidance with regression coverage.
+
+## Risks
+
+- Risk level: not recorded
+- Breaking change: no
+
+### Rollback
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-04T18:55:16.828Z
+- Branch: task/202605041849-WF1Q77/teaching-diagnostics
+- Head: 45a242eec857
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605041849-WF1Q77/pr/review.md
+++ b/.agentplane/tasks/202605041849-WF1Q77/pr/review.md
@@ -47,12 +47,26 @@ Introduce a shared agent-facing remediation contract for diagnostic failures and
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-04T18:55:16.828Z
+- Updated: 2026-05-04T19:05:07.465Z
 - Branch: task/202605041849-WF1Q77/teaching-diagnostics
-- Head: 45a242eec857
+- Head: 50405bd32810
 
 ```text
-No changes detected.
+ .../agentplane/assets/policy/check-routing.mjs     | 46 ++++++++++-
+ packages/agentplane/bin/agentplane.js              |  7 +-
+ .../src/agents/policy-routing-check.test.ts        | 50 ++++++++++++
+ packages/agentplane/src/cli/error-map.ts           | 15 ++++
+ .../agentplane/src/cli/stale-dist-readonly.test.ts | 66 +++++++++++++++-
+ .../src/commands/acr/acr.command.test.ts           | 13 ++++
+ .../agentplane/src/commands/acr/acr.command.ts     | 77 +++++++++++++++++++
+ .../agentplane/src/commands/doctor/workflow.ts     |  5 +-
+ .../agentplane/src/commands/shared/diagnostics.ts  | 35 +++++++++
+ .../src/shared/diagnostic-remediation.ts           | 17 +++++
+ packages/agentplane/src/shared/errors.ts           | 16 ++++
+ packages/agentplane/src/workflow-runtime/types.ts  |  7 ++
+ .../src/workflow-runtime/validate.test.ts          |  7 ++
+ .../src/workflow-runtime/validation-helpers.ts     | 88 +++++++++++++++++++++-
+ 14 files changed, 442 insertions(+), 7 deletions(-)
 ```
 
 </details>

--- a/packages/agentplane/assets/policy/check-routing.mjs
+++ b/packages/agentplane/assets/policy/check-routing.mjs
@@ -34,6 +34,46 @@ function assertFilesExist(repoRoot, paths, label, errors) {
   }
 }
 
+function remediationForRoutingError(error) {
+  if (error.includes("exceeds policy budget")) {
+    return {
+      code: "POLICY_ROUTING_BUDGET",
+      why: "Large gateway or policy modules make agent startup context harder to route deterministically.",
+      fix: "Move scenario-specific detail into the correct canonical module or shorten duplicate rule text.",
+      safeCommand: "node .agentplane/policy/check-routing.mjs",
+      stopCondition:
+        "Stop if the size reduction would remove a hard constraint or source-of-truth rule.",
+    };
+  }
+  if (error.includes("path does not exist") || error.includes("Missing canonical")) {
+    return {
+      code: "POLICY_ROUTING_MISSING_PATH",
+      why: "AGENTS.md references a policy file that agents cannot load.",
+      fix: "Restore the referenced file or update the gateway reference to the canonical existing path.",
+      safeCommand: "agentplane doctor",
+      stopCondition: "Stop if the missing file is a policy module deleted by another active task.",
+    };
+  }
+  return {
+    code: "POLICY_ROUTING_FAILED",
+    why: "The policy gateway no longer matches the deterministic load-rule contract.",
+    fix: "Repair AGENTS.md load rules, canonical docs, examples, or policy module layout.",
+    safeCommand: "node .agentplane/policy/check-routing.mjs",
+    stopCondition: "Stop if the repair changes workflow mode, approval gates, or policy ownership.",
+  };
+}
+
+function renderRemediation(error) {
+  const r = remediationForRoutingError(error);
+  return [
+    `  Code: ${r.code}`,
+    `  Why: ${r.why}`,
+    `  Fix: ${r.fix}`,
+    `  Safe command: ${r.safeCommand}`,
+    `  Stop condition: ${r.stopCondition}`,
+  ].join("\n");
+}
+
 function listFilesRecursive(dirPath, relPrefix = "") {
   if (!fs.existsSync(dirPath)) return [];
   const entries = fs.readdirSync(dirPath).toSorted((a, b) => a.localeCompare(b));
@@ -171,7 +211,11 @@ function main() {
   }
 
   if (errors.length > 0) {
-    throw new Error(`Policy routing check failed:\n- ${errors.join("\n- ")}`);
+    throw new Error(
+      `Policy routing check failed:\n${errors
+        .map((error) => `- ${error}\n${renderRemediation(error)}`)
+        .join("\n")}`,
+    );
   }
 
   process.stdout.write("policy routing OK\n");

--- a/packages/agentplane/bin/agentplane.js
+++ b/packages/agentplane/bin/agentplane.js
@@ -297,7 +297,7 @@ function missingRepoRuntimeDependencies(agentplaneRoot) {
   const requiredSpecifiers = ["@agentplaneorg/core"];
   return requiredSpecifiers.filter((specifier) => {
     try {
-      const resolved = requireFromAgentplane.resolve(specifier);
+      const resolved = requireFromAgentplane.resolve(`${specifier}/package.json`);
       if (isPathInside(frameworkRoot, resolved)) return false;
       return !existsSync(path.join(agentplaneRoot, "node_modules", ...specifier.split("/")));
     } catch {
@@ -332,6 +332,11 @@ async function assertDistUpToDate() {
   if (missingDeps.length > 0) {
     process.stderr.write(
       "error: repo-local runtime dependencies are missing for this framework checkout.\n" +
+        "Code: FRAMEWORK_RUNTIME_DEPENDENCY_MISSING\n" +
+        "Why: the repo-local CLI cannot resolve its workspace runtime packages from this checkout.\n" +
+        "Fix: restore the framework install layout, then rebuild the repo-local packages.\n" +
+        `Safe command: ${FRAMEWORK_DEV_BOOTSTRAP_COMMAND}\n` +
+        "Stop condition: stop if the missing package resolves outside this repository or bun install would need unapproved network access.\n" +
         "This worktree is not bootstrapped yet.\n" +
         "Missing module resolution:\n" +
         missingDeps.map((specifier) => `  ${specifier}\n`).join("") +

--- a/packages/agentplane/src/agents/policy-routing-check.test.ts
+++ b/packages/agentplane/src/agents/policy-routing-check.test.ts
@@ -1,5 +1,8 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
@@ -11,5 +14,52 @@ describe("policy routing check script", () => {
         cwd: process.cwd(),
       }),
     ).resolves.toBeDefined();
+  });
+
+  it("prints remediation fields when routing fails", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "agentplane-routing-check-"));
+    try {
+      const scriptPath = path.join(root, ".agentplane", "policy", "check-routing.mjs");
+      await mkdir(path.dirname(scriptPath), { recursive: true });
+      await writeFile(
+        path.join(root, "AGENTS.md"),
+        [
+          "# PURPOSE",
+          "## PROJECT",
+          "## SOURCES OF TRUTH",
+          "## COMMANDS",
+          "## TOOLING",
+          "## LOAD RULES",
+          "- `@.agentplane/policy/missing.md`",
+          "## MUST / MUST NOT",
+          "MUST NOT load unrelated policy modules",
+          "MUST NOT use wildcard policy paths",
+          "## CORE DOD",
+          "## SIZE BUDGET",
+          "## CANONICAL DOCS",
+          "- DOC `.agentplane/policy/incidents.md`",
+          "## REFERENCE EXAMPLES",
+          "- EXAMPLE `.agentplane/policy/examples/pr-note.md`",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      await writeFile(
+        scriptPath,
+        await readFile("packages/agentplane/assets/policy/check-routing.mjs", "utf8"),
+      );
+      try {
+        await execFileAsync("node", [scriptPath], { cwd: root });
+        throw new Error("Expected policy routing check to fail.");
+      } catch (err) {
+        const stderr =
+          typeof (err as { stderr?: unknown }).stderr === "string"
+            ? (err as { stderr: string }).stderr
+            : "";
+        expect(stderr).toContain("Safe command:");
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/agentplane/src/cli/error-map.ts
+++ b/packages/agentplane/src/cli/error-map.ts
@@ -12,6 +12,7 @@ import {
 import type { CliError } from "../shared/errors.js";
 import { BackendError } from "../backends/task-backend.js";
 import { getReasonCodeMeta } from "./reason-codes.js";
+import { renderRemediationLines } from "../shared/diagnostic-remediation.js";
 
 export type NextAction = {
   command: string;
@@ -23,6 +24,13 @@ type ErrorGuidance = {
   state?: string;
   likelyCause?: string;
   hint?: string;
+  remediation?: {
+    code: string;
+    why: string;
+    fix: string;
+    safeCommand: string;
+    stopCondition: string;
+  };
   nextAction?: NextAction;
 };
 
@@ -98,6 +106,7 @@ export function writeError(err: CliError, jsonErrors: boolean): void {
         state: guidance.state,
         likelyCause: guidance.likelyCause,
         hint: guidance.hint,
+        remediation: guidance.remediation,
         nextAction: guidance.nextAction,
         reasonDecode,
       })}\n`,
@@ -119,6 +128,11 @@ export function writeError(err: CliError, jsonErrors: boolean): void {
   }
   if (guidance.hint) {
     process.stderr.write(`hint: ${guidance.hint}\n`);
+  }
+  if (guidance.remediation) {
+    for (const line of renderRemediationLines(guidance.remediation)) {
+      process.stderr.write(`${line}\n`);
+    }
   }
   if (guidance.nextAction) {
     process.stderr.write(
@@ -143,6 +157,7 @@ function resolveErrorGuidance(err: CliError): ErrorGuidance {
     state: explicit.state ?? fallback.state,
     likelyCause: explicit.likelyCause ?? fallback.likelyCause,
     hint: explicit.hint ?? fallback.hint,
+    remediation: explicit.remediation ?? fallback.remediation,
     nextAction: explicit.nextAction ?? fallback.nextAction,
   });
   switch (err.code) {

--- a/packages/agentplane/src/cli/stale-dist-readonly.test.ts
+++ b/packages/agentplane/src/cli/stale-dist-readonly.test.ts
@@ -1,5 +1,15 @@
 import { execFile } from "node:child_process";
-import { chmod, copyFile, mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  copyFile,
+  mkdtemp,
+  mkdir,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -96,6 +106,48 @@ async function setupFrameworkCheckout() {
   await writeFile(cliPath, `${current}export const dirty = true;\n`, "utf8");
 
   return { repoRoot, repoBin };
+}
+
+async function setupFrameworkCheckoutWithWorkspaceDependency() {
+  const setup = await setupFrameworkCheckout();
+  const packageRoot = path.join(setup.repoRoot, "packages", "agentplane");
+  const coreRoot = path.join(setup.repoRoot, "packages", "core");
+  await mkdir(path.join(packageRoot, "node_modules", "@agentplaneorg"), { recursive: true });
+  await mkdir(coreRoot, { recursive: true });
+  await writeFile(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify(
+      {
+        type: "module",
+        dependencies: {
+          "@agentplaneorg/core": "workspace:*",
+        },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await writeFile(
+    path.join(coreRoot, "package.json"),
+    JSON.stringify(
+      {
+        name: "@agentplaneorg/core",
+        type: "module",
+        exports: {
+          ".": "./dist/index.js",
+          "./package.json": "./package.json",
+        },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await mkdir(path.join(coreRoot, "dist"), { recursive: true });
+  await writeFile(path.join(coreRoot, "dist", "index.js"), "export {};\n", "utf8");
+  await symlink("../../../core", path.join(packageRoot, "node_modules", "@agentplaneorg", "core"));
+  return setup;
 }
 
 async function setupFakeBootstrapBin() {
@@ -392,5 +444,17 @@ describe("stale-dist warn-and-run command policy", { timeout: 180_000 }, () => {
     expect(execError.stdout).toBe("");
     expect(typeof execError.stderr).toBe("string");
     expect(execError.stderr).toContain("another framework dev bootstrap is already running");
+  });
+
+  it("accepts workspace dependency packages that only expose package.json", async () => {
+    const { repoRoot, repoBin } = await setupFrameworkCheckoutWithWorkspaceDependency();
+
+    const { stdout } = await execFileAsync(process.execPath, [repoBin, "config", "show"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: warnOnlyEnv,
+    });
+
+    expect(stdout).toContain("DIST");
   });
 });

--- a/packages/agentplane/src/commands/acr/acr.command.test.ts
+++ b/packages/agentplane/src/commands/acr/acr.command.test.ts
@@ -12,6 +12,8 @@ import {
   assertAcrCiSemantics,
   makeRunAcrSchemaHandler,
 } from "./acr.command.js";
+import { CliError } from "../../shared/errors.js";
+import { readDiagnosticContext } from "../shared/diagnostics.js";
 
 const ciOptions = {
   requirePlanApproved: true,
@@ -136,6 +138,17 @@ describe("ACR CI semantics", () => {
     record.approvals = [];
 
     expect(() => assertAcrCiSemantics(record, ciOptions)).toThrow("ACR_E_PLAN_APPROVAL_REQUIRED");
+    try {
+      assertAcrCiSemantics(record, ciOptions);
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError);
+      const diagnostic = readDiagnosticContext((err as CliError).context);
+      expect(diagnostic.remediation).toMatchObject({
+        code: "ACR_E_PLAN_APPROVAL_REQUIRED",
+        safeCommand: "agentplane task plan approve <task-id> --by ORCHESTRATOR",
+      });
+      expect(diagnostic.remediation?.stopCondition).toContain("Stop");
+    }
   });
 
   it("rejects null digest on merge-ready records", () => {

--- a/packages/agentplane/src/commands/acr/acr.command.ts
+++ b/packages/agentplane/src/commands/acr/acr.command.ts
@@ -23,6 +23,7 @@ import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
 import { CliError } from "../../shared/errors.js";
 import { writeTextIfChanged } from "../../shared/write-if-changed.js";
 import { loadTaskFromContext, type CommandContext } from "../shared/task-backend.js";
+import { withDiagnosticContext } from "../shared/diagnostics.js";
 
 type AcrMode = "schema" | "local" | "ci";
 type AcrCiSemanticOptions = Pick<
@@ -1096,5 +1097,81 @@ function acrValidationError(code: string, message: string): CliError {
     exitCode: exitCodeForError("E_VALIDATION"),
     code: "E_VALIDATION",
     message: `${code}: ${message}`,
+    context: withDiagnosticContext(
+      { reason_code: code },
+      {
+        state: "ACR validation failed.",
+        likelyCause: message,
+        hint: "ACR is a derived evidence record; regenerate it from task, policy, verification, and Git state instead of hand-editing it.",
+        nextAction: {
+          command: "agentplane acr explain <task-id>",
+          reason: "inspect the current ACR readiness summary before retrying the gate",
+          reasonCode: code,
+        },
+        remediation: acrRemediationForCode(code, message),
+      },
+    ),
   });
+}
+
+function acrRemediationForCode(
+  code: string,
+  message: string,
+): NonNullable<Parameters<typeof withDiagnosticContext>[1]["remediation"]> {
+  if (code.includes("PLAN")) {
+    return {
+      code,
+      why: "The ACR cannot prove that the implementation followed an approved plan.",
+      fix: "Approve the task plan through AgentPlane, then regenerate or refresh the task-local ACR.",
+      safeCommand: "agentplane task plan approve <task-id> --by ORCHESTRATOR",
+      stopCondition:
+        "Stop if the plan is missing, stale, or no longer matches the implementation scope.",
+    };
+  }
+  if (code.includes("VERIFICATION")) {
+    return {
+      code,
+      why: "The ACR cannot prove that required checks ran and passed.",
+      fix: "Run the task Verify Steps, record verification through AgentPlane, then regenerate the ACR.",
+      safeCommand: "agentplane task verify-show <task-id>",
+      stopCondition:
+        "Stop if a required check must be skipped without explicit approval and recorded risk.",
+    };
+  }
+  if (code.includes("EVIDENCE") || code.includes("DIGEST")) {
+    return {
+      code,
+      why: "The ACR evidence does not match the current repository artifact state.",
+      fix: "Regenerate the ACR from current task evidence and verify the digest again.",
+      safeCommand: "agentplane acr generate <task-id> --work-commit HEAD --write --refresh",
+      stopCondition:
+        "Stop if the evidence mismatch points to uncommitted or unintended task artifact changes.",
+    };
+  }
+  if (code.includes("GIT")) {
+    return {
+      code,
+      why: "The ACR Git range cannot be validated locally.",
+      fix: "Confirm the base and work commits exist and that work_commit descends from base_commit.",
+      safeCommand: "git merge-base --is-ancestor <base_commit> <work_commit>",
+      stopCondition:
+        "Stop if the recorded commits are from another branch, checkout, or repository.",
+    };
+  }
+  if (code.includes("POLICY")) {
+    return {
+      code,
+      why: "The ACR records a policy decision that is not merge-ready.",
+      fix: "Resolve the failed policy decision or record an approved policy override when allowed.",
+      safeCommand: "agentplane acr explain <task-id>",
+      stopCondition: "Stop if resolving the policy failure requires changing repository policy.",
+    };
+  }
+  return {
+    code,
+    why: message,
+    fix: "Inspect the ACR target, regenerate it from canonical task evidence, and rerun validation.",
+    safeCommand: "agentplane acr validate <task-id> --mode local",
+    stopCondition: "Stop if the target ACR was hand-edited or cannot be traced to a task README.",
+  };
 }

--- a/packages/agentplane/src/commands/doctor/workflow.ts
+++ b/packages/agentplane/src/commands/doctor/workflow.ts
@@ -8,12 +8,11 @@ import {
   safeAutofixWorkflowText,
   validateWorkflowAtPath,
 } from "../../workflow-runtime/index.js";
+import { renderWorkflowDiagnostic } from "../../workflow-runtime/validation-helpers.js";
 
 export async function checkWorkflowContract(repoRoot: string): Promise<string[]> {
   const result = await validateWorkflowAtPath(repoRoot);
-  const findings = result.diagnostics.map(
-    (d) => `[${d.severity}] ${d.code} ${d.path}: ${d.message}`,
-  );
+  const findings = result.diagnostics.map((d) => renderWorkflowDiagnostic(d));
   emitWorkflowEvent({
     event: "workflow_doctor_check",
     details: { ok: result.ok, findings: result.diagnostics.length },

--- a/packages/agentplane/src/commands/shared/diagnostics.ts
+++ b/packages/agentplane/src/commands/shared/diagnostics.ts
@@ -1,3 +1,9 @@
+import {
+  renderRemediationLines,
+  type DiagnosticRemediation,
+} from "../../shared/diagnostic-remediation.js";
+export type { DiagnosticRemediation } from "../../shared/diagnostic-remediation.js";
+
 export type DiagnosticNextAction = {
   command: string;
   reason: string;
@@ -9,6 +15,7 @@ export type DiagnosticInfo = {
   likelyCause: string;
   nextAction?: DiagnosticNextAction;
   hint?: string;
+  remediation?: DiagnosticRemediation;
 };
 
 type DiagnosticContextRecord = Record<string, unknown>;
@@ -27,6 +34,15 @@ export function withDiagnosticContext(
     diagnostic_state: diagnostic.state,
     diagnostic_likely_cause: diagnostic.likelyCause,
     ...(diagnostic.hint ? { diagnostic_hint: diagnostic.hint } : {}),
+    ...(diagnostic.remediation
+      ? {
+          diagnostic_code: diagnostic.remediation.code,
+          diagnostic_why: diagnostic.remediation.why,
+          diagnostic_fix: diagnostic.remediation.fix,
+          diagnostic_safe_command: diagnostic.remediation.safeCommand,
+          diagnostic_stop_condition: diagnostic.remediation.stopCondition,
+        }
+      : {}),
     ...(diagnostic.nextAction
       ? {
           diagnostic_next_action_command: diagnostic.nextAction.command,
@@ -48,11 +64,26 @@ export function readDiagnosticContext(
   const nextActionCommand = readString(context?.diagnostic_next_action_command);
   const nextActionReason = readString(context?.diagnostic_next_action_reason);
   const nextActionReasonCode = readString(context?.diagnostic_next_action_reason_code);
+  const diagnosticCode = readString(context?.diagnostic_code);
+  const why = readString(context?.diagnostic_why);
+  const fix = readString(context?.diagnostic_fix);
+  const safeCommand = readString(context?.diagnostic_safe_command);
+  const stopCondition = readString(context?.diagnostic_stop_condition);
 
   return {
     state,
     likelyCause,
     hint,
+    remediation:
+      diagnosticCode && why && fix && safeCommand && stopCondition
+        ? {
+            code: diagnosticCode,
+            why,
+            fix,
+            safeCommand,
+            stopCondition,
+          }
+        : undefined,
     nextAction:
       nextActionCommand && nextActionReason
         ? {
@@ -69,9 +100,13 @@ export function renderDiagnosticFinding(opts: {
   state: string;
   likelyCause: string;
   nextAction?: DiagnosticNextAction;
+  remediation?: DiagnosticRemediation;
   details?: string[];
 }): string {
   const lines = [`[${opts.severity}] State: ${opts.state}`, `Likely cause: ${opts.likelyCause}`];
+  if (opts.remediation) {
+    lines.push(...renderRemediationLines(opts.remediation));
+  }
   if (opts.nextAction) {
     lines.push(`Next action: ${opts.nextAction.command} (${opts.nextAction.reason})`);
   }

--- a/packages/agentplane/src/shared/diagnostic-remediation.ts
+++ b/packages/agentplane/src/shared/diagnostic-remediation.ts
@@ -1,0 +1,17 @@
+export type DiagnosticRemediation = {
+  code: string;
+  why: string;
+  fix: string;
+  safeCommand: string;
+  stopCondition: string;
+};
+
+export function renderRemediationLines(remediation: DiagnosticRemediation): string[] {
+  return [
+    `Code: ${remediation.code}`,
+    `Why: ${remediation.why}`,
+    `Fix: ${remediation.fix}`,
+    `Safe command: ${remediation.safeCommand}`,
+    `Stop condition: ${remediation.stopCondition}`,
+  ];
+}

--- a/packages/agentplane/src/shared/errors.ts
+++ b/packages/agentplane/src/shared/errors.ts
@@ -131,6 +131,13 @@ export type JsonErrorGuidance = {
   state?: string;
   likelyCause?: string;
   hint?: string;
+  remediation?: {
+    code: string;
+    why: string;
+    fix: string;
+    safeCommand: string;
+    stopCondition: string;
+  };
   nextAction?: {
     command: string;
     reason: string;
@@ -154,6 +161,15 @@ export function formatJsonError(err: CliError, guidance?: JsonErrorGuidance): st
         state: guidance?.state,
         likely_cause: guidance?.likelyCause,
         hint: guidance?.hint,
+        remediation: guidance?.remediation
+          ? {
+              code: guidance.remediation.code,
+              why: guidance.remediation.why,
+              fix: guidance.remediation.fix,
+              safe_command: guidance.remediation.safeCommand,
+              stop_condition: guidance.remediation.stopCondition,
+            }
+          : undefined,
         next_action: guidance?.nextAction,
         reason_decode: guidance?.reasonDecode,
       },

--- a/packages/agentplane/src/workflow-runtime/types.ts
+++ b/packages/agentplane/src/workflow-runtime/types.ts
@@ -66,6 +66,13 @@ export type WorkflowDiagnostic = {
   severity: WorkflowSeverity;
   path: string;
   message: string;
+  remediation?: {
+    code: WorkflowErrorCode;
+    why: string;
+    fix: string;
+    safeCommand: string;
+    stopCondition: string;
+  };
 };
 
 export type WorkflowValidationResult = {

--- a/packages/agentplane/src/workflow-runtime/validate.test.ts
+++ b/packages/agentplane/src/workflow-runtime/validate.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { parseWorkflowMarkdown } from "./markdown.js";
 import { validateWorkflowDocument } from "./validate.js";
+import { renderWorkflowDiagnostic } from "./validation-helpers.js";
 
 describe("workflow-runtime/validate", () => {
   it("accepts canonical WORKFLOW v2 front matter", () => {
@@ -98,5 +99,11 @@ x
     expect(result.diagnostics.some((d) => d.code === "WF_SCHEMA_UNKNOWN_KEY")).toBe(true);
     expect(result.diagnostics.some((d) => d.code === "WF_SCHEMA_TYPE")).toBe(true);
     expect(result.diagnostics.some((d) => d.code === "WF_SCHEMA_ENUM")).toBe(true);
+    const typeDiagnostic = result.diagnostics.find((d) => d.code === "WF_SCHEMA_TYPE");
+    expect(typeDiagnostic?.remediation).toMatchObject({
+      code: "WF_SCHEMA_TYPE",
+      safeCommand: "agentplane doctor",
+    });
+    expect(renderWorkflowDiagnostic(typeDiagnostic!)).toContain("Stop condition:");
   });
 });

--- a/packages/agentplane/src/workflow-runtime/validation-helpers.ts
+++ b/packages/agentplane/src/workflow-runtime/validation-helpers.ts
@@ -1,7 +1,93 @@
 import type { WorkflowDiagnostic } from "./types.js";
+import { renderRemediationLines } from "../shared/diagnostic-remediation.js";
 
 export function pushDiagnostic(diags: WorkflowDiagnostic[], diagnostic: WorkflowDiagnostic): void {
-  diags.push(diagnostic);
+  diags.push({
+    ...diagnostic,
+    remediation: diagnostic.remediation ?? remediationForWorkflowDiagnostic(diagnostic),
+  });
+}
+
+export function remediationForWorkflowDiagnostic(
+  diagnostic: Pick<WorkflowDiagnostic, "code" | "path" | "message">,
+): NonNullable<WorkflowDiagnostic["remediation"]> {
+  const safePath = diagnostic.path || ".agentplane/WORKFLOW.md";
+  switch (diagnostic.code) {
+    case "WF_MISSING_FILE": {
+      return {
+        code: diagnostic.code,
+        why: "The repository has no workflow contract for agents to follow.",
+        fix: "Restore .agentplane/WORKFLOW.md from the initialized template or last-known-good copy.",
+        safeCommand: "agentplane doctor --fix",
+        stopCondition:
+          "Stop if .agentplane/workflows/last-known-good.md is also missing or contains unknown policy changes.",
+      };
+    }
+    case "WF_SCHEMA_MISSING":
+    case "WF_SCHEMA_TYPE":
+    case "WF_SCHEMA_ENUM":
+    case "WF_SCHEMA_RANGE":
+    case "WF_SCHEMA_UNKNOWN_KEY": {
+      return {
+        code: diagnostic.code,
+        why: `The workflow field ${safePath} does not match the supported schema.`,
+        fix: "Edit the field to match the canonical workflow shape, then re-run workflow diagnostics.",
+        safeCommand: "agentplane doctor",
+        stopCondition:
+          "Stop before editing if the field changes workflow mode, approval gates, or task paths without explicit approval.",
+      };
+    }
+    case "WF_REQUIRED_SECTION_MISSING": {
+      return {
+        code: diagnostic.code,
+        why: `The workflow document is missing a section agents rely on: ${safePath}.`,
+        fix: "Restore the missing section from the generated workflow template or last-known-good copy.",
+        safeCommand: "agentplane doctor --fix",
+        stopCondition:
+          "Stop if the missing section contains project-specific policy that cannot be inferred safely.",
+      };
+    }
+    case "WF_TEMPLATE_UNKNOWN_VARIABLE":
+    case "WF_TEMPLATE_UNKNOWN_FILTER": {
+      return {
+        code: diagnostic.code,
+        why: "The workflow prompt template references a variable or filter the renderer cannot resolve.",
+        fix: "Replace the template reference with a supported runtime/workflow variable or remove the unsupported filter.",
+        safeCommand: "agentplane workflow build",
+        stopCondition:
+          "Stop if the template reference is part of a recipe or policy override outside the current task scope.",
+      };
+    }
+    case "WF_POLICY_MISMATCH": {
+      return {
+        code: diagnostic.code,
+        why: "The workflow contract and loaded config disagree on a policy-critical value.",
+        fix: "Treat .agentplane/WORKFLOW.md as the canonical workflow source and reconcile lower-priority config.",
+        safeCommand: "agentplane config show",
+        stopCondition:
+          "Stop if reconciling the value would change approval, network, or branch policy.",
+      };
+    }
+    default: {
+      return {
+        code: diagnostic.code,
+        why: diagnostic.message,
+        fix: "Inspect the referenced workflow path and repair the contract before continuing agent work.",
+        safeCommand: "agentplane doctor",
+        stopCondition:
+          "Stop if the repair path is ambiguous or requires changing policy outside the approved scope.",
+      };
+    }
+  }
+}
+
+export function renderWorkflowDiagnostic(diagnostic: WorkflowDiagnostic): string {
+  const lines = [
+    `[${diagnostic.severity}] ${diagnostic.code} ${diagnostic.path}: ${diagnostic.message}`,
+  ];
+  const remediation = diagnostic.remediation ?? remediationForWorkflowDiagnostic(diagnostic);
+  lines.push(...renderRemediationLines(remediation));
+  return lines.join("\n");
 }
 
 export function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
Task: `202605041849-WF1Q77`
Title: Make diagnostics teach remediation

## Summary

Make diagnostics teach remediation

Introduce a shared agent-facing remediation contract for diagnostic failures and apply it to high-value doctor, workflow, ACR, and policy routing surfaces.

## Scope

- In scope: Introduce a shared agent-facing remediation contract for diagnostic failures and apply it to high-value doctor, workflow, ACR, and policy routing surfaces.
- Out of scope: unrelated refactors not required for "Make diagnostics teach remediation".

## Verification

- State: ok
- Note: Focused remediation diagnostics implementation verified: ACR, workflow doctor, policy routing, and framework runtime dependency surfaces now emit or preserve actionable code, why, fix, safe command, and stop condition guidance with regression coverage.
- Full verification checklist lives in local review.md.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-04T19:05:07.465Z
- Branch: task/202605041849-WF1Q77/teaching-diagnostics
- Head: 50405bd32810

```text
 .../agentplane/assets/policy/check-routing.mjs     | 46 ++++++++++-
 packages/agentplane/bin/agentplane.js              |  7 +-
 .../src/agents/policy-routing-check.test.ts        | 50 ++++++++++++
 packages/agentplane/src/cli/error-map.ts           | 15 ++++
 .../agentplane/src/cli/stale-dist-readonly.test.ts | 66 +++++++++++++++-
 .../src/commands/acr/acr.command.test.ts           | 13 ++++
 .../agentplane/src/commands/acr/acr.command.ts     | 77 +++++++++++++++++++
 .../agentplane/src/commands/doctor/workflow.ts     |  5 +-
 .../agentplane/src/commands/shared/diagnostics.ts  | 35 +++++++++
 .../src/shared/diagnostic-remediation.ts           | 17 +++++
 packages/agentplane/src/shared/errors.ts           | 16 ++++
 packages/agentplane/src/workflow-runtime/types.ts  |  7 ++
 .../src/workflow-runtime/validate.test.ts          |  7 ++
 .../src/workflow-runtime/validation-helpers.ts     | 88 +++++++++++++++++++++-
 14 files changed, 442 insertions(+), 7 deletions(-)
```

</details>
