### PR TITLE
🚧 P86BJS task: Preview blueprint route during task creation [202605061609-P86BJS]

### DIFF
--- a/.agentplane/tasks/202605061609-P86BJS/README.md
+++ b/.agentplane/tasks/202605061609-P86BJS/README.md
@@ -1,0 +1,91 @@
+---
+id: "202605061609-P86BJS"
+title: "Preview blueprint route during task creation"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 7
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "blueprints"
+  - "cli"
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-06T16:10:03.787Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-06T16:22:45.921Z"
+  updated_by: "CODER"
+  note: "Preview flag verified: task new keeps stdout as the generated id and emits resolved blueprint route details to stderr when --show-blueprint is passed."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Implement opt-in blueprint route preview for task creation without changing default stdout id output."
+events:
+  -
+    type: "status"
+    at: "2026-05-06T16:11:45.215Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Implement opt-in blueprint route preview for task creation without changing default stdout id output."
+  -
+    type: "verify"
+    at: "2026-05-06T16:22:45.921Z"
+    author: "CODER"
+    state: "ok"
+    note: "Preview flag verified: task new keeps stdout as the generated id and emits resolved blueprint route details to stderr when --show-blueprint is passed."
+doc_version: 3
+doc_updated_at: "2026-05-06T16:22:45.935Z"
+doc_updated_by: "CODER"
+description: "Add an opt-in task new flag that prints the resolved blueprint route after task creation without changing the default stdout task-id contract."
+sections:
+  Summary: |-
+    Preview blueprint route during task creation
+    
+    Add an opt-in task new flag that prints the resolved blueprint route after task creation without changing the default stdout task-id contract.
+  Scope: |-
+    - In scope: Add an opt-in task new flag that prints the resolved blueprint route after task creation without changing the default stdout task-id contract.
+    - Out of scope: unrelated refactors not required for "Preview blueprint route during task creation".
+  Plan: "Primary batch task. Scope: add non-breaking task new --show-blueprint that keeps stdout as the generated task id and prints the resolved blueprint route/expected evidence to stderr after creation. Reuse the task blueprint summary helper from lifecycle surfaces. Include related docs task 202605061609-PD9A1Y in the same branch/worktree. Verification: focused task creation/listing tests, real command smoke for stdout/stderr contract, typecheck, docs:cli:check, doctor, routing, diff check."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-06T16:22:45.921Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Preview flag verified: task new keeps stdout as the generated id and emits resolved blueprint route details to stderr when --show-blueprint is passed.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T16:11:45.215Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605061609-P86BJS-blueprint-task-new-preview/.agentplane/tasks/202605061609-P86BJS/blueprint/resolved-snapshot.json
+    - old_digest: 73486482511cfe94fcbd24a37c601dea01d59a770fdac1237b1552069143b595
+    - current_digest: 73486482511cfe94fcbd24a37c601dea01d59a770fdac1237b1552069143b595
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605061609-P86BJS
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Commands: bun test packages/agentplane/src/cli/run-cli.core.tasks.create.test.ts -t 'task new can preview'; bun test packages/agentplane/src/cli/run-cli.core.tasks.query-listing.test.ts -t 'task list'; bun test packages/agentplane/src/cli/run-cli.core.help-snap.test.ts -t 'help task new'; bun run typecheck; bun run build; bun run lint:core; bun run docs:cli:check; node .agentplane/policy/check-routing.mjs; ap doctor; git diff --check; temp-repo smoke with node packages/agentplane/dist/cli.js task new --show-blueprint.
+      Impact: stdout contract remained exactly one task id; stderr preview includes blueprint_id, version, workflow mode, route, selection reasons, required evidence, stop reasons, explain command, and snapshot command.
+      Resolution: Full bun run lint was also attempted and failed only in unrelated website files under website/src; touched package/core lint passed with bun run lint:core.
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605061609-P86BJS/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605061609-P86BJS/blueprint/resolved-snapshot.json
@@ -1,0 +1,498 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605061609-P86BJS",
+    "title": "Preview blueprint route during task creation",
+    "description": "Add an opt-in task new flag that prints the resolved blueprint route after task creation without changing the default stdout task-id contract.",
+    "tags": [
+      "blueprints",
+      "cli",
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605061609-P86BJS",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "73486482511cfe94fcbd24a37c601dea01d59a770fdac1237b1552069143b595"
+  }
+}

--- a/.agentplane/tasks/202605061609-P86BJS/pr/diffstat.txt
+++ b/.agentplane/tasks/202605061609-P86BJS/pr/diffstat.txt
@@ -1,0 +1,11 @@
+ .../blueprint/resolved-snapshot.json               | 498 +++++++++++++++++++++
+ .agentplane/tasks/202605061609-PD9A1Y/README.md    |  90 ++++
+ .../blueprint/resolved-snapshot.json               | 342 ++++++++++++++
+ docs/developer/blueprints.mdx                      |  26 +-
+ docs/user/cli-reference.generated.mdx              |   8 +
+ .../run-cli.core.help-snap.test.ts.snap            |  23 +
+ .../src/cli/run-cli.core.tasks.create.test.ts      |  46 ++
+ .../src/commands/task/blueprint-summary.ts         |  28 ++
+ packages/agentplane/src/commands/task/new.spec.ts  |  13 +
+ packages/agentplane/src/commands/task/new.ts       |  13 +
+ 10 files changed, 1086 insertions(+), 1 deletion(-)

--- a/.agentplane/tasks/202605061609-P86BJS/pr/github-body.md
+++ b/.agentplane/tasks/202605061609-P86BJS/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605061609-P86BJS`
+Title: Preview blueprint route during task creation
+Canonical task record: `.agentplane/tasks/202605061609-P86BJS/README.md`
+
+## Summary
+
+Preview blueprint route during task creation
+
+Add an opt-in task new flag that prints the resolved blueprint route after task creation without changing the default stdout task-id contract.
+
+## Scope
+
+- In scope: Add an opt-in task new flag that prints the resolved blueprint route after task creation without changing the default stdout task-id contract.
+- Out of scope: unrelated refactors not required for "Preview blueprint route during task creation".
+
+## Verification
+
+- State: ok
+- Note: Preview flag verified: task new keeps stdout as the generated id and emits resolved blueprint route details to stderr when --show-blueprint is passed.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-06T16:11:45.394Z
+- Branch: task/202605061609-P86BJS/blueprint-task-new-preview
+- Head: 8dac6d76b4ca
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605061609-P86BJS/pr/github-body.md
+++ b/.agentplane/tasks/202605061609-P86BJS/pr/github-body.md
@@ -22,12 +22,22 @@ Add an opt-in task new flag that prints the resolved blueprint route after task 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-06T16:11:45.394Z
+- Updated: 2026-05-06T16:24:37.002Z
 - Branch: task/202605061609-P86BJS/blueprint-task-new-preview
-- Head: 8dac6d76b4ca
+- Head: 281f0acd803c
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 498 +++++++++++++++++++++
+ .agentplane/tasks/202605061609-PD9A1Y/README.md    |  90 ++++
+ .../blueprint/resolved-snapshot.json               | 342 ++++++++++++++
+ docs/developer/blueprints.mdx                      |  26 +-
+ docs/user/cli-reference.generated.mdx              |   8 +
+ .../run-cli.core.help-snap.test.ts.snap            |  23 +
+ .../src/cli/run-cli.core.tasks.create.test.ts      |  46 ++
+ .../src/commands/task/blueprint-summary.ts         |  28 ++
+ packages/agentplane/src/commands/task/new.spec.ts  |  13 +
+ packages/agentplane/src/commands/task/new.ts       |  13 +
+ 10 files changed, 1086 insertions(+), 1 deletion(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605061609-P86BJS/pr/github-title.txt
+++ b/.agentplane/tasks/202605061609-P86BJS/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 P86BJS task: Preview blueprint route during task creation [202605061609-P86BJS]

--- a/.agentplane/tasks/202605061609-P86BJS/pr/meta.json
+++ b/.agentplane/tasks/202605061609-P86BJS/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605061609-P86BJS/blueprint-task-new-preview",
+  "created_at": "2026-05-06T16:11:45.394Z",
+  "head_sha": "8dac6d76b4ca215301eb16f7577056b0e3015a80",
+  "last_verified_at": "2026-05-06T16:22:45.921Z",
+  "last_verified_sha": "8dac6d76b4ca215301eb16f7577056b0e3015a80",
+  "schema_version": 1,
+  "task_id": "202605061609-P86BJS",
+  "updated_at": "2026-05-06T16:11:45.394Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605061609-P86BJS/pr/meta.json
+++ b/.agentplane/tasks/202605061609-P86BJS/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605061609-P86BJS/blueprint-task-new-preview",
   "created_at": "2026-05-06T16:11:45.394Z",
-  "head_sha": "8dac6d76b4ca215301eb16f7577056b0e3015a80",
+  "head_sha": "281f0acd803cf86fad5e5374e910b0e291438700",
   "last_verified_at": "2026-05-06T16:22:45.921Z",
   "last_verified_sha": "8dac6d76b4ca215301eb16f7577056b0e3015a80",
   "schema_version": 1,
   "task_id": "202605061609-P86BJS",
-  "updated_at": "2026-05-06T16:11:45.394Z",
+  "updated_at": "2026-05-06T16:24:37.002Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605061609-P86BJS/pr/review.md
+++ b/.agentplane/tasks/202605061609-P86BJS/pr/review.md
@@ -24,12 +24,22 @@ Created: 2026-05-06T16:11:45.394Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-06T16:11:45.394Z
+- Updated: 2026-05-06T16:24:37.002Z
 - Branch: task/202605061609-P86BJS/blueprint-task-new-preview
-- Head: 8dac6d76b4ca
+- Head: 281f0acd803c
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 498 +++++++++++++++++++++
+ .agentplane/tasks/202605061609-PD9A1Y/README.md    |  90 ++++
+ .../blueprint/resolved-snapshot.json               | 342 ++++++++++++++
+ docs/developer/blueprints.mdx                      |  26 +-
+ docs/user/cli-reference.generated.mdx              |   8 +
+ .../run-cli.core.help-snap.test.ts.snap            |  23 +
+ .../src/cli/run-cli.core.tasks.create.test.ts      |  46 ++
+ .../src/commands/task/blueprint-summary.ts         |  28 ++
+ packages/agentplane/src/commands/task/new.spec.ts  |  13 +
+ packages/agentplane/src/commands/task/new.ts       |  13 +
+ 10 files changed, 1086 insertions(+), 1 deletion(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605061609-P86BJS/pr/review.md
+++ b/.agentplane/tasks/202605061609-P86BJS/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-06T16:11:45.394Z
+
+## Task
+
+- Task: `202605061609-P86BJS`
+- Title: Preview blueprint route during task creation
+- Status: DOING
+- Branch: `task/202605061609-P86BJS/blueprint-task-new-preview`
+- Canonical task record: `.agentplane/tasks/202605061609-P86BJS/README.md`
+
+## Verification
+
+- State: ok
+- Note: Preview flag verified: task new keeps stdout as the generated id and emits resolved blueprint route details to stderr when --show-blueprint is passed.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-06T16:11:45.394Z
+- Branch: task/202605061609-P86BJS/blueprint-task-new-preview
+- Head: 8dac6d76b4ca
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605061609-PD9A1Y/README.md
+++ b/.agentplane/tasks/202605061609-PD9A1Y/README.md
@@ -1,0 +1,90 @@
+---
+id: "202605061609-PD9A1Y"
+title: "Document blueprint creation hints"
+status: "DOING"
+priority: "med"
+owner: "DOCS"
+revision: 7
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "blueprints"
+  - "docs"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-06T16:10:06.893Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-06T16:22:54.736Z"
+  updated_by: "DOCS"
+  note: "Documentation updated for blueprint-aware task creation hints and --show-blueprint stderr route preview."
+commit: null
+comments:
+  -
+    author: "DOCS"
+    body: "Start: Document blueprint-aware task creation hints and the new task creation route preview flag."
+events:
+  -
+    type: "status"
+    at: "2026-05-06T16:11:49.549Z"
+    author: "DOCS"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Document blueprint-aware task creation hints and the new task creation route preview flag."
+  -
+    type: "verify"
+    at: "2026-05-06T16:22:54.736Z"
+    author: "DOCS"
+    state: "ok"
+    note: "Documentation updated for blueprint-aware task creation hints and --show-blueprint stderr route preview."
+doc_version: 3
+doc_updated_at: "2026-05-06T16:22:54.746Z"
+doc_updated_by: "DOCS"
+description: "Document task-kind, mutation-scope, risk, blueprint-request, and task new route preview usage for blueprint-aware task creation."
+sections:
+  Summary: |-
+    Document blueprint creation hints
+    
+    Document task-kind, mutation-scope, risk, blueprint-request, and task new route preview usage for blueprint-aware task creation.
+  Scope: |-
+    - In scope: Document task-kind, mutation-scope, risk, blueprint-request, and task new route preview usage for blueprint-aware task creation.
+    - Out of scope: unrelated refactors not required for "Document blueprint creation hints".
+  Plan: "Document blueprint-aware task creation. Scope: update blueprint developer docs and generated CLI reference for task new structured hints and --show-blueprint. Verification: docs:cli:check, actual command output review, doctor, routing."
+  Verify Steps: |-
+    1. Review the requested outcome for "Document blueprint creation hints". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-06T16:22:54.736Z — VERIFY — ok
+    
+    By: DOCS
+    
+    Note: Documentation updated for blueprint-aware task creation hints and --show-blueprint stderr route preview.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T16:11:49.549Z, excerpt_hash=sha256:b2f6c0239a770f7cb8ebbc35d0a649840ab52e7c9dd98cff9094422b302fecdf
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605061609-P86BJS-blueprint-task-new-preview/.agentplane/tasks/202605061609-PD9A1Y/blueprint/resolved-snapshot.json
+    - old_digest: 5589ce371b9eabde15012ad19c313128d6cc736f345ff36655f737a216e2b716
+    - current_digest: 5589ce371b9eabde15012ad19c313128d6cc736f345ff36655f737a216e2b716
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605061609-PD9A1Y
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Commands: bun run docs:cli:generate; bun run docs:cli:check; bun test packages/agentplane/src/cli/run-cli.core.help-snap.test.ts -t 'help task new'; node .agentplane/policy/check-routing.mjs; ap doctor; git diff --check.
+      Impact: Developer blueprint docs now describe structured creation fields, stdout/stderr behavior, and a preview example; generated CLI reference includes the new flag, note, and example.
+      Resolution: Docs remain aligned with generated command spec and current resolver output.
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605061609-PD9A1Y/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605061609-PD9A1Y/blueprint/resolved-snapshot.json
@@ -1,0 +1,342 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605061609-PD9A1Y",
+    "title": "Document blueprint creation hints",
+    "description": "Document task-kind, mutation-scope, risk, blueprint-request, and task new route preview usage for blueprint-aware task creation.",
+    "tags": [
+      "blueprints",
+      "docs"
+    ],
+    "owner": "DOCS",
+    "workflowMode": "branch_pr",
+    "mutation": "docs",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "docs.change",
+    "version": 1,
+    "title": "Documentation change",
+    "taskKinds": [
+      "docs"
+    ],
+    "workflowModes": [
+      "direct",
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "docs.change",
+    "blueprintVersion": 1,
+    "title": "Documentation change",
+    "taskId": "202605061609-PD9A1Y",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "mutationScope": "docs"
+    },
+    "whySelected": [
+      "task kind resolved to docs",
+      "workflow mode: branch_pr",
+      "mutation scope: docs"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.docs.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "artifact"
+        ]
+      },
+      {
+        "id": "deterministic_check",
+        "kind": "deterministic_check",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "docs.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed documentation paths."
+      },
+      {
+        "id": "docs.check",
+        "kind": "check_result",
+        "producedBy": "deterministic_check",
+        "required": true,
+        "description": "Documentation checks."
+      },
+      {
+        "id": "docs.artifact",
+        "kind": "artifact",
+        "producedBy": "artifact_write",
+        "required": true,
+        "description": "Updated documentation artifact."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/dod.docs.md",
+      ".agentplane/policy/security.must.md"
+    ],
+    "allowedCommands": [
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "documentation checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 3,
+      "maxPromptBlocks": 10,
+      "rationale": "Documentation changes need docs DoD and minimal workflow/security policy."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.docs.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "artifact"
+      ]
+    },
+    {
+      "id": "deterministic_check",
+      "kind": "deterministic_check",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "docs.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed documentation paths."
+    },
+    {
+      "id": "docs.check",
+      "kind": "check_result",
+      "producedBy": "deterministic_check",
+      "required": true,
+      "description": "Documentation checks."
+    },
+    {
+      "id": "docs.artifact",
+      "kind": "artifact",
+      "producedBy": "artifact_write",
+      "required": true,
+      "description": "Updated documentation artifact."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/dod.docs.md",
+    ".agentplane/policy/security.must.md"
+  ],
+  "allowedCommands": [
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "documentation checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 3,
+    "maxPromptBlocks": 10,
+    "rationale": "Documentation changes need docs DoD and minimal workflow/security policy."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to docs",
+    "workflow mode: branch_pr",
+    "mutation scope: docs"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "5589ce371b9eabde15012ad19c313128d6cc736f345ff36655f737a216e2b716"
+  }
+}

--- a/docs/developer/blueprints.mdx
+++ b/docs/developer/blueprints.mdx
@@ -665,8 +665,32 @@ agentplane task new \
   --task-kind analysis \
   --mutation-scope none \
   --risk network \
-  --blueprint-request analysis.light
+  --blueprint-request analysis.light \
+  --show-blueprint
 ```
+
+`task new` keeps stdout stable: it prints only the generated task id. `--show-blueprint` writes the
+route preview to stderr so scripts can keep capturing stdout as the id while humans and agents see
+the selected route immediately.
+
+Example preview:
+
+```text
+Blueprint route preview:
+blueprint_id: analysis.light
+blueprint_version: 1
+workflow_mode: branch_pr
+route: intake -> scope -> context_resolve -> work_unit -> artifact_write -> verify_record -> finish
+selection_reasons: explicit blueprint requested: analysis.light; task intent kind: analysis; workflow mode: branch_pr; task intent mutation scope: none
+required_evidence: analysis.sources, analysis.assumptions, analysis.weak_links, analysis.final
+stop_reasons: none
+explain_command: agentplane blueprint explain <task-id>
+snapshot_command: agentplane blueprint snapshot <task-id>
+```
+
+Use the preview when creating tasks from weak natural-language intent, recipe templates, or
+agent-generated task graphs. It is a creation-time check, not a stored override; the resolver still
+uses the task fields and project config as the source of truth.
 
 Resolver precedence:
 

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -564,12 +564,14 @@ Options:
 - `--blueprint-request <id>`: Explicit blueprint request stored on the task; resolver still validates it. (choices=analysis.light|content.light|docs.change|code.direct|code.branch_pr|release.strict|ops.approval)
 - `--depends-on <task-id>`: Repeatable. Adds a dependency. Special-case: '[]' is treated as empty. (repeatable)
 - `--verify <command>`: Repeatable. Verification commands/checks to run for this task. (repeatable)
+- `--show-blueprint`: Print a resolved blueprint route preview to stderr after creation without changing stdout. (default=false)
 - `--allow-duplicate`: Allow creating a task even when an open task with a highly similar title already exists. (default=false)
 
 Notes:
 
 - Task creation defaults to doc_version=3 and seeds the README v3 section contract automatically.
 - For verify-required primary tags, this command seeds a default ## Verify Steps acceptance contract in README.
+- \`--show-blueprint\` writes route preview details to stderr; stdout remains only the generated task id.
 
 Examples:
 
@@ -578,6 +580,12 @@ agentplane task new --title "Refactor CLI" --description "Improve CLI output" --
 ```
 
 - Create a new task with one tag.
+
+```sh
+agentplane task new --title "Market analysis note" --description "Analyze market context" --owner ANALYST --tag analysis --task-kind analysis --mutation-scope none --show-blueprint
+```
+
+- Create a task and preview the resolved route without changing the task-id stdout contract.
 
 ### task next
 

--- a/packages/agentplane/src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap
+++ b/packages/agentplane/src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap
@@ -320,3 +320,26 @@ exports[`runCli help snapshots (cli2) > help work start --json snapshot 1`] = `
   ],
 }
 `;
+
+exports[`runCli help snapshots (cli2) help task new --compact snapshot 1`] = `
+"task new - Create a new task (prints the generated task id).
+
+Usage:
+  agentplane task new --title <text> --description <text> --owner <id> [options]
+
+Options:
+  --title <text>  Task title. (required)
+  --description <text>  Task description. (required)
+  --owner <id>  Owner id (e.g. CODER). (required)
+  --priority <low|normal|med|high>  Task priority (default: med). (choices=low|normal|med|high, default=med)
+  --tag <tag>  Repeatable. Adds a tag (must provide at least one). (repeatable, min=1)
+  --task-kind <analysis|content|docs|code|release|ops>  Structured blueprint task-kind intent. Tags/title remain fallback hints. (choices=analysis|content|docs|code|release|ops)
+  --mutation-scope <none|docs|code|release|ops|unknown>  Structured mutation scope used by blueprint resolution. (choices=none|docs|code|release|ops|unknown)
+  --risk <risk>  Structured risk flag used by blueprint resolution. Repeatable. (repeatable, choices=network|credentials|deploy|publish|merge|security|external_system)
+  --blueprint-request <id>  Explicit blueprint request stored on the task; resolver still validates it. (choices=analysis.light|content.light|docs.change|code.direct|code.branch_pr|release.strict|ops.approval)
+  --depends-on <task-id>  Repeatable. Adds a dependency. Special-case: '[]' is treated as empty. (repeatable)
+  --verify <command>  Repeatable. Verification commands/checks to run for this task. (repeatable)
+  --show-blueprint  Print a resolved blueprint route preview to stderr after creation without changing stdout. (default=false)
+  --allow-duplicate  Allow creating a task even when an open task with a highly similar title already exists. (default=false)
+"
+`;

--- a/packages/agentplane/src/cli/run-cli.core.tasks.create.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.tasks.create.test.ts
@@ -212,6 +212,52 @@ describe("runCli", { timeout: TASKS_CLI_TIMEOUT_MS }, () => {
     expect(task.frontmatter.blueprint_request).toBe("analysis.light");
   });
 
+  it("task new can preview the resolved blueprint route without changing stdout", async () => {
+    const root = await mkGitRepoRoot();
+    const io = captureStdIO();
+    let taskId = "";
+    try {
+      const code = await runCli([
+        "task",
+        "new",
+        "--title",
+        "Market analysis route preview",
+        "--description",
+        "Analyze market context without repository mutation",
+        "--priority",
+        "med",
+        "--owner",
+        "CODER",
+        "--tag",
+        "analysis",
+        "--task-kind",
+        "analysis",
+        "--mutation-scope",
+        "none",
+        "--blueprint-request",
+        "analysis.light",
+        "--show-blueprint",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(0);
+      taskId = io.stdout.trim();
+      expect(taskId).toMatch(/^\d{12}-[A-Z0-9]{6}$/);
+      expect(io.stdout).toBe(`${taskId}\n`);
+      expect(io.stderr).toContain("Blueprint route preview:");
+      expect(io.stderr).toContain("blueprint_id: analysis.light");
+      expect(io.stderr).toContain(
+        "route: intake -> scope -> context_resolve -> work_unit -> artifact_write -> verify_record -> finish",
+      );
+      expect(io.stderr).toContain("selection_reasons: explicit blueprint requested: analysis.light");
+      expect(io.stderr).toContain("required_evidence: analysis.sources");
+      expect(io.stderr).toContain(`explain_command: agentplane blueprint explain ${taskId}`);
+      expect(io.stderr).toContain(`snapshot_command: agentplane blueprint snapshot ${taskId}`);
+    } finally {
+      io.restore();
+    }
+  });
+
   it("task new rejects highly similar open task titles unless --allow-duplicate is passed", async () => {
     const root = await mkGitRepoRoot();
     const firstIo = captureStdIO();

--- a/packages/agentplane/src/commands/task/blueprint-summary.ts
+++ b/packages/agentplane/src/commands/task/blueprint-summary.ts
@@ -75,3 +75,31 @@ export function formatTaskBlueprintListExtra(summary: TaskBlueprintLifecycleSumm
   if (summary.blueprint_id) return `blueprint=${summary.blueprint_id}`;
   return "blueprint=unresolved";
 }
+
+function joinOrNone(values: string[] | undefined, separator: string): string {
+  return values && values.length > 0 ? values.join(separator) : "none";
+}
+
+export function formatTaskBlueprintCreationPreview(
+  summary: TaskBlueprintLifecycleSummary,
+): string {
+  const lines = summary.error
+    ? ["Blueprint route preview:", "blueprint_id: unresolved", `error: ${summary.error}`]
+    : [
+        "Blueprint route preview:",
+        `blueprint_id: ${summary.blueprint_id ?? "unresolved"}`,
+        ...(summary.blueprint_version === undefined
+          ? []
+          : [`blueprint_version: ${summary.blueprint_version}`]),
+        ...(summary.workflow_mode ? [`workflow_mode: ${summary.workflow_mode}`] : []),
+        `route: ${joinOrNone(summary.route, " -> ")}`,
+        `selection_reasons: ${joinOrNone(summary.selection_reasons, "; ")}`,
+        `required_evidence: ${joinOrNone(summary.required_evidence, ", ")}`,
+        `stop_reasons: ${joinOrNone(summary.stop_reasons, ", ")}`,
+      ];
+  return `${[
+    ...lines,
+    `explain_command: ${summary.explain_command}`,
+    `snapshot_command: ${summary.snapshot_command}`,
+  ].join("\n")}\n`;
+}

--- a/packages/agentplane/src/commands/task/new.spec.ts
+++ b/packages/agentplane/src/commands/task/new.spec.ts
@@ -109,6 +109,13 @@ export const taskNewSpec: CommandSpec<TaskNewParsed> = {
     },
     {
       kind: "boolean",
+      name: "show-blueprint",
+      default: false,
+      description:
+        "Print a resolved blueprint route preview to stderr after creation without changing stdout.",
+    },
+    {
+      kind: "boolean",
       name: "allow-duplicate",
       default: false,
       description:
@@ -120,10 +127,15 @@ export const taskNewSpec: CommandSpec<TaskNewParsed> = {
       cmd: 'agentplane task new --title "Refactor CLI" --description "Improve CLI output" --owner CODER --tag cli',
       why: "Create a new task with one tag.",
     },
+    {
+      cmd: 'agentplane task new --title "Market analysis note" --description "Analyze market context" --owner ANALYST --tag analysis --task-kind analysis --mutation-scope none --show-blueprint',
+      why: "Create a task and preview the resolved route without changing the task-id stdout contract.",
+    },
   ],
   notes: [
     "Task creation defaults to doc_version=3 and seeds the README v3 section contract automatically.",
     "For verify-required primary tags, this command seeds a default ## Verify Steps acceptance contract in README.",
+    "`--show-blueprint` writes route preview details to stderr; stdout remains only the generated task id.",
   ],
   parse: (raw) => ({
     title: raw.opts.title as string,
@@ -137,6 +149,7 @@ export const taskNewSpec: CommandSpec<TaskNewParsed> = {
     blueprintRequest: raw.opts["blueprint-request"] as TaskNewParsed["blueprintRequest"],
     dependsOn: (raw.opts["depends-on"] ?? []) as string[],
     verify: (raw.opts.verify ?? []) as string[],
+    showBlueprint: raw.opts["show-blueprint"] === true,
     allowDuplicate: raw.opts["allow-duplicate"] === true,
   }),
 };

--- a/packages/agentplane/src/commands/task/new.ts
+++ b/packages/agentplane/src/commands/task/new.ts
@@ -24,6 +24,10 @@ import {
   defaultTaskDocV3,
   TASK_DOC_VERSION_V3,
 } from "./doc-template.js";
+import {
+  formatTaskBlueprintCreationPreview,
+  resolveTaskBlueprintLifecycleSummary,
+} from "./blueprint-summary.js";
 
 export type TaskNewParsed = {
   title: string;
@@ -37,6 +41,7 @@ export type TaskNewParsed = {
   blueprintRequest?: TaskData["blueprint_request"];
   dependsOn: string[];
   verify: string[];
+  showBlueprint: boolean;
   allowDuplicate: boolean;
 };
 
@@ -381,6 +386,14 @@ export async function runTaskNewParsed(opts: {
 
     await ctx.taskBackend.writeTask(task);
     process.stdout.write(`${taskId}\n`);
+    if (p.showBlueprint) {
+      const summary = await resolveTaskBlueprintLifecycleSummary({
+        task,
+        config: ctx.config,
+        projectRoot: ctx.resolvedProject.gitRoot,
+      });
+      process.stderr.write(formatTaskBlueprintCreationPreview(summary));
+    }
     return 0;
   } catch (err) {
     throw mapBackendError(err, { command: "task new", root: opts.rootOverride ?? null });


### PR DESCRIPTION
Task: `202605061609-P86BJS`
Title: Preview blueprint route during task creation
Canonical task record: `.agentplane/tasks/202605061609-P86BJS/README.md`

## Summary

Preview blueprint route during task creation

Add an opt-in task new flag that prints the resolved blueprint route after task creation without changing the default stdout task-id contract.

## Scope

- In scope: Add an opt-in task new flag that prints the resolved blueprint route after task creation without changing the default stdout task-id contract.
- Out of scope: unrelated refactors not required for "Preview blueprint route during task creation".

## Verification

- State: ok
- Note: Preview flag verified: task new keeps stdout as the generated id and emits resolved blueprint route details to stderr when --show-blueprint is passed.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-06T16:24:37.002Z
- Branch: task/202605061609-P86BJS/blueprint-task-new-preview
- Head: 281f0acd803c

```text
 .../blueprint/resolved-snapshot.json               | 498 +++++++++++++++++++++
 .agentplane/tasks/202605061609-PD9A1Y/README.md    |  90 ++++
 .../blueprint/resolved-snapshot.json               | 342 ++++++++++++++
 docs/developer/blueprints.mdx                      |  26 +-
 docs/user/cli-reference.generated.mdx              |   8 +
 .../run-cli.core.help-snap.test.ts.snap            |  23 +
 .../src/cli/run-cli.core.tasks.create.test.ts      |  46 ++
 .../src/commands/task/blueprint-summary.ts         |  28 ++
 packages/agentplane/src/commands/task/new.spec.ts  |  13 +
 packages/agentplane/src/commands/task/new.ts       |  13 +
 10 files changed, 1086 insertions(+), 1 deletion(-)
```

</details>
