### PR TITLE
🚧 B5JJYR task: Deduplicate async JSON file reader [202605091443-B5JJYR]

### DIFF
--- a/.agentplane/tasks/202605091443-B5JJYR/README.md
+++ b/.agentplane/tasks/202605091443-B5JJYR/README.md
@@ -1,0 +1,91 @@
+---
+id: "202605091443-B5JJYR"
+title: "Deduplicate async JSON file reader"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-09T14:43:35.950Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-09T14:55:49.335Z"
+  updated_by: "CODER"
+  note: "Async JSON reader deduplication verified."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Deduplicate async JSON file reading while preserving strict release errors and tolerant task-index cache reads."
+events:
+  -
+    type: "status"
+    at: "2026-05-09T14:43:59.116Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Deduplicate async JSON file reading while preserving strict release errors and tolerant task-index cache reads."
+  -
+    type: "verify"
+    at: "2026-05-09T14:55:49.335Z"
+    author: "CODER"
+    state: "ok"
+    note: "Async JSON reader deduplication verified."
+doc_version: 3
+doc_updated_at: "2026-05-09T14:55:49.359Z"
+doc_updated_by: "CODER"
+description: "Add a shared async JSON file reader for agentplane CLI code and replace the duplicated release preflight and task-index readJsonFile helpers while preserving their different error handling behavior."
+sections:
+  Summary: |-
+    Deduplicate async JSON file reader
+    
+    Add a shared async JSON file reader for agentplane CLI code and replace the duplicated release preflight and task-index readJsonFile helpers while preserving their different error handling behavior.
+  Scope: |-
+    - In scope: Add a shared async JSON file reader for agentplane CLI code and replace the duplicated release preflight and task-index readJsonFile helpers while preserving their different error handling behavior.
+    - Out of scope: unrelated refactors not required for "Deduplicate async JSON file reader".
+  Plan: |-
+    1. Add a shared async JSON reader in agentplane shared utilities with default-value support for tolerant cache reads.
+    2. Replace release preflight and task-index local readJsonFile helpers with the shared helper, preserving strict release parsing and nullable task-index cache behavior.
+    3. Run focused tests for release preflight/task index surfaces plus typecheck/lint.
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-09T14:55:49.335Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Async JSON reader deduplication verified.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T14:43:59.134Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    Added packages/agentplane/src/shared/json-io.ts with strict default behavior and optional defaultValue for tolerant cache reads. Replaced release preflight and task-index local async readJsonFile helpers while leaving runtime-source sync bootstrap reader unchanged. Checks passed after bootstrapping the isolated worktree: bun run typecheck; focused Vitest json-io/task-index/release-preflight suite (3 files, 15 tests); targeted eslint on touched files. Full bun run lint:core was attempted but stopped after more than five minutes without output; targeted eslint completed successfully.
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/codex-v05-clean-base/.agentplane/tasks/202605091443-B5JJYR/blueprint/resolved-snapshot.json
+    - old_digest: ed85430248dd01928a925708cb33263f8e5dd415d911fcab644bb4703a0f6067
+    - current_digest: ed85430248dd01928a925708cb33263f8e5dd415d911fcab644bb4703a0f6067
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605091443-B5JJYR
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605091443-B5JJYR/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605091443-B5JJYR/blueprint/resolved-snapshot.json
@@ -1,0 +1,496 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605091443-B5JJYR",
+    "title": "Deduplicate async JSON file reader",
+    "description": "Add a shared async JSON file reader for agentplane CLI code and replace the duplicated release preflight and task-index readJsonFile helpers while preserving their different error handling behavior.",
+    "tags": [
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605091443-B5JJYR",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "ed85430248dd01928a925708cb33263f8e5dd415d911fcab644bb4703a0f6067"
+  }
+}

--- a/.agentplane/tasks/202605091443-B5JJYR/pr/diffstat.txt
+++ b/.agentplane/tasks/202605091443-B5JJYR/pr/diffstat.txt
@@ -1,0 +1,6 @@
+ .../blueprint/resolved-snapshot.json               | 496 +++++++++++++++++++++
+ packages/agentplane/src/backends/task-index.ts     |  18 +-
+ .../src/commands/release/apply.preflight.plan.ts   |   5 +-
+ packages/agentplane/src/shared/json-io.test.ts     |  37 ++
+ packages/agentplane/src/shared/json-io.ts          |  17 +
+ 5 files changed, 553 insertions(+), 20 deletions(-)

--- a/.agentplane/tasks/202605091443-B5JJYR/pr/github-body.md
+++ b/.agentplane/tasks/202605091443-B5JJYR/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605091443-B5JJYR`
+Title: Deduplicate async JSON file reader
+Canonical task record: `.agentplane/tasks/202605091443-B5JJYR/README.md`
+
+## Summary
+
+Deduplicate async JSON file reader
+
+Add a shared async JSON file reader for agentplane CLI code and replace the duplicated release preflight and task-index readJsonFile helpers while preserving their different error handling behavior.
+
+## Scope
+
+- In scope: Add a shared async JSON file reader for agentplane CLI code and replace the duplicated release preflight and task-index readJsonFile helpers while preserving their different error handling behavior.
+- Out of scope: unrelated refactors not required for "Deduplicate async JSON file reader".
+
+## Verification
+
+- State: ok
+- Note: Async JSON reader deduplication verified.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-09T14:43:59.251Z
+- Branch: task/202605091443-B5JJYR/async-json-reader
+- Head: db4396d080d8
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605091443-B5JJYR/pr/github-body.md
+++ b/.agentplane/tasks/202605091443-B5JJYR/pr/github-body.md
@@ -22,12 +22,17 @@ Add a shared async JSON file reader for agentplane CLI code and replace the dupl
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-09T14:43:59.251Z
+- Updated: 2026-05-09T14:56:13.910Z
 - Branch: task/202605091443-B5JJYR/async-json-reader
-- Head: db4396d080d8
+- Head: ca94aa77d8f3
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 496 +++++++++++++++++++++
+ packages/agentplane/src/backends/task-index.ts     |  18 +-
+ .../src/commands/release/apply.preflight.plan.ts   |   5 +-
+ packages/agentplane/src/shared/json-io.test.ts     |  37 ++
+ packages/agentplane/src/shared/json-io.ts          |  17 +
+ 5 files changed, 553 insertions(+), 20 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605091443-B5JJYR/pr/github-title.txt
+++ b/.agentplane/tasks/202605091443-B5JJYR/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 B5JJYR task: Deduplicate async JSON file reader [202605091443-B5JJYR]

--- a/.agentplane/tasks/202605091443-B5JJYR/pr/meta.json
+++ b/.agentplane/tasks/202605091443-B5JJYR/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605091443-B5JJYR/async-json-reader",
   "created_at": "2026-05-09T14:43:59.251Z",
-  "head_sha": "db4396d080d871eb39c1871ebeff9bcb9aae8079",
+  "head_sha": "ca94aa77d8f3166f725f20940c9f0d41685e4e5b",
   "last_verified_at": "2026-05-09T14:55:49.335Z",
   "last_verified_sha": "db4396d080d871eb39c1871ebeff9bcb9aae8079",
   "schema_version": 1,
   "task_id": "202605091443-B5JJYR",
-  "updated_at": "2026-05-09T14:43:59.251Z",
+  "updated_at": "2026-05-09T14:56:13.910Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605091443-B5JJYR/pr/meta.json
+++ b/.agentplane/tasks/202605091443-B5JJYR/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605091443-B5JJYR/async-json-reader",
+  "created_at": "2026-05-09T14:43:59.251Z",
+  "head_sha": "db4396d080d871eb39c1871ebeff9bcb9aae8079",
+  "last_verified_at": "2026-05-09T14:55:49.335Z",
+  "last_verified_sha": "db4396d080d871eb39c1871ebeff9bcb9aae8079",
+  "schema_version": 1,
+  "task_id": "202605091443-B5JJYR",
+  "updated_at": "2026-05-09T14:43:59.251Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605091443-B5JJYR/pr/review.md
+++ b/.agentplane/tasks/202605091443-B5JJYR/pr/review.md
@@ -24,12 +24,17 @@ Created: 2026-05-09T14:43:59.251Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-09T14:43:59.251Z
+- Updated: 2026-05-09T14:56:13.910Z
 - Branch: task/202605091443-B5JJYR/async-json-reader
-- Head: db4396d080d8
+- Head: ca94aa77d8f3
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 496 +++++++++++++++++++++
+ packages/agentplane/src/backends/task-index.ts     |  18 +-
+ .../src/commands/release/apply.preflight.plan.ts   |   5 +-
+ packages/agentplane/src/shared/json-io.test.ts     |  37 ++
+ packages/agentplane/src/shared/json-io.ts          |  17 +
+ 5 files changed, 553 insertions(+), 20 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605091443-B5JJYR/pr/review.md
+++ b/.agentplane/tasks/202605091443-B5JJYR/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-09T14:43:59.251Z
+
+## Task
+
+- Task: `202605091443-B5JJYR`
+- Title: Deduplicate async JSON file reader
+- Status: DOING
+- Branch: `task/202605091443-B5JJYR/async-json-reader`
+- Canonical task record: `.agentplane/tasks/202605091443-B5JJYR/README.md`
+
+## Verification
+
+- State: ok
+- Note: Async JSON reader deduplication verified.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-09T14:43:59.251Z
+- Branch: task/202605091443-B5JJYR/async-json-reader
+- Head: db4396d080d8
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/backends/task-index.ts
+++ b/packages/agentplane/src/backends/task-index.ts
@@ -1,6 +1,6 @@
-import { readFile } from "node:fs/promises";
 import path from "node:path";
 
+import { readJsonFile } from "../shared/json-io.js";
 import { writeJsonStableIfChanged } from "../shared/write-if-changed.js";
 
 import type { TaskData, TaskSummary } from "./task-backend.js";
@@ -101,22 +101,8 @@ function isTaskIndexFileV2(value: unknown): value is TaskIndexFileV2 {
   return true;
 }
 
-async function readJsonFile(p: string): Promise<unknown> {
-  let raw = "";
-  try {
-    raw = await readFile(p, "utf8");
-  } catch {
-    return null;
-  }
-  try {
-    return JSON.parse(raw) as unknown;
-  } catch {
-    return null;
-  }
-}
-
 export async function loadTaskIndex(indexPath: string): Promise<TaskIndexFile | null> {
-  const v2 = await readJsonFile(indexPath);
+  const v2 = await readJsonFile<unknown>(indexPath, { defaultValue: null });
   if (v2 && isTaskIndexFileV2(v2)) return v2;
   return null;
 }

--- a/packages/agentplane/src/commands/release/apply.preflight.plan.ts
+++ b/packages/agentplane/src/commands/release/apply.preflight.plan.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import { exitCodeForError } from "../../cli/exit-codes.js";
 import { CliError } from "../../shared/errors.js";
+import { readJsonFile } from "../../shared/json-io.js";
 
 import type { PlanChange, ReleaseVersionPlan } from "./apply.types.js";
 
@@ -13,10 +14,6 @@ export async function fileExists(p: string): Promise<boolean> {
   } catch {
     return false;
   }
-}
-
-export async function readJsonFile<T>(p: string): Promise<T> {
-  return JSON.parse(await readFile(p, "utf8")) as T;
 }
 
 function assertNonEmptyString(value: unknown, label: string): string {

--- a/packages/agentplane/src/shared/json-io.test.ts
+++ b/packages/agentplane/src/shared/json-io.test.ts
@@ -1,0 +1,37 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { readJsonFile } from "./json-io.js";
+
+describe("shared/json-io", () => {
+  it("reads JSON files", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "agentplane-json-io-"));
+    const filePath = path.join(root, "data.json");
+    await writeFile(filePath, JSON.stringify({ ok: true }), "utf8");
+
+    await expect(readJsonFile<{ ok: boolean }>(filePath)).resolves.toEqual({ ok: true });
+  });
+
+  it("returns the configured default for missing or invalid JSON", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "agentplane-json-io-"));
+    const missingPath = path.join(root, "missing.json");
+    const invalidPath = path.join(root, "invalid.json");
+    await writeFile(invalidPath, "{", "utf8");
+
+    await expect(readJsonFile(missingPath, { defaultValue: null })).resolves.toBeNull();
+    await expect(readJsonFile(invalidPath, { defaultValue: null })).resolves.toBeNull();
+  });
+
+  it("throws read or parse errors when no default is configured", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "agentplane-json-io-"));
+    const invalidPath = path.join(root, "invalid.json");
+    await writeFile(invalidPath, "{", "utf8");
+
+    await expect(readJsonFile(path.join(root, "missing.json"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(readJsonFile(invalidPath)).rejects.toBeInstanceOf(SyntaxError);
+  });
+});

--- a/packages/agentplane/src/shared/json-io.ts
+++ b/packages/agentplane/src/shared/json-io.ts
@@ -1,0 +1,17 @@
+import { readFile } from "node:fs/promises";
+
+export type ReadJsonFileOptions<T> = {
+  defaultValue?: T;
+};
+
+export async function readJsonFile<T = unknown>(
+  filePath: string,
+  options: ReadJsonFileOptions<T> = {},
+): Promise<T> {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8")) as T;
+  } catch (error) {
+    if ("defaultValue" in options) return options.defaultValue as T;
+    throw error;
+  }
+}


### PR DESCRIPTION
Task: `202605091443-B5JJYR`
Title: Deduplicate async JSON file reader
Canonical task record: `.agentplane/tasks/202605091443-B5JJYR/README.md`

## Summary

Deduplicate async JSON file reader

Add a shared async JSON file reader for agentplane CLI code and replace the duplicated release preflight and task-index readJsonFile helpers while preserving their different error handling behavior.

## Scope

- In scope: Add a shared async JSON file reader for agentplane CLI code and replace the duplicated release preflight and task-index readJsonFile helpers while preserving their different error handling behavior.
- Out of scope: unrelated refactors not required for "Deduplicate async JSON file reader".

## Verification

- State: ok
- Note: Async JSON reader deduplication verified.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-09T14:56:13.910Z
- Branch: task/202605091443-B5JJYR/async-json-reader
- Head: ca94aa77d8f3

```text
 .../blueprint/resolved-snapshot.json               | 496 +++++++++++++++++++++
 packages/agentplane/src/backends/task-index.ts     |  18 +-
 .../src/commands/release/apply.preflight.plan.ts   |   5 +-
 packages/agentplane/src/shared/json-io.test.ts     |  37 ++
 packages/agentplane/src/shared/json-io.ts          |  17 +
 5 files changed, 553 insertions(+), 20 deletions(-)
```

</details>
