### PR TITLE
✅ H4PPTY close: Reconcile shipped blueprint tasks

### DIFF
--- a/.agentplane/tasks/202605041903-H4PPTY/README.md
+++ b/.agentplane/tasks/202605041903-H4PPTY/README.md
@@ -1,7 +1,8 @@
 ---
 id: "202605041903-H4PPTY"
 title: "Document blueprint execution-route contracts"
-status: "DOING"
+result_summary: "Shipped on main and reconciled from local branch_pr state."
+status: "DONE"
 priority: "high"
 owner: "DOCS"
 revision: 6
@@ -21,7 +22,9 @@ verification:
   updated_at: "2026-05-04T19:05:54.510Z"
   updated_by: "DOCS"
   note: "Blueprint developer specification docs passed verification."
-commit: null
+commit:
+  hash: "83c5d227897bd8dd81ad0dcd59af0be15875b9f7"
+  message: "Shipped on main before canonical task closure"
 comments:
   -
     author: "DOCS"
@@ -40,9 +43,16 @@ events:
     author: "DOCS"
     state: "ok"
     note: "Blueprint developer specification docs passed verification."
+  -
+    type: "status"
+    at: "2026-05-04T20:28:07.994Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Local branch_pr reconciliation detected task commit 83c5d227897b on base main; canonical task state normalized after shipment."
 doc_version: 3
-doc_updated_at: "2026-05-04T19:05:54.520Z"
-doc_updated_by: "DOCS"
+doc_updated_at: "2026-05-04T20:28:07.994Z"
+doc_updated_by: "INTEGRATOR"
 description: "Add a detailed developer specification for AgentPlane blueprints as task-specific execution-route contracts, including layer boundaries, node catalog, built-in blueprint routes, recipe extension rules, evidence, ACR relationship, runner relationship, stop rules, non-goals, and implementation backlog."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605041903-H4PPTY/pr/meta.json
+++ b/.agentplane/tasks/202605041903-H4PPTY/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "83c5d227897bd8dd81ad0dcd59af0be15875b9f7",
   "last_verified_at": null,
   "last_verified_sha": null,
+  "merge_commit": "83c5d227897bd8dd81ad0dcd59af0be15875b9f7",
+  "merged_at": "2026-05-04T20:28:07.993Z",
   "schema_version": 1,
+  "status": "MERGED",
   "task_id": "202605041903-H4PPTY",
-  "updated_at": "2026-05-04T19:06:23.275Z",
+  "updated_at": "2026-05-04T20:28:07.993Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202605041907-B7VKWQ/README.md
+++ b/.agentplane/tasks/202605041907-B7VKWQ/README.md
@@ -1,7 +1,8 @@
 ---
 id: "202605041907-B7VKWQ"
 title: "Fix lint blockers for docs branch push"
-status: "DOING"
+result_summary: "Shipped on main and reconciled from local branch_pr state."
+status: "DONE"
 priority: "high"
 owner: "CODER"
 revision: 6
@@ -21,7 +22,9 @@ verification:
   updated_at: "2026-05-04T19:09:59.462Z"
   updated_by: "CODER"
   note: "Focused lint blockers fixed and verified."
-commit: null
+commit:
+  hash: "7d4834fbe9a28ff98437d465c87a1220fb35088d"
+  message: "Shipped on main before canonical task closure"
 comments:
   -
     author: "CODER"
@@ -40,9 +43,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Focused lint blockers fixed and verified."
+  -
+    type: "status"
+    at: "2026-05-04T20:28:07.994Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Local branch_pr reconciliation detected task commit 7d4834fbe9a2 on base main; canonical task state normalized after shipment."
 doc_version: 3
-doc_updated_at: "2026-05-04T19:09:59.466Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-04T20:28:07.994Z"
+doc_updated_by: "INTEGRATOR"
 description: "Fix the two ESLint errors blocking pre-push on the docs branch: prefer RegExp.exec in runtime.command.test.ts and remove the unused CONFIG_REL_PATH import in upgrade.ts."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605041907-B7VKWQ/pr/meta.json
+++ b/.agentplane/tasks/202605041907-B7VKWQ/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "7d4834fbe9a28ff98437d465c87a1220fb35088d",
   "last_verified_at": null,
   "last_verified_sha": null,
+  "merge_commit": "7d4834fbe9a28ff98437d465c87a1220fb35088d",
+  "merged_at": "2026-05-04T20:28:07.994Z",
   "schema_version": 1,
+  "status": "MERGED",
   "task_id": "202605041907-B7VKWQ",
-  "updated_at": "2026-05-04T19:11:16.012Z",
+  "updated_at": "2026-05-04T20:28:07.994Z",
   "verify": {
     "status": "skipped"
   }

--- a/website/scripts/generate-social-images.mjs
+++ b/website/scripts/generate-social-images.mjs
@@ -95,7 +95,11 @@ async function collectDocs(directory, files = []) {
       continue;
     }
 
-    if (!/\.(md|mdx)$/.test(entry.name) || entry.name === "README.md" || entry.name.startsWith("_")) {
+    if (
+      !/\.(md|mdx)$/.test(entry.name) ||
+      entry.name === "README.md" ||
+      entry.name.startsWith("_")
+    ) {
       continue;
     }
 
@@ -127,7 +131,10 @@ function outputPathFromRoute(route) {
 }
 
 function labelsFromRoute(route, title) {
-  const parts = route.replace(/^\/docs\/?/, "").split("/").filter(Boolean);
+  const parts = route
+    .replace(/^\/docs\/?/, "")
+    .split("/")
+    .filter(Boolean);
   const section = parts[0] ? titleCase(parts[0]) : "Docs";
   const breadcrumb = ["docs", ...parts].join(" / ");
 
@@ -211,7 +218,9 @@ async function main() {
   for (const doc of docs) {
     const source = await readFile(doc, "utf8");
     const route = routeFromDocPath(doc);
-    const fallbackTitle = titleCase(path.parse(doc).name === "index" ? "Docs" : path.parse(doc).name);
+    const fallbackTitle = titleCase(
+      path.parse(doc).name === "index" ? "Docs" : path.parse(doc).name,
+    );
     const title = readFrontMatterTitle(source) ?? fallbackTitle;
 
     entries.push({


### PR DESCRIPTION
Reconciles shipped branch_pr task state for H4PPTY and B7VKWQ after their implementation commits already landed on main.\n\nAlso formats the already-merged social-image generator so the repository pre-push formatting gate stays green.\n\nVerification:\n- agentplane doctor: OK, warnings=0 before commit\n- git diff --check: pass\n- bun run format:check: pass\n- bun run --cwd website check-social-images: pass\n- pre-push fast local CI: pass