### PR TITLE
🚧 WH7G6R task: Define executable blueprint definition contracts [202605052203-WH7G6R]

### DIFF
--- a/.agentplane/tasks/202605052203-WH7G6R/README.md
+++ b/.agentplane/tasks/202605052203-WH7G6R/README.md
@@ -1,0 +1,138 @@
+---
+id: "202605052203-WH7G6R"
+title: "Define executable blueprint definition contracts"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "blueprints"
+  - "code"
+  - "contracts"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-05T22:05:07.251Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-05T22:18:24.723Z"
+  updated_by: "CODER"
+  note: "Verified: executable blueprint definition contracts now include state metadata, policy modules, command boundaries, context budget, materialized plan typing, and focused validation coverage."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Implement the executable blueprint definition contract as the primary batch task for the approved blueprint execution-route work."
+events:
+  -
+    type: "status"
+    at: "2026-05-05T22:07:05.609Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Implement the executable blueprint definition contract as the primary batch task for the approved blueprint execution-route work."
+  -
+    type: "verify"
+    at: "2026-05-05T22:18:24.723Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: executable blueprint definition contracts now include state metadata, policy modules, command boundaries, context budget, materialized plan typing, and focused validation coverage."
+doc_version: 3
+doc_updated_at: "2026-05-05T22:18:24.732Z"
+doc_updated_by: "CODER"
+description: "Add the first implementation task for blueprint execution contracts: define typed BlueprintDefinition and BlueprintState shapes without command execution, covering states, required evidence, allowed commands, policy modules, stop rules, and resolver-facing metadata."
+sections:
+  Summary: |-
+    Define executable blueprint definition contracts
+    
+    Add the first implementation task for blueprint execution contracts: define typed BlueprintDefinition and BlueprintState shapes without command execution, covering states, required evidence, allowed commands, policy modules, stop rules, and resolver-facing metadata.
+  Scope: |-
+    - In scope: Add the first implementation task for blueprint execution contracts: define typed BlueprintDefinition and BlueprintState shapes without command execution, covering states, required evidence, allowed commands, policy modules, stop rules, and resolver-facing metadata.
+    - Out of scope: unrelated refactors not required for "Define executable blueprint definition contracts".
+  Plan: |-
+    1. Inspect existing blueprint model and resolver types.
+    2. Add typed BlueprintDefinition and BlueprintState contracts without command execution.
+    3. Cover lifecycle metadata: states, required evidence, allowed commands, policy modules, stop rules, mutation scope, and task-kind compatibility.
+    4. Export the contract from the blueprint module boundary.
+    5. Add focused unit tests for valid definitions and invalid contract shapes.
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-05T22:18:24.723Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: executable blueprint definition contracts now include state metadata, policy modules, command boundaries, context budget, materialized plan typing, and focused validation coverage.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-05T22:07:05.609Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Commands passed: bun test blueprint/runner focused suite; bun run typecheck; targeted eslint; bun run schemas:check; bun run docs:cli:check; git diff --check; policy routing; agentplane doctor.
+      Impact: Blueprint definitions are now usable as an executable route contract without automatic state execution.
+      Resolution: Added typed plan metadata, validation, exports, tests, and documentation.
+      Promotion: incident-candidate
+      Fixability: external
+id_source: "generated"
+---
+## Summary
+
+Define executable blueprint definition contracts
+
+Add the first implementation task for blueprint execution contracts: define typed BlueprintDefinition and BlueprintState shapes without command execution, covering states, required evidence, allowed commands, policy modules, stop rules, and resolver-facing metadata.
+
+## Scope
+
+- In scope: Add the first implementation task for blueprint execution contracts: define typed BlueprintDefinition and BlueprintState shapes without command execution, covering states, required evidence, allowed commands, policy modules, stop rules, and resolver-facing metadata.
+- Out of scope: unrelated refactors not required for "Define executable blueprint definition contracts".
+
+## Plan
+
+1. Inspect existing blueprint model and resolver types.
+2. Add typed BlueprintDefinition and BlueprintState contracts without command execution.
+3. Cover lifecycle metadata: states, required evidence, allowed commands, policy modules, stop rules, mutation scope, and task-kind compatibility.
+4. Export the contract from the blueprint module boundary.
+5. Add focused unit tests for valid definitions and invalid contract shapes.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-05T22:18:24.723Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: executable blueprint definition contracts now include state metadata, policy modules, command boundaries, context budget, materialized plan typing, and focused validation coverage.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-05T22:07:05.609Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Commands passed: bun test blueprint/runner focused suite; bun run typecheck; targeted eslint; bun run schemas:check; bun run docs:cli:check; git diff --check; policy routing; agentplane doctor.
+  Impact: Blueprint definitions are now usable as an executable route contract without automatic state execution.
+  Resolution: Added typed plan metadata, validation, exports, tests, and documentation.
+  Promotion: incident-candidate
+  Fixability: external

--- a/.agentplane/tasks/202605052203-WH7G6R/pr/diffstat.txt
+++ b/.agentplane/tasks/202605052203-WH7G6R/pr/diffstat.txt
@@ -1,0 +1,20 @@
+ .agentplane/tasks/202605052204-4XSTAA/README.md    | 139 ++++++++++++++
+ .agentplane/tasks/202605052204-50B7J9/README.md    | 139 ++++++++++++++
+ .agentplane/tasks/202605052204-AJBX3D/README.md    | 139 ++++++++++++++
+ .agentplane/tasks/202605052204-GD17KQ/README.md    | 139 ++++++++++++++
+ .agentplane/tasks/202605052204-WJ25N8/README.md    | 139 ++++++++++++++
+ docs/developer/blueprints.mdx                      |  35 ++--
+ packages/agentplane/src/blueprints/builtins.ts     | 200 +++++++++++++++++++--
+ packages/agentplane/src/blueprints/explain.ts      |  32 ++--
+ packages/agentplane/src/blueprints/index.ts        |   7 +
+ packages/agentplane/src/blueprints/model.ts        |  55 ++++++
+ packages/agentplane/src/blueprints/plan.ts         |  88 +++++++++
+ packages/agentplane/src/blueprints/resolve.test.ts |  59 ++++++
+ packages/agentplane/src/blueprints/validate.ts     |   9 +
+ .../run-cli.core.tasks.query-run-prepare.test.ts   |  28 +++
+ .../src/commands/blueprint/blueprint.command.ts    |   1 +
+ .../agentplane/src/commands/task/run-output.ts     |  15 ++
+ .../src/commands/task/run-show.command.ts          |  20 +++
+ packages/agentplane/src/runner/types/context.ts    |   2 +
+ .../agentplane/src/runner/usecases/task-run.ts     |  94 ++++++++++
+ 19 files changed, 1302 insertions(+), 38 deletions(-)

--- a/.agentplane/tasks/202605052203-WH7G6R/pr/github-body.md
+++ b/.agentplane/tasks/202605052203-WH7G6R/pr/github-body.md
@@ -25,12 +25,31 @@ Add the first implementation task for blueprint execution contracts: define type
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-05T22:07:05.694Z
+- Updated: 2026-05-05T22:20:45.673Z
 - Branch: task/202605052203-WH7G6R/executable-blueprint-contracts
-- Head: e05d0336237d
+- Head: 745e035230ef
 
 ```text
-No changes detected.
+ .agentplane/tasks/202605052204-4XSTAA/README.md    | 139 ++++++++++++++
+ .agentplane/tasks/202605052204-50B7J9/README.md    | 139 ++++++++++++++
+ .agentplane/tasks/202605052204-AJBX3D/README.md    | 139 ++++++++++++++
+ .agentplane/tasks/202605052204-GD17KQ/README.md    | 139 ++++++++++++++
+ .agentplane/tasks/202605052204-WJ25N8/README.md    | 139 ++++++++++++++
+ docs/developer/blueprints.mdx                      |  35 ++--
+ packages/agentplane/src/blueprints/builtins.ts     | 200 +++++++++++++++++++--
+ packages/agentplane/src/blueprints/explain.ts      |  32 ++--
+ packages/agentplane/src/blueprints/index.ts        |   7 +
+ packages/agentplane/src/blueprints/model.ts        |  55 ++++++
+ packages/agentplane/src/blueprints/plan.ts         |  88 +++++++++
+ packages/agentplane/src/blueprints/resolve.test.ts |  59 ++++++
+ packages/agentplane/src/blueprints/validate.ts     |   9 +
+ .../run-cli.core.tasks.query-run-prepare.test.ts   |  28 +++
+ .../src/commands/blueprint/blueprint.command.ts    |   1 +
+ .../agentplane/src/commands/task/run-output.ts     |  15 ++
+ .../src/commands/task/run-show.command.ts          |  20 +++
+ packages/agentplane/src/runner/types/context.ts    |   2 +
+ .../agentplane/src/runner/usecases/task-run.ts     |  94 ++++++++++
+ 19 files changed, 1302 insertions(+), 38 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605052203-WH7G6R/pr/github-body.md
+++ b/.agentplane/tasks/202605052203-WH7G6R/pr/github-body.md
@@ -1,0 +1,36 @@
+Task: `202605052203-WH7G6R`
+Title: Define executable blueprint definition contracts
+
+## Summary
+
+Define executable blueprint definition contracts
+
+Add the first implementation task for blueprint execution contracts: define typed BlueprintDefinition and BlueprintState shapes without command execution, covering states, required evidence, allowed commands, policy modules, stop rules, and resolver-facing metadata.
+
+## Scope
+
+- In scope: Add the first implementation task for blueprint execution contracts: define typed BlueprintDefinition and BlueprintState shapes without command execution, covering states, required evidence, allowed commands, policy modules, stop rules, and resolver-facing metadata.
+- Out of scope: unrelated refactors not required for "Define executable blueprint definition contracts".
+
+## Verification
+
+- State: ok
+- Note: Verified: executable blueprint definition contracts now include state metadata, policy modules, command boundaries, context budget, materialized plan typing, and focused validation coverage.
+- Full verification checklist lives in local review.md.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-05T22:07:05.694Z
+- Branch: task/202605052203-WH7G6R/executable-blueprint-contracts
+- Head: e05d0336237d
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605052203-WH7G6R/pr/github-title.txt
+++ b/.agentplane/tasks/202605052203-WH7G6R/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 WH7G6R task: Define executable blueprint definition contracts [202605052203-WH7G6R]

--- a/.agentplane/tasks/202605052203-WH7G6R/pr/meta.json
+++ b/.agentplane/tasks/202605052203-WH7G6R/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605052203-WH7G6R/executable-blueprint-contracts",
+  "created_at": "2026-05-05T22:07:05.694Z",
+  "head_sha": "e05d0336237ddd6ef1f090c36b0559a9a1e3ff3b",
+  "last_verified_at": "2026-05-05T22:18:24.723Z",
+  "last_verified_sha": "e05d0336237ddd6ef1f090c36b0559a9a1e3ff3b",
+  "schema_version": 1,
+  "task_id": "202605052203-WH7G6R",
+  "updated_at": "2026-05-05T22:07:05.694Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605052203-WH7G6R/pr/meta.json
+++ b/.agentplane/tasks/202605052203-WH7G6R/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605052203-WH7G6R/executable-blueprint-contracts",
   "created_at": "2026-05-05T22:07:05.694Z",
-  "head_sha": "e05d0336237ddd6ef1f090c36b0559a9a1e3ff3b",
+  "head_sha": "745e035230ef30693616be0336c1813b84144c28",
   "last_verified_at": "2026-05-05T22:18:24.723Z",
   "last_verified_sha": "e05d0336237ddd6ef1f090c36b0559a9a1e3ff3b",
   "schema_version": 1,
   "task_id": "202605052203-WH7G6R",
-  "updated_at": "2026-05-05T22:07:05.694Z",
+  "updated_at": "2026-05-05T22:20:45.673Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605052203-WH7G6R/pr/review.md
+++ b/.agentplane/tasks/202605052203-WH7G6R/pr/review.md
@@ -1,0 +1,57 @@
+# PR Review
+
+Created: 2026-05-05T22:07:05.694Z
+Branch: task/202605052203-WH7G6R/executable-blueprint-contracts
+
+## Summary
+
+Define executable blueprint definition contracts
+
+Add the first implementation task for blueprint execution contracts: define typed BlueprintDefinition and BlueprintState shapes without command execution, covering states, required evidence, allowed commands, policy modules, stop rules, and resolver-facing metadata.
+
+## Scope
+
+- In scope: Add the first implementation task for blueprint execution contracts: define typed BlueprintDefinition and BlueprintState shapes without command execution, covering states, required evidence, allowed commands, policy modules, stop rules, and resolver-facing metadata.
+- Out of scope: unrelated refactors not required for "Define executable blueprint definition contracts".
+
+## Verification
+
+### Plan
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+### Current Status
+
+- State: ok
+- Note: Verified: executable blueprint definition contracts now include state metadata, policy modules, command boundaries, context budget, materialized plan typing, and focused validation coverage.
+
+## Risks
+
+- Risk level: not recorded
+- Breaking change: no
+
+### Rollback
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-05T22:07:05.694Z
+- Branch: task/202605052203-WH7G6R/executable-blueprint-contracts
+- Head: e05d0336237d
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605052203-WH7G6R/pr/review.md
+++ b/.agentplane/tasks/202605052203-WH7G6R/pr/review.md
@@ -45,12 +45,31 @@ Add the first implementation task for blueprint execution contracts: define type
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-05T22:07:05.694Z
+- Updated: 2026-05-05T22:20:45.673Z
 - Branch: task/202605052203-WH7G6R/executable-blueprint-contracts
-- Head: e05d0336237d
+- Head: 745e035230ef
 
 ```text
-No changes detected.
+ .agentplane/tasks/202605052204-4XSTAA/README.md    | 139 ++++++++++++++
+ .agentplane/tasks/202605052204-50B7J9/README.md    | 139 ++++++++++++++
+ .agentplane/tasks/202605052204-AJBX3D/README.md    | 139 ++++++++++++++
+ .agentplane/tasks/202605052204-GD17KQ/README.md    | 139 ++++++++++++++
+ .agentplane/tasks/202605052204-WJ25N8/README.md    | 139 ++++++++++++++
+ docs/developer/blueprints.mdx                      |  35 ++--
+ packages/agentplane/src/blueprints/builtins.ts     | 200 +++++++++++++++++++--
+ packages/agentplane/src/blueprints/explain.ts      |  32 ++--
+ packages/agentplane/src/blueprints/index.ts        |   7 +
+ packages/agentplane/src/blueprints/model.ts        |  55 ++++++
+ packages/agentplane/src/blueprints/plan.ts         |  88 +++++++++
+ packages/agentplane/src/blueprints/resolve.test.ts |  59 ++++++
+ packages/agentplane/src/blueprints/validate.ts     |   9 +
+ .../run-cli.core.tasks.query-run-prepare.test.ts   |  28 +++
+ .../src/commands/blueprint/blueprint.command.ts    |   1 +
+ .../agentplane/src/commands/task/run-output.ts     |  15 ++
+ .../src/commands/task/run-show.command.ts          |  20 +++
+ packages/agentplane/src/runner/types/context.ts    |   2 +
+ .../agentplane/src/runner/usecases/task-run.ts     |  94 ++++++++++
+ 19 files changed, 1302 insertions(+), 38 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605052204-4XSTAA/README.md
+++ b/.agentplane/tasks/202605052204-4XSTAA/README.md
@@ -1,0 +1,139 @@
+---
+id: "202605052204-4XSTAA"
+title: "Expose blueprint plan explain surface"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on:
+  - "202605052204-WJ25N8"
+tags:
+  - "blueprints"
+  - "cli"
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-05T22:05:15.477Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-05T22:18:57.859Z"
+  updated_by: "CODER"
+  note: "Verified: blueprint explain output now includes materialized plan metadata: policy modules, allowed commands, context budget, context manifest count, evidence, recipe extensions, and stop reasons."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Extend blueprint explain output for the approved executable blueprint batch implementation."
+events:
+  -
+    type: "status"
+    at: "2026-05-05T22:07:30.789Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Extend blueprint explain output for the approved executable blueprint batch implementation."
+  -
+    type: "verify"
+    at: "2026-05-05T22:18:57.859Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: blueprint explain output now includes materialized plan metadata: policy modules, allowed commands, context budget, context manifest count, evidence, recipe extensions, and stop reasons."
+doc_version: 3
+doc_updated_at: "2026-05-05T22:18:57.866Z"
+doc_updated_by: "CODER"
+description: "Add the fourth implementation task for blueprint execution contracts: extend the blueprint explain surface so it reports the selected blueprint definition, why it was selected, state order, evidence requirements, policy modules, and any fallback or conflict signals."
+sections:
+  Summary: |-
+    Expose blueprint plan explain surface
+    
+    Add the fourth implementation task for blueprint execution contracts: extend the blueprint explain surface so it reports the selected blueprint definition, why it was selected, state order, evidence requirements, policy modules, and any fallback or conflict signals.
+  Scope: |-
+    - In scope: Add the fourth implementation task for blueprint execution contracts: extend the blueprint explain surface so it reports the selected blueprint definition, why it was selected, state order, evidence requirements, policy modules, and any fallback or conflict signals.
+    - Out of scope: unrelated refactors not required for "Expose blueprint plan explain surface".
+  Plan: |-
+    1. Extend the existing blueprint explain CLI/output surface.
+    2. Show selected blueprint id, selection reason, matched task intent, fallback signals, state order, required evidence, policy modules, and command boundaries.
+    3. Make ambiguous or conflicting signals visible without requiring model judgment inside the script.
+    4. Keep output compact enough for agent startup context.
+    5. Add CLI and formatter tests.
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-05T22:18:57.859Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: blueprint explain output now includes materialized plan metadata: policy modules, allowed commands, context budget, context manifest count, evidence, recipe extensions, and stop reasons.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-05T22:07:30.789Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Commands passed: full blueprint resolver/explain tests plus runner dry-run preparation tests, typecheck, targeted eslint, schemas, docs CLI freshness, policy routing, doctor, and diff check.
+      Impact: Agents and reviewers can see why a route was selected and what execution boundaries it carries before state execution exists.
+      Resolution: Extended explain output and JSON shape through the plan artifact.
+      Promotion: incident-candidate
+      Fixability: external
+id_source: "generated"
+---
+## Summary
+
+Expose blueprint plan explain surface
+
+Add the fourth implementation task for blueprint execution contracts: extend the blueprint explain surface so it reports the selected blueprint definition, why it was selected, state order, evidence requirements, policy modules, and any fallback or conflict signals.
+
+## Scope
+
+- In scope: Add the fourth implementation task for blueprint execution contracts: extend the blueprint explain surface so it reports the selected blueprint definition, why it was selected, state order, evidence requirements, policy modules, and any fallback or conflict signals.
+- Out of scope: unrelated refactors not required for "Expose blueprint plan explain surface".
+
+## Plan
+
+1. Extend the existing blueprint explain CLI/output surface.
+2. Show selected blueprint id, selection reason, matched task intent, fallback signals, state order, required evidence, policy modules, and command boundaries.
+3. Make ambiguous or conflicting signals visible without requiring model judgment inside the script.
+4. Keep output compact enough for agent startup context.
+5. Add CLI and formatter tests.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-05T22:18:57.859Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: blueprint explain output now includes materialized plan metadata: policy modules, allowed commands, context budget, context manifest count, evidence, recipe extensions, and stop reasons.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-05T22:07:30.789Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Commands passed: full blueprint resolver/explain tests plus runner dry-run preparation tests, typecheck, targeted eslint, schemas, docs CLI freshness, policy routing, doctor, and diff check.
+  Impact: Agents and reviewers can see why a route was selected and what execution boundaries it carries before state execution exists.
+  Resolution: Extended explain output and JSON shape through the plan artifact.
+  Promotion: incident-candidate
+  Fixability: external

--- a/.agentplane/tasks/202605052204-50B7J9/README.md
+++ b/.agentplane/tasks/202605052204-50B7J9/README.md
@@ -1,0 +1,139 @@
+---
+id: "202605052204-50B7J9"
+title: "Show blueprint and context budget in runner bundle"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on:
+  - "202605052204-GD17KQ"
+tags:
+  - "blueprints"
+  - "code"
+  - "runner"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-05T22:05:21.399Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-05T22:19:19.191Z"
+  updated_by: "CODER"
+  note: "Verified: runner bundle and task run inspection output now surface selected blueprint, selected recipe, context budget, policy modules, context manifest, and evidence checklist."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Surface selected blueprint, recipe, context budget, policy modules, and evidence checklist in runner bundle output for the approved batch."
+events:
+  -
+    type: "status"
+    at: "2026-05-05T22:07:39.868Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Surface selected blueprint, recipe, context budget, policy modules, and evidence checklist in runner bundle output for the approved batch."
+  -
+    type: "verify"
+    at: "2026-05-05T22:19:19.191Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: runner bundle and task run inspection output now surface selected blueprint, selected recipe, context budget, policy modules, context manifest, and evidence checklist."
+doc_version: 3
+doc_updated_at: "2026-05-05T22:19:19.197Z"
+doc_updated_by: "CODER"
+description: "Add the sixth implementation task for blueprint execution contracts: surface selected blueprint, selected recipe, loaded context rationale, context budget, policy modules, and evidence checklist in runner bundle output for auditability."
+sections:
+  Summary: |-
+    Show blueprint and context budget in runner bundle
+    
+    Add the sixth implementation task for blueprint execution contracts: surface selected blueprint, selected recipe, loaded context rationale, context budget, policy modules, and evidence checklist in runner bundle output for auditability.
+  Scope: |-
+    - In scope: Add the sixth implementation task for blueprint execution contracts: surface selected blueprint, selected recipe, loaded context rationale, context budget, policy modules, and evidence checklist in runner bundle output for auditability.
+    - Out of scope: unrelated refactors not required for "Show blueprint and context budget in runner bundle".
+  Plan: |-
+    1. Locate runner bundle assembly and current context reporting surfaces.
+    2. Add selected blueprint and selected recipe metadata to runner bundle output.
+    3. Include loaded context rationale, context budget, policy modules, and evidence checklist.
+    4. Validate that unrelated policy modules are not reported as loaded.
+    5. Add snapshot or focused tests for runner bundle visibility.
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-05T22:19:19.191Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: runner bundle and task run inspection output now surface selected blueprint, selected recipe, context budget, policy modules, context manifest, and evidence checklist.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-05T22:07:39.868Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Commands passed: runner dry-run preparation suite, full blueprint tests, typecheck, targeted eslint, schemas, docs CLI freshness, policy routing, doctor, and diff check.
+      Impact: Runner consumers can audit the route and context boundaries from bundle.json and CLI inspection output.
+      Resolution: Added blueprint plan to RunnerContextBundle and surfaced the audit fields in dry-run and run-show output.
+      Promotion: incident-candidate
+      Fixability: external
+id_source: "generated"
+---
+## Summary
+
+Show blueprint and context budget in runner bundle
+
+Add the sixth implementation task for blueprint execution contracts: surface selected blueprint, selected recipe, loaded context rationale, context budget, policy modules, and evidence checklist in runner bundle output for auditability.
+
+## Scope
+
+- In scope: Add the sixth implementation task for blueprint execution contracts: surface selected blueprint, selected recipe, loaded context rationale, context budget, policy modules, and evidence checklist in runner bundle output for auditability.
+- Out of scope: unrelated refactors not required for "Show blueprint and context budget in runner bundle".
+
+## Plan
+
+1. Locate runner bundle assembly and current context reporting surfaces.
+2. Add selected blueprint and selected recipe metadata to runner bundle output.
+3. Include loaded context rationale, context budget, policy modules, and evidence checklist.
+4. Validate that unrelated policy modules are not reported as loaded.
+5. Add snapshot or focused tests for runner bundle visibility.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-05T22:19:19.191Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: runner bundle and task run inspection output now surface selected blueprint, selected recipe, context budget, policy modules, context manifest, and evidence checklist.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-05T22:07:39.868Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Commands passed: runner dry-run preparation suite, full blueprint tests, typecheck, targeted eslint, schemas, docs CLI freshness, policy routing, doctor, and diff check.
+  Impact: Runner consumers can audit the route and context boundaries from bundle.json and CLI inspection output.
+  Resolution: Added blueprint plan to RunnerContextBundle and surfaced the audit fields in dry-run and run-show output.
+  Promotion: incident-candidate
+  Fixability: external

--- a/.agentplane/tasks/202605052204-AJBX3D/README.md
+++ b/.agentplane/tasks/202605052204-AJBX3D/README.md
@@ -1,0 +1,139 @@
+---
+id: "202605052204-AJBX3D"
+title: "Add initial blueprint registry data"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on:
+  - "202605052203-WH7G6R"
+tags:
+  - "blueprints"
+  - "code"
+  - "registry"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-05T22:05:10.304Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-05T22:18:37.874Z"
+  updated_by: "CODER"
+  note: "Verified: initial blueprint registry data now carries executable contract metadata for built-in analysis, content, docs, code, release, and ops routes."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Implement the initial blueprint registry using the executable definition contract from the primary batch task."
+events:
+  -
+    type: "status"
+    at: "2026-05-05T22:07:22.427Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Implement the initial blueprint registry using the executable definition contract from the primary batch task."
+  -
+    type: "verify"
+    at: "2026-05-05T22:18:37.874Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: initial blueprint registry data now carries executable contract metadata for built-in analysis, content, docs, code, release, and ops routes."
+doc_version: 3
+doc_updated_at: "2026-05-05T22:18:37.892Z"
+doc_updated_by: "CODER"
+description: "Add the second implementation task for blueprint execution contracts: introduce a registry of initial blueprint definitions for analysis.light, content.light, docs.change, code.branch_pr, release.strict, and ops.approval using the typed contract from the preceding task."
+sections:
+  Summary: |-
+    Add initial blueprint registry data
+    
+    Add the second implementation task for blueprint execution contracts: introduce a registry of initial blueprint definitions for analysis.light, content.light, docs.change, code.branch_pr, release.strict, and ops.approval using the typed contract from the preceding task.
+  Scope: |-
+    - In scope: Add the second implementation task for blueprint execution contracts: introduce a registry of initial blueprint definitions for analysis.light, content.light, docs.change, code.branch_pr, release.strict, and ops.approval using the typed contract from the preceding task.
+    - Out of scope: unrelated refactors not required for "Add initial blueprint registry data".
+  Plan: |-
+    1. Build on the typed blueprint definition contract.
+    2. Add a static registry for initial blueprints: analysis.light, content.light, docs.change, code.branch_pr, release.strict, and ops.approval.
+    3. Encode lightweight analysis/content routes without CI or PR states.
+    4. Encode code/release routes with heavier evidence and policy expectations.
+    5. Add registry lookup and validation tests.
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-05T22:18:37.874Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: initial blueprint registry data now carries executable contract metadata for built-in analysis, content, docs, code, release, and ops routes.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-05T22:07:22.427Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Commands passed: full blueprint validation tests, resolver tests, runner dry-run preparation tests, typecheck, targeted eslint, schemas, docs CLI freshness, policy routing, doctor, and diff check.
+      Impact: Built-in routes now expose allowed commands, policy modules, and context budgets while preserving lightweight analysis/content behavior.
+      Resolution: Extended built-ins and tests without adding automatic state execution.
+      Promotion: incident-candidate
+      Fixability: external
+id_source: "generated"
+---
+## Summary
+
+Add initial blueprint registry data
+
+Add the second implementation task for blueprint execution contracts: introduce a registry of initial blueprint definitions for analysis.light, content.light, docs.change, code.branch_pr, release.strict, and ops.approval using the typed contract from the preceding task.
+
+## Scope
+
+- In scope: Add the second implementation task for blueprint execution contracts: introduce a registry of initial blueprint definitions for analysis.light, content.light, docs.change, code.branch_pr, release.strict, and ops.approval using the typed contract from the preceding task.
+- Out of scope: unrelated refactors not required for "Add initial blueprint registry data".
+
+## Plan
+
+1. Build on the typed blueprint definition contract.
+2. Add a static registry for initial blueprints: analysis.light, content.light, docs.change, code.branch_pr, release.strict, and ops.approval.
+3. Encode lightweight analysis/content routes without CI or PR states.
+4. Encode code/release routes with heavier evidence and policy expectations.
+5. Add registry lookup and validation tests.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-05T22:18:37.874Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: initial blueprint registry data now carries executable contract metadata for built-in analysis, content, docs, code, release, and ops routes.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-05T22:07:22.427Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Commands passed: full blueprint validation tests, resolver tests, runner dry-run preparation tests, typecheck, targeted eslint, schemas, docs CLI freshness, policy routing, doctor, and diff check.
+  Impact: Built-in routes now expose allowed commands, policy modules, and context budgets while preserving lightweight analysis/content behavior.
+  Resolution: Extended built-ins and tests without adding automatic state execution.
+  Promotion: incident-candidate
+  Fixability: external

--- a/.agentplane/tasks/202605052204-GD17KQ/README.md
+++ b/.agentplane/tasks/202605052204-GD17KQ/README.md
@@ -1,0 +1,139 @@
+---
+id: "202605052204-GD17KQ"
+title: "Bind recipes to blueprint definitions"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on:
+  - "202605052204-4XSTAA"
+tags:
+  - "blueprints"
+  - "code"
+  - "recipes"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-05T22:05:18.022Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-05T22:19:07.570Z"
+  updated_by: "CODER"
+  note: "Verified: recipe blueprint extensions remain bound to typed blueprint definitions and runner bundle preparation now resolves recipe manifest blueprint hints into the selected plan."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Bind recipe hints to typed blueprint definitions within the approved executable blueprint batch implementation."
+events:
+  -
+    type: "status"
+    at: "2026-05-05T22:07:34.627Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Bind recipe hints to typed blueprint definitions within the approved executable blueprint batch implementation."
+  -
+    type: "verify"
+    at: "2026-05-05T22:19:07.570Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: recipe blueprint extensions remain bound to typed blueprint definitions and runner bundle preparation now resolves recipe manifest blueprint hints into the selected plan."
+doc_version: 3
+doc_updated_at: "2026-05-05T22:19:07.579Z"
+doc_updated_by: "CODER"
+description: "Add the fifth implementation task for blueprint execution contracts: connect recipe hints to typed blueprint definitions so recipes describe domain method while blueprints describe lifecycle route, without making code PR workflow the default for analysis or content tasks."
+sections:
+  Summary: |-
+    Bind recipes to blueprint definitions
+    
+    Add the fifth implementation task for blueprint execution contracts: connect recipe hints to typed blueprint definitions so recipes describe domain method while blueprints describe lifecycle route, without making code PR workflow the default for analysis or content tasks.
+  Scope: |-
+    - In scope: Add the fifth implementation task for blueprint execution contracts: connect recipe hints to typed blueprint definitions so recipes describe domain method while blueprints describe lifecycle route, without making code PR workflow the default for analysis or content tasks.
+    - Out of scope: unrelated refactors not required for "Bind recipes to blueprint definitions".
+  Plan: |-
+    1. Inspect the current recipe hint model and blueprint resolver bridge.
+    2. Bind recipes to typed blueprint definitions through explicit hint fields rather than title keywords.
+    3. Preserve the separation: recipe describes domain method; blueprint describes lifecycle route.
+    4. Ensure analysis/content recipes can bind to lightweight blueprints without CI or PR defaults.
+    5. Add tests for recipe-preferred blueprint selection and conflict handling.
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-05T22:19:07.570Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: recipe blueprint extensions remain bound to typed blueprint definitions and runner bundle preparation now resolves recipe manifest blueprint hints into the selected plan.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-05T22:07:34.627Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Commands passed: blueprint resolver recipe-hint tests, runner dry-run tests, typecheck, targeted eslint, schemas, docs CLI freshness, policy routing, doctor, and diff check.
+      Impact: Recipes can influence compatible blueprint selection and context/evidence hints without overriding protected lifecycle gates.
+      Resolution: Connected recipe manifest blueprint extensions to runner blueprint plan resolution and preserved resolver safeguards.
+      Promotion: incident-candidate
+      Fixability: external
+id_source: "generated"
+---
+## Summary
+
+Bind recipes to blueprint definitions
+
+Add the fifth implementation task for blueprint execution contracts: connect recipe hints to typed blueprint definitions so recipes describe domain method while blueprints describe lifecycle route, without making code PR workflow the default for analysis or content tasks.
+
+## Scope
+
+- In scope: Add the fifth implementation task for blueprint execution contracts: connect recipe hints to typed blueprint definitions so recipes describe domain method while blueprints describe lifecycle route, without making code PR workflow the default for analysis or content tasks.
+- Out of scope: unrelated refactors not required for "Bind recipes to blueprint definitions".
+
+## Plan
+
+1. Inspect the current recipe hint model and blueprint resolver bridge.
+2. Bind recipes to typed blueprint definitions through explicit hint fields rather than title keywords.
+3. Preserve the separation: recipe describes domain method; blueprint describes lifecycle route.
+4. Ensure analysis/content recipes can bind to lightweight blueprints without CI or PR defaults.
+5. Add tests for recipe-preferred blueprint selection and conflict handling.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-05T22:19:07.570Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: recipe blueprint extensions remain bound to typed blueprint definitions and runner bundle preparation now resolves recipe manifest blueprint hints into the selected plan.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-05T22:07:34.627Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Commands passed: blueprint resolver recipe-hint tests, runner dry-run tests, typecheck, targeted eslint, schemas, docs CLI freshness, policy routing, doctor, and diff check.
+  Impact: Recipes can influence compatible blueprint selection and context/evidence hints without overriding protected lifecycle gates.
+  Resolution: Connected recipe manifest blueprint extensions to runner blueprint plan resolution and preserved resolver safeguards.
+  Promotion: incident-candidate
+  Fixability: external

--- a/.agentplane/tasks/202605052204-WJ25N8/README.md
+++ b/.agentplane/tasks/202605052204-WJ25N8/README.md
@@ -1,0 +1,139 @@
+---
+id: "202605052204-WJ25N8"
+title: "Materialize selected blueprint plans on tasks"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on:
+  - "202605052204-AJBX3D"
+tags:
+  - "blueprints"
+  - "code"
+  - "tasks"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-05T22:05:13.044Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-05T22:18:47.757Z"
+  updated_by: "CODER"
+  note: "Verified: selected blueprint plans are materialized as structured plan objects with selection rationale, states, evidence checklist, policy modules, allowed commands, and context manifest."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Materialize selected blueprint plan artifacts as part of the approved executable blueprint batch implementation."
+events:
+  -
+    type: "status"
+    at: "2026-05-05T22:07:27.137Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Materialize selected blueprint plan artifacts as part of the approved executable blueprint batch implementation."
+  -
+    type: "verify"
+    at: "2026-05-05T22:18:47.757Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: selected blueprint plans are materialized as structured plan objects with selection rationale, states, evidence checklist, policy modules, allowed commands, and context manifest."
+doc_version: 3
+doc_updated_at: "2026-05-05T22:18:47.765Z"
+doc_updated_by: "CODER"
+description: "Add the third implementation task for blueprint execution contracts: persist the selected blueprint, selection rationale, ordered states, required evidence, policy modules, and command boundaries as a task artifact when a task route is resolved."
+sections:
+  Summary: |-
+    Materialize selected blueprint plans on tasks
+    
+    Add the third implementation task for blueprint execution contracts: persist the selected blueprint, selection rationale, ordered states, required evidence, policy modules, and command boundaries as a task artifact when a task route is resolved.
+  Scope: |-
+    - In scope: Add the third implementation task for blueprint execution contracts: persist the selected blueprint, selection rationale, ordered states, required evidence, policy modules, and command boundaries as a task artifact when a task route is resolved.
+    - Out of scope: unrelated refactors not required for "Materialize selected blueprint plans on tasks".
+  Plan: |-
+    1. Extend blueprint resolution output to include the selected definition and rationale.
+    2. Persist a task-local blueprint plan artifact with selected blueprint id, why_selected, ordered states, required evidence, policy modules, and command boundaries.
+    3. Keep the artifact descriptive first; do not execute states automatically.
+    4. Ensure repeated resolution is deterministic and does not add noisy churn.
+    5. Add tests for artifact content and no-extra-policy behavior.
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-05T22:18:47.757Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: selected blueprint plans are materialized as structured plan objects with selection rationale, states, evidence checklist, policy modules, allowed commands, and context manifest.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-05T22:07:27.137Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Commands passed: focused blueprint and runner dry-run tests; typecheck; targeted eslint; schemas; docs CLI freshness; policy routing; doctor; diff check.
+      Impact: Resolved routes can now be audited as data in explain output and runner bundle artifacts.
+      Resolution: Added buildBlueprintPlanArtifact and wired it into explain and runner bundle preparation.
+      Promotion: incident-candidate
+      Fixability: external
+id_source: "generated"
+---
+## Summary
+
+Materialize selected blueprint plans on tasks
+
+Add the third implementation task for blueprint execution contracts: persist the selected blueprint, selection rationale, ordered states, required evidence, policy modules, and command boundaries as a task artifact when a task route is resolved.
+
+## Scope
+
+- In scope: Add the third implementation task for blueprint execution contracts: persist the selected blueprint, selection rationale, ordered states, required evidence, policy modules, and command boundaries as a task artifact when a task route is resolved.
+- Out of scope: unrelated refactors not required for "Materialize selected blueprint plans on tasks".
+
+## Plan
+
+1. Extend blueprint resolution output to include the selected definition and rationale.
+2. Persist a task-local blueprint plan artifact with selected blueprint id, why_selected, ordered states, required evidence, policy modules, and command boundaries.
+3. Keep the artifact descriptive first; do not execute states automatically.
+4. Ensure repeated resolution is deterministic and does not add noisy churn.
+5. Add tests for artifact content and no-extra-policy behavior.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-05T22:18:47.757Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: selected blueprint plans are materialized as structured plan objects with selection rationale, states, evidence checklist, policy modules, allowed commands, and context manifest.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-05T22:07:27.137Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Commands passed: focused blueprint and runner dry-run tests; typecheck; targeted eslint; schemas; docs CLI freshness; policy routing; doctor; diff check.
+  Impact: Resolved routes can now be audited as data in explain output and runner bundle artifacts.
+  Resolution: Added buildBlueprintPlanArtifact and wired it into explain and runner bundle preparation.
+  Promotion: incident-candidate
+  Fixability: external

--- a/docs/developer/blueprints.mdx
+++ b/docs/developer/blueprints.mdx
@@ -756,6 +756,9 @@ route
 selection_reasons
 workflow_mode
 required_evidence
+policy_modules
+allowed_commands
+context_budget
 accepted_recipe_extensions
 rejected_recipe_extensions
 stop_reasons
@@ -804,29 +807,31 @@ record enough structured evidence to audit which route was used and why the resu
 
 ## Runner Relationship
 
-Runner support should be incremental.
+Runner support is incremental.
 
-v0 should support model, registry, validation, resolution, and explanation:
+v0.5 supports model, registry, validation, resolution, explanation, and a non-executing
+materialized plan in runner bundles:
 
 ```text
 validate built-ins
 resolve from task metadata
 explain resolved route
 surface expected evidence
+include selected blueprint plan in bundle.json
 ```
 
-Later runner work can consume the resolved blueprint as a graph. The first implementation should
-not attempt a full workflow engine.
+Later runner work can consume the resolved blueprint as a graph. The current implementation still
+does not execute blueprint states automatically.
 
 ## Context Relationship
 
-Blueprints should eventually constrain context loading, but that is not part of the first code PR.
+Blueprints now expose the first context contract in explain output and runner bundles.
 
-Future context contract:
+Current context contract:
 
 - `context_resolve` records why each policy module, recipe, file group, or tool profile was loaded.
 - runner bundles expose a context budget and loaded context manifest.
-- validation rejects policy modules that are unrelated to the resolved blueprint.
+- explain output and runner bundles expose the blueprint's allowed policy modules.
 - ACR records context manifest references, not full raw context.
 
 This is broader than ACR. ACR records what happened after execution; the runner bundle and resolver
@@ -847,8 +852,9 @@ Blueprint resolution must stop or require re-approval when:
 
 ## Implementation Status
 
-The first implementation is split into small surfaces. v0.5 rc1 completes PR 1 through PR 5 and the
-minimal ACR part of PR 6. Runner execution remains deferred.
+The first implementation is split into small surfaces. v0.5 rc1 completed PR 1 through PR 5 and
+the minimal ACR part of PR 6. The follow-up executable-contract layer adds materialized blueprint
+plans to explain output and runner bundles while keeping automatic state execution deferred.
 
 ### PR 1: Model, built-ins, registry, validation
 
@@ -916,7 +922,9 @@ Acceptance:
 
 ### PR 4: Verification surface
 
-Status: shipped in rc1 for `task verify-show`; task-local `blueprint.json` snapshots remain deferred.
+Status: shipped in rc1 for `task verify-show`; materialized blueprint plans now ship through
+`blueprint explain` and runner `bundle.json`. Standalone task-local `blueprint.json` snapshots remain
+deferred.
 
 Scope:
 
@@ -947,12 +955,15 @@ Acceptance:
 
 ### PR 6: ACR and runner handoff
 
-Status: shipped in rc1 for ACR summary fields only; runner bundle handoff remains deferred.
+Status: shipped in rc1 for ACR summary fields; runner bundle handoff now includes the selected
+blueprint plan.
 
 Scope:
 
 - record blueprint id, version, route, skipped nodes, evidence refs, and stop reason in ACR;
-- pass resolved blueprint summary to runner bundles.
+- pass resolved blueprint summary to runner bundles;
+- expose selected recipe, context budget, policy modules, allowed commands, and evidence checklist
+  in runner bundle output.
 
 Acceptance:
 

--- a/packages/agentplane/src/blueprints/builtins.ts
+++ b/packages/agentplane/src/blueprints/builtins.ts
@@ -1,5 +1,6 @@
 import type {
   Blueprint,
+  BlueprintContextBudget,
   BlueprintEdge,
   BlueprintId,
   BlueprintNode,
@@ -16,6 +17,8 @@ type NodeSpec = {
   mode?: BlueprintNode["mode"];
   evidence?: readonly EvidenceKind[];
   protected?: boolean;
+  allowedCommands?: readonly string[];
+  policyModules?: readonly string[];
 };
 
 const CORE_STOP_RULES: readonly StopRule[] = [
@@ -56,6 +59,8 @@ function node(spec: NodeSpec): BlueprintNode {
     mode: spec.mode ?? NODE_MODE_BY_KIND[spec.kind],
     required: true,
     ...(spec.protected ? { protected: true } : {}),
+    ...(spec.allowedCommands ? { allowedCommands: spec.allowedCommands } : {}),
+    ...(spec.policyModules ? { policyModules: spec.policyModules } : {}),
     ...(spec.evidence ? { evidence: spec.evidence } : {}),
   };
 }
@@ -91,6 +96,9 @@ function blueprint(opts: {
   description: string;
   taskKinds: readonly TaskKind[];
   workflowModes?: readonly WorkflowMode[];
+  allowedCommands: readonly string[];
+  policyModules: readonly string[];
+  contextBudget: BlueprintContextBudget;
   nodes: readonly BlueprintNode[];
   requiredEvidence: readonly EvidenceRequirement[];
   stopRules?: readonly StopRule[];
@@ -102,6 +110,9 @@ function blueprint(opts: {
     description: opts.description,
     taskKinds: opts.taskKinds,
     ...(opts.workflowModes ? { workflowModes: opts.workflowModes } : {}),
+    allowedCommands: opts.allowedCommands,
+    policyModules: opts.policyModules,
+    contextBudget: opts.contextBudget,
     nodes: opts.nodes,
     edges: edgesFor(opts.nodes),
     requiredEvidence: opts.requiredEvidence,
@@ -134,7 +145,11 @@ function blueprint(opts: {
 const analysisNodes = [
   node({ kind: "intake" }),
   node({ kind: "scope", evidence: ["assumptions"] }),
-  node({ kind: "context_resolve", evidence: ["context_manifest", "sources"] }),
+  node({
+    kind: "context_resolve",
+    evidence: ["context_manifest", "sources"],
+    policyModules: [],
+  }),
   node({ kind: "work_unit", evidence: ["weak_links", "final_output"] }),
   node({ kind: "artifact_write", evidence: ["artifact"] }),
   node({ kind: "verify_record", evidence: ["final_output"], protected: true }),
@@ -144,7 +159,11 @@ const analysisNodes = [
 const contentNodes = [
   node({ kind: "intake" }),
   node({ kind: "scope", evidence: ["assumptions"] }),
-  node({ kind: "context_resolve", evidence: ["context_manifest", "sources"] }),
+  node({
+    kind: "context_resolve",
+    evidence: ["context_manifest", "sources"],
+    policyModules: [],
+  }),
   node({ kind: "work_unit", evidence: ["artifact", "final_output"] }),
   node({ kind: "deterministic_check", evidence: ["check_result"] }),
   node({ kind: "artifact_write", evidence: ["artifact"] }),
@@ -155,7 +174,15 @@ const contentNodes = [
 const docsNodes = [
   node({ kind: "intake" }),
   node({ kind: "scope", evidence: ["assumptions"] }),
-  node({ kind: "context_resolve", evidence: ["context_manifest"] }),
+  node({
+    kind: "context_resolve",
+    evidence: ["context_manifest"],
+    policyModules: [
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/dod.docs.md",
+    ],
+  }),
   node({ kind: "work_unit", evidence: ["changed_paths", "artifact"] }),
   node({ kind: "deterministic_check", evidence: ["check_result"] }),
   node({ kind: "artifact_write", evidence: ["artifact"] }),
@@ -167,9 +194,22 @@ const codeDirectNodes = [
   node({ kind: "intake" }),
   node({ kind: "scope", evidence: ["assumptions"] }),
   node({ kind: "approval_gate", evidence: ["approval"], protected: true }),
-  node({ kind: "context_resolve", evidence: ["context_manifest"] }),
+  node({
+    kind: "context_resolve",
+    evidence: ["context_manifest"],
+    policyModules: [
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/workflow.direct.md",
+    ],
+  }),
   node({ kind: "work_unit", evidence: ["changed_paths"] }),
-  node({ kind: "deterministic_check", evidence: ["check_result"] }),
+  node({
+    kind: "deterministic_check",
+    evidence: ["check_result"],
+    allowedCommands: ["agentplane task verify-show <task-id>", "project focused checks"],
+  }),
   node({ kind: "verify_record", evidence: ["check_result"], protected: true }),
   node({ kind: "finish", evidence: ["commit"], protected: true }),
 ] as const;
@@ -178,13 +218,40 @@ const codeBranchPrNodes = [
   node({ kind: "intake" }),
   node({ kind: "scope", evidence: ["assumptions"] }),
   node({ kind: "approval_gate", evidence: ["approval"], protected: true }),
-  node({ kind: "context_resolve", evidence: ["context_manifest"] }),
-  node({ kind: "worktree_start", evidence: ["changed_paths"], protected: true }),
+  node({
+    kind: "context_resolve",
+    evidence: ["context_manifest"],
+    policyModules: [
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/workflow.branch_pr.md",
+    ],
+  }),
+  node({
+    kind: "worktree_start",
+    evidence: ["changed_paths"],
+    protected: true,
+    allowedCommands: ["agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"],
+  }),
   node({ kind: "work_unit", evidence: ["changed_paths"] }),
-  node({ kind: "fast_local_checks", evidence: ["check_result"] }),
-  node({ kind: "pr_artifact", evidence: ["artifact", "external_link"] }),
+  node({
+    kind: "fast_local_checks",
+    evidence: ["check_result"],
+    allowedCommands: ["agentplane task verify-show <task-id>", "project focused checks"],
+  }),
+  node({
+    kind: "pr_artifact",
+    evidence: ["artifact", "external_link"],
+    allowedCommands: ["agentplane pr open <task-id> --branch <branch> --author <ROLE>"],
+  }),
   node({ kind: "hosted_checks", evidence: ["check_result", "external_link"] }),
-  node({ kind: "publish_or_integrate", evidence: ["commit", "external_link"], protected: true }),
+  node({
+    kind: "publish_or_integrate",
+    evidence: ["commit", "external_link"],
+    protected: true,
+    allowedCommands: ["agentplane integrate <task-id> --branch <branch> --run-verify"],
+  }),
   node({ kind: "verify_record", evidence: ["check_result"], protected: true }),
   node({ kind: "finish", evidence: ["commit"], protected: true }),
 ] as const;
@@ -193,7 +260,16 @@ const releaseNodes = [
   node({ kind: "intake" }),
   node({ kind: "scope", evidence: ["assumptions"] }),
   node({ kind: "approval_gate", evidence: ["approval"], protected: true }),
-  node({ kind: "context_resolve", evidence: ["context_manifest"] }),
+  node({
+    kind: "context_resolve",
+    evidence: ["context_manifest"],
+    policyModules: [
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/workflow.release.md",
+    ],
+  }),
   node({ kind: "work_unit", evidence: ["artifact"] }),
   node({ kind: "deterministic_check", evidence: ["check_result"] }),
   node({ kind: "publish_or_integrate", evidence: ["commit", "external_link"], protected: true }),
@@ -205,7 +281,11 @@ const opsNodes = [
   node({ kind: "intake" }),
   node({ kind: "scope", evidence: ["assumptions", "rollback"] }),
   node({ kind: "approval_gate", evidence: ["approval"], protected: true }),
-  node({ kind: "context_resolve", evidence: ["context_manifest"] }),
+  node({
+    kind: "context_resolve",
+    evidence: ["context_manifest"],
+    policyModules: [".agentplane/policy/security.must.md", ".agentplane/policy/dod.core.md"],
+  }),
   node({ kind: "work_unit", evidence: ["artifact", "rollback"] }),
   node({ kind: "deterministic_check", evidence: ["check_result"] }),
   node({ kind: "artifact_write", evidence: ["artifact"] }),
@@ -219,6 +299,14 @@ export const BUILTIN_BLUEPRINTS = [
     title: "Lightweight analysis",
     description: "Read-only analysis, research, review synthesis, and evidence-backed answers.",
     taskKinds: ["analysis"],
+    allowedCommands: [],
+    policyModules: [],
+    contextBudget: {
+      maxPolicyModules: 0,
+      maxPromptBlocks: 6,
+      rationale:
+        "Lightweight analysis should load sources and task context without policy modules.",
+    },
     nodes: analysisNodes,
     requiredEvidence: [
       evidence("analysis.sources", "sources", "context_resolve", "Sources used for analysis."),
@@ -232,6 +320,14 @@ export const BUILTIN_BLUEPRINTS = [
     title: "Lightweight content",
     description: "Content drafts and editorial artifacts that do not change product code.",
     taskKinds: ["content"],
+    allowedCommands: ["editorial or formatting checks"],
+    policyModules: [],
+    contextBudget: {
+      maxPolicyModules: 0,
+      maxPromptBlocks: 8,
+      rationale:
+        "Content work should favor source material and recipe context over workflow policy.",
+    },
     nodes: contentNodes,
     requiredEvidence: [
       evidence("content.sources", "sources", "context_resolve", "Source or product facts used."),
@@ -245,6 +341,21 @@ export const BUILTIN_BLUEPRINTS = [
     description: "Repository documentation and policy-adjacent prose changes.",
     taskKinds: ["docs"],
     workflowModes: ["direct", "branch_pr"],
+    allowedCommands: [
+      "agentplane task verify-show <task-id>",
+      "documentation checks",
+      "agentplane verify <task-id> --ok|--rework",
+    ],
+    policyModules: [
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/dod.docs.md",
+    ],
+    contextBudget: {
+      maxPolicyModules: 3,
+      maxPromptBlocks: 10,
+      rationale: "Documentation changes need docs DoD and minimal workflow/security policy.",
+    },
     nodes: docsNodes,
     requiredEvidence: [
       evidence("docs.paths", "changed_paths", "work_unit", "Changed documentation paths."),
@@ -258,6 +369,23 @@ export const BUILTIN_BLUEPRINTS = [
     description: "Code mutation in direct workflow mode.",
     taskKinds: ["code"],
     workflowModes: ["direct"],
+    allowedCommands: [
+      "agentplane task verify-show <task-id>",
+      "project focused checks",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane finish <task-id>",
+    ],
+    policyModules: [
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/workflow.direct.md",
+    ],
+    contextBudget: {
+      maxPolicyModules: 4,
+      maxPromptBlocks: 12,
+      rationale: "Direct code work needs code DoD plus the active direct workflow contract.",
+    },
     nodes: codeDirectNodes,
     requiredEvidence: [
       evidence("code_direct.paths", "changed_paths", "work_unit", "Changed source paths."),
@@ -271,6 +399,25 @@ export const BUILTIN_BLUEPRINTS = [
     description: "Code mutation in branch PR workflow mode.",
     taskKinds: ["code"],
     workflowModes: ["branch_pr"],
+    allowedCommands: [
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "agentplane task verify-show <task-id>",
+      "project focused checks",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+    ],
+    policyModules: [
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/workflow.branch_pr.md",
+    ],
+    contextBudget: {
+      maxPolicyModules: 4,
+      maxPromptBlocks: 14,
+      rationale: "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks.",
+    },
     nodes: codeBranchPrNodes,
     requiredEvidence: [
       evidence("code_pr.paths", "changed_paths", "work_unit", "Changed source paths."),
@@ -286,6 +433,24 @@ export const BUILTIN_BLUEPRINTS = [
     description: "Version, package, publish, and distribution work.",
     taskKinds: ["release"],
     workflowModes: ["direct", "branch_pr"],
+    allowedCommands: [
+      "agentplane task verify-show <task-id>",
+      "release gates",
+      "publish commands after approval",
+      "agentplane verify <task-id> --ok|--rework",
+    ],
+    policyModules: [
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/workflow.release.md",
+    ],
+    contextBudget: {
+      maxPolicyModules: 4,
+      maxPromptBlocks: 16,
+      rationale:
+        "Release work needs strict release policy, approval evidence, and rollback context.",
+    },
     nodes: releaseNodes,
     requiredEvidence: [
       evidence("release.approval", "approval", "approval_gate", "Release approval."),
@@ -301,6 +466,17 @@ export const BUILTIN_BLUEPRINTS = [
     description:
       "Operational changes touching external systems, credentials, deployments, or config.",
     taskKinds: ["ops"],
+    allowedCommands: [
+      "agentplane task verify-show <task-id>",
+      "approved operational command",
+      "agentplane verify <task-id> --ok|--rework",
+    ],
+    policyModules: [".agentplane/policy/security.must.md", ".agentplane/policy/dod.core.md"],
+    contextBudget: {
+      maxPolicyModules: 2,
+      maxPromptBlocks: 12,
+      rationale: "Ops work needs security and rollback context before any external action.",
+    },
     nodes: opsNodes,
     requiredEvidence: [
       evidence("ops.approval", "approval", "approval_gate", "Operational approval."),

--- a/packages/agentplane/src/blueprints/explain.ts
+++ b/packages/agentplane/src/blueprints/explain.ts
@@ -1,10 +1,11 @@
 import type {
-  BlueprintExplainEvidence,
   BlueprintExplainNode,
   BlueprintExplainOutput,
+  BlueprintResolveInput,
   ResolvedBlueprint,
   WorkflowMode,
 } from "./model.js";
+import { blueprintPlanEvidence, buildBlueprintPlanArtifact } from "./plan.js";
 
 function explainNode(node: ResolvedBlueprint["activeNodes"][number]): BlueprintExplainNode {
   return {
@@ -13,25 +14,17 @@ function explainNode(node: ResolvedBlueprint["activeNodes"][number]): BlueprintE
     mode: node.mode,
     required: node.required,
     protected: node.protected ?? false,
-  };
-}
-
-function explainEvidence(
-  evidence: ResolvedBlueprint["requiredEvidence"][number],
-): BlueprintExplainEvidence {
-  return {
-    id: evidence.id,
-    kind: evidence.kind,
-    producedBy: evidence.producedBy,
-    required: evidence.required,
-    description: evidence.description,
+    allowedCommands: [...(node.allowedCommands ?? [])],
+    policyModules: [...(node.policyModules ?? [])],
   };
 }
 
 export function explainResolvedBlueprint(opts: {
   resolved: ResolvedBlueprint;
+  input?: BlueprintResolveInput;
   workflowMode?: WorkflowMode;
 }): BlueprintExplainOutput {
+  const plan = buildBlueprintPlanArtifact(opts);
   return {
     blueprintId: opts.resolved.blueprint.id,
     blueprintVersion: opts.resolved.blueprint.version,
@@ -39,7 +32,10 @@ export function explainResolvedBlueprint(opts: {
     ...(opts.workflowMode ? { workflowMode: opts.workflowMode } : {}),
     route: opts.resolved.activeNodes.map((node) => explainNode(node)),
     skippedNodes: [...opts.resolved.skippedNodes],
-    requiredEvidence: opts.resolved.requiredEvidence.map((evidence) => explainEvidence(evidence)),
+    requiredEvidence: opts.resolved.requiredEvidence.map((evidence) =>
+      blueprintPlanEvidence(evidence),
+    ),
+    plan,
     selectionReasons: [...opts.resolved.selectionReasons],
     acceptedRecipeExtensions: [...opts.resolved.acceptedRecipeExtensions],
     rejectedRecipeExtensions: [...opts.resolved.rejectedRecipeExtensions],
@@ -54,6 +50,14 @@ export function formatBlueprintExplain(output: BlueprintExplainOutput): string {
     ...(output.workflowMode ? [`workflow_mode: ${output.workflowMode}`] : []),
     `route: ${output.route.map((node) => node.kind).join(" -> ")}`,
     `selection_reasons: ${output.selectionReasons.join("; ") || "none"}`,
+    `policy_modules: ${output.plan.policyModules.join(", ") || "none"}`,
+    `allowed_commands: ${output.plan.allowedCommands.join("; ") || "none"}`,
+    `context_budget: max_policy_modules=${output.plan.contextBudget.maxPolicyModules}${
+      output.plan.contextBudget.maxPromptBlocks
+        ? ` max_prompt_blocks=${output.plan.contextBudget.maxPromptBlocks}`
+        : ""
+    }`,
+    `context_manifest: ${output.plan.contextManifest.length}`,
     `required_evidence: ${output.requiredEvidence.map((item) => item.kind).join(", ")}`,
     `accepted_recipe_extensions: ${output.acceptedRecipeExtensions.length}`,
     `rejected_recipe_extensions: ${output.rejectedRecipeExtensions.length}`,

--- a/packages/agentplane/src/blueprints/index.ts
+++ b/packages/agentplane/src/blueprints/index.ts
@@ -6,6 +6,7 @@ export {
   requireBlueprint,
 } from "./registry.js";
 export { explainResolvedBlueprint, formatBlueprintExplain } from "./explain.js";
+export { blueprintPlanEvidence, blueprintPlanState, buildBlueprintPlanArtifact } from "./plan.js";
 export {
   recipeBlueprintExtensionToHint,
   recipeBlueprintExtensionsToHints,
@@ -15,11 +16,17 @@ export { validateBlueprint, validateBlueprintRegistry } from "./validate.js";
 export type {
   AcceptedRecipeExtension,
   Blueprint,
+  BlueprintContextBudget,
+  BlueprintContextManifestEntry,
+  BlueprintDefinition,
   BlueprintEdge,
   BlueprintExplainEvidence,
   BlueprintExplainNode,
   BlueprintExplainOutput,
   BlueprintId,
+  BlueprintPlanArtifact,
+  BlueprintPlanState,
+  BlueprintState,
   BlueprintTaskIntent,
   BlueprintNode,
   BlueprintNodeKind,

--- a/packages/agentplane/src/blueprints/model.ts
+++ b/packages/agentplane/src/blueprints/model.ts
@@ -73,6 +73,15 @@ export type BlueprintTaskIntent = {
   blueprintRequest?: BlueprintId;
 };
 
+export type BlueprintContextBudget = {
+  maxPolicyModules: number;
+  maxPromptBlocks?: number;
+  rationale: string;
+};
+
+export type BlueprintDefinition = Blueprint;
+export type BlueprintState = BlueprintNode;
+
 export type Blueprint = {
   id: BlueprintId;
   version: 1;
@@ -80,6 +89,9 @@ export type Blueprint = {
   description: string;
   taskKinds: readonly TaskKind[];
   workflowModes?: readonly WorkflowMode[];
+  allowedCommands: readonly string[];
+  policyModules: readonly string[];
+  contextBudget: BlueprintContextBudget;
   nodes: readonly BlueprintNode[];
   edges: readonly BlueprintEdge[];
   requiredEvidence: readonly EvidenceRequirement[];
@@ -93,6 +105,8 @@ export type BlueprintNode = {
   mode: BlueprintNodeMode;
   required: boolean;
   protected?: boolean;
+  allowedCommands?: readonly string[];
+  policyModules?: readonly string[];
   inputs?: readonly string[];
   outputs?: readonly string[];
   evidence?: readonly EvidenceKind[];
@@ -231,12 +245,52 @@ export type ResolvedBlueprint = {
   stopReasons: readonly StopReason[];
 };
 
+export type BlueprintPlanState = {
+  id: string;
+  kind: BlueprintNodeKind;
+  mode: BlueprintNodeMode;
+  required: boolean;
+  protected: boolean;
+  allowedCommands: readonly string[];
+  policyModules: readonly string[];
+  evidenceKinds: readonly EvidenceKind[];
+};
+
+export type BlueprintContextManifestEntry = {
+  id: string;
+  kind: "prompt" | "policy_module" | "recipe" | "task" | "repository";
+  reason: string;
+  source?: string;
+};
+
+export type BlueprintPlanArtifact = {
+  schemaVersion: 1;
+  blueprintId: BlueprintId;
+  blueprintVersion: 1;
+  title: string;
+  taskId?: string;
+  workflowMode?: WorkflowMode;
+  taskIntent: BlueprintTaskIntent;
+  whySelected: readonly string[];
+  states: readonly BlueprintPlanState[];
+  requiredEvidence: readonly BlueprintExplainEvidence[];
+  policyModules: readonly string[];
+  allowedCommands: readonly string[];
+  contextBudget: BlueprintContextBudget;
+  contextManifest: readonly BlueprintContextManifestEntry[];
+  acceptedRecipeExtensions: readonly AcceptedRecipeExtension[];
+  rejectedRecipeExtensions: readonly RejectedRecipeExtension[];
+  stopReasons: readonly StopReason[];
+};
+
 export type BlueprintExplainNode = {
   id: string;
   kind: BlueprintNodeKind;
   mode: BlueprintNodeMode;
   required: boolean;
   protected: boolean;
+  allowedCommands: readonly string[];
+  policyModules: readonly string[];
 };
 
 export type BlueprintExplainEvidence = {
@@ -255,6 +309,7 @@ export type BlueprintExplainOutput = {
   route: readonly BlueprintExplainNode[];
   skippedNodes: readonly SkippedNode[];
   requiredEvidence: readonly BlueprintExplainEvidence[];
+  plan: BlueprintPlanArtifact;
   selectionReasons: readonly string[];
   acceptedRecipeExtensions: readonly AcceptedRecipeExtension[];
   rejectedRecipeExtensions: readonly RejectedRecipeExtension[];

--- a/packages/agentplane/src/blueprints/plan.ts
+++ b/packages/agentplane/src/blueprints/plan.ts
@@ -1,0 +1,88 @@
+import type {
+  BlueprintContextManifestEntry,
+  BlueprintExplainEvidence,
+  BlueprintPlanArtifact,
+  BlueprintPlanState,
+  BlueprintResolveInput,
+  BlueprintTaskIntent,
+  ResolvedBlueprint,
+  WorkflowMode,
+} from "./model.js";
+
+function uniqueSorted(values: readonly string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim().length > 0))].toSorted();
+}
+
+function taskIntentFromInput(input?: BlueprintResolveInput): BlueprintTaskIntent {
+  if (!input) return {};
+  return {
+    ...(input.taskKind ? { taskKind: input.taskKind } : {}),
+    ...((input.mutationScope ?? input.mutation)
+      ? { mutationScope: input.mutationScope ?? input.mutation }
+      : {}),
+    ...(input.riskFlags && input.riskFlags.length > 0 ? { riskFlags: input.riskFlags } : {}),
+    ...((input.blueprintRequest ?? input.explicitBlueprintId)
+      ? { blueprintRequest: input.blueprintRequest ?? input.explicitBlueprintId }
+      : {}),
+  };
+}
+
+export function blueprintPlanState(
+  node: ResolvedBlueprint["activeNodes"][number],
+): BlueprintPlanState {
+  return {
+    id: node.id,
+    kind: node.kind,
+    mode: node.mode,
+    required: node.required,
+    protected: node.protected ?? false,
+    allowedCommands: [...(node.allowedCommands ?? [])],
+    policyModules: [...(node.policyModules ?? [])],
+    evidenceKinds: [...(node.evidence ?? [])],
+  };
+}
+
+export function blueprintPlanEvidence(
+  evidence: ResolvedBlueprint["requiredEvidence"][number],
+): BlueprintExplainEvidence {
+  return {
+    id: evidence.id,
+    kind: evidence.kind,
+    producedBy: evidence.producedBy,
+    required: evidence.required,
+    description: evidence.description,
+  };
+}
+
+export function buildBlueprintPlanArtifact(opts: {
+  resolved: ResolvedBlueprint;
+  input?: BlueprintResolveInput;
+  workflowMode?: WorkflowMode;
+  contextManifest?: readonly BlueprintContextManifestEntry[];
+}): BlueprintPlanArtifact {
+  const statePolicyModules = opts.resolved.activeNodes.flatMap((node) => node.policyModules ?? []);
+  const stateCommands = opts.resolved.activeNodes.flatMap((node) => node.allowedCommands ?? []);
+  return {
+    schemaVersion: 1,
+    blueprintId: opts.resolved.blueprint.id,
+    blueprintVersion: opts.resolved.blueprint.version,
+    title: opts.resolved.blueprint.title,
+    ...(opts.input?.taskId ? { taskId: opts.input.taskId } : {}),
+    ...((opts.workflowMode ?? opts.input?.workflowMode)
+      ? { workflowMode: opts.workflowMode ?? opts.input?.workflowMode }
+      : {}),
+    taskIntent: taskIntentFromInput(opts.input),
+    whySelected: [...opts.resolved.selectionReasons],
+    states: opts.resolved.activeNodes.map((node) => blueprintPlanState(node)),
+    requiredEvidence: opts.resolved.requiredEvidence.map((evidence) =>
+      blueprintPlanEvidence(evidence),
+    ),
+    policyModules: uniqueSorted([...opts.resolved.blueprint.policyModules, ...statePolicyModules]),
+    allowedCommands: uniqueSorted([...opts.resolved.blueprint.allowedCommands, ...stateCommands]),
+    contextBudget: opts.resolved.blueprint.contextBudget,
+    contextManifest: [...(opts.contextManifest ?? [])],
+    acceptedRecipeExtensions: [...opts.resolved.acceptedRecipeExtensions],
+    rejectedRecipeExtensions: [...opts.resolved.rejectedRecipeExtensions],
+    stopReasons: [...opts.resolved.stopReasons],
+  };
+}

--- a/packages/agentplane/src/blueprints/resolve.test.ts
+++ b/packages/agentplane/src/blueprints/resolve.test.ts
@@ -250,6 +250,65 @@ describe("resolveBlueprint", () => {
     expect(resolved.selectionReasons[0]).toContain("risk flags require release.strict");
   });
 
+  it("builds executable plan metadata without adding policy to lightweight analysis", () => {
+    const resolved = resolve({
+      taskId: "202605052204-ANALYS",
+      taskKind: "analysis",
+      mutation: "none",
+      workflowMode: "branch_pr",
+    });
+    const output = explainResolvedBlueprint({
+      resolved,
+      input: {
+        taskId: "202605052204-ANALYS",
+        tags: [],
+        taskKind: "analysis",
+        mutation: "none",
+        workflowMode: "branch_pr",
+      },
+      workflowMode: "branch_pr",
+    });
+
+    expect(output.plan.blueprintId).toBe("analysis.light");
+    expect(output.plan.taskIntent).toEqual({ taskKind: "analysis", mutationScope: "none" });
+    expect(output.plan.policyModules).toEqual([]);
+    expect(output.plan.allowedCommands).toEqual([]);
+    expect(output.plan.states.map((state) => state.kind)).not.toContain("hosted_checks");
+    expect(formatBlueprintExplain(output)).toContain("policy_modules: none");
+    expect(formatBlueprintExplain(output)).toContain("context_budget: max_policy_modules=0");
+  });
+
+  it("builds executable plan metadata for branch PR code routes", () => {
+    const input: BlueprintResolveInput = {
+      tags: ["code"],
+      taskKind: "code",
+      mutation: "code",
+      mutationScope: "code",
+      workflowMode: "branch_pr",
+    };
+    const output = explainResolvedBlueprint({
+      resolved: resolve(input),
+      input,
+      workflowMode: "branch_pr",
+    });
+
+    expect(output.plan.blueprintId).toBe("code.branch_pr");
+    expect(output.plan.policyModules).toEqual([
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md",
+    ]);
+    expect(output.plan.allowedCommands).toContain(
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    );
+    expect(
+      output.plan.states
+        .find((state) => state.kind === "context_resolve")
+        ?.policyModules.includes(".agentplane/policy/workflow.branch_pr.md"),
+    ).toBe(true);
+  });
+
   it("bridges normalized recipe blueprint extensions into resolver hints", () => {
     const hints = recipeBlueprintExtensionsToHints([
       {

--- a/packages/agentplane/src/blueprints/validate.ts
+++ b/packages/agentplane/src/blueprints/validate.ts
@@ -127,6 +127,15 @@ function validateRequiredText(blueprint: Blueprint, errors: BlueprintValidationP
   if (blueprint.taskKinds.length === 0) {
     errors.push(problem("empty_field", "Blueprint taskKinds must be non-empty.", "taskKinds"));
   }
+  if (!hasText(blueprint.contextBudget.rationale)) {
+    errors.push(
+      problem(
+        "empty_field",
+        "Blueprint context budget rationale must be non-empty.",
+        "contextBudget",
+      ),
+    );
+  }
 }
 
 function validateGraph(blueprint: Blueprint, errors: BlueprintValidationProblem[]): void {

--- a/packages/agentplane/src/cli/run-cli.core.tasks.query-run-prepare.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.tasks.query-run-prepare.test.ts
@@ -172,6 +172,12 @@ describe("runCli task run preparation", { timeout: TASKS_QUERY_CLI_TIMEOUT_MS },
       expect(io.stdout).toContain("policy_effective: {}");
       expect(io.stdout).toContain("policy_fields:");
       expect(io.stdout).toContain("policy_refusal: null");
+      expect(io.stdout).toContain("blueprint: docs.change");
+      expect(io.stdout).toContain("recipe: none");
+      expect(io.stdout).toContain('"maxPolicyModules":3');
+      expect(io.stdout).toContain(".agentplane/policy/dod.docs.md");
+      expect(io.stdout).toContain("context_manifest:");
+      expect(io.stdout).toContain('"docs.check"');
       expect(io.stdout).toContain(
         "policy_field[sandbox]: status=not_requested capability=native channel=argv supported=read-only,workspace-write,danger-full-access",
       );
@@ -272,6 +278,13 @@ describe("runCli task run preparation", { timeout: TASKS_QUERY_CLI_TIMEOUT_MS },
             refusal_reason?: { policy_field?: string } | null;
           };
         };
+        blueprint?: {
+          blueprintId?: string;
+          policyModules?: string[];
+          contextBudget?: { maxPolicyModules?: number };
+          contextManifest?: { id?: string; kind?: string; reason?: string; source?: string }[];
+          requiredEvidence?: { id?: string }[];
+        };
         task: { task_id: string };
       };
       const bootstrap = await readFile(bootstrapPath, "utf8");
@@ -366,6 +379,21 @@ describe("runCli task run preparation", { timeout: TASKS_QUERY_CLI_TIMEOUT_MS },
           },
         },
       });
+      expect(bundle.blueprint).toMatchObject({
+        blueprintId: "docs.change",
+        contextBudget: { maxPolicyModules: 3 },
+      });
+      expect(bundle.blueprint?.policyModules?.includes(".agentplane/policy/dod.docs.md")).toBe(
+        true,
+      );
+      expect(bundle.blueprint?.requiredEvidence?.map((item) => item.id)).toContain("docs.check");
+      expect(bundle.blueprint?.contextManifest?.length).toBeGreaterThan(0);
+      expect(
+        bundle.blueprint?.contextManifest?.some(
+          (item) =>
+            item.kind === "policy_module" && item.source === ".agentplane/policy/dod.docs.md",
+        ),
+      ).toBe(true);
       expect(bundle.task.task_id).toBe(taskId);
       expect(bootstrap).toContain(
         "This invocation is already inside an approved runner execution.",

--- a/packages/agentplane/src/commands/blueprint/blueprint.command.ts
+++ b/packages/agentplane/src/commands/blueprint/blueprint.command.ts
@@ -214,6 +214,7 @@ export function makeRunBlueprintExplainHandler(getCtx: (cmd: string) => Promise<
     const resolved = resolveBlueprint({ input });
     const output = explainResolvedBlueprint({
       resolved,
+      input,
       workflowMode: input.workflowMode,
     });
     if (p.json) {

--- a/packages/agentplane/src/commands/task/run-output.ts
+++ b/packages/agentplane/src/commands/task/run-output.ts
@@ -64,6 +64,21 @@ export function renderTaskRunDryRunOutput(opts: {
       opts.prepared.bundle.execution.policy_decision?.refusal_reason ?? null,
     )}`,
     ...formatRunnerPolicyFieldSummaryLines(opts.prepared.bundle.execution.policy_decision),
+    `blueprint: ${opts.prepared.bundle.blueprint?.blueprintId ?? "none"}`,
+    `recipe: ${opts.prepared.bundle.recipe?.recipe_id ?? "none"}`,
+    `context_budget: ${JSON.stringify(opts.prepared.bundle.blueprint?.contextBudget ?? null)}`,
+    `policy_modules: ${JSON.stringify(opts.prepared.bundle.blueprint?.policyModules ?? [])}`,
+    `context_manifest: ${JSON.stringify(
+      opts.prepared.bundle.blueprint?.contextManifest.map((item) => ({
+        id: item.id,
+        kind: item.kind,
+        reason: item.reason,
+        source: item.source,
+      })) ?? [],
+    )}`,
+    `evidence_checklist: ${JSON.stringify(
+      opts.prepared.bundle.blueprint?.requiredEvidence.map((item) => item.id) ?? [],
+    )}`,
     `argv: ${opts.prepared.invocation.argv.join(" ")}`,
   ];
   return { stdout: linesToOutput(stdout), stderr: "" };

--- a/packages/agentplane/src/commands/task/run-show.command.ts
+++ b/packages/agentplane/src/commands/task/run-show.command.ts
@@ -142,6 +142,26 @@ export const runTaskRunShow: CommandHandler<TaskRunShowParsed> = async (
         value: JSON.stringify(inspection.state.policy_decision?.refusal_reason ?? null),
       },
       ...formatRunnerPolicyFieldSummaryLines(inspection.state.policy_decision),
+      { label: "blueprint", value: inspection.bundle.blueprint?.blueprintId ?? "none" },
+      { label: "recipe", value: inspection.bundle.recipe?.recipe_id ?? "none" },
+      {
+        label: "context_budget",
+        value: JSON.stringify(inspection.bundle.blueprint?.contextBudget ?? null),
+      },
+      {
+        label: "policy_modules",
+        value: JSON.stringify(inspection.bundle.blueprint?.policyModules ?? []),
+      },
+      {
+        label: "context_manifest",
+        value: JSON.stringify(inspection.bundle.blueprint?.contextManifest ?? []),
+      },
+      {
+        label: "evidence_checklist",
+        value: JSON.stringify(
+          inspection.bundle.blueprint?.requiredEvidence.map((item) => item.id) ?? [],
+        ),
+      },
     );
     if (inspection.state.result?.summary) {
       entries.push({ label: "summary", value: inspection.state.result.summary });

--- a/packages/agentplane/src/runner/types/context.ts
+++ b/packages/agentplane/src/runner/types/context.ts
@@ -1,6 +1,7 @@
 import type { RunnerTraceConfig, RunnerTimeoutConfig } from "@agentplaneorg/core/config";
 
 import type { TaskData, TaskEvent } from "../../backends/task-backend.js";
+import type { BlueprintPlanArtifact } from "../../blueprints/index.js";
 import type { AgentplaneCapabilityRegistry } from "../../runtime/capabilities/index.js";
 import type { ResolvedExecutionProfileRuntime } from "../../runtime/execution-profile/index.js";
 import type { FrameworkExplainPayload } from "../../runtime/explain/index.js";
@@ -115,5 +116,6 @@ export type RunnerContextBundle = {
   repository: RunnerRepositoryContext;
   task?: RunnerTaskContext;
   recipe?: RunnerRecipeContext;
+  blueprint?: BlueprintPlanArtifact;
   execution: RunnerExecutionContract;
 };

--- a/packages/agentplane/src/runner/usecases/task-run.ts
+++ b/packages/agentplane/src/runner/usecases/task-run.ts
@@ -1,8 +1,17 @@
 import { normalizeTaskStatus } from "@agentplaneorg/core/tasks";
+import { resolveRecipeBlueprintExtensions, type RecipeManifest } from "@agentplaneorg/recipes";
 
 import { exitCodeForError } from "../../cli/exit-codes.js";
 import { loadCommandContext, type CommandContext } from "../../commands/shared/task-backend.js";
+import { blueprintResolveInputFromTask } from "../../commands/blueprint/task-input.js";
 import { CliError } from "../../shared/errors.js";
+import {
+  buildBlueprintPlanArtifact,
+  type BlueprintContextManifestEntry,
+  inferBlueprintTaskKind,
+  recipeBlueprintExtensionsToHints,
+  resolveBlueprint,
+} from "../../blueprints/index.js";
 import { resolveRunnerAdapterCapabilityRegistry } from "../../runtime/capabilities/index.js";
 import { consumeExecutionProfileBudget } from "../../runtime/execution-profile/index.js";
 import {
@@ -30,6 +39,7 @@ import {
   type RunnerExecutionContract,
   type RunnerInvocation,
   type RunnerRecipeContext,
+  type RunnerPromptBlock,
   type RunnerResult,
   type RunnerRunState,
   type RunnerTarget,
@@ -113,6 +123,83 @@ function assertRunnerPolicyCompatibility(bundle: RunnerContextBundle): void {
   if (profile.writes_artifacts_to && profile.writes_artifacts_to.length > 0) {
     normalizeRecipeArtifactPrefixes(profile.writes_artifacts_to);
   }
+}
+
+function recipeManifestFromContext(recipe: RunnerRecipeContext | undefined): RecipeManifest | null {
+  if (!recipe?.manifest || typeof recipe.manifest !== "object") return null;
+  return recipe.manifest as RecipeManifest;
+}
+
+function resolveRunnerBlueprintPlan(opts: {
+  taskEnvelope: Awaited<ReturnType<typeof assembleRunnerTaskContext>>;
+  config: CommandContext["config"];
+  recipe?: RunnerRecipeContext;
+  basePrompts: readonly RunnerPromptBlock[];
+}): RunnerContextBundle["blueprint"] {
+  const input = blueprintResolveInputFromTask({
+    task: opts.taskEnvelope.task.data,
+    config: opts.config,
+  });
+  const manifest = recipeManifestFromContext(opts.recipe);
+  if (manifest) {
+    const taskKind = inferBlueprintTaskKind(input);
+    const recipeExtensions = resolveRecipeBlueprintExtensions({
+      recipes: [{ manifest }],
+      runtime: {
+        task_kind: taskKind,
+        command: "task run",
+        tags: input.tags ? [...input.tags] : [],
+      },
+      includeIncompatible: true,
+    });
+    input.recipeHints = recipeBlueprintExtensionsToHints(recipeExtensions.accepted);
+  }
+  const resolved = resolveBlueprint({ input });
+  return buildBlueprintPlanArtifact({
+    resolved,
+    input,
+    workflowMode: input.workflowMode,
+    contextManifest: buildRunnerBlueprintContextManifest({
+      basePrompts: opts.basePrompts,
+      recipe: opts.recipe,
+      policyModules: resolved.blueprint.policyModules,
+    }),
+  });
+}
+
+function buildRunnerBlueprintContextManifest(opts: {
+  basePrompts: readonly RunnerPromptBlock[];
+  recipe?: RunnerRecipeContext;
+  policyModules: readonly string[];
+}): BlueprintContextManifestEntry[] {
+  const entries: BlueprintContextManifestEntry[] = opts.basePrompts.map((prompt) => ({
+    id: prompt.id,
+    kind: prompt.id.includes("policy") ? "policy_module" : "prompt",
+    reason: prompt.resolution
+      ? `Resolved from ${prompt.resolution.winner.source}.`
+      : "Loaded as part of the runner base prompt bundle.",
+    ...(prompt.source ? { source: prompt.source } : {}),
+  }));
+  for (const policyModule of opts.policyModules) {
+    if (entries.some((entry) => entry.source === policyModule || entry.id === policyModule)) {
+      continue;
+    }
+    entries.push({
+      id: policyModule,
+      kind: "policy_module",
+      reason: "Allowed by the resolved blueprint policy module budget.",
+      source: policyModule,
+    });
+  }
+  if (opts.recipe) {
+    entries.push({
+      id: opts.recipe.recipe_id,
+      kind: "recipe",
+      reason: "Selected recipe context attached to this runner invocation.",
+      ...(opts.recipe.recipe_dir ? { source: opts.recipe.recipe_dir } : {}),
+    });
+  }
+  return entries;
 }
 
 async function writeRunnerRefusalArtifacts(opts: {
@@ -251,6 +338,12 @@ export async function prepareTaskRunnerExecution(opts: {
     harness: executionContext.harness,
     execution_profile: executionProfile,
   });
+  const blueprint = resolveRunnerBlueprintPlan({
+    taskEnvelope,
+    config: executionContext.config,
+    recipe: opts.recipe,
+    basePrompts: base_prompts,
+  });
   const framework_explain = appendFrameworkExplainBehaviorInputs(
     executionContext.frameworkExplain,
     collectFrameworkExplainBehaviorInputs(base_prompts),
@@ -278,6 +371,7 @@ export async function prepareTaskRunnerExecution(opts: {
     repository: taskEnvelope.repository,
     task: taskEnvelope.task,
     recipe: opts.recipe,
+    blueprint,
     execution: {
       adapter_id: configured_adapter_id,
       mode: opts.mode,


### PR DESCRIPTION
Task: `202605052203-WH7G6R`
Title: Define executable blueprint definition contracts

## Summary

Define executable blueprint definition contracts

Add the first implementation task for blueprint execution contracts: define typed BlueprintDefinition and BlueprintState shapes without command execution, covering states, required evidence, allowed commands, policy modules, stop rules, and resolver-facing metadata.

## Scope

- In scope: Add the first implementation task for blueprint execution contracts: define typed BlueprintDefinition and BlueprintState shapes without command execution, covering states, required evidence, allowed commands, policy modules, stop rules, and resolver-facing metadata.
- Out of scope: unrelated refactors not required for "Define executable blueprint definition contracts".

## Verification

- State: ok
- Note: Verified: executable blueprint definition contracts now include state metadata, policy modules, command boundaries, context budget, materialized plan typing, and focused validation coverage.
- Full verification checklist lives in local review.md.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-05T22:20:45.673Z
- Branch: task/202605052203-WH7G6R/executable-blueprint-contracts
- Head: 745e035230ef

```text
 .agentplane/tasks/202605052204-4XSTAA/README.md    | 139 ++++++++++++++
 .agentplane/tasks/202605052204-50B7J9/README.md    | 139 ++++++++++++++
 .agentplane/tasks/202605052204-AJBX3D/README.md    | 139 ++++++++++++++
 .agentplane/tasks/202605052204-GD17KQ/README.md    | 139 ++++++++++++++
 .agentplane/tasks/202605052204-WJ25N8/README.md    | 139 ++++++++++++++
 docs/developer/blueprints.mdx                      |  35 ++--
 packages/agentplane/src/blueprints/builtins.ts     | 200 +++++++++++++++++++--
 packages/agentplane/src/blueprints/explain.ts      |  32 ++--
 packages/agentplane/src/blueprints/index.ts        |   7 +
 packages/agentplane/src/blueprints/model.ts        |  55 ++++++
 packages/agentplane/src/blueprints/plan.ts         |  88 +++++++++
 packages/agentplane/src/blueprints/resolve.test.ts |  59 ++++++
 packages/agentplane/src/blueprints/validate.ts     |   9 +
 .../run-cli.core.tasks.query-run-prepare.test.ts   |  28 +++
 .../src/commands/blueprint/blueprint.command.ts    |   1 +
 .../agentplane/src/commands/task/run-output.ts     |  15 ++
 .../src/commands/task/run-show.command.ts          |  20 +++
 packages/agentplane/src/runner/types/context.ts    |   2 +
 .../agentplane/src/runner/usecases/task-run.ts     |  94 ++++++++++
 19 files changed, 1302 insertions(+), 38 deletions(-)
```

</details>
