### PR TITLE
🚧 B55DQR task: Add project-local blueprint scaffold command [202605060730-B55DQR]

### DIFF
--- a/.agentplane/tasks/202605060730-B55DQR/README.md
+++ b/.agentplane/tasks/202605060730-B55DQR/README.md
@@ -1,0 +1,117 @@
+---
+id: "202605060730-B55DQR"
+title: "Add project-local blueprint scaffold command"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "blueprints"
+  - "cli"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-06T07:31:24.636Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-06T07:46:52.928Z"
+  updated_by: "CODER"
+  note: "Verified: scaffold command creates project-local blueprint JSON without enabling execution; focused tests and ci:local:fast passed."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement safe project-local blueprint authoring in batch worktree."
+events:
+  -
+    type: "status"
+    at: "2026-05-06T07:31:43.837Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement safe project-local blueprint authoring in batch worktree."
+  -
+    type: "verify"
+    at: "2026-05-06T07:46:52.928Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: scaffold command creates project-local blueprint JSON without enabling execution; focused tests and ci:local:fast passed."
+doc_version: 3
+doc_updated_at: "2026-05-06T07:46:52.935Z"
+doc_updated_by: "CODER"
+description: "Add a safe blueprint scaffold command that writes a local JSON template for project authors without registering or executing the custom blueprint."
+sections:
+  Summary: |-
+    Add project-local blueprint scaffold command
+    
+    Add a safe blueprint scaffold command that writes a local JSON template for project authors without registering or executing the custom blueprint.
+  Scope: |-
+    - In scope: Add a safe blueprint scaffold command that writes a local JSON template for project authors without registering or executing the custom blueprint.
+    - Out of scope: unrelated refactors not required for "Add project-local blueprint scaffold command".
+  Plan: "1. Inspect existing blueprint CLI command structure and tests. 2. Add blueprint scaffold <id> that writes a JSON template to .agentplane/blueprints/<id>.json or a supplied path. 3. Keep scaffold validate-only and non-registering. 4. Add focused CLI tests and refresh CLI docs."
+  Verify Steps: |-
+    1. Review the requested outcome for "Add project-local blueprint scaffold command". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-06T07:46:52.928Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: scaffold command creates project-local blueprint JSON without enabling execution; focused tests and ci:local:fast passed.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T07:31:43.837Z, excerpt_hash=sha256:d2c4fbc2ec412f9c9fcb64c45b9e575d91219c3e58e8007f544d87b79b27a11e
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add project-local blueprint scaffold command
+
+Add a safe blueprint scaffold command that writes a local JSON template for project authors without registering or executing the custom blueprint.
+
+## Scope
+
+- In scope: Add a safe blueprint scaffold command that writes a local JSON template for project authors without registering or executing the custom blueprint.
+- Out of scope: unrelated refactors not required for "Add project-local blueprint scaffold command".
+
+## Plan
+
+1. Inspect existing blueprint CLI command structure and tests. 2. Add blueprint scaffold <id> that writes a JSON template to .agentplane/blueprints/<id>.json or a supplied path. 3. Keep scaffold validate-only and non-registering. 4. Add focused CLI tests and refresh CLI docs.
+
+## Verify Steps
+
+1. Review the requested outcome for "Add project-local blueprint scaffold command". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-06T07:46:52.928Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: scaffold command creates project-local blueprint JSON without enabling execution; focused tests and ci:local:fast passed.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T07:31:43.837Z, excerpt_hash=sha256:d2c4fbc2ec412f9c9fcb64c45b9e575d91219c3e58e8007f544d87b79b27a11e
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605060730-B55DQR/pr/diffstat.txt
+++ b/.agentplane/tasks/202605060730-B55DQR/pr/diffstat.txt
@@ -1,15 +1,15 @@
  .agentplane/tasks/202605060730-PW6S0R/README.md    | 118 +++++++++
  .agentplane/tasks/202605060730-Y7T26J/README.md    | 118 +++++++++
  .agentplane/tasks/202605060731-GK1JRH/README.md    | 118 +++++++++
- docs/developer/blueprints.mdx                      |  78 ++++--
+ docs/developer/blueprints.mdx                      |  79 ++++--
  docs/user/cli-reference.generated.mdx              |  62 ++++-
  packages/agentplane/src/blueprints/index.ts        |  15 ++
- .../agentplane/src/blueprints/project-local.ts     | 216 ++++++++++++++++
- .../src/cli/run-cli.core.blueprint.test.ts         |  66 ++++-
+ .../agentplane/src/blueprints/project-local.ts     | 239 +++++++++++++++++
+ .../src/cli/run-cli.core.blueprint.test.ts         | 120 ++++++++-
  .../src/cli/run-cli/command-catalog/project.ts     |   3 +
  .../src/cli/run-cli/command-loaders/project.ts     |   2 +
  .../src/commands/blueprint/blueprint.command.ts    | 285 ++++++++++++++++-----
  .../agentplane/src/commands/doctor.fast.test.ts    |  19 ++
  packages/agentplane/src/commands/doctor.run.ts     |   3 +
  .../agentplane/src/commands/doctor/blueprints.ts   |  15 ++
- 14 files changed, 1031 insertions(+), 87 deletions(-)
+ 14 files changed, 1109 insertions(+), 87 deletions(-)

--- a/.agentplane/tasks/202605060730-B55DQR/pr/diffstat.txt
+++ b/.agentplane/tasks/202605060730-B55DQR/pr/diffstat.txt
@@ -1,0 +1,15 @@
+ .agentplane/tasks/202605060730-PW6S0R/README.md    | 118 +++++++++
+ .agentplane/tasks/202605060730-Y7T26J/README.md    | 118 +++++++++
+ .agentplane/tasks/202605060731-GK1JRH/README.md    | 118 +++++++++
+ docs/developer/blueprints.mdx                      |  78 ++++--
+ docs/user/cli-reference.generated.mdx              |  62 ++++-
+ packages/agentplane/src/blueprints/index.ts        |  15 ++
+ .../agentplane/src/blueprints/project-local.ts     | 216 ++++++++++++++++
+ .../src/cli/run-cli.core.blueprint.test.ts         |  66 ++++-
+ .../src/cli/run-cli/command-catalog/project.ts     |   3 +
+ .../src/cli/run-cli/command-loaders/project.ts     |   2 +
+ .../src/commands/blueprint/blueprint.command.ts    | 285 ++++++++++++++++-----
+ .../agentplane/src/commands/doctor.fast.test.ts    |  19 ++
+ packages/agentplane/src/commands/doctor.run.ts     |   3 +
+ .../agentplane/src/commands/doctor/blueprints.ts   |  15 ++
+ 14 files changed, 1031 insertions(+), 87 deletions(-)

--- a/.agentplane/tasks/202605060730-B55DQR/pr/github-body.md
+++ b/.agentplane/tasks/202605060730-B55DQR/pr/github-body.md
@@ -25,12 +25,26 @@ Add a safe blueprint scaffold command that writes a local JSON template for proj
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-06T07:31:43.904Z
+- Updated: 2026-05-06T07:47:49.435Z
 - Branch: task/202605060730-B55DQR/local-blueprint-authoring
-- Head: 189d3d1be142
+- Head: a9f142c37f71
 
 ```text
-No changes detected.
+ .agentplane/tasks/202605060730-PW6S0R/README.md    | 118 +++++++++
+ .agentplane/tasks/202605060730-Y7T26J/README.md    | 118 +++++++++
+ .agentplane/tasks/202605060731-GK1JRH/README.md    | 118 +++++++++
+ docs/developer/blueprints.mdx                      |  78 ++++--
+ docs/user/cli-reference.generated.mdx              |  62 ++++-
+ packages/agentplane/src/blueprints/index.ts        |  15 ++
+ .../agentplane/src/blueprints/project-local.ts     | 216 ++++++++++++++++
+ .../src/cli/run-cli.core.blueprint.test.ts         |  66 ++++-
+ .../src/cli/run-cli/command-catalog/project.ts     |   3 +
+ .../src/cli/run-cli/command-loaders/project.ts     |   2 +
+ .../src/commands/blueprint/blueprint.command.ts    | 285 ++++++++++++++++-----
+ .../agentplane/src/commands/doctor.fast.test.ts    |  19 ++
+ packages/agentplane/src/commands/doctor.run.ts     |   3 +
+ .../agentplane/src/commands/doctor/blueprints.ts   |  15 ++
+ 14 files changed, 1031 insertions(+), 87 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605060730-B55DQR/pr/github-body.md
+++ b/.agentplane/tasks/202605060730-B55DQR/pr/github-body.md
@@ -1,0 +1,36 @@
+Task: `202605060730-B55DQR`
+Title: Add project-local blueprint scaffold command
+
+## Summary
+
+Add project-local blueprint scaffold command
+
+Add a safe blueprint scaffold command that writes a local JSON template for project authors without registering or executing the custom blueprint.
+
+## Scope
+
+- In scope: Add a safe blueprint scaffold command that writes a local JSON template for project authors without registering or executing the custom blueprint.
+- Out of scope: unrelated refactors not required for "Add project-local blueprint scaffold command".
+
+## Verification
+
+- State: ok
+- Note: Verified: scaffold command creates project-local blueprint JSON without enabling execution; focused tests and ci:local:fast passed.
+- Full verification checklist lives in local review.md.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-06T07:31:43.904Z
+- Branch: task/202605060730-B55DQR/local-blueprint-authoring
+- Head: 189d3d1be142
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605060730-B55DQR/pr/github-body.md
+++ b/.agentplane/tasks/202605060730-B55DQR/pr/github-body.md
@@ -25,26 +25,26 @@ Add a safe blueprint scaffold command that writes a local JSON template for proj
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-06T07:47:49.435Z
+- Updated: 2026-05-06T08:06:03.465Z
 - Branch: task/202605060730-B55DQR/local-blueprint-authoring
-- Head: a9f142c37f71
+- Head: 6ab093da1868
 
 ```text
  .agentplane/tasks/202605060730-PW6S0R/README.md    | 118 +++++++++
  .agentplane/tasks/202605060730-Y7T26J/README.md    | 118 +++++++++
  .agentplane/tasks/202605060731-GK1JRH/README.md    | 118 +++++++++
- docs/developer/blueprints.mdx                      |  78 ++++--
+ docs/developer/blueprints.mdx                      |  79 ++++--
  docs/user/cli-reference.generated.mdx              |  62 ++++-
  packages/agentplane/src/blueprints/index.ts        |  15 ++
- .../agentplane/src/blueprints/project-local.ts     | 216 ++++++++++++++++
- .../src/cli/run-cli.core.blueprint.test.ts         |  66 ++++-
+ .../agentplane/src/blueprints/project-local.ts     | 239 +++++++++++++++++
+ .../src/cli/run-cli.core.blueprint.test.ts         | 120 ++++++++-
  .../src/cli/run-cli/command-catalog/project.ts     |   3 +
  .../src/cli/run-cli/command-loaders/project.ts     |   2 +
  .../src/commands/blueprint/blueprint.command.ts    | 285 ++++++++++++++++-----
  .../agentplane/src/commands/doctor.fast.test.ts    |  19 ++
  packages/agentplane/src/commands/doctor.run.ts     |   3 +
  .../agentplane/src/commands/doctor/blueprints.ts   |  15 ++
- 14 files changed, 1031 insertions(+), 87 deletions(-)
+ 14 files changed, 1109 insertions(+), 87 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605060730-B55DQR/pr/github-title.txt
+++ b/.agentplane/tasks/202605060730-B55DQR/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 B55DQR task: Add project-local blueprint scaffold command [202605060730-B55DQR]

--- a/.agentplane/tasks/202605060730-B55DQR/pr/meta.json
+++ b/.agentplane/tasks/202605060730-B55DQR/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605060730-B55DQR/local-blueprint-authoring",
   "created_at": "2026-05-06T07:31:43.904Z",
-  "head_sha": "a9f142c37f715d7d940c42873f75906e43862d01",
+  "head_sha": "6ab093da18685cc0b7f20aa4bc521208914e9fec",
   "last_verified_at": "2026-05-06T07:46:52.928Z",
   "last_verified_sha": "189d3d1be142e1e6790bffba890ff24fa7474648",
   "schema_version": 1,
   "task_id": "202605060730-B55DQR",
-  "updated_at": "2026-05-06T07:47:49.435Z",
+  "updated_at": "2026-05-06T08:06:03.465Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605060730-B55DQR/pr/meta.json
+++ b/.agentplane/tasks/202605060730-B55DQR/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605060730-B55DQR/local-blueprint-authoring",
   "created_at": "2026-05-06T07:31:43.904Z",
-  "head_sha": "189d3d1be142e1e6790bffba890ff24fa7474648",
+  "head_sha": "a9f142c37f715d7d940c42873f75906e43862d01",
   "last_verified_at": "2026-05-06T07:46:52.928Z",
   "last_verified_sha": "189d3d1be142e1e6790bffba890ff24fa7474648",
   "schema_version": 1,
   "task_id": "202605060730-B55DQR",
-  "updated_at": "2026-05-06T07:31:43.904Z",
+  "updated_at": "2026-05-06T07:47:49.435Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605060730-B55DQR/pr/meta.json
+++ b/.agentplane/tasks/202605060730-B55DQR/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605060730-B55DQR/local-blueprint-authoring",
+  "created_at": "2026-05-06T07:31:43.904Z",
+  "head_sha": "189d3d1be142e1e6790bffba890ff24fa7474648",
+  "last_verified_at": "2026-05-06T07:46:52.928Z",
+  "last_verified_sha": "189d3d1be142e1e6790bffba890ff24fa7474648",
+  "schema_version": 1,
+  "task_id": "202605060730-B55DQR",
+  "updated_at": "2026-05-06T07:31:43.904Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605060730-B55DQR/pr/review.md
+++ b/.agentplane/tasks/202605060730-B55DQR/pr/review.md
@@ -45,26 +45,26 @@ Add a safe blueprint scaffold command that writes a local JSON template for proj
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-06T07:47:49.435Z
+- Updated: 2026-05-06T08:06:03.465Z
 - Branch: task/202605060730-B55DQR/local-blueprint-authoring
-- Head: a9f142c37f71
+- Head: 6ab093da1868
 
 ```text
  .agentplane/tasks/202605060730-PW6S0R/README.md    | 118 +++++++++
  .agentplane/tasks/202605060730-Y7T26J/README.md    | 118 +++++++++
  .agentplane/tasks/202605060731-GK1JRH/README.md    | 118 +++++++++
- docs/developer/blueprints.mdx                      |  78 ++++--
+ docs/developer/blueprints.mdx                      |  79 ++++--
  docs/user/cli-reference.generated.mdx              |  62 ++++-
  packages/agentplane/src/blueprints/index.ts        |  15 ++
- .../agentplane/src/blueprints/project-local.ts     | 216 ++++++++++++++++
- .../src/cli/run-cli.core.blueprint.test.ts         |  66 ++++-
+ .../agentplane/src/blueprints/project-local.ts     | 239 +++++++++++++++++
+ .../src/cli/run-cli.core.blueprint.test.ts         | 120 ++++++++-
  .../src/cli/run-cli/command-catalog/project.ts     |   3 +
  .../src/cli/run-cli/command-loaders/project.ts     |   2 +
  .../src/commands/blueprint/blueprint.command.ts    | 285 ++++++++++++++++-----
  .../agentplane/src/commands/doctor.fast.test.ts    |  19 ++
  packages/agentplane/src/commands/doctor.run.ts     |   3 +
  .../agentplane/src/commands/doctor/blueprints.ts   |  15 ++
- 14 files changed, 1031 insertions(+), 87 deletions(-)
+ 14 files changed, 1109 insertions(+), 87 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605060730-B55DQR/pr/review.md
+++ b/.agentplane/tasks/202605060730-B55DQR/pr/review.md
@@ -1,0 +1,57 @@
+# PR Review
+
+Created: 2026-05-06T07:31:43.904Z
+Branch: task/202605060730-B55DQR/local-blueprint-authoring
+
+## Summary
+
+Add project-local blueprint scaffold command
+
+Add a safe blueprint scaffold command that writes a local JSON template for project authors without registering or executing the custom blueprint.
+
+## Scope
+
+- In scope: Add a safe blueprint scaffold command that writes a local JSON template for project authors without registering or executing the custom blueprint.
+- Out of scope: unrelated refactors not required for "Add project-local blueprint scaffold command".
+
+## Verification
+
+### Plan
+
+1. Review the requested outcome for "Add project-local blueprint scaffold command". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+### Current Status
+
+- State: ok
+- Note: Verified: scaffold command creates project-local blueprint JSON without enabling execution; focused tests and ci:local:fast passed.
+
+## Risks
+
+- Risk level: not recorded
+- Breaking change: no
+
+### Rollback
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-06T07:31:43.904Z
+- Branch: task/202605060730-B55DQR/local-blueprint-authoring
+- Head: 189d3d1be142
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605060730-B55DQR/pr/review.md
+++ b/.agentplane/tasks/202605060730-B55DQR/pr/review.md
@@ -45,12 +45,26 @@ Add a safe blueprint scaffold command that writes a local JSON template for proj
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-06T07:31:43.904Z
+- Updated: 2026-05-06T07:47:49.435Z
 - Branch: task/202605060730-B55DQR/local-blueprint-authoring
-- Head: 189d3d1be142
+- Head: a9f142c37f71
 
 ```text
-No changes detected.
+ .agentplane/tasks/202605060730-PW6S0R/README.md    | 118 +++++++++
+ .agentplane/tasks/202605060730-Y7T26J/README.md    | 118 +++++++++
+ .agentplane/tasks/202605060731-GK1JRH/README.md    | 118 +++++++++
+ docs/developer/blueprints.mdx                      |  78 ++++--
+ docs/user/cli-reference.generated.mdx              |  62 ++++-
+ packages/agentplane/src/blueprints/index.ts        |  15 ++
+ .../agentplane/src/blueprints/project-local.ts     | 216 ++++++++++++++++
+ .../src/cli/run-cli.core.blueprint.test.ts         |  66 ++++-
+ .../src/cli/run-cli/command-catalog/project.ts     |   3 +
+ .../src/cli/run-cli/command-loaders/project.ts     |   2 +
+ .../src/commands/blueprint/blueprint.command.ts    | 285 ++++++++++++++++-----
+ .../agentplane/src/commands/doctor.fast.test.ts    |  19 ++
+ packages/agentplane/src/commands/doctor.run.ts     |   3 +
+ .../agentplane/src/commands/doctor/blueprints.ts   |  15 ++
+ 14 files changed, 1031 insertions(+), 87 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605060730-PW6S0R/README.md
+++ b/.agentplane/tasks/202605060730-PW6S0R/README.md
@@ -1,0 +1,118 @@
+---
+id: "202605060730-PW6S0R"
+title: "Validate local blueprints in doctor"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on:
+  - "202605060730-Y7T26J"
+tags:
+  - "blueprints"
+  - "doctor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-06T07:31:25.206Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-06T07:46:57.051Z"
+  updated_by: "CODER"
+  note: "Verified: doctor reports invalid project-local blueprints as warnings; doctor test and ci:local:fast passed."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: batch execution in B55DQR worktree; add doctor validation for local blueprints."
+events:
+  -
+    type: "status"
+    at: "2026-05-06T07:31:57.581Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: batch execution in B55DQR worktree; add doctor validation for local blueprints."
+  -
+    type: "verify"
+    at: "2026-05-06T07:46:57.051Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: doctor reports invalid project-local blueprints as warnings; doctor test and ci:local:fast passed."
+doc_version: 3
+doc_updated_at: "2026-05-06T07:46:57.057Z"
+doc_updated_by: "CODER"
+description: "Add doctor coverage for project-local blueprint definitions so invalid .agentplane/blueprints/*.json files are reported before custom routes can be trusted."
+sections:
+  Summary: |-
+    Validate local blueprints in doctor
+    
+    Add doctor coverage for project-local blueprint definitions so invalid .agentplane/blueprints/*.json files are reported before custom routes can be trusted.
+  Scope: |-
+    - In scope: Add doctor coverage for project-local blueprint definitions so invalid .agentplane/blueprints/*.json files are reported before custom routes can be trusted.
+    - Out of scope: unrelated refactors not required for "Validate local blueprints in doctor".
+  Plan: "1. Locate doctor check structure. 2. Add local blueprint validation to doctor as a project authoring guard. 3. Report invalid local blueprint files with actionable diagnostics. 4. Add doctor tests for valid and invalid local blueprints."
+  Verify Steps: |-
+    1. Review the requested outcome for "Validate local blueprints in doctor". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-06T07:46:57.051Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: doctor reports invalid project-local blueprints as warnings; doctor test and ci:local:fast passed.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T07:31:57.581Z, excerpt_hash=sha256:2abfb185be54401f950899f7a0db8df96e3dbee1eb3e93e67abcb7b0c8e680fe
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Validate local blueprints in doctor
+
+Add doctor coverage for project-local blueprint definitions so invalid .agentplane/blueprints/*.json files are reported before custom routes can be trusted.
+
+## Scope
+
+- In scope: Add doctor coverage for project-local blueprint definitions so invalid .agentplane/blueprints/*.json files are reported before custom routes can be trusted.
+- Out of scope: unrelated refactors not required for "Validate local blueprints in doctor".
+
+## Plan
+
+1. Locate doctor check structure. 2. Add local blueprint validation to doctor as a project authoring guard. 3. Report invalid local blueprint files with actionable diagnostics. 4. Add doctor tests for valid and invalid local blueprints.
+
+## Verify Steps
+
+1. Review the requested outcome for "Validate local blueprints in doctor". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-06T07:46:57.051Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: doctor reports invalid project-local blueprints as warnings; doctor test and ci:local:fast passed.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T07:31:57.581Z, excerpt_hash=sha256:2abfb185be54401f950899f7a0db8df96e3dbee1eb3e93e67abcb7b0c8e680fe
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605060730-Y7T26J/README.md
+++ b/.agentplane/tasks/202605060730-Y7T26J/README.md
@@ -1,0 +1,118 @@
+---
+id: "202605060730-Y7T26J"
+title: "Load project-local blueprint registry safely"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on:
+  - "202605060730-B55DQR"
+tags:
+  - "blueprints"
+  - "registry"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-06T07:31:24.921Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-06T07:46:55.599Z"
+  updated_by: "CODER"
+  note: "Verified: project-local registry listing validates JSON definitions before listing; focused tests and ci:local:fast passed."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: batch execution in B55DQR worktree; add safe local blueprint registry loading."
+events:
+  -
+    type: "status"
+    at: "2026-05-06T07:31:57.413Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: batch execution in B55DQR worktree; add safe local blueprint registry loading."
+  -
+    type: "verify"
+    at: "2026-05-06T07:46:55.599Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: project-local registry listing validates JSON definitions before listing; focused tests and ci:local:fast passed."
+doc_version: 3
+doc_updated_at: "2026-05-06T07:46:55.605Z"
+doc_updated_by: "CODER"
+description: "Add a validate-only project-local blueprint registry loader for .agentplane/blueprints/*.json and expose list/validate-all surfaces without automatic resolver selection."
+sections:
+  Summary: |-
+    Load project-local blueprint registry safely
+    
+    Add a validate-only project-local blueprint registry loader for .agentplane/blueprints/*.json and expose list/validate-all surfaces without automatic resolver selection.
+  Scope: |-
+    - In scope: Add a validate-only project-local blueprint registry loader for .agentplane/blueprints/*.json and expose list/validate-all surfaces without automatic resolver selection.
+    - Out of scope: unrelated refactors not required for "Load project-local blueprint registry safely".
+  Plan: "1. Add project-local blueprint JSON discovery under .agentplane/blueprints/*.json. 2. Reuse validateBlueprint for each file and surface deterministic errors. 3. Extend blueprint list/validate surfaces to include project-local entries without feeding them into resolver by default. 4. Add focused tests."
+  Verify Steps: |-
+    1. Review the requested outcome for "Load project-local blueprint registry safely". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-06T07:46:55.599Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: project-local registry listing validates JSON definitions before listing; focused tests and ci:local:fast passed.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T07:31:57.413Z, excerpt_hash=sha256:851f38c7379d116d85dca34e6f933cb93dd56a2c9d6cf925579370bbc111ff43
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Load project-local blueprint registry safely
+
+Add a validate-only project-local blueprint registry loader for .agentplane/blueprints/*.json and expose list/validate-all surfaces without automatic resolver selection.
+
+## Scope
+
+- In scope: Add a validate-only project-local blueprint registry loader for .agentplane/blueprints/*.json and expose list/validate-all surfaces without automatic resolver selection.
+- Out of scope: unrelated refactors not required for "Load project-local blueprint registry safely".
+
+## Plan
+
+1. Add project-local blueprint JSON discovery under .agentplane/blueprints/*.json. 2. Reuse validateBlueprint for each file and surface deterministic errors. 3. Extend blueprint list/validate surfaces to include project-local entries without feeding them into resolver by default. 4. Add focused tests.
+
+## Verify Steps
+
+1. Review the requested outcome for "Load project-local blueprint registry safely". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-06T07:46:55.599Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: project-local registry listing validates JSON definitions before listing; focused tests and ci:local:fast passed.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T07:31:57.413Z, excerpt_hash=sha256:851f38c7379d116d85dca34e6f933cb93dd56a2c9d6cf925579370bbc111ff43
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605060731-GK1JRH/README.md
+++ b/.agentplane/tasks/202605060731-GK1JRH/README.md
@@ -1,0 +1,118 @@
+---
+id: "202605060731-GK1JRH"
+title: "Document local blueprint authoring"
+status: "DOING"
+priority: "med"
+owner: "DOCS"
+revision: 5
+origin:
+  system: "manual"
+depends_on:
+  - "202605060730-PW6S0R"
+tags:
+  - "blueprints"
+  - "docs"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-06T07:31:25.499Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-06T07:46:58.471Z"
+  updated_by: "CODER"
+  note: "Verified: blueprint authoring documentation and generated CLI reference were updated; docs freshness and ci:local:fast passed."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: batch execution in B55DQR worktree; document safe local blueprint authoring."
+events:
+  -
+    type: "status"
+    at: "2026-05-06T07:31:57.749Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: batch execution in B55DQR worktree; document safe local blueprint authoring."
+  -
+    type: "verify"
+    at: "2026-05-06T07:46:58.471Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: blueprint authoring documentation and generated CLI reference were updated; docs freshness and ci:local:fast passed."
+doc_version: 3
+doc_updated_at: "2026-05-06T07:46:58.476Z"
+doc_updated_by: "CODER"
+description: "Document safe project-local blueprint authoring, scaffold, validate, registry listing, and current non-execution limits for v0.5."
+sections:
+  Summary: |-
+    Document local blueprint authoring
+    
+    Document safe project-local blueprint authoring, scaffold, validate, registry listing, and current non-execution limits for v0.5.
+  Scope: |-
+    - In scope: Document safe project-local blueprint authoring, scaffold, validate, registry listing, and current non-execution limits for v0.5.
+    - Out of scope: unrelated refactors not required for "Document local blueprint authoring".
+  Plan: "1. Add documentation for local blueprint authoring and current safe-mode limits. 2. Document scaffold, validate, list visibility, and doctor validation. 3. Clarify that custom blueprints are not selected by resolver automatically in this phase. 4. Run docs freshness checks."
+  Verify Steps: |-
+    1. Review the requested outcome for "Document local blueprint authoring". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-06T07:46:58.471Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: blueprint authoring documentation and generated CLI reference were updated; docs freshness and ci:local:fast passed.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T07:31:57.749Z, excerpt_hash=sha256:b70f7e9e34d8bf07102231c8522cc2edea7df34dabf400f7ec26318576fe099f
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Document local blueprint authoring
+
+Document safe project-local blueprint authoring, scaffold, validate, registry listing, and current non-execution limits for v0.5.
+
+## Scope
+
+- In scope: Document safe project-local blueprint authoring, scaffold, validate, registry listing, and current non-execution limits for v0.5.
+- Out of scope: unrelated refactors not required for "Document local blueprint authoring".
+
+## Plan
+
+1. Add documentation for local blueprint authoring and current safe-mode limits. 2. Document scaffold, validate, list visibility, and doctor validation. 3. Clarify that custom blueprints are not selected by resolver automatically in this phase. 4. Run docs freshness checks.
+
+## Verify Steps
+
+1. Review the requested outcome for "Document local blueprint authoring". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-06T07:46:58.471Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: blueprint authoring documentation and generated CLI reference were updated; docs freshness and ci:local:fast passed.
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T07:31:57.749Z, excerpt_hash=sha256:b70f7e9e34d8bf07102231c8522cc2edea7df34dabf400f7ec26318576fe099f
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/docs/developer/blueprints.mdx
+++ b/docs/developer/blueprints.mdx
@@ -816,6 +816,7 @@ Command semantics:
 | ----------------------------------------------- | ---------------------------------------------------------------------- |
 | `blueprint scaffold <id>`                       | Clones a built-in route, defaults to `analysis.light`, and writes JSON |
 | `blueprint scaffold <id> --from code.branch_pr` | Starts from a specific built-in route                                  |
+| `blueprint scaffold <id> --out <path>`          | Writes to a custom path, restricted to the current project             |
 | `blueprint validate <path>`                     | Validates one JSON blueprint file                                      |
 | `blueprint validate --project`                  | Validates every `.json` file under `.agentplane/blueprints`            |
 | `blueprint list --project`                      | Lists built-ins plus valid local definitions                           |

--- a/docs/developer/blueprints.mdx
+++ b/docs/developer/blueprints.mdx
@@ -105,6 +105,7 @@ blueprints/
   model.ts
   builtins.ts
   registry.ts
+  project-local.ts
   validate.ts
   resolve.ts
   explain.ts
@@ -115,16 +116,17 @@ blueprints/
 
 Initial responsibilities:
 
-| File              | Responsibility                                                                 |
-| ----------------- | ------------------------------------------------------------------------------ |
-| `model.ts`        | Pure types, string unions, and small helper predicates                         |
-| `builtins.ts`     | Built-in blueprint definitions and node catalog                                |
-| `registry.ts`     | Registry lookup, duplicate detection, and built-in export                      |
-| `validate.ts`     | Structural validation and invariant checks                                     |
-| `resolve.ts`      | Select a blueprint from task metadata, workflow mode, mutation, risk, recipes  |
-| `explain.ts`      | Convert resolved blueprint data into stable human-readable explanation objects |
-| `recipe-hints.ts` | Convert normalized recipe blueprint extensions into resolver hints             |
-| `index.ts`        | Public internal exports for CLI and verification integrations                  |
+| File               | Responsibility                                                                 |
+| ------------------ | ------------------------------------------------------------------------------ |
+| `model.ts`         | Pure types, string unions, and small helper predicates                         |
+| `builtins.ts`      | Built-in blueprint definitions and node catalog                                |
+| `registry.ts`      | Registry lookup, duplicate detection, and built-in export                      |
+| `project-local.ts` | Safe JSON parsing, scaffold writing, and project-local blueprint validation    |
+| `validate.ts`      | Structural validation and invariant checks                                     |
+| `resolve.ts`       | Select a blueprint from task metadata, workflow mode, mutation, risk, recipes  |
+| `explain.ts`       | Convert resolved blueprint data into stable human-readable explanation objects |
+| `recipe-hints.ts`  | Convert normalized recipe blueprint extensions into resolver hints             |
+| `index.ts`         | Public internal exports for CLI and verification integrations                  |
 
 Do not place route logic inside command handlers. Commands should call the resolver and formatter.
 
@@ -662,12 +664,12 @@ The current built-in registry is code-backed. Add a new built-in blueprint with 
 
 Efficient authoring path for the next implementation step:
 
-- introduce data-driven specs under `.agentplane/blueprints/*.yaml` or `.json`;
-- add `agentplane blueprint scaffold <id>`;
-- add `agentplane blueprint validate <path>`;
-- load project-local blueprints after built-ins but before recipe hints;
-- generate compatibility fixtures from the registry so every new blueprint gets route, evidence,
-  and stop-rule coverage.
+- add explicit opt-in resolver support for trusted project-local blueprints;
+- generate compatibility fixtures from the combined registry so every new blueprint gets route,
+  evidence, and stop-rule coverage;
+- add runner bundle visibility for the selected blueprint id, route, context budget, and policy
+  module budget;
+- keep project-local route selection disabled unless the repository explicitly opts in.
 
 Recipes should not define full lifecycle graphs yet. They may request compatible blueprints and add
 extension hints, but the resolver and registry remain the authority for lifecycle topology.
@@ -742,9 +744,13 @@ CLI shape:
 
 ```text
 agentplane blueprint list
+agentplane blueprint list --project
 agentplane blueprint explain <task-id>
 agentplane blueprint explain --kind analysis --mutation none
 agentplane blueprint explain <task-id> --json
+agentplane blueprint scaffold <id>
+agentplane blueprint validate <path>
+agentplane blueprint validate --project
 ```
 
 Expected explain fields:
@@ -784,6 +790,46 @@ Not required:
 - CI
 - merge
 ```
+
+## Project-Local Authoring
+
+Project-local blueprints live under `.agentplane/blueprints/*.json`.
+
+This is an authoring and validation surface, not automatic execution. A local blueprint can be
+scaffolded, listed, and validated, but the resolver does not select it by default and the runner does
+not execute custom node graphs yet. That boundary is intentional: custom lifecycle topology must be
+visible and valid before it can become an execution route.
+
+Safe authoring loop:
+
+```bash
+agentplane blueprint scaffold analysis.custom
+agentplane blueprint validate .agentplane/blueprints/analysis.custom.json
+agentplane blueprint validate --project
+agentplane blueprint list --project
+agentplane doctor
+```
+
+Command semantics:
+
+| Command                                         | Effect                                                                 |
+| ----------------------------------------------- | ---------------------------------------------------------------------- |
+| `blueprint scaffold <id>`                       | Clones a built-in route, defaults to `analysis.light`, and writes JSON |
+| `blueprint scaffold <id> --from code.branch_pr` | Starts from a specific built-in route                                  |
+| `blueprint validate <path>`                     | Validates one JSON blueprint file                                      |
+| `blueprint validate --project`                  | Validates every `.json` file under `.agentplane/blueprints`            |
+| `blueprint list --project`                      | Lists built-ins plus valid local definitions                           |
+| `doctor`                                        | Reports invalid local blueprints as warnings                           |
+
+Authoring constraints:
+
+1. Keep the id stable and project-specific, for example `analysis.custom` or `docs.api-review`.
+2. Prefer cloning the closest built-in route instead of inventing a full graph from scratch.
+3. Keep `analysis` and `content` routes lightweight: no PR, CI, hosted checks, merge, or publish
+   nodes unless the task class truly mutates external state.
+4. Validate the full project registry before relying on a custom route in docs or experiments.
+5. Treat custom blueprints as contracts for future execution, not as permission to bypass policy
+   modules, approvals, or workflow mode constraints.
 
 ## ACR Relationship
 

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -22,6 +22,7 @@ This page is generated from the CLI command specs. Do not edit it by hand; edit 
   - [blueprint](#blueprint)
   - [blueprint explain](#blueprint-explain)
   - [blueprint list](#blueprint-list)
+  - [blueprint scaffold](#blueprint-scaffold)
   - [blueprint validate](#blueprint-validate)
 - Branch
   - [branch base](#branch-base)
@@ -496,7 +497,7 @@ agentplane sync redmine --direction push --yes
 
 List and explain blueprint routing without executing a task.
 
-This is a command group. Use \`agentplane blueprint list\` or \`agentplane blueprint explain ...\`.
+This is a command group. Use \`agentplane blueprint list\`, \`agentplane blueprint explain ...\`, \`agentplane blueprint scaffold ...\`, or \`agentplane blueprint validate ...\`.
 
 Usage:
 
@@ -511,6 +512,12 @@ agentplane blueprint list
 ```
 
 - Show built-in blueprint routes.
+
+```sh
+agentplane blueprint scaffold analysis.custom
+```
+
+- Create a project-local blueprint scaffold.
 
 ```sh
 agentplane blueprint explain 202605051957-5WRJZK
@@ -556,7 +563,7 @@ agentplane blueprint explain --kind analysis --mutation none
 
 ### blueprint list
 
-List built-in blueprint routes.
+List built-in and optional project-local blueprint routes.
 
 Usage:
 
@@ -566,6 +573,7 @@ agentplane blueprint list [options]
 
 Options:
 
+- `--project`: Include validated project-local blueprints from .agentplane/blueprints. (default=false)
 - `--json`: Emit JSON. (default=false)
 
 Examples:
@@ -574,20 +582,58 @@ Examples:
 agentplane blueprint list --json
 ```
 
-- Emit machine-readable routes.
+- Emit machine-readable built-in routes.
 
-### blueprint validate
+```sh
+agentplane blueprint list --project
+```
 
-Validate a project-local blueprint JSON file without registering or executing it.
+- Include project-local blueprint definitions.
+
+### blueprint scaffold
+
+Create a project-local blueprint JSON scaffold without enabling it.
 
 Usage:
 
 ```text
-agentplane blueprint validate <path> [options]
+agentplane blueprint scaffold <blueprint-id> [options]
 ```
 
 Options:
 
+- `--from <builtin-blueprint-id>`: Built-in blueprint to clone as a starting point.
+- `--out <path>`: Output path; defaults to .agentplane/blueprints/&lt;id&gt;.json.
+- `--force`: Overwrite an existing file. (default=false)
+- `--json`: Emit JSON. (default=false)
+
+Examples:
+
+```sh
+agentplane blueprint scaffold analysis.custom
+```
+
+- Create .agentplane/blueprints/analysis.custom.json from analysis.light.
+
+```sh
+agentplane blueprint scaffold code.custom --from code.branch_pr
+```
+
+- Start from an existing code workflow route.
+
+### blueprint validate
+
+Validate project-local blueprint JSON without registering or executing it.
+
+Usage:
+
+```text
+agentplane blueprint validate [<path>] [options]
+```
+
+Options:
+
+- `--project`: Validate all JSON blueprints in .agentplane/blueprints or the supplied directory. (default=false)
 - `--json`: Emit JSON. (default=false)
 
 Examples:
@@ -597,6 +643,12 @@ agentplane blueprint validate .agentplane/blueprints/analysis.json
 ```
 
 - Validate a local blueprint definition.
+
+```sh
+agentplane blueprint validate --project
+```
+
+- Validate the project-local blueprint registry directory.
 
 ## Branch
 

--- a/packages/agentplane/src/blueprints/index.ts
+++ b/packages/agentplane/src/blueprints/index.ts
@@ -5,6 +5,14 @@ export {
   listBlueprints,
   requireBlueprint,
 } from "./registry.js";
+export {
+  PROJECT_BLUEPRINTS_DIR,
+  parseProjectBlueprintJson,
+  projectBlueprintsDirectory,
+  scaffoldProjectBlueprint,
+  validateProjectBlueprintDirectory,
+  validateProjectBlueprintFile,
+} from "./project-local.js";
 export { explainResolvedBlueprint, formatBlueprintExplain } from "./explain.js";
 export { blueprintPlanEvidence, blueprintPlanState, buildBlueprintPlanArtifact } from "./plan.js";
 export {
@@ -57,3 +65,10 @@ export type {
   TaskKind,
   WorkflowMode,
 } from "./model.js";
+export type {
+  ProjectBlueprintDirectoryResult,
+  ProjectBlueprintFileResult,
+  ProjectBlueprintProblem,
+  ProjectBlueprintProblemCode,
+  ScaffoldProjectBlueprintOptions,
+} from "./project-local.js";

--- a/packages/agentplane/src/blueprints/project-local.ts
+++ b/packages/agentplane/src/blueprints/project-local.ts
@@ -132,7 +132,24 @@ export function parseProjectBlueprintJson(
   }
 
   const blueprint = parsed as Blueprint;
-  const validation = validateBlueprint(blueprint);
+  let validation: BlueprintValidationResult;
+  try {
+    validation = validateBlueprint(blueprint);
+  } catch (err) {
+    return {
+      ok: false,
+      path: filePath,
+      blueprintId: typeof parsed.id === "string" ? parsed.id : undefined,
+      errors: [
+        problem(
+          "invalid_shape",
+          `Blueprint file ${JSON.stringify(filePath)} has an invalid blueprint shape: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        ),
+      ],
+    };
+  }
   return {
     ok: validation.ok,
     path: filePath,
@@ -190,8 +207,14 @@ function filenameForBlueprintId(id: string): string {
 }
 
 function scaffoldPath(opts: ScaffoldProjectBlueprintOptions): string {
-  if (opts.out) return path.resolve(opts.projectRoot, opts.out);
-  return path.join(projectBlueprintsDirectory(opts.projectRoot), filenameForBlueprintId(opts.id));
+  const outPath = opts.out
+    ? path.resolve(opts.projectRoot, opts.out)
+    : path.join(projectBlueprintsDirectory(opts.projectRoot), filenameForBlueprintId(opts.id));
+  const relative = path.relative(opts.projectRoot, outPath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Blueprint scaffold output must stay inside the project: ${opts.out}`);
+  }
+  return outPath;
 }
 
 export async function scaffoldProjectBlueprint(

--- a/packages/agentplane/src/blueprints/project-local.ts
+++ b/packages/agentplane/src/blueprints/project-local.ts
@@ -1,0 +1,216 @@
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { requireBlueprint } from "./registry.js";
+import { validateBlueprint } from "./validate.js";
+import type {
+  Blueprint,
+  BlueprintId,
+  BlueprintValidationProblem,
+  BlueprintValidationResult,
+} from "./model.js";
+
+export const PROJECT_BLUEPRINTS_DIR = ".agentplane/blueprints";
+
+export type ProjectBlueprintProblemCode =
+  | BlueprintValidationProblem["code"]
+  | "invalid_json"
+  | "invalid_shape"
+  | "missing_blueprint_directory";
+
+export type ProjectBlueprintProblem = {
+  code: ProjectBlueprintProblemCode;
+  message: string;
+  path?: string;
+};
+
+export type ProjectBlueprintFileResult = {
+  ok: boolean;
+  path: string;
+  blueprint?: Blueprint;
+  blueprintId?: string;
+  errors: ProjectBlueprintProblem[];
+};
+
+export type ProjectBlueprintDirectoryResult = {
+  ok: boolean;
+  directory: string;
+  files: ProjectBlueprintFileResult[];
+  errors: ProjectBlueprintProblem[];
+};
+
+export type ScaffoldProjectBlueprintOptions = {
+  projectRoot: string;
+  id: BlueprintId;
+  from?: BlueprintId;
+  out?: string;
+  force?: boolean;
+};
+
+function problem(
+  code: ProjectBlueprintProblemCode,
+  message: string,
+  path?: string,
+): ProjectBlueprintProblem {
+  return { code, message, ...(path ? { path } : {}) };
+}
+
+function requireObjectResult(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function requiredArrayFieldErrors(
+  value: Record<string, unknown>,
+  filePath: string,
+): ProjectBlueprintProblem[] {
+  const errors: ProjectBlueprintProblem[] = [];
+  for (const field of [
+    "taskKinds",
+    "allowedCommands",
+    "policyModules",
+    "nodes",
+    "edges",
+    "requiredEvidence",
+    "stopRules",
+  ]) {
+    if (!Array.isArray(value[field])) {
+      errors.push(
+        problem(
+          "invalid_shape",
+          `Blueprint file ${JSON.stringify(filePath)} is missing array field ${JSON.stringify(field)}.`,
+          field,
+        ),
+      );
+    }
+  }
+  return errors;
+}
+
+export function parseProjectBlueprintJson(
+  raw: string,
+  filePath: string,
+): ProjectBlueprintFileResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return {
+      ok: false,
+      path: filePath,
+      errors: [
+        problem(
+          "invalid_json",
+          `Blueprint file ${JSON.stringify(filePath)} is not valid JSON: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        ),
+      ],
+    };
+  }
+
+  if (!requireObjectResult(parsed)) {
+    return {
+      ok: false,
+      path: filePath,
+      errors: [
+        problem(
+          "invalid_shape",
+          `Blueprint file ${JSON.stringify(filePath)} must contain one JSON object.`,
+        ),
+      ],
+    };
+  }
+
+  const shapeErrors = requiredArrayFieldErrors(parsed, filePath);
+  if (shapeErrors.length > 0) {
+    return {
+      ok: false,
+      path: filePath,
+      blueprintId: typeof parsed.id === "string" ? parsed.id : undefined,
+      errors: shapeErrors,
+    };
+  }
+
+  const blueprint = parsed as Blueprint;
+  const validation = validateBlueprint(blueprint);
+  return {
+    ok: validation.ok,
+    path: filePath,
+    blueprint,
+    blueprintId: typeof blueprint.id === "string" ? blueprint.id : undefined,
+    errors: validation.errors,
+  };
+}
+
+export async function validateProjectBlueprintFile(
+  filePath: string,
+): Promise<ProjectBlueprintFileResult> {
+  return parseProjectBlueprintJson(await readFile(filePath, "utf8"), filePath);
+}
+
+async function listJsonFiles(directory: string): Promise<string[]> {
+  try {
+    const entries = await readdir(directory, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+      .map((entry) => path.join(directory, entry.name))
+      .toSorted();
+  } catch (err) {
+    if (err instanceof Error && "code" in err && err.code === "ENOENT") return [];
+    throw err;
+  }
+}
+
+export async function validateProjectBlueprintDirectory(
+  directory: string,
+): Promise<ProjectBlueprintDirectoryResult> {
+  const jsonFiles = await listJsonFiles(directory);
+  const files = await Promise.all(
+    jsonFiles.map((filePath) => validateProjectBlueprintFile(filePath)),
+  );
+  const errors = files.flatMap((file) => file.errors);
+  return {
+    ok: errors.length === 0,
+    directory,
+    files,
+    errors,
+  };
+}
+
+export function projectBlueprintsDirectory(projectRoot: string): string {
+  return path.join(projectRoot, PROJECT_BLUEPRINTS_DIR);
+}
+
+function filenameForBlueprintId(id: string): string {
+  const filename = id.replaceAll(/[^A-Za-z0-9._-]/g, "-");
+  if (!filename || filename === "." || filename === ".." || filename.includes("..")) {
+    throw new Error(`Invalid blueprint id for file scaffold: ${id}`);
+  }
+  return `${filename}.json`;
+}
+
+function scaffoldPath(opts: ScaffoldProjectBlueprintOptions): string {
+  if (opts.out) return path.resolve(opts.projectRoot, opts.out);
+  return path.join(projectBlueprintsDirectory(opts.projectRoot), filenameForBlueprintId(opts.id));
+}
+
+export async function scaffoldProjectBlueprint(
+  opts: ScaffoldProjectBlueprintOptions,
+): Promise<{ path: string; blueprint: Blueprint; validation: BlueprintValidationResult }> {
+  const source = structuredClone(requireBlueprint(opts.from ?? "analysis.light"));
+  const blueprint: Blueprint = {
+    ...source,
+    id: opts.id,
+    title: `Project blueprint: ${opts.id}`,
+    description:
+      "Project-local blueprint scaffold. Edit taskKinds, nodes, evidence, and stopRules, then run blueprint validate before use.",
+  };
+  const validation = validateBlueprint(blueprint);
+  const outPath = scaffoldPath(opts);
+  await mkdir(path.dirname(outPath), { recursive: true });
+  await writeFile(outPath, `${JSON.stringify(blueprint, null, 2)}\n`, {
+    encoding: "utf8",
+    flag: opts.force ? "w" : "wx",
+  });
+  return { path: outPath, blueprint, validation };
+}

--- a/packages/agentplane/src/cli/run-cli.core.blueprint.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.blueprint.test.ts
@@ -80,6 +80,40 @@ describe("runCli blueprint commands", () => {
     }
   });
 
+  it("blueprint validate reports malformed blueprint objects without crashing", async () => {
+    const root = await mkTempDir();
+    const blueprintPath = path.join(root, "malformed.json");
+    await writeFile(
+      blueprintPath,
+      JSON.stringify(
+        {
+          id: "analysis.malformed",
+          title: "Malformed",
+          description: "Missing context budget",
+          taskKinds: ["analysis"],
+          allowedCommands: [],
+          policyModules: [],
+          nodes: [],
+          edges: [],
+          requiredEvidence: [],
+          stopRules: [],
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["blueprint", "validate", blueprintPath]);
+      expect(code).toBe(3);
+      expect(io.stderr).toContain("invalid_shape");
+    } finally {
+      io.restore();
+    }
+  });
+
   it("blueprint scaffold creates a project-local blueprint file", async () => {
     const root = await mkProject();
     const io = captureStdIO();
@@ -90,6 +124,26 @@ describe("runCli blueprint commands", () => {
       const blueprint = JSON.parse(await readFile(blueprintPath, "utf8")) as { id?: string };
       expect(blueprint.id).toBe("analysis.custom");
       expect(io.stdout).toContain("blueprint scaffolded:");
+    } finally {
+      io.restore();
+    }
+  });
+
+  it("blueprint scaffold rejects output paths outside the project", async () => {
+    const root = await mkProject();
+    const io = captureStdIO();
+    try {
+      const code = await runCli([
+        "--root",
+        root,
+        "blueprint",
+        "scaffold",
+        "analysis.custom",
+        "--out",
+        "../outside.json",
+      ]);
+      expect(code).not.toBe(0);
+      expect(io.stderr).toContain("output must stay inside the project");
     } finally {
       io.restore();
     }

--- a/packages/agentplane/src/cli/run-cli.core.blueprint.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.blueprint.test.ts
@@ -1,4 +1,4 @@
-import { writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { requireBlueprint } from "../blueprints/registry.js";
@@ -6,6 +6,18 @@ import { captureStdIO, mkTempDir } from "@agentplane/testkit";
 import { describe, expect, it } from "vitest";
 
 import { runCli } from "./run-cli.js";
+
+async function mkProject(): Promise<string> {
+  const root = await mkTempDir();
+  await mkdir(path.join(root, ".git"));
+  await mkdir(path.join(root, ".agentplane"), { recursive: true });
+  await writeFile(
+    path.join(root, ".agentplane", "config.json"),
+    '{\n  "schema_version": 1,\n  "workflow_mode": "direct"\n}\n',
+    "utf8",
+  );
+  return root;
+}
 
 describe("runCli blueprint commands", () => {
   it("blueprint validate accepts a project-local blueprint JSON file", async () => {
@@ -63,6 +75,58 @@ describe("runCli blueprint commands", () => {
       const code = await runCli(["blueprint", "validate", blueprintPath]);
       expect(code).toBe(3);
       expect(io.stderr).toContain("missing_core_node");
+    } finally {
+      io.restore();
+    }
+  });
+
+  it("blueprint scaffold creates a project-local blueprint file", async () => {
+    const root = await mkProject();
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["--root", root, "blueprint", "scaffold", "analysis.custom"]);
+      expect(code).toBe(0);
+      const blueprintPath = path.join(root, ".agentplane", "blueprints", "analysis.custom.json");
+      const blueprint = JSON.parse(await readFile(blueprintPath, "utf8")) as { id?: string };
+      expect(blueprint.id).toBe("analysis.custom");
+      expect(io.stdout).toContain("blueprint scaffolded:");
+    } finally {
+      io.restore();
+    }
+  });
+
+  it("blueprint list --project includes validated project-local blueprints", async () => {
+    const root = await mkProject();
+    const blueprintPath = path.join(root, ".agentplane", "blueprints", "analysis.custom.json");
+    await mkdir(path.dirname(blueprintPath), { recursive: true });
+    await writeFile(
+      blueprintPath,
+      `${JSON.stringify(
+        {
+          ...structuredClone(requireBlueprint("analysis.light")),
+          id: "analysis.custom",
+          title: "Custom analysis",
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["--root", root, "blueprint", "list", "--project", "--json"]);
+      expect(code).toBe(0);
+      const payload = JSON.parse(io.stdout) as {
+        blueprints: { id: string; source: string; path?: string }[];
+      };
+      expect(payload.blueprints).toContainEqual(
+        expect.objectContaining({
+          id: "analysis.custom",
+          source: "project",
+          path: blueprintPath,
+        }),
+      );
     } finally {
       io.restore();
     }

--- a/packages/agentplane/src/cli/run-cli/command-catalog/project.ts
+++ b/packages/agentplane/src/cli/run-cli/command-catalog/project.ts
@@ -10,6 +10,7 @@ import {
 import {
   blueprintExplainSpec,
   blueprintListSpec,
+  blueprintScaffoldSpec,
   blueprintSpec,
   blueprintValidateSpec,
 } from "../../../commands/blueprint/blueprint.command.js";
@@ -105,6 +106,7 @@ import {
   loadBlueprintListSpec,
   loadBlueprintExplainSpec,
   loadBlueprintValidateSpec,
+  loadBlueprintScaffoldSpec,
 } from "../command-loaders/project.js";
 
 export const PROJECT_COMMANDS = [
@@ -117,6 +119,7 @@ export const PROJECT_COMMANDS = [
   declareCommand(blueprintSpec, { load: loadBlueprintSpec, needs: "none" }),
   declareCommand(blueprintListSpec, { load: loadBlueprintListSpec, needs: "none" }),
   declareCommand(blueprintExplainSpec, { load: loadBlueprintExplainSpec }),
+  declareCommand(blueprintScaffoldSpec, { load: loadBlueprintScaffoldSpec, needs: "none" }),
   declareCommand(blueprintValidateSpec, { load: loadBlueprintValidateSpec, needs: "none" }),
   declareCommand(workStartSpec, { load: loadWorkStartSpec }),
   fromCommandsRecipesRecipesCommand(recipesSpec, "runRecipes", { needs: "none" }),

--- a/packages/agentplane/src/cli/run-cli/command-loaders/project.ts
+++ b/packages/agentplane/src/cli/run-cli/command-loaders/project.ts
@@ -31,6 +31,8 @@ export const loadBlueprintExplainSpec = (deps: RunDeps) =>
   );
 export const loadBlueprintValidateSpec = () =>
   import("../../../commands/blueprint/blueprint.command.js").then((m) => m.runBlueprintValidate);
+export const loadBlueprintScaffoldSpec = () =>
+  import("../../../commands/blueprint/blueprint.command.js").then((m) => m.runBlueprintScaffold);
 
 export const fromCommandsRecipesRecipesCommand = commandModule(
   () => import("../../../commands/recipes/recipes.command.js"),

--- a/packages/agentplane/src/commands/blueprint/blueprint.command.ts
+++ b/packages/agentplane/src/commands/blueprint/blueprint.command.ts
@@ -1,11 +1,17 @@
-import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { resolveProject } from "@agentplaneorg/core/project";
 
 import {
   createBlueprintRegistry,
   explainResolvedBlueprint,
   formatBlueprintExplain,
   listBlueprints,
+  projectBlueprintsDirectory,
   resolveBlueprint,
+  scaffoldProjectBlueprint,
+  validateProjectBlueprintDirectory,
+  validateProjectBlueprintFile,
   validateBlueprint,
   type Blueprint,
   type BlueprintId,
@@ -30,6 +36,7 @@ import { blueprintResolveInputFromTask, workflowModeFromConfig } from "./task-in
 
 export type BlueprintListParsed = {
   json: boolean;
+  project: boolean;
 };
 
 export type BlueprintExplainParsed = {
@@ -46,7 +53,16 @@ export type BlueprintExplainParsed = {
 };
 
 export type BlueprintValidateParsed = {
-  path: string;
+  path?: string;
+  project: boolean;
+  json: boolean;
+};
+
+export type BlueprintScaffoldParsed = {
+  id: BlueprintId;
+  from?: BlueprintId;
+  out?: string;
+  force: boolean;
   json: boolean;
 };
 
@@ -61,10 +77,14 @@ export const blueprintSpec: CommandSpec<GroupCommandParsed> = {
   group: "Blueprints",
   summary: "List and explain blueprint routing without executing a task.",
   description:
-    "This is a command group. Use `agentplane blueprint list` or `agentplane blueprint explain ...`.",
+    "This is a command group. Use `agentplane blueprint list`, `agentplane blueprint explain ...`, `agentplane blueprint scaffold ...`, or `agentplane blueprint validate ...`.",
   args: [{ name: "cmd", required: false, variadic: true, valueHint: "<cmd>" }],
   examples: [
     { cmd: "agentplane blueprint list", why: "Show built-in blueprint routes." },
+    {
+      cmd: "agentplane blueprint scaffold analysis.custom",
+      why: "Create a project-local blueprint scaffold.",
+    },
     {
       cmd: "agentplane blueprint explain 202605051957-5WRJZK",
       why: "Explain the resolved route for a task.",
@@ -76,10 +96,24 @@ export const blueprintSpec: CommandSpec<GroupCommandParsed> = {
 export const blueprintListSpec: CommandSpec<BlueprintListParsed> = {
   id: ["blueprint", "list"],
   group: "Blueprints",
-  summary: "List built-in blueprint routes.",
-  options: [{ kind: "boolean", name: "json", default: false, description: "Emit JSON." }],
-  examples: [{ cmd: "agentplane blueprint list --json", why: "Emit machine-readable routes." }],
-  parse: (raw) => ({ json: raw.opts.json === true }),
+  summary: "List built-in and optional project-local blueprint routes.",
+  options: [
+    {
+      kind: "boolean",
+      name: "project",
+      default: false,
+      description: "Include validated project-local blueprints from .agentplane/blueprints.",
+    },
+    { kind: "boolean", name: "json", default: false, description: "Emit JSON." },
+  ],
+  examples: [
+    { cmd: "agentplane blueprint list --json", why: "Emit machine-readable built-in routes." },
+    {
+      cmd: "agentplane blueprint list --project",
+      why: "Include project-local blueprint definitions.",
+    },
+  ],
+  parse: (raw) => ({ json: raw.opts.json === true, project: raw.opts.project === true }),
 };
 
 export const blueprintExplainSpec: CommandSpec<BlueprintExplainParsed> = {
@@ -165,17 +199,80 @@ export const blueprintExplainSpec: CommandSpec<BlueprintExplainParsed> = {
 export const blueprintValidateSpec: CommandSpec<BlueprintValidateParsed> = {
   id: ["blueprint", "validate"],
   group: "Blueprints",
-  summary: "Validate a project-local blueprint JSON file without registering or executing it.",
-  args: [{ name: "path", required: true, valueHint: "<path>" }],
-  options: [{ kind: "boolean", name: "json", default: false, description: "Emit JSON." }],
+  summary: "Validate project-local blueprint JSON without registering or executing it.",
+  args: [{ name: "path", required: false, valueHint: "<path>" }],
+  options: [
+    {
+      kind: "boolean",
+      name: "project",
+      default: false,
+      description:
+        "Validate all JSON blueprints in .agentplane/blueprints or the supplied directory.",
+    },
+    { kind: "boolean", name: "json", default: false, description: "Emit JSON." },
+  ],
   examples: [
     {
       cmd: "agentplane blueprint validate .agentplane/blueprints/analysis.json",
       why: "Validate a local blueprint definition.",
     },
+    {
+      cmd: "agentplane blueprint validate --project",
+      why: "Validate the project-local blueprint registry directory.",
+    },
+  ],
+  validateRaw: (raw) => {
+    if (!raw.args.path && raw.opts.project !== true) {
+      throw usageError({
+        spec: blueprintValidateSpec,
+        command: "blueprint validate",
+        message: "Provide a blueprint file path, or use --project.",
+      });
+    }
+  },
+  parse: (raw) => ({
+    path: typeof raw.args.path === "string" ? raw.args.path : undefined,
+    project: raw.opts.project === true,
+    json: raw.opts.json === true,
+  }),
+};
+
+export const blueprintScaffoldSpec: CommandSpec<BlueprintScaffoldParsed> = {
+  id: ["blueprint", "scaffold"],
+  group: "Blueprints",
+  summary: "Create a project-local blueprint JSON scaffold without enabling it.",
+  args: [{ name: "id", required: true, valueHint: "<blueprint-id>" }],
+  options: [
+    {
+      kind: "string",
+      name: "from",
+      valueHint: "<builtin-blueprint-id>",
+      description: "Built-in blueprint to clone as a starting point.",
+    },
+    {
+      kind: "string",
+      name: "out",
+      valueHint: "<path>",
+      description: "Output path; defaults to .agentplane/blueprints/<id>.json.",
+    },
+    { kind: "boolean", name: "force", default: false, description: "Overwrite an existing file." },
+    { kind: "boolean", name: "json", default: false, description: "Emit JSON." },
+  ],
+  examples: [
+    {
+      cmd: "agentplane blueprint scaffold analysis.custom",
+      why: "Create .agentplane/blueprints/analysis.custom.json from analysis.light.",
+    },
+    {
+      cmd: "agentplane blueprint scaffold code.custom --from code.branch_pr",
+      why: "Start from an existing code workflow route.",
+    },
   ],
   parse: (raw) => ({
-    path: String(raw.args.path),
+    id: String(raw.args.id) as BlueprintId,
+    from: typeof raw.opts.from === "string" ? (raw.opts.from as BlueprintId) : undefined,
+    out: typeof raw.opts.out === "string" ? raw.opts.out : undefined,
+    force: raw.opts.force === true,
     json: raw.opts.json === true,
   }),
 };
@@ -203,73 +300,61 @@ function syntheticInput(ctx: CommandContext, p: BlueprintExplainParsed): Bluepri
   };
 }
 
-function requireObject(value: unknown, path: string): asserts value is Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new ValidationError({
-      message: `Blueprint file ${JSON.stringify(path)} must contain one JSON object.`,
-      context: { path },
-    });
-  }
-}
-
-function requireArrayField(value: Record<string, unknown>, field: string, path: string): void {
-  if (!Array.isArray(value[field])) {
-    throw new ValidationError({
-      message: `Blueprint file ${JSON.stringify(path)} is missing array field ${JSON.stringify(field)}.`,
-      context: { path, field },
-    });
-  }
-}
-
-function parseBlueprintJson(raw: string, path: string): Blueprint {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (err) {
-    throw new ValidationError({
-      message: `Blueprint file ${JSON.stringify(path)} is not valid JSON: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-      context: { path },
-    });
-  }
-  requireObject(parsed, path);
-  for (const field of [
-    "taskKinds",
-    "allowedCommands",
-    "policyModules",
-    "nodes",
-    "edges",
-    "requiredEvidence",
-    "stopRules",
-  ]) {
-    requireArrayField(parsed, field, path);
-  }
-  return parsed as Blueprint;
-}
-
 export function makeRunBlueprintHandler(_getCtx: (cmd: string) => Promise<CommandContext>) {
   return runBlueprintRoot;
 }
 
-export const runBlueprintList: CommandHandler<BlueprintListParsed> = (_ctx, p) => {
-  const registry = createBlueprintRegistry();
-  const routes = listBlueprints(registry).map((blueprint) => ({
+function blueprintRoute(blueprint: Blueprint, source: "builtin" | "project", filePath?: string) {
+  return {
     id: blueprint.id,
     version: blueprint.version,
     title: blueprint.title,
+    source,
+    ...(filePath ? { path: filePath } : {}),
     task_kinds: blueprint.taskKinds,
     workflow_modes: blueprint.workflowModes ?? ["direct", "branch_pr"],
     route: blueprint.nodes.map((node) => node.kind),
-  }));
+  };
+}
+
+function validationErrorFromProjectFile(
+  filePath: string,
+  errors: readonly { code: string; message: string }[],
+) {
+  return new ValidationError({
+    message: `Project blueprint ${JSON.stringify(filePath)} is invalid:\n${errors
+      .map((error) => `- ${error.code}: ${error.message}`)
+      .join("\n")}`,
+    context: { path: filePath },
+  });
+}
+
+export const runBlueprintList: CommandHandler<BlueprintListParsed> = async (ctx, p) => {
+  const registry = createBlueprintRegistry();
+  const routes = listBlueprints(registry).map((blueprint) => blueprintRoute(blueprint, "builtin"));
+  if (p.project) {
+    const resolved = await resolveProject({ cwd: ctx.cwd, rootOverride: ctx.rootOverride ?? null });
+    const local = await validateProjectBlueprintDirectory(
+      projectBlueprintsDirectory(resolved.gitRoot),
+    );
+    const invalid = local.files.find((file) => !file.ok);
+    if (invalid) throw validationErrorFromProjectFile(invalid.path, invalid.errors);
+    routes.push(
+      ...local.files.flatMap((file) =>
+        file.blueprint ? [blueprintRoute(file.blueprint, "project", file.path)] : [],
+      ),
+    );
+  }
   if (p.json) {
     process.stdout.write(`${JSON.stringify({ blueprints: routes }, null, 2)}\n`);
-    return Promise.resolve(0);
+    return 0;
   }
   for (const route of routes) {
-    process.stdout.write(`${route.id}@${route.version} ${route.route.join(" -> ")}\n`);
+    process.stdout.write(
+      `${route.source} ${route.id}@${route.version} ${route.route.join(" -> ")}\n`,
+    );
   }
-  return Promise.resolve(0);
+  return 0;
 };
 
 export function makeRunBlueprintExplainHandler(getCtx: (cmd: string) => Promise<CommandContext>) {
@@ -299,8 +384,50 @@ export function makeRunBlueprintExplainHandler(getCtx: (cmd: string) => Promise<
   };
 }
 
-export const runBlueprintValidate: CommandHandler<BlueprintValidateParsed> = async (_ctx, p) => {
-  const blueprint = parseBlueprintJson(await readFile(p.path, "utf8"), p.path);
+export const runBlueprintValidate: CommandHandler<BlueprintValidateParsed> = async (ctx, p) => {
+  if (p.project) {
+    const resolved = await resolveProject({ cwd: ctx.cwd, rootOverride: ctx.rootOverride ?? null });
+    const directory = p.path
+      ? path.resolve(resolved.gitRoot, p.path)
+      : projectBlueprintsDirectory(resolved.gitRoot);
+    const result = await validateProjectBlueprintDirectory(directory);
+    const output = {
+      ok: result.ok,
+      directory: result.directory,
+      blueprints: result.files.map((file) => ({
+        ok: file.ok,
+        path: file.path,
+        blueprint_id: file.blueprintId ?? null,
+        errors: file.errors,
+      })),
+      errors: result.errors,
+    };
+    if (p.json) {
+      process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+    } else if (result.ok) {
+      process.stdout.write(
+        `project blueprints valid: ${result.files.length} file${result.files.length === 1 ? "" : "s"}\n`,
+      );
+    } else {
+      for (const file of result.files) {
+        for (const error of file.errors) {
+          process.stderr.write(`${file.path}: ${error.code}: ${error.message}\n`);
+        }
+      }
+    }
+    return result.ok ? 0 : 3;
+  }
+
+  if (!p.path) {
+    throw new ValidationError({
+      message: "Blueprint validate requires a file path unless --project is set.",
+    });
+  }
+  const file = await validateProjectBlueprintFile(p.path);
+  if (!file.blueprint) {
+    throw validationErrorFromProjectFile(file.path, file.errors);
+  }
+  const blueprint = file.blueprint;
   const result = validateBlueprint(blueprint);
   const output = {
     ok: result.ok,
@@ -318,4 +445,32 @@ export const runBlueprintValidate: CommandHandler<BlueprintValidateParsed> = asy
     }
   }
   return result.ok ? 0 : 3;
+};
+
+export const runBlueprintScaffold: CommandHandler<BlueprintScaffoldParsed> = async (ctx, p) => {
+  const resolved = await resolveProject({ cwd: ctx.cwd, rootOverride: ctx.rootOverride ?? null });
+  const result = await scaffoldProjectBlueprint({
+    projectRoot: resolved.gitRoot,
+    id: p.id,
+    from: p.from,
+    out: p.out,
+    force: p.force,
+  });
+  const output = {
+    path: result.path,
+    blueprint_id: result.blueprint.id,
+    from: p.from ?? "analysis.light",
+    validation: result.validation,
+  };
+  if (p.json) {
+    process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+    return result.validation.ok ? 0 : 3;
+  }
+  process.stdout.write(`blueprint scaffolded: ${result.path}\n`);
+  if (!result.validation.ok) {
+    for (const error of result.validation.errors) {
+      process.stderr.write(`${error.code}: ${error.message}\n`);
+    }
+  }
+  return result.validation.ok ? 0 : 3;
 };

--- a/packages/agentplane/src/commands/doctor.fast.test.ts
+++ b/packages/agentplane/src/commands/doctor.fast.test.ts
@@ -192,6 +192,25 @@ describe("doctor.fast", () => {
     expect(rc).toBe(1);
   });
 
+  it("reports invalid project-local blueprints as doctor warnings", async () => {
+    const ws = await mkWorkspace();
+    await mkdir(path.join(ws.root, ".agentplane", "blueprints"), { recursive: true });
+    await writeFile(path.join(ws.root, ".agentplane", "blueprints", "broken.json"), "{", "utf8");
+    const stderr = spyOnStderrWrite();
+    try {
+      const rc = await runDoctor(
+        { cwd: ws.root, rootOverride: null } as unknown as Parameters<typeof runDoctor>[0],
+        { fix: false, dev: false },
+      );
+      expect(rc).toBe(0);
+      const output = stderr.mock.calls.flat().join("\n");
+      expect(output).toContain("Project blueprint");
+      expect(output).toContain("invalid_json");
+    } finally {
+      stderr.mockRestore();
+    }
+  });
+
   it("fails when DONE task misses implementation commit hash", async () => {
     const ws = await mkWorkspace();
     await gitInitWithCommit(ws.root, "feat: initial");

--- a/packages/agentplane/src/commands/doctor.run.ts
+++ b/packages/agentplane/src/commands/doctor.run.ts
@@ -6,6 +6,7 @@ import { warnMessage, successMessage } from "../cli/output.js";
 import type { DoctorParsed } from "./doctor.spec.js";
 import { loadCommandContext } from "./shared/task-backend.js";
 import { checkDoneTaskCommitInvariants } from "./doctor/archive.js";
+import { checkProjectBlueprints } from "./doctor/blueprints.js";
 import {
   checkBranchPrBatchIncludedTaskDrift,
   checkBranchPrDoneTaskOpenPrDrift,
@@ -49,6 +50,8 @@ export const runDoctor: CommandHandler<DoctorParsed> = async (ctx, p) => {
     );
     reportProgress("checking runtime source");
     checks.push(...checkRuntimeSourceFacts(ctx.cwd, loadedConfig.config));
+    reportProgress("checking project-local blueprints");
+    checks.push(...(await checkProjectBlueprints(repoRoot)));
     reportProgress("checking prompt graph");
     checks.push(...(await checkPromptGraphFacts(resolved)));
     reportProgress(

--- a/packages/agentplane/src/commands/doctor/blueprints.ts
+++ b/packages/agentplane/src/commands/doctor/blueprints.ts
@@ -1,0 +1,15 @@
+import {
+  projectBlueprintsDirectory,
+  validateProjectBlueprintDirectory,
+} from "../../blueprints/index.js";
+
+export async function checkProjectBlueprints(repoRoot: string): Promise<string[]> {
+  const result = await validateProjectBlueprintDirectory(projectBlueprintsDirectory(repoRoot));
+  if (result.files.length === 0) return [];
+  return result.files.flatMap((file) =>
+    file.errors.map(
+      (error) =>
+        `[WARN] Project blueprint ${file.path} is invalid: ${error.code}: ${error.message}`,
+    ),
+  );
+}


### PR DESCRIPTION
Task: `202605060730-B55DQR`
Title: Add project-local blueprint scaffold command

## Summary

Add project-local blueprint scaffold command

Add a safe blueprint scaffold command that writes a local JSON template for project authors without registering or executing the custom blueprint.

## Scope

- In scope: Add a safe blueprint scaffold command that writes a local JSON template for project authors without registering or executing the custom blueprint.
- Out of scope: unrelated refactors not required for "Add project-local blueprint scaffold command".

## Verification

- State: ok
- Note: Verified: scaffold command creates project-local blueprint JSON without enabling execution; focused tests and ci:local:fast passed.
- Full verification checklist lives in local review.md.

## Handoff Notes

- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-06T07:47:49.435Z
- Branch: task/202605060730-B55DQR/local-blueprint-authoring
- Head: a9f142c37f71

```text
 .agentplane/tasks/202605060730-PW6S0R/README.md    | 118 +++++++++
 .agentplane/tasks/202605060730-Y7T26J/README.md    | 118 +++++++++
 .agentplane/tasks/202605060731-GK1JRH/README.md    | 118 +++++++++
 docs/developer/blueprints.mdx                      |  78 ++++--
 docs/user/cli-reference.generated.mdx              |  62 ++++-
 packages/agentplane/src/blueprints/index.ts        |  15 ++
 .../agentplane/src/blueprints/project-local.ts     | 216 ++++++++++++++++
 .../src/cli/run-cli.core.blueprint.test.ts         |  66 ++++-
 .../src/cli/run-cli/command-catalog/project.ts     |   3 +
 .../src/cli/run-cli/command-loaders/project.ts     |   2 +
 .../src/commands/blueprint/blueprint.command.ts    | 285 ++++++++++++++++-----
 .../agentplane/src/commands/doctor.fast.test.ts    |  19 ++
 packages/agentplane/src/commands/doctor.run.ts     |   3 +
 .../agentplane/src/commands/doctor/blueprints.ts   |  15 ++
 14 files changed, 1031 insertions(+), 87 deletions(-)
```

</details>
