### PR TITLE
🚧 9P1DS0 task: Fix cloud backend Node address selection [202605090831-9P1DS0]

### DIFF
--- a/.agentplane/tasks/202605090831-9P1DS0/README.md
+++ b/.agentplane/tasks/202605090831-9P1DS0/README.md
@@ -1,0 +1,94 @@
+---
+id: "202605090831-9P1DS0"
+title: "Fix cloud backend Node address selection"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+task_kind: "code"
+mutation_scope: "code"
+risk_flags:
+  - "network"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-09T08:32:13.272Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-09T08:36:00.932Z"
+  updated_by: "CODER"
+  note: "Verified: bun test packages/agentplane/src/backends/task-backend.cloud.test.ts passed 24 tests; bun run typecheck passed; bun run --filter=agentplane build passed; git diff --check passed; node .agentplane/policy/check-routing.mjs passed; agentplane doctor OK; live patched CLI without NODE_OPTIONS successfully ran backend inspect cloud --yes and backend sync cloud --direction pull --yes against agentplane-cloud-sync, producing cloud pull diff changed=0 ignored_remote_only=0 conflicts=0."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement the cloud backend transport fix in the dedicated task worktree and verify Node v24 address-selection behavior without requiring NODE_OPTIONS."
+events:
+  -
+    type: "status"
+    at: "2026-05-09T08:33:06.089Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement the cloud backend transport fix in the dedicated task worktree and verify Node v24 address-selection behavior without requiring NODE_OPTIONS."
+  -
+    type: "verify"
+    at: "2026-05-09T08:36:00.932Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: bun test packages/agentplane/src/backends/task-backend.cloud.test.ts passed 24 tests; bun run typecheck passed; bun run --filter=agentplane build passed; git diff --check passed; node .agentplane/policy/check-routing.mjs passed; agentplane doctor OK; live patched CLI without NODE_OPTIONS successfully ran backend inspect cloud --yes and backend sync cloud --direction pull --yes against agentplane-cloud-sync, producing cloud pull diff changed=0 ignored_remote_only=0 conflicts=0."
+doc_version: 3
+doc_updated_at: "2026-05-09T08:36:00.942Z"
+doc_updated_by: "CODER"
+description: "Make AgentPlane cloud backend requests resilient to Node v24 network-family autoselection failures when IPv4 is slightly slower than the default 250ms attempt timeout and NAT64 IPv6 is unusable."
+sections:
+  Summary: |-
+    Fix cloud backend Node address selection
+    
+    Make AgentPlane cloud backend requests resilient to Node v24 network-family autoselection failures when IPv4 is slightly slower than the default 250ms attempt timeout and NAT64 IPv6 is unusable.
+  Scope: |-
+    - In scope: Make AgentPlane cloud backend requests resilient to Node v24 network-family autoselection failures when IPv4 is slightly slower than the default 250ms attempt timeout and NAT64 IPv6 is unusable.
+    - Out of scope: unrelated refactors not required for "Fix cloud backend Node address selection".
+  Plan: |-
+    1. Add a cloud backend transport helper that applies a safer Node network-family autoselection attempt timeout for built-in fetch without changing injected test fetch implementations.
+    2. Route cloud sync-state, pull, push, and push-batch requests through that helper so CLI users do not need NODE_OPTIONS for NAT64/slow-IPv4 environments.
+    3. Add focused unit coverage that verifies default cloud requests use the safer dispatcher/transport option while injected fetch remains untouched.
+    4. Verify with focused cloud backend tests, typecheck, and live cloud inspect/pull without NODE_OPTIONS from the affected environment.
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-09T08:36:00.932Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: bun test packages/agentplane/src/backends/task-backend.cloud.test.ts passed 24 tests; bun run typecheck passed; bun run --filter=agentplane build passed; git diff --check passed; node .agentplane/policy/check-routing.mjs passed; agentplane doctor OK; live patched CLI without NODE_OPTIONS successfully ran backend inspect cloud --yes and backend sync cloud --direction pull --yes against agentplane-cloud-sync, producing cloud pull diff changed=0 ignored_remote_only=0 conflicts=0.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T08:33:06.099Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605090831-9P1DS0-cloud-node-address-selection/.agentplane/tasks/202605090831-9P1DS0/blueprint/resolved-snapshot.json
+    - old_digest: 96c6302f381cecd05effa184eeeddb95eb8eaeeb5ced8ab67796d61f75c18e9e
+    - current_digest: 96c6302f381cecd05effa184eeeddb95eb8eaeeb5ced8ab67796d61f75c18e9e
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605090831-9P1DS0
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605090831-9P1DS0/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605090831-9P1DS0/blueprint/resolved-snapshot.json
@@ -1,0 +1,554 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605090831-9P1DS0",
+    "title": "Fix cloud backend Node address selection",
+    "description": "Make AgentPlane cloud backend requests resilient to Node v24 network-family autoselection failures when IPv4 is slightly slower than the default 250ms attempt timeout and NAT64 IPv6 is unusable.",
+    "tags": [
+      "code"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [
+      "network"
+    ]
+  },
+  "selectedBlueprint": {
+    "id": "performance.benchmark",
+    "version": 1,
+    "title": "Performance benchmark",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "performance.benchmark",
+    "blueprintVersion": 1,
+    "title": "Performance benchmark",
+    "taskId": "202605090831-9P1DS0",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "riskFlags": [
+        "network"
+      ]
+    },
+    "whySelected": [
+      "specialized code domain resolved to performance.benchmark",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "artifact"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "final_output"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "benchmark.baseline",
+        "kind": "artifact",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Baseline measurement artifact."
+      },
+      {
+        "id": "benchmark.method",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Benchmark method, environment, and warm/cold mode."
+      },
+      {
+        "id": "benchmark.runs",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Run count and raw measurement results."
+      },
+      {
+        "id": "benchmark.threshold",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Accepted threshold or noise tolerance."
+      },
+      {
+        "id": "benchmark.comparison",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Before/after comparison result."
+      },
+      {
+        "id": "benchmark.verdict",
+        "kind": "final_output",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Faster, slower, unchanged, or noisy verdict."
+      },
+      {
+        "id": "benchmark.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "benchmark baseline command",
+      "benchmark comparison command",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Benchmark work needs normal branch_pr code policy plus room for baseline and comparison artifacts."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": [
+      {
+        "id": "network_risk",
+        "severity": "warn",
+        "reason": "Task declares network risk; preserve explicit evidence for that step."
+      }
+    ]
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "artifact"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "final_output"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "benchmark.baseline",
+      "kind": "artifact",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Baseline measurement artifact."
+    },
+    {
+      "id": "benchmark.method",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Benchmark method, environment, and warm/cold mode."
+    },
+    {
+      "id": "benchmark.runs",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Run count and raw measurement results."
+    },
+    {
+      "id": "benchmark.threshold",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Accepted threshold or noise tolerance."
+    },
+    {
+      "id": "benchmark.comparison",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Before/after comparison result."
+    },
+    {
+      "id": "benchmark.verdict",
+      "kind": "final_output",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Faster, slower, unchanged, or noisy verdict."
+    },
+    {
+      "id": "benchmark.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "benchmark baseline command",
+    "benchmark comparison command",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Benchmark work needs normal branch_pr code policy plus room for baseline and comparison artifacts."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [
+    {
+      "id": "network_risk",
+      "severity": "warn",
+      "reason": "Task declares network risk; preserve explicit evidence for that step."
+    }
+  ],
+  "selectionReasons": [
+    "specialized code domain resolved to performance.benchmark",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "96c6302f381cecd05effa184eeeddb95eb8eaeeb5ced8ab67796d61f75c18e9e"
+  }
+}

--- a/.agentplane/tasks/202605090831-9P1DS0/pr/diffstat.txt
+++ b/.agentplane/tasks/202605090831-9P1DS0/pr/diffstat.txt
@@ -1,0 +1,5 @@
+ .../blueprint/resolved-snapshot.json               | 554 +++++++++++++++++++++
+ .../src/backends/task-backend.cloud.test.ts        |  23 +
+ .../backends/task-backend/cloud-backend-utils.ts   |  22 +
+ .../src/backends/task-backend/cloud-backend.ts     |   2 +
+ 4 files changed, 601 insertions(+)

--- a/.agentplane/tasks/202605090831-9P1DS0/pr/github-body.md
+++ b/.agentplane/tasks/202605090831-9P1DS0/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605090831-9P1DS0`
+Title: Fix cloud backend Node address selection
+Canonical task record: `.agentplane/tasks/202605090831-9P1DS0/README.md`
+
+## Summary
+
+Fix cloud backend Node address selection
+
+Make AgentPlane cloud backend requests resilient to Node v24 network-family autoselection failures when IPv4 is slightly slower than the default 250ms attempt timeout and NAT64 IPv6 is unusable.
+
+## Scope
+
+- In scope: Make AgentPlane cloud backend requests resilient to Node v24 network-family autoselection failures when IPv4 is slightly slower than the default 250ms attempt timeout and NAT64 IPv6 is unusable.
+- Out of scope: unrelated refactors not required for "Fix cloud backend Node address selection".
+
+## Verification
+
+- State: ok
+- Note: Verified: bun test packages/agentplane/src/backends/task-backend.cloud.test.ts passed 24 tests; bun run typecheck passed; bun run --filter=agentplane build passed; git diff --check passed; node .agentplane/policy/check-routing.mjs passed; agentplane doctor OK; live patched CLI without NODE_OPTIONS successfully ran backend inspect cloud --yes and backend sync cloud --direction pull --yes against agentplane-cloud-sync, producing cloud pull diff changed=0 ignored_remote_only=0 conflicts=0.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-09T08:33:06.157Z
+- Branch: task/202605090831-9P1DS0/cloud-node-address-selection
+- Head: 1178f3e0b7b2
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605090831-9P1DS0/pr/github-body.md
+++ b/.agentplane/tasks/202605090831-9P1DS0/pr/github-body.md
@@ -22,12 +22,16 @@ Make AgentPlane cloud backend requests resilient to Node v24 network-family auto
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-09T08:33:06.157Z
+- Updated: 2026-05-09T08:36:51.448Z
 - Branch: task/202605090831-9P1DS0/cloud-node-address-selection
-- Head: 1178f3e0b7b2
+- Head: 0ea79236d7c1
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 554 +++++++++++++++++++++
+ .../src/backends/task-backend.cloud.test.ts        |  23 +
+ .../backends/task-backend/cloud-backend-utils.ts   |  22 +
+ .../src/backends/task-backend/cloud-backend.ts     |   2 +
+ 4 files changed, 601 insertions(+)
 ```
 
 </details>

--- a/.agentplane/tasks/202605090831-9P1DS0/pr/github-title.txt
+++ b/.agentplane/tasks/202605090831-9P1DS0/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 9P1DS0 task: Fix cloud backend Node address selection [202605090831-9P1DS0]

--- a/.agentplane/tasks/202605090831-9P1DS0/pr/meta.json
+++ b/.agentplane/tasks/202605090831-9P1DS0/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605090831-9P1DS0/cloud-node-address-selection",
+  "created_at": "2026-05-09T08:33:06.157Z",
+  "head_sha": "1178f3e0b7b2b4e369f2ad66c5b21ed98cb1f1fb",
+  "last_verified_at": "2026-05-09T08:36:00.932Z",
+  "last_verified_sha": "1178f3e0b7b2b4e369f2ad66c5b21ed98cb1f1fb",
+  "schema_version": 1,
+  "task_id": "202605090831-9P1DS0",
+  "updated_at": "2026-05-09T08:33:06.157Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605090831-9P1DS0/pr/meta.json
+++ b/.agentplane/tasks/202605090831-9P1DS0/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605090831-9P1DS0/cloud-node-address-selection",
   "created_at": "2026-05-09T08:33:06.157Z",
-  "head_sha": "1178f3e0b7b2b4e369f2ad66c5b21ed98cb1f1fb",
+  "head_sha": "0ea79236d7c1f4612d7a7e53bbd12f7f168f424e",
   "last_verified_at": "2026-05-09T08:36:00.932Z",
   "last_verified_sha": "1178f3e0b7b2b4e369f2ad66c5b21ed98cb1f1fb",
   "schema_version": 1,
   "task_id": "202605090831-9P1DS0",
-  "updated_at": "2026-05-09T08:33:06.157Z",
+  "updated_at": "2026-05-09T08:36:51.448Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605090831-9P1DS0/pr/review.md
+++ b/.agentplane/tasks/202605090831-9P1DS0/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-09T08:33:06.157Z
+
+## Task
+
+- Task: `202605090831-9P1DS0`
+- Title: Fix cloud backend Node address selection
+- Status: DOING
+- Branch: `task/202605090831-9P1DS0/cloud-node-address-selection`
+- Canonical task record: `.agentplane/tasks/202605090831-9P1DS0/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified: bun test packages/agentplane/src/backends/task-backend.cloud.test.ts passed 24 tests; bun run typecheck passed; bun run --filter=agentplane build passed; git diff --check passed; node .agentplane/policy/check-routing.mjs passed; agentplane doctor OK; live patched CLI without NODE_OPTIONS successfully ran backend inspect cloud --yes and backend sync cloud --direction pull --yes against agentplane-cloud-sync, producing cloud pull diff changed=0 ignored_remote_only=0 conflicts=0.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-09T08:33:06.157Z
+- Branch: task/202605090831-9P1DS0/cloud-node-address-selection
+- Head: 1178f3e0b7b2
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605090831-9P1DS0/pr/review.md
+++ b/.agentplane/tasks/202605090831-9P1DS0/pr/review.md
@@ -24,12 +24,16 @@ Created: 2026-05-09T08:33:06.157Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-09T08:33:06.157Z
+- Updated: 2026-05-09T08:36:51.448Z
 - Branch: task/202605090831-9P1DS0/cloud-node-address-selection
-- Head: 1178f3e0b7b2
+- Head: 0ea79236d7c1
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 554 +++++++++++++++++++++
+ .../src/backends/task-backend.cloud.test.ts        |  23 +
+ .../backends/task-backend/cloud-backend-utils.ts   |  22 +
+ .../src/backends/task-backend/cloud-backend.ts     |   2 +
+ 4 files changed, 601 insertions(+)
 ```
 
 </details>

--- a/packages/agentplane/src/backends/task-backend.cloud.test.ts
+++ b/packages/agentplane/src/backends/task-backend.cloud.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { captureStdIO, mkTempDir, silenceStdIO } from "@agentplane/testkit";
 
 import { CloudBackend, LocalBackend, type TaskData } from "./task-backend.js";
+import { configureCloudFetchAddressSelection } from "./task-backend/cloud-backend-utils.js";
 
 function parseRequestBody<T>(body: unknown): T {
   if (typeof body !== "string") {
@@ -47,6 +48,28 @@ describe("CloudBackend", () => {
     restoreStdIO = null;
     process.env = originalEnv;
     if (tempDir) await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("raises Node address-selection attempt timeout for cloud fetch transport", () => {
+    const setDefaultAutoSelectFamilyAttemptTimeout = vi.fn();
+
+    configureCloudFetchAddressSelection({
+      getDefaultAutoSelectFamilyAttemptTimeout: () => 250,
+      setDefaultAutoSelectFamilyAttemptTimeout,
+    });
+
+    expect(setDefaultAutoSelectFamilyAttemptTimeout).toHaveBeenCalledWith(1_000);
+  });
+
+  it("preserves an already safer Node address-selection attempt timeout", () => {
+    const setDefaultAutoSelectFamilyAttemptTimeout = vi.fn();
+
+    configureCloudFetchAddressSelection({
+      getDefaultAutoSelectFamilyAttemptTimeout: () => 1_500,
+      setDefaultAutoSelectFamilyAttemptTimeout,
+    });
+
+    expect(setDefaultAutoSelectFamilyAttemptTimeout).not.toHaveBeenCalled();
   });
 
   it("inspects connection and freshness state without requiring configuration", async () => {

--- a/packages/agentplane/src/backends/task-backend/cloud-backend-utils.ts
+++ b/packages/agentplane/src/backends/task-backend/cloud-backend-utils.ts
@@ -1,3 +1,5 @@
+import * as net from "node:net";
+
 import { BackendError, type TaskData } from "./shared.js";
 import { isDotEnvLoadedKey } from "../../shared/env.js";
 import { isRecord } from "../../shared/guards.js";
@@ -17,7 +19,13 @@ export const CLOUD_PUSH_BATCH_RETRY_DELAYS_MS = [0, 1500, 3000] as const;
 export const CLOUD_REQUEST_TIMEOUT_MS = 30_000;
 export const CLOUD_PULL_REQUEST_TIMEOUT_MS = 120_000;
 export const CLOUD_PUSH_BATCH_REQUEST_TIMEOUT_MS = 60_000;
+export const CLOUD_NETWORK_FAMILY_ATTEMPT_TIMEOUT_MS = 1_000;
 const CLOUD_RETRIABLE_HTTP_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+type NetworkFamilyAttemptTimeoutApi = {
+  getDefaultAutoSelectFamilyAttemptTimeout?: () => number;
+  setDefaultAutoSelectFamilyAttemptTimeout?: (value: number) => void;
+};
 
 export type CloudSyncStateDiagnostics = {
   unavailable: boolean;
@@ -56,6 +64,20 @@ export class CloudNetworkError extends BackendError {
   constructor(message: string) {
     super(message, "E_NETWORK");
   }
+}
+
+export function configureCloudFetchAddressSelection(
+  api: NetworkFamilyAttemptTimeoutApi = net,
+): void {
+  if (
+    typeof api.getDefaultAutoSelectFamilyAttemptTimeout !== "function" ||
+    typeof api.setDefaultAutoSelectFamilyAttemptTimeout !== "function"
+  ) {
+    return;
+  }
+  const current = api.getDefaultAutoSelectFamilyAttemptTimeout();
+  if (!Number.isFinite(current) || current >= CLOUD_NETWORK_FAMILY_ATTEMPT_TIMEOUT_MS) return;
+  api.setDefaultAutoSelectFamilyAttemptTimeout(CLOUD_NETWORK_FAMILY_ATTEMPT_TIMEOUT_MS);
 }
 
 export function normalizeCloudPullResponse(

--- a/packages/agentplane/src/backends/task-backend/cloud-backend.ts
+++ b/packages/agentplane/src/backends/task-backend/cloud-backend.ts
@@ -28,6 +28,7 @@ import {
   cloudHttpErrorMessage,
   cloudPushBatchFinalized,
   cloudNetworkErrorMessage,
+  configureCloudFetchAddressSelection,
   createTimeoutSignal,
   isOptionalSyncStateFailure,
   isCloudRetriableError,
@@ -126,6 +127,7 @@ export class CloudBackend implements TaskBackend {
       firstNonEmptyString(settings.state_path, ".agentplane/backends/cloud/state.json"),
     );
     this.staleAfterSeconds = normalizePositiveInteger(settings.stale_after_seconds) ?? 300;
+    if (!opts.fetchImpl) configureCloudFetchAddressSelection();
     this.fetchImpl = opts.fetchImpl ?? fetch;
   }
 


### PR DESCRIPTION
Task: `202605090831-9P1DS0`
Title: Fix cloud backend Node address selection
Canonical task record: `.agentplane/tasks/202605090831-9P1DS0/README.md`

## Summary

Fix cloud backend Node address selection

Make AgentPlane cloud backend requests resilient to Node v24 network-family autoselection failures when IPv4 is slightly slower than the default 250ms attempt timeout and NAT64 IPv6 is unusable.

## Scope

- In scope: Make AgentPlane cloud backend requests resilient to Node v24 network-family autoselection failures when IPv4 is slightly slower than the default 250ms attempt timeout and NAT64 IPv6 is unusable.
- Out of scope: unrelated refactors not required for "Fix cloud backend Node address selection".

## Verification

- State: ok
- Note: Verified: bun test packages/agentplane/src/backends/task-backend.cloud.test.ts passed 24 tests; bun run typecheck passed; bun run --filter=agentplane build passed; git diff --check passed; node .agentplane/policy/check-routing.mjs passed; agentplane doctor OK; live patched CLI without NODE_OPTIONS successfully ran backend inspect cloud --yes and backend sync cloud --direction pull --yes against agentplane-cloud-sync, producing cloud pull diff changed=0 ignored_remote_only=0 conflicts=0.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-09T08:36:51.448Z
- Branch: task/202605090831-9P1DS0/cloud-node-address-selection
- Head: 0ea79236d7c1

```text
 .../blueprint/resolved-snapshot.json               | 554 +++++++++++++++++++++
 .../src/backends/task-backend.cloud.test.ts        |  23 +
 .../backends/task-backend/cloud-backend-utils.ts   |  22 +
 .../src/backends/task-backend/cloud-backend.ts     |   2 +
 4 files changed, 601 insertions(+)
```

</details>
