### PR TITLE
🚧 2W42MM task: Expose blueprint discoverability in CLI [202605061515-2W42MM]

### DIFF
--- a/.agentplane/tasks/202605061515-2W42MM/README.md
+++ b/.agentplane/tasks/202605061515-2W42MM/README.md
@@ -1,0 +1,88 @@
+---
+id: "202605061515-2W42MM"
+title: "Expose blueprint discoverability in CLI"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "blueprints"
+  - "cli"
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-06T15:16:36.121Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-06T15:25:29.806Z"
+  updated_by: "CODER"
+  note: "Verified: blueprint examples command, quickstart hint, CLI docs generation, targeted tests, typecheck, doctor, routing, release gate, and diff check passed."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Implement blueprint discoverability surfaces, docs examples, and prerelease release-version validation in the approved batch worktree."
+events:
+  -
+    type: "status"
+    at: "2026-05-06T15:17:10.889Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Implement blueprint discoverability surfaces, docs examples, and prerelease release-version validation in the approved batch worktree."
+  -
+    type: "verify"
+    at: "2026-05-06T15:25:29.806Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: blueprint examples command, quickstart hint, CLI docs generation, targeted tests, typecheck, doctor, routing, release gate, and diff check passed."
+doc_version: 3
+doc_updated_at: "2026-05-06T15:25:29.828Z"
+doc_updated_by: "CODER"
+description: "Make blueprint commands easier to find from quickstart, task surfaces, and examples without changing blueprint execution semantics."
+sections:
+  Summary: |-
+    Expose blueprint discoverability in CLI
+    
+    Make blueprint commands easier to find from quickstart, task surfaces, and examples without changing blueprint execution semantics.
+  Scope: |-
+    - In scope: Make blueprint commands easier to find from quickstart, task surfaces, and examples without changing blueprint execution semantics.
+    - Out of scope: unrelated refactors not required for "Expose blueprint discoverability in CLI".
+  Plan: "Primary batch branch for blueprint usability after 0.5 rc1. Scope: expose blueprint discovery in quickstart/help/task inspection surfaces; add a concrete examples command or equivalent visible examples; keep route selection semantics unchanged. Batch includes docs task 202605061515-EPEVHQ and release-gate task 202605061515-WJWM2W. Verification: targeted blueprint/CLI tests, release version/parity checks for prerelease, doctor, typecheck, diff check."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-06T15:25:29.806Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: blueprint examples command, quickstart hint, CLI docs generation, targeted tests, typecheck, doctor, routing, release gate, and diff check passed.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T15:17:10.889Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605061515-2W42MM-blueprint-discoverability/.agentplane/tasks/202605061515-2W42MM/blueprint/resolved-snapshot.json
+    - old_digest: 30aa560f36ac204e8a2f5a40fb216dac8b44b844c39595878399b10ab4c1dc25
+    - current_digest: 30aa560f36ac204e8a2f5a40fb216dac8b44b844c39595878399b10ab4c1dc25
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605061515-2W42MM
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605061515-2W42MM/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605061515-2W42MM/blueprint/resolved-snapshot.json
@@ -1,0 +1,498 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605061515-2W42MM",
+    "title": "Expose blueprint discoverability in CLI",
+    "description": "Make blueprint commands easier to find from quickstart, task surfaces, and examples without changing blueprint execution semantics.",
+    "tags": [
+      "blueprints",
+      "cli",
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605061515-2W42MM",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "30aa560f36ac204e8a2f5a40fb216dac8b44b844c39595878399b10ab4c1dc25"
+  }
+}

--- a/.agentplane/tasks/202605061515-2W42MM/pr/diffstat.txt
+++ b/.agentplane/tasks/202605061515-2W42MM/pr/diffstat.txt
@@ -1,0 +1,16 @@
+ .../blueprint/resolved-snapshot.json               | 498 +++++++++++++++++++++
+ .agentplane/tasks/202605061515-EPEVHQ/README.md    |  87 ++++
+ .../blueprint/resolved-snapshot.json               | 342 ++++++++++++++
+ .agentplane/tasks/202605061515-WJWM2W/README.md    |  88 ++++
+ .../blueprint/resolved-snapshot.json               | 401 +++++++++++++++++
+ docs/developer/blueprints.mdx                      |  37 ++
+ docs/user/cli-reference.generated.mdx              |  37 +-
+ packages/agentplane/src/cli/command-guide.ts       |   1 +
+ .../src/cli/run-cli.core.blueprint.test.ts         |  14 +
+ .../src/cli/run-cli/command-catalog/project.ts     |   3 +
+ .../src/cli/run-cli/command-loaders/project.ts     |   2 +
+ .../src/commands/blueprint/blueprint.command.ts    |  67 +++
+ .../src/commands/blueprint/blueprint.specs.ts      |  25 +-
+ .../release/check-release-version-script.test.ts   |  15 +
+ scripts/check-release-version.mjs                  |   8 +-
+ 15 files changed, 1620 insertions(+), 5 deletions(-)

--- a/.agentplane/tasks/202605061515-2W42MM/pr/github-body.md
+++ b/.agentplane/tasks/202605061515-2W42MM/pr/github-body.md
@@ -1,0 +1,48 @@
+Task: `202605061515-2W42MM`
+Title: Expose blueprint discoverability in CLI
+Canonical task record: `.agentplane/tasks/202605061515-2W42MM/README.md`
+
+## Summary
+
+Expose blueprint discoverability in CLI
+
+Make blueprint commands easier to find from quickstart, task surfaces, and examples without changing blueprint execution semantics.
+
+## Scope
+
+- In scope: Make blueprint commands easier to find from quickstart, task surfaces, and examples without changing blueprint execution semantics.
+- Out of scope: unrelated refactors not required for "Expose blueprint discoverability in CLI".
+
+## Verification
+
+- State: ok
+- Note: Verified: blueprint examples command, quickstart hint, CLI docs generation, targeted tests, typecheck, doctor, routing, release gate, and diff check passed.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-06T15:27:38.922Z
+- Branch: task/202605061515-2W42MM/blueprint-discoverability
+- Head: a2bdf69b7a18
+
+```text
+ .../blueprint/resolved-snapshot.json               | 498 +++++++++++++++++++++
+ .agentplane/tasks/202605061515-EPEVHQ/README.md    |  87 ++++
+ .../blueprint/resolved-snapshot.json               | 342 ++++++++++++++
+ .agentplane/tasks/202605061515-WJWM2W/README.md    |  88 ++++
+ .../blueprint/resolved-snapshot.json               | 401 +++++++++++++++++
+ docs/developer/blueprints.mdx                      |  37 ++
+ docs/user/cli-reference.generated.mdx              |  37 +-
+ packages/agentplane/src/cli/command-guide.ts       |   1 +
+ .../src/cli/run-cli.core.blueprint.test.ts         |  14 +
+ .../src/cli/run-cli/command-catalog/project.ts     |   3 +
+ .../src/cli/run-cli/command-loaders/project.ts     |   2 +
+ .../src/commands/blueprint/blueprint.command.ts    |  67 +++
+ .../src/commands/blueprint/blueprint.specs.ts      |  25 +-
+ .../release/check-release-version-script.test.ts   |  15 +
+ scripts/check-release-version.mjs                  |   8 +-
+ 15 files changed, 1620 insertions(+), 5 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605061515-2W42MM/pr/github-title.txt
+++ b/.agentplane/tasks/202605061515-2W42MM/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 2W42MM task: Expose blueprint discoverability in CLI [202605061515-2W42MM]

--- a/.agentplane/tasks/202605061515-2W42MM/pr/meta.json
+++ b/.agentplane/tasks/202605061515-2W42MM/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605061515-2W42MM/blueprint-discoverability",
+  "created_at": "2026-05-06T15:17:11.157Z",
+  "head_sha": "a2bdf69b7a1889aaf5ccdb8466abd43dd119853f",
+  "last_verified_at": "2026-05-06T15:25:29.806Z",
+  "last_verified_sha": "6feb8fc5d8847df58de97b7f2028f55c1794d575",
+  "schema_version": 1,
+  "task_id": "202605061515-2W42MM",
+  "updated_at": "2026-05-06T15:27:38.922Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605061515-2W42MM/pr/review.md
+++ b/.agentplane/tasks/202605061515-2W42MM/pr/review.md
@@ -1,0 +1,51 @@
+# PR Review
+
+Created: 2026-05-06T15:17:11.157Z
+
+## Task
+
+- Task: `202605061515-2W42MM`
+- Title: Expose blueprint discoverability in CLI
+- Status: DOING
+- Branch: `task/202605061515-2W42MM/blueprint-discoverability`
+- Canonical task record: `.agentplane/tasks/202605061515-2W42MM/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified: blueprint examples command, quickstart hint, CLI docs generation, targeted tests, typecheck, doctor, routing, release gate, and diff check passed.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-06T15:27:38.922Z
+- Branch: task/202605061515-2W42MM/blueprint-discoverability
+- Head: a2bdf69b7a18
+
+```text
+ .../blueprint/resolved-snapshot.json               | 498 +++++++++++++++++++++
+ .agentplane/tasks/202605061515-EPEVHQ/README.md    |  87 ++++
+ .../blueprint/resolved-snapshot.json               | 342 ++++++++++++++
+ .agentplane/tasks/202605061515-WJWM2W/README.md    |  88 ++++
+ .../blueprint/resolved-snapshot.json               | 401 +++++++++++++++++
+ docs/developer/blueprints.mdx                      |  37 ++
+ docs/user/cli-reference.generated.mdx              |  37 +-
+ packages/agentplane/src/cli/command-guide.ts       |   1 +
+ .../src/cli/run-cli.core.blueprint.test.ts         |  14 +
+ .../src/cli/run-cli/command-catalog/project.ts     |   3 +
+ .../src/cli/run-cli/command-loaders/project.ts     |   2 +
+ .../src/commands/blueprint/blueprint.command.ts    |  67 +++
+ .../src/commands/blueprint/blueprint.specs.ts      |  25 +-
+ .../release/check-release-version-script.test.ts   |  15 +
+ scripts/check-release-version.mjs                  |   8 +-
+ 15 files changed, 1620 insertions(+), 5 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605061515-EPEVHQ/README.md
+++ b/.agentplane/tasks/202605061515-EPEVHQ/README.md
@@ -1,0 +1,87 @@
+---
+id: "202605061515-EPEVHQ"
+title: "Document blueprint task selection examples"
+status: "DOING"
+priority: "med"
+owner: "DOCS"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "blueprints"
+  - "docs"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-06T15:16:45.189Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-06T15:25:42.779Z"
+  updated_by: "DOCS"
+  note: "Verified: developer blueprint documentation now includes CLI route inspection examples and generated CLI reference is fresh."
+commit: null
+comments:
+  -
+    author: "DOCS"
+    body: "Start: Document blueprint selection and inspection examples inside the approved blueprint discoverability batch."
+events:
+  -
+    type: "status"
+    at: "2026-05-06T15:17:21.396Z"
+    author: "DOCS"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Document blueprint selection and inspection examples inside the approved blueprint discoverability batch."
+  -
+    type: "verify"
+    at: "2026-05-06T15:25:42.779Z"
+    author: "DOCS"
+    state: "ok"
+    note: "Verified: developer blueprint documentation now includes CLI route inspection examples and generated CLI reference is fresh."
+doc_version: 3
+doc_updated_at: "2026-05-06T15:25:42.797Z"
+doc_updated_by: "DOCS"
+description: "Add practical documentation that shows how tasks choose blueprints and how users can inspect route selection."
+sections:
+  Summary: |-
+    Document blueprint task selection examples
+    
+    Add practical documentation that shows how tasks choose blueprints and how users can inspect route selection.
+  Scope: |-
+    - In scope: Add practical documentation that shows how tasks choose blueprints and how users can inspect route selection.
+    - Out of scope: unrelated refactors not required for "Document blueprint task selection examples".
+  Plan: "Document practical blueprint selection and inspection examples. Scope: add/update user/developer docs showing built-in routes, common explain examples for analysis/content/code/release, and how to inspect task snapshots. Depends on the CLI surfaces from 202605061515-2W42MM. Verification: docs links exist, docs checks/generation if touched, doctor, diff check."
+  Verify Steps: |-
+    1. Review the requested outcome for "Document blueprint task selection examples". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-06T15:25:42.779Z — VERIFY — ok
+    
+    By: DOCS
+    
+    Note: Verified: developer blueprint documentation now includes CLI route inspection examples and generated CLI reference is fresh.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T15:17:21.396Z, excerpt_hash=sha256:5bb61343fcd9c54437b566ad6dacb55e2df0a1c7f5147da865534dd215124488
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605061515-2W42MM-blueprint-discoverability/.agentplane/tasks/202605061515-EPEVHQ/blueprint/resolved-snapshot.json
+    - old_digest: 363b864d93d83941abf67aa2e9210162caf21b467c2f555ea47198eaad02982f
+    - current_digest: 363b864d93d83941abf67aa2e9210162caf21b467c2f555ea47198eaad02982f
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605061515-EPEVHQ
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605061515-EPEVHQ/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605061515-EPEVHQ/blueprint/resolved-snapshot.json
@@ -1,0 +1,342 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605061515-EPEVHQ",
+    "title": "Document blueprint task selection examples",
+    "description": "Add practical documentation that shows how tasks choose blueprints and how users can inspect route selection.",
+    "tags": [
+      "blueprints",
+      "docs"
+    ],
+    "owner": "DOCS",
+    "workflowMode": "branch_pr",
+    "mutation": "docs",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "docs.change",
+    "version": 1,
+    "title": "Documentation change",
+    "taskKinds": [
+      "docs"
+    ],
+    "workflowModes": [
+      "direct",
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "docs.change",
+    "blueprintVersion": 1,
+    "title": "Documentation change",
+    "taskId": "202605061515-EPEVHQ",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "mutationScope": "docs"
+    },
+    "whySelected": [
+      "task kind resolved to docs",
+      "workflow mode: branch_pr",
+      "mutation scope: docs"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.docs.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "artifact"
+        ]
+      },
+      {
+        "id": "deterministic_check",
+        "kind": "deterministic_check",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "docs.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed documentation paths."
+      },
+      {
+        "id": "docs.check",
+        "kind": "check_result",
+        "producedBy": "deterministic_check",
+        "required": true,
+        "description": "Documentation checks."
+      },
+      {
+        "id": "docs.artifact",
+        "kind": "artifact",
+        "producedBy": "artifact_write",
+        "required": true,
+        "description": "Updated documentation artifact."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/dod.docs.md",
+      ".agentplane/policy/security.must.md"
+    ],
+    "allowedCommands": [
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "documentation checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 3,
+      "maxPromptBlocks": 10,
+      "rationale": "Documentation changes need docs DoD and minimal workflow/security policy."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.docs.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "artifact"
+      ]
+    },
+    {
+      "id": "deterministic_check",
+      "kind": "deterministic_check",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "docs.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed documentation paths."
+    },
+    {
+      "id": "docs.check",
+      "kind": "check_result",
+      "producedBy": "deterministic_check",
+      "required": true,
+      "description": "Documentation checks."
+    },
+    {
+      "id": "docs.artifact",
+      "kind": "artifact",
+      "producedBy": "artifact_write",
+      "required": true,
+      "description": "Updated documentation artifact."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/dod.docs.md",
+    ".agentplane/policy/security.must.md"
+  ],
+  "allowedCommands": [
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "documentation checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 3,
+    "maxPromptBlocks": 10,
+    "rationale": "Documentation changes need docs DoD and minimal workflow/security policy."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to docs",
+    "workflow mode: branch_pr",
+    "mutation scope: docs"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "363b864d93d83941abf67aa2e9210162caf21b467c2f555ea47198eaad02982f"
+  }
+}

--- a/.agentplane/tasks/202605061515-WJWM2W/README.md
+++ b/.agentplane/tasks/202605061515-WJWM2W/README.md
@@ -1,0 +1,88 @@
+---
+id: "202605061515-WJWM2W"
+title: "Allow prerelease release-version checks"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "blueprints"
+  - "code"
+  - "release"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-06T15:16:49.790Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-06T15:25:51.716Z"
+  updated_by: "CODER"
+  note: "Verified: release-version script preserves prerelease tag suffixes; prerelease unit test and v0.5.0-rc.1 script check pass."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Fix prerelease release-version validation for rc tags as part of the blueprint discoverability batch."
+events:
+  -
+    type: "status"
+    at: "2026-05-06T15:17:29.746Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Fix prerelease release-version validation for rc tags as part of the blueprint discoverability batch."
+  -
+    type: "verify"
+    at: "2026-05-06T15:25:51.716Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: release-version script preserves prerelease tag suffixes; prerelease unit test and v0.5.0-rc.1 script check pass."
+doc_version: 3
+doc_updated_at: "2026-05-06T15:25:51.731Z"
+doc_updated_by: "CODER"
+description: "Make release-version validation handle prerelease tags such as v0.5.0-rc.1 consistently with release parity checks."
+sections:
+  Summary: |-
+    Allow prerelease release-version checks
+    
+    Make release-version validation handle prerelease tags such as v0.5.0-rc.1 consistently with release parity checks.
+  Scope: |-
+    - In scope: Make release-version validation handle prerelease tags such as v0.5.0-rc.1 consistently with release parity checks.
+    - Out of scope: unrelated refactors not required for "Allow prerelease release-version checks".
+  Plan: "Fix prerelease release-version validation so v0.5.0-rc.1 resolves to required version 0.5.0-rc.1 instead of 0.5.0. Scope: script parsing and focused tests only; do not change release apply semantics unless required by the parser contract. Verification: release-version focused tests, check-release-version --tag v0.5.0-rc.1, release parity, doctor, typecheck."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-06T15:25:51.716Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: release-version script preserves prerelease tag suffixes; prerelease unit test and v0.5.0-rc.1 script check pass.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T15:17:29.746Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605061515-2W42MM-blueprint-discoverability/.agentplane/tasks/202605061515-WJWM2W/blueprint/resolved-snapshot.json
+    - old_digest: 64f1f44bfdc2b38eaa117c3b8e466c4cf953caa5c485486dbeec247a961d36bb
+    - current_digest: 64f1f44bfdc2b38eaa117c3b8e466c4cf953caa5c485486dbeec247a961d36bb
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605061515-WJWM2W
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605061515-WJWM2W/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605061515-WJWM2W/blueprint/resolved-snapshot.json
@@ -1,0 +1,401 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605061515-WJWM2W",
+    "title": "Allow prerelease release-version checks",
+    "description": "Make release-version validation handle prerelease tags such as v0.5.0-rc.1 consistently with release parity checks.",
+    "tags": [
+      "blueprints",
+      "code",
+      "release"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "mutation": "release",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "release.strict",
+    "version": 1,
+    "title": "Strict release",
+    "taskKinds": [
+      "release"
+    ],
+    "workflowModes": [
+      "direct",
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "release.strict",
+    "blueprintVersion": 1,
+    "title": "Strict release",
+    "taskId": "202605061515-WJWM2W",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "mutationScope": "release"
+    },
+    "whySelected": [
+      "task kind resolved to release",
+      "workflow mode: branch_pr",
+      "mutation scope: release"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.release.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "deterministic_check",
+        "kind": "deterministic_check",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "release.approval",
+        "kind": "approval",
+        "producedBy": "approval_gate",
+        "required": true,
+        "description": "Release approval."
+      },
+      {
+        "id": "release.plan",
+        "kind": "artifact",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Release plan or candidate artifact."
+      },
+      {
+        "id": "release.check",
+        "kind": "check_result",
+        "producedBy": "deterministic_check",
+        "required": true,
+        "description": "Release gates."
+      },
+      {
+        "id": "release.publish",
+        "kind": "external_link",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Publish evidence."
+      },
+      {
+        "id": "release.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Release commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.release.md"
+    ],
+    "allowedCommands": [
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "publish commands after approval",
+      "release gates"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Release work needs strict release policy, approval evidence, and rollback context."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.release.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "deterministic_check",
+      "kind": "deterministic_check",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "release.approval",
+      "kind": "approval",
+      "producedBy": "approval_gate",
+      "required": true,
+      "description": "Release approval."
+    },
+    {
+      "id": "release.plan",
+      "kind": "artifact",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Release plan or candidate artifact."
+    },
+    {
+      "id": "release.check",
+      "kind": "check_result",
+      "producedBy": "deterministic_check",
+      "required": true,
+      "description": "Release gates."
+    },
+    {
+      "id": "release.publish",
+      "kind": "external_link",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Publish evidence."
+    },
+    {
+      "id": "release.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Release commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.release.md"
+  ],
+  "allowedCommands": [
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "publish commands after approval",
+    "release gates"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Release work needs strict release policy, approval evidence, and rollback context."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to release",
+    "workflow mode: branch_pr",
+    "mutation scope: release"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "64f1f44bfdc2b38eaa117c3b8e466c4cf953caa5c485486dbeec247a961d36bb"
+  }
+}

--- a/docs/developer/blueprints.mdx
+++ b/docs/developer/blueprints.mdx
@@ -29,6 +29,43 @@ A blueprint is not:
 The purpose is to let AgentPlane select a task-specific route. Analysis, content, documentation,
 code, release, and operational tasks should not inherit the same code-oriented PR flow.
 
+## CLI Route Inspection
+
+Blueprints are visible before execution. Use the CLI to inspect route selection, compare task
+classes, and confirm that a read-only task is not being pushed through a code PR route.
+
+```bash
+agentplane blueprint examples
+```
+
+Common route probes:
+
+```bash
+agentplane blueprint explain --kind analysis --mutation none
+agentplane blueprint explain --kind content --mutation none
+agentplane blueprint explain --kind docs --mutation docs
+agentplane blueprint explain --kind code --mutation code --workflow-mode branch_pr
+agentplane blueprint explain --kind release --mutation release --risk external_publish
+agentplane blueprint explain <task-id>
+```
+
+Expected shape:
+
+- `analysis.light`: lightweight analysis route with evidence and final output, no CI or PR gates.
+- `content.light`: content-generation route with output/evidence emphasis, no code lifecycle.
+- `docs.change`: documentation mutation route with docs checks.
+- `code.branch_pr`: code mutation route in `branch_pr`, including local checks and PR/integration
+  gates.
+- `release.strict`: release/publish route with version, parity, manifest, and publish safety gates.
+
+For project-local blueprints, inspect trust and compatibility before runner materialization:
+
+```bash
+agentplane blueprint list --project --trusted
+agentplane blueprint report
+agentplane blueprint validate --project
+```
+
 ## Design Premises
 
 Blueprints are useful only if they preserve the difference between task classes.

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -21,6 +21,7 @@ This page is generated from the CLI command specs. Do not edit it by hand; edit 
 - Blueprints
   - [blueprint](#blueprint)
   - [blueprint drift](#blueprint-drift)
+  - [blueprint examples](#blueprint-examples)
   - [blueprint explain](#blueprint-explain)
   - [blueprint list](#blueprint-list)
   - [blueprint report](#blueprint-report)
@@ -500,7 +501,7 @@ agentplane sync redmine --direction push --yes
 
 List and explain blueprint routing without executing a task.
 
-This is a command group. Use \`agentplane blueprint list\`, \`agentplane blueprint explain ...\`, \`agentplane blueprint scaffold ...\`, or \`agentplane blueprint validate ...\`.
+This is a command group. Use \`agentplane blueprint examples\`, \`agentplane blueprint list\`, \`agentplane blueprint explain ...\`, \`agentplane blueprint scaffold ...\`, or \`agentplane blueprint validate ...\`.
 
 Usage:
 
@@ -509,6 +510,12 @@ agentplane blueprint [<cmd> ...]
 ```
 
 Examples:
+
+```sh
+agentplane blueprint examples
+```
+
+- Show practical route inspection commands.
 
 ```sh
 agentplane blueprint list
@@ -549,6 +556,34 @@ agentplane blueprint drift 202605060915-3NBTGG
 ```
 
 - Check a task-local resolved snapshot before runner materialization.
+
+### blueprint examples
+
+Show practical blueprint route inspection examples.
+
+Usage:
+
+```text
+agentplane blueprint examples [options]
+```
+
+Options:
+
+- `--json`: Emit JSON. (default=false)
+
+Examples:
+
+```sh
+agentplane blueprint examples
+```
+
+- Inspect which route different task classes resolve to.
+
+```sh
+agentplane blueprint examples --json
+```
+
+- Emit route examples for agents or documentation tooling.
 
 ### blueprint explain
 

--- a/packages/agentplane/src/cli/command-guide.ts
+++ b/packages/agentplane/src/cli/command-guide.ts
@@ -218,6 +218,7 @@ export function renderQuickstart(): string {
     "## Go deeper",
     "",
     `- \`${COMMAND_SNIPPETS.core.role}\` to activate ORCHESTRATOR for planning and the task owner role before owner-scoped execution.`,
+    "- `agentplane blueprint examples` to inspect how analysis, content, docs, code, and release tasks resolve to different routes.",
     "- `agentplane help <command>` for flags, examples, and exceptional/manual flows.",
     "- Keep installed runtime guidance self-contained; do not depend on repo-only docs files.",
     "- If you need the docs site, treat it as a public reference surface rather than a required local file.",

--- a/packages/agentplane/src/cli/run-cli.core.blueprint.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.blueprint.test.ts
@@ -20,6 +20,20 @@ async function mkProject(): Promise<string> {
 }
 
 describe("runCli blueprint commands", () => {
+  it("blueprint examples shows practical route inspection commands", async () => {
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["blueprint", "examples"]);
+      expect(code).toBe(0);
+      expect(io.stdout).toContain("Blueprint route inspection examples");
+      expect(io.stdout).toContain("analysis.light");
+      expect(io.stdout).toContain("code.branch_pr");
+      expect(io.stdout).toContain("agentplane blueprint explain --kind analysis --mutation none");
+    } finally {
+      io.restore();
+    }
+  });
+
   it("blueprint validate accepts a project-local blueprint JSON file", async () => {
     const root = await mkTempDir();
     const blueprintPath = path.join(root, "analysis.custom.json");

--- a/packages/agentplane/src/cli/run-cli/command-catalog/project.ts
+++ b/packages/agentplane/src/cli/run-cli/command-catalog/project.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../commands/acr/acr.command.js";
 import {
   blueprintDriftSpec,
+  blueprintExamplesSpec,
   blueprintExplainSpec,
   blueprintListSpec,
   blueprintReportSpec,
@@ -107,6 +108,7 @@ import {
   loadAcrExplainSpec,
   loadBlueprintSpec,
   loadBlueprintListSpec,
+  loadBlueprintExamplesSpec,
   loadBlueprintDriftSpec,
   loadBlueprintExplainSpec,
   loadBlueprintSnapshotSpec,
@@ -124,6 +126,7 @@ export const PROJECT_COMMANDS = [
   declareCommand(acrExplainSpec, { load: loadAcrExplainSpec }),
   declareCommand(blueprintSpec, { load: loadBlueprintSpec, needs: "none" }),
   declareCommand(blueprintListSpec, { load: loadBlueprintListSpec, needs: "none" }),
+  declareCommand(blueprintExamplesSpec, { load: loadBlueprintExamplesSpec, needs: "none" }),
   declareCommand(blueprintExplainSpec, { load: loadBlueprintExplainSpec }),
   declareCommand(blueprintSnapshotSpec, { load: loadBlueprintSnapshotSpec }),
   declareCommand(blueprintDriftSpec, { load: loadBlueprintDriftSpec }),

--- a/packages/agentplane/src/cli/run-cli/command-loaders/project.ts
+++ b/packages/agentplane/src/cli/run-cli/command-loaders/project.ts
@@ -25,6 +25,8 @@ export const loadBlueprintSpec = (deps: RunDeps) =>
   );
 export const loadBlueprintListSpec = () =>
   import("../../../commands/blueprint/blueprint.command.js").then((m) => m.runBlueprintList);
+export const loadBlueprintExamplesSpec = () =>
+  import("../../../commands/blueprint/blueprint.command.js").then((m) => m.runBlueprintExamples);
 export const loadBlueprintExplainSpec = (deps: RunDeps) =>
   import("../../../commands/blueprint/blueprint.command.js").then((m) =>
     m.makeRunBlueprintExplainHandler(deps.getCtx),

--- a/packages/agentplane/src/commands/blueprint/blueprint.command.ts
+++ b/packages/agentplane/src/commands/blueprint/blueprint.command.ts
@@ -31,6 +31,7 @@ import { loadTaskFromContext, type CommandContext } from "../shared/task-backend
 
 export {
   blueprintDriftSpec,
+  blueprintExamplesSpec,
   blueprintExplainSpec,
   blueprintListSpec,
   blueprintReportSpec,
@@ -41,6 +42,7 @@ export {
 } from "./blueprint.specs.js";
 import type {
   BlueprintDriftParsed,
+  BlueprintExamplesParsed,
   BlueprintExplainParsed,
   BlueprintListParsed,
   BlueprintReportParsed,
@@ -106,6 +108,71 @@ function validationErrorFromProjectFile(
     context: { path: filePath },
   });
 }
+
+const BLUEPRINT_ROUTE_EXAMPLES = [
+  {
+    id: "analysis.readonly",
+    title: "Read-only analysis",
+    command: "agentplane blueprint explain --kind analysis --mutation none",
+    expected: "analysis.light",
+    note: "No CI, PR, worktree, or merge gates.",
+  },
+  {
+    id: "content.readonly",
+    title: "Content generation",
+    command: "agentplane blueprint explain --kind content --mutation none",
+    expected: "content.light",
+    note: "Evidence and final output, not code lifecycle.",
+  },
+  {
+    id: "docs.change",
+    title: "Documentation change",
+    command: "agentplane blueprint explain --kind docs --mutation docs",
+    expected: "docs.change",
+    note: "Docs verification without code checks by default.",
+  },
+  {
+    id: "code.branch_pr",
+    title: "Code change in branch_pr",
+    command: "agentplane blueprint explain --kind code --mutation code --workflow-mode branch_pr",
+    expected: "code.branch_pr",
+    note: "Task branch, local checks, PR artifact, integration gate.",
+  },
+  {
+    id: "release.strict",
+    title: "Release or publish",
+    command:
+      "agentplane blueprint explain --kind release --mutation release --risk external_publish",
+    expected: "release.strict",
+    note: "Version, manifest, parity, and publish safety gates.",
+  },
+  {
+    id: "existing.task",
+    title: "Existing task",
+    command: "agentplane blueprint explain <task-id>",
+    expected: "task-specific route",
+    note: "Uses task fields, tags, workflow mode, mutation scope, and risk hints.",
+  },
+] as const;
+
+export const runBlueprintExamples: CommandHandler<BlueprintExamplesParsed> = async (_ctx, p) => {
+  if (p.json) {
+    process.stdout.write(`${JSON.stringify({ examples: BLUEPRINT_ROUTE_EXAMPLES }, null, 2)}\n`);
+    return 0;
+  }
+  process.stdout.write("Blueprint route inspection examples\n");
+  for (const example of BLUEPRINT_ROUTE_EXAMPLES) {
+    process.stdout.write(`\n- ${example.title}\n`);
+    process.stdout.write(`  command: ${example.command}\n`);
+    process.stdout.write(`  expected: ${example.expected}\n`);
+    process.stdout.write(`  note: ${example.note}\n`);
+  }
+  process.stdout.write("\nNext commands:\n");
+  process.stdout.write("- agentplane blueprint list\n");
+  process.stdout.write("- agentplane blueprint report\n");
+  process.stdout.write("- agentplane help blueprint explain --compact\n");
+  return 0;
+};
 
 export const runBlueprintList: CommandHandler<BlueprintListParsed> = async (ctx, p) => {
   const registry = createBlueprintRegistry();

--- a/packages/agentplane/src/commands/blueprint/blueprint.specs.ts
+++ b/packages/agentplane/src/commands/blueprint/blueprint.specs.ts
@@ -32,6 +32,10 @@ export type BlueprintReportParsed = {
   json: boolean;
 };
 
+export type BlueprintExamplesParsed = {
+  json: boolean;
+};
+
 export type BlueprintScaffoldParsed = {
   id: BlueprintId;
   from?: BlueprintId;
@@ -61,9 +65,10 @@ export const blueprintSpec: CommandSpec<GroupCommandParsed> = {
   group: "Blueprints",
   summary: "List and explain blueprint routing without executing a task.",
   description:
-    "This is a command group. Use `agentplane blueprint list`, `agentplane blueprint explain ...`, `agentplane blueprint scaffold ...`, or `agentplane blueprint validate ...`.",
+    "This is a command group. Use `agentplane blueprint examples`, `agentplane blueprint list`, `agentplane blueprint explain ...`, `agentplane blueprint scaffold ...`, or `agentplane blueprint validate ...`.",
   args: [{ name: "cmd", required: false, variadic: true, valueHint: "<cmd>" }],
   examples: [
+    { cmd: "agentplane blueprint examples", why: "Show practical route inspection commands." },
     { cmd: "agentplane blueprint list", why: "Show built-in blueprint routes." },
     {
       cmd: "agentplane blueprint scaffold analysis.custom",
@@ -240,6 +245,24 @@ export const blueprintReportSpec: CommandSpec<BlueprintReportParsed> = {
     {
       cmd: "agentplane blueprint report --json",
       why: "Inspect project-local blueprint trust compatibility before runner materialization.",
+    },
+  ],
+  parse: (raw) => ({ json: raw.opts.json === true }),
+};
+
+export const blueprintExamplesSpec: CommandSpec<BlueprintExamplesParsed> = {
+  id: ["blueprint", "examples"],
+  group: "Blueprints",
+  summary: "Show practical blueprint route inspection examples.",
+  options: [{ kind: "boolean", name: "json", default: false, description: "Emit JSON." }],
+  examples: [
+    {
+      cmd: "agentplane blueprint examples",
+      why: "Inspect which route different task classes resolve to.",
+    },
+    {
+      cmd: "agentplane blueprint examples --json",
+      why: "Emit route examples for agents or documentation tooling.",
     },
   ],
   parse: (raw) => ({ json: raw.opts.json === true }),

--- a/packages/agentplane/src/commands/release/check-release-version-script.test.ts
+++ b/packages/agentplane/src/commands/release/check-release-version-script.test.ts
@@ -19,6 +19,21 @@ describe("check-release-version script", () => {
     ).resolves.toBeDefined();
   });
 
+  it("passes when prerelease tag and package versions are aligned", async () => {
+    const root = await initReleaseWorkspace({
+      prefix: "agentplane-release-check-",
+      coreVersion: "1.2.3-rc.1",
+      cliVersion: "1.2.3-rc.1",
+      recipesVersion: "1.2.3-rc.1",
+      dependencyVersion: "1.2.3-rc.1",
+      recipesDependencyVersion: "1.2.3-rc.1",
+    });
+
+    await expect(
+      execFileAsync("node", [SCRIPT_PATH, "--tag", "v1.2.3-rc.1"], { cwd: root }),
+    ).resolves.toBeDefined();
+  });
+
   it("fails when agentplane depends on a different core version", async () => {
     const root = await initReleaseWorkspace({
       prefix: "agentplane-release-check-",

--- a/scripts/check-release-version.mjs
+++ b/scripts/check-release-version.mjs
@@ -37,11 +37,13 @@ const main = defineCheck({
     const { tagArg } = options;
     const tag = resolveTag(tagArg);
     if (!tag) {
-      throw new Error("Missing release tag. Provide --tag vX.Y.Z or run under tag ref.");
+      throw new Error(
+        "Missing release tag. Provide --tag vX.Y.Z[-prerelease][+build] or run under tag ref.",
+      );
     }
-    const match = tag.match(/^v(\d+\.\d+\.\d+)(?:-.+)?$/);
+    const match = tag.match(/^v(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)$/);
     if (!match) {
-      throw new Error(`Tag ${tag} does not match vX.Y.Z format.`);
+      throw new Error(`Tag ${tag} does not match vX.Y.Z[-prerelease][+build] format.`);
     }
     const version = match[1];
     return assertReleaseParity(process.cwd(), { requiredVersion: version });


### PR DESCRIPTION
Task: `202605061515-2W42MM`
Title: Expose blueprint discoverability in CLI
Canonical task record: `.agentplane/tasks/202605061515-2W42MM/README.md`

## Summary

Expose blueprint discoverability in CLI

Make blueprint commands easier to find from quickstart, task surfaces, and examples without changing blueprint execution semantics.

## Scope

- In scope: Make blueprint commands easier to find from quickstart, task surfaces, and examples without changing blueprint execution semantics.
- Out of scope: unrelated refactors not required for "Expose blueprint discoverability in CLI".

## Verification

- State: ok
- Note: Verified: blueprint examples command, quickstart hint, CLI docs generation, targeted tests, typecheck, doctor, routing, release gate, and diff check passed.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-06T15:27:38.922Z
- Branch: task/202605061515-2W42MM/blueprint-discoverability
- Head: a2bdf69b7a18

```text
 .../blueprint/resolved-snapshot.json               | 498 +++++++++++++++++++++
 .agentplane/tasks/202605061515-EPEVHQ/README.md    |  87 ++++
 .../blueprint/resolved-snapshot.json               | 342 ++++++++++++++
 .agentplane/tasks/202605061515-WJWM2W/README.md    |  88 ++++
 .../blueprint/resolved-snapshot.json               | 401 +++++++++++++++++
 docs/developer/blueprints.mdx                      |  37 ++
 docs/user/cli-reference.generated.mdx              |  37 +-
 packages/agentplane/src/cli/command-guide.ts       |   1 +
 .../src/cli/run-cli.core.blueprint.test.ts         |  14 +
 .../src/cli/run-cli/command-catalog/project.ts     |   3 +
 .../src/cli/run-cli/command-loaders/project.ts     |   2 +
 .../src/commands/blueprint/blueprint.command.ts    |  67 +++
 .../src/commands/blueprint/blueprint.specs.ts      |  25 +-
 .../release/check-release-version-script.test.ts   |  15 +
 scripts/check-release-version.mjs                  |   8 +-
 15 files changed, 1620 insertions(+), 5 deletions(-)
```

</details>
