### PR TITLE
🚧 MRT9N7 task: Fix cloud push freshness timestamp semantics [202605081305-MRT9N7]

### DIFF
--- a/.agentplane/tasks/202605081305-9GE36C/README.md
+++ b/.agentplane/tasks/202605081305-9GE36C/README.md
@@ -1,0 +1,88 @@
+---
+id: "202605081305-9GE36C"
+title: "Deduplicate cloud backend helper utilities"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "backend"
+  - "cloud"
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-08T13:07:18.326Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-08T13:44:48.806Z"
+  updated_by: "CODER"
+  note: "Verified: cloud-backend-utils no longer exports local generic isRecord, firstNonEmpty, or sleep helpers; cloud backend now uses shared guard/string/concurrency helpers. Commands: bun x vitest run packages/agentplane/src/backends/task-backend.cloud.test.ts (17 passed); bun x eslint touched cloud files; bun run lint:core; bun run release:check; bun run hotspots:check."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: deduplicate generic cloud backend helper utilities within the approved release-cleanup batch."
+events:
+  -
+    type: "status"
+    at: "2026-05-08T13:09:48.755Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: deduplicate generic cloud backend helper utilities within the approved release-cleanup batch."
+  -
+    type: "verify"
+    at: "2026-05-08T13:44:48.806Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: cloud-backend-utils no longer exports local generic isRecord, firstNonEmpty, or sleep helpers; cloud backend now uses shared guard/string/concurrency helpers. Commands: bun x vitest run packages/agentplane/src/backends/task-backend.cloud.test.ts (17 passed); bun x eslint touched cloud files; bun run lint:core; bun run release:check; bun run hotspots:check."
+doc_version: 3
+doc_updated_at: "2026-05-08T13:44:48.811Z"
+doc_updated_by: "CODER"
+description: "Replace cloud-backend-utils local generic helpers with existing shared guard/string/concurrency helpers so the new cloud helper module only contains cloud-specific behavior."
+sections:
+  Summary: |-
+    Deduplicate cloud backend helper utilities
+    
+    Replace cloud-backend-utils local generic helpers with existing shared guard/string/concurrency helpers so the new cloud helper module only contains cloud-specific behavior.
+  Scope: |-
+    - In scope: Replace cloud-backend-utils local generic helpers with existing shared guard/string/concurrency helpers so the new cloud helper module only contains cloud-specific behavior.
+    - Out of scope: unrelated refactors not required for "Deduplicate cloud backend helper utilities".
+  Plan: "Related batch task included in primary 202605081305-MRT9N7. 1. Replace cloud-backend-utils generic helper exports with existing shared helpers where semantics match. 2. Keep cloud-backend-utils scoped to cloud-specific response/remediation/chunk helpers. 3. Verify cloud backend tests and lint."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-08T13:44:48.806Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: cloud-backend-utils no longer exports local generic isRecord, firstNonEmpty, or sleep helpers; cloud backend now uses shared guard/string/concurrency helpers. Commands: bun x vitest run packages/agentplane/src/backends/task-backend.cloud.test.ts (17 passed); bun x eslint touched cloud files; bun run lint:core; bun run release:check; bun run hotspots:check.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-08T13:09:48.800Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605081305-MRT9N7-release-cleanup/.agentplane/tasks/202605081305-9GE36C/blueprint/resolved-snapshot.json
+    - old_digest: 871793d26e4915dea6c11f1cb51dd2ff8d319abf91e9ebf0f1d75d1b942774f0
+    - current_digest: 871793d26e4915dea6c11f1cb51dd2ff8d319abf91e9ebf0f1d75d1b942774f0
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605081305-9GE36C
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605081305-9GE36C/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605081305-9GE36C/blueprint/resolved-snapshot.json
@@ -1,0 +1,498 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605081305-9GE36C",
+    "title": "Deduplicate cloud backend helper utilities",
+    "description": "Replace cloud-backend-utils local generic helpers with existing shared guard/string/concurrency helpers so the new cloud helper module only contains cloud-specific behavior.",
+    "tags": [
+      "backend",
+      "cloud",
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605081305-9GE36C",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "871793d26e4915dea6c11f1cb51dd2ff8d319abf91e9ebf0f1d75d1b942774f0"
+  }
+}

--- a/.agentplane/tasks/202605081305-MRT9N7/README.md
+++ b/.agentplane/tasks/202605081305-MRT9N7/README.md
@@ -1,0 +1,89 @@
+---
+id: "202605081305-MRT9N7"
+title: "Fix cloud push freshness timestamp semantics"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "backend"
+  - "cloud"
+  - "code"
+  - "sync"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-08T13:07:00.563Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-08T13:44:33.135Z"
+  updated_by: "CODER"
+  note: "Verified: cloud push freshness now preserves prior state when push response omits last_checked_at. Commands: bun x vitest run packages/agentplane/src/backends/task-backend.cloud.test.ts (17 passed); bun run --filter=agentplane build; bun run release:check; bun run lint:core; bun run hotspots:check; ap doctor; node .agentplane/policy/check-routing.mjs; git diff --check."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement cloud push freshness semantics and coordinate the approved release-cleanup batch tasks."
+events:
+  -
+    type: "status"
+    at: "2026-05-08T13:09:35.362Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement cloud push freshness semantics and coordinate the approved release-cleanup batch tasks."
+  -
+    type: "verify"
+    at: "2026-05-08T13:44:33.135Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: cloud push freshness now preserves prior state when push response omits last_checked_at. Commands: bun x vitest run packages/agentplane/src/backends/task-backend.cloud.test.ts (17 passed); bun run --filter=agentplane build; bun run release:check; bun run lint:core; bun run hotspots:check; ap doctor; node .agentplane/policy/check-routing.mjs; git diff --check."
+doc_version: 3
+doc_updated_at: "2026-05-08T13:44:33.140Z"
+doc_updated_by: "CODER"
+description: "Update cloud backend push sync so local freshness state changes only when the cloud service explicitly returns last_checked_at, avoiding a false-fresh state after push responses without server freshness evidence."
+sections:
+  Summary: |-
+    Fix cloud push freshness timestamp semantics
+    
+    Update cloud backend push sync so local freshness state changes only when the cloud service explicitly returns last_checked_at, avoiding a false-fresh state after push responses without server freshness evidence.
+  Scope: |-
+    - In scope: Update cloud backend push sync so local freshness state changes only when the cloud service explicitly returns last_checked_at, avoiding a false-fresh state after push responses without server freshness evidence.
+    - Out of scope: unrelated refactors not required for "Fix cloud push freshness timestamp semantics".
+  Plan: "Primary batch task for release cleanup. Included tasks: 202605081305-MRT9N7, 202605081305-9GE36C, 202605081306-MACWWY. 1. Add regression coverage for cloud push responses that omit last_checked_at. 2. Change push sync state handling so it preserves previous freshness when the server omits last_checked_at. 3. Verify focused cloud backend tests and release gates."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-08T13:44:33.135Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: cloud push freshness now preserves prior state when push response omits last_checked_at. Commands: bun x vitest run packages/agentplane/src/backends/task-backend.cloud.test.ts (17 passed); bun run --filter=agentplane build; bun run release:check; bun run lint:core; bun run hotspots:check; ap doctor; node .agentplane/policy/check-routing.mjs; git diff --check.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-08T13:09:35.424Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605081305-MRT9N7-release-cleanup/.agentplane/tasks/202605081305-MRT9N7/blueprint/resolved-snapshot.json
+    - old_digest: 67692a92b75ae7bd82b7fb382430df912f28de7c0a775fb8e8becb772a4d539f
+    - current_digest: 67692a92b75ae7bd82b7fb382430df912f28de7c0a775fb8e8becb772a4d539f
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605081305-MRT9N7
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605081305-MRT9N7/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605081305-MRT9N7/blueprint/resolved-snapshot.json
@@ -1,0 +1,499 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605081305-MRT9N7",
+    "title": "Fix cloud push freshness timestamp semantics",
+    "description": "Update cloud backend push sync so local freshness state changes only when the cloud service explicitly returns last_checked_at, avoiding a false-fresh state after push responses without server freshness evidence.",
+    "tags": [
+      "backend",
+      "cloud",
+      "code",
+      "sync"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605081305-MRT9N7",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "67692a92b75ae7bd82b7fb382430df912f28de7c0a775fb8e8becb772a4d539f"
+  }
+}

--- a/.agentplane/tasks/202605081305-MRT9N7/pr/diffstat.txt
+++ b/.agentplane/tasks/202605081305-MRT9N7/pr/diffstat.txt
@@ -1,0 +1,11 @@
+ .agentplane/tasks/202605081305-9GE36C/README.md    |  88 +++
+ .../blueprint/resolved-snapshot.json               | 498 ++++++++++++++++
+ .../blueprint/resolved-snapshot.json               | 499 ++++++++++++++++
+ .agentplane/tasks/202605081306-MACWWY/README.md    |  88 +++
+ .../blueprint/resolved-snapshot.json               | 498 ++++++++++++++++
+ knip.json                                          |   3 +-
+ .../src/backends/task-backend.cloud.test.ts        |  40 ++
+ .../backends/task-backend/cloud-backend-utils.ts   |  18 +-
+ .../src/backends/task-backend/cloud-backend.ts     |  21 +-
+ scripts/baselines/knip-baseline.json               | 629 +++++++++++++++++++--
+ 10 files changed, 2305 insertions(+), 77 deletions(-)

--- a/.agentplane/tasks/202605081305-MRT9N7/pr/github-body.md
+++ b/.agentplane/tasks/202605081305-MRT9N7/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605081305-MRT9N7`
+Title: Fix cloud push freshness timestamp semantics
+Canonical task record: `.agentplane/tasks/202605081305-MRT9N7/README.md`
+
+## Summary
+
+Fix cloud push freshness timestamp semantics
+
+Update cloud backend push sync so local freshness state changes only when the cloud service explicitly returns last_checked_at, avoiding a false-fresh state after push responses without server freshness evidence.
+
+## Scope
+
+- In scope: Update cloud backend push sync so local freshness state changes only when the cloud service explicitly returns last_checked_at, avoiding a false-fresh state after push responses without server freshness evidence.
+- Out of scope: unrelated refactors not required for "Fix cloud push freshness timestamp semantics".
+
+## Verification
+
+- State: ok
+- Note: Verified: cloud push freshness now preserves prior state when push response omits last_checked_at. Commands: bun x vitest run packages/agentplane/src/backends/task-backend.cloud.test.ts (17 passed); bun run --filter=agentplane build; bun run release:check; bun run lint:core; bun run hotspots:check; ap doctor; node .agentplane/policy/check-routing.mjs; git diff --check.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-08T13:09:35.782Z
+- Branch: task/202605081305-MRT9N7/release-cleanup
+- Head: 408172ebeae8
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605081305-MRT9N7/pr/github-body.md
+++ b/.agentplane/tasks/202605081305-MRT9N7/pr/github-body.md
@@ -22,12 +22,22 @@ Update cloud backend push sync so local freshness state changes only when the cl
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-08T13:09:35.782Z
+- Updated: 2026-05-08T13:45:58.452Z
 - Branch: task/202605081305-MRT9N7/release-cleanup
-- Head: 408172ebeae8
+- Head: 0dc0172521f0
 
 ```text
-No changes detected.
+ .agentplane/tasks/202605081305-9GE36C/README.md    |  88 +++
+ .../blueprint/resolved-snapshot.json               | 498 ++++++++++++++++
+ .../blueprint/resolved-snapshot.json               | 499 ++++++++++++++++
+ .agentplane/tasks/202605081306-MACWWY/README.md    |  88 +++
+ .../blueprint/resolved-snapshot.json               | 498 ++++++++++++++++
+ knip.json                                          |   3 +-
+ .../src/backends/task-backend.cloud.test.ts        |  40 ++
+ .../backends/task-backend/cloud-backend-utils.ts   |  18 +-
+ .../src/backends/task-backend/cloud-backend.ts     |  21 +-
+ scripts/baselines/knip-baseline.json               | 629 +++++++++++++++++++--
+ 10 files changed, 2305 insertions(+), 77 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605081305-MRT9N7/pr/github-title.txt
+++ b/.agentplane/tasks/202605081305-MRT9N7/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 MRT9N7 task: Fix cloud push freshness timestamp semantics [202605081305-MRT9N7]

--- a/.agentplane/tasks/202605081305-MRT9N7/pr/meta.json
+++ b/.agentplane/tasks/202605081305-MRT9N7/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605081305-MRT9N7/release-cleanup",
   "created_at": "2026-05-08T13:09:35.782Z",
-  "head_sha": "408172ebeae83bb536e5bab1054cd75a6425c991",
+  "head_sha": "0dc0172521f09a6f8162ea2a94ca4dc778bc2ab8",
   "last_verified_at": "2026-05-08T13:44:33.135Z",
   "last_verified_sha": "408172ebeae83bb536e5bab1054cd75a6425c991",
   "schema_version": 1,
   "task_id": "202605081305-MRT9N7",
-  "updated_at": "2026-05-08T13:09:35.782Z",
+  "updated_at": "2026-05-08T13:45:58.452Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605081305-MRT9N7/pr/meta.json
+++ b/.agentplane/tasks/202605081305-MRT9N7/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605081305-MRT9N7/release-cleanup",
+  "created_at": "2026-05-08T13:09:35.782Z",
+  "head_sha": "408172ebeae83bb536e5bab1054cd75a6425c991",
+  "last_verified_at": "2026-05-08T13:44:33.135Z",
+  "last_verified_sha": "408172ebeae83bb536e5bab1054cd75a6425c991",
+  "schema_version": 1,
+  "task_id": "202605081305-MRT9N7",
+  "updated_at": "2026-05-08T13:09:35.782Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605081305-MRT9N7/pr/review.md
+++ b/.agentplane/tasks/202605081305-MRT9N7/pr/review.md
@@ -24,12 +24,22 @@ Created: 2026-05-08T13:09:35.782Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-08T13:09:35.782Z
+- Updated: 2026-05-08T13:45:58.452Z
 - Branch: task/202605081305-MRT9N7/release-cleanup
-- Head: 408172ebeae8
+- Head: 0dc0172521f0
 
 ```text
-No changes detected.
+ .agentplane/tasks/202605081305-9GE36C/README.md    |  88 +++
+ .../blueprint/resolved-snapshot.json               | 498 ++++++++++++++++
+ .../blueprint/resolved-snapshot.json               | 499 ++++++++++++++++
+ .agentplane/tasks/202605081306-MACWWY/README.md    |  88 +++
+ .../blueprint/resolved-snapshot.json               | 498 ++++++++++++++++
+ knip.json                                          |   3 +-
+ .../src/backends/task-backend.cloud.test.ts        |  40 ++
+ .../backends/task-backend/cloud-backend-utils.ts   |  18 +-
+ .../src/backends/task-backend/cloud-backend.ts     |  21 +-
+ scripts/baselines/knip-baseline.json               | 629 +++++++++++++++++++--
+ 10 files changed, 2305 insertions(+), 77 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605081305-MRT9N7/pr/review.md
+++ b/.agentplane/tasks/202605081305-MRT9N7/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-08T13:09:35.782Z
+
+## Task
+
+- Task: `202605081305-MRT9N7`
+- Title: Fix cloud push freshness timestamp semantics
+- Status: DOING
+- Branch: `task/202605081305-MRT9N7/release-cleanup`
+- Canonical task record: `.agentplane/tasks/202605081305-MRT9N7/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified: cloud push freshness now preserves prior state when push response omits last_checked_at. Commands: bun x vitest run packages/agentplane/src/backends/task-backend.cloud.test.ts (17 passed); bun run --filter=agentplane build; bun run release:check; bun run lint:core; bun run hotspots:check; ap doctor; node .agentplane/policy/check-routing.mjs; git diff --check.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-08T13:09:35.782Z
+- Branch: task/202605081305-MRT9N7/release-cleanup
+- Head: 408172ebeae8
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605081306-MACWWY/README.md
+++ b/.agentplane/tasks/202605081306-MACWWY/README.md
@@ -1,0 +1,88 @@
+---
+id: "202605081306-MACWWY"
+title: "Ignore bin declaration files in knip baseline"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "ci"
+  - "code"
+  - "knip"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-08T13:07:32.749Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-08T13:45:01.562Z"
+  updated_by: "CODER"
+  note: "Verified: knip ignores package bin declaration files and baseline was refreshed for reviewed current unused-code debt after removing stale declaration-file false positives. Commands: bun run knip:check -- --update-baseline; bun run knip:check (OK, total=572); bun run lint:core; bun run release:check; ap doctor."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: remove knip false-positive bin declaration files from the release-cleanup baseline."
+events:
+  -
+    type: "status"
+    at: "2026-05-08T13:10:00.775Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: remove knip false-positive bin declaration files from the release-cleanup baseline."
+  -
+    type: "verify"
+    at: "2026-05-08T13:45:01.562Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: knip ignores package bin declaration files and baseline was refreshed for reviewed current unused-code debt after removing stale declaration-file false positives. Commands: bun run knip:check -- --update-baseline; bun run knip:check (OK, total=572); bun run lint:core; bun run release:check; ap doctor."
+doc_version: 3
+doc_updated_at: "2026-05-08T13:45:01.568Z"
+doc_updated_by: "CODER"
+description: "Teach knip baseline handling to ignore package bin declaration files that are required as sibling TypeScript declarations for JavaScript bin imports, then refresh the baseline."
+sections:
+  Summary: |-
+    Ignore bin declaration files in knip baseline
+    
+    Teach knip baseline handling to ignore package bin declaration files that are required as sibling TypeScript declarations for JavaScript bin imports, then refresh the baseline.
+  Scope: |-
+    - In scope: Teach knip baseline handling to ignore package bin declaration files that are required as sibling TypeScript declarations for JavaScript bin imports, then refresh the baseline.
+    - Out of scope: unrelated refactors not required for "Ignore bin declaration files in knip baseline".
+  Plan: "Related batch task included in primary 202605081305-MRT9N7. 1. Add a knip ignore for package bin declaration files that are required as sibling declarations for JavaScript bin modules. 2. Refresh/check the knip baseline so false-positive file entries disappear without masking real unused exports/types. 3. Verify knip baseline check and lint."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-08T13:45:01.562Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: knip ignores package bin declaration files and baseline was refreshed for reviewed current unused-code debt after removing stale declaration-file false positives. Commands: bun run knip:check -- --update-baseline; bun run knip:check (OK, total=572); bun run lint:core; bun run release:check; ap doctor.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-08T13:10:00.802Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605081305-MRT9N7-release-cleanup/.agentplane/tasks/202605081306-MACWWY/blueprint/resolved-snapshot.json
+    - old_digest: 35c083bafec3d5111d309e85957fe4f2eb5b94a13af0e47447000f2a9eb74ef3
+    - current_digest: 35c083bafec3d5111d309e85957fe4f2eb5b94a13af0e47447000f2a9eb74ef3
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605081306-MACWWY
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605081306-MACWWY/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605081306-MACWWY/blueprint/resolved-snapshot.json
@@ -1,0 +1,498 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605081306-MACWWY",
+    "title": "Ignore bin declaration files in knip baseline",
+    "description": "Teach knip baseline handling to ignore package bin declaration files that are required as sibling TypeScript declarations for JavaScript bin imports, then refresh the baseline.",
+    "tags": [
+      "ci",
+      "code",
+      "knip"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605081306-MACWWY",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "35c083bafec3d5111d309e85957fe4f2eb5b94a13af0e47447000f2a9eb74ef3"
+  }
+}

--- a/knip.json
+++ b/knip.json
@@ -21,7 +21,8 @@
     "docs/**",
     "website/**",
     "packages/*/dist/**",
-    "packages/*/node_modules/**"
+    "packages/*/node_modules/**",
+    "packages/agentplane/bin/*.d.ts"
   ],
   "lefthook": false
 }

--- a/packages/agentplane/src/backends/task-backend.cloud.test.ts
+++ b/packages/agentplane/src/backends/task-backend.cloud.test.ts
@@ -111,6 +111,46 @@ describe("CloudBackend", () => {
     expect(stateText).toContain("2026-05-06T00:00:00.000Z");
   });
 
+  it("push sync preserves previous freshness when response omits last check time", async () => {
+    const cache = new LocalBackend({ dir: path.join(tempDir, ".agentplane", "tasks") });
+    await cache.writeTask({
+      id: "202605051806-C1D2",
+      title: "Cloud task",
+      description: "Sync this task",
+      status: "TODO",
+      priority: "med",
+      owner: "CODER",
+      depends_on: [],
+      tags: ["cloud"],
+      verify: [],
+    });
+    const stateDir = path.join(tempDir, ".agentplane", "backends", "cloud");
+    await mkdir(stateDir, { recursive: true });
+    await writeFile(
+      path.join(stateDir, "state.json"),
+      `${JSON.stringify({ last_checked_at: "2026-05-05T00:00:00.000Z" }, null, 2)}\n`,
+      "utf8",
+    );
+    const fetchImpl = vi.fn<typeof fetch>(() =>
+      Promise.resolve(Response.json({ data: { no_projection_changes: true } })),
+    );
+    const backend = new CloudBackend(
+      {
+        endpoint: "https://cloud.example/",
+        token: "token",
+        project_id: "project-1",
+        provider: "github-projects",
+      },
+      { root: tempDir, cache, fetchImpl },
+    );
+
+    await backend.sync({ direction: "push", conflict: "diff", quiet: true, confirm: true });
+
+    const stateText = await readFile(path.join(stateDir, "state.json"), "utf8");
+    expect(stateText).toContain("2026-05-05T00:00:00.000Z");
+    expect(stateText).not.toContain("2026-05-06T00:00:00.000Z");
+  });
+
   it("push sync uploads oversized projections in finalized batches", async () => {
     const cache = new LocalBackend({ dir: path.join(tempDir, ".agentplane", "tasks") });
     const largeText = "x".repeat(400_000);

--- a/packages/agentplane/src/backends/task-backend/cloud-backend-utils.ts
+++ b/packages/agentplane/src/backends/task-backend/cloud-backend-utils.ts
@@ -1,4 +1,5 @@
 import { BackendError, type TaskData } from "./shared.js";
+import { isRecord } from "../../shared/guards.js";
 
 export type CloudSyncResponse = {
   data?: unknown;
@@ -12,19 +13,6 @@ export type CloudSyncResponse = {
 export const CLOUD_PUSH_DIRECT_BODY_LIMIT_BYTES = 750_000;
 export const CLOUD_PUSH_BATCH_TASK_BYTES = 600_000;
 export const CLOUD_PUSH_BATCH_RETRY_DELAYS_MS = [0, 1500, 3000] as const;
-
-export function firstNonEmpty(...values: unknown[]): string {
-  for (const value of values) {
-    if (typeof value !== "string") continue;
-    const trimmed = value.trim();
-    if (trimmed) return trimmed;
-  }
-  return "";
-}
-
-export function isRecord(input: unknown): input is Record<string, unknown> {
-  return Boolean(input && typeof input === "object" && !Array.isArray(input));
-}
 
 export function normalizeCloudPullResponse(
   response: CloudSyncResponse,
@@ -105,10 +93,6 @@ export function normalizePositiveInteger(input: unknown): number | null {
   if (typeof input !== "number" || !Number.isFinite(input)) return null;
   const value = Math.trunc(input);
   return value > 0 ? value : null;
-}
-
-export function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export function splitTasksByPayloadBytes(tasks: TaskData[], maxBytes: number): TaskData[][] {

--- a/packages/agentplane/src/backends/task-backend/cloud-backend.ts
+++ b/packages/agentplane/src/backends/task-backend/cloud-backend.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 
 import { loadDotEnv } from "../../shared/env.js";
+import { isRecord } from "../../shared/guards.js";
 import {
   BackendError,
   type TaskBackend,
@@ -20,17 +21,16 @@ import {
   cloudConflictMessage,
   cloudHttpErrorMessage,
   cloudPushBatchFinalized,
-  firstNonEmpty,
   isOptionalSyncStateFailure,
-  isRecord,
   isStale,
   normalizeCloudPullResponse,
   normalizePositiveInteger,
   readSafeCommand,
-  sleep,
   splitTasksByPayloadBytes,
   type CloudSyncResponse,
 } from "./cloud-backend-utils.js";
+import { sleep } from "./shared/concurrency.js";
+import { firstNonEmptyString } from "./shared/strings.js";
 
 export type CloudBackendSettings = {
   endpoint?: string;
@@ -87,18 +87,22 @@ export class CloudBackend implements TaskBackend {
     settings: CloudBackendSettings,
     opts: { cache: LocalBackend; root: string; fetchImpl?: FetchLike },
   ) {
-    const endpoint = firstNonEmpty(
+    const endpoint = firstNonEmptyString(
       process.env.AGENTPLANE_CLOUD_ENDPOINT,
       settings.endpoint,
     ).replaceAll(/\/+$/gu, "");
     this.endpoint = endpoint;
-    this.token = firstNonEmpty(process.env.AGENTPLANE_CLOUD_TOKEN, settings.token);
-    this.projectId = firstNonEmpty(process.env.AGENTPLANE_CLOUD_PROJECT_ID, settings.project_id);
-    this.provider = firstNonEmpty(process.env.AGENTPLANE_CLOUD_PROVIDER, settings.provider) || null;
+    this.token = firstNonEmptyString(process.env.AGENTPLANE_CLOUD_TOKEN, settings.token);
+    this.projectId = firstNonEmptyString(
+      process.env.AGENTPLANE_CLOUD_PROJECT_ID,
+      settings.project_id,
+    );
+    this.provider =
+      firstNonEmptyString(process.env.AGENTPLANE_CLOUD_PROVIDER, settings.provider) || null;
     this.cache = opts.cache;
     this.statePath = path.resolve(
       opts.root,
-      firstNonEmpty(settings.state_path, ".agentplane/backends/cloud/state.json"),
+      firstNonEmptyString(settings.state_path, ".agentplane/backends/cloud/state.json"),
     );
     this.staleAfterSeconds = normalizePositiveInteger(settings.stale_after_seconds) ?? 300;
     this.fetchImpl = opts.fetchImpl ?? fetch;
@@ -286,6 +290,7 @@ export class CloudBackend implements TaskBackend {
         await this.cache.writeTasks(plan.changed);
       }
     }
+    if (opts.direction === "push" && !pull.lastCheckedAt) return;
     await this.writeState({
       last_checked_at: pull.lastCheckedAt ?? new Date().toISOString(),
     });

--- a/scripts/baselines/knip-baseline.json
+++ b/scripts/baselines/knip-baseline.json
@@ -3,38 +3,6 @@
   "generated_by": "check-knip-baseline.mjs",
   "entries": [
     {
-      "file": "packages/agentplane/bin/framework-dev-contract.d.ts",
-      "files": [
-        {
-          "name": "packages/agentplane/bin/framework-dev-contract.d.ts"
-        }
-      ]
-    },
-    {
-      "file": "packages/agentplane/bin/runtime-context.d.ts",
-      "files": [
-        {
-          "name": "packages/agentplane/bin/runtime-context.d.ts"
-        }
-      ]
-    },
-    {
-      "file": "packages/agentplane/bin/runtime-watch.d.ts",
-      "files": [
-        {
-          "name": "packages/agentplane/bin/runtime-watch.d.ts"
-        }
-      ]
-    },
-    {
-      "file": "packages/agentplane/bin/stale-dist-policy.d.ts",
-      "files": [
-        {
-          "name": "packages/agentplane/bin/stale-dist-policy.d.ts"
-        }
-      ]
-    },
-    {
       "file": "packages/agentplane/src/agents/agents-template.ts",
       "types": [
         {
@@ -45,6 +13,16 @@
         {
           "name": "MarkdownPromptTemplate",
           "line": 35,
+          "col": 13
+        }
+      ]
+    },
+    {
+      "file": "packages/agentplane/src/backends/task-backend/cloud-pull.ts",
+      "types": [
+        {
+          "name": "CloudPullPlan",
+          "line": 3,
           "col": 13
         }
       ]
@@ -136,12 +114,496 @@
       "types": [
         {
           "name": "TaskIndexFile",
-          "line": 23,
+          "line": 35,
           "col": 13
         },
         {
           "name": "TaskIndexFileV2",
+          "line": 28,
+          "col": 13
+        }
+      ]
+    },
+    {
+      "file": "packages/agentplane/src/blueprints/execution.ts",
+      "exports": [
+        {
+          "name": "blueprintExecutionPlanStep",
+          "line": 22,
+          "col": 17
+        },
+        {
+          "name": "blueprintNodeExecutionContract",
+          "line": 167,
+          "col": 17
+        }
+      ]
+    },
+    {
+      "file": "packages/agentplane/src/blueprints/index.ts",
+      "exports": [
+        {
+          "name": "blueprintExecutionPlanStep",
+          "line": 24,
+          "col": 3
+        },
+        {
+          "name": "blueprintNodeExecutionContract",
+          "line": 25,
+          "col": 3
+        },
+        {
+          "name": "blueprintPlanEvidence",
+          "line": 31,
+          "col": 10
+        },
+        {
+          "name": "blueprintPlanState",
+          "line": 31,
+          "col": 33
+        },
+        {
+          "name": "blueprintSnapshotDigest",
+          "line": 42,
+          "col": 3
+        },
+        {
+          "name": "blueprintSnapshotPayloadForDigest",
+          "line": 43,
+          "col": 3
+        },
+        {
+          "name": "BUILTIN_BLUEPRINTS",
+          "line": 1,
+          "col": 10
+        },
+        {
+          "name": "checkBlueprintExecutionReplay",
+          "line": 28,
+          "col": 3
+        },
+        {
+          "name": "checkBlueprintExecutionResume",
+          "line": 29,
+          "col": 3
+        },
+        {
+          "name": "getBlueprint",
+          "line": 4,
+          "col": 3
+        },
+        {
+          "name": "loadProjectBlueprintTrustConfig",
+          "line": 13,
+          "col": 3
+        },
+        {
+          "name": "parseProjectBlueprintJson",
+          "line": 15,
+          "col": 3
+        },
+        {
+          "name": "PROJECT_BLUEPRINTS_CONFIG_NAME",
+          "line": 10,
+          "col": 3
+        },
+        {
+          "name": "PROJECT_BLUEPRINTS_DIR",
+          "line": 9,
+          "col": 3
+        },
+        {
+          "name": "projectBlueprintsConfigPath",
+          "line": 16,
+          "col": 3
+        },
+        {
+          "name": "recipeBlueprintExtensionToHint",
+          "line": 33,
+          "col": 3
+        },
+        {
+          "name": "requireBlueprint",
+          "line": 6,
+          "col": 3
+        },
+        {
+          "name": "stableBlueprintSnapshotJson",
+          "line": 45,
+          "col": 3
+        },
+        {
+          "name": "validateBlueprintPlanArtifact",
+          "line": 50,
+          "col": 3
+        },
+        {
+          "name": "validateBlueprintRegistry",
+          "line": 51,
+          "col": 3
+        },
+        {
+          "name": "validateRecipeHintsForBlueprint",
+          "line": 39,
+          "col": 3
+        }
+      ],
+      "types": [
+        {
+          "name": "AcceptedRecipeExtension",
+          "line": 54,
+          "col": 3
+        },
+        {
+          "name": "BlueprintContextBudget",
+          "line": 56,
+          "col": 3
+        },
+        {
+          "name": "BlueprintDefinition",
+          "line": 58,
+          "col": 3
+        },
+        {
+          "name": "BlueprintEdge",
+          "line": 59,
+          "col": 3
+        },
+        {
+          "name": "BlueprintExecutionCheckProblem",
+          "line": 64,
+          "col": 3
+        },
+        {
+          "name": "BlueprintExecutionCheckProblemCode",
+          "line": 65,
+          "col": 3
+        },
+        {
+          "name": "BlueprintExecutionCheckResult",
+          "line": 66,
+          "col": 3
+        },
+        {
+          "name": "BlueprintExecutionEventType",
+          "line": 63,
+          "col": 3
+        },
+        {
+          "name": "BlueprintExecutionEvidenceRef",
+          "line": 67,
+          "col": 3
+        },
+        {
+          "name": "BlueprintExecutionNodeStatus",
+          "line": 68,
+          "col": 3
+        },
+        {
+          "name": "BlueprintExecutionPlanArtifact",
+          "line": 69,
+          "col": 3
+        },
+        {
+          "name": "BlueprintExecutionPlanStep",
+          "line": 70,
+          "col": 3
+        },
+        {
+          "name": "BlueprintExecutionStateArtifact",
+          "line": 71,
+          "col": 3
+        },
+        {
+          "name": "BlueprintExecutionStateEvent",
+          "line": 72,
+          "col": 3
+        },
+        {
+          "name": "BlueprintExecutionStateNode",
+          "line": 73,
+          "col": 3
+        },
+        {
+          "name": "BlueprintExplainEvidence",
+          "line": 60,
+          "col": 3
+        },
+        {
+          "name": "BlueprintExplainNode",
+          "line": 61,
+          "col": 3
+        },
+        {
+          "name": "BlueprintNode",
+          "line": 88,
+          "col": 3
+        },
+        {
+          "name": "BlueprintNodeExecutionContract",
+          "line": 75,
+          "col": 3
+        },
+        {
+          "name": "BlueprintNodeKind",
+          "line": 89,
+          "col": 3
+        },
+        {
+          "name": "BlueprintNodeMode",
+          "line": 90,
+          "col": 3
+        },
+        {
+          "name": "BlueprintPlanState",
+          "line": 77,
+          "col": 3
+        },
+        {
+          "name": "BlueprintPlanValidationProblem",
+          "line": 78,
+          "col": 3
+        },
+        {
+          "name": "BlueprintPlanValidationResult",
+          "line": 79,
+          "col": 3
+        },
+        {
+          "name": "BlueprintRegistry",
+          "line": 92,
+          "col": 3
+        },
+        {
+          "name": "BlueprintSnapshotDigest",
+          "line": 81,
+          "col": 3
+        },
+        {
+          "name": "BlueprintSnapshotResolverInput",
+          "line": 82,
+          "col": 3
+        },
+        {
+          "name": "BlueprintSnapshotSelectedBlueprint",
+          "line": 83,
+          "col": 3
+        },
+        {
+          "name": "BlueprintSnapshotValidationProblem",
+          "line": 84,
+          "col": 3
+        },
+        {
+          "name": "BlueprintState",
+          "line": 86,
+          "col": 3
+        },
+        {
+          "name": "BlueprintTaskIntent",
+          "line": 87,
+          "col": 3
+        },
+        {
+          "name": "BlueprintValidationProblem",
+          "line": 93,
+          "col": 3
+        },
+        {
+          "name": "BlueprintValidationResult",
+          "line": 94,
+          "col": 3
+        },
+        {
+          "name": "EvidenceKind",
+          "line": 95,
+          "col": 3
+        },
+        {
+          "name": "EvidenceRequirement",
+          "line": 96,
+          "col": 3
+        },
+        {
+          "name": "ProjectBlueprintCompatibilityReport",
+          "line": 114,
+          "col": 3
+        },
+        {
+          "name": "ProjectBlueprintDirectoryResult",
+          "line": 112,
+          "col": 3
+        },
+        {
+          "name": "ProjectBlueprintFileResult",
+          "line": 113,
+          "col": 3
+        },
+        {
+          "name": "ProjectBlueprintProblem",
+          "line": 115,
+          "col": 3
+        },
+        {
+          "name": "ProjectBlueprintProblemCode",
+          "line": 116,
+          "col": 3
+        },
+        {
+          "name": "ProjectBlueprintTrustConfig",
+          "line": 117,
+          "col": 3
+        },
+        {
+          "name": "ProjectBlueprintTrustConfigResult",
+          "line": 118,
+          "col": 3
+        },
+        {
+          "name": "RecipeExtensionKind",
+          "line": 98,
+          "col": 3
+        },
+        {
+          "name": "RecipeExtensionPoint",
+          "line": 100,
+          "col": 3
+        },
+        {
+          "name": "RecipeHint",
+          "line": 99,
+          "col": 3
+        },
+        {
+          "name": "RejectedRecipeExtension",
+          "line": 101,
+          "col": 3
+        },
+        {
+          "name": "ResolvedBlueprint",
+          "line": 102,
+          "col": 3
+        },
+        {
+          "name": "ScaffoldProjectBlueprintOptions",
+          "line": 119,
+          "col": 3
+        },
+        {
+          "name": "SkippedNode",
+          "line": 104,
+          "col": 3
+        },
+        {
+          "name": "StopReason",
+          "line": 105,
+          "col": 3
+        },
+        {
+          "name": "StopRule",
+          "line": 106,
+          "col": 3
+        },
+        {
+          "name": "StopRuleSeverity",
+          "line": 107,
+          "col": 3
+        },
+        {
+          "name": "TrustedProjectBlueprintRegistryResult",
+          "line": 120,
+          "col": 3
+        }
+      ]
+    },
+    {
+      "file": "packages/agentplane/src/blueprints/model.ts",
+      "types": [
+        {
+          "name": "BlueprintDefinition",
+          "line": 84,
+          "col": 13
+        },
+        {
+          "name": "BlueprintState",
+          "line": 85,
+          "col": 13
+        }
+      ]
+    },
+    {
+      "file": "packages/agentplane/src/blueprints/plan.ts",
+      "exports": [
+        {
+          "name": "blueprintPlanState",
+          "line": 31,
+          "col": 17
+        }
+      ]
+    },
+    {
+      "file": "packages/agentplane/src/blueprints/project-local.ts",
+      "exports": [
+        {
+          "name": "parseProjectBlueprintJson",
+          "line": 247,
+          "col": 17
+        },
+        {
+          "name": "PROJECT_BLUEPRINTS_CONFIG_NAME",
+          "line": 15,
+          "col": 14
+        },
+        {
+          "name": "PROJECT_BLUEPRINTS_DIR",
+          "line": 14,
+          "col": 14
+        }
+      ],
+      "types": [
+        {
+          "name": "ProjectBlueprintCompatibilityReport",
+          "line": 71,
+          "col": 13
+        },
+        {
+          "name": "ProjectBlueprintDirectoryResult",
+          "line": 39,
+          "col": 13
+        },
+        {
+          "name": "ProjectBlueprintFileResult",
+          "line": 31,
+          "col": 13
+        },
+        {
+          "name": "ProjectBlueprintProblem",
+          "line": 25,
+          "col": 13
+        },
+        {
+          "name": "ProjectBlueprintProblemCode",
           "line": 17,
+          "col": 13
+        },
+        {
+          "name": "ProjectBlueprintTrustConfig",
+          "line": 46,
+          "col": 13
+        },
+        {
+          "name": "ProjectBlueprintTrustConfigResult",
+          "line": 54,
+          "col": 13
+        },
+        {
+          "name": "ScaffoldProjectBlueprintOptions",
+          "line": 92,
+          "col": 13
+        },
+        {
+          "name": "TrustedProjectBlueprintRegistryResult",
+          "line": 62,
           "col": 13
         }
       ]
@@ -288,7 +750,12 @@
       "exports": [
         {
           "name": "getCommandInvocation",
-          "line": 51,
+          "line": 52,
+          "col": 17
+        },
+        {
+          "name": "isCommandVisibleInHelp",
+          "line": 60,
           "col": 17
         }
       ],
@@ -315,12 +782,12 @@
       "types": [
         {
           "name": "CommandMeta",
-          "line": 31,
+          "line": 34,
           "col": 13
         },
         {
           "name": "CommandModule",
-          "line": 36,
+          "line": 41,
           "col": 13
         }
       ]
@@ -385,7 +852,7 @@
         },
         {
           "name": "HelpRegistryView",
-          "line": 19,
+          "line": 20,
           "col": 13
         }
       ]
@@ -439,6 +906,36 @@
           "name": "UpdateCheckFetchResult",
           "line": 21,
           "col": 13
+        }
+      ]
+    },
+    {
+      "file": "packages/agentplane/src/commands/blueprint/snapshot-artifact.ts",
+      "exports": [
+        {
+          "name": "BLUEPRINT_SNAPSHOT_ARTIFACT_PATH",
+          "line": 19,
+          "col": 14
+        },
+        {
+          "name": "buildTaskBlueprintResolvedSnapshot",
+          "line": 30,
+          "col": 23
+        },
+        {
+          "name": "readTaskBlueprintResolvedSnapshot",
+          "line": 69,
+          "col": 23
+        }
+      ]
+    },
+    {
+      "file": "packages/agentplane/src/commands/blueprint/task-input.ts",
+      "exports": [
+        {
+          "name": "inferMutationFromTask",
+          "line": 47,
+          "col": 17
         }
       ]
     },
@@ -589,17 +1086,17 @@
       "exports": [
         {
           "name": "renderPrHandoffNotes",
-          "line": 215,
+          "line": 165,
           "col": 17
         },
         {
           "name": "updateAutoSummaryBlock",
-          "line": 193,
+          "line": 143,
           "col": 17
         },
         {
           "name": "updateHandoffNotesBlock",
-          "line": 224,
+          "line": 174,
           "col": 17
         }
       ]
@@ -1389,6 +1886,16 @@
       ]
     },
     {
+      "file": "packages/agentplane/src/commands/task/blueprint-summary.ts",
+      "types": [
+        {
+          "name": "TaskBlueprintLifecycleSummary",
+          "line": 12,
+          "col": 13
+        }
+      ]
+    },
+    {
       "file": "packages/agentplane/src/commands/task/findings.ts",
       "exports": [
         {
@@ -1420,7 +1927,7 @@
       "exports": [
         {
           "name": "assertTaskCanFinish",
-          "line": 79,
+          "line": 81,
           "col": 17
         }
       ]
@@ -1506,6 +2013,11 @@
           "col": 10
         },
         {
+          "name": "cmdTaskObsidian",
+          "line": 30,
+          "col": 10
+        },
+        {
           "name": "cmdTaskSetStatus",
           "line": 18,
           "col": 10
@@ -1550,6 +2062,26 @@
         {
           "name": "TaskDocMigrationResult",
           "line": 23,
+          "col": 13
+        }
+      ]
+    },
+    {
+      "file": "packages/agentplane/src/commands/task/obsidian.ts",
+      "types": [
+        {
+          "name": "ObsidianCleanResult",
+          "line": 22,
+          "col": 13
+        },
+        {
+          "name": "ObsidianProjectionFile",
+          "line": 12,
+          "col": 13
+        },
+        {
+          "name": "ObsidianProjectionResult",
+          "line": 17,
           "col": 13
         }
       ]
@@ -1793,11 +2325,6 @@
     {
       "file": "packages/agentplane/src/commands/upgrade/policy.ts",
       "exports": [
-        {
-          "name": "CONFIG_REL_PATH",
-          "line": 5,
-          "col": 14
-        },
         {
           "name": "INCIDENTS_APPEND_MARKER",
           "line": 4,
@@ -2169,7 +2696,7 @@
       "exports": [
         {
           "name": "parseRunnerEventsText",
-          "line": 28,
+          "line": 34,
           "col": 17
         }
       ]
@@ -3263,11 +3790,11 @@
     }
   ],
   "counts": {
-    "files": 5,
-    "exports": 174,
-    "types": 296,
+    "files": 1,
+    "exports": 206,
+    "types": 365,
     "enumMembers": 0,
     "namespaceMembers": 0,
-    "total": 475
+    "total": 572
   }
 }


### PR DESCRIPTION
Task: `202605081305-MRT9N7`
Title: Fix cloud push freshness timestamp semantics
Canonical task record: `.agentplane/tasks/202605081305-MRT9N7/README.md`

## Summary

Fix cloud push freshness timestamp semantics

Update cloud backend push sync so local freshness state changes only when the cloud service explicitly returns last_checked_at, avoiding a false-fresh state after push responses without server freshness evidence.

## Scope

- In scope: Update cloud backend push sync so local freshness state changes only when the cloud service explicitly returns last_checked_at, avoiding a false-fresh state after push responses without server freshness evidence.
- Out of scope: unrelated refactors not required for "Fix cloud push freshness timestamp semantics".

## Verification

- State: ok
- Note: Verified: cloud push freshness now preserves prior state when push response omits last_checked_at. Commands: bun x vitest run packages/agentplane/src/backends/task-backend.cloud.test.ts (17 passed); bun run --filter=agentplane build; bun run release:check; bun run lint:core; bun run hotspots:check; ap doctor; node .agentplane/policy/check-routing.mjs; git diff --check.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-08T13:45:58.452Z
- Branch: task/202605081305-MRT9N7/release-cleanup
- Head: 0dc0172521f0

```text
 .agentplane/tasks/202605081305-9GE36C/README.md    |  88 +++
 .../blueprint/resolved-snapshot.json               | 498 ++++++++++++++++
 .../blueprint/resolved-snapshot.json               | 499 ++++++++++++++++
 .agentplane/tasks/202605081306-MACWWY/README.md    |  88 +++
 .../blueprint/resolved-snapshot.json               | 498 ++++++++++++++++
 knip.json                                          |   3 +-
 .../src/backends/task-backend.cloud.test.ts        |  40 ++
 .../backends/task-backend/cloud-backend-utils.ts   |  18 +-
 .../src/backends/task-backend/cloud-backend.ts     |  21 +-
 scripts/baselines/knip-baseline.json               | 629 +++++++++++++++++++--
 10 files changed, 2305 insertions(+), 77 deletions(-)
```

</details>
