### PR TITLE
🚧 QWE78P task: Validate blueprint plan policy budgets [202605052303-QWE78P]

### DIFF
--- a/.agentplane/tasks/202605052303-1CEGJD/README.md
+++ b/.agentplane/tasks/202605052303-1CEGJD/README.md
@@ -1,0 +1,129 @@
+---
+id: "202605052303-1CEGJD"
+title: "Add project-local blueprint validation command"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on:
+  - "202605052303-FXGCNC"
+tags:
+  - "blueprint"
+  - "recipes"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-05T23:04:02.222Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-05T23:13:00.704Z"
+  updated_by: "CODER"
+  note: "Implemented and tested validate-only CLI for project-local blueprint JSON."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: batch execution in QWE78P worktree; add validate-only CLI for project-local blueprint JSON definitions."
+events:
+  -
+    type: "status"
+    at: "2026-05-05T23:09:24.349Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: batch execution in QWE78P worktree; add validate-only CLI for project-local blueprint JSON definitions."
+  -
+    type: "verify"
+    at: "2026-05-05T23:13:00.704Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented and tested validate-only CLI for project-local blueprint JSON."
+doc_version: 3
+doc_updated_at: "2026-05-05T23:13:00.711Z"
+doc_updated_by: "CODER"
+description: "Add a validate-only CLI path for project-local blueprint JSON definitions, reusing the built-in blueprint validation contract without executing or registering custom routes by default."
+sections:
+  Summary: |-
+    Add project-local blueprint validation command
+    
+    Add a validate-only CLI path for project-local blueprint JSON definitions, reusing the built-in blueprint validation contract without executing or registering custom routes by default.
+  Scope: |-
+    - In scope: Add a validate-only CLI path for project-local blueprint JSON definitions, reusing the built-in blueprint validation contract without executing or registering custom routes by default.
+    - Out of scope: unrelated refactors not required for "Add project-local blueprint validation command".
+  Plan: "1. Add a validate-only CLI subcommand for project-local blueprint JSON files. 2. Parse JSON through the same BlueprintDefinition validation contract used by built-ins. 3. Print deterministic success/error output without registering or executing custom blueprints. 4. Add CLI tests for valid JSON, invalid JSON, and schema/contract errors."
+  Verify Steps: |-
+    1. Review the requested outcome for "Add project-local blueprint validation command". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-05T23:13:00.704Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Implemented and tested validate-only CLI for project-local blueprint JSON.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-05T23:09:24.349Z, excerpt_hash=sha256:bff0c8ba3fa2222f9467c0380b4337fc2ca38abaa10b48859c27c697d65e80de
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Command: bun test packages/agentplane/src/cli/run-cli.core.blueprint.test.ts; Result: pass; Evidence: valid local blueprint JSON exits 0, invalid JSON exits 3, contract errors are reported. Scope: blueprint validate CLI command.
+      Impact: Custom blueprint definitions can be checked before any future registration or execution path exists.
+      Resolution: Added agentplane blueprint validate <path> with deterministic text and JSON output, backed by validateBlueprint.
+      Promotion: incident-candidate
+      Fixability: external
+id_source: "generated"
+---
+## Summary
+
+Add project-local blueprint validation command
+
+Add a validate-only CLI path for project-local blueprint JSON definitions, reusing the built-in blueprint validation contract without executing or registering custom routes by default.
+
+## Scope
+
+- In scope: Add a validate-only CLI path for project-local blueprint JSON definitions, reusing the built-in blueprint validation contract without executing or registering custom routes by default.
+- Out of scope: unrelated refactors not required for "Add project-local blueprint validation command".
+
+## Plan
+
+1. Add a validate-only CLI subcommand for project-local blueprint JSON files. 2. Parse JSON through the same BlueprintDefinition validation contract used by built-ins. 3. Print deterministic success/error output without registering or executing custom blueprints. 4. Add CLI tests for valid JSON, invalid JSON, and schema/contract errors.
+
+## Verify Steps
+
+1. Review the requested outcome for "Add project-local blueprint validation command". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-05T23:13:00.704Z — VERIFY — ok
+
+By: CODER
+
+Note: Implemented and tested validate-only CLI for project-local blueprint JSON.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-05T23:09:24.349Z, excerpt_hash=sha256:bff0c8ba3fa2222f9467c0380b4337fc2ca38abaa10b48859c27c697d65e80de
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Command: bun test packages/agentplane/src/cli/run-cli.core.blueprint.test.ts; Result: pass; Evidence: valid local blueprint JSON exits 0, invalid JSON exits 3, contract errors are reported. Scope: blueprint validate CLI command.
+  Impact: Custom blueprint definitions can be checked before any future registration or execution path exists.
+  Resolution: Added agentplane blueprint validate <path> with deterministic text and JSON output, backed by validateBlueprint.
+  Promotion: incident-candidate
+  Fixability: external

--- a/.agentplane/tasks/202605052303-FXGCNC/README.md
+++ b/.agentplane/tasks/202605052303-FXGCNC/README.md
@@ -1,0 +1,129 @@
+---
+id: "202605052303-FXGCNC"
+title: "Persist task-local blueprint plan snapshots"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on:
+  - "202605052303-N37XQ0"
+tags:
+  - "blueprint"
+  - "recipes"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-05T23:03:56.480Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-05T23:12:50.427Z"
+  updated_by: "CODER"
+  note: "Implemented and tested task-local blueprint plan snapshots."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: batch execution in QWE78P worktree; persist selected blueprint plan snapshots as task-local artifacts."
+events:
+  -
+    type: "status"
+    at: "2026-05-05T23:09:20.347Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: batch execution in QWE78P worktree; persist selected blueprint plan snapshots as task-local artifacts."
+  -
+    type: "verify"
+    at: "2026-05-05T23:12:50.427Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented and tested task-local blueprint plan snapshots."
+doc_version: 3
+doc_updated_at: "2026-05-05T23:12:50.433Z"
+doc_updated_by: "CODER"
+description: "Persist selected blueprint plan snapshots as task-local artifacts when a route is materialized, so task audits can read a stable blueprint.json without re-resolving mutable inputs."
+sections:
+  Summary: |-
+    Persist task-local blueprint plan snapshots
+    
+    Persist selected blueprint plan snapshots as task-local artifacts when a route is materialized, so task audits can read a stable blueprint.json without re-resolving mutable inputs.
+  Scope: |-
+    - In scope: Persist selected blueprint plan snapshots as task-local artifacts when a route is materialized, so task audits can read a stable blueprint.json without re-resolving mutable inputs.
+    - Out of scope: unrelated refactors not required for "Persist task-local blueprint plan snapshots".
+  Plan: "1. Choose a task-local blueprint plan snapshot path that does not replace resolver output. 2. Persist selected BlueprintPlanArtifact as a stable task artifact when run preparation materializes a route. 3. Keep snapshot writing best-effort but observable through tests. 4. Add tests proving the file is written for a task and contains selected blueprint/context budget data."
+  Verify Steps: |-
+    1. Review the requested outcome for "Persist task-local blueprint plan snapshots". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-05T23:12:50.427Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Implemented and tested task-local blueprint plan snapshots.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-05T23:09:20.347Z, excerpt_hash=sha256:f021fe5b171c5ce124cf48ad00c2d56f5dd9684ac2eeb8594437a3a1a32cafc5
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Command: bun test packages/agentplane/src/cli/run-cli.core.tasks.query-run-prepare.test.ts; Result: pass; Evidence: dry-run preparation writes .agentplane/tasks/<task-id>/blueprint.json and matches bundle blueprint policyModules/contextBudget. Scope: runner preparation artifact materialization.
+      Impact: Task audits can read a stable blueprint.json snapshot without re-resolving mutable task input.
+      Resolution: prepareTaskRunnerExecution writes the selected BlueprintPlanArtifact after task executability is confirmed.
+      Promotion: incident-candidate
+      Fixability: external
+id_source: "generated"
+---
+## Summary
+
+Persist task-local blueprint plan snapshots
+
+Persist selected blueprint plan snapshots as task-local artifacts when a route is materialized, so task audits can read a stable blueprint.json without re-resolving mutable inputs.
+
+## Scope
+
+- In scope: Persist selected blueprint plan snapshots as task-local artifacts when a route is materialized, so task audits can read a stable blueprint.json without re-resolving mutable inputs.
+- Out of scope: unrelated refactors not required for "Persist task-local blueprint plan snapshots".
+
+## Plan
+
+1. Choose a task-local blueprint plan snapshot path that does not replace resolver output. 2. Persist selected BlueprintPlanArtifact as a stable task artifact when run preparation materializes a route. 3. Keep snapshot writing best-effort but observable through tests. 4. Add tests proving the file is written for a task and contains selected blueprint/context budget data.
+
+## Verify Steps
+
+1. Review the requested outcome for "Persist task-local blueprint plan snapshots". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-05T23:12:50.427Z — VERIFY — ok
+
+By: CODER
+
+Note: Implemented and tested task-local blueprint plan snapshots.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-05T23:09:20.347Z, excerpt_hash=sha256:f021fe5b171c5ce124cf48ad00c2d56f5dd9684ac2eeb8594437a3a1a32cafc5
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Command: bun test packages/agentplane/src/cli/run-cli.core.tasks.query-run-prepare.test.ts; Result: pass; Evidence: dry-run preparation writes .agentplane/tasks/<task-id>/blueprint.json and matches bundle blueprint policyModules/contextBudget. Scope: runner preparation artifact materialization.
+  Impact: Task audits can read a stable blueprint.json snapshot without re-resolving mutable task input.
+  Resolution: prepareTaskRunnerExecution writes the selected BlueprintPlanArtifact after task executability is confirmed.
+  Promotion: incident-candidate
+  Fixability: external

--- a/.agentplane/tasks/202605052303-N37XQ0/README.md
+++ b/.agentplane/tasks/202605052303-N37XQ0/README.md
@@ -1,0 +1,129 @@
+---
+id: "202605052303-N37XQ0"
+title: "Validate blueprint plan state transitions"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on:
+  - "202605052303-QWE78P"
+tags:
+  - "blueprint"
+  - "recipes"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-05T23:03:50.027Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-05T23:12:39.369Z"
+  updated_by: "CODER"
+  note: "Implemented and tested validate-only blueprint plan state transition checks."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: batch execution in QWE78P worktree; implement validate-only blueprint plan state transition checks."
+events:
+  -
+    type: "status"
+    at: "2026-05-05T23:09:15.757Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: batch execution in QWE78P worktree; implement validate-only blueprint plan state transition checks."
+  -
+    type: "verify"
+    at: "2026-05-05T23:12:39.369Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented and tested validate-only blueprint plan state transition checks."
+doc_version: 3
+doc_updated_at: "2026-05-05T23:12:39.375Z"
+doc_updated_by: "CODER"
+description: "Add validate-only checks for materialized blueprint plan state order against the selected blueprint edge graph, including duplicate/missing/unknown state transition diagnostics."
+sections:
+  Summary: |-
+    Validate blueprint plan state transitions
+    
+    Add validate-only checks for materialized blueprint plan state order against the selected blueprint edge graph, including duplicate/missing/unknown state transition diagnostics.
+  Scope: |-
+    - In scope: Add validate-only checks for materialized blueprint plan state order against the selected blueprint edge graph, including duplicate/missing/unknown state transition diagnostics.
+    - Out of scope: unrelated refactors not required for "Validate blueprint plan state transitions".
+  Plan: "1. Reuse the blueprint definition graph already selected for a materialized plan. 2. Add validate-only state order checks for unknown states, missing entry/final state coverage, duplicate materialized states, and edges not allowed by the blueprint graph. 3. Cover failures and a valid built-in plan with focused tests. 4. Run targeted tests and required checks."
+  Verify Steps: |-
+    1. Review the requested outcome for "Validate blueprint plan state transitions". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-05T23:12:39.369Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Implemented and tested validate-only blueprint plan state transition checks.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-05T23:09:15.757Z, excerpt_hash=sha256:2723aae130b05343633d65d16392d68ff6e945a12c0d787a0e49708c26968878
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Command: bun test packages/agentplane/src/blueprints/validate.test.ts; Result: pass; Evidence: built-ins and plan validation tests pass, including duplicate, missing, unknown, and invalidly ordered states. Scope: selected blueprint graph validation.
+      Impact: Plans now fail fast when their states drift from the selected blueprint graph.
+      Resolution: validateBlueprintPlanArtifact compares plan state ids and adjacent transitions against the blueprint node/edge graph.
+      Promotion: incident-candidate
+      Fixability: external
+id_source: "generated"
+---
+## Summary
+
+Validate blueprint plan state transitions
+
+Add validate-only checks for materialized blueprint plan state order against the selected blueprint edge graph, including duplicate/missing/unknown state transition diagnostics.
+
+## Scope
+
+- In scope: Add validate-only checks for materialized blueprint plan state order against the selected blueprint edge graph, including duplicate/missing/unknown state transition diagnostics.
+- Out of scope: unrelated refactors not required for "Validate blueprint plan state transitions".
+
+## Plan
+
+1. Reuse the blueprint definition graph already selected for a materialized plan. 2. Add validate-only state order checks for unknown states, missing entry/final state coverage, duplicate materialized states, and edges not allowed by the blueprint graph. 3. Cover failures and a valid built-in plan with focused tests. 4. Run targeted tests and required checks.
+
+## Verify Steps
+
+1. Review the requested outcome for "Validate blueprint plan state transitions". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-05T23:12:39.369Z — VERIFY — ok
+
+By: CODER
+
+Note: Implemented and tested validate-only blueprint plan state transition checks.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-05T23:09:15.757Z, excerpt_hash=sha256:2723aae130b05343633d65d16392d68ff6e945a12c0d787a0e49708c26968878
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Command: bun test packages/agentplane/src/blueprints/validate.test.ts; Result: pass; Evidence: built-ins and plan validation tests pass, including duplicate, missing, unknown, and invalidly ordered states. Scope: selected blueprint graph validation.
+  Impact: Plans now fail fast when their states drift from the selected blueprint graph.
+  Resolution: validateBlueprintPlanArtifact compares plan state ids and adjacent transitions against the blueprint node/edge graph.
+  Promotion: incident-candidate
+  Fixability: external

--- a/.agentplane/tasks/202605052303-QWE78P/README.md
+++ b/.agentplane/tasks/202605052303-QWE78P/README.md
@@ -1,0 +1,128 @@
+---
+id: "202605052303-QWE78P"
+title: "Validate blueprint plan policy budgets"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "blueprint"
+  - "recipes"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-05T23:03:42.909Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-05T23:12:30.006Z"
+  updated_by: "CODER"
+  note: "Implemented and tested blueprint plan policy budget validation."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement blueprint plan validation layer in task worktree."
+events:
+  -
+    type: "status"
+    at: "2026-05-05T23:04:25.946Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement blueprint plan validation layer in task worktree."
+  -
+    type: "verify"
+    at: "2026-05-05T23:12:30.006Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented and tested blueprint plan policy budget validation."
+doc_version: 3
+doc_updated_at: "2026-05-05T23:12:30.014Z"
+doc_updated_by: "CODER"
+description: "Add validation that materialized blueprint plans do not report policy modules outside the selected blueprint contract or exceed context budget, without executing blueprint states."
+sections:
+  Summary: |-
+    Validate blueprint plan policy budgets
+    
+    Add validation that materialized blueprint plans do not report policy modules outside the selected blueprint contract or exceed context budget, without executing blueprint states.
+  Scope: |-
+    - In scope: Add validation that materialized blueprint plans do not report policy modules outside the selected blueprint contract or exceed context budget, without executing blueprint states.
+    - Out of scope: unrelated refactors not required for "Validate blueprint plan policy budgets".
+  Plan: "1. Inspect current blueprint model, plan materialization, resolver, runner bundle, and tests. 2. Add validate-only checks that a materialized blueprint plan does not exceed contextBudget.maxPolicyModules and does not report policy modules outside the selected blueprint node/definition contract. 3. Add focused tests for valid and invalid policy budget cases. 4. Run targeted tests and required checks."
+  Verify Steps: |-
+    1. Review the requested outcome for "Validate blueprint plan policy budgets". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-05T23:12:30.006Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Implemented and tested blueprint plan policy budget validation.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-05T23:04:25.946Z, excerpt_hash=sha256:2dc28a325c50fcf7dd9a89a08c5fd710ef0df297e6c403f5c47a50ecb6aef0eb
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Command: bun test packages/agentplane/src/blueprints/validate.test.ts packages/agentplane/src/cli/run-cli.core.blueprint.test.ts packages/agentplane/src/cli/run-cli.core.tasks.query-run-prepare.test.ts; Result: pass; Evidence: 29 pass, 0 fail, 149 expect calls. Scope: blueprint plan policy module budgets and runner bundle regressions.
+      Impact: Materialized BlueprintPlanArtifact now rejects policyModules outside the selected blueprint contract and maxPolicyModules overruns.
+      Resolution: Validation runs inside buildBlueprintPlanArtifact before plans are returned.
+      Promotion: incident-candidate
+      Fixability: external
+id_source: "generated"
+---
+## Summary
+
+Validate blueprint plan policy budgets
+
+Add validation that materialized blueprint plans do not report policy modules outside the selected blueprint contract or exceed context budget, without executing blueprint states.
+
+## Scope
+
+- In scope: Add validation that materialized blueprint plans do not report policy modules outside the selected blueprint contract or exceed context budget, without executing blueprint states.
+- Out of scope: unrelated refactors not required for "Validate blueprint plan policy budgets".
+
+## Plan
+
+1. Inspect current blueprint model, plan materialization, resolver, runner bundle, and tests. 2. Add validate-only checks that a materialized blueprint plan does not exceed contextBudget.maxPolicyModules and does not report policy modules outside the selected blueprint node/definition contract. 3. Add focused tests for valid and invalid policy budget cases. 4. Run targeted tests and required checks.
+
+## Verify Steps
+
+1. Review the requested outcome for "Validate blueprint plan policy budgets". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-05T23:12:30.006Z — VERIFY — ok
+
+By: CODER
+
+Note: Implemented and tested blueprint plan policy budget validation.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-05T23:04:25.946Z, excerpt_hash=sha256:2dc28a325c50fcf7dd9a89a08c5fd710ef0df297e6c403f5c47a50ecb6aef0eb
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Command: bun test packages/agentplane/src/blueprints/validate.test.ts packages/agentplane/src/cli/run-cli.core.blueprint.test.ts packages/agentplane/src/cli/run-cli.core.tasks.query-run-prepare.test.ts; Result: pass; Evidence: 29 pass, 0 fail, 149 expect calls. Scope: blueprint plan policy module budgets and runner bundle regressions.
+  Impact: Materialized BlueprintPlanArtifact now rejects policyModules outside the selected blueprint contract and maxPolicyModules overruns.
+  Resolution: Validation runs inside buildBlueprintPlanArtifact before plans are returned.
+  Promotion: incident-candidate
+  Fixability: external

--- a/.agentplane/tasks/202605052303-QWE78P/pr/diffstat.txt
+++ b/.agentplane/tasks/202605052303-QWE78P/pr/diffstat.txt
@@ -1,0 +1,16 @@
+ .agentplane/tasks/202605052303-1CEGJD/README.md    | 129 +++++++++++++++++
+ .agentplane/tasks/202605052303-FXGCNC/README.md    | 129 +++++++++++++++++
+ .agentplane/tasks/202605052303-N37XQ0/README.md    | 129 +++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |  23 +++
+ packages/agentplane/src/blueprints/index.ts        |   8 +-
+ packages/agentplane/src/blueprints/model.ts        |  23 ++-
+ packages/agentplane/src/blueprints/plan.ts         |  15 +-
+ .../agentplane/src/blueprints/validate.test.ts     | 113 ++++++++++++++-
+ packages/agentplane/src/blueprints/validate.ts     | 157 +++++++++++++++++++++
+ .../src/cli/run-cli.core.blueprint.test.ts         |  70 +++++++++
+ .../run-cli.core.tasks.query-run-prepare.test.ts   |  12 ++
+ .../src/cli/run-cli/command-catalog/project.ts     |   3 +
+ .../src/cli/run-cli/command-loaders/project.ts     |   2 +
+ .../src/commands/blueprint/blueprint.command.ts    |  94 ++++++++++++
+ .../agentplane/src/runner/usecases/task-run.ts     |  16 +++
+ 15 files changed, 919 insertions(+), 4 deletions(-)

--- a/.agentplane/tasks/202605052303-QWE78P/pr/github-body.md
+++ b/.agentplane/tasks/202605052303-QWE78P/pr/github-body.md
@@ -1,0 +1,36 @@
+Task: `202605052303-QWE78P`
+Title: Validate blueprint plan policy budgets
+
+## Summary
+
+Validate blueprint plan policy budgets
+
+Add validation that materialized blueprint plans do not report policy modules outside the selected blueprint contract or exceed context budget, without executing blueprint states.
+
+## Scope
+
+- In scope: Add validation that materialized blueprint plans do not report policy modules outside the selected blueprint contract or exceed context budget, without executing blueprint states.
+- Out of scope: unrelated refactors not required for "Validate blueprint plan policy budgets".
+
+## Verification
+
+- State: ok
+- Note: Implemented and tested blueprint plan policy budget validation.
+- Full verification checklist lives in local review.md.
+
+## Handoff Notes
+
+- 2026-05-05T23:13:27Z CODER: Batch scope includes dependent tasks 202605052303-N37XQ0, 202605052303-FXGCNC, and 202605052303-1CEGJD. The PR covers blueprint plan policy budget validation, plan state transition validation, task-local blueprint snapshots, and project-local blueprint JSON validation.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-05T23:04:26.057Z
+- Branch: task/202605052303-QWE78P/blueprint-plan-validation
+- Head: 95ac0d6a3459
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605052303-QWE78P/pr/github-body.md
+++ b/.agentplane/tasks/202605052303-QWE78P/pr/github-body.md
@@ -25,12 +25,27 @@ Add validation that materialized blueprint plans do not report policy modules ou
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-05T23:04:26.057Z
+- Updated: 2026-05-05T23:13:44.651Z
 - Branch: task/202605052303-QWE78P/blueprint-plan-validation
-- Head: 95ac0d6a3459
+- Head: 3212ba2b0830
 
 ```text
-No changes detected.
+ .agentplane/tasks/202605052303-1CEGJD/README.md    | 129 +++++++++++++++++
+ .agentplane/tasks/202605052303-FXGCNC/README.md    | 129 +++++++++++++++++
+ .agentplane/tasks/202605052303-N37XQ0/README.md    | 129 +++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |  23 +++
+ packages/agentplane/src/blueprints/index.ts        |   8 +-
+ packages/agentplane/src/blueprints/model.ts        |  23 ++-
+ packages/agentplane/src/blueprints/plan.ts         |  15 +-
+ .../agentplane/src/blueprints/validate.test.ts     | 113 ++++++++++++++-
+ packages/agentplane/src/blueprints/validate.ts     | 157 +++++++++++++++++++++
+ .../src/cli/run-cli.core.blueprint.test.ts         |  70 +++++++++
+ .../run-cli.core.tasks.query-run-prepare.test.ts   |  12 ++
+ .../src/cli/run-cli/command-catalog/project.ts     |   3 +
+ .../src/cli/run-cli/command-loaders/project.ts     |   2 +
+ .../src/commands/blueprint/blueprint.command.ts    |  94 ++++++++++++
+ .../agentplane/src/runner/usecases/task-run.ts     |  16 +++
+ 15 files changed, 919 insertions(+), 4 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605052303-QWE78P/pr/github-title.txt
+++ b/.agentplane/tasks/202605052303-QWE78P/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 QWE78P task: Validate blueprint plan policy budgets [202605052303-QWE78P]

--- a/.agentplane/tasks/202605052303-QWE78P/pr/meta.json
+++ b/.agentplane/tasks/202605052303-QWE78P/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605052303-QWE78P/blueprint-plan-validation",
   "created_at": "2026-05-05T23:04:26.057Z",
-  "head_sha": "95ac0d6a3459dcc8292cbddd93c6d23acd07bdd0",
+  "head_sha": "3212ba2b0830bcc33d66bbd0a53467aa81d54e68",
   "last_verified_at": "2026-05-05T23:12:30.006Z",
   "last_verified_sha": "95ac0d6a3459dcc8292cbddd93c6d23acd07bdd0",
   "schema_version": 1,
   "task_id": "202605052303-QWE78P",
-  "updated_at": "2026-05-05T23:04:26.057Z",
+  "updated_at": "2026-05-05T23:13:44.651Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605052303-QWE78P/pr/meta.json
+++ b/.agentplane/tasks/202605052303-QWE78P/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605052303-QWE78P/blueprint-plan-validation",
+  "created_at": "2026-05-05T23:04:26.057Z",
+  "head_sha": "95ac0d6a3459dcc8292cbddd93c6d23acd07bdd0",
+  "last_verified_at": "2026-05-05T23:12:30.006Z",
+  "last_verified_sha": "95ac0d6a3459dcc8292cbddd93c6d23acd07bdd0",
+  "schema_version": 1,
+  "task_id": "202605052303-QWE78P",
+  "updated_at": "2026-05-05T23:04:26.057Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605052303-QWE78P/pr/notes.jsonl
+++ b/.agentplane/tasks/202605052303-QWE78P/pr/notes.jsonl
@@ -1,0 +1,1 @@
+{"schema_version":1,"created_at":"2026-05-05T23:13:27.938Z","author":"CODER","body":"Batch scope includes dependent tasks 202605052303-N37XQ0, 202605052303-FXGCNC, and 202605052303-1CEGJD. The PR covers blueprint plan policy budget validation, plan state transition validation, task-local blueprint snapshots, and project-local blueprint JSON validation."}

--- a/.agentplane/tasks/202605052303-QWE78P/pr/review.md
+++ b/.agentplane/tasks/202605052303-QWE78P/pr/review.md
@@ -45,12 +45,27 @@ Add validation that materialized blueprint plans do not report policy modules ou
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-05T23:04:26.057Z
+- Updated: 2026-05-05T23:13:44.651Z
 - Branch: task/202605052303-QWE78P/blueprint-plan-validation
-- Head: 95ac0d6a3459
+- Head: 3212ba2b0830
 
 ```text
-No changes detected.
+ .agentplane/tasks/202605052303-1CEGJD/README.md    | 129 +++++++++++++++++
+ .agentplane/tasks/202605052303-FXGCNC/README.md    | 129 +++++++++++++++++
+ .agentplane/tasks/202605052303-N37XQ0/README.md    | 129 +++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |  23 +++
+ packages/agentplane/src/blueprints/index.ts        |   8 +-
+ packages/agentplane/src/blueprints/model.ts        |  23 ++-
+ packages/agentplane/src/blueprints/plan.ts         |  15 +-
+ .../agentplane/src/blueprints/validate.test.ts     | 113 ++++++++++++++-
+ packages/agentplane/src/blueprints/validate.ts     | 157 +++++++++++++++++++++
+ .../src/cli/run-cli.core.blueprint.test.ts         |  70 +++++++++
+ .../run-cli.core.tasks.query-run-prepare.test.ts   |  12 ++
+ .../src/cli/run-cli/command-catalog/project.ts     |   3 +
+ .../src/cli/run-cli/command-loaders/project.ts     |   2 +
+ .../src/commands/blueprint/blueprint.command.ts    |  94 ++++++++++++
+ .../agentplane/src/runner/usecases/task-run.ts     |  16 +++
+ 15 files changed, 919 insertions(+), 4 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605052303-QWE78P/pr/review.md
+++ b/.agentplane/tasks/202605052303-QWE78P/pr/review.md
@@ -1,0 +1,57 @@
+# PR Review
+
+Created: 2026-05-05T23:04:26.057Z
+Branch: task/202605052303-QWE78P/blueprint-plan-validation
+
+## Summary
+
+Validate blueprint plan policy budgets
+
+Add validation that materialized blueprint plans do not report policy modules outside the selected blueprint contract or exceed context budget, without executing blueprint states.
+
+## Scope
+
+- In scope: Add validation that materialized blueprint plans do not report policy modules outside the selected blueprint contract or exceed context budget, without executing blueprint states.
+- Out of scope: unrelated refactors not required for "Validate blueprint plan policy budgets".
+
+## Verification
+
+### Plan
+
+1. Review the requested outcome for "Validate blueprint plan policy budgets". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+### Current Status
+
+- State: ok
+- Note: Implemented and tested blueprint plan policy budget validation.
+
+## Risks
+
+- Risk level: not recorded
+- Breaking change: no
+
+### Rollback
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Handoff Notes
+
+- 2026-05-05T23:13:27Z CODER: Batch scope includes dependent tasks 202605052303-N37XQ0, 202605052303-FXGCNC, and 202605052303-1CEGJD. The PR covers blueprint plan policy budget validation, plan state transition validation, task-local blueprint snapshots, and project-local blueprint JSON validation.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-05T23:04:26.057Z
+- Branch: task/202605052303-QWE78P/blueprint-plan-validation
+- Head: 95ac0d6a3459
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -22,6 +22,7 @@ This page is generated from the CLI command specs. Do not edit it by hand; edit 
   - [blueprint](#blueprint)
   - [blueprint explain](#blueprint-explain)
   - [blueprint list](#blueprint-list)
+  - [blueprint validate](#blueprint-validate)
 - Branch
   - [branch base](#branch-base)
   - [branch base clear](#branch-base-clear)
@@ -574,6 +575,28 @@ agentplane blueprint list --json
 ```
 
 - Emit machine-readable routes.
+
+### blueprint validate
+
+Validate a project-local blueprint JSON file without registering or executing it.
+
+Usage:
+
+```text
+agentplane blueprint validate <path> [options]
+```
+
+Options:
+
+- `--json`: Emit JSON. (default=false)
+
+Examples:
+
+```sh
+agentplane blueprint validate .agentplane/blueprints/analysis.json
+```
+
+- Validate a local blueprint definition.
 
 ## Branch
 

--- a/packages/agentplane/src/blueprints/index.ts
+++ b/packages/agentplane/src/blueprints/index.ts
@@ -12,7 +12,11 @@ export {
   recipeBlueprintExtensionsToHints,
 } from "./recipe-hints.js";
 export { inferBlueprintTaskKind, resolveBlueprint } from "./resolve.js";
-export { validateBlueprint, validateBlueprintRegistry } from "./validate.js";
+export {
+  validateBlueprint,
+  validateBlueprintPlanArtifact,
+  validateBlueprintRegistry,
+} from "./validate.js";
 export type {
   AcceptedRecipeExtension,
   Blueprint,
@@ -26,6 +30,8 @@ export type {
   BlueprintId,
   BlueprintPlanArtifact,
   BlueprintPlanState,
+  BlueprintPlanValidationProblem,
+  BlueprintPlanValidationResult,
   BlueprintState,
   BlueprintTaskIntent,
   BlueprintNode,

--- a/packages/agentplane/src/blueprints/model.ts
+++ b/packages/agentplane/src/blueprints/model.ts
@@ -1,4 +1,4 @@
-export type BlueprintId =
+export type BuiltinBlueprintId =
   | "analysis.light"
   | "content.light"
   | "docs.change"
@@ -6,6 +6,8 @@ export type BlueprintId =
   | "code.branch_pr"
   | "release.strict"
   | "ops.approval";
+
+export type BlueprintId = BuiltinBlueprintId | (string & {});
 
 export type TaskKind = "analysis" | "content" | "docs" | "code" | "release" | "ops";
 
@@ -165,6 +167,25 @@ export type BlueprintValidationProblem = {
 export type BlueprintValidationResult = {
   ok: boolean;
   errors: BlueprintValidationProblem[];
+};
+
+export type BlueprintPlanValidationProblem = {
+  code:
+    | "plan_policy_budget_exceeded"
+    | "plan_unknown_policy_module"
+    | "plan_unknown_context_policy_module"
+    | "plan_duplicate_state"
+    | "plan_unknown_state"
+    | "plan_missing_entry_state"
+    | "plan_missing_finish_state"
+    | "plan_invalid_state_transition";
+  message: string;
+  path?: string;
+};
+
+export type BlueprintPlanValidationResult = {
+  ok: boolean;
+  errors: BlueprintPlanValidationProblem[];
 };
 
 export type BlueprintRegistry = {

--- a/packages/agentplane/src/blueprints/plan.ts
+++ b/packages/agentplane/src/blueprints/plan.ts
@@ -8,6 +8,7 @@ import type {
   ResolvedBlueprint,
   WorkflowMode,
 } from "./model.js";
+import { validateBlueprintPlanArtifact } from "./validate.js";
 
 function uniqueSorted(values: readonly string[]): string[] {
   return [...new Set(values.filter((value) => value.trim().length > 0))].toSorted();
@@ -62,7 +63,7 @@ export function buildBlueprintPlanArtifact(opts: {
 }): BlueprintPlanArtifact {
   const statePolicyModules = opts.resolved.activeNodes.flatMap((node) => node.policyModules ?? []);
   const stateCommands = opts.resolved.activeNodes.flatMap((node) => node.allowedCommands ?? []);
-  return {
+  const plan: BlueprintPlanArtifact = {
     schemaVersion: 1,
     blueprintId: opts.resolved.blueprint.id,
     blueprintVersion: opts.resolved.blueprint.version,
@@ -85,4 +86,16 @@ export function buildBlueprintPlanArtifact(opts: {
     rejectedRecipeExtensions: [...opts.resolved.rejectedRecipeExtensions],
     stopReasons: [...opts.resolved.stopReasons],
   };
+  const validation = validateBlueprintPlanArtifact({
+    blueprint: opts.resolved.blueprint,
+    plan,
+  });
+  if (!validation.ok) {
+    throw new Error(
+      `Invalid blueprint plan for ${opts.resolved.blueprint.id}: ${validation.errors
+        .map((error) => error.code)
+        .join(", ")}`,
+    );
+  }
+  return plan;
 }

--- a/packages/agentplane/src/blueprints/validate.test.ts
+++ b/packages/agentplane/src/blueprints/validate.test.ts
@@ -8,7 +8,13 @@ import {
   listBlueprints,
   requireBlueprint,
 } from "./registry.js";
-import { validateBlueprint, validateBlueprintRegistry } from "./validate.js";
+import { buildBlueprintPlanArtifact } from "./plan.js";
+import { resolveBlueprint } from "./resolve.js";
+import {
+  validateBlueprint,
+  validateBlueprintPlanArtifact,
+  validateBlueprintRegistry,
+} from "./validate.js";
 
 function cloneBlueprint(blueprint: Blueprint): Blueprint {
   return structuredClone(blueprint);
@@ -18,6 +24,21 @@ function expectError(blueprint: Blueprint, code: string): void {
   const result = validateBlueprint(blueprint);
   expect(result.ok).toBe(false);
   expect(result.errors.map((error) => error.code)).toContain(code);
+}
+
+function docsPlan() {
+  const resolved = resolveBlueprint({
+    input: {
+      tags: ["docs"],
+      taskKind: "docs",
+      mutation: "docs",
+      workflowMode: "branch_pr",
+    },
+  });
+  return {
+    blueprint: resolved.blueprint,
+    plan: buildBlueprintPlanArtifact({ resolved }),
+  };
 }
 
 describe("blueprint built-ins", () => {
@@ -194,5 +215,95 @@ describe("blueprint validation", () => {
     );
 
     expectError(blueprint, "missing_rollback_evidence");
+  });
+});
+
+describe("blueprint plan validation", () => {
+  it("accepts a materialized plan that matches the selected blueprint contract", () => {
+    const { blueprint, plan } = docsPlan();
+
+    expect(validateBlueprintPlanArtifact({ blueprint, plan })).toEqual({ ok: true, errors: [] });
+  });
+
+  it("rejects policy modules outside the selected blueprint contract", () => {
+    const { blueprint, plan } = docsPlan();
+    const result = validateBlueprintPlanArtifact({
+      blueprint,
+      plan: {
+        ...plan,
+        policyModules: [...plan.policyModules, ".agentplane/policy/workflow.release.md"],
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.map((error) => error.code)).toContain("plan_unknown_policy_module");
+  });
+
+  it("rejects context policy modules outside the selected blueprint contract", () => {
+    const { blueprint, plan } = docsPlan();
+    const result = validateBlueprintPlanArtifact({
+      blueprint,
+      plan: {
+        ...plan,
+        contextManifest: [
+          ...plan.contextManifest,
+          {
+            id: ".agentplane/policy/workflow.release.md",
+            kind: "policy_module",
+            reason: "Injected unrelated policy.",
+            source: ".agentplane/policy/workflow.release.md",
+          },
+        ],
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.map((error) => error.code)).toContain(
+      "plan_unknown_context_policy_module",
+    );
+  });
+
+  it("rejects policy module budgets exceeded by the plan or context manifest", () => {
+    const { blueprint, plan } = docsPlan();
+    const result = validateBlueprintPlanArtifact({
+      blueprint,
+      plan: {
+        ...plan,
+        contextBudget: { ...plan.contextBudget, maxPolicyModules: 0 },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.map((error) => error.code)).toContain("plan_policy_budget_exceeded");
+  });
+
+  it("rejects duplicate, missing, unknown, and invalidly ordered states", () => {
+    const { blueprint, plan } = docsPlan();
+    const firstState = plan.states[0];
+    const secondState = plan.states[1];
+    if (!firstState || !secondState) throw new Error("docs plan must contain states");
+
+    const result = validateBlueprintPlanArtifact({
+      blueprint,
+      plan: {
+        ...plan,
+        states: [
+          { ...secondState },
+          { ...firstState },
+          { ...firstState },
+          { ...firstState, id: "unknown" },
+        ],
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.map((error) => error.code)).toEqual(
+      expect.arrayContaining([
+        "plan_duplicate_state",
+        "plan_unknown_state",
+        "plan_missing_finish_state",
+        "plan_invalid_state_transition",
+      ]),
+    );
   });
 });

--- a/packages/agentplane/src/blueprints/validate.ts
+++ b/packages/agentplane/src/blueprints/validate.ts
@@ -1,6 +1,9 @@
 import type {
   Blueprint,
   BlueprintNodeKind,
+  BlueprintPlanArtifact,
+  BlueprintPlanValidationProblem,
+  BlueprintPlanValidationResult,
   BlueprintRegistry,
   BlueprintValidationProblem,
   BlueprintValidationResult,
@@ -29,6 +32,18 @@ function problem(
   message: string,
   path?: string,
 ): BlueprintValidationProblem {
+  return {
+    code,
+    message,
+    ...(path ? { path } : {}),
+  };
+}
+
+function planProblem(
+  code: BlueprintPlanValidationProblem["code"],
+  message: string,
+  path?: string,
+): BlueprintPlanValidationProblem {
   return {
     code,
     message,
@@ -326,6 +341,148 @@ export function validateBlueprintRegistry(registry: BlueprintRegistry): Blueprin
 
   for (const blueprint of registry.blueprints) {
     errors.push(...validateBlueprint(blueprint).errors);
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+  };
+}
+
+function blueprintPolicyModuleSet(blueprint: Blueprint): Set<string> {
+  return new Set([
+    ...blueprint.policyModules,
+    ...blueprint.nodes.flatMap((node) => node.policyModules ?? []),
+  ]);
+}
+
+function entryNodeIds(blueprint: Blueprint): string[] {
+  return collectEntryNodeIds(blueprint);
+}
+
+function hasEdge(blueprint: Blueprint, from: string, to: string): boolean {
+  return blueprint.edges.some((edge) => edge.from === from && edge.to === to);
+}
+
+function isPolicyModulePath(value: string): boolean {
+  return value.startsWith(".agentplane/policy/");
+}
+
+export function validateBlueprintPlanArtifact(opts: {
+  blueprint: Blueprint;
+  plan: BlueprintPlanArtifact;
+}): BlueprintPlanValidationResult {
+  const errors: BlueprintPlanValidationProblem[] = [];
+  const allowedPolicyModules = blueprintPolicyModuleSet(opts.blueprint);
+  const policyModules = opts.plan.policyModules.filter((item) => item.trim().length > 0);
+  const policyManifestEntries = opts.plan.contextManifest.filter((entry) =>
+    entry.kind === "policy_module" && isPolicyModulePath(entry.source ?? entry.id),
+  );
+
+  if (policyModules.length > opts.plan.contextBudget.maxPolicyModules) {
+    errors.push(
+      planProblem(
+        "plan_policy_budget_exceeded",
+        `Blueprint plan reports ${policyModules.length} policy modules, but the budget allows ${opts.plan.contextBudget.maxPolicyModules}.`,
+        "policyModules",
+      ),
+    );
+  }
+  if (policyManifestEntries.length > opts.plan.contextBudget.maxPolicyModules) {
+    errors.push(
+      planProblem(
+        "plan_policy_budget_exceeded",
+        `Blueprint context manifest reports ${policyManifestEntries.length} policy modules, but the budget allows ${opts.plan.contextBudget.maxPolicyModules}.`,
+        "contextManifest",
+      ),
+    );
+  }
+
+  for (const policyModule of policyModules) {
+    if (!allowedPolicyModules.has(policyModule)) {
+      errors.push(
+        planProblem(
+          "plan_unknown_policy_module",
+          `Blueprint plan reports policy module outside the selected blueprint contract: ${policyModule}`,
+          "policyModules",
+        ),
+      );
+    }
+  }
+  for (const [index, entry] of policyManifestEntries.entries()) {
+    const policyModule = entry.source ?? entry.id;
+    if (!allowedPolicyModules.has(policyModule)) {
+      errors.push(
+        planProblem(
+          "plan_unknown_context_policy_module",
+          `Blueprint context manifest reports policy module outside the selected blueprint contract: ${policyModule}`,
+          `contextManifest.${index}`,
+        ),
+      );
+    }
+  }
+
+  const blueprintNodeIds = nodeIds(opts.blueprint);
+  const seenStateIds = new Set<string>();
+  const duplicateStateIds = new Set<string>();
+  for (const state of opts.plan.states) {
+    if (seenStateIds.has(state.id)) {
+      duplicateStateIds.add(state.id);
+    }
+    seenStateIds.add(state.id);
+    if (!blueprintNodeIds.has(state.id)) {
+      errors.push(
+        planProblem(
+          "plan_unknown_state",
+          `Blueprint plan state is not part of the selected blueprint graph: ${state.id}`,
+          "states",
+        ),
+      );
+    }
+  }
+  for (const duplicate of [...duplicateStateIds].toSorted()) {
+    errors.push(
+      planProblem("plan_duplicate_state", `Blueprint plan contains duplicate state: ${duplicate}`),
+    );
+  }
+
+  for (const entryId of entryNodeIds(opts.blueprint)) {
+    if (!seenStateIds.has(entryId)) {
+      errors.push(
+        planProblem(
+          "plan_missing_entry_state",
+          `Blueprint plan is missing entry state: ${entryId}`,
+          "states",
+        ),
+      );
+    }
+  }
+  const finishIds = opts.blueprint.nodes
+    .filter((node) => node.kind === "finish")
+    .map((node) => node.id);
+  if (!finishIds.some((id) => seenStateIds.has(id))) {
+    errors.push(
+      planProblem(
+        "plan_missing_finish_state",
+        `Blueprint plan is missing finish state; expected one of: ${finishIds.join(", ")}`,
+        "states",
+      ),
+    );
+  }
+
+  for (let index = 0; index < opts.plan.states.length - 1; index += 1) {
+    const from = opts.plan.states[index]?.id;
+    const to = opts.plan.states[index + 1]?.id;
+    if (!from || !to || !blueprintNodeIds.has(from) || !blueprintNodeIds.has(to)) continue;
+    if (!hasEdge(opts.blueprint, from, to)) {
+      errors.push(
+        planProblem(
+          "plan_invalid_state_transition",
+          `Blueprint plan transition is not allowed by the selected blueprint graph: ${from} -> ${to}`,
+          `states.${index}`,
+        ),
+      );
+    }
   }
 
   return {

--- a/packages/agentplane/src/cli/run-cli.core.blueprint.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.blueprint.test.ts
@@ -1,0 +1,70 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { requireBlueprint } from "../blueprints/registry.js";
+import { captureStdIO, mkTempDir } from "@agentplane/testkit";
+import { describe, expect, it } from "vitest";
+
+import { runCli } from "./run-cli.js";
+
+describe("runCli blueprint commands", () => {
+  it("blueprint validate accepts a project-local blueprint JSON file", async () => {
+    const root = await mkTempDir();
+    const blueprintPath = path.join(root, "analysis.custom.json");
+    const blueprint = {
+      ...structuredClone(requireBlueprint("analysis.light")),
+      id: "analysis.custom",
+      title: "Custom analysis",
+    };
+    await writeFile(blueprintPath, `${JSON.stringify(blueprint, null, 2)}\n`, "utf8");
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["blueprint", "validate", blueprintPath, "--json"]);
+      expect(code).toBe(0);
+      expect(JSON.parse(io.stdout)).toMatchObject({
+        ok: true,
+        path: blueprintPath,
+        blueprint_id: "analysis.custom",
+        errors: [],
+      });
+    } finally {
+      io.restore();
+    }
+  });
+
+  it("blueprint validate rejects invalid JSON", async () => {
+    const root = await mkTempDir();
+    const blueprintPath = path.join(root, "invalid.json");
+    await writeFile(blueprintPath, "{", "utf8");
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["blueprint", "validate", blueprintPath]);
+      expect(code).toBe(3);
+      expect(io.stderr).toContain("not valid JSON");
+    } finally {
+      io.restore();
+    }
+  });
+
+  it("blueprint validate reports blueprint contract errors", async () => {
+    const root = await mkTempDir();
+    const blueprintPath = path.join(root, "missing-core.json");
+    const blueprint = structuredClone(requireBlueprint("analysis.light"));
+    blueprint.nodes = blueprint.nodes.filter((node) => node.kind !== "context_resolve");
+    blueprint.edges = blueprint.edges.filter(
+      (edge) => edge.from !== "context_resolve" && edge.to !== "context_resolve",
+    );
+    await writeFile(blueprintPath, `${JSON.stringify(blueprint, null, 2)}\n`, "utf8");
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["blueprint", "validate", blueprintPath]);
+      expect(code).toBe(3);
+      expect(io.stderr).toContain("missing_core_node");
+    } finally {
+      io.restore();
+    }
+  });
+});

--- a/packages/agentplane/src/cli/run-cli.core.tasks.query-run-prepare.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.tasks.query-run-prepare.test.ts
@@ -192,9 +192,11 @@ describe("runCli task run preparation", { timeout: TASKS_QUERY_CLI_TIMEOUT_MS },
       const bundlePath = path.join(runDir, "bundle.json");
       const bootstrapPath = path.join(runDir, "bootstrap.md");
       const statePath = path.join(runDir, "run-state.json");
+      const blueprintSnapshotPath = path.join(root, ".agentplane", "tasks", taskId, "blueprint.json");
       expect(await pathExists(bundlePath)).toBe(true);
       expect(await pathExists(bootstrapPath)).toBe(true);
       expect(await pathExists(statePath)).toBe(true);
+      expect(await pathExists(blueprintSnapshotPath)).toBe(true);
 
       const bundle = JSON.parse(await readFile(bundlePath, "utf8")) as {
         base_prompts?: { id?: string; title?: string; content?: string }[];
@@ -286,6 +288,11 @@ describe("runCli task run preparation", { timeout: TASKS_QUERY_CLI_TIMEOUT_MS },
           requiredEvidence?: { id?: string }[];
         };
         task: { task_id: string };
+      };
+      const blueprintSnapshot = JSON.parse(await readFile(blueprintSnapshotPath, "utf8")) as {
+        blueprintId?: string;
+        contextBudget?: { maxPolicyModules?: number };
+        policyModules?: string[];
       };
       const bootstrap = await readFile(bootstrapPath, "utf8");
       expect(bundle.execution.mode).toBe("dry_run");
@@ -383,6 +390,11 @@ describe("runCli task run preparation", { timeout: TASKS_QUERY_CLI_TIMEOUT_MS },
         blueprintId: "docs.change",
         contextBudget: { maxPolicyModules: 3 },
       });
+      expect(blueprintSnapshot).toMatchObject({
+        blueprintId: "docs.change",
+        contextBudget: { maxPolicyModules: 3 },
+      });
+      expect(blueprintSnapshot.policyModules).toEqual(bundle.blueprint?.policyModules);
       expect(bundle.blueprint?.policyModules?.includes(".agentplane/policy/dod.docs.md")).toBe(
         true,
       );

--- a/packages/agentplane/src/cli/run-cli/command-catalog/project.ts
+++ b/packages/agentplane/src/cli/run-cli/command-catalog/project.ts
@@ -11,6 +11,7 @@ import {
   blueprintExplainSpec,
   blueprintListSpec,
   blueprintSpec,
+  blueprintValidateSpec,
 } from "../../../commands/blueprint/blueprint.command.js";
 import {
   backendInspectSpec,
@@ -103,6 +104,7 @@ import {
   loadBlueprintSpec,
   loadBlueprintListSpec,
   loadBlueprintExplainSpec,
+  loadBlueprintValidateSpec,
 } from "../command-loaders/project.js";
 
 export const PROJECT_COMMANDS = [
@@ -115,6 +117,7 @@ export const PROJECT_COMMANDS = [
   declareCommand(blueprintSpec, { load: loadBlueprintSpec, needs: "none" }),
   declareCommand(blueprintListSpec, { load: loadBlueprintListSpec, needs: "none" }),
   declareCommand(blueprintExplainSpec, { load: loadBlueprintExplainSpec }),
+  declareCommand(blueprintValidateSpec, { load: loadBlueprintValidateSpec, needs: "none" }),
   declareCommand(workStartSpec, { load: loadWorkStartSpec }),
   fromCommandsRecipesRecipesCommand(recipesSpec, "runRecipes", { needs: "none" }),
   fromCommandsRecipesCacheCommand(recipesCacheSpec, "runRecipesCache", { needs: "none" }),

--- a/packages/agentplane/src/cli/run-cli/command-loaders/project.ts
+++ b/packages/agentplane/src/cli/run-cli/command-loaders/project.ts
@@ -29,6 +29,8 @@ export const loadBlueprintExplainSpec = (deps: RunDeps) =>
   import("../../../commands/blueprint/blueprint.command.js").then((m) =>
     m.makeRunBlueprintExplainHandler(deps.getCtx),
   );
+export const loadBlueprintValidateSpec = () =>
+  import("../../../commands/blueprint/blueprint.command.js").then((m) => m.runBlueprintValidate);
 
 export const fromCommandsRecipesRecipesCommand = commandModule(
   () => import("../../../commands/recipes/recipes.command.js"),

--- a/packages/agentplane/src/commands/blueprint/blueprint.command.ts
+++ b/packages/agentplane/src/commands/blueprint/blueprint.command.ts
@@ -1,9 +1,13 @@
+import { readFile } from "node:fs/promises";
+
 import {
   createBlueprintRegistry,
   explainResolvedBlueprint,
   formatBlueprintExplain,
   listBlueprints,
   resolveBlueprint,
+  validateBlueprint,
+  type Blueprint,
   type BlueprintId,
   type BlueprintResolveInput,
   type MutationKind,
@@ -19,6 +23,7 @@ import {
 } from "../../cli/group-command.js";
 import type { CommandCtx, CommandHandler, CommandSpec } from "../../cli/spec/spec.js";
 import { usageError } from "../../cli/spec/errors.js";
+import { ValidationError } from "../../shared/errors.js";
 import { loadTaskFromContext, type CommandContext } from "../shared/task-backend.js";
 
 import { blueprintResolveInputFromTask, workflowModeFromConfig } from "./task-input.js";
@@ -37,6 +42,11 @@ export type BlueprintExplainParsed = {
   description?: string;
   riskFlags: RiskFlag[];
   explicitBlueprintId?: BlueprintId;
+  json: boolean;
+};
+
+export type BlueprintValidateParsed = {
+  path: string;
   json: boolean;
 };
 
@@ -152,6 +162,24 @@ export const blueprintExplainSpec: CommandSpec<BlueprintExplainParsed> = {
   }),
 };
 
+export const blueprintValidateSpec: CommandSpec<BlueprintValidateParsed> = {
+  id: ["blueprint", "validate"],
+  group: "Blueprints",
+  summary: "Validate a project-local blueprint JSON file without registering or executing it.",
+  args: [{ name: "path", required: true, valueHint: "<path>" }],
+  options: [{ kind: "boolean", name: "json", default: false, description: "Emit JSON." }],
+  examples: [
+    {
+      cmd: "agentplane blueprint validate .agentplane/blueprints/analysis.json",
+      why: "Validate a local blueprint definition.",
+    },
+  ],
+  parse: (raw) => ({
+    path: String(raw.args.path),
+    json: raw.opts.json === true,
+  }),
+};
+
 async function runBlueprintRoot(_ctx: CommandCtx, p: GroupCommandParsed): Promise<number> {
   throwGroupCommandUsage({
     spec: blueprintSpec,
@@ -173,6 +201,51 @@ function syntheticInput(ctx: CommandContext, p: BlueprintExplainParsed): Bluepri
     riskFlags: p.riskFlags,
     explicitBlueprintId: p.explicitBlueprintId,
   };
+}
+
+function requireObject(value: unknown, path: string): asserts value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ValidationError({
+      message: `Blueprint file ${JSON.stringify(path)} must contain one JSON object.`,
+      context: { path },
+    });
+  }
+}
+
+function requireArrayField(value: Record<string, unknown>, field: string, path: string): void {
+  if (!Array.isArray(value[field])) {
+    throw new ValidationError({
+      message: `Blueprint file ${JSON.stringify(path)} is missing array field ${JSON.stringify(field)}.`,
+      context: { path, field },
+    });
+  }
+}
+
+function parseBlueprintJson(raw: string, path: string): Blueprint {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new ValidationError({
+      message: `Blueprint file ${JSON.stringify(path)} is not valid JSON: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      context: { path },
+    });
+  }
+  requireObject(parsed, path);
+  for (const field of [
+    "taskKinds",
+    "allowedCommands",
+    "policyModules",
+    "nodes",
+    "edges",
+    "requiredEvidence",
+    "stopRules",
+  ]) {
+    requireArrayField(parsed, field, path);
+  }
+  return parsed as Blueprint;
 }
 
 export function makeRunBlueprintHandler(_getCtx: (cmd: string) => Promise<CommandContext>) {
@@ -225,3 +298,24 @@ export function makeRunBlueprintExplainHandler(getCtx: (cmd: string) => Promise<
     return 0;
   };
 }
+
+export const runBlueprintValidate: CommandHandler<BlueprintValidateParsed> = async (_ctx, p) => {
+  const blueprint = parseBlueprintJson(await readFile(p.path, "utf8"), p.path);
+  const result = validateBlueprint(blueprint);
+  const output = {
+    ok: result.ok,
+    path: p.path,
+    blueprint_id: typeof blueprint.id === "string" ? blueprint.id : null,
+    errors: result.errors,
+  };
+  if (p.json) {
+    process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+  } else if (result.ok) {
+    process.stdout.write(`blueprint valid: ${blueprint.id}@${blueprint.version}\n`);
+  } else {
+    for (const error of result.errors) {
+      process.stderr.write(`${error.code}: ${error.message}\n`);
+    }
+  }
+  return result.ok ? 0 : 3;
+};

--- a/packages/agentplane/src/runner/usecases/task-run.ts
+++ b/packages/agentplane/src/runner/usecases/task-run.ts
@@ -1,3 +1,6 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
 import { normalizeTaskStatus } from "@agentplaneorg/core/tasks";
 import { resolveRecipeBlueprintExtensions, type RecipeManifest } from "@agentplaneorg/recipes";
 
@@ -202,6 +205,18 @@ function buildRunnerBlueprintContextManifest(opts: {
   return entries;
 }
 
+async function writeTaskBlueprintSnapshot(bundle: RunnerContextBundle): Promise<void> {
+  if (bundle.target.kind !== "task" || !bundle.blueprint) return;
+  const snapshotPath = path.join(
+    bundle.repository.git_root,
+    bundle.repository.workflow_dir,
+    bundle.target.task_id,
+    "blueprint.json",
+  );
+  await mkdir(path.dirname(snapshotPath), { recursive: true });
+  await writeFile(snapshotPath, `${JSON.stringify(bundle.blueprint, null, 2)}\n`, "utf8");
+}
+
 async function writeRunnerRefusalArtifacts(opts: {
   bundle: RunnerContextBundle;
   error: CliError;
@@ -404,6 +419,7 @@ export async function prepareTaskRunnerExecution(opts: {
     requested: bundle.execution.policy_decision.requested,
   });
   assertRunnerTaskExecutable(bundle);
+  await writeTaskBlueprintSnapshot(bundle);
   try {
     assertRunnerPolicyCompatibility(bundle);
   } catch (err) {


### PR DESCRIPTION
Task: `202605052303-QWE78P`
Title: Validate blueprint plan policy budgets

## Summary

Validate blueprint plan policy budgets

Add validation that materialized blueprint plans do not report policy modules outside the selected blueprint contract or exceed context budget, without executing blueprint states.

## Scope

- In scope: Add validation that materialized blueprint plans do not report policy modules outside the selected blueprint contract or exceed context budget, without executing blueprint states.
- Out of scope: unrelated refactors not required for "Validate blueprint plan policy budgets".

## Verification

- State: ok
- Note: Implemented and tested blueprint plan policy budget validation.
- Full verification checklist lives in local review.md.

## Handoff Notes

- 2026-05-05T23:13:27Z CODER: Batch scope includes dependent tasks 202605052303-N37XQ0, 202605052303-FXGCNC, and 202605052303-1CEGJD. The PR covers blueprint plan policy budget validation, plan state transition validation, task-local blueprint snapshots, and project-local blueprint JSON validation.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-05T23:13:44.651Z
- Branch: task/202605052303-QWE78P/blueprint-plan-validation
- Head: 3212ba2b0830

```text
 .agentplane/tasks/202605052303-1CEGJD/README.md    | 129 +++++++++++++++++
 .agentplane/tasks/202605052303-FXGCNC/README.md    | 129 +++++++++++++++++
 .agentplane/tasks/202605052303-N37XQ0/README.md    | 129 +++++++++++++++++
 docs/user/cli-reference.generated.mdx              |  23 +++
 packages/agentplane/src/blueprints/index.ts        |   8 +-
 packages/agentplane/src/blueprints/model.ts        |  23 ++-
 packages/agentplane/src/blueprints/plan.ts         |  15 +-
 .../agentplane/src/blueprints/validate.test.ts     | 113 ++++++++++++++-
 packages/agentplane/src/blueprints/validate.ts     | 157 +++++++++++++++++++++
 .../src/cli/run-cli.core.blueprint.test.ts         |  70 +++++++++
 .../run-cli.core.tasks.query-run-prepare.test.ts   |  12 ++
 .../src/cli/run-cli/command-catalog/project.ts     |   3 +
 .../src/cli/run-cli/command-loaders/project.ts     |   2 +
 .../src/commands/blueprint/blueprint.command.ts    |  94 ++++++++++++
 .../agentplane/src/runner/usecases/task-run.ts     |  16 +++
 15 files changed, 919 insertions(+), 4 deletions(-)
```

</details>
