### PR TITLE
🚧 VWSY04 task: Format task new blueprint preview files [202605061635-VWSY04]

### DIFF
--- a/.agentplane/tasks/202605061635-VWSY04/README.md
+++ b/.agentplane/tasks/202605061635-VWSY04/README.md
@@ -1,0 +1,92 @@
+---
+id: "202605061635-VWSY04"
+title: "Format task new blueprint preview files"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "formatting"
+task_kind: "code"
+mutation_scope: "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-06T16:36:03.117Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-06T16:40:17.830Z"
+  updated_by: "CODER"
+  note: "Formatting fix verified: Prettier-clean output for the two task new blueprint preview files and focused preview behavior still passes."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Format the task new blueprint preview source and test files that local pre-push reported as not Prettier-clean."
+events:
+  -
+    type: "status"
+    at: "2026-05-06T16:36:20.814Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Format the task new blueprint preview source and test files that local pre-push reported as not Prettier-clean."
+  -
+    type: "verify"
+    at: "2026-05-06T16:40:17.830Z"
+    author: "CODER"
+    state: "ok"
+    note: "Formatting fix verified: Prettier-clean output for the two task new blueprint preview files and focused preview behavior still passes."
+doc_version: 3
+doc_updated_at: "2026-05-06T16:40:17.842Z"
+doc_updated_by: "CODER"
+description: "Run Prettier on files changed by task new blueprint preview so local pre-push format checks pass."
+sections:
+  Summary: |-
+    Format task new blueprint preview files
+    
+    Run Prettier on files changed by task new blueprint preview so local pre-push format checks pass.
+  Scope: |-
+    - In scope: Run Prettier on files changed by task new blueprint preview so local pre-push format checks pass.
+    - Out of scope: unrelated refactors not required for "Format task new blueprint preview files".
+  Plan: "Scope: format the two files flagged by local pre-push after PR #987: packages/agentplane/src/cli/run-cli.core.tasks.create.test.ts and packages/agentplane/src/commands/task/blueprint-summary.ts. Verification: prettier check on touched files, bun run lint:core, focused preview test, git diff --check, ap doctor."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-06T16:40:17.830Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Formatting fix verified: Prettier-clean output for the two task new blueprint preview files and focused preview behavior still passes.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T16:36:20.814Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605061635-VWSY04-format-blueprint-preview/.agentplane/tasks/202605061635-VWSY04/blueprint/resolved-snapshot.json
+    - old_digest: 97e6076f1785a927af2594f6fa53f8232768eacfaed8ee9793d80afeb90307cc
+    - current_digest: 97e6076f1785a927af2594f6fa53f8232768eacfaed8ee9793d80afeb90307cc
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605061635-VWSY04
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Commands: bunx prettier packages/agentplane/src/cli/run-cli.core.tasks.create.test.ts packages/agentplane/src/commands/task/blueprint-summary.ts --check; bun test packages/agentplane/src/cli/run-cli.core.tasks.create.test.ts -t 'task new can preview'; bun run lint:core; git diff --check; ap doctor.
+      Impact: Local pre-push formatting gate no longer reports these two files as non-Prettier-clean.
+      Resolution: Only formatting changes were made; no route-preview behavior changed.
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605061635-VWSY04/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605061635-VWSY04/blueprint/resolved-snapshot.json
@@ -1,0 +1,502 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605061635-VWSY04",
+    "title": "Format task new blueprint preview files",
+    "description": "Run Prettier on files changed by task new blueprint preview so local pre-push format checks pass.",
+    "tags": [
+      "code",
+      "formatting"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605061635-VWSY04",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "97e6076f1785a927af2594f6fa53f8232768eacfaed8ee9793d80afeb90307cc"
+  }
+}

--- a/.agentplane/tasks/202605061635-VWSY04/pr/diffstat.txt
+++ b/.agentplane/tasks/202605061635-VWSY04/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ .../blueprint/resolved-snapshot.json               | 502 +++++++++++++++++++++
+ .../src/cli/run-cli.core.tasks.create.test.ts      |   4 +-
+ .../src/commands/task/blueprint-summary.ts         |   4 +-
+ 3 files changed, 506 insertions(+), 4 deletions(-)

--- a/.agentplane/tasks/202605061635-VWSY04/pr/github-body.md
+++ b/.agentplane/tasks/202605061635-VWSY04/pr/github-body.md
@@ -22,12 +22,15 @@ Run Prettier on files changed by task new blueprint preview so local pre-push fo
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-06T16:36:20.900Z
+- Updated: 2026-05-06T16:40:51.908Z
 - Branch: task/202605061635-VWSY04/format-blueprint-preview
-- Head: abb467e93938
+- Head: 0d81e3e6df47
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 502 +++++++++++++++++++++
+ .../src/cli/run-cli.core.tasks.create.test.ts      |   4 +-
+ .../src/commands/task/blueprint-summary.ts         |   4 +-
+ 3 files changed, 506 insertions(+), 4 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605061635-VWSY04/pr/github-body.md
+++ b/.agentplane/tasks/202605061635-VWSY04/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605061635-VWSY04`
+Title: Format task new blueprint preview files
+Canonical task record: `.agentplane/tasks/202605061635-VWSY04/README.md`
+
+## Summary
+
+Format task new blueprint preview files
+
+Run Prettier on files changed by task new blueprint preview so local pre-push format checks pass.
+
+## Scope
+
+- In scope: Run Prettier on files changed by task new blueprint preview so local pre-push format checks pass.
+- Out of scope: unrelated refactors not required for "Format task new blueprint preview files".
+
+## Verification
+
+- State: ok
+- Note: Formatting fix verified: Prettier-clean output for the two task new blueprint preview files and focused preview behavior still passes.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-06T16:36:20.900Z
+- Branch: task/202605061635-VWSY04/format-blueprint-preview
+- Head: abb467e93938
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605061635-VWSY04/pr/github-title.txt
+++ b/.agentplane/tasks/202605061635-VWSY04/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 VWSY04 task: Format task new blueprint preview files [202605061635-VWSY04]

--- a/.agentplane/tasks/202605061635-VWSY04/pr/meta.json
+++ b/.agentplane/tasks/202605061635-VWSY04/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605061635-VWSY04/format-blueprint-preview",
   "created_at": "2026-05-06T16:36:20.900Z",
-  "head_sha": "abb467e939389fdb00834bf09db3a827e80fb4de",
+  "head_sha": "0d81e3e6df47f2d2240a8dbd780f2ef3007ce825",
   "last_verified_at": "2026-05-06T16:40:17.830Z",
   "last_verified_sha": "abb467e939389fdb00834bf09db3a827e80fb4de",
   "schema_version": 1,
   "task_id": "202605061635-VWSY04",
-  "updated_at": "2026-05-06T16:36:20.900Z",
+  "updated_at": "2026-05-06T16:40:51.908Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605061635-VWSY04/pr/meta.json
+++ b/.agentplane/tasks/202605061635-VWSY04/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605061635-VWSY04/format-blueprint-preview",
+  "created_at": "2026-05-06T16:36:20.900Z",
+  "head_sha": "abb467e939389fdb00834bf09db3a827e80fb4de",
+  "last_verified_at": "2026-05-06T16:40:17.830Z",
+  "last_verified_sha": "abb467e939389fdb00834bf09db3a827e80fb4de",
+  "schema_version": 1,
+  "task_id": "202605061635-VWSY04",
+  "updated_at": "2026-05-06T16:36:20.900Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605061635-VWSY04/pr/review.md
+++ b/.agentplane/tasks/202605061635-VWSY04/pr/review.md
@@ -24,12 +24,15 @@ Created: 2026-05-06T16:36:20.900Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-06T16:36:20.900Z
+- Updated: 2026-05-06T16:40:51.908Z
 - Branch: task/202605061635-VWSY04/format-blueprint-preview
-- Head: abb467e93938
+- Head: 0d81e3e6df47
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 502 +++++++++++++++++++++
+ .../src/cli/run-cli.core.tasks.create.test.ts      |   4 +-
+ .../src/commands/task/blueprint-summary.ts         |   4 +-
+ 3 files changed, 506 insertions(+), 4 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605061635-VWSY04/pr/review.md
+++ b/.agentplane/tasks/202605061635-VWSY04/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-06T16:36:20.900Z
+
+## Task
+
+- Task: `202605061635-VWSY04`
+- Title: Format task new blueprint preview files
+- Status: DOING
+- Branch: `task/202605061635-VWSY04/format-blueprint-preview`
+- Canonical task record: `.agentplane/tasks/202605061635-VWSY04/README.md`
+
+## Verification
+
+- State: ok
+- Note: Formatting fix verified: Prettier-clean output for the two task new blueprint preview files and focused preview behavior still passes.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-06T16:36:20.900Z
+- Branch: task/202605061635-VWSY04/format-blueprint-preview
+- Head: abb467e93938
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/cli/run-cli.core.tasks.create.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.tasks.create.test.ts
@@ -249,7 +249,9 @@ describe("runCli", { timeout: TASKS_CLI_TIMEOUT_MS }, () => {
       expect(io.stderr).toContain(
         "route: intake -> scope -> context_resolve -> work_unit -> artifact_write -> verify_record -> finish",
       );
-      expect(io.stderr).toContain("selection_reasons: explicit blueprint requested: analysis.light");
+      expect(io.stderr).toContain(
+        "selection_reasons: explicit blueprint requested: analysis.light",
+      );
       expect(io.stderr).toContain("required_evidence: analysis.sources");
       expect(io.stderr).toContain(`explain_command: agentplane blueprint explain ${taskId}`);
       expect(io.stderr).toContain(`snapshot_command: agentplane blueprint snapshot ${taskId}`);

--- a/packages/agentplane/src/commands/task/blueprint-summary.ts
+++ b/packages/agentplane/src/commands/task/blueprint-summary.ts
@@ -80,9 +80,7 @@ function joinOrNone(values: string[] | undefined, separator: string): string {
   return values && values.length > 0 ? values.join(separator) : "none";
 }
 
-export function formatTaskBlueprintCreationPreview(
-  summary: TaskBlueprintLifecycleSummary,
-): string {
+export function formatTaskBlueprintCreationPreview(summary: TaskBlueprintLifecycleSummary): string {
   const lines = summary.error
     ? ["Blueprint route preview:", "blueprint_id: unresolved", `error: ${summary.error}`]
     : [


### PR DESCRIPTION
Task: `202605061635-VWSY04`
Title: Format task new blueprint preview files
Canonical task record: `.agentplane/tasks/202605061635-VWSY04/README.md`

## Summary

Format task new blueprint preview files

Run Prettier on files changed by task new blueprint preview so local pre-push format checks pass.

## Scope

- In scope: Run Prettier on files changed by task new blueprint preview so local pre-push format checks pass.
- Out of scope: unrelated refactors not required for "Format task new blueprint preview files".

## Verification

- State: ok
- Note: Formatting fix verified: Prettier-clean output for the two task new blueprint preview files and focused preview behavior still passes.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-06T16:40:51.908Z
- Branch: task/202605061635-VWSY04/format-blueprint-preview
- Head: 0d81e3e6df47

```text
 .../blueprint/resolved-snapshot.json               | 502 +++++++++++++++++++++
 .../src/cli/run-cli.core.tasks.create.test.ts      |   4 +-
 .../src/commands/task/blueprint-summary.ts         |   4 +-
 3 files changed, 506 insertions(+), 4 deletions(-)
```

</details>
