### PR TITLE
🚧 9JE6YN task: Expose blueprint route in task lifecycle surfaces [202605061546-9JE6YN]

### DIFF
--- a/.agentplane/tasks/202605061546-6XX986/README.md
+++ b/.agentplane/tasks/202605061546-6XX986/README.md
@@ -1,0 +1,87 @@
+---
+id: "202605061546-6XX986"
+title: "Document blueprint lifecycle visibility"
+status: "DOING"
+priority: "med"
+owner: "DOCS"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "blueprints"
+  - "docs"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-06T15:47:28.180Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-06T15:55:21.062Z"
+  updated_by: "DOCS"
+  note: "Verified: developer docs and generated CLI reference describe blueprint lifecycle visibility and match actual command output."
+commit: null
+comments:
+  -
+    author: "DOCS"
+    body: "Start: Document the shipped blueprint lifecycle visibility behavior in the shared batch worktree."
+events:
+  -
+    type: "status"
+    at: "2026-05-06T15:48:02.078Z"
+    author: "DOCS"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Document the shipped blueprint lifecycle visibility behavior in the shared batch worktree."
+  -
+    type: "verify"
+    at: "2026-05-06T15:55:21.062Z"
+    author: "DOCS"
+    state: "ok"
+    note: "Verified: developer docs and generated CLI reference describe blueprint lifecycle visibility and match actual command output."
+doc_version: 3
+doc_updated_at: "2026-05-06T15:55:21.087Z"
+doc_updated_by: "DOCS"
+description: "Document how task lifecycle commands expose resolved blueprints and how users should inspect route selection during planning and verification."
+sections:
+  Summary: |-
+    Document blueprint lifecycle visibility
+    
+    Document how task lifecycle commands expose resolved blueprints and how users should inspect route selection during planning and verification.
+  Scope: |-
+    - In scope: Document how task lifecycle commands expose resolved blueprints and how users should inspect route selection during planning and verification.
+    - Out of scope: unrelated refactors not required for "Document blueprint lifecycle visibility".
+  Plan: "Document shipped lifecycle visibility behavior after implementation. Scope: update developer/user docs explaining where resolved blueprint appears in task show/list/verify-show and how to use blueprint explain for deeper diagnostics. Verification: docs CLI check/generation if needed, routing check, ap doctor, and review against actual command output."
+  Verify Steps: |-
+    1. Review the requested outcome for "Document blueprint lifecycle visibility". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-06T15:55:21.062Z — VERIFY — ok
+    
+    By: DOCS
+    
+    Note: Verified: developer docs and generated CLI reference describe blueprint lifecycle visibility and match actual command output.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T15:48:02.078Z, excerpt_hash=sha256:58e54803933e5f1d4ec88fb13d2687bb4004712e5278da27c70201f2e205b1d9
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605061546-9JE6YN-blueprint-task-lifecycle/.agentplane/tasks/202605061546-6XX986/blueprint/resolved-snapshot.json
+    - old_digest: 9379e2ad309069e8b160ae73907020087a0ea06d12d465375d00e22732f1b1c0
+    - current_digest: 9379e2ad309069e8b160ae73907020087a0ea06d12d465375d00e22732f1b1c0
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605061546-6XX986
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605061546-6XX986/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605061546-6XX986/blueprint/resolved-snapshot.json
@@ -1,0 +1,342 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605061546-6XX986",
+    "title": "Document blueprint lifecycle visibility",
+    "description": "Document how task lifecycle commands expose resolved blueprints and how users should inspect route selection during planning and verification.",
+    "tags": [
+      "blueprints",
+      "docs"
+    ],
+    "owner": "DOCS",
+    "workflowMode": "branch_pr",
+    "mutation": "docs",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "docs.change",
+    "version": 1,
+    "title": "Documentation change",
+    "taskKinds": [
+      "docs"
+    ],
+    "workflowModes": [
+      "direct",
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "docs.change",
+    "blueprintVersion": 1,
+    "title": "Documentation change",
+    "taskId": "202605061546-6XX986",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "mutationScope": "docs"
+    },
+    "whySelected": [
+      "task kind resolved to docs",
+      "workflow mode: branch_pr",
+      "mutation scope: docs"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.docs.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "artifact"
+        ]
+      },
+      {
+        "id": "deterministic_check",
+        "kind": "deterministic_check",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "docs.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed documentation paths."
+      },
+      {
+        "id": "docs.check",
+        "kind": "check_result",
+        "producedBy": "deterministic_check",
+        "required": true,
+        "description": "Documentation checks."
+      },
+      {
+        "id": "docs.artifact",
+        "kind": "artifact",
+        "producedBy": "artifact_write",
+        "required": true,
+        "description": "Updated documentation artifact."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/dod.docs.md",
+      ".agentplane/policy/security.must.md"
+    ],
+    "allowedCommands": [
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "documentation checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 3,
+      "maxPromptBlocks": 10,
+      "rationale": "Documentation changes need docs DoD and minimal workflow/security policy."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.docs.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "artifact"
+      ]
+    },
+    {
+      "id": "deterministic_check",
+      "kind": "deterministic_check",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "docs.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed documentation paths."
+    },
+    {
+      "id": "docs.check",
+      "kind": "check_result",
+      "producedBy": "deterministic_check",
+      "required": true,
+      "description": "Documentation checks."
+    },
+    {
+      "id": "docs.artifact",
+      "kind": "artifact",
+      "producedBy": "artifact_write",
+      "required": true,
+      "description": "Updated documentation artifact."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/dod.docs.md",
+    ".agentplane/policy/security.must.md"
+  ],
+  "allowedCommands": [
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "documentation checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 3,
+    "maxPromptBlocks": 10,
+    "rationale": "Documentation changes need docs DoD and minimal workflow/security policy."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to docs",
+    "workflow mode: branch_pr",
+    "mutation scope: docs"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "9379e2ad309069e8b160ae73907020087a0ea06d12d465375d00e22732f1b1c0"
+  }
+}

--- a/.agentplane/tasks/202605061546-9JE6YN/README.md
+++ b/.agentplane/tasks/202605061546-9JE6YN/README.md
@@ -1,0 +1,88 @@
+---
+id: "202605061546-9JE6YN"
+title: "Expose blueprint route in task lifecycle surfaces"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "blueprints"
+  - "cli"
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-06T15:47:26.499Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-06T15:55:19.567Z"
+  updated_by: "CODER"
+  note: "Verified: task show/list/verify-show expose resolved blueprint route; focused lifecycle and blueprint tests, typecheck, docs:cli:check, routing, doctor, and diff check passed."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Implement blueprint route visibility on task lifecycle read surfaces in the approved primary worktree."
+events:
+  -
+    type: "status"
+    at: "2026-05-06T15:47:53.078Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Implement blueprint route visibility on task lifecycle read surfaces in the approved primary worktree."
+  -
+    type: "verify"
+    at: "2026-05-06T15:55:19.567Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: task show/list/verify-show expose resolved blueprint route; focused lifecycle and blueprint tests, typecheck, docs:cli:check, routing, doctor, and diff check passed."
+doc_version: 3
+doc_updated_at: "2026-05-06T15:55:19.652Z"
+doc_updated_by: "CODER"
+description: "Show resolved blueprint route on task show, task list, and task verify-show so agents can see the selected route without running separate blueprint diagnostics."
+sections:
+  Summary: |-
+    Expose blueprint route in task lifecycle surfaces
+    
+    Show resolved blueprint route on task show, task list, and task verify-show so agents can see the selected route without running separate blueprint diagnostics.
+  Scope: |-
+    - In scope: Show resolved blueprint route on task show, task list, and task verify-show so agents can see the selected route without running separate blueprint diagnostics.
+    - Out of scope: unrelated refactors not required for "Expose blueprint route in task lifecycle surfaces".
+  Plan: "Primary batch task. Scope: expose resolved blueprint information directly in task lifecycle read surfaces: task show JSON, task list text/JSON where practical, and task verify-show contract output. Keep blueprint resolver semantics unchanged. Include related docs task 202605061546-6XX986 in the same branch/worktree. Verification: focused task listing/show tests, blueprint lifecycle output checks, docs CLI generation/check if specs change, typecheck, ap doctor, routing check, diff check."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-06T15:55:19.567Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: task show/list/verify-show expose resolved blueprint route; focused lifecycle and blueprint tests, typecheck, docs:cli:check, routing, doctor, and diff check passed.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T15:47:53.078Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605061546-9JE6YN-blueprint-task-lifecycle/.agentplane/tasks/202605061546-9JE6YN/blueprint/resolved-snapshot.json
+    - old_digest: 16a1e2be26607066269fa872341b581dfa869ef4da3bfc1562c21338fbbd421d
+    - current_digest: 16a1e2be26607066269fa872341b581dfa869ef4da3bfc1562c21338fbbd421d
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605061546-9JE6YN
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605061546-9JE6YN/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605061546-9JE6YN/blueprint/resolved-snapshot.json
@@ -1,0 +1,498 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605061546-9JE6YN",
+    "title": "Expose blueprint route in task lifecycle surfaces",
+    "description": "Show resolved blueprint route on task show, task list, and task verify-show so agents can see the selected route without running separate blueprint diagnostics.",
+    "tags": [
+      "blueprints",
+      "cli",
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605061546-9JE6YN",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "16a1e2be26607066269fa872341b581dfa869ef4da3bfc1562c21338fbbd421d"
+  }
+}

--- a/.agentplane/tasks/202605061546-9JE6YN/pr/diffstat.txt
+++ b/.agentplane/tasks/202605061546-9JE6YN/pr/diffstat.txt
@@ -1,0 +1,13 @@
+ .agentplane/tasks/202605061546-6XX986/README.md    |  87 ++++
+ .../blueprint/resolved-snapshot.json               | 342 ++++++++++++++
+ .../blueprint/resolved-snapshot.json               | 498 +++++++++++++++++++++
+ docs/developer/blueprints.mdx                      |  26 ++
+ docs/user/cli-reference.generated.mdx              |   4 +-
+ .../cli/run-cli.core.tasks.query-listing.test.ts   |   7 +-
+ .../src/commands/task/blueprint-summary.ts         |  77 ++++
+ packages/agentplane/src/commands/task/list.spec.ts |   2 +-
+ packages/agentplane/src/commands/task/list.ts      |  13 +-
+ .../src/commands/task/shared/dependencies.ts       |   7 +-
+ packages/agentplane/src/commands/task/show.spec.ts |   2 +-
+ packages/agentplane/src/commands/task/show.ts      |   9 +-
+ 12 files changed, 1065 insertions(+), 9 deletions(-)

--- a/.agentplane/tasks/202605061546-9JE6YN/pr/github-body.md
+++ b/.agentplane/tasks/202605061546-9JE6YN/pr/github-body.md
@@ -1,0 +1,45 @@
+Task: `202605061546-9JE6YN`
+Title: Expose blueprint route in task lifecycle surfaces
+Canonical task record: `.agentplane/tasks/202605061546-9JE6YN/README.md`
+
+## Summary
+
+Expose blueprint route in task lifecycle surfaces
+
+Show resolved blueprint route on task show, task list, and task verify-show so agents can see the selected route without running separate blueprint diagnostics.
+
+## Scope
+
+- In scope: Show resolved blueprint route on task show, task list, and task verify-show so agents can see the selected route without running separate blueprint diagnostics.
+- Out of scope: unrelated refactors not required for "Expose blueprint route in task lifecycle surfaces".
+
+## Verification
+
+- State: ok
+- Note: Verified: task show/list/verify-show expose resolved blueprint route; focused lifecycle and blueprint tests, typecheck, docs:cli:check, routing, doctor, and diff check passed.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-06T15:56:41.479Z
+- Branch: task/202605061546-9JE6YN/blueprint-task-lifecycle
+- Head: 01e9489d0798
+
+```text
+ .agentplane/tasks/202605061546-6XX986/README.md    |  87 ++++
+ .../blueprint/resolved-snapshot.json               | 342 ++++++++++++++
+ .../blueprint/resolved-snapshot.json               | 498 +++++++++++++++++++++
+ docs/developer/blueprints.mdx                      |  26 ++
+ docs/user/cli-reference.generated.mdx              |   4 +-
+ .../cli/run-cli.core.tasks.query-listing.test.ts   |   7 +-
+ .../src/commands/task/blueprint-summary.ts         |  77 ++++
+ packages/agentplane/src/commands/task/list.spec.ts |   2 +-
+ packages/agentplane/src/commands/task/list.ts      |  13 +-
+ .../src/commands/task/shared/dependencies.ts       |   7 +-
+ packages/agentplane/src/commands/task/show.spec.ts |   2 +-
+ packages/agentplane/src/commands/task/show.ts      |   9 +-
+ 12 files changed, 1065 insertions(+), 9 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605061546-9JE6YN/pr/github-title.txt
+++ b/.agentplane/tasks/202605061546-9JE6YN/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 9JE6YN task: Expose blueprint route in task lifecycle surfaces [202605061546-9JE6YN]

--- a/.agentplane/tasks/202605061546-9JE6YN/pr/meta.json
+++ b/.agentplane/tasks/202605061546-9JE6YN/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605061546-9JE6YN/blueprint-task-lifecycle",
+  "created_at": "2026-05-06T15:47:53.223Z",
+  "head_sha": "01e9489d079839bbe30e558b07a5d512f012c720",
+  "last_verified_at": "2026-05-06T15:55:19.567Z",
+  "last_verified_sha": "c247a02444e9acc2e2b458438b6e83f1d1ef29e9",
+  "schema_version": 1,
+  "task_id": "202605061546-9JE6YN",
+  "updated_at": "2026-05-06T15:56:41.479Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605061546-9JE6YN/pr/review.md
+++ b/.agentplane/tasks/202605061546-9JE6YN/pr/review.md
@@ -1,0 +1,48 @@
+# PR Review
+
+Created: 2026-05-06T15:47:53.223Z
+
+## Task
+
+- Task: `202605061546-9JE6YN`
+- Title: Expose blueprint route in task lifecycle surfaces
+- Status: DOING
+- Branch: `task/202605061546-9JE6YN/blueprint-task-lifecycle`
+- Canonical task record: `.agentplane/tasks/202605061546-9JE6YN/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified: task show/list/verify-show expose resolved blueprint route; focused lifecycle and blueprint tests, typecheck, docs:cli:check, routing, doctor, and diff check passed.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-06T15:56:41.479Z
+- Branch: task/202605061546-9JE6YN/blueprint-task-lifecycle
+- Head: 01e9489d0798
+
+```text
+ .agentplane/tasks/202605061546-6XX986/README.md    |  87 ++++
+ .../blueprint/resolved-snapshot.json               | 342 ++++++++++++++
+ .../blueprint/resolved-snapshot.json               | 498 +++++++++++++++++++++
+ docs/developer/blueprints.mdx                      |  26 ++
+ docs/user/cli-reference.generated.mdx              |   4 +-
+ .../cli/run-cli.core.tasks.query-listing.test.ts   |   7 +-
+ .../src/commands/task/blueprint-summary.ts         |  77 ++++
+ packages/agentplane/src/commands/task/list.spec.ts |   2 +-
+ packages/agentplane/src/commands/task/list.ts      |  13 +-
+ .../src/commands/task/shared/dependencies.ts       |   7 +-
+ packages/agentplane/src/commands/task/show.spec.ts |   2 +-
+ packages/agentplane/src/commands/task/show.ts      |   9 +-
+ 12 files changed, 1065 insertions(+), 9 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/docs/developer/blueprints.mdx
+++ b/docs/developer/blueprints.mdx
@@ -66,6 +66,32 @@ agentplane blueprint report
 agentplane blueprint validate --project
 ```
 
+## Task Lifecycle Visibility
+
+Blueprint selection is also visible on task lifecycle surfaces. Agents should use these commands in
+the normal task flow before falling back to standalone blueprint diagnostics.
+
+```bash
+agentplane task show <task-id>
+agentplane task list
+agentplane task verify-show <task-id>
+```
+
+Behavior:
+
+- `task show` includes a `blueprint` object with the resolved `blueprint_id`, route, selection
+  reasons, required evidence, stop reasons, and safe follow-up commands.
+- `task list` prints a compact `blueprint=<id>` field per row so route class is visible while
+  scanning active work.
+- `task verify-show` remains the verifier-facing acceptance surface: it prints `## Verify Steps`,
+  resolved blueprint expected evidence, and snapshot drift state.
+- If route resolution fails, lifecycle surfaces keep the task readable and expose
+  `blueprint=unresolved` or a task-local `blueprint.error` instead of hiding the task.
+
+The lifecycle view is intentionally compact. Use `agentplane blueprint explain <task-id>` when the
+operator needs full selection reasons, policy modules, context budget, allowed commands, and recipe
+extension decisions.
+
 ## Design Premises
 
 Blueprints are useful only if they preserve the difference between task classes.

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -3320,7 +3320,7 @@ agentplane task lint
 
 ### task list
 
-List tasks (optionally filtered by status/owner/tag).
+List tasks with compact resolved blueprint route hints.
 
 Usage:
 
@@ -4040,7 +4040,7 @@ agentplane task set-status 202602030608-F1Q8AB DOING --commit-from-comment --aut
 
 ### task show
 
-Print task metadata as JSON (frontmatter shape).
+Print task metadata and resolved blueprint route as JSON.
 
 Usage:
 

--- a/packages/agentplane/src/cli/run-cli.core.tasks.query-listing.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.tasks.query-listing.test.ts
@@ -919,6 +919,9 @@ describe(
         expect(io2.stdout).toContain('"origin"');
         expect(io2.stdout).toContain('"system": "manual"');
         expect(io2.stdout).toContain('"status": "TODO"');
+        expect(io2.stdout).toContain('"blueprint"');
+        expect(io2.stdout).toContain('"blueprint_id": "analysis.light"');
+        expect(io2.stdout).toContain('"route"');
       } finally {
         io2.restore();
       }
@@ -1015,8 +1018,8 @@ describe(
         ]);
         expect(code).toBe(0);
         expect(io.stdout).toBe(
-          `${firstTaskId} [TODO] Alpha ready (owner=CODER, prio=med, deps=none, tags=docs)\n` +
-            `${secondTaskId} [TODO] Beta blocked (owner=CODER, prio=med, deps=wait:${firstTaskId}, tags=docs)\n`,
+          `${firstTaskId} [TODO] Alpha ready (owner=CODER, prio=med, deps=none, tags=docs, blueprint=docs.change)\n` +
+            `${secondTaskId} [TODO] Beta blocked (owner=CODER, prio=med, deps=wait:${firstTaskId}, tags=docs, blueprint=docs.change)\n`,
         );
         expect(io.stderr).toBe("");
       } finally {

--- a/packages/agentplane/src/commands/task/blueprint-summary.ts
+++ b/packages/agentplane/src/commands/task/blueprint-summary.ts
@@ -1,0 +1,77 @@
+import type { AgentplaneConfig } from "@agentplaneorg/core/config";
+
+import type { TaskData, TaskSummary } from "../../backends/task-backend.js";
+import {
+  createTrustedProjectBlueprintRegistry,
+  explainResolvedBlueprint,
+  resolveBlueprint,
+  type BlueprintExplainOutput,
+} from "../../blueprints/index.js";
+import { blueprintResolveInputFromTask } from "../blueprint/task-input.js";
+
+export type TaskBlueprintLifecycleSummary = {
+  blueprint_id?: string;
+  blueprint_version?: string | number;
+  workflow_mode?: string;
+  route?: string[];
+  selection_reasons?: string[];
+  required_evidence?: string[];
+  stop_reasons?: string[];
+  explain_command: string;
+  snapshot_command: string;
+  error?: string;
+};
+
+function lifecycleSummaryFromExplain(
+  taskId: string,
+  output: BlueprintExplainOutput,
+): TaskBlueprintLifecycleSummary {
+  return {
+    blueprint_id: output.blueprintId,
+    blueprint_version: output.blueprintVersion,
+    ...(output.workflowMode ? { workflow_mode: output.workflowMode } : {}),
+    route: output.route.map((node) => node.kind),
+    selection_reasons: [...output.selectionReasons],
+    required_evidence: output.requiredEvidence.map((item) => item.id),
+    stop_reasons: output.stopReasons.map((reason) => reason.id),
+    explain_command: `agentplane blueprint explain ${taskId}`,
+    snapshot_command: `agentplane blueprint snapshot ${taskId}`,
+  };
+}
+
+export async function resolveTaskBlueprintLifecycleSummary(opts: {
+  task: TaskData | TaskSummary;
+  config: AgentplaneConfig;
+  projectRoot?: string;
+}): Promise<TaskBlueprintLifecycleSummary> {
+  const input = blueprintResolveInputFromTask({ task: opts.task as TaskData, config: opts.config });
+  try {
+    const projectRegistry = opts.projectRoot
+      ? await createTrustedProjectBlueprintRegistry(opts.projectRoot)
+      : null;
+    const resolved = resolveBlueprint({
+      input,
+      ...(projectRegistry
+        ? {
+            registry: projectRegistry.registry,
+            projectBlueprintIds: projectRegistry.projectBlueprintIds,
+          }
+        : {}),
+    });
+    return lifecycleSummaryFromExplain(
+      opts.task.id,
+      explainResolvedBlueprint({ resolved, input, workflowMode: input.workflowMode }),
+    );
+  } catch (error) {
+    return {
+      explain_command: `agentplane blueprint explain ${opts.task.id}`,
+      snapshot_command: `agentplane blueprint snapshot ${opts.task.id}`,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export function formatTaskBlueprintListExtra(summary: TaskBlueprintLifecycleSummary): string {
+  if (summary.blueprint_id) return `blueprint=${summary.blueprint_id}`;
+  return "blueprint=unresolved";
+}

--- a/packages/agentplane/src/commands/task/list.spec.ts
+++ b/packages/agentplane/src/commands/task/list.spec.ts
@@ -9,7 +9,7 @@ export type TaskListParsed = { filters: TaskListFilters };
 export const taskListSpec: CommandSpec<TaskListParsed> = {
   id: ["task", "list"],
   group: "Task",
-  summary: "List tasks (optionally filtered by status/owner/tag).",
+  summary: "List tasks with compact resolved blueprint route hints.",
   options: [
     {
       kind: "string",

--- a/packages/agentplane/src/commands/task/list.ts
+++ b/packages/agentplane/src/commands/task/list.ts
@@ -13,6 +13,10 @@ import {
   queryTaskProjection,
   type TaskListFilters,
 } from "./shared.js";
+import {
+  formatTaskBlueprintListExtra,
+  resolveTaskBlueprintLifecycleSummary,
+} from "./blueprint-summary.js";
 
 export async function cmdTaskListWithFilters(opts: {
   ctx?: CommandContext;
@@ -28,7 +32,14 @@ export async function cmdTaskListWithFilters(opts: {
     handleTaskListWarnings({ backend: ctx.taskBackend, strictRead: opts.filters.strictRead });
     const { depState, items } = queryTaskProjection({ tasks, filters: opts.filters });
     for (const task of items) {
-      process.stdout.write(`${formatTaskLine(task, depState.get(task.id))}\n`);
+      const blueprint = await resolveTaskBlueprintLifecycleSummary({
+        task,
+        config: ctx.config,
+        projectRoot: ctx.resolvedProject.gitRoot,
+      });
+      process.stdout.write(
+        `${formatTaskLine(task, depState.get(task.id), [formatTaskBlueprintListExtra(blueprint)])}\n`,
+      );
     }
     if (!opts.filters.quiet) {
       const counts: Record<string, number> = {};

--- a/packages/agentplane/src/commands/task/shared/dependencies.ts
+++ b/packages/agentplane/src/commands/task/shared/dependencies.ts
@@ -163,7 +163,11 @@ function formatDepsSummary(dep: DependencyState | undefined): string | null {
   return `deps=${parts.join(",")}`;
 }
 
-export function formatTaskLine(task: TaskSummary, depState?: DependencyState): string {
+export function formatTaskLine(
+  task: TaskSummary,
+  depState?: DependencyState,
+  extraFields: readonly string[] = [],
+): string {
   const status = normalizeTaskStatus(task.status);
   const extras: string[] = [];
   if (task.owner?.trim()) extras.push(`owner=${task.owner.trim()}`);
@@ -176,6 +180,7 @@ export function formatTaskLine(task: TaskSummary, depState?: DependencyState): s
   if (tags.length > 0) extras.push(`tags=${tags.join(",")}`);
   const verify = dedupeStrings(toStringArray(task.verify));
   if (verify.length > 0) extras.push(`verify=${verify.length}`);
+  extras.push(...extraFields.filter((field) => field.trim().length > 0));
   const suffix = extras.length > 0 ? ` (${extras.join(", ")})` : "";
   return `${task.id} [${status}] ${task.title?.trim() || "(untitled task)"}${suffix}`;
 }

--- a/packages/agentplane/src/commands/task/show.spec.ts
+++ b/packages/agentplane/src/commands/task/show.spec.ts
@@ -5,7 +5,7 @@ export type TaskShowParsed = { taskId: string };
 export const taskShowSpec: CommandSpec<TaskShowParsed> = {
   id: ["task", "show"],
   group: "Task",
-  summary: "Print task metadata as JSON (frontmatter shape).",
+  summary: "Print task metadata and resolved blueprint route as JSON.",
   args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
   examples: [{ cmd: "agentplane task show 202602030608-F1Q8AB", why: "Show task metadata." }],
   parse: (raw) => ({ taskId: String(raw.args["task-id"]) }),

--- a/packages/agentplane/src/commands/task/show.ts
+++ b/packages/agentplane/src/commands/task/show.ts
@@ -17,6 +17,8 @@ import {
   type CommandContext,
 } from "../shared/task-backend.js";
 
+import { resolveTaskBlueprintLifecycleSummary } from "./blueprint-summary.js";
+
 async function detectLocalTaskMetadataErrors(
   ctx: CommandContext,
   taskId: string,
@@ -66,7 +68,12 @@ export async function cmdTaskShow(opts: {
         });
       }
     }
-    process.stdout.write(`${JSON.stringify(frontmatter, null, 2)}\n`);
+    const blueprint = await resolveTaskBlueprintLifecycleSummary({
+      task,
+      config: ctx.config,
+      projectRoot: ctx.resolvedProject.gitRoot,
+    });
+    process.stdout.write(`${JSON.stringify({ ...frontmatter, blueprint }, null, 2)}\n`);
     return 0;
   } catch (err) {
     if (!(err instanceof CliError) && ctx) {


### PR DESCRIPTION
Task: `202605061546-9JE6YN`
Title: Expose blueprint route in task lifecycle surfaces
Canonical task record: `.agentplane/tasks/202605061546-9JE6YN/README.md`

## Summary

Expose blueprint route in task lifecycle surfaces

Show resolved blueprint route on task show, task list, and task verify-show so agents can see the selected route without running separate blueprint diagnostics.

## Scope

- In scope: Show resolved blueprint route on task show, task list, and task verify-show so agents can see the selected route without running separate blueprint diagnostics.
- Out of scope: unrelated refactors not required for "Expose blueprint route in task lifecycle surfaces".

## Verification

- State: ok
- Note: Verified: task show/list/verify-show expose resolved blueprint route; focused lifecycle and blueprint tests, typecheck, docs:cli:check, routing, doctor, and diff check passed.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-06T15:56:41.479Z
- Branch: task/202605061546-9JE6YN/blueprint-task-lifecycle
- Head: 01e9489d0798

```text
 .agentplane/tasks/202605061546-6XX986/README.md    |  87 ++++
 .../blueprint/resolved-snapshot.json               | 342 ++++++++++++++
 .../blueprint/resolved-snapshot.json               | 498 +++++++++++++++++++++
 docs/developer/blueprints.mdx                      |  26 ++
 docs/user/cli-reference.generated.mdx              |   4 +-
 .../cli/run-cli.core.tasks.query-listing.test.ts   |   7 +-
 .../src/commands/task/blueprint-summary.ts         |  77 ++++
 packages/agentplane/src/commands/task/list.spec.ts |   2 +-
 packages/agentplane/src/commands/task/list.ts      |  13 +-
 .../src/commands/task/shared/dependencies.ts       |   7 +-
 packages/agentplane/src/commands/task/show.spec.ts |   2 +-
 packages/agentplane/src/commands/task/show.ts      |   9 +-
 12 files changed, 1065 insertions(+), 9 deletions(-)
```

</details>
