### PR TITLE
🚧 FZ9FV6 task: Add trusted project-local blueprint config [202605060826-FZ9FV6]

### DIFF
--- a/.agentplane/tasks/202605060826-0GB6WB/README.md
+++ b/.agentplane/tasks/202605060826-0GB6WB/README.md
@@ -1,0 +1,78 @@
+---
+id: "202605060826-0GB6WB"
+title: "Resolve trusted project-local blueprints explicitly"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "blueprints"
+  - "code"
+  - "resolver"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-06T08:27:11.564Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-06T08:36:07.004Z"
+  updated_by: "CODER"
+  note: "Resolver now includes only explicitly trusted project-local blueprints and rejects untrusted ids."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement explicit trusted project-local blueprint resolver selection after the config gate."
+events:
+  -
+    type: "status"
+    at: "2026-05-06T08:27:29.168Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement explicit trusted project-local blueprint resolver selection after the config gate."
+  -
+    type: "verify"
+    at: "2026-05-06T08:36:07.004Z"
+    author: "CODER"
+    state: "ok"
+    note: "Resolver now includes only explicitly trusted project-local blueprints and rejects untrusted ids."
+doc_version: 3
+doc_updated_at: "2026-05-06T08:36:07.009Z"
+doc_updated_by: "CODER"
+description: "Allow resolver/explain to use project-local blueprints only when trusted config enables them and the task explicitly requests a compatible id."
+sections:
+  Summary: |-
+    Resolve trusted project-local blueprints explicitly
+    
+    Allow resolver/explain to use project-local blueprints only when trusted config enables them and the task explicitly requests a compatible id.
+  Scope: |-
+    - In scope: Allow resolver/explain to use project-local blueprints only when trusted config enables them and the task explicitly requests a compatible id.
+    - Out of scope: unrelated refactors not required for "Resolve trusted project-local blueprints explicitly".
+  Plan: "After FZ9FV6, extend resolver/explain plumbing so project-local blueprints are selectable only when trusted config enables them and an explicit blueprint id or recipe preferred_blueprint requests a compatible local id. Built-in default selection remains unchanged."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-06T08:36:07.004Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Resolver now includes only explicitly trusted project-local blueprints and rejects untrusted ids.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T08:27:29.168Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605060826-97XHD3/README.md
+++ b/.agentplane/tasks/202605060826-97XHD3/README.md
@@ -1,0 +1,78 @@
+---
+id: "202605060826-97XHD3"
+title: "Surface trusted blueprint selection in CLI and doctor"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "blueprints"
+  - "cli"
+  - "doctor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-06T08:27:11.848Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-06T08:36:07.395Z"
+  updated_by: "CODER"
+  note: "CLI and doctor surfaces report trust config state and trusted selection behavior."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: surface trusted local blueprint decisions in CLI and doctor after resolver support."
+events:
+  -
+    type: "status"
+    at: "2026-05-06T08:27:29.335Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: surface trusted local blueprint decisions in CLI and doctor after resolver support."
+  -
+    type: "verify"
+    at: "2026-05-06T08:36:07.395Z"
+    author: "CODER"
+    state: "ok"
+    note: "CLI and doctor surfaces report trust config state and trusted selection behavior."
+doc_version: 3
+doc_updated_at: "2026-05-06T08:36:07.397Z"
+doc_updated_by: "CODER"
+description: "Make blueprint list/explain/validate and doctor expose trusted local blueprint selection decisions and invalid trust config failures."
+sections:
+  Summary: |-
+    Surface trusted blueprint selection in CLI and doctor
+    
+    Make blueprint list/explain/validate and doctor expose trusted local blueprint selection decisions and invalid trust config failures.
+  Scope: |-
+    - In scope: Make blueprint list/explain/validate and doctor expose trusted local blueprint selection decisions and invalid trust config failures.
+    - Out of scope: unrelated refactors not required for "Surface trusted blueprint selection in CLI and doctor".
+  Plan: "After 0GB6WB, surface trusted local selection through blueprint CLI and doctor: list/explain should report trusted local source and reasons, validate/doctor should reject invalid trust config or invalid trusted local registries without enabling execution."
+  Verify Steps: |-
+    1. Review the requested outcome for "Surface trusted blueprint selection in CLI and doctor". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-06T08:36:07.395Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: CLI and doctor surfaces report trust config state and trusted selection behavior.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T08:27:29.335Z, excerpt_hash=sha256:668346bb0205eb89c221610eeaf9fe062a78377c450b0eeeae203035bb4edbdf
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605060826-FZ9FV6/README.md
+++ b/.agentplane/tasks/202605060826-FZ9FV6/README.md
@@ -1,0 +1,78 @@
+---
+id: "202605060826-FZ9FV6"
+title: "Add trusted project-local blueprint config"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "blueprints"
+  - "code"
+  - "config"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-06T08:27:11.268Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-06T08:36:05.812Z"
+  updated_by: "CODER"
+  note: "Trusted project-local blueprint config implemented and validated."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement trusted project-local blueprint config in the shared batch worktree."
+events:
+  -
+    type: "status"
+    at: "2026-05-06T08:27:27.404Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement trusted project-local blueprint config in the shared batch worktree."
+  -
+    type: "verify"
+    at: "2026-05-06T08:36:05.812Z"
+    author: "CODER"
+    state: "ok"
+    note: "Trusted project-local blueprint config implemented and validated."
+doc_version: 3
+doc_updated_at: "2026-05-06T08:36:05.816Z"
+doc_updated_by: "CODER"
+description: "Define and validate an opt-in .agentplane/blueprints/config.json trust gate for project-local blueprint selection."
+sections:
+  Summary: |-
+    Add trusted project-local blueprint config
+    
+    Define and validate an opt-in .agentplane/blueprints/config.json trust gate for project-local blueprint selection.
+  Scope: |-
+    - In scope: Define and validate an opt-in .agentplane/blueprints/config.json trust gate for project-local blueprint selection.
+    - Out of scope: unrelated refactors not required for "Add trusted project-local blueprint config".
+  Plan: "Implement the trust gate for project-local blueprints. Add a typed config model/parser for .agentplane/blueprints/config.json with default disabled behavior, allowed_ids validation, no built-in shadowing, and focused tests."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-06T08:36:05.812Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Trusted project-local blueprint config implemented and validated.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T08:27:27.404Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605060826-FZ9FV6/pr/diffstat.txt
+++ b/.agentplane/tasks/202605060826-FZ9FV6/pr/diffstat.txt
@@ -1,12 +1,13 @@
  .agentplane/tasks/202605060826-0GB6WB/README.md    |  78 +++++++
  .agentplane/tasks/202605060826-97XHD3/README.md    |  78 +++++++
  .agentplane/tasks/202605060826-VY5AKF/README.md    |  77 +++++++
- docs/developer/blueprints.mdx                      |  81 ++++++--
+ docs/developer/blueprints.mdx                      |  81 +++++--
  docs/user/cli-reference.generated.mdx              |   1 +
  packages/agentplane/src/blueprints/index.ts        |   8 +
- .../agentplane/src/blueprints/project-local.ts     | 228 ++++++++++++++++++++-
+ .../agentplane/src/blueprints/project-local.ts     | 237 ++++++++++++++++++++-
  packages/agentplane/src/blueprints/resolve.ts      |   4 +
- .../src/cli/run-cli.core.blueprint.test.ts         | 110 ++++++++++
+ .../src/cli/run-cli.core.blueprint.test.ts         | 150 +++++++++++++
  .../src/commands/blueprint/blueprint.command.ts    |  86 ++++++--
- .../agentplane/src/commands/doctor/blueprints.ts   |  25 ++-
- 11 files changed, 734 insertions(+), 42 deletions(-)
+ .../agentplane/src/commands/doctor.fast.test.ts    |  23 ++
+ .../agentplane/src/commands/doctor/blueprints.ts   |  26 ++-
+ 12 files changed, 806 insertions(+), 43 deletions(-)

--- a/.agentplane/tasks/202605060826-FZ9FV6/pr/diffstat.txt
+++ b/.agentplane/tasks/202605060826-FZ9FV6/pr/diffstat.txt
@@ -1,0 +1,12 @@
+ .agentplane/tasks/202605060826-0GB6WB/README.md    |  78 +++++++
+ .agentplane/tasks/202605060826-97XHD3/README.md    |  78 +++++++
+ .agentplane/tasks/202605060826-VY5AKF/README.md    |  77 +++++++
+ docs/developer/blueprints.mdx                      |  81 ++++++--
+ docs/user/cli-reference.generated.mdx              |   1 +
+ packages/agentplane/src/blueprints/index.ts        |   8 +
+ .../agentplane/src/blueprints/project-local.ts     | 228 ++++++++++++++++++++-
+ packages/agentplane/src/blueprints/resolve.ts      |   4 +
+ .../src/cli/run-cli.core.blueprint.test.ts         | 110 ++++++++++
+ .../src/commands/blueprint/blueprint.command.ts    |  86 ++++++--
+ .../agentplane/src/commands/doctor/blueprints.ts   |  25 ++-
+ 11 files changed, 734 insertions(+), 42 deletions(-)

--- a/.agentplane/tasks/202605060826-FZ9FV6/pr/github-body.md
+++ b/.agentplane/tasks/202605060826-FZ9FV6/pr/github-body.md
@@ -1,0 +1,44 @@
+Task: `202605060826-FZ9FV6`
+Title: Add trusted project-local blueprint config
+Canonical task record: `.agentplane/tasks/202605060826-FZ9FV6/README.md`
+
+## Summary
+
+Add trusted project-local blueprint config
+
+Define and validate an opt-in .agentplane/blueprints/config.json trust gate for project-local blueprint selection.
+
+## Scope
+
+- In scope: Define and validate an opt-in .agentplane/blueprints/config.json trust gate for project-local blueprint selection.
+- Out of scope: unrelated refactors not required for "Add trusted project-local blueprint config".
+
+## Verification
+
+- State: ok
+- Note: Trusted project-local blueprint config implemented and validated.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-06T08:37:30.269Z
+- Branch: task/202605060826-FZ9FV6/trusted-local-blueprints
+- Head: eb898d64fdf6
+
+```text
+ .agentplane/tasks/202605060826-0GB6WB/README.md    |  78 +++++++
+ .agentplane/tasks/202605060826-97XHD3/README.md    |  78 +++++++
+ .agentplane/tasks/202605060826-VY5AKF/README.md    |  77 +++++++
+ docs/developer/blueprints.mdx                      |  81 ++++++--
+ docs/user/cli-reference.generated.mdx              |   1 +
+ packages/agentplane/src/blueprints/index.ts        |   8 +
+ .../agentplane/src/blueprints/project-local.ts     | 228 ++++++++++++++++++++-
+ packages/agentplane/src/blueprints/resolve.ts      |   4 +
+ .../src/cli/run-cli.core.blueprint.test.ts         | 110 ++++++++++
+ .../src/commands/blueprint/blueprint.command.ts    |  86 ++++++--
+ .../agentplane/src/commands/doctor/blueprints.ts   |  25 ++-
+ 11 files changed, 734 insertions(+), 42 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605060826-FZ9FV6/pr/github-body.md
+++ b/.agentplane/tasks/202605060826-FZ9FV6/pr/github-body.md
@@ -22,23 +22,24 @@ Define and validate an opt-in .agentplane/blueprints/config.json trust gate for 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-06T08:37:30.269Z
+- Updated: 2026-05-06T08:45:45.560Z
 - Branch: task/202605060826-FZ9FV6/trusted-local-blueprints
-- Head: eb898d64fdf6
+- Head: c2e2e3325b69
 
 ```text
  .agentplane/tasks/202605060826-0GB6WB/README.md    |  78 +++++++
  .agentplane/tasks/202605060826-97XHD3/README.md    |  78 +++++++
  .agentplane/tasks/202605060826-VY5AKF/README.md    |  77 +++++++
- docs/developer/blueprints.mdx                      |  81 ++++++--
+ docs/developer/blueprints.mdx                      |  81 +++++--
  docs/user/cli-reference.generated.mdx              |   1 +
  packages/agentplane/src/blueprints/index.ts        |   8 +
- .../agentplane/src/blueprints/project-local.ts     | 228 ++++++++++++++++++++-
+ .../agentplane/src/blueprints/project-local.ts     | 237 ++++++++++++++++++++-
  packages/agentplane/src/blueprints/resolve.ts      |   4 +
- .../src/cli/run-cli.core.blueprint.test.ts         | 110 ++++++++++
+ .../src/cli/run-cli.core.blueprint.test.ts         | 150 +++++++++++++
  .../src/commands/blueprint/blueprint.command.ts    |  86 ++++++--
- .../agentplane/src/commands/doctor/blueprints.ts   |  25 ++-
- 11 files changed, 734 insertions(+), 42 deletions(-)
+ .../agentplane/src/commands/doctor.fast.test.ts    |  23 ++
+ .../agentplane/src/commands/doctor/blueprints.ts   |  26 ++-
+ 12 files changed, 806 insertions(+), 43 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605060826-FZ9FV6/pr/github-title.txt
+++ b/.agentplane/tasks/202605060826-FZ9FV6/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 FZ9FV6 task: Add trusted project-local blueprint config [202605060826-FZ9FV6]

--- a/.agentplane/tasks/202605060826-FZ9FV6/pr/meta.json
+++ b/.agentplane/tasks/202605060826-FZ9FV6/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605060826-FZ9FV6/trusted-local-blueprints",
   "created_at": "2026-05-06T08:37:30.269Z",
-  "head_sha": "eb898d64fdf6ba3843f8c251d3e9df7d57296b68",
+  "head_sha": "c2e2e3325b691b6beb1ca20a3be6385dda44325c",
   "last_verified_at": null,
   "last_verified_sha": null,
   "schema_version": 1,
   "task_id": "202605060826-FZ9FV6",
-  "updated_at": "2026-05-06T08:37:30.269Z",
+  "updated_at": "2026-05-06T08:45:45.560Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202605060826-FZ9FV6/pr/meta.json
+++ b/.agentplane/tasks/202605060826-FZ9FV6/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605060826-FZ9FV6/trusted-local-blueprints",
+  "created_at": "2026-05-06T08:37:30.269Z",
+  "head_sha": "eb898d64fdf6ba3843f8c251d3e9df7d57296b68",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202605060826-FZ9FV6",
+  "updated_at": "2026-05-06T08:37:30.269Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605060826-FZ9FV6/pr/review.md
+++ b/.agentplane/tasks/202605060826-FZ9FV6/pr/review.md
@@ -1,0 +1,47 @@
+# PR Review
+
+Created: 2026-05-06T08:37:30.269Z
+
+## Task
+
+- Task: `202605060826-FZ9FV6`
+- Title: Add trusted project-local blueprint config
+- Status: DOING
+- Branch: `task/202605060826-FZ9FV6/trusted-local-blueprints`
+- Canonical task record: `.agentplane/tasks/202605060826-FZ9FV6/README.md`
+
+## Verification
+
+- State: ok
+- Note: Trusted project-local blueprint config implemented and validated.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-06T08:37:30.269Z
+- Branch: task/202605060826-FZ9FV6/trusted-local-blueprints
+- Head: eb898d64fdf6
+
+```text
+ .agentplane/tasks/202605060826-0GB6WB/README.md    |  78 +++++++
+ .agentplane/tasks/202605060826-97XHD3/README.md    |  78 +++++++
+ .agentplane/tasks/202605060826-VY5AKF/README.md    |  77 +++++++
+ docs/developer/blueprints.mdx                      |  81 ++++++--
+ docs/user/cli-reference.generated.mdx              |   1 +
+ packages/agentplane/src/blueprints/index.ts        |   8 +
+ .../agentplane/src/blueprints/project-local.ts     | 228 ++++++++++++++++++++-
+ packages/agentplane/src/blueprints/resolve.ts      |   4 +
+ .../src/cli/run-cli.core.blueprint.test.ts         | 110 ++++++++++
+ .../src/commands/blueprint/blueprint.command.ts    |  86 ++++++--
+ .../agentplane/src/commands/doctor/blueprints.ts   |  25 ++-
+ 11 files changed, 734 insertions(+), 42 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605060826-FZ9FV6/pr/review.md
+++ b/.agentplane/tasks/202605060826-FZ9FV6/pr/review.md
@@ -24,23 +24,24 @@ Created: 2026-05-06T08:37:30.269Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-06T08:37:30.269Z
+- Updated: 2026-05-06T08:45:45.560Z
 - Branch: task/202605060826-FZ9FV6/trusted-local-blueprints
-- Head: eb898d64fdf6
+- Head: c2e2e3325b69
 
 ```text
  .agentplane/tasks/202605060826-0GB6WB/README.md    |  78 +++++++
  .agentplane/tasks/202605060826-97XHD3/README.md    |  78 +++++++
  .agentplane/tasks/202605060826-VY5AKF/README.md    |  77 +++++++
- docs/developer/blueprints.mdx                      |  81 ++++++--
+ docs/developer/blueprints.mdx                      |  81 +++++--
  docs/user/cli-reference.generated.mdx              |   1 +
  packages/agentplane/src/blueprints/index.ts        |   8 +
- .../agentplane/src/blueprints/project-local.ts     | 228 ++++++++++++++++++++-
+ .../agentplane/src/blueprints/project-local.ts     | 237 ++++++++++++++++++++-
  packages/agentplane/src/blueprints/resolve.ts      |   4 +
- .../src/cli/run-cli.core.blueprint.test.ts         | 110 ++++++++++
+ .../src/cli/run-cli.core.blueprint.test.ts         | 150 +++++++++++++
  .../src/commands/blueprint/blueprint.command.ts    |  86 ++++++--
- .../agentplane/src/commands/doctor/blueprints.ts   |  25 ++-
- 11 files changed, 734 insertions(+), 42 deletions(-)
+ .../agentplane/src/commands/doctor.fast.test.ts    |  23 ++
+ .../agentplane/src/commands/doctor/blueprints.ts   |  26 ++-
+ 12 files changed, 806 insertions(+), 43 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605060826-VY5AKF/README.md
+++ b/.agentplane/tasks/202605060826-VY5AKF/README.md
@@ -1,0 +1,77 @@
+---
+id: "202605060826-VY5AKF"
+title: "Document trusted local blueprint selection"
+status: "DOING"
+priority: "med"
+owner: "DOCS"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "blueprints"
+  - "docs"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-06T08:27:12.134Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-06T08:36:18.554Z"
+  updated_by: "DOCS"
+  note: "Blueprint documentation now describes trusted project-local config, explicit-only selection, recipe interaction, and CLI surfaces."
+commit: null
+comments:
+  -
+    author: "DOCS"
+    body: "Start: document trusted project-local blueprint selection after CLI behavior lands."
+events:
+  -
+    type: "status"
+    at: "2026-05-06T08:27:29.504Z"
+    author: "DOCS"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: document trusted project-local blueprint selection after CLI behavior lands."
+  -
+    type: "verify"
+    at: "2026-05-06T08:36:18.554Z"
+    author: "DOCS"
+    state: "ok"
+    note: "Blueprint documentation now describes trusted project-local config, explicit-only selection, recipe interaction, and CLI surfaces."
+doc_version: 3
+doc_updated_at: "2026-05-06T08:36:18.559Z"
+doc_updated_by: "DOCS"
+description: "Document opt-in project-local blueprint selection, trust boundaries, and recipe interaction constraints for implementation users."
+sections:
+  Summary: |-
+    Document trusted local blueprint selection
+    
+    Document opt-in project-local blueprint selection, trust boundaries, and recipe interaction constraints for implementation users.
+  Scope: |-
+    - In scope: Document opt-in project-local blueprint selection, trust boundaries, and recipe interaction constraints for implementation users.
+    - Out of scope: unrelated refactors not required for "Document trusted local blueprint selection".
+  Plan: "After 97XHD3, update developer and CLI documentation for the trusted-local blueprint selection contract, including opt-in config, explicit-only selection, recipe hint boundaries, and safety constraints."
+  Verify Steps: |-
+    1. Review the requested outcome for "Document trusted local blueprint selection". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-06T08:36:18.554Z — VERIFY — ok
+    
+    By: DOCS
+    
+    Note: Blueprint documentation now describes trusted project-local config, explicit-only selection, recipe interaction, and CLI surfaces.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T08:27:29.504Z, excerpt_hash=sha256:e560f80bb0080469de83ec07f9525d63beff4e3bf846485818b37e898e57fd5a
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/docs/developer/blueprints.mdx
+++ b/docs/developer/blueprints.mdx
@@ -6,8 +6,9 @@ description: "Typed execution-route contracts for task-specific AgentPlane harne
 Blueprints are AgentPlane's typed route contracts for task-specific harness behavior.
 
 v0.5 rc1 ships the model, built-in registry, validation, resolver, explain output, recipe hint
-bridge, task verification visibility, and ACR summary extension. It does not ship blueprint node
-execution or a runner workflow engine.
+bridge, task verification visibility, ACR summary extension, and explicit opt-in selection for
+trusted project-local blueprints. It does not ship blueprint node execution or a runner workflow
+engine.
 
 ## Definition
 
@@ -116,17 +117,17 @@ blueprints/
 
 Initial responsibilities:
 
-| File               | Responsibility                                                                 |
-| ------------------ | ------------------------------------------------------------------------------ |
-| `model.ts`         | Pure types, string unions, and small helper predicates                         |
-| `builtins.ts`      | Built-in blueprint definitions and node catalog                                |
-| `registry.ts`      | Registry lookup, duplicate detection, and built-in export                      |
-| `project-local.ts` | Safe JSON parsing, scaffold writing, and project-local blueprint validation    |
-| `validate.ts`      | Structural validation and invariant checks                                     |
-| `resolve.ts`       | Select a blueprint from task metadata, workflow mode, mutation, risk, recipes  |
-| `explain.ts`       | Convert resolved blueprint data into stable human-readable explanation objects |
-| `recipe-hints.ts`  | Convert normalized recipe blueprint extensions into resolver hints             |
-| `index.ts`         | Public internal exports for CLI and verification integrations                  |
+| File               | Responsibility                                                                  |
+| ------------------ | ------------------------------------------------------------------------------- |
+| `model.ts`         | Pure types, string unions, and small helper predicates                          |
+| `builtins.ts`      | Built-in blueprint definitions and node catalog                                 |
+| `registry.ts`      | Registry lookup, duplicate detection, and built-in export                       |
+| `project-local.ts` | Safe JSON parsing, scaffold writing, project-local validation, and trust config |
+| `validate.ts`      | Structural validation and invariant checks                                      |
+| `resolve.ts`       | Select a blueprint from task metadata, workflow mode, mutation, risk, recipes   |
+| `explain.ts`       | Convert resolved blueprint data into stable human-readable explanation objects  |
+| `recipe-hints.ts`  | Convert normalized recipe blueprint extensions into resolver hints              |
+| `index.ts`         | Public internal exports for CLI and verification integrations                   |
 
 Do not place route logic inside command handlers. Commands should call the resolver and formatter.
 
@@ -745,6 +746,7 @@ CLI shape:
 ```text
 agentplane blueprint list
 agentplane blueprint list --project
+agentplane blueprint list --trusted
 agentplane blueprint explain <task-id>
 agentplane blueprint explain --kind analysis --mutation none
 agentplane blueprint explain <task-id> --json
@@ -793,12 +795,14 @@ Not required:
 
 ## Project-Local Authoring
 
-Project-local blueprints live under `.agentplane/blueprints/*.json`.
+Project-local blueprints live under `.agentplane/blueprints/*.json`. The optional trust config lives
+at `.agentplane/blueprints/config.json` and is not treated as a blueprint definition.
 
 This is an authoring and validation surface, not automatic execution. A local blueprint can be
-scaffolded, listed, and validated, but the resolver does not select it by default and the runner does
-not execute custom node graphs yet. That boundary is intentional: custom lifecycle topology must be
-visible and valid before it can become an execution route.
+scaffolded, listed, validated, and explicitly trusted. The resolver still does not select local
+blueprints by default, and the runner does not execute custom node graphs yet. That boundary is
+intentional: custom lifecycle topology must be visible, valid, and deliberately allowed before it can
+become an execution route.
 
 Safe authoring loop:
 
@@ -807,8 +811,46 @@ agentplane blueprint scaffold analysis.custom
 agentplane blueprint validate .agentplane/blueprints/analysis.custom.json
 agentplane blueprint validate --project
 agentplane blueprint list --project
+agentplane blueprint list --trusted
 agentplane doctor
 ```
+
+Trusted selection is an explicit repository opt-in:
+
+```json
+{
+  "enabled": true,
+  "allowed_ids": ["analysis.custom"],
+  "selection": "explicit_only"
+}
+```
+
+Trust semantics:
+
+1. `enabled: false` or a missing config means local blueprints remain authoring-only.
+2. `allowed_ids` is an allowlist. Only ids listed there can be added to the resolver registry.
+3. `selection` is currently only `explicit_only`; there is no automatic project-local route
+   selection.
+4. Built-in ids cannot be shadowed by project-local blueprints.
+5. Unknown, duplicate, or invalid allowlist entries block trusted selection and surface through
+   `blueprint validate --project`, `blueprint list --trusted`, and `doctor`.
+6. Trust does not bypass compatibility checks. Explicit blueprint requests and recipe
+   `preferred_blueprint` hints are still validated against task kind, workflow mode, mutation scope,
+   and risk rules.
+
+Selection examples:
+
+```bash
+agentplane blueprint explain --kind analysis --mutation none --blueprint analysis.custom
+agentplane blueprint explain <task-id> --blueprint analysis.custom
+```
+
+Recipe interaction:
+
+- A recipe may request a trusted local blueprint through `preferred_blueprint`.
+- The resolver accepts that preference only when the local id is trusted and compatible.
+- A trusted local blueprint still cannot make a content or analysis task inherit PR, CI, merge, or
+  publish nodes unless the task metadata and workflow mode make that route valid.
 
 Command semantics:
 
@@ -818,8 +860,9 @@ Command semantics:
 | `blueprint scaffold <id> --from code.branch_pr` | Starts from a specific built-in route                                  |
 | `blueprint scaffold <id> --out <path>`          | Writes to a custom path, restricted to the current project             |
 | `blueprint validate <path>`                     | Validates one JSON blueprint file                                      |
-| `blueprint validate --project`                  | Validates every `.json` file under `.agentplane/blueprints`            |
+| `blueprint validate --project`                  | Validates local blueprint files and the optional trust config          |
 | `blueprint list --project`                      | Lists built-ins plus valid local definitions                           |
+| `blueprint list --trusted`                      | Lists built-ins plus local definitions allowed by trust config         |
 | `doctor`                                        | Reports invalid local blueprints as warnings                           |
 
 Authoring constraints:
@@ -831,6 +874,8 @@ Authoring constraints:
 4. Validate the full project registry before relying on a custom route in docs or experiments.
 5. Treat custom blueprints as contracts for future execution, not as permission to bypass policy
    modules, approvals, or workflow mode constraints.
+6. Add a local id to `allowed_ids` only after validating its route, evidence, stop rules, and recipe
+   extension points.
 
 ## ACR Relationship
 

--- a/docs/developer/blueprints.mdx
+++ b/docs/developer/blueprints.mdx
@@ -795,8 +795,8 @@ Not required:
 
 ## Project-Local Authoring
 
-Project-local blueprints live under `.agentplane/blueprints/*.json`. The optional trust config lives
-at `.agentplane/blueprints/config.json` and is not treated as a blueprint definition.
+Project-local blueprints live under `.agentplane/blueprints/*.json`. The optional trust config is a
+`config.json` file in that directory and is not treated as a blueprint definition.
 
 This is an authoring and validation surface, not automatic execution. A local blueprint can be
 scaffolded, listed, validated, and explicitly trusted. The resolver still does not select local

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -574,6 +574,7 @@ agentplane blueprint list [options]
 Options:
 
 - `--project`: Include validated project-local blueprints from .agentplane/blueprints. (default=false)
+- `--trusted`: Show trust status from .agentplane/blueprints/config.json. (default=false)
 - `--json`: Emit JSON. (default=false)
 
 Examples:

--- a/packages/agentplane/src/blueprints/index.ts
+++ b/packages/agentplane/src/blueprints/index.ts
@@ -7,7 +7,12 @@ export {
 } from "./registry.js";
 export {
   PROJECT_BLUEPRINTS_DIR,
+  PROJECT_BLUEPRINTS_CONFIG_NAME,
+  createTrustedProjectBlueprintRegistry,
+  loadProjectBlueprintTrustConfig,
+  loadTrustedProjectBlueprintRegistry,
   parseProjectBlueprintJson,
+  projectBlueprintsConfigPath,
   projectBlueprintsDirectory,
   scaffoldProjectBlueprint,
   validateProjectBlueprintDirectory,
@@ -70,5 +75,8 @@ export type {
   ProjectBlueprintFileResult,
   ProjectBlueprintProblem,
   ProjectBlueprintProblemCode,
+  ProjectBlueprintTrustConfig,
+  ProjectBlueprintTrustConfigResult,
   ScaffoldProjectBlueprintOptions,
+  TrustedProjectBlueprintRegistryResult,
 } from "./project-local.js";

--- a/packages/agentplane/src/blueprints/project-local.ts
+++ b/packages/agentplane/src/blueprints/project-local.ts
@@ -90,11 +90,6 @@ function defaultTrustConfig(): ProjectBlueprintTrustConfig {
   };
 }
 
-function stringArray(value: unknown): string[] {
-  if (!Array.isArray(value)) return [];
-  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
-}
-
 function parseTrustConfigJson(raw: string, filePath: string): ProjectBlueprintTrustConfigResult {
   let parsed: unknown;
   try {
@@ -136,11 +131,25 @@ function parseTrustConfigJson(raw: string, filePath: string): ProjectBlueprintTr
   if ("enabled" in parsed && typeof parsed.enabled !== "boolean") {
     errors.push(problem("invalid_trust_config", "Blueprint trust config enabled must be boolean."));
   }
-  const allowedIds = stringArray(parsed.allowed_ids);
+  const allowedIds: string[] = [];
   if ("allowed_ids" in parsed && !Array.isArray(parsed.allowed_ids)) {
     errors.push(
       problem("invalid_trust_config", "Blueprint trust config allowed_ids must be an array."),
     );
+  }
+  if (Array.isArray(parsed.allowed_ids)) {
+    for (const [index, item] of parsed.allowed_ids.entries()) {
+      if (typeof item !== "string" || item.trim().length === 0) {
+        errors.push(
+          problem(
+            "invalid_trust_config",
+            `Blueprint trust config allowed_ids[${index}] must be a non-empty string.`,
+          ),
+        );
+        continue;
+      }
+      allowedIds.push(item.trim());
+    }
   }
   const selection = parsed.selection === undefined ? "explicit_only" : parsed.selection;
   if (selection !== "explicit_only") {

--- a/packages/agentplane/src/blueprints/project-local.ts
+++ b/packages/agentplane/src/blueprints/project-local.ts
@@ -1,21 +1,25 @@
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { requireBlueprint } from "./registry.js";
+import { createBlueprintRegistry, getBlueprint, requireBlueprint } from "./registry.js";
 import { validateBlueprint } from "./validate.js";
 import type {
   Blueprint,
   BlueprintId,
+  BlueprintRegistry,
   BlueprintValidationProblem,
   BlueprintValidationResult,
 } from "./model.js";
 
 export const PROJECT_BLUEPRINTS_DIR = ".agentplane/blueprints";
+export const PROJECT_BLUEPRINTS_CONFIG_NAME = "config.json";
 
 export type ProjectBlueprintProblemCode =
   | BlueprintValidationProblem["code"]
+  | "builtin_shadow"
   | "invalid_json"
   | "invalid_shape"
+  | "invalid_trust_config"
   | "missing_blueprint_directory";
 
 export type ProjectBlueprintProblem = {
@@ -39,6 +43,29 @@ export type ProjectBlueprintDirectoryResult = {
   errors: ProjectBlueprintProblem[];
 };
 
+export type ProjectBlueprintTrustConfig = {
+  enabled: boolean;
+  allowedIds: readonly BlueprintId[];
+  selection: "explicit_only";
+};
+
+export type ProjectBlueprintTrustConfigResult = {
+  ok: boolean;
+  path: string;
+  exists: boolean;
+  config: ProjectBlueprintTrustConfig;
+  errors: ProjectBlueprintProblem[];
+};
+
+export type TrustedProjectBlueprintRegistryResult = {
+  ok: boolean;
+  directory: string;
+  trustConfig: ProjectBlueprintTrustConfigResult;
+  files: ProjectBlueprintFileResult[];
+  trustedBlueprints: Blueprint[];
+  errors: ProjectBlueprintProblem[];
+};
+
 export type ScaffoldProjectBlueprintOptions = {
   projectRoot: string;
   id: BlueprintId;
@@ -53,6 +80,86 @@ function problem(
   path?: string,
 ): ProjectBlueprintProblem {
   return { code, message, ...(path ? { path } : {}) };
+}
+
+function defaultTrustConfig(): ProjectBlueprintTrustConfig {
+  return {
+    enabled: false,
+    allowedIds: [],
+    selection: "explicit_only",
+  };
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+function parseTrustConfigJson(raw: string, filePath: string): ProjectBlueprintTrustConfigResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return {
+      ok: false,
+      path: filePath,
+      exists: true,
+      config: defaultTrustConfig(),
+      errors: [
+        problem(
+          "invalid_json",
+          `Blueprint trust config ${JSON.stringify(filePath)} is not valid JSON: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        ),
+      ],
+    };
+  }
+
+  if (!requireObjectResult(parsed)) {
+    return {
+      ok: false,
+      path: filePath,
+      exists: true,
+      config: defaultTrustConfig(),
+      errors: [
+        problem(
+          "invalid_trust_config",
+          `Blueprint trust config ${JSON.stringify(filePath)} must contain one JSON object.`,
+        ),
+      ],
+    };
+  }
+
+  const errors: ProjectBlueprintProblem[] = [];
+  const enabled = parsed.enabled === true;
+  if ("enabled" in parsed && typeof parsed.enabled !== "boolean") {
+    errors.push(problem("invalid_trust_config", "Blueprint trust config enabled must be boolean."));
+  }
+  const allowedIds = stringArray(parsed.allowed_ids);
+  if ("allowed_ids" in parsed && !Array.isArray(parsed.allowed_ids)) {
+    errors.push(
+      problem("invalid_trust_config", "Blueprint trust config allowed_ids must be an array."),
+    );
+  }
+  const selection = parsed.selection === undefined ? "explicit_only" : parsed.selection;
+  if (selection !== "explicit_only") {
+    errors.push(
+      problem("invalid_trust_config", "Blueprint trust config selection must be explicit_only."),
+    );
+  }
+
+  return {
+    ok: errors.length === 0,
+    path: filePath,
+    exists: true,
+    config: {
+      enabled,
+      allowedIds: allowedIds.map((id) => id.trim() as BlueprintId),
+      selection: "explicit_only",
+    },
+    errors,
+  };
 }
 
 function requireObjectResult(value: unknown): value is Record<string, unknown> {
@@ -170,6 +277,7 @@ async function listJsonFiles(directory: string): Promise<string[]> {
     const entries = await readdir(directory, { withFileTypes: true });
     return entries
       .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+      .filter((entry) => entry.name !== PROJECT_BLUEPRINTS_CONFIG_NAME)
       .map((entry) => path.join(directory, entry.name))
       .toSorted();
   } catch (err) {
@@ -191,6 +299,124 @@ export async function validateProjectBlueprintDirectory(
     directory,
     files,
     errors,
+  };
+}
+
+export function projectBlueprintsConfigPath(projectRoot: string): string {
+  return path.join(projectBlueprintsDirectory(projectRoot), PROJECT_BLUEPRINTS_CONFIG_NAME);
+}
+
+export async function loadProjectBlueprintTrustConfig(
+  projectRoot: string,
+): Promise<ProjectBlueprintTrustConfigResult> {
+  const configPath = projectBlueprintsConfigPath(projectRoot);
+  try {
+    return parseTrustConfigJson(await readFile(configPath, "utf8"), configPath);
+  } catch (err) {
+    if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+      return {
+        ok: true,
+        path: configPath,
+        exists: false,
+        config: defaultTrustConfig(),
+        errors: [],
+      };
+    }
+    throw err;
+  }
+}
+
+function duplicateIds(ids: readonly BlueprintId[]): BlueprintId[] {
+  const seen = new Set<string>();
+  const duplicates = new Set<BlueprintId>();
+  for (const id of ids) {
+    if (seen.has(id)) duplicates.add(id);
+    seen.add(id);
+  }
+  return [...duplicates].toSorted((a, b) => a.localeCompare(b));
+}
+
+export async function loadTrustedProjectBlueprintRegistry(
+  projectRoot: string,
+): Promise<TrustedProjectBlueprintRegistryResult> {
+  const directory = projectBlueprintsDirectory(projectRoot);
+  const [trustConfig, directoryResult] = await Promise.all([
+    loadProjectBlueprintTrustConfig(projectRoot),
+    validateProjectBlueprintDirectory(directory),
+  ]);
+  const errors: ProjectBlueprintProblem[] = [...trustConfig.errors, ...directoryResult.errors];
+  const byId = new Map<string, Blueprint>();
+
+  for (const file of directoryResult.files) {
+    if (!file.blueprint) continue;
+    if (getBlueprint(file.blueprint.id, createBlueprintRegistry())) {
+      errors.push(
+        problem(
+          "builtin_shadow",
+          `Project blueprint ${file.blueprint.id} must not shadow a built-in blueprint id.`,
+          file.path,
+        ),
+      );
+      continue;
+    }
+    byId.set(file.blueprint.id, file.blueprint);
+  }
+
+  for (const duplicate of duplicateIds(trustConfig.config.allowedIds)) {
+    errors.push(
+      problem(
+        "invalid_trust_config",
+        `Blueprint trust config allowed_ids contains duplicate id: ${duplicate}`,
+        trustConfig.path,
+      ),
+    );
+  }
+
+  const trustedBlueprints: Blueprint[] = [];
+  if (trustConfig.config.enabled && trustConfig.ok) {
+    for (const id of trustConfig.config.allowedIds) {
+      const blueprint = byId.get(id);
+      if (!blueprint) {
+        errors.push(
+          problem(
+            "invalid_trust_config",
+            `Blueprint trust config allows unknown project-local blueprint id: ${id}`,
+            trustConfig.path,
+          ),
+        );
+        continue;
+      }
+      trustedBlueprints.push(blueprint);
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    directory,
+    trustConfig,
+    files: directoryResult.files,
+    trustedBlueprints,
+    errors,
+  };
+}
+
+export async function createTrustedProjectBlueprintRegistry(
+  projectRoot: string,
+): Promise<{ registry: BlueprintRegistry; projectBlueprintIds: BlueprintId[] }> {
+  const trusted = await loadTrustedProjectBlueprintRegistry(projectRoot);
+  if (!trusted.ok) {
+    throw new Error(
+      `Invalid project-local blueprint trust registry:\n${trusted.errors
+        .map((error) => `- ${error.code}: ${error.message}`)
+        .join("\n")}`,
+    );
+  }
+  return {
+    registry: createBlueprintRegistry([
+      ...createBlueprintRegistry().blueprints,
+      ...trusted.trustedBlueprints,
+    ]),
+    projectBlueprintIds: trusted.trustedBlueprints.map((blueprint) => blueprint.id),
   };
 }
 

--- a/packages/agentplane/src/blueprints/resolve.ts
+++ b/packages/agentplane/src/blueprints/resolve.ts
@@ -360,9 +360,13 @@ function resolveRecipeExtensions(opts: {
 export function resolveBlueprint(opts: {
   input: BlueprintResolveInput;
   registry?: BlueprintRegistry;
+  projectBlueprintIds?: readonly BlueprintId[];
 }): ResolvedBlueprint {
   const registry = opts.registry ?? createBlueprintRegistry();
   const { blueprint, reasons, stopReasons } = selectBlueprint({ input: opts.input, registry });
+  if (opts.projectBlueprintIds?.includes(blueprint.id)) {
+    reasons.push(`trusted project-local blueprint selected: ${blueprint.id}`);
+  }
   const { acceptedRecipeExtensions, rejectedRecipeExtensions } = resolveRecipeExtensions({
     blueprint,
     recipeHints: opts.input.recipeHints ?? [],

--- a/packages/agentplane/src/cli/run-cli.core.blueprint.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.blueprint.test.ts
@@ -185,4 +185,114 @@ describe("runCli blueprint commands", () => {
       io.restore();
     }
   });
+
+  it("blueprint explain resolves an explicitly trusted project-local blueprint", async () => {
+    const root = await mkProject();
+    const blueprintPath = path.join(root, ".agentplane", "blueprints", "analysis.custom.json");
+    await mkdir(path.dirname(blueprintPath), { recursive: true });
+    await writeFile(
+      blueprintPath,
+      `${JSON.stringify(
+        {
+          ...structuredClone(requireBlueprint("analysis.light")),
+          id: "analysis.custom",
+          title: "Custom analysis",
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    await writeFile(
+      path.join(root, ".agentplane", "blueprints", "config.json"),
+      '{\n  "enabled": true,\n  "allowed_ids": ["analysis.custom"],\n  "selection": "explicit_only"\n}\n',
+      "utf8",
+    );
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli([
+        "--root",
+        root,
+        "blueprint",
+        "explain",
+        "--kind",
+        "analysis",
+        "--mutation",
+        "none",
+        "--blueprint",
+        "analysis.custom",
+        "--json",
+      ]);
+      expect(code).toBe(0);
+      const payload = JSON.parse(io.stdout) as {
+        blueprintId: string;
+        selectionReasons: string[];
+      };
+      expect(payload.blueprintId).toBe("analysis.custom");
+      expect(payload.selectionReasons).toContain(
+        "trusted project-local blueprint selected: analysis.custom",
+      );
+    } finally {
+      io.restore();
+    }
+  });
+
+  it("blueprint explain rejects project-local blueprints without trust config opt-in", async () => {
+    const root = await mkProject();
+    const blueprintPath = path.join(root, ".agentplane", "blueprints", "analysis.custom.json");
+    await mkdir(path.dirname(blueprintPath), { recursive: true });
+    await writeFile(
+      blueprintPath,
+      `${JSON.stringify(
+        {
+          ...structuredClone(requireBlueprint("analysis.light")),
+          id: "analysis.custom",
+          title: "Custom analysis",
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli([
+        "--root",
+        root,
+        "blueprint",
+        "explain",
+        "--kind",
+        "analysis",
+        "--mutation",
+        "none",
+        "--blueprint",
+        "analysis.custom",
+      ]);
+      expect(code).not.toBe(0);
+      expect(io.stderr).toContain("Unknown blueprint in registry: analysis.custom");
+    } finally {
+      io.restore();
+    }
+  });
+
+  it("blueprint validate --project reports invalid trust config entries", async () => {
+    const root = await mkProject();
+    await mkdir(path.join(root, ".agentplane", "blueprints"), { recursive: true });
+    await writeFile(
+      path.join(root, ".agentplane", "blueprints", "config.json"),
+      '{\n  "enabled": true,\n  "allowed_ids": ["analysis.missing"],\n  "selection": "explicit_only"\n}\n',
+      "utf8",
+    );
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["--root", root, "blueprint", "validate", "--project"]);
+      expect(code).toBe(3);
+      expect(io.stderr).toContain("allows unknown project-local blueprint id");
+    } finally {
+      io.restore();
+    }
+  });
 });

--- a/packages/agentplane/src/cli/run-cli.core.blueprint.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.blueprint.test.ts
@@ -295,4 +295,44 @@ describe("runCli blueprint commands", () => {
       io.restore();
     }
   });
+
+  it("blueprint validate --project rejects non-string trust allowlist entries", async () => {
+    const root = await mkProject();
+    await mkdir(path.join(root, ".agentplane", "blueprints"), { recursive: true });
+    await writeFile(
+      path.join(root, ".agentplane", "blueprints", "config.json"),
+      '{\n  "enabled": true,\n  "allowed_ids": ["analysis.custom", 7, ""],\n  "selection": "explicit_only"\n}\n',
+      "utf8",
+    );
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["--root", root, "blueprint", "validate", "--project"]);
+      expect(code).toBe(3);
+      expect(io.stderr).toContain("allowed_ids[1] must be a non-empty string");
+      expect(io.stderr).toContain("allowed_ids[2] must be a non-empty string");
+    } finally {
+      io.restore();
+    }
+  });
+
+  it("blueprint list --project rejects local blueprints that shadow built-ins", async () => {
+    const root = await mkProject();
+    const blueprintPath = path.join(root, ".agentplane", "blueprints", "analysis.light.json");
+    await mkdir(path.dirname(blueprintPath), { recursive: true });
+    await writeFile(
+      blueprintPath,
+      `${JSON.stringify(requireBlueprint("analysis.light"), null, 2)}\n`,
+      "utf8",
+    );
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["--root", root, "blueprint", "list", "--project"]);
+      expect(code).toBe(3);
+      expect(io.stderr).toContain("must not shadow a built-in blueprint id");
+    } finally {
+      io.restore();
+    }
+  });
 });

--- a/packages/agentplane/src/commands/blueprint/blueprint.command.ts
+++ b/packages/agentplane/src/commands/blueprint/blueprint.command.ts
@@ -350,7 +350,7 @@ export const runBlueprintList: CommandHandler<BlueprintListParsed> = async (ctx,
   if (p.project || p.trusted) {
     const resolved = await resolveProject({ cwd: ctx.cwd, rootOverride: ctx.rootOverride ?? null });
     const trusted = await loadTrustedProjectBlueprintRegistry(resolved.gitRoot);
-    if (p.trusted && !trusted.ok) {
+    if (!trusted.ok) {
       throw new ValidationError({
         message: `Invalid project-local blueprint trust registry:\n${trusted.errors
           .map((error) => `- ${error.code}: ${error.message}`)

--- a/packages/agentplane/src/commands/blueprint/blueprint.command.ts
+++ b/packages/agentplane/src/commands/blueprint/blueprint.command.ts
@@ -4,8 +4,10 @@ import { resolveProject } from "@agentplaneorg/core/project";
 
 import {
   createBlueprintRegistry,
+  createTrustedProjectBlueprintRegistry,
   explainResolvedBlueprint,
   formatBlueprintExplain,
+  loadTrustedProjectBlueprintRegistry,
   listBlueprints,
   projectBlueprintsDirectory,
   resolveBlueprint,
@@ -37,6 +39,7 @@ import { blueprintResolveInputFromTask, workflowModeFromConfig } from "./task-in
 export type BlueprintListParsed = {
   json: boolean;
   project: boolean;
+  trusted: boolean;
 };
 
 export type BlueprintExplainParsed = {
@@ -104,6 +107,12 @@ export const blueprintListSpec: CommandSpec<BlueprintListParsed> = {
       default: false,
       description: "Include validated project-local blueprints from .agentplane/blueprints.",
     },
+    {
+      kind: "boolean",
+      name: "trusted",
+      default: false,
+      description: "Show trust status from .agentplane/blueprints/config.json.",
+    },
     { kind: "boolean", name: "json", default: false, description: "Emit JSON." },
   ],
   examples: [
@@ -113,7 +122,11 @@ export const blueprintListSpec: CommandSpec<BlueprintListParsed> = {
       why: "Include project-local blueprint definitions.",
     },
   ],
-  parse: (raw) => ({ json: raw.opts.json === true, project: raw.opts.project === true }),
+  parse: (raw) => ({
+    json: raw.opts.json === true,
+    project: raw.opts.project === true,
+    trusted: raw.opts.trusted === true,
+  }),
 };
 
 export const blueprintExplainSpec: CommandSpec<BlueprintExplainParsed> = {
@@ -332,11 +345,26 @@ function validationErrorFromProjectFile(
 export const runBlueprintList: CommandHandler<BlueprintListParsed> = async (ctx, p) => {
   const registry = createBlueprintRegistry();
   const routes = listBlueprints(registry).map((blueprint) => blueprintRoute(blueprint, "builtin"));
-  if (p.project) {
+  let trustedIds = new Set<string>();
+  let trustConfig: unknown = null;
+  if (p.project || p.trusted) {
     const resolved = await resolveProject({ cwd: ctx.cwd, rootOverride: ctx.rootOverride ?? null });
-    const local = await validateProjectBlueprintDirectory(
-      projectBlueprintsDirectory(resolved.gitRoot),
-    );
+    const trusted = await loadTrustedProjectBlueprintRegistry(resolved.gitRoot);
+    if (p.trusted && !trusted.ok) {
+      throw new ValidationError({
+        message: `Invalid project-local blueprint trust registry:\n${trusted.errors
+          .map((error) => `- ${error.code}: ${error.message}`)
+          .join("\n")}`,
+      });
+    }
+    trustedIds = new Set(trusted.trustedBlueprints.map((blueprint) => blueprint.id));
+    trustConfig = {
+      enabled: trusted.trustConfig.config.enabled,
+      exists: trusted.trustConfig.exists,
+      allowed_ids: trusted.trustConfig.config.allowedIds,
+      selection: trusted.trustConfig.config.selection,
+    };
+    const local = trusted;
     const invalid = local.files.find((file) => !file.ok);
     if (invalid) throw validationErrorFromProjectFile(invalid.path, invalid.errors);
     routes.push(
@@ -345,13 +373,21 @@ export const runBlueprintList: CommandHandler<BlueprintListParsed> = async (ctx,
       ),
     );
   }
+  const outputRoutes = routes.map((route) => ({
+    ...route,
+    ...(p.trusted && route.source === "project" ? { trusted: trustedIds.has(route.id) } : {}),
+  }));
   if (p.json) {
-    process.stdout.write(`${JSON.stringify({ blueprints: routes }, null, 2)}\n`);
+    process.stdout.write(
+      `${JSON.stringify({ blueprints: outputRoutes, ...(p.trusted ? { trust: trustConfig } : {}) }, null, 2)}\n`,
+    );
     return 0;
   }
-  for (const route of routes) {
+  for (const route of outputRoutes) {
+    const trustLabel =
+      p.trusted && route.source === "project" ? ` trusted=${route.trusted ? "yes" : "no"}` : "";
     process.stdout.write(
-      `${route.source} ${route.id}@${route.version} ${route.route.join(" -> ")}\n`,
+      `${route.source}${trustLabel} ${route.id}@${route.version} ${route.route.join(" -> ")}\n`,
     );
   }
   return 0;
@@ -369,7 +405,14 @@ export function makeRunBlueprintExplainHandler(getCtx: (cmd: string) => Promise<
           riskFlags: p.riskFlags,
         })
       : syntheticInput(commandCtx, p);
-    const resolved = resolveBlueprint({ input });
+    const projectRegistry = await createTrustedProjectBlueprintRegistry(
+      commandCtx.resolvedProject.gitRoot,
+    );
+    const resolved = resolveBlueprint({
+      input,
+      registry: projectRegistry.registry,
+      projectBlueprintIds: projectRegistry.projectBlueprintIds,
+    });
     const output = explainResolvedBlueprint({
       resolved,
       input,
@@ -391,8 +434,13 @@ export const runBlueprintValidate: CommandHandler<BlueprintValidateParsed> = asy
       ? path.resolve(resolved.gitRoot, p.path)
       : projectBlueprintsDirectory(resolved.gitRoot);
     const result = await validateProjectBlueprintDirectory(directory);
+    const trusted =
+      !p.path ||
+      path.resolve(resolved.gitRoot, p.path) === projectBlueprintsDirectory(resolved.gitRoot)
+        ? await loadTrustedProjectBlueprintRegistry(resolved.gitRoot)
+        : null;
     const output = {
-      ok: result.ok,
+      ok: result.ok && (trusted ? trusted.ok : true),
       directory: result.directory,
       blueprints: result.files.map((file) => ({
         ok: file.ok,
@@ -400,11 +448,20 @@ export const runBlueprintValidate: CommandHandler<BlueprintValidateParsed> = asy
         blueprint_id: file.blueprintId ?? null,
         errors: file.errors,
       })),
-      errors: result.errors,
+      trust: trusted
+        ? {
+            enabled: trusted.trustConfig.config.enabled,
+            exists: trusted.trustConfig.exists,
+            allowed_ids: trusted.trustConfig.config.allowedIds,
+            trusted_blueprint_ids: trusted.trustedBlueprints.map((blueprint) => blueprint.id),
+            errors: trusted.errors,
+          }
+        : null,
+      errors: [...result.errors, ...(trusted ? trusted.errors : [])],
     };
     if (p.json) {
       process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
-    } else if (result.ok) {
+    } else if (output.ok) {
       process.stdout.write(
         `project blueprints valid: ${result.files.length} file${result.files.length === 1 ? "" : "s"}\n`,
       );
@@ -414,8 +471,11 @@ export const runBlueprintValidate: CommandHandler<BlueprintValidateParsed> = asy
           process.stderr.write(`${file.path}: ${error.code}: ${error.message}\n`);
         }
       }
+      for (const error of trusted?.errors ?? []) {
+        process.stderr.write(`trust: ${error.code}: ${error.message}\n`);
+      }
     }
-    return result.ok ? 0 : 3;
+    return output.ok ? 0 : 3;
   }
 
   if (!p.path) {

--- a/packages/agentplane/src/commands/doctor.fast.test.ts
+++ b/packages/agentplane/src/commands/doctor.fast.test.ts
@@ -211,6 +211,29 @@ describe("doctor.fast", () => {
     }
   });
 
+  it("reports invalid project-local blueprint trust config without blueprint files", async () => {
+    const ws = await mkWorkspace();
+    await mkdir(path.join(ws.root, ".agentplane", "blueprints"), { recursive: true });
+    await writeFile(
+      path.join(ws.root, ".agentplane", "blueprints", "config.json"),
+      '{\n  "enabled": true,\n  "allowed_ids": [7],\n  "selection": "explicit_only"\n}\n',
+      "utf8",
+    );
+    const stderr = spyOnStderrWrite();
+    try {
+      const rc = await runDoctor(
+        { cwd: ws.root, rootOverride: null } as unknown as Parameters<typeof runDoctor>[0],
+        { fix: false, dev: false },
+      );
+      expect(rc).toBe(0);
+      const output = stderr.mock.calls.flat().join("\n");
+      expect(output).toContain("Project blueprint trust config is invalid");
+      expect(output).toContain("allowed_ids[0]");
+    } finally {
+      stderr.mockRestore();
+    }
+  });
+
   it("fails when DONE task misses implementation commit hash", async () => {
     const ws = await mkWorkspace();
     await gitInitWithCommit(ws.root, "feat: initial");

--- a/packages/agentplane/src/commands/doctor/blueprints.ts
+++ b/packages/agentplane/src/commands/doctor/blueprints.ts
@@ -2,7 +2,6 @@ import { loadTrustedProjectBlueprintRegistry } from "../../blueprints/index.js";
 
 export async function checkProjectBlueprints(repoRoot: string): Promise<string[]> {
   const result = await loadTrustedProjectBlueprintRegistry(repoRoot);
-  if (result.files.length === 0) return [];
   return [
     ...result.files.flatMap((file) =>
       file.errors.map(

--- a/packages/agentplane/src/commands/doctor/blueprints.ts
+++ b/packages/agentplane/src/commands/doctor/blueprints.ts
@@ -1,15 +1,20 @@
-import {
-  projectBlueprintsDirectory,
-  validateProjectBlueprintDirectory,
-} from "../../blueprints/index.js";
+import { loadTrustedProjectBlueprintRegistry } from "../../blueprints/index.js";
 
 export async function checkProjectBlueprints(repoRoot: string): Promise<string[]> {
-  const result = await validateProjectBlueprintDirectory(projectBlueprintsDirectory(repoRoot));
+  const result = await loadTrustedProjectBlueprintRegistry(repoRoot);
   if (result.files.length === 0) return [];
-  return result.files.flatMap((file) =>
-    file.errors.map(
-      (error) =>
-        `[WARN] Project blueprint ${file.path} is invalid: ${error.code}: ${error.message}`,
+  return [
+    ...result.files.flatMap((file) =>
+      file.errors.map(
+        (error) =>
+          `[WARN] Project blueprint ${file.path} is invalid: ${error.code}: ${error.message}`,
+      ),
     ),
-  );
+    ...result.errors
+      .filter((error) => !result.files.some((file) => file.errors.includes(error)))
+      .map(
+        (error) =>
+          `[WARN] Project blueprint trust config is invalid: ${error.code}: ${error.message}`,
+      ),
+  ];
 }


### PR DESCRIPTION
Task: `202605060826-FZ9FV6`
Title: Add trusted project-local blueprint config
Canonical task record: `.agentplane/tasks/202605060826-FZ9FV6/README.md`

## Summary

Add trusted project-local blueprint config

Define and validate an opt-in .agentplane/blueprints/config.json trust gate for project-local blueprint selection.

## Scope

- In scope: Define and validate an opt-in .agentplane/blueprints/config.json trust gate for project-local blueprint selection.
- Out of scope: unrelated refactors not required for "Add trusted project-local blueprint config".

## Verification

- State: ok
- Note: Trusted project-local blueprint config implemented and validated.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-06T08:37:30.269Z
- Branch: task/202605060826-FZ9FV6/trusted-local-blueprints
- Head: eb898d64fdf6

```text
 .agentplane/tasks/202605060826-0GB6WB/README.md    |  78 +++++++
 .agentplane/tasks/202605060826-97XHD3/README.md    |  78 +++++++
 .agentplane/tasks/202605060826-VY5AKF/README.md    |  77 +++++++
 docs/developer/blueprints.mdx                      |  81 ++++++--
 docs/user/cli-reference.generated.mdx              |   1 +
 packages/agentplane/src/blueprints/index.ts        |   8 +
 .../agentplane/src/blueprints/project-local.ts     | 228 ++++++++++++++++++++-
 packages/agentplane/src/blueprints/resolve.ts      |   4 +
 .../src/cli/run-cli.core.blueprint.test.ts         | 110 ++++++++++
 .../src/commands/blueprint/blueprint.command.ts    |  86 ++++++--
 .../agentplane/src/commands/doctor/blueprints.ts   |  25 ++-
 11 files changed, 734 insertions(+), 42 deletions(-)
```

</details>
