### PR TITLE
🚧 DRD78G task: Add batched cloud push client [202605061738-DRD78G]

### DIFF
--- a/.agentplane/tasks/202605061738-DRD78G/README.md
+++ b/.agentplane/tasks/202605061738-DRD78G/README.md
@@ -1,0 +1,99 @@
+---
+id: "202605061738-DRD78G"
+title: "Add batched cloud push client"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "backend"
+  - "cloud"
+  - "sync"
+task_kind: "code"
+mutation_scope: "code"
+risk_flags:
+  - "external_system"
+verify:
+  - "bun run --filter=agentplane build"
+  - "bun x vitest run packages/agentplane/src/backends/task-backend.cloud.test.ts"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-06T17:38:29.512Z"
+  updated_by: "CODER"
+  note: "Approved after service-side /sync/push-batch landed in agentplane-cloud-sync main."
+verification:
+  state: "ok"
+  updated_at: "2026-05-06T17:39:23.250Z"
+  updated_by: "CODER"
+  note: "Batched cloud push client implemented and focused checks passed."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement batched cloud push client in the dedicated branch_pr worktree after service endpoint publication."
+events:
+  -
+    type: "status"
+    at: "2026-05-06T17:38:55.438Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement batched cloud push client in the dedicated branch_pr worktree after service endpoint publication."
+  -
+    type: "verify"
+    at: "2026-05-06T17:39:23.250Z"
+    author: "CODER"
+    state: "ok"
+    note: "Batched cloud push client implemented and focused checks passed."
+doc_version: 3
+doc_updated_at: "2026-05-06T17:39:23.256Z"
+doc_updated_by: "CODER"
+description: "Update the public cloud task backend to upload oversized push projections through the cloud service batch endpoint while keeping small pushes on the existing direct endpoint."
+sections:
+  Summary: |-
+    Add batched cloud push client
+    
+    Update the public cloud task backend to upload oversized push projections through the cloud service batch endpoint while keeping small pushes on the existing direct endpoint.
+  Scope: |-
+    - In scope: Update the public cloud task backend to upload oversized push projections through the cloud service batch endpoint while keeping small pushes on the existing direct endpoint.
+    - Out of scope: unrelated refactors not required for "Add batched cloud push client".
+  Plan: |-
+    1. Apply the cloud backend client patch in a dedicated branch_pr worktree without staging unrelated local backend config or handoff drift.
+    2. Verify oversized cloud push switches to /sync/push-batch while small push behavior remains unchanged.
+    3. Update user docs for large archive behavior and publish a PR with focused test/build evidence.
+  Verify Steps: |-
+    1. Review the requested outcome for "Add batched cloud push client". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-06T17:39:23.250Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Batched cloud push client implemented and focused checks passed.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-06T17:38:55.438Z, excerpt_hash=sha256:89d54fb946cf5a9717f72c4134bcc1ceb2ed08ddc4d401aa040269d888344f79
+    
+    Details:
+    
+    Updated cloud backend to use direct /sync/push for small projections and /sync/push-batch for oversized projections. Added cloud backend test for oversized batch finalization and updated user docs. Checks: bun x vitest run packages/agentplane/src/backends/task-backend.cloud.test.ts; bun run --filter=agentplane build; git diff --check; node .agentplane/policy/check-routing.mjs; agentplane doctor.
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605061738-DRD78G-batched-cloud-push/.agentplane/tasks/202605061738-DRD78G/blueprint/resolved-snapshot.json
+    - old_digest: b7e62420914853e6b96fb71d4cbaa06080e64e88a941386db5489fcd70febd73
+    - current_digest: b7e62420914853e6b96fb71d4cbaa06080e64e88a941386db5489fcd70febd73
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605061738-DRD78G
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605061738-DRD78G/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605061738-DRD78G/blueprint/resolved-snapshot.json
@@ -1,0 +1,386 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605061738-DRD78G",
+    "title": "Add batched cloud push client",
+    "description": "Update the public cloud task backend to upload oversized push projections through the cloud service batch endpoint while keeping small pushes on the existing direct endpoint.",
+    "tags": [
+      "backend",
+      "cloud",
+      "sync"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [
+      "external_system"
+    ]
+  },
+  "selectedBlueprint": {
+    "id": "ops.approval",
+    "version": 1,
+    "title": "Approval-gated operations",
+    "taskKinds": [
+      "ops"
+    ],
+    "workflowModes": []
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "ops.approval",
+    "blueprintVersion": 1,
+    "title": "Approval-gated operations",
+    "taskId": "202605061738-DRD78G",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "riskFlags": [
+        "external_system"
+      ]
+    },
+    "whySelected": [
+      "risk flags require ops.approval: external_system",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions",
+          "rollback"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "rollback"
+        ]
+      },
+      {
+        "id": "deterministic_check",
+        "kind": "deterministic_check",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "ops.approval",
+        "kind": "approval",
+        "producedBy": "approval_gate",
+        "required": true,
+        "description": "Operational approval."
+      },
+      {
+        "id": "ops.rollback",
+        "kind": "rollback",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Rollback or recovery path."
+      },
+      {
+        "id": "ops.action",
+        "kind": "artifact",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Action log or operational artifact."
+      },
+      {
+        "id": "ops.check",
+        "kind": "check_result",
+        "producedBy": "deterministic_check",
+        "required": true,
+        "description": "Post-action check."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md"
+    ],
+    "allowedCommands": [
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "approved operational command"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 2,
+      "maxPromptBlocks": 12,
+      "rationale": "Ops work needs security and rollback context before any external action."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions",
+        "rollback"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "rollback"
+      ]
+    },
+    {
+      "id": "deterministic_check",
+      "kind": "deterministic_check",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "ops.approval",
+      "kind": "approval",
+      "producedBy": "approval_gate",
+      "required": true,
+      "description": "Operational approval."
+    },
+    {
+      "id": "ops.rollback",
+      "kind": "rollback",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Rollback or recovery path."
+    },
+    {
+      "id": "ops.action",
+      "kind": "artifact",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Action log or operational artifact."
+    },
+    {
+      "id": "ops.check",
+      "kind": "check_result",
+      "producedBy": "deterministic_check",
+      "required": true,
+      "description": "Post-action check."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md"
+  ],
+  "allowedCommands": [
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "approved operational command"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 2,
+    "maxPromptBlocks": 12,
+    "rationale": "Ops work needs security and rollback context before any external action."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "risk flags require ops.approval: external_system",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "b7e62420914853e6b96fb71d4cbaa06080e64e88a941386db5489fcd70febd73"
+  }
+}

--- a/.agentplane/tasks/202605061738-DRD78G/pr/diffstat.txt
+++ b/.agentplane/tasks/202605061738-DRD78G/pr/diffstat.txt
@@ -1,0 +1,5 @@
+ .../blueprint/resolved-snapshot.json               | 386 +++++++++++++++++++++
+ docs/user/backends/cloud.mdx                       |   7 +
+ .../src/backends/task-backend.cloud.test.ts        |  71 ++++
+ .../src/backends/task-backend/cloud-backend.ts     | 133 ++++++-
+ 4 files changed, 585 insertions(+), 12 deletions(-)

--- a/.agentplane/tasks/202605061738-DRD78G/pr/github-body.md
+++ b/.agentplane/tasks/202605061738-DRD78G/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605061738-DRD78G`
+Title: Add batched cloud push client
+Canonical task record: `.agentplane/tasks/202605061738-DRD78G/README.md`
+
+## Summary
+
+Add batched cloud push client
+
+Update the public cloud task backend to upload oversized push projections through the cloud service batch endpoint while keeping small pushes on the existing direct endpoint.
+
+## Scope
+
+- In scope: Update the public cloud task backend to upload oversized push projections through the cloud service batch endpoint while keeping small pushes on the existing direct endpoint.
+- Out of scope: unrelated refactors not required for "Add batched cloud push client".
+
+## Verification
+
+- State: ok
+- Note: Batched cloud push client implemented and focused checks passed.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-06T17:38:55.473Z
+- Branch: task/202605061738-DRD78G/batched-cloud-push
+- Head: e0dfae52e936
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605061738-DRD78G/pr/github-body.md
+++ b/.agentplane/tasks/202605061738-DRD78G/pr/github-body.md
@@ -22,12 +22,16 @@ Update the public cloud task backend to upload oversized push projections throug
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-06T17:38:55.473Z
+- Updated: 2026-05-06T17:39:35.482Z
 - Branch: task/202605061738-DRD78G/batched-cloud-push
-- Head: e0dfae52e936
+- Head: 98e017eeecda
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 386 +++++++++++++++++++++
+ docs/user/backends/cloud.mdx                       |   7 +
+ .../src/backends/task-backend.cloud.test.ts        |  71 ++++
+ .../src/backends/task-backend/cloud-backend.ts     | 133 ++++++-
+ 4 files changed, 585 insertions(+), 12 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605061738-DRD78G/pr/github-title.txt
+++ b/.agentplane/tasks/202605061738-DRD78G/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 DRD78G task: Add batched cloud push client [202605061738-DRD78G]

--- a/.agentplane/tasks/202605061738-DRD78G/pr/meta.json
+++ b/.agentplane/tasks/202605061738-DRD78G/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605061738-DRD78G/batched-cloud-push",
+  "created_at": "2026-05-06T17:38:55.473Z",
+  "head_sha": "e0dfae52e936ef780ae2c7cdfd767c84ae8e2ea5",
+  "last_verified_at": "2026-05-06T17:39:23.250Z",
+  "last_verified_sha": "e0dfae52e936ef780ae2c7cdfd767c84ae8e2ea5",
+  "schema_version": 1,
+  "task_id": "202605061738-DRD78G",
+  "updated_at": "2026-05-06T17:38:55.473Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605061738-DRD78G/pr/meta.json
+++ b/.agentplane/tasks/202605061738-DRD78G/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605061738-DRD78G/batched-cloud-push",
   "created_at": "2026-05-06T17:38:55.473Z",
-  "head_sha": "e0dfae52e936ef780ae2c7cdfd767c84ae8e2ea5",
+  "head_sha": "98e017eeecdaf666d683cc6570c40b43f687d985",
   "last_verified_at": "2026-05-06T17:39:23.250Z",
   "last_verified_sha": "e0dfae52e936ef780ae2c7cdfd767c84ae8e2ea5",
   "schema_version": 1,
   "task_id": "202605061738-DRD78G",
-  "updated_at": "2026-05-06T17:38:55.473Z",
+  "updated_at": "2026-05-06T17:39:35.482Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605061738-DRD78G/pr/review.md
+++ b/.agentplane/tasks/202605061738-DRD78G/pr/review.md
@@ -24,12 +24,16 @@ Created: 2026-05-06T17:38:55.473Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-06T17:38:55.473Z
+- Updated: 2026-05-06T17:39:35.482Z
 - Branch: task/202605061738-DRD78G/batched-cloud-push
-- Head: e0dfae52e936
+- Head: 98e017eeecda
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 386 +++++++++++++++++++++
+ docs/user/backends/cloud.mdx                       |   7 +
+ .../src/backends/task-backend.cloud.test.ts        |  71 ++++
+ .../src/backends/task-backend/cloud-backend.ts     | 133 ++++++-
+ 4 files changed, 585 insertions(+), 12 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605061738-DRD78G/pr/review.md
+++ b/.agentplane/tasks/202605061738-DRD78G/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-06T17:38:55.473Z
+
+## Task
+
+- Task: `202605061738-DRD78G`
+- Title: Add batched cloud push client
+- Status: DOING
+- Branch: `task/202605061738-DRD78G/batched-cloud-push`
+- Canonical task record: `.agentplane/tasks/202605061738-DRD78G/README.md`
+
+## Verification
+
+- State: ok
+- Note: Batched cloud push client implemented and focused checks passed.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-06T17:38:55.473Z
+- Branch: task/202605061738-DRD78G/batched-cloud-push
+- Head: e0dfae52e936
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/docs/user/backends/cloud.mdx
+++ b/docs/user/backends/cloud.mdx
@@ -114,6 +114,13 @@ Push local dirty task state to the cloud service:
 agentplane backend sync cloud --direction push --yes
 ```
 
+For large task archives, the CLI automatically uploads the push projection in
+byte-limited batches. The cloud service stages those chunks and only replaces
+the canonical projection after the final batch is received, then enqueues one
+publish job for connected views. This keeps `backend sync cloud --direction
+push --yes` as the user-facing command while avoiding oversized HTTP request
+bodies.
+
 Operational rule:
 
 - use `pull` before local task mutations when the projection is stale;

--- a/packages/agentplane/src/backends/task-backend.cloud.test.ts
+++ b/packages/agentplane/src/backends/task-backend.cloud.test.ts
@@ -95,6 +95,77 @@ describe("CloudBackend", () => {
     expect(stateText).toContain("2026-05-06T00:00:00.000Z");
   });
 
+  it("push sync uploads oversized projections in finalized batches", async () => {
+    const cache = new LocalBackend({ dir: path.join(tempDir, ".agentplane", "tasks") });
+    const largeText = "x".repeat(400_000);
+    for (const suffix of ["C1D2", "C1D3"]) {
+      await cache.writeTask({
+        id: `202605051806-${suffix}`,
+        title: `Cloud task ${suffix}`,
+        description: largeText,
+        status: "TODO",
+        priority: "med",
+        owner: "CODER",
+        depends_on: [],
+        tags: ["cloud"],
+        verify: [],
+      });
+    }
+    const fetchImpl = vi.fn<typeof fetch>((_url, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        batch?: { finalize?: boolean };
+      };
+      return Promise.resolve(
+        Response.json({
+          data: {
+            last_checked_at: "2026-05-06T00:00:00.000Z",
+            batch: { finalized: body.batch?.finalize === true },
+            no_projection_changes: body.batch?.finalize !== true,
+          },
+        }),
+      );
+    });
+    const backend = new CloudBackend(
+      {
+        endpoint: "https://cloud.example/",
+        token: "token",
+        project_id: "project-1",
+        provider: "github-projects",
+      },
+      { root: tempDir, cache, fetchImpl },
+    );
+
+    await backend.sync({ direction: "push", conflict: "diff", quiet: true, confirm: true });
+
+    const calls = fetchImpl.mock.calls.map(([url, init]) => ({
+      url: String(url),
+      body: JSON.parse(String(init?.body ?? "{}")) as {
+        batch?: {
+          total_batches: number;
+          chunk_index: number;
+          finalize: boolean;
+        };
+        tasks?: unknown[];
+      },
+    }));
+    expect(calls.map((call) => call.url)).toEqual([
+      "https://cloud.example/v1/projects/project-1/sync/push-batch",
+      "https://cloud.example/v1/projects/project-1/sync/push-batch",
+    ]);
+    expect(calls[0]?.body.batch).toMatchObject({
+      total_batches: 2,
+      chunk_index: 0,
+      finalize: false,
+    });
+    expect(calls[1]?.body.batch).toMatchObject({
+      total_batches: 2,
+      chunk_index: 1,
+      finalize: true,
+    });
+    expect(calls[0]?.body.tasks).toHaveLength(1);
+    expect(calls[1]?.body.tasks).toHaveLength(1);
+  });
+
   it("pull sync does not rewrite identical local projection tasks", async () => {
     const cache = new LocalBackend({ dir: path.join(tempDir, ".agentplane", "tasks") });
     const task: TaskData = {

--- a/packages/agentplane/src/backends/task-backend/cloud-backend.ts
+++ b/packages/agentplane/src/backends/task-backend/cloud-backend.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 
 import { loadDotEnv } from "../../shared/env.js";
 import {
@@ -46,6 +47,9 @@ type CloudSyncStateSnapshot = {
   safeCommand: string | null;
   unavailable: boolean;
 };
+
+const CLOUD_PUSH_DIRECT_BODY_LIMIT_BYTES = 750_000;
+const CLOUD_PUSH_BATCH_TASK_BYTES = 600_000;
 
 export class CloudBackend implements TaskBackend {
   id = "cloud";
@@ -224,18 +228,20 @@ export class CloudBackend implements TaskBackend {
         "E_BACKEND",
       );
     }
-    const response = await this.request<CloudSyncResponse>(
-      `/v1/projects/${encodeURIComponent(this.projectId)}/sync/${action}`,
-      {
-        method: "POST",
-        body: JSON.stringify({
-          provider: this.provider,
-          direction: opts.direction,
-          conflict: opts.conflict,
-          tasks: opts.direction === "push" ? localTasks : undefined,
-        }),
-      },
-    );
+    const response =
+      opts.direction === "push"
+        ? await this.requestCloudPush(localTasks, opts)
+        : await this.request<CloudSyncResponse>(
+            `/v1/projects/${encodeURIComponent(this.projectId)}/sync/${action}`,
+            {
+              method: "POST",
+              body: JSON.stringify({
+                provider: this.provider,
+                direction: opts.direction,
+                conflict: opts.conflict,
+              }),
+            },
+          );
     const data = isRecord(response.data) ? response.data : {};
     const pull = normalizeCloudPullResponse(response, data);
     if (opts.direction === "pull") {
@@ -315,6 +321,70 @@ export class CloudBackend implements TaskBackend {
         "agentplane backend sync cloud --direction pull --conflict=diff",
       unavailable: false,
     };
+  }
+
+  private async requestCloudPush(
+    localTasks: TaskData[],
+    opts: {
+      conflict: "diff" | "prefer-local" | "prefer-remote" | "fail";
+      quiet: boolean;
+    },
+  ): Promise<CloudSyncResponse> {
+    const directBody = JSON.stringify({
+      provider: this.provider,
+      direction: "push",
+      conflict: opts.conflict,
+      tasks: localTasks,
+    });
+    if (Buffer.byteLength(directBody, "utf8") <= CLOUD_PUSH_DIRECT_BODY_LIMIT_BYTES) {
+      return await this.request<CloudSyncResponse>(
+        `/v1/projects/${encodeURIComponent(this.projectId)}/sync/push`,
+        { method: "POST", body: directBody },
+      );
+    }
+
+    const chunks = splitTasksByPayloadBytes(localTasks, CLOUD_PUSH_BATCH_TASK_BYTES);
+    const batchId = `batch_${Date.now()}_${randomUUID()}`;
+    let lastResponse: CloudSyncResponse | null = null;
+    for (const [index, tasks] of chunks.entries()) {
+      lastResponse = await this.request<CloudSyncResponse>(
+        `/v1/projects/${encodeURIComponent(this.projectId)}/sync/push-batch`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            provider: this.provider,
+            direction: "push",
+            conflict: opts.conflict,
+            batch: {
+              id: batchId,
+              total_batches: chunks.length,
+              total_tasks: localTasks.length,
+              chunk_index: index,
+              finalize: index === chunks.length - 1,
+            },
+            tasks,
+          }),
+        },
+      );
+      if (!opts.quiet) {
+        process.stderr.write(
+          `cloud push uploaded batch ${index + 1}/${chunks.length} tasks=${tasks.length}\n`,
+        );
+      }
+      if (index === chunks.length - 1 && !cloudPushBatchFinalized(lastResponse)) {
+        throw new BackendError(
+          [
+            "Cloud backend batch push did not finalize.",
+            "Why: the service did not confirm that every expected chunk was received before replacing the projection.",
+            "Fix: retry the cloud push; chunks are idempotent for one batch id during the run.",
+            "Safe command: agentplane backend sync cloud --direction push --yes",
+            "Stop condition: stop if the service repeatedly reports an incomplete batch after all chunks are uploaded.",
+          ].join("\n"),
+          "E_BACKEND",
+        );
+      }
+    }
+    return lastResponse ?? { data: { last_checked_at: new Date().toISOString() } };
   }
 
   async inspectConfiguration(): Promise<TaskBackendInspectionResult> {
@@ -468,6 +538,12 @@ function readSafeCommand(response: CloudSyncResponse, data: Record<string, unkno
   return command ?? "agentplane backend inspect cloud --yes";
 }
 
+function cloudPushBatchFinalized(response: CloudSyncResponse): boolean {
+  const data = isRecord(response.data) ? response.data : {};
+  const batch = isRecord(data.batch) ? data.batch : null;
+  return batch?.finalized === true;
+}
+
 function readString(input: unknown, key: string): string | null {
   if (!isRecord(input)) return null;
   const value = input[key];
@@ -534,6 +610,39 @@ function normalizePositiveInteger(input: unknown): number | null {
   if (typeof input !== "number" || !Number.isFinite(input)) return null;
   const value = Math.trunc(input);
   return value > 0 ? value : null;
+}
+
+function splitTasksByPayloadBytes(tasks: TaskData[], maxBytes: number): TaskData[][] {
+  const chunks: TaskData[][] = [];
+  let current: TaskData[] = [];
+  let currentBytes = 2;
+  for (const task of tasks) {
+    const taskBytes = Buffer.byteLength(JSON.stringify(task), "utf8");
+    if (taskBytes > maxBytes) {
+      throw new BackendError(
+        [
+          "Cloud backend cannot batch a single oversized task projection.",
+          `Why: task ${task.id} is larger than the per-batch payload budget.`,
+          "Fix: reduce large task README metadata or raise the service request-body limit before syncing.",
+          "Safe command: agentplane task show <task-id>",
+          "Stop condition: stop if the task contains secrets or large embedded artifacts.",
+        ].join("\n"),
+        "E_BACKEND",
+      );
+    }
+    const separatorBytes = current.length === 0 ? 0 : 1;
+    if (current.length > 0 && currentBytes + separatorBytes + taskBytes > maxBytes) {
+      chunks.push(current);
+      current = [];
+      currentBytes = 2;
+    }
+    current.push(task);
+    currentBytes += separatorBytes + taskBytes;
+  }
+  if (current.length > 0 || tasks.length === 0) {
+    chunks.push(current);
+  }
+  return chunks;
 }
 
 function isStale(lastCheckedAt: string | null, staleAfterSeconds: number | null): boolean {


### PR DESCRIPTION
Task: `202605061738-DRD78G`
Title: Add batched cloud push client
Canonical task record: `.agentplane/tasks/202605061738-DRD78G/README.md`

## Summary

Add batched cloud push client

Update the public cloud task backend to upload oversized push projections through the cloud service batch endpoint while keeping small pushes on the existing direct endpoint.

## Scope

- In scope: Update the public cloud task backend to upload oversized push projections through the cloud service batch endpoint while keeping small pushes on the existing direct endpoint.
- Out of scope: unrelated refactors not required for "Add batched cloud push client".

## Verification

- State: ok
- Note: Batched cloud push client implemented and focused checks passed.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-06T17:39:35.482Z
- Branch: task/202605061738-DRD78G/batched-cloud-push
- Head: 98e017eeecda

```text
 .../blueprint/resolved-snapshot.json               | 386 +++++++++++++++++++++
 docs/user/backends/cloud.mdx                       |   7 +
 .../src/backends/task-backend.cloud.test.ts        |  71 ++++
 .../src/backends/task-backend/cloud-backend.ts     | 133 ++++++-
 4 files changed, 585 insertions(+), 12 deletions(-)
```

</details>
