### PR TITLE
🧩 7F28YM release: align ACR example version

### DIFF
--- a/packages/spec/examples/acr.json
+++ b/packages/spec/examples/acr.json
@@ -5,7 +5,7 @@
   "created_at": "2026-05-03T12:00:00.000Z",
   "producer": {
     "name": "agentplane",
-    "version": "0.4.3"
+    "version": "0.4.4"
   },
   "repository": {
     "vcs": "git",
@@ -31,7 +31,7 @@
     "toolchain": [
       {
         "name": "agentplane",
-        "version": "0.4.3"
+        "version": "0.4.4"
       }
     ]
   },


### PR DESCRIPTION
Fixes the v0.4.4 publish payload validation failure by aligning packages/spec/examples/acr.json with the released package version.\n\nValidation:\n- bun run release:acr-example:check