### PR TITLE
✅ 0EDRBK close: Implemented and verified in the v0.5 blueprint stack

### DIFF
--- a/.agentplane/tasks/202605060915-0EDRBK/README.md
+++ b/.agentplane/tasks/202605060915-0EDRBK/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202605060915-0EDRBK"
 title: "Persist resolved blueprint snapshot on task start"
-status: "DOING"
+result_summary: "Implemented and verified in the v0.5 blueprint stack."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 5
+revision: 7
 origin:
   system: "manual"
 depends_on:
@@ -25,11 +26,16 @@ verification:
   updated_at: "2026-05-06T09:30:09.218Z"
   updated_by: "CODER"
   note: "Implemented task-start snapshot persistence. Verification passed: bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/blueprint/snapshot-artifact.test.ts packages/agentplane/src/commands/task/start.unit.test.ts packages/agentplane/src/blueprints/snapshot.test.ts packages/agentplane/src/blueprints/resolve.test.ts; bun run typecheck; prettier/eslint on touched files; git diff --check; bun run framework:dev:bootstrap."
-commit: null
+commit:
+  hash: "0d21e9139c3ec226ad684768e34338bc815d62e5"
+  message: "🚧 0EDRBK task: persist snapshots on start"
 comments:
   -
     author: "CODER"
     body: "Start: Persist resolved blueprint snapshots during task lifecycle using the committed YN0VAQ snapshot contract in this epic branch. Dependency is force-started because branch_pr mode permits DONE only after base integration; foundation commit a503b82 is present locally."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: implemented in the v0.5 blueprint stack and covered by final focused checks."
 events:
   -
     type: "status"
@@ -44,9 +50,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Implemented task-start snapshot persistence. Verification passed: bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/blueprint/snapshot-artifact.test.ts packages/agentplane/src/commands/task/start.unit.test.ts packages/agentplane/src/blueprints/snapshot.test.ts packages/agentplane/src/blueprints/resolve.test.ts; bun run typecheck; prettier/eslint on touched files; git diff --check; bun run framework:dev:bootstrap."
+  -
+    type: "status"
+    at: "2026-05-06T12:20:40.500Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: implemented in the v0.5 blueprint stack and covered by final focused checks."
 doc_version: 3
-doc_updated_at: "2026-05-06T09:30:09.222Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-06T12:20:40.500Z"
+doc_updated_by: "INTEGRATOR"
 description: "Materialize the resolver output into the active task artifacts during task start-ready or equivalent lifecycle start, without executing blueprint nodes."
 sections:
   Summary: |-
@@ -95,60 +108,3 @@ sections:
       Resolution: Added snapshot artifact helper and wired cmdStart to write the artifact after status transition and before branch_pr PR artifact sync.
 id_source: "generated"
 ---
-## Summary
-
-Persist resolved blueprint snapshot on task start
-
-Materialize the resolver output into the active task artifacts during task start-ready or equivalent lifecycle start, without executing blueprint nodes.
-
-## Scope
-
-- In scope: Materialize the resolver output into the active task artifacts during task start-ready or equivalent lifecycle start, without executing blueprint nodes.
-- Out of scope: unrelated refactors not required for "Persist resolved blueprint snapshot on task start".
-
-## Plan
-
-Persist the resolved blueprint snapshot when a task enters execution.
-
-Depends on: 202605060915-YN0VAQ.
-
-Steps:
-1. Reuse the snapshot contract and digest from YN0VAQ.
-2. Locate the task start/start-ready lifecycle path and existing task artifact writers.
-3. Persist the resolved blueprint snapshot under the task artifact directory without changing task semantics for non-blueprint workflows.
-4. Ensure persistence is deterministic and does not overwrite unrelated task artifacts unexpectedly.
-5. Add tests around task start persistence and artifact shape.
-
-Verification:
-- Lifecycle tests pass.
-- Snapshot artifact can be read back and matches the resolver output digest.
-
-## Verify Steps
-
-1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
-2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
-3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
-
-## Verification
-
-<!-- BEGIN VERIFICATION RESULTS -->
-### 2026-05-06T09:30:09.218Z — VERIFY — ok
-
-By: CODER
-
-Note: Implemented task-start snapshot persistence. Verification passed: bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/blueprint/snapshot-artifact.test.ts packages/agentplane/src/commands/task/start.unit.test.ts packages/agentplane/src/blueprints/snapshot.test.ts packages/agentplane/src/blueprints/resolve.test.ts; bun run typecheck; prettier/eslint on touched files; git diff --check; bun run framework:dev:bootstrap.
-
-VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T09:26:11.066Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
-
-<!-- END VERIFICATION RESULTS -->
-
-## Rollback Plan
-
-- Revert task-related commit(s).
-- Re-run required checks to confirm rollback safety.
-
-## Findings
-
-- Observation: task start now writes .agentplane/tasks/<task-id>/blueprint/resolved-snapshot.json from the same trusted blueprint resolver used by blueprint explain.
-  Impact: Dependent refresh and drift detection tasks have a deterministic persisted baseline to compare against.
-  Resolution: Added snapshot artifact helper and wired cmdStart to write the artifact after status transition and before branch_pr PR artifact sync.


### PR DESCRIPTION
Close task 202605060915-0EDRBK after the v0.5 blueprint stack was integrated into main.\n\nScope: task closure metadata only after updating the close branch onto current main.\n\nLocal verification before opening:\n- bun run framework:dev:bootstrap\n- pre-push docs-only fast checks