### PR TITLE
Fix cloud pull fetch timeout

### DIFF
--- a/.agentplane/tasks/202605091226-1DH19J/README.md
+++ b/.agentplane/tasks/202605091226-1DH19J/README.md
@@ -19,9 +19,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-09T12:29:50.051Z"
+  updated_at: "2026-05-09T12:41:04.173Z"
   updated_by: "CODER"
-  note: "Cloud pull fetch timeout fix verified after hotspot-safe test split."
+  note: "Cloud pull timeout fix reverified with targeted backend route, canonical test fix, and live cloud pull before publish."
 commit: null
 comments:
   -
@@ -47,8 +47,14 @@ events:
     author: "CODER"
     state: "ok"
     note: "Cloud pull fetch timeout fix verified after hotspot-safe test split."
+  -
+    type: "verify"
+    at: "2026-05-09T12:41:04.173Z"
+    author: "CODER"
+    state: "ok"
+    note: "Cloud pull timeout fix reverified with targeted backend route, canonical test fix, and live cloud pull before publish."
 doc_version: 3
-doc_updated_at: "2026-05-09T12:29:50.061Z"
+doc_updated_at: "2026-05-09T12:41:04.195Z"
 doc_updated_by: "CODER"
 description: "Normalize Node address-selection attempt timeout for cloud fetch so backend sync pull can refresh large cloud projections instead of failing with UND_ERR_CONNECT_TIMEOUT."
 sections:
@@ -96,6 +102,31 @@ sections:
     VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T12:26:38.545Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
     
     Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tasks/202605091226-1DH19J/blueprint/resolved-snapshot.json
+    - old_digest: b66b9eb8b8de1712464aaa28bafd9de0f4a1e7e1f3ff6ad737b29b426d975cf4
+    - current_digest: b66b9eb8b8de1712464aaa28bafd9de0f4a1e7e1f3ff6ad737b29b426d975cf4
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605091226-1DH19J
+    
+    ### 2026-05-09T12:41:04.173Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Cloud pull timeout fix reverified with targeted backend route, canonical test fix, and live cloud pull before publish.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T12:29:50.061Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    Command: bun test packages/agentplane/src/backends/task-backend.cloud.test.ts packages/agentplane/src/backends/task-backend/cloud-backend-utils.test.ts. Result: pass. Evidence: 25 tests passed. Scope: cloud backend timeout/freshness coverage.
+    Command: bunx vitest run targeted backend/task CLI suite. Result: pass. Evidence: 19 files, 186 tests passed. Scope: pre-push backend route.
+    Command: bun run hotspots:check. Result: pass. Evidence: threshold check passed; oversized test baseline OK. Scope: hotspot budgets.
+    Command: bun run typecheck. Result: pass. Evidence: tsc -b exited 0. Scope: TypeScript project references.
+    Command: bun run lint:core. Result: pass. Evidence: eslint exited 0. Scope: core lint surface.
+    Command: bun run framework:dev:bootstrap && ap backend sync cloud --direction pull --conflict=diff --yes. Result: pass. Evidence: cloud pull diff changed=0 ignored_remote_only=0 conflicts=0. Scope: repo-local CLI build and live cloud pull.
     
     BlueprintSnapshotRef:
     - state: current

--- a/.agentplane/tasks/202605091226-1DH19J/README.md
+++ b/.agentplane/tasks/202605091226-1DH19J/README.md
@@ -1,0 +1,93 @@
+---
+id: "202605091226-1DH19J"
+title: "Fix cloud pull Node fetch timeout"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "backend"
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-09T12:26:17.225Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-09T12:26:38.539Z"
+  updated_by: "CODER"
+  note: "Cloud pull Node fetch timeout fix verified with focused tests, typecheck, lint, bootstrap, and live pull."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: fix cloud pull Node fetch connect timeout by normalizing address-selection attempt timing and proving live pull refresh."
+events:
+  -
+    type: "status"
+    at: "2026-05-09T12:26:22.164Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: fix cloud pull Node fetch connect timeout by normalizing address-selection attempt timing and proving live pull refresh."
+  -
+    type: "verify"
+    at: "2026-05-09T12:26:38.539Z"
+    author: "CODER"
+    state: "ok"
+    note: "Cloud pull Node fetch timeout fix verified with focused tests, typecheck, lint, bootstrap, and live pull."
+doc_version: 3
+doc_updated_at: "2026-05-09T12:26:38.545Z"
+doc_updated_by: "CODER"
+description: "Normalize Node address-selection attempt timeout for cloud fetch so backend sync pull can refresh large cloud projections instead of failing with UND_ERR_CONNECT_TIMEOUT."
+sections:
+  Summary: |-
+    Fix cloud pull Node fetch timeout
+    
+    Normalize Node address-selection attempt timeout for cloud fetch so backend sync pull can refresh large cloud projections instead of failing with UND_ERR_CONNECT_TIMEOUT.
+  Scope: |-
+    - In scope: Normalize Node address-selection attempt timeout for cloud fetch so backend sync pull can refresh large cloud projections instead of failing with UND_ERR_CONNECT_TIMEOUT.
+    - Out of scope: unrelated refactors not required for "Fix cloud pull Node fetch timeout".
+  Plan: |-
+    1. Normalize Node cloud fetch address-selection attempt timeout to 1000ms so dead first addresses do not exhaust undici's 10s connect path.
+    2. Add focused regression coverage for the Node default 10000ms case while preserving the existing too-low timeout behavior.
+    3. Verify with cloud backend tests, typecheck, lint, framework bootstrap, and live cloud pull.
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-09T12:26:38.539Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Cloud pull Node fetch timeout fix verified with focused tests, typecheck, lint, bootstrap, and live pull.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T12:26:22.169Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tasks/202605091226-1DH19J/blueprint/resolved-snapshot.json
+    - old_digest: b66b9eb8b8de1712464aaa28bafd9de0f4a1e7e1f3ff6ad737b29b426d975cf4
+    - current_digest: b66b9eb8b8de1712464aaa28bafd9de0f4a1e7e1f3ff6ad737b29b426d975cf4
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605091226-1DH19J
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Command: bun test packages/agentplane/src/backends/task-backend.cloud.test.ts | Result: pass | Evidence: 25 tests passed, including Node default 10000ms timeout normalization regression. Scope: cloud backend sync behavior.\nCommand: bun run typecheck | Result: pass | Evidence: tsc -b completed. Scope: workspace TypeScript contracts.\nCommand: bun run lint:core | Result: pass | Evidence: eslint completed. Scope: repo lint contract.\nCommand: bun run framework:dev:bootstrap && ap backend sync cloud --direction pull --conflict=diff --yes | Result: pass | Evidence: repo-local runtime rebuilt; live pull returned changed=0 ignored_remote_only=0 conflicts=0. Scope: live cloud projection refresh.
+      Impact: Node fetch no longer keeps the unsafe 10000ms address-selection attempt timeout that produced UND_ERR_CONNECT_TIMEOUT against sync.agentplane.cloud.
+      Resolution: Normalize cloud fetch address-selection attempt timeout to 1000ms and cover both too-low and Node-default cases.
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605091226-1DH19J/README.md
+++ b/.agentplane/tasks/202605091226-1DH19J/README.md
@@ -19,9 +19,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-09T12:26:38.539Z"
+  updated_at: "2026-05-09T12:29:50.051Z"
   updated_by: "CODER"
-  note: "Cloud pull Node fetch timeout fix verified with focused tests, typecheck, lint, bootstrap, and live pull."
+  note: "Cloud pull fetch timeout fix verified after hotspot-safe test split."
 commit: null
 comments:
   -
@@ -41,8 +41,14 @@ events:
     author: "CODER"
     state: "ok"
     note: "Cloud pull Node fetch timeout fix verified with focused tests, typecheck, lint, bootstrap, and live pull."
+  -
+    type: "verify"
+    at: "2026-05-09T12:29:50.051Z"
+    author: "CODER"
+    state: "ok"
+    note: "Cloud pull fetch timeout fix verified after hotspot-safe test split."
 doc_version: 3
-doc_updated_at: "2026-05-09T12:26:38.545Z"
+doc_updated_at: "2026-05-09T12:29:50.061Z"
 doc_updated_by: "CODER"
 description: "Normalize Node address-selection attempt timeout for cloud fetch so backend sync pull can refresh large cloud projections instead of failing with UND_ERR_CONNECT_TIMEOUT."
 sections:
@@ -81,6 +87,24 @@ sections:
     - route_changed: no
     - safe_command: agentplane blueprint snapshot 202605091226-1DH19J
     
+    ### 2026-05-09T12:29:50.051Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Cloud pull fetch timeout fix verified after hotspot-safe test split.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T12:26:38.545Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tasks/202605091226-1DH19J/blueprint/resolved-snapshot.json
+    - old_digest: b66b9eb8b8de1712464aaa28bafd9de0f4a1e7e1f3ff6ad737b29b426d975cf4
+    - current_digest: b66b9eb8b8de1712464aaa28bafd9de0f4a1e7e1f3ff6ad737b29b426d975cf4
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605091226-1DH19J
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -89,5 +113,9 @@ sections:
     - Observation: Command: bun test packages/agentplane/src/backends/task-backend.cloud.test.ts | Result: pass | Evidence: 25 tests passed, including Node default 10000ms timeout normalization regression. Scope: cloud backend sync behavior.\nCommand: bun run typecheck | Result: pass | Evidence: tsc -b completed. Scope: workspace TypeScript contracts.\nCommand: bun run lint:core | Result: pass | Evidence: eslint completed. Scope: repo lint contract.\nCommand: bun run framework:dev:bootstrap && ap backend sync cloud --direction pull --conflict=diff --yes | Result: pass | Evidence: repo-local runtime rebuilt; live pull returned changed=0 ignored_remote_only=0 conflicts=0. Scope: live cloud projection refresh.
       Impact: Node fetch no longer keeps the unsafe 10000ms address-selection attempt timeout that produced UND_ERR_CONNECT_TIMEOUT against sync.agentplane.cloud.
       Resolution: Normalize cloud fetch address-selection attempt timeout to 1000ms and cover both too-low and Node-default cases.
+    
+    - Observation: Command: bun test packages/agentplane/src/backends/task-backend.cloud.test.ts packages/agentplane/src/backends/task-backend/cloud-backend-utils.test.ts | Result: pass | Evidence: 25 tests passed across cloud backend and cloud backend utility suites. Scope: sync behavior and address-selection timeout normalization.\nCommand: bun run hotspots:check | Result: pass | Evidence: cloud-backend.ts is 598 LoC; oversized test baseline remains 10 entries. Scope: hotspot guard.\nCommand: bun run typecheck | Result: pass | Evidence: tsc -b completed. Scope: workspace TypeScript contracts.\nCommand: bun run lint:core | Result: pass | Evidence: eslint completed. Scope: repo lint contract.\nCommand: bun run framework:dev:bootstrap && ap backend sync cloud --direction pull --conflict=diff --yes | Result: pass | Evidence: live pull returned changed=0 ignored_remote_only=0 conflicts=0. Scope: live cloud projection refresh.
+      Impact: Node fetch no longer keeps the unsafe 10000ms address-selection attempt timeout that produced UND_ERR_CONNECT_TIMEOUT; hotspot guard stays green without reintroducing allow-lists.
+      Resolution: Normalize cloud fetch address-selection attempt timeout to 1000ms and move focused utility tests out of the oversized cloud backend suite.
 id_source: "generated"
 ---

--- a/.agentplane/tasks/202605091226-1DH19J/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605091226-1DH19J/blueprint/resolved-snapshot.json
@@ -1,0 +1,497 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605091226-1DH19J",
+    "title": "Fix cloud pull Node fetch timeout",
+    "description": "Normalize Node address-selection attempt timeout for cloud fetch so backend sync pull can refresh large cloud projections instead of failing with UND_ERR_CONNECT_TIMEOUT.",
+    "tags": [
+      "backend",
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605091226-1DH19J",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "b66b9eb8b8de1712464aaa28bafd9de0f4a1e7e1f3ff6ad737b29b426d975cf4"
+  }
+}

--- a/.agentplane/tasks/202605091233-GJX6S4/README.md
+++ b/.agentplane/tasks/202605091233-GJX6S4/README.md
@@ -1,0 +1,97 @@
+---
+id: "202605091233-GJX6S4"
+title: "Align task new tests with canonical sections"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-09T12:33:35.432Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-09T12:40:51.056Z"
+  updated_by: "CODER"
+  note: "Task new regression tests aligned with canonical README sections and targeted backend route verified."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Update the task new regression assertions to match doc_version=3 canonical sections and unblock the targeted backend pre-push route."
+events:
+  -
+    type: "status"
+    at: "2026-05-09T12:33:38.965Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Update the task new regression assertions to match doc_version=3 canonical sections and unblock the targeted backend pre-push route."
+  -
+    type: "verify"
+    at: "2026-05-09T12:40:51.056Z"
+    author: "CODER"
+    state: "ok"
+    note: "Task new regression tests aligned with canonical README sections and targeted backend route verified."
+doc_version: 3
+doc_updated_at: "2026-05-09T12:40:51.096Z"
+doc_updated_by: "CODER"
+description: "Update task new regression tests to assert doc_version=3 canonical sections instead of duplicated Markdown body so targeted backend pre-push route reflects the current task README contract."
+sections:
+  Summary: |-
+    Align task new tests with canonical sections
+    
+    Update task new regression tests to assert doc_version=3 canonical sections instead of duplicated Markdown body so targeted backend pre-push route reflects the current task README contract.
+  Scope: |-
+    - In scope: Update task new regression tests to assert doc_version=3 canonical sections instead of duplicated Markdown body so targeted backend pre-push route reflects the current task README contract.
+    - Out of scope: unrelated refactors not required for "Align task new tests with canonical sections".
+  Plan: |-
+    1. Update task new tests to assert doc_version=3 canonical frontmatter sections through readTask() instead of expecting duplicated Markdown body.
+    2. Keep coverage for escaped newline normalization, Verify Steps content, and absence of scaffold TODO markers.
+    3. Re-run the failing CLI test, targeted backend pre-push suite, cloud focused tests, hotspots, typecheck, lint, and live cloud pull before publishing.
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-09T12:40:51.056Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Task new regression tests aligned with canonical README sections and targeted backend route verified.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T12:33:38.972Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    Command: bunx vitest run packages/agentplane/src/cli/run-cli.core.tasks.create.test.ts --pool=forks --maxWorkers 1 --testTimeout 60000 --hookTimeout 60000. Result: pass. Evidence: 13 tests passed. Scope: task new README canonical section assertions.
+    Command: bunx vitest run targeted backend/task CLI suite. Result: pass. Evidence: 19 files, 186 tests passed. Scope: pre-push backend route that previously failed.
+    Command: bun test packages/agentplane/src/backends/task-backend.cloud.test.ts packages/agentplane/src/backends/task-backend/cloud-backend-utils.test.ts. Result: pass. Evidence: 25 tests passed. Scope: cloud backend timeout/freshness coverage.
+    Command: bun run hotspots:check. Result: pass. Evidence: threshold check passed; oversized test baseline OK. Scope: hotspot budgets.
+    Command: bun run typecheck. Result: pass. Evidence: tsc -b exited 0. Scope: TypeScript project references.
+    Command: bun run lint:core. Result: pass. Evidence: eslint exited 0. Scope: core lint surface.
+    Command: bun run framework:dev:bootstrap && ap backend sync cloud --direction pull --conflict=diff --yes. Result: pass. Evidence: cloud pull diff changed=0 ignored_remote_only=0 conflicts=0. Scope: repo-local CLI build and live cloud pull.
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tasks/202605091233-GJX6S4/blueprint/resolved-snapshot.json
+    - old_digest: 6168f3104df4da4f0d7da107b28a498865674bf3d51e111e2e45886e5cf8994b
+    - current_digest: 6168f3104df4da4f0d7da107b28a498865674bf3d51e111e2e45886e5cf8994b
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605091233-GJX6S4
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605091233-GJX6S4/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605091233-GJX6S4/blueprint/resolved-snapshot.json
@@ -1,0 +1,536 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605091233-GJX6S4",
+    "title": "Align task new tests with canonical sections",
+    "description": "Update task new regression tests to assert doc_version=3 canonical sections instead of duplicated Markdown body so targeted backend pre-push route reflects the current task README contract.",
+    "tags": [
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "quality.regression",
+    "version": 1,
+    "title": "Quality regression",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "quality.regression",
+    "blueprintVersion": 1,
+    "title": "Quality regression",
+    "taskId": "202605091233-GJX6S4",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to quality.regression",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest",
+          "artifact"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "check_result"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "weak_links"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "regression.original_failure",
+        "kind": "artifact",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Original failure log or check output."
+      },
+      {
+        "id": "regression.reproduction",
+        "kind": "check_result",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Local reproduction or explicit non-reproduction result."
+      },
+      {
+        "id": "regression.focused_check",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Focused regression check."
+      },
+      {
+        "id": "regression.matrix_or_scope",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Affected test/check matrix or bounded scope."
+      },
+      {
+        "id": "regression.full_gate",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Full relevant gate or hosted check evidence."
+      },
+      {
+        "id": "regression.flake_classification",
+        "kind": "weak_links",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Flake classification or residual risk."
+      },
+      {
+        "id": "regression.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "affected matrix or full relevant gate",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "failure reproduction command",
+      "focused regression check",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest",
+        "artifact"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "check_result"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "weak_links"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "regression.original_failure",
+      "kind": "artifact",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Original failure log or check output."
+    },
+    {
+      "id": "regression.reproduction",
+      "kind": "check_result",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Local reproduction or explicit non-reproduction result."
+    },
+    {
+      "id": "regression.focused_check",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Focused regression check."
+    },
+    {
+      "id": "regression.matrix_or_scope",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Affected test/check matrix or bounded scope."
+    },
+    {
+      "id": "regression.full_gate",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Full relevant gate or hosted check evidence."
+    },
+    {
+      "id": "regression.flake_classification",
+      "kind": "weak_links",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Flake classification or residual risk."
+    },
+    {
+      "id": "regression.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "affected matrix or full relevant gate",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "failure reproduction command",
+    "focused regression check",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to quality.regression",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "6168f3104df4da4f0d7da107b28a498865674bf3d51e111e2e45886e5cf8994b"
+  }
+}

--- a/.agentplane/tasks/202605091300-HAT904/README.md
+++ b/.agentplane/tasks/202605091300-HAT904/README.md
@@ -1,0 +1,94 @@
+---
+id: "202605091300-HAT904"
+title: "Stabilize standalone asset tests in pre-push"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-09T13:00:18.861Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-09T13:02:49.977Z"
+  updated_by: "CODER"
+  note: "Standalone release asset test timeouts stabilized without changing coverage."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Stabilize the standalone release asset tests by keeping coverage intact and giving heavy archive checks enough time under full-fast parallel pre-push load."
+events:
+  -
+    type: "status"
+    at: "2026-05-09T13:00:23.158Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Stabilize the standalone release asset tests by keeping coverage intact and giving heavy archive checks enough time under full-fast parallel pre-push load."
+  -
+    type: "verify"
+    at: "2026-05-09T13:02:49.977Z"
+    author: "CODER"
+    state: "ok"
+    note: "Standalone release asset test timeouts stabilized without changing coverage."
+doc_version: 3
+doc_updated_at: "2026-05-09T13:02:49.984Z"
+doc_updated_by: "CODER"
+description: "Raise standalone release asset test timeouts to match full-fast parallel pre-push load after isolated runs pass but two archive smoke tests hit the current 90s limit."
+sections:
+  Summary: |-
+    Stabilize standalone asset tests in pre-push
+    
+    Raise standalone release asset test timeouts to match full-fast parallel pre-push load after isolated runs pass but two archive smoke tests hit the current 90s limit.
+  Scope: |-
+    - In scope: Raise standalone release asset test timeouts to match full-fast parallel pre-push load after isolated runs pass but two archive smoke tests hit the current 90s limit.
+    - Out of scope: unrelated refactors not required for "Stabilize standalone asset tests in pre-push".
+  Plan: |-
+    1. Raise only the per-test timeout for standalone archive generation/smoke tests that perform heavy packaging work under full-fast parallel load.
+    2. Preserve assertions and implementation behavior; do not skip or weaken coverage.
+    3. Verify isolated standalone suite and rerun pre-push/full-fast publication path.
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-09T13:02:49.977Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Standalone release asset test timeouts stabilized without changing coverage.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T13:00:23.165Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    Command: bunx vitest run packages/agentplane/src/commands/release/generate-standalone-cli-assets-script.test.ts --pool=forks --maxWorkers 1 --testTimeout 60000 --hookTimeout 60000. Result: pass. Evidence: 5 tests passed; suite duration 30.61s after timeout constant update. Scope: standalone archive generation and smoke tests.
+    Command: bun run typecheck. Result: pass. Evidence: tsc -b exited 0. Scope: TypeScript project references.
+    Command: bun run lint:core. Result: pass. Evidence: eslint exited 0. Scope: core lint surface.
+    Command: git push -u origin codex/v05-cloud-pull-fetch-fix. Result: prior pre-push fail reproduced the issue. Evidence: full-fast timed out two standalone asset tests at 90s while isolated suite passed at 90.34s with 180s CLI cap. Scope: pre-push instability root cause.
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tasks/202605091300-HAT904/blueprint/resolved-snapshot.json
+    - old_digest: 307a340979490e59107817ab9c125f81befc6d7a3b2081e3f831e82c4093475d
+    - current_digest: 307a340979490e59107817ab9c125f81befc6d7a3b2081e3f831e82c4093475d
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605091300-HAT904
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605091300-HAT904/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605091300-HAT904/blueprint/resolved-snapshot.json
@@ -1,0 +1,496 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605091300-HAT904",
+    "title": "Stabilize standalone asset tests in pre-push",
+    "description": "Raise standalone release asset test timeouts to match full-fast parallel pre-push load after isolated runs pass but two archive smoke tests hit the current 90s limit.",
+    "tags": [
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605091300-HAT904",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "307a340979490e59107817ab9c125f81befc6d7a3b2081e3f831e82c4093475d"
+  }
+}

--- a/packages/agentplane/src/backends/task-backend.cloud.test.ts
+++ b/packages/agentplane/src/backends/task-backend.cloud.test.ts
@@ -5,7 +5,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { captureStdIO, mkTempDir, silenceStdIO } from "@agentplane/testkit";
 
 import { CloudBackend, LocalBackend, type TaskData } from "./task-backend.js";
-import { configureCloudFetchAddressSelection } from "./task-backend/cloud-backend-utils.js";
 
 function parseRequestBody<T>(body: unknown): T {
   if (typeof body !== "string") {
@@ -48,39 +47,6 @@ describe("CloudBackend", () => {
     restoreStdIO = null;
     process.env = originalEnv;
     if (tempDir) await rm(tempDir, { recursive: true, force: true });
-  });
-
-  it("raises Node address-selection attempt timeout for cloud fetch transport", () => {
-    const setDefaultAutoSelectFamilyAttemptTimeout = vi.fn();
-
-    configureCloudFetchAddressSelection({
-      getDefaultAutoSelectFamilyAttemptTimeout: () => 250,
-      setDefaultAutoSelectFamilyAttemptTimeout,
-    });
-
-    expect(setDefaultAutoSelectFamilyAttemptTimeout).toHaveBeenCalledWith(1000);
-  });
-
-  it("preserves an already safer Node address-selection attempt timeout", () => {
-    const setDefaultAutoSelectFamilyAttemptTimeout = vi.fn();
-
-    configureCloudFetchAddressSelection({
-      getDefaultAutoSelectFamilyAttemptTimeout: () => 1000,
-      setDefaultAutoSelectFamilyAttemptTimeout,
-    });
-
-    expect(setDefaultAutoSelectFamilyAttemptTimeout).not.toHaveBeenCalled();
-  });
-
-  it("lowers the default Node address-selection attempt timeout for cloud fetch transport", () => {
-    const setDefaultAutoSelectFamilyAttemptTimeout = vi.fn();
-
-    configureCloudFetchAddressSelection({
-      getDefaultAutoSelectFamilyAttemptTimeout: () => 10_000,
-      setDefaultAutoSelectFamilyAttemptTimeout,
-    });
-
-    expect(setDefaultAutoSelectFamilyAttemptTimeout).toHaveBeenCalledWith(1000);
   });
 
   it("inspects connection and freshness state without requiring configuration", async () => {

--- a/packages/agentplane/src/backends/task-backend.cloud.test.ts
+++ b/packages/agentplane/src/backends/task-backend.cloud.test.ts
@@ -58,18 +58,29 @@ describe("CloudBackend", () => {
       setDefaultAutoSelectFamilyAttemptTimeout,
     });
 
-    expect(setDefaultAutoSelectFamilyAttemptTimeout).toHaveBeenCalledWith(1_000);
+    expect(setDefaultAutoSelectFamilyAttemptTimeout).toHaveBeenCalledWith(1000);
   });
 
   it("preserves an already safer Node address-selection attempt timeout", () => {
     const setDefaultAutoSelectFamilyAttemptTimeout = vi.fn();
 
     configureCloudFetchAddressSelection({
-      getDefaultAutoSelectFamilyAttemptTimeout: () => 1_500,
+      getDefaultAutoSelectFamilyAttemptTimeout: () => 1000,
       setDefaultAutoSelectFamilyAttemptTimeout,
     });
 
     expect(setDefaultAutoSelectFamilyAttemptTimeout).not.toHaveBeenCalled();
+  });
+
+  it("lowers the default Node address-selection attempt timeout for cloud fetch transport", () => {
+    const setDefaultAutoSelectFamilyAttemptTimeout = vi.fn();
+
+    configureCloudFetchAddressSelection({
+      getDefaultAutoSelectFamilyAttemptTimeout: () => 10_000,
+      setDefaultAutoSelectFamilyAttemptTimeout,
+    });
+
+    expect(setDefaultAutoSelectFamilyAttemptTimeout).toHaveBeenCalledWith(1000);
   });
 
   it("inspects connection and freshness state without requiring configuration", async () => {

--- a/packages/agentplane/src/backends/task-backend/cloud-backend-utils.test.ts
+++ b/packages/agentplane/src/backends/task-backend/cloud-backend-utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { configureCloudFetchAddressSelection } from "./cloud-backend-utils.js";
+
+describe("cloud backend utilities", () => {
+  it("raises too-low Node address-selection attempt timeout for cloud fetch transport", () => {
+    const setDefaultAutoSelectFamilyAttemptTimeout = vi.fn();
+
+    configureCloudFetchAddressSelection({
+      getDefaultAutoSelectFamilyAttemptTimeout: () => 250,
+      setDefaultAutoSelectFamilyAttemptTimeout,
+    });
+
+    expect(setDefaultAutoSelectFamilyAttemptTimeout).toHaveBeenCalledWith(1000);
+  });
+
+  it("preserves the target Node address-selection attempt timeout", () => {
+    const setDefaultAutoSelectFamilyAttemptTimeout = vi.fn();
+
+    configureCloudFetchAddressSelection({
+      getDefaultAutoSelectFamilyAttemptTimeout: () => 1000,
+      setDefaultAutoSelectFamilyAttemptTimeout,
+    });
+
+    expect(setDefaultAutoSelectFamilyAttemptTimeout).not.toHaveBeenCalled();
+  });
+
+  it("lowers the default Node address-selection attempt timeout for cloud fetch transport", () => {
+    const setDefaultAutoSelectFamilyAttemptTimeout = vi.fn();
+
+    configureCloudFetchAddressSelection({
+      getDefaultAutoSelectFamilyAttemptTimeout: () => 10_000,
+      setDefaultAutoSelectFamilyAttemptTimeout,
+    });
+
+    expect(setDefaultAutoSelectFamilyAttemptTimeout).toHaveBeenCalledWith(1000);
+  });
+});

--- a/packages/agentplane/src/backends/task-backend/cloud-backend-utils.ts
+++ b/packages/agentplane/src/backends/task-backend/cloud-backend-utils.ts
@@ -19,7 +19,7 @@ export const CLOUD_PUSH_BATCH_RETRY_DELAYS_MS = [0, 1500, 3000] as const;
 export const CLOUD_REQUEST_TIMEOUT_MS = 30_000;
 export const CLOUD_PULL_REQUEST_TIMEOUT_MS = 120_000;
 export const CLOUD_PUSH_BATCH_REQUEST_TIMEOUT_MS = 60_000;
-export const CLOUD_NETWORK_FAMILY_ATTEMPT_TIMEOUT_MS = 1_000;
+export const CLOUD_NETWORK_FAMILY_ATTEMPT_TIMEOUT_MS = 1000;
 const CLOUD_RETRIABLE_HTTP_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
 
 type NetworkFamilyAttemptTimeoutApi = {
@@ -76,7 +76,7 @@ export function configureCloudFetchAddressSelection(
     return;
   }
   const current = api.getDefaultAutoSelectFamilyAttemptTimeout();
-  if (!Number.isFinite(current) || current >= CLOUD_NETWORK_FAMILY_ATTEMPT_TIMEOUT_MS) return;
+  if (current === CLOUD_NETWORK_FAMILY_ATTEMPT_TIMEOUT_MS) return;
   api.setDefaultAutoSelectFamilyAttemptTimeout(CLOUD_NETWORK_FAMILY_ATTEMPT_TIMEOUT_MS);
 }
 

--- a/packages/agentplane/src/backends/task-backend/cloud-backend.ts
+++ b/packages/agentplane/src/backends/task-backend/cloud-backend.ts
@@ -511,11 +511,7 @@ export class CloudBackend implements TaskBackend {
     };
   }
 
-  private async request<T>(
-    pathname: string,
-    init: RequestInit,
-    opts?: { timeoutMs?: number },
-  ): Promise<T> {
+  private async request<T>(pathname: string, init: RequestInit, opts?: { timeoutMs?: number }) {
     const headers = this.cloudHeaders();
     for (const [key, value] of new Headers(init.headers)) {
       headers.set(key, value);

--- a/packages/agentplane/src/cli/run-cli.core.tasks.create.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.tasks.create.test.ts
@@ -128,9 +128,13 @@ describe("runCli", { timeout: TASKS_CLI_TIMEOUT_MS }, () => {
     expect(readme).toContain("description: |-");
     expect(readme).toContain("  Line one");
     expect(readme).toContain("  Line two");
-    expect(readme).toContain("Line one\n\nLine two");
     expect(readme).not.toContain(String.raw`literal \n sequences`);
-    expect(readme).toContain("- In scope: Line one Line two.");
+    expect(readme).not.toMatch(/\n## Summary\n/);
+
+    const task = await readTask({ cwd: root, rootOverride: root, taskId: id });
+    expect(task.frontmatter.description).toBe("Line one\n\nLine two");
+    expect(task.frontmatter.sections?.Summary).toContain("Line one\n\nLine two");
+    expect(task.frontmatter.sections?.Scope).toContain("- In scope: Line one Line two.");
   });
 
   it("task new supports depends-on and verify flags", async () => {
@@ -458,14 +462,17 @@ describe("runCli", { timeout: TASKS_CLI_TIMEOUT_MS }, () => {
 
     const readmePath = path.join(root, ".agentplane", "tasks", id, "README.md");
     const readme = await readFile(readmePath, "utf8");
-    expect(readme).toContain("## Verify Steps");
-    expect(readme).toContain("Run `bun run test:fast`.");
-    expect(readme).toContain("Expected: it succeeds and confirms the requested outcome");
-    expect(readme).toContain("## Findings");
+    expect(readme).toContain("sections:");
+    expect(readme).not.toMatch(/\n## Verify Steps\n/);
+    expect(readme).not.toMatch(/\n## Findings\n/);
     expect(readme).not.toContain("<!-- TODO: REPLACE WITH TASK-SPECIFIC ACCEPTANCE STEPS -->");
 
     const task = await readTask({ cwd: root, rootOverride: root, taskId: id });
     expect(task.frontmatter.sections?.["Verify Steps"]).toContain("Run `bun run test:fast`.");
+    expect(task.frontmatter.sections?.["Verify Steps"]).toContain(
+      "Expected: it succeeds and confirms the requested outcome",
+    );
+    expect(task.frontmatter.sections?.Findings).toBe("");
     expect(task.frontmatter.sections?.Summary).toContain("Code task");
   });
 
@@ -499,10 +506,17 @@ describe("runCli", { timeout: TASKS_CLI_TIMEOUT_MS }, () => {
 
     const readmePath = path.join(root, ".agentplane", "tasks", id, "README.md");
     const readme = await readFile(readmePath, "utf8");
-    expect(readme).toContain("## Verify Steps");
-    expect(readme).toContain("Review the changed artifact or behavior for the `code` task.");
-    expect(readme).toContain("Run the most relevant validation step for the `code` task.");
+    expect(readme).toContain("sections:");
+    expect(readme).not.toMatch(/\n## Verify Steps\n/);
     expect(readme).not.toContain("<!-- TODO: REPLACE WITH TASK-SPECIFIC ACCEPTANCE STEPS -->");
+
+    const task = await readTask({ cwd: root, rootOverride: root, taskId: id });
+    expect(task.frontmatter.sections?.["Verify Steps"]).toContain(
+      "Review the changed artifact or behavior for the `code` task.",
+    );
+    expect(task.frontmatter.sections?.["Verify Steps"]).toContain(
+      "Run the most relevant validation step for the `code` task.",
+    );
   });
 
   it("task new seeds concrete Verify Steps even for non-verify-required tags", async () => {
@@ -535,10 +549,17 @@ describe("runCli", { timeout: TASKS_CLI_TIMEOUT_MS }, () => {
 
     const readmePath = path.join(root, ".agentplane", "tasks", id, "README.md");
     const readme = await readFile(readmePath, "utf8");
-    expect(readme).toContain("## Verify Steps");
-    expect(readme).toContain('Review the requested outcome for "Workflow task".');
-    expect(readme).toContain("Run the most relevant validation step for this task.");
+    expect(readme).toContain("sections:");
+    expect(readme).not.toMatch(/\n## Verify Steps\n/);
     expect(readme).not.toContain("<!-- TODO: REPLACE WITH TASK-SPECIFIC ACCEPTANCE STEPS -->");
+
+    const task = await readTask({ cwd: root, rootOverride: root, taskId: id });
+    expect(task.frontmatter.sections?.["Verify Steps"]).toContain(
+      'Review the requested outcome for "Workflow task".',
+    );
+    expect(task.frontmatter.sections?.["Verify Steps"]).toContain(
+      "Run the most relevant validation step for this task.",
+    );
   });
 
   it("task add creates tasks with explicit ids", async () => {

--- a/packages/agentplane/src/commands/release/generate-standalone-cli-assets-script.test.ts
+++ b/packages/agentplane/src/commands/release/generate-standalone-cli-assets-script.test.ts
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it } from "vitest";
 const execFileAsync = promisify(execFile);
 const SCRIPT_PATH = path.resolve(process.cwd(), "scripts/generate-standalone-cli-assets.mjs");
 const SMOKE_SCRIPT_PATH = path.resolve(process.cwd(), "scripts/smoke-standalone-cli-artifact.mjs");
+const STANDALONE_ASSET_TEST_TIMEOUT_MS = 180_000;
 const tempRoots: string[] = [];
 
 async function makeTempRoot() {
@@ -56,223 +57,248 @@ function hostStandaloneTarget() {
 }
 
 describe("generate-standalone-cli-assets script", () => {
-  it("generates POSIX standalone archive layout in offline check mode", async () => {
-    const outDir = path.join(await makeTempRoot(), "out");
+  it(
+    "generates POSIX standalone archive layout in offline check mode",
+    async () => {
+      const outDir = path.join(await makeTempRoot(), "out");
 
-    await execFileAsync(
-      "node",
-      [
-        SCRIPT_PATH,
-        "--out",
-        outDir,
-        "--target",
-        "darwin-arm64",
-        "--version",
-        "1.2.3",
-        "--tag",
-        "v1.2.3",
-        "--sha",
-        "abc123",
-        "--synthetic-node",
-        "--skip-install",
-      ],
-      { cwd: process.cwd() },
-    );
+      await execFileAsync(
+        "node",
+        [
+          SCRIPT_PATH,
+          "--out",
+          outDir,
+          "--target",
+          "darwin-arm64",
+          "--version",
+          "1.2.3",
+          "--tag",
+          "v1.2.3",
+          "--sha",
+          "abc123",
+          "--synthetic-node",
+          "--skip-install",
+        ],
+        { cwd: process.cwd() },
+      );
 
-    const archivePath = path.join(outDir, "agentplane-v1.2.3-darwin-arm64.tar.gz");
-    const manifest = JSON.parse(
-      await readFile(path.join(outDir, "standalone-assets.json"), "utf8"),
-    ) as {
-      assets: {
-        name: string;
-        kind: string;
-        platform: string;
-        arch: string;
-        archive: string;
-        installStrategy: string;
-        entrypoint: string;
-        dependencyStatus: string;
-      }[];
-    };
-    const checksum = await readFile(path.join(outDir, "SHA256SUMS"), "utf8");
-    const listing = await listTar(archivePath);
+      const archivePath = path.join(outDir, "agentplane-v1.2.3-darwin-arm64.tar.gz");
+      const manifest = JSON.parse(
+        await readFile(path.join(outDir, "standalone-assets.json"), "utf8"),
+      ) as {
+        assets: {
+          name: string;
+          kind: string;
+          platform: string;
+          arch: string;
+          archive: string;
+          installStrategy: string;
+          entrypoint: string;
+          dependencyStatus: string;
+        }[];
+      };
+      const checksum = await readFile(path.join(outDir, "SHA256SUMS"), "utf8");
+      const listing = await listTar(archivePath);
 
-    expect(manifest.assets).toHaveLength(1);
-    expect(manifest.assets[0]).toMatchObject({
-      name: "agentplane-v1.2.3-darwin-arm64.tar.gz",
-      kind: "standalone_cli",
-      platform: "darwin",
-      arch: "arm64",
-      archive: "tar.gz",
-      installStrategy: "bundled_node",
-      entrypoint: "bin/agentplane",
-      dependencyStatus: "skipped_check_mode",
-    });
-    expect(checksum).toContain("agentplane-v1.2.3-darwin-arm64.tar.gz");
-    expect(listing).toContain("./bin/agentplane");
-    expect(listing).toContain("./lib/node/bin/node");
-    expect(listing).toContain("./lib/agentplane/package/bin/agentplane.js");
-    expect(listing).toContain("./share/agentplane/VERSION");
-    expect(listing).toContain("./share/agentplane/manifest.json");
-  }, 90_000);
-
-  it("generates Windows standalone archive layout in offline check mode", async () => {
-    const outDir = path.join(await makeTempRoot(), "out");
-
-    await execFileAsync(
-      "node",
-      [
-        SCRIPT_PATH,
-        "--out",
-        outDir,
-        "--target",
-        "win32-x64",
-        "--version",
-        "1.2.3",
-        "--tag",
-        "v1.2.3",
-        "--sha",
-        "abc123",
-        "--synthetic-node",
-        "--skip-install",
-      ],
-      { cwd: process.cwd() },
-    );
-
-    const archivePath = path.join(outDir, "agentplane-v1.2.3-win32-x64.zip");
-    const manifest = JSON.parse(
-      await readFile(path.join(outDir, "standalone-assets.json"), "utf8"),
-    ) as {
-      assets: { entrypoint: string; platform: string; archive: string }[];
-    };
-    const listing = await listZip(archivePath);
-    const wrapper = await readZipEntry(archivePath, "bin/agentplane.cmd");
-
-    expect(existsSync(archivePath)).toBe(true);
-    expect(manifest.assets[0]).toMatchObject({
-      platform: "win32",
-      archive: "zip",
-      entrypoint: "bin/agentplane.cmd",
-    });
-    expect(listing).toContain("bin/agentplane.cmd");
-    expect(listing).toContain("lib/node/node.exe");
-    expect(listing).toContain("lib/agentplane/package/bin/agentplane.js");
-    expect(listing).toContain("share/agentplane/manifest.json");
-    expect(wrapper).toContain(String.raw`"%~dp0..\lib\node\node.exe"`);
-    expect(wrapper).toContain(String.raw`"%~dp0..\lib\agentplane\package\bin\agentplane.js"`);
-  }, 90_000);
-
-  it("validates every contract target through --check without writing final outputs", async () => {
-    const outDir = path.join(await makeTempRoot(), "out");
-    const { stdout } = await execFileAsync("node", [SCRIPT_PATH, "--out", outDir, "--check"], {
-      cwd: process.cwd(),
-    });
-
-    expect(stdout).toContain("standalone CLI assets check");
-    expect(existsSync(outDir)).toBe(false);
-  }, 90_000);
-
-  it("installs production dependencies from a sanitized package payload", async () => {
-    const root = await makeTempRoot();
-    const outDir = path.join(root, "out");
-    const extractDir = path.join(root, "extract");
-
-    await execFileAsync(
-      "node",
-      [
-        SCRIPT_PATH,
-        "--out",
-        outDir,
-        "--target",
-        "linux-x64",
-        "--version",
-        "1.2.3",
-        "--tag",
-        "v1.2.3",
-        "--sha",
-        "abc123",
-        "--synthetic-node",
-      ],
-      { cwd: process.cwd() },
-    );
-
-    const archivePath = path.join(outDir, "agentplane-v1.2.3-linux-x64.tar.gz");
-    await mkdir(extractDir, { recursive: true });
-    await execFileAsync("tar", ["-xzf", archivePath, "-C", extractDir], { cwd: process.cwd() });
-    const manifest = JSON.parse(
-      await readFile(path.join(outDir, "standalone-assets.json"), "utf8"),
-    ) as { assets: { dependencyStatus: string }[] };
-    const packageJson = JSON.parse(
-      await readFile(path.join(extractDir, "lib", "agentplane", "package", "package.json"), "utf8"),
-    ) as {
-      dependencies?: Record<string, string>;
-      devDependencies?: Record<string, string>;
-      scripts?: Record<string, string>;
-    };
-
-    expect(manifest.assets[0]?.dependencyStatus).toBe("installed_npm_ci_local_workspace_tarballs");
-    expect(packageJson.dependencies?.["@agentplaneorg/core"]).toBe("1.2.3");
-    expect(packageJson.dependencies?.["@agentplaneorg/recipes"]).toBe("1.2.3");
-    expect(packageJson.devDependencies).toBeUndefined();
-    expect(packageJson.scripts).toBeUndefined();
-  }, 90_000);
-
-  it("smoke-tests a standalone archive fixture without a PATH node dependency", async () => {
-    const outDir = path.join(await makeTempRoot(), "out");
-    const target = hostStandaloneTarget();
-
-    await execFileAsync(
-      "node",
-      [
-        SCRIPT_PATH,
-        "--out",
-        outDir,
-        "--target",
-        target,
-        "--version",
-        "1.2.3",
-        "--tag",
-        "v1.2.3",
-        "--sha",
-        "abc123",
-        "--synthetic-node",
-        "--skip-install",
-      ],
-      { cwd: process.cwd() },
-    );
-
-    const extension = target.startsWith("win32-") ? "zip" : "tar.gz";
-    const archivePath = path.join(outDir, `agentplane-v1.2.3-${target}.${extension}`);
-    const smokeArgs = [
-      SMOKE_SCRIPT_PATH,
-      "--artifact",
-      archivePath,
-      "--expected-version",
-      "1.2.3",
-      "--allow-synthetic-runtime",
-      "--json",
-    ];
-    if (target.startsWith("win32-")) smokeArgs.push("--skip-cli-commands");
-
-    const { stdout } = await execFileAsync("node", smokeArgs, { cwd: process.cwd() });
-    const result = JSON.parse(stdout) as {
-      artifact: string;
-      version: string;
-      commandResult: { executed: boolean; syntheticRuntime?: boolean; reason?: string };
-    };
-
-    expect(result.artifact).toBe(`agentplane-v1.2.3-${target}.${extension}`);
-    expect(result.version).toBe("1.2.3");
-    if (target.startsWith("win32-")) {
-      expect(result.commandResult).toMatchObject({
-        executed: false,
-        reason: "skip_cli_commands",
+      expect(manifest.assets).toHaveLength(1);
+      expect(manifest.assets[0]).toMatchObject({
+        name: "agentplane-v1.2.3-darwin-arm64.tar.gz",
+        kind: "standalone_cli",
+        platform: "darwin",
+        arch: "arm64",
+        archive: "tar.gz",
+        installStrategy: "bundled_node",
+        entrypoint: "bin/agentplane",
+        dependencyStatus: "skipped_check_mode",
       });
-    } else {
-      expect(result.commandResult).toMatchObject({
-        executed: true,
-        syntheticRuntime: true,
+      expect(checksum).toContain("agentplane-v1.2.3-darwin-arm64.tar.gz");
+      expect(listing).toContain("./bin/agentplane");
+      expect(listing).toContain("./lib/node/bin/node");
+      expect(listing).toContain("./lib/agentplane/package/bin/agentplane.js");
+      expect(listing).toContain("./share/agentplane/VERSION");
+      expect(listing).toContain("./share/agentplane/manifest.json");
+    },
+    STANDALONE_ASSET_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "generates Windows standalone archive layout in offline check mode",
+    async () => {
+      const outDir = path.join(await makeTempRoot(), "out");
+
+      await execFileAsync(
+        "node",
+        [
+          SCRIPT_PATH,
+          "--out",
+          outDir,
+          "--target",
+          "win32-x64",
+          "--version",
+          "1.2.3",
+          "--tag",
+          "v1.2.3",
+          "--sha",
+          "abc123",
+          "--synthetic-node",
+          "--skip-install",
+        ],
+        { cwd: process.cwd() },
+      );
+
+      const archivePath = path.join(outDir, "agentplane-v1.2.3-win32-x64.zip");
+      const manifest = JSON.parse(
+        await readFile(path.join(outDir, "standalone-assets.json"), "utf8"),
+      ) as {
+        assets: { entrypoint: string; platform: string; archive: string }[];
+      };
+      const listing = await listZip(archivePath);
+      const wrapper = await readZipEntry(archivePath, "bin/agentplane.cmd");
+
+      expect(existsSync(archivePath)).toBe(true);
+      expect(manifest.assets[0]).toMatchObject({
+        platform: "win32",
+        archive: "zip",
+        entrypoint: "bin/agentplane.cmd",
       });
-    }
-  }, 90_000);
+      expect(listing).toContain("bin/agentplane.cmd");
+      expect(listing).toContain("lib/node/node.exe");
+      expect(listing).toContain("lib/agentplane/package/bin/agentplane.js");
+      expect(listing).toContain("share/agentplane/manifest.json");
+      expect(wrapper).toContain(String.raw`"%~dp0..\lib\node\node.exe"`);
+      expect(wrapper).toContain(String.raw`"%~dp0..\lib\agentplane\package\bin\agentplane.js"`);
+    },
+    STANDALONE_ASSET_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "validates every contract target through --check without writing final outputs",
+    async () => {
+      const outDir = path.join(await makeTempRoot(), "out");
+      const { stdout } = await execFileAsync("node", [SCRIPT_PATH, "--out", outDir, "--check"], {
+        cwd: process.cwd(),
+      });
+
+      expect(stdout).toContain("standalone CLI assets check");
+      expect(existsSync(outDir)).toBe(false);
+    },
+    STANDALONE_ASSET_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "installs production dependencies from a sanitized package payload",
+    async () => {
+      const root = await makeTempRoot();
+      const outDir = path.join(root, "out");
+      const extractDir = path.join(root, "extract");
+
+      await execFileAsync(
+        "node",
+        [
+          SCRIPT_PATH,
+          "--out",
+          outDir,
+          "--target",
+          "linux-x64",
+          "--version",
+          "1.2.3",
+          "--tag",
+          "v1.2.3",
+          "--sha",
+          "abc123",
+          "--synthetic-node",
+        ],
+        { cwd: process.cwd() },
+      );
+
+      const archivePath = path.join(outDir, "agentplane-v1.2.3-linux-x64.tar.gz");
+      await mkdir(extractDir, { recursive: true });
+      await execFileAsync("tar", ["-xzf", archivePath, "-C", extractDir], { cwd: process.cwd() });
+      const manifest = JSON.parse(
+        await readFile(path.join(outDir, "standalone-assets.json"), "utf8"),
+      ) as { assets: { dependencyStatus: string }[] };
+      const packageJson = JSON.parse(
+        await readFile(
+          path.join(extractDir, "lib", "agentplane", "package", "package.json"),
+          "utf8",
+        ),
+      ) as {
+        dependencies?: Record<string, string>;
+        devDependencies?: Record<string, string>;
+        scripts?: Record<string, string>;
+      };
+
+      expect(manifest.assets[0]?.dependencyStatus).toBe(
+        "installed_npm_ci_local_workspace_tarballs",
+      );
+      expect(packageJson.dependencies?.["@agentplaneorg/core"]).toBe("1.2.3");
+      expect(packageJson.dependencies?.["@agentplaneorg/recipes"]).toBe("1.2.3");
+      expect(packageJson.devDependencies).toBeUndefined();
+      expect(packageJson.scripts).toBeUndefined();
+    },
+    STANDALONE_ASSET_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "smoke-tests a standalone archive fixture without a PATH node dependency",
+    async () => {
+      const outDir = path.join(await makeTempRoot(), "out");
+      const target = hostStandaloneTarget();
+
+      await execFileAsync(
+        "node",
+        [
+          SCRIPT_PATH,
+          "--out",
+          outDir,
+          "--target",
+          target,
+          "--version",
+          "1.2.3",
+          "--tag",
+          "v1.2.3",
+          "--sha",
+          "abc123",
+          "--synthetic-node",
+          "--skip-install",
+        ],
+        { cwd: process.cwd() },
+      );
+
+      const extension = target.startsWith("win32-") ? "zip" : "tar.gz";
+      const archivePath = path.join(outDir, `agentplane-v1.2.3-${target}.${extension}`);
+      const smokeArgs = [
+        SMOKE_SCRIPT_PATH,
+        "--artifact",
+        archivePath,
+        "--expected-version",
+        "1.2.3",
+        "--allow-synthetic-runtime",
+        "--json",
+      ];
+      if (target.startsWith("win32-")) smokeArgs.push("--skip-cli-commands");
+
+      const { stdout } = await execFileAsync("node", smokeArgs, { cwd: process.cwd() });
+      const result = JSON.parse(stdout) as {
+        artifact: string;
+        version: string;
+        commandResult: { executed: boolean; syntheticRuntime?: boolean; reason?: string };
+      };
+
+      expect(result.artifact).toBe(`agentplane-v1.2.3-${target}.${extension}`);
+      expect(result.version).toBe("1.2.3");
+      if (target.startsWith("win32-")) {
+        expect(result.commandResult).toMatchObject({
+          executed: false,
+          reason: "skip_cli_commands",
+        });
+      } else {
+        expect(result.commandResult).toMatchObject({
+          executed: true,
+          syntheticRuntime: true,
+        });
+      }
+    },
+    STANDALONE_ASSET_TEST_TIMEOUT_MS,
+  );
 });


### PR DESCRIPTION
## Summary\n- normalize Node address-selection timeout for cloud backend fetches so cloud pull no longer stalls on slow address attempts\n- add focused coverage for the Node default timeout case and keep cloud backend hotspot checks under budget\n- align task-new tests with canonical README sections and stabilize standalone asset tests observed during pre-push\n\n## Verification\n- bun test packages/agentplane/src/backends/task-backend.cloud.test.ts packages/agentplane/src/backends/task-backend/cloud-backend-utils.test.ts\n- bunx vitest run packages/agentplane/src/cli/run-cli.core.tasks.create.test.ts --pool=forks --maxWorkers 1 --testTimeout 60000 --hookTimeout 60000\n- bunx vitest run packages/agentplane/src/commands/release/generate-standalone-cli-assets-script.test.ts --pool=forks --maxWorkers 1 --testTimeout 60000 --hookTimeout 60000\n- bunx vitest run targeted backend/task CLI suite\n- bun run hotspots:check\n- bun run typecheck\n- bun run lint:core\n- bun run framework:dev:bootstrap && ap backend sync cloud --direction pull --conflict=diff --yes\n- git push pre-push gate: full-fast 286 files / 1684 passed / 2 skipped, critical 5 files / 14 passed