### PR TITLE
✅ 1KPX8Z close: stale release tasks

### DIFF
--- a/.agentplane/tasks/202605090759-1KPX8Z/README.md
+++ b/.agentplane/tasks/202605090759-1KPX8Z/README.md
@@ -1,7 +1,8 @@
 ---
 id: "202605090759-1KPX8Z"
 title: "Harden cloud sync and ACR git helpers"
-status: "DOING"
+result_summary: "Closed stale lifecycle state after merged implementation commit ce9150eae."
+status: "DONE"
 priority: "high"
 owner: "CODER"
 revision: 1
@@ -17,15 +18,20 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
-commit: null
+  state: "ok"
+  updated_at: "2026-05-09T15:26:10.264Z"
+  updated_by: "CODER"
+  note: "Cloud sync hardening and ACR git helper reuse verified on current main."
+commit:
+  hash: "ce9150eaefcd8e3f03df29301c8cb13406e9e4f9"
+  message: "🛠️ 1KPX8Z fix: harden cloud sync and ACR git helpers"
 comments:
   -
     author: "CODER"
     body: "Start: implement cloud sync release blockers and ACR git-helper consolidation with focused verification."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: cloud sync timeout/retry fixes and ACR core git helper reuse are present on current main, with focused backend and typecheck evidence recorded."
 events:
   -
     type: "status"
@@ -34,9 +40,22 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: implement cloud sync release blockers and ACR git-helper consolidation with focused verification."
+  -
+    type: "verify"
+    at: "2026-05-09T15:26:10.264Z"
+    author: "CODER"
+    state: "ok"
+    note: "Cloud sync hardening and ACR git helper reuse verified on current main."
+  -
+    type: "status"
+    at: "2026-05-09T15:26:39.431Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: cloud sync timeout/retry fixes and ACR core git helper reuse are present on current main, with focused backend and typecheck evidence recorded."
 doc_version: 3
-doc_updated_at: "2026-05-09T08:00:09.539Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-09T15:26:39.434Z"
+doc_updated_by: "INTEGRATOR"
 description: "Fix cloud backend release blockers around freshness timestamps, request timeouts, transient retry behavior, cloud diagnostics, and ACR git helper duplication."
 sections:
   Summary: |-
@@ -57,6 +76,29 @@ sections:
     3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-09T15:26:10.264Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Cloud sync hardening and ACR git helper reuse verified on current main.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T08:00:09.539Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    Command: bunx vitest run packages/agentplane/src/backends/task-backend.cloud.test.ts packages/agentplane/src/backends/task-backend/cloud-backend-utils.test.ts --pool=forks --maxWorkers 2 --testTimeout 120000 --hookTimeout 120000 | Result: pass | Evidence: 25 tests passed. Scope: cloud backend timeout, retry, sync-state helpers.
+    Command: rg CLOUD_REQUEST_TIMEOUT_MS packages/agentplane/src/backends/task-backend/cloud-backend.ts packages/agentplane/src/backends/task-backend/cloud-backend-utils.ts -n | Result: pass | Evidence: timeout constants and createTimeoutSignal are wired into cloud requests. Scope: A2 timeout implementation.
+    Command: rg "gitRevParse|gitIsAncestor|gitDiffStat" packages/agentplane/src/commands/acr -n | Result: pass | Evidence: ACR modules import core git helpers. Scope: A4 git helper dedupe.
+    Command: bun run typecheck | Result: pass | Evidence: tsc -b completed. Scope: workspace TypeScript contracts.
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tasks/202605090759-1KPX8Z/blueprint/resolved-snapshot.json
+    - old_digest: ddcb90bc327e12f5344925ee34398fd0f29fade2e0140b5238fd5e88577768eb
+    - current_digest: ddcb90bc327e12f5344925ee34398fd0f29fade2e0140b5238fd5e88577768eb
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605090759-1KPX8Z
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).

--- a/.agentplane/tasks/202605090759-1KPX8Z/acr.json
+++ b/.agentplane/tasks/202605090759-1KPX8Z/acr.json
@@ -1,0 +1,219 @@
+{
+  "acr_version": "0.1.0",
+  "record_type": "agent_change_record",
+  "record_id": "acr_202605090759-1KPX8Z",
+  "created_at": "2026-05-09T15:26:40.322Z",
+  "producer": {
+    "name": "agentplane",
+    "version": "0.4.2"
+  },
+  "repository": {
+    "vcs": "git",
+    "remote": "https://github.com/basilisk-labs/agentplane.git",
+    "base_ref": "main",
+    "base_commit": "ce9150eaefcd8e3f03df29301c8cb13406e9e4f9",
+    "work_ref": "main",
+    "work_commit": "ce9150eaefcd8e3f03df29301c8cb13406e9e4f9"
+  },
+  "task": {
+    "task_id": "202605090759-1KPX8Z",
+    "title": "Harden cloud sync and ACR git helpers",
+    "intent": "Fix cloud backend release blockers around freshness timestamps, request timeouts, transient retry behavior, cloud diagnostics, and ACR git helper duplication.",
+    "requested_by": {
+      "type": "agentplane_role",
+      "id": "ORCHESTRATOR"
+    }
+  },
+  "agent": {
+    "id": "INTEGRATOR",
+    "name": "INTEGRATOR",
+    "agent_type": "coding_agent",
+    "model": {
+      "provider": "unknown",
+      "name": "unknown",
+      "version": "unknown"
+    },
+    "toolchain": [
+      {
+        "name": "agentplane",
+        "version": "0.4.2"
+      }
+    ]
+  },
+  "plan": {
+    "status": "approved",
+    "artifact": {
+      "path": ".agentplane/tasks/202605090759-1KPX8Z/README.md",
+      "sha256": "sha256:3e40061418dbe19812179cd29381ef7f31ea9e2f27f0af0218bf9a989570b969"
+    },
+    "approved_at": "2026-05-09T08:00:08.361Z",
+    "approved_by": {
+      "type": "agentplane_role",
+      "id": "ORCHESTRATOR"
+    }
+  },
+  "permissions": {
+    "network": {
+      "mode": "unknown"
+    },
+    "secrets": {
+      "access": "none"
+    },
+    "tools": [
+      {
+        "name": "shell",
+        "allowed": true
+      }
+    ]
+  },
+  "policy": {
+    "policy_version": "0.1.0",
+    "decisions": [
+      {
+        "rule_id": "plan.required",
+        "decision": "pass",
+        "reason": "Approved plan exists."
+      },
+      {
+        "rule_id": "verification.required",
+        "decision": "pass",
+        "reason": "Verification is recorded as ok."
+      }
+    ]
+  },
+  "changes": {
+    "summary": "Closed stale lifecycle state after merged implementation commit ce9150eae.",
+    "diff_stats": {
+      "files_changed": 0,
+      "insertions": 0,
+      "deletions": 0
+    },
+    "files": [],
+    "risk": {
+      "level": "medium",
+      "categories": [],
+      "protected_paths_touched": false
+    }
+  },
+  "verification": {
+    "status": "passed",
+    "checks": []
+  },
+  "approvals": [
+    {
+      "approval_id": "approval_202605090759-1KPX8Z_plan",
+      "type": "plan_approval",
+      "decision": "approved",
+      "approved_by": {
+        "type": "agentplane_role",
+        "id": "ORCHESTRATOR"
+      },
+      "approved_at": "2026-05-09T08:00:08.361Z",
+      "scope": "task"
+    }
+  ],
+  "evidence": [
+    {
+      "type": "task",
+      "path": ".agentplane/tasks/202605090759-1KPX8Z/README.md",
+      "sha256": "sha256:3e40061418dbe19812179cd29381ef7f31ea9e2f27f0af0218bf9a989570b969"
+    },
+    {
+      "type": "plan",
+      "path": ".agentplane/tasks/202605090759-1KPX8Z/README.md",
+      "sha256": "sha256:3e40061418dbe19812179cd29381ef7f31ea9e2f27f0af0218bf9a989570b969"
+    },
+    {
+      "type": "verification_log",
+      "path": ".agentplane/tasks/202605090759-1KPX8Z/README.md",
+      "sha256": "sha256:3e40061418dbe19812179cd29381ef7f31ea9e2f27f0af0218bf9a989570b969"
+    },
+    {
+      "type": "other",
+      "path": ".agentplane/tasks/202605090759-1KPX8Z/blueprint/resolved-snapshot.json",
+      "sha256": "sha256:4166e6ced5f39989585726aec82d7398e23fbf38e1a10bda05dc7ee4df6c4de8"
+    }
+  ],
+  "result": {
+    "status": "finished",
+    "merge_ready": false,
+    "residual_risks": [
+      "Passed verification has no checks."
+    ],
+    "rollback": {
+      "available": true,
+      "notes": "Revert work_commit ce9150eaefcd8e3f03df29301c8cb13406e9e4f9 if downstream validation fails."
+    }
+  },
+  "integrity": {
+    "digest_algorithm": "sha256",
+    "record_digest": "sha256:c20f65524aada60a389ee8307510128a8d5c82cacea0408fa6ef9726d90f67aa",
+    "canonicalization": "rfc8785-jcs",
+    "signatures": []
+  },
+  "extensions": {
+    "agentplane.blueprint": {
+      "blueprint_id": "code.branch_pr",
+      "blueprint_version": 1,
+      "workflow_mode": "branch_pr",
+      "route": [
+        "intake",
+        "scope",
+        "approval_gate",
+        "context_resolve",
+        "worktree_start",
+        "work_unit",
+        "fast_local_checks",
+        "pr_artifact",
+        "hosted_checks",
+        "publish_or_integrate",
+        "verify_record",
+        "finish"
+      ],
+      "required_evidence": [
+        {
+          "id": "code_pr.paths",
+          "kind": "changed_paths",
+          "produced_by": "work_unit",
+          "required": true
+        },
+        {
+          "id": "code_pr.fast_checks",
+          "kind": "check_result",
+          "produced_by": "fast_local_checks",
+          "required": true
+        },
+        {
+          "id": "code_pr.pr",
+          "kind": "external_link",
+          "produced_by": "pr_artifact",
+          "required": true
+        },
+        {
+          "id": "code_pr.hosted",
+          "kind": "check_result",
+          "produced_by": "hosted_checks",
+          "required": true
+        },
+        {
+          "id": "code_pr.commit",
+          "kind": "commit",
+          "produced_by": "publish_or_integrate",
+          "required": true
+        }
+      ],
+      "accepted_recipe_extensions": [],
+      "rejected_recipe_extensions": [],
+      "stop_reasons": [],
+      "snapshot": {
+        "state": "current",
+        "path": ".agentplane/tasks/202605090759-1KPX8Z/blueprint/resolved-snapshot.json",
+        "digest": "ddcb90bc327e12f5344925ee34398fd0f29fade2e0140b5238fd5e88577768eb",
+        "current_digest": "ddcb90bc327e12f5344925ee34398fd0f29fade2e0140b5238fd5e88577768eb",
+        "route_changed": false,
+        "artifact_sha256": "sha256:4166e6ced5f39989585726aec82d7398e23fbf38e1a10bda05dc7ee4df6c4de8",
+        "safe_command": "agentplane blueprint snapshot 202605090759-1KPX8Z"
+      }
+    }
+  }
+}

--- a/.agentplane/tasks/202605090908-VND44D/README.md
+++ b/.agentplane/tasks/202605090908-VND44D/README.md
@@ -1,7 +1,8 @@
 ---
 id: "202605090908-VND44D"
 title: "Split ACR command helper modules"
-status: "DOING"
+result_summary: "Closed stale lifecycle state after merged implementation commit 0e5dae238."
+status: "DONE"
 priority: "med"
 owner: "CODER"
 revision: 1
@@ -18,14 +19,19 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-09T09:12:17.192Z"
+  updated_at: "2026-05-09T15:26:11.398Z"
   updated_by: "CODER"
-  note: "ACR helper split verified with focused tests, typecheck, and hotspot check."
-commit: null
+  note: "ACR helper module split verified on current main."
+commit:
+  hash: "0e5dae2387ef30b256dbb7baa72f1245e1c9bb73"
+  message: "🚧 VND44D acr: split helper modules"
 comments:
   -
     author: "CODER"
     body: "Start: split pure ACR helper modules while preserving CLI behavior and release-gate checks."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: ACR helper-module split is present on current main, focused ACR tests, hotspot check, and typecheck evidence are recorded."
 events:
   -
     type: "status"
@@ -40,9 +46,22 @@ events:
     author: "CODER"
     state: "ok"
     note: "ACR helper split verified with focused tests, typecheck, and hotspot check."
+  -
+    type: "verify"
+    at: "2026-05-09T15:26:11.398Z"
+    author: "CODER"
+    state: "ok"
+    note: "ACR helper module split verified on current main."
+  -
+    type: "status"
+    at: "2026-05-09T15:27:42.371Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: ACR helper-module split is present on current main, focused ACR tests, hotspot check, and typecheck evidence are recorded."
 doc_version: 3
-doc_updated_at: "2026-05-09T09:12:17.206Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-09T15:27:42.375Z"
+doc_updated_by: "INTEGRATOR"
 description: "Reduce the ACR command hotspot by moving pure diff, summary, and remediation helpers into focused modules without changing CLI behavior."
 sections:
   Summary: |-
@@ -72,6 +91,28 @@ sections:
     VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T09:08:45.316Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
     
     Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tasks/202605090908-VND44D/blueprint/resolved-snapshot.json
+    - old_digest: e66ba9f7a2c9edcc587fd256ce0fbf19cc44c82ea7296a73425ebda8f05f8cb9
+    - current_digest: e66ba9f7a2c9edcc587fd256ce0fbf19cc44c82ea7296a73425ebda8f05f8cb9
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605090908-VND44D
+    
+    ### 2026-05-09T15:26:11.398Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: ACR helper module split verified on current main.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T09:12:17.206Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    Command: bunx vitest run packages/agentplane/src/commands/acr/acr.command.test.ts --pool=forks --maxWorkers 2 --testTimeout 120000 --hookTimeout 120000 | Result: pass | Evidence: 10 tests passed. Scope: ACR command behavior.
+    Command: bun run hotspots:check | Result: pass | Evidence: threshold check passed; acr.command.ts is 453 lines. Scope: hotspot regression.
+    Command: bun run typecheck | Result: pass | Evidence: tsc -b completed. Scope: workspace TypeScript contracts.
     
     BlueprintSnapshotRef:
     - state: current

--- a/.agentplane/tasks/202605090908-VND44D/acr.json
+++ b/.agentplane/tasks/202605090908-VND44D/acr.json
@@ -1,0 +1,219 @@
+{
+  "acr_version": "0.1.0",
+  "record_type": "agent_change_record",
+  "record_id": "acr_202605090908-VND44D",
+  "created_at": "2026-05-09T15:27:43.535Z",
+  "producer": {
+    "name": "agentplane",
+    "version": "0.4.2"
+  },
+  "repository": {
+    "vcs": "git",
+    "remote": "https://github.com/basilisk-labs/agentplane.git",
+    "base_ref": "main",
+    "base_commit": "0e5dae2387ef30b256dbb7baa72f1245e1c9bb73",
+    "work_ref": "main",
+    "work_commit": "0e5dae2387ef30b256dbb7baa72f1245e1c9bb73"
+  },
+  "task": {
+    "task_id": "202605090908-VND44D",
+    "title": "Split ACR command helper modules",
+    "intent": "Reduce the ACR command hotspot by moving pure diff, summary, and remediation helpers into focused modules without changing CLI behavior.",
+    "requested_by": {
+      "type": "agentplane_role",
+      "id": "ORCHESTRATOR"
+    }
+  },
+  "agent": {
+    "id": "INTEGRATOR",
+    "name": "INTEGRATOR",
+    "agent_type": "coding_agent",
+    "model": {
+      "provider": "unknown",
+      "name": "unknown",
+      "version": "unknown"
+    },
+    "toolchain": [
+      {
+        "name": "agentplane",
+        "version": "0.4.2"
+      }
+    ]
+  },
+  "plan": {
+    "status": "approved",
+    "artifact": {
+      "path": ".agentplane/tasks/202605090908-VND44D/README.md",
+      "sha256": "sha256:1344a0e21f8a9e40545d54306481f3d893ccb4415e2443fa168163fdb45c9ea1"
+    },
+    "approved_at": "2026-05-09T09:08:44.192Z",
+    "approved_by": {
+      "type": "agentplane_role",
+      "id": "ORCHESTRATOR"
+    }
+  },
+  "permissions": {
+    "network": {
+      "mode": "unknown"
+    },
+    "secrets": {
+      "access": "none"
+    },
+    "tools": [
+      {
+        "name": "shell",
+        "allowed": true
+      }
+    ]
+  },
+  "policy": {
+    "policy_version": "0.1.0",
+    "decisions": [
+      {
+        "rule_id": "plan.required",
+        "decision": "pass",
+        "reason": "Approved plan exists."
+      },
+      {
+        "rule_id": "verification.required",
+        "decision": "pass",
+        "reason": "Verification is recorded as ok."
+      }
+    ]
+  },
+  "changes": {
+    "summary": "Closed stale lifecycle state after merged implementation commit 0e5dae238.",
+    "diff_stats": {
+      "files_changed": 0,
+      "insertions": 0,
+      "deletions": 0
+    },
+    "files": [],
+    "risk": {
+      "level": "medium",
+      "categories": [],
+      "protected_paths_touched": false
+    }
+  },
+  "verification": {
+    "status": "passed",
+    "checks": []
+  },
+  "approvals": [
+    {
+      "approval_id": "approval_202605090908-VND44D_plan",
+      "type": "plan_approval",
+      "decision": "approved",
+      "approved_by": {
+        "type": "agentplane_role",
+        "id": "ORCHESTRATOR"
+      },
+      "approved_at": "2026-05-09T09:08:44.192Z",
+      "scope": "task"
+    }
+  ],
+  "evidence": [
+    {
+      "type": "task",
+      "path": ".agentplane/tasks/202605090908-VND44D/README.md",
+      "sha256": "sha256:1344a0e21f8a9e40545d54306481f3d893ccb4415e2443fa168163fdb45c9ea1"
+    },
+    {
+      "type": "plan",
+      "path": ".agentplane/tasks/202605090908-VND44D/README.md",
+      "sha256": "sha256:1344a0e21f8a9e40545d54306481f3d893ccb4415e2443fa168163fdb45c9ea1"
+    },
+    {
+      "type": "verification_log",
+      "path": ".agentplane/tasks/202605090908-VND44D/README.md",
+      "sha256": "sha256:1344a0e21f8a9e40545d54306481f3d893ccb4415e2443fa168163fdb45c9ea1"
+    },
+    {
+      "type": "other",
+      "path": ".agentplane/tasks/202605090908-VND44D/blueprint/resolved-snapshot.json",
+      "sha256": "sha256:871fed3a8ea9714c57738daf44d590fcf605cbd7b9067ed4654b61fd11b529a1"
+    }
+  ],
+  "result": {
+    "status": "finished",
+    "merge_ready": false,
+    "residual_risks": [
+      "Passed verification has no checks."
+    ],
+    "rollback": {
+      "available": true,
+      "notes": "Revert work_commit 0e5dae2387ef30b256dbb7baa72f1245e1c9bb73 if downstream validation fails."
+    }
+  },
+  "integrity": {
+    "digest_algorithm": "sha256",
+    "record_digest": "sha256:c606db53e564de935c7795564fdcfc8407fe2b03954256efca0813916868ccf6",
+    "canonicalization": "rfc8785-jcs",
+    "signatures": []
+  },
+  "extensions": {
+    "agentplane.blueprint": {
+      "blueprint_id": "code.branch_pr",
+      "blueprint_version": 1,
+      "workflow_mode": "branch_pr",
+      "route": [
+        "intake",
+        "scope",
+        "approval_gate",
+        "context_resolve",
+        "worktree_start",
+        "work_unit",
+        "fast_local_checks",
+        "pr_artifact",
+        "hosted_checks",
+        "publish_or_integrate",
+        "verify_record",
+        "finish"
+      ],
+      "required_evidence": [
+        {
+          "id": "code_pr.paths",
+          "kind": "changed_paths",
+          "produced_by": "work_unit",
+          "required": true
+        },
+        {
+          "id": "code_pr.fast_checks",
+          "kind": "check_result",
+          "produced_by": "fast_local_checks",
+          "required": true
+        },
+        {
+          "id": "code_pr.pr",
+          "kind": "external_link",
+          "produced_by": "pr_artifact",
+          "required": true
+        },
+        {
+          "id": "code_pr.hosted",
+          "kind": "check_result",
+          "produced_by": "hosted_checks",
+          "required": true
+        },
+        {
+          "id": "code_pr.commit",
+          "kind": "commit",
+          "produced_by": "publish_or_integrate",
+          "required": true
+        }
+      ],
+      "accepted_recipe_extensions": [],
+      "rejected_recipe_extensions": [],
+      "stop_reasons": [],
+      "snapshot": {
+        "state": "current",
+        "path": ".agentplane/tasks/202605090908-VND44D/blueprint/resolved-snapshot.json",
+        "digest": "e66ba9f7a2c9edcc587fd256ce0fbf19cc44c82ea7296a73425ebda8f05f8cb9",
+        "current_digest": "e66ba9f7a2c9edcc587fd256ce0fbf19cc44c82ea7296a73425ebda8f05f8cb9",
+        "route_changed": false,
+        "artifact_sha256": "sha256:871fed3a8ea9714c57738daf44d590fcf605cbd7b9067ed4654b61fd11b529a1",
+        "safe_command": "agentplane blueprint snapshot 202605090908-VND44D"
+      }
+    }
+  }
+}

--- a/.agentplane/tasks/202605090913-E0Z7PF/README.md
+++ b/.agentplane/tasks/202605090913-E0Z7PF/README.md
@@ -1,7 +1,8 @@
 ---
 id: "202605090913-E0Z7PF"
 title: "Split ACR validation module"
-status: "DOING"
+result_summary: "Closed stale lifecycle state after merged implementation commit 1cacfa9ff."
+status: "DONE"
 priority: "med"
 owner: "CODER"
 revision: 1
@@ -18,14 +19,19 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-09T09:16:35.797Z"
+  updated_at: "2026-05-09T15:26:13.456Z"
   updated_by: "CODER"
-  note: "ACR validation split verified with focused tests, typecheck, and hotspot check."
-commit: null
+  note: "ACR validation module split verified on current main."
+commit:
+  hash: "1cacfa9ff5a8b8613bf5d53fd502511aba47e868"
+  message: "🚧 E0Z7PF acr: split validation module"
 comments:
   -
     author: "CODER"
     body: "Start: split ACR validation helpers into a focused module while preserving command behavior."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: ACR validation-module split is present on current main, focused ACR tests, hotspot check, and typecheck evidence are recorded."
 events:
   -
     type: "status"
@@ -40,9 +46,22 @@ events:
     author: "CODER"
     state: "ok"
     note: "ACR validation split verified with focused tests, typecheck, and hotspot check."
+  -
+    type: "verify"
+    at: "2026-05-09T15:26:13.456Z"
+    author: "CODER"
+    state: "ok"
+    note: "ACR validation module split verified on current main."
+  -
+    type: "status"
+    at: "2026-05-09T15:27:49.565Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: ACR validation-module split is present on current main, focused ACR tests, hotspot check, and typecheck evidence are recorded."
 doc_version: 3
-doc_updated_at: "2026-05-09T09:16:35.811Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-09T15:27:49.569Z"
+doc_updated_by: "INTEGRATOR"
 description: "Move ACR validation target, CI semantics, and validation output helpers into a focused validation module without changing ACR CLI behavior."
 sections:
   Summary: |-
@@ -71,6 +90,28 @@ sections:
     VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T09:13:33.296Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
     
     Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tasks/202605090913-E0Z7PF/blueprint/resolved-snapshot.json
+    - old_digest: c05d4162b249eda54b60dba82af8a8e9e04bc9caa9d2e10599578cdd4e64dadc
+    - current_digest: c05d4162b249eda54b60dba82af8a8e9e04bc9caa9d2e10599578cdd4e64dadc
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605090913-E0Z7PF
+    
+    ### 2026-05-09T15:26:13.456Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: ACR validation module split verified on current main.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T09:16:35.811Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    Command: bunx vitest run packages/agentplane/src/commands/acr/acr.command.test.ts --pool=forks --maxWorkers 2 --testTimeout 120000 --hookTimeout 120000 | Result: pass | Evidence: 10 tests passed. Scope: ACR validation and CI semantics.
+    Command: bun run hotspots:check | Result: pass | Evidence: threshold check passed. Scope: runtime hotspot guard.
+    Command: bun run typecheck | Result: pass | Evidence: tsc -b completed. Scope: workspace TypeScript contracts.
     
     BlueprintSnapshotRef:
     - state: current

--- a/.agentplane/tasks/202605090913-E0Z7PF/acr.json
+++ b/.agentplane/tasks/202605090913-E0Z7PF/acr.json
@@ -1,0 +1,219 @@
+{
+  "acr_version": "0.1.0",
+  "record_type": "agent_change_record",
+  "record_id": "acr_202605090913-E0Z7PF",
+  "created_at": "2026-05-09T15:27:50.731Z",
+  "producer": {
+    "name": "agentplane",
+    "version": "0.4.2"
+  },
+  "repository": {
+    "vcs": "git",
+    "remote": "https://github.com/basilisk-labs/agentplane.git",
+    "base_ref": "main",
+    "base_commit": "1cacfa9ff5a8b8613bf5d53fd502511aba47e868",
+    "work_ref": "main",
+    "work_commit": "1cacfa9ff5a8b8613bf5d53fd502511aba47e868"
+  },
+  "task": {
+    "task_id": "202605090913-E0Z7PF",
+    "title": "Split ACR validation module",
+    "intent": "Move ACR validation target, CI semantics, and validation output helpers into a focused validation module without changing ACR CLI behavior.",
+    "requested_by": {
+      "type": "agentplane_role",
+      "id": "ORCHESTRATOR"
+    }
+  },
+  "agent": {
+    "id": "INTEGRATOR",
+    "name": "INTEGRATOR",
+    "agent_type": "coding_agent",
+    "model": {
+      "provider": "unknown",
+      "name": "unknown",
+      "version": "unknown"
+    },
+    "toolchain": [
+      {
+        "name": "agentplane",
+        "version": "0.4.2"
+      }
+    ]
+  },
+  "plan": {
+    "status": "approved",
+    "artifact": {
+      "path": ".agentplane/tasks/202605090913-E0Z7PF/README.md",
+      "sha256": "sha256:99b858df469e53c9fbd00464eb0637913d619cc245057d3df9a866bfc0976499"
+    },
+    "approved_at": "2026-05-09T09:13:25.474Z",
+    "approved_by": {
+      "type": "agentplane_role",
+      "id": "ORCHESTRATOR"
+    }
+  },
+  "permissions": {
+    "network": {
+      "mode": "unknown"
+    },
+    "secrets": {
+      "access": "none"
+    },
+    "tools": [
+      {
+        "name": "shell",
+        "allowed": true
+      }
+    ]
+  },
+  "policy": {
+    "policy_version": "0.1.0",
+    "decisions": [
+      {
+        "rule_id": "plan.required",
+        "decision": "pass",
+        "reason": "Approved plan exists."
+      },
+      {
+        "rule_id": "verification.required",
+        "decision": "pass",
+        "reason": "Verification is recorded as ok."
+      }
+    ]
+  },
+  "changes": {
+    "summary": "Closed stale lifecycle state after merged implementation commit 1cacfa9ff.",
+    "diff_stats": {
+      "files_changed": 0,
+      "insertions": 0,
+      "deletions": 0
+    },
+    "files": [],
+    "risk": {
+      "level": "medium",
+      "categories": [],
+      "protected_paths_touched": false
+    }
+  },
+  "verification": {
+    "status": "passed",
+    "checks": []
+  },
+  "approvals": [
+    {
+      "approval_id": "approval_202605090913-E0Z7PF_plan",
+      "type": "plan_approval",
+      "decision": "approved",
+      "approved_by": {
+        "type": "agentplane_role",
+        "id": "ORCHESTRATOR"
+      },
+      "approved_at": "2026-05-09T09:13:25.474Z",
+      "scope": "task"
+    }
+  ],
+  "evidence": [
+    {
+      "type": "task",
+      "path": ".agentplane/tasks/202605090913-E0Z7PF/README.md",
+      "sha256": "sha256:99b858df469e53c9fbd00464eb0637913d619cc245057d3df9a866bfc0976499"
+    },
+    {
+      "type": "plan",
+      "path": ".agentplane/tasks/202605090913-E0Z7PF/README.md",
+      "sha256": "sha256:99b858df469e53c9fbd00464eb0637913d619cc245057d3df9a866bfc0976499"
+    },
+    {
+      "type": "verification_log",
+      "path": ".agentplane/tasks/202605090913-E0Z7PF/README.md",
+      "sha256": "sha256:99b858df469e53c9fbd00464eb0637913d619cc245057d3df9a866bfc0976499"
+    },
+    {
+      "type": "other",
+      "path": ".agentplane/tasks/202605090913-E0Z7PF/blueprint/resolved-snapshot.json",
+      "sha256": "sha256:edaf2a113cef78fd3ab26e59c787c3dc88df792f5ce9a32bd924793aead410f3"
+    }
+  ],
+  "result": {
+    "status": "finished",
+    "merge_ready": false,
+    "residual_risks": [
+      "Passed verification has no checks."
+    ],
+    "rollback": {
+      "available": true,
+      "notes": "Revert work_commit 1cacfa9ff5a8b8613bf5d53fd502511aba47e868 if downstream validation fails."
+    }
+  },
+  "integrity": {
+    "digest_algorithm": "sha256",
+    "record_digest": "sha256:0da0b84400a81833613976457af7f153eedd38bd34e47489365991c7fdad598c",
+    "canonicalization": "rfc8785-jcs",
+    "signatures": []
+  },
+  "extensions": {
+    "agentplane.blueprint": {
+      "blueprint_id": "code.branch_pr",
+      "blueprint_version": 1,
+      "workflow_mode": "branch_pr",
+      "route": [
+        "intake",
+        "scope",
+        "approval_gate",
+        "context_resolve",
+        "worktree_start",
+        "work_unit",
+        "fast_local_checks",
+        "pr_artifact",
+        "hosted_checks",
+        "publish_or_integrate",
+        "verify_record",
+        "finish"
+      ],
+      "required_evidence": [
+        {
+          "id": "code_pr.paths",
+          "kind": "changed_paths",
+          "produced_by": "work_unit",
+          "required": true
+        },
+        {
+          "id": "code_pr.fast_checks",
+          "kind": "check_result",
+          "produced_by": "fast_local_checks",
+          "required": true
+        },
+        {
+          "id": "code_pr.pr",
+          "kind": "external_link",
+          "produced_by": "pr_artifact",
+          "required": true
+        },
+        {
+          "id": "code_pr.hosted",
+          "kind": "check_result",
+          "produced_by": "hosted_checks",
+          "required": true
+        },
+        {
+          "id": "code_pr.commit",
+          "kind": "commit",
+          "produced_by": "publish_or_integrate",
+          "required": true
+        }
+      ],
+      "accepted_recipe_extensions": [],
+      "rejected_recipe_extensions": [],
+      "stop_reasons": [],
+      "snapshot": {
+        "state": "current",
+        "path": ".agentplane/tasks/202605090913-E0Z7PF/blueprint/resolved-snapshot.json",
+        "digest": "c05d4162b249eda54b60dba82af8a8e9e04bc9caa9d2e10599578cdd4e64dadc",
+        "current_digest": "c05d4162b249eda54b60dba82af8a8e9e04bc9caa9d2e10599578cdd4e64dadc",
+        "route_changed": false,
+        "artifact_sha256": "sha256:edaf2a113cef78fd3ab26e59c787c3dc88df792f5ce9a32bd924793aead410f3",
+        "safe_command": "agentplane blueprint snapshot 202605090913-E0Z7PF"
+      }
+    }
+  }
+}

--- a/.agentplane/tasks/202605090917-VMPWJP/README.md
+++ b/.agentplane/tasks/202605090917-VMPWJP/README.md
@@ -1,7 +1,8 @@
 ---
 id: "202605090917-VMPWJP"
 title: "Split ACR generation module"
-status: "DOING"
+result_summary: "Closed stale lifecycle state after merged implementation commit 85ccddf95."
+status: "DONE"
 priority: "med"
 owner: "CODER"
 revision: 1
@@ -18,14 +19,19 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-09T09:20:42.358Z"
+  updated_at: "2026-05-09T15:26:15.486Z"
   updated_by: "CODER"
-  note: "ACR generation split verified with focused tests, typecheck, and hotspot check."
-commit: null
+  note: "ACR generation module split verified on current main."
+commit:
+  hash: "85ccddf951ce14a7282f7780e18085eb31c3c0d7"
+  message: "🚧 VMPWJP acr: format command imports"
 comments:
   -
     author: "CODER"
     body: "Start: split ACR generation logic into a focused module while preserving generated record output."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: ACR generation-module split is present on current main, focused ACR tests, hotspot check, and typecheck evidence are recorded."
 events:
   -
     type: "status"
@@ -40,9 +46,22 @@ events:
     author: "CODER"
     state: "ok"
     note: "ACR generation split verified with focused tests, typecheck, and hotspot check."
+  -
+    type: "verify"
+    at: "2026-05-09T15:26:15.486Z"
+    author: "CODER"
+    state: "ok"
+    note: "ACR generation module split verified on current main."
+  -
+    type: "status"
+    at: "2026-05-09T15:27:56.306Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: ACR generation-module split is present on current main, focused ACR tests, hotspot check, and typecheck evidence are recorded."
 doc_version: 3
-doc_updated_at: "2026-05-09T09:20:42.380Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-09T15:27:56.310Z"
+doc_updated_by: "INTEGRATOR"
 description: "Move ACR generation, blueprint extension builders, and generation-only helpers into a focused module without changing generated ACR output."
 sections:
   Summary: |-
@@ -72,6 +91,28 @@ sections:
     VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T09:17:14.075Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
     
     Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tasks/202605090917-VMPWJP/blueprint/resolved-snapshot.json
+    - old_digest: fa99eef09e18edac74063fd6f1243c88c7bcf888bcefe13f25d8f819a954f0ea
+    - current_digest: fa99eef09e18edac74063fd6f1243c88c7bcf888bcefe13f25d8f819a954f0ea
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605090917-VMPWJP
+    
+    ### 2026-05-09T15:26:15.486Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: ACR generation module split verified on current main.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T09:20:42.380Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    Command: bunx vitest run packages/agentplane/src/commands/acr/acr.command.test.ts --pool=forks --maxWorkers 2 --testTimeout 120000 --hookTimeout 120000 | Result: pass | Evidence: 10 tests passed. Scope: ACR generation and command integration.
+    Command: bun run hotspots:check | Result: pass | Evidence: threshold check passed; acr.command.ts is 453 lines and generate.ts is 438 lines. Scope: hotspot guard.
+    Command: bun run typecheck | Result: pass | Evidence: tsc -b completed. Scope: workspace TypeScript contracts.
     
     BlueprintSnapshotRef:
     - state: current

--- a/.agentplane/tasks/202605090917-VMPWJP/acr.json
+++ b/.agentplane/tasks/202605090917-VMPWJP/acr.json
@@ -1,0 +1,219 @@
+{
+  "acr_version": "0.1.0",
+  "record_type": "agent_change_record",
+  "record_id": "acr_202605090917-VMPWJP",
+  "created_at": "2026-05-09T15:27:57.330Z",
+  "producer": {
+    "name": "agentplane",
+    "version": "0.4.2"
+  },
+  "repository": {
+    "vcs": "git",
+    "remote": "https://github.com/basilisk-labs/agentplane.git",
+    "base_ref": "main",
+    "base_commit": "85ccddf951ce14a7282f7780e18085eb31c3c0d7",
+    "work_ref": "main",
+    "work_commit": "85ccddf951ce14a7282f7780e18085eb31c3c0d7"
+  },
+  "task": {
+    "task_id": "202605090917-VMPWJP",
+    "title": "Split ACR generation module",
+    "intent": "Move ACR generation, blueprint extension builders, and generation-only helpers into a focused module without changing generated ACR output.",
+    "requested_by": {
+      "type": "agentplane_role",
+      "id": "ORCHESTRATOR"
+    }
+  },
+  "agent": {
+    "id": "INTEGRATOR",
+    "name": "INTEGRATOR",
+    "agent_type": "coding_agent",
+    "model": {
+      "provider": "unknown",
+      "name": "unknown",
+      "version": "unknown"
+    },
+    "toolchain": [
+      {
+        "name": "agentplane",
+        "version": "0.4.2"
+      }
+    ]
+  },
+  "plan": {
+    "status": "approved",
+    "artifact": {
+      "path": ".agentplane/tasks/202605090917-VMPWJP/README.md",
+      "sha256": "sha256:3d936869ebd2d530505134b02850bc1d0aa75288f7eac94822fb123fea1736f2"
+    },
+    "approved_at": "2026-05-09T09:17:09.766Z",
+    "approved_by": {
+      "type": "agentplane_role",
+      "id": "ORCHESTRATOR"
+    }
+  },
+  "permissions": {
+    "network": {
+      "mode": "unknown"
+    },
+    "secrets": {
+      "access": "none"
+    },
+    "tools": [
+      {
+        "name": "shell",
+        "allowed": true
+      }
+    ]
+  },
+  "policy": {
+    "policy_version": "0.1.0",
+    "decisions": [
+      {
+        "rule_id": "plan.required",
+        "decision": "pass",
+        "reason": "Approved plan exists."
+      },
+      {
+        "rule_id": "verification.required",
+        "decision": "pass",
+        "reason": "Verification is recorded as ok."
+      }
+    ]
+  },
+  "changes": {
+    "summary": "Closed stale lifecycle state after merged implementation commit 85ccddf95.",
+    "diff_stats": {
+      "files_changed": 0,
+      "insertions": 0,
+      "deletions": 0
+    },
+    "files": [],
+    "risk": {
+      "level": "medium",
+      "categories": [],
+      "protected_paths_touched": false
+    }
+  },
+  "verification": {
+    "status": "passed",
+    "checks": []
+  },
+  "approvals": [
+    {
+      "approval_id": "approval_202605090917-VMPWJP_plan",
+      "type": "plan_approval",
+      "decision": "approved",
+      "approved_by": {
+        "type": "agentplane_role",
+        "id": "ORCHESTRATOR"
+      },
+      "approved_at": "2026-05-09T09:17:09.766Z",
+      "scope": "task"
+    }
+  ],
+  "evidence": [
+    {
+      "type": "task",
+      "path": ".agentplane/tasks/202605090917-VMPWJP/README.md",
+      "sha256": "sha256:3d936869ebd2d530505134b02850bc1d0aa75288f7eac94822fb123fea1736f2"
+    },
+    {
+      "type": "plan",
+      "path": ".agentplane/tasks/202605090917-VMPWJP/README.md",
+      "sha256": "sha256:3d936869ebd2d530505134b02850bc1d0aa75288f7eac94822fb123fea1736f2"
+    },
+    {
+      "type": "verification_log",
+      "path": ".agentplane/tasks/202605090917-VMPWJP/README.md",
+      "sha256": "sha256:3d936869ebd2d530505134b02850bc1d0aa75288f7eac94822fb123fea1736f2"
+    },
+    {
+      "type": "other",
+      "path": ".agentplane/tasks/202605090917-VMPWJP/blueprint/resolved-snapshot.json",
+      "sha256": "sha256:338cca977f45df78314cb07c5b5951e0bc575222dfbed821b3f4cd7ad591901a"
+    }
+  ],
+  "result": {
+    "status": "finished",
+    "merge_ready": false,
+    "residual_risks": [
+      "Passed verification has no checks."
+    ],
+    "rollback": {
+      "available": true,
+      "notes": "Revert work_commit 85ccddf951ce14a7282f7780e18085eb31c3c0d7 if downstream validation fails."
+    }
+  },
+  "integrity": {
+    "digest_algorithm": "sha256",
+    "record_digest": "sha256:9107cb2f0e0c620be4208de735018974739919774e44c712a7433aba77c27616",
+    "canonicalization": "rfc8785-jcs",
+    "signatures": []
+  },
+  "extensions": {
+    "agentplane.blueprint": {
+      "blueprint_id": "code.branch_pr",
+      "blueprint_version": 1,
+      "workflow_mode": "branch_pr",
+      "route": [
+        "intake",
+        "scope",
+        "approval_gate",
+        "context_resolve",
+        "worktree_start",
+        "work_unit",
+        "fast_local_checks",
+        "pr_artifact",
+        "hosted_checks",
+        "publish_or_integrate",
+        "verify_record",
+        "finish"
+      ],
+      "required_evidence": [
+        {
+          "id": "code_pr.paths",
+          "kind": "changed_paths",
+          "produced_by": "work_unit",
+          "required": true
+        },
+        {
+          "id": "code_pr.fast_checks",
+          "kind": "check_result",
+          "produced_by": "fast_local_checks",
+          "required": true
+        },
+        {
+          "id": "code_pr.pr",
+          "kind": "external_link",
+          "produced_by": "pr_artifact",
+          "required": true
+        },
+        {
+          "id": "code_pr.hosted",
+          "kind": "check_result",
+          "produced_by": "hosted_checks",
+          "required": true
+        },
+        {
+          "id": "code_pr.commit",
+          "kind": "commit",
+          "produced_by": "publish_or_integrate",
+          "required": true
+        }
+      ],
+      "accepted_recipe_extensions": [],
+      "rejected_recipe_extensions": [],
+      "stop_reasons": [],
+      "snapshot": {
+        "state": "current",
+        "path": ".agentplane/tasks/202605090917-VMPWJP/blueprint/resolved-snapshot.json",
+        "digest": "fa99eef09e18edac74063fd6f1243c88c7bcf888bcefe13f25d8f819a954f0ea",
+        "current_digest": "fa99eef09e18edac74063fd6f1243c88c7bcf888bcefe13f25d8f819a954f0ea",
+        "route_changed": false,
+        "artifact_sha256": "sha256:338cca977f45df78314cb07c5b5951e0bc575222dfbed821b3f4cd7ad591901a",
+        "safe_command": "agentplane blueprint snapshot 202605090917-VMPWJP"
+      }
+    }
+  }
+}

--- a/.agentplane/tasks/202605090921-J01VGF/README.md
+++ b/.agentplane/tasks/202605090921-J01VGF/README.md
@@ -1,7 +1,8 @@
 ---
 id: "202605090921-J01VGF"
 title: "Remove ACR hotspot allowlist"
-status: "DOING"
+result_summary: "Closed stale lifecycle state after merged implementation commit 4e2420cfc."
+status: "DONE"
 priority: "med"
 owner: "CODER"
 revision: 1
@@ -18,14 +19,19 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-09T09:21:58.648Z"
+  updated_at: "2026-05-09T15:26:17.388Z"
   updated_by: "CODER"
-  note: "ACR hotspot allow-list removal verified with hotspot, script docs, and type checks."
-commit: null
+  note: "ACR hotspot allowlist removal verified on current main."
+commit:
+  hash: "4e2420cfcebcd1621ace310849bd343c1bc8f15a"
+  message: "🚧 J01VGF hotspots: remove acr allowlist"
 comments:
   -
     author: "CODER"
     body: "Start: remove stale ACR hotspot allow-list entry after the ACR split dropped below the oversized threshold."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: ACR hotspot allowlist removal is present on current main, hotspot check and typecheck evidence are recorded."
 events:
   -
     type: "status"
@@ -40,9 +46,22 @@ events:
     author: "CODER"
     state: "ok"
     note: "ACR hotspot allow-list removal verified with hotspot, script docs, and type checks."
+  -
+    type: "verify"
+    at: "2026-05-09T15:26:17.388Z"
+    author: "CODER"
+    state: "ok"
+    note: "ACR hotspot allowlist removal verified on current main."
+  -
+    type: "status"
+    at: "2026-05-09T15:28:02.509Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: ACR hotspot allowlist removal is present on current main, hotspot check and typecheck evidence are recorded."
 doc_version: 3
-doc_updated_at: "2026-05-09T09:21:58.660Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-09T15:28:02.513Z"
+doc_updated_by: "INTEGRATOR"
 description: "Remove acr.command.ts from hotspots:check allow-list after ACR split brings it below the oversized threshold, and update generated script docs if required."
 sections:
   Summary: |-
@@ -71,6 +90,28 @@ sections:
     VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T09:21:21.090Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
     
     Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tasks/202605090921-J01VGF/blueprint/resolved-snapshot.json
+    - old_digest: 9624a1ed1bd600d360975acc05d1aeb9e6543aa8519402f249532dbb8eb434fb
+    - current_digest: 9624a1ed1bd600d360975acc05d1aeb9e6543aa8519402f249532dbb8eb434fb
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605090921-J01VGF
+    
+    ### 2026-05-09T15:26:17.388Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: ACR hotspot allowlist removal verified on current main.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T09:21:58.660Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    Command: bun run hotspots:check | Result: pass | Evidence: threshold check passed without ACR allow-list. Scope: hotspot script configuration.
+    Command: jq -r '.scripts["hotspots:check"]' package.json | Result: pass | Evidence: script has no --allow-oversized entry. Scope: package script.
+    Command: bun run typecheck | Result: pass | Evidence: tsc -b completed. Scope: workspace TypeScript contracts.
     
     BlueprintSnapshotRef:
     - state: current

--- a/.agentplane/tasks/202605090921-J01VGF/acr.json
+++ b/.agentplane/tasks/202605090921-J01VGF/acr.json
@@ -1,0 +1,219 @@
+{
+  "acr_version": "0.1.0",
+  "record_type": "agent_change_record",
+  "record_id": "acr_202605090921-J01VGF",
+  "created_at": "2026-05-09T15:28:03.662Z",
+  "producer": {
+    "name": "agentplane",
+    "version": "0.4.2"
+  },
+  "repository": {
+    "vcs": "git",
+    "remote": "https://github.com/basilisk-labs/agentplane.git",
+    "base_ref": "main",
+    "base_commit": "4e2420cfcebcd1621ace310849bd343c1bc8f15a",
+    "work_ref": "main",
+    "work_commit": "4e2420cfcebcd1621ace310849bd343c1bc8f15a"
+  },
+  "task": {
+    "task_id": "202605090921-J01VGF",
+    "title": "Remove ACR hotspot allowlist",
+    "intent": "Remove acr.command.ts from hotspots:check allow-list after ACR split brings it below the oversized threshold, and update generated script docs if required.",
+    "requested_by": {
+      "type": "agentplane_role",
+      "id": "ORCHESTRATOR"
+    }
+  },
+  "agent": {
+    "id": "INTEGRATOR",
+    "name": "INTEGRATOR",
+    "agent_type": "coding_agent",
+    "model": {
+      "provider": "unknown",
+      "name": "unknown",
+      "version": "unknown"
+    },
+    "toolchain": [
+      {
+        "name": "agentplane",
+        "version": "0.4.2"
+      }
+    ]
+  },
+  "plan": {
+    "status": "approved",
+    "artifact": {
+      "path": ".agentplane/tasks/202605090921-J01VGF/README.md",
+      "sha256": "sha256:bc65e0fff27ba7f6ef9647f8616a4b7c9caf343aca3de9df3d11983bd4eba853"
+    },
+    "approved_at": "2026-05-09T09:21:13.207Z",
+    "approved_by": {
+      "type": "agentplane_role",
+      "id": "ORCHESTRATOR"
+    }
+  },
+  "permissions": {
+    "network": {
+      "mode": "unknown"
+    },
+    "secrets": {
+      "access": "none"
+    },
+    "tools": [
+      {
+        "name": "shell",
+        "allowed": true
+      }
+    ]
+  },
+  "policy": {
+    "policy_version": "0.1.0",
+    "decisions": [
+      {
+        "rule_id": "plan.required",
+        "decision": "pass",
+        "reason": "Approved plan exists."
+      },
+      {
+        "rule_id": "verification.required",
+        "decision": "pass",
+        "reason": "Verification is recorded as ok."
+      }
+    ]
+  },
+  "changes": {
+    "summary": "Closed stale lifecycle state after merged implementation commit 4e2420cfc.",
+    "diff_stats": {
+      "files_changed": 0,
+      "insertions": 0,
+      "deletions": 0
+    },
+    "files": [],
+    "risk": {
+      "level": "medium",
+      "categories": [],
+      "protected_paths_touched": false
+    }
+  },
+  "verification": {
+    "status": "passed",
+    "checks": []
+  },
+  "approvals": [
+    {
+      "approval_id": "approval_202605090921-J01VGF_plan",
+      "type": "plan_approval",
+      "decision": "approved",
+      "approved_by": {
+        "type": "agentplane_role",
+        "id": "ORCHESTRATOR"
+      },
+      "approved_at": "2026-05-09T09:21:13.207Z",
+      "scope": "task"
+    }
+  ],
+  "evidence": [
+    {
+      "type": "task",
+      "path": ".agentplane/tasks/202605090921-J01VGF/README.md",
+      "sha256": "sha256:bc65e0fff27ba7f6ef9647f8616a4b7c9caf343aca3de9df3d11983bd4eba853"
+    },
+    {
+      "type": "plan",
+      "path": ".agentplane/tasks/202605090921-J01VGF/README.md",
+      "sha256": "sha256:bc65e0fff27ba7f6ef9647f8616a4b7c9caf343aca3de9df3d11983bd4eba853"
+    },
+    {
+      "type": "verification_log",
+      "path": ".agentplane/tasks/202605090921-J01VGF/README.md",
+      "sha256": "sha256:bc65e0fff27ba7f6ef9647f8616a4b7c9caf343aca3de9df3d11983bd4eba853"
+    },
+    {
+      "type": "other",
+      "path": ".agentplane/tasks/202605090921-J01VGF/blueprint/resolved-snapshot.json",
+      "sha256": "sha256:6e980f4d23ba2603c8f0dae73ea43fc8504c985e5136fc0227eed49573bdf3ac"
+    }
+  ],
+  "result": {
+    "status": "finished",
+    "merge_ready": false,
+    "residual_risks": [
+      "Passed verification has no checks."
+    ],
+    "rollback": {
+      "available": true,
+      "notes": "Revert work_commit 4e2420cfcebcd1621ace310849bd343c1bc8f15a if downstream validation fails."
+    }
+  },
+  "integrity": {
+    "digest_algorithm": "sha256",
+    "record_digest": "sha256:404b691b2445ae03c5bfd83073945f9a5137d30ecc9500e3bdae82327612829f",
+    "canonicalization": "rfc8785-jcs",
+    "signatures": []
+  },
+  "extensions": {
+    "agentplane.blueprint": {
+      "blueprint_id": "code.branch_pr",
+      "blueprint_version": 1,
+      "workflow_mode": "branch_pr",
+      "route": [
+        "intake",
+        "scope",
+        "approval_gate",
+        "context_resolve",
+        "worktree_start",
+        "work_unit",
+        "fast_local_checks",
+        "pr_artifact",
+        "hosted_checks",
+        "publish_or_integrate",
+        "verify_record",
+        "finish"
+      ],
+      "required_evidence": [
+        {
+          "id": "code_pr.paths",
+          "kind": "changed_paths",
+          "produced_by": "work_unit",
+          "required": true
+        },
+        {
+          "id": "code_pr.fast_checks",
+          "kind": "check_result",
+          "produced_by": "fast_local_checks",
+          "required": true
+        },
+        {
+          "id": "code_pr.pr",
+          "kind": "external_link",
+          "produced_by": "pr_artifact",
+          "required": true
+        },
+        {
+          "id": "code_pr.hosted",
+          "kind": "check_result",
+          "produced_by": "hosted_checks",
+          "required": true
+        },
+        {
+          "id": "code_pr.commit",
+          "kind": "commit",
+          "produced_by": "publish_or_integrate",
+          "required": true
+        }
+      ],
+      "accepted_recipe_extensions": [],
+      "rejected_recipe_extensions": [],
+      "stop_reasons": [],
+      "snapshot": {
+        "state": "current",
+        "path": ".agentplane/tasks/202605090921-J01VGF/blueprint/resolved-snapshot.json",
+        "digest": "9624a1ed1bd600d360975acc05d1aeb9e6543aa8519402f249532dbb8eb434fb",
+        "current_digest": "9624a1ed1bd600d360975acc05d1aeb9e6543aa8519402f249532dbb8eb434fb",
+        "route_changed": false,
+        "artifact_sha256": "sha256:6e980f4d23ba2603c8f0dae73ea43fc8504c985e5136fc0227eed49573bdf3ac",
+        "safe_command": "agentplane blueprint snapshot 202605090921-J01VGF"
+      }
+    }
+  }
+}

--- a/.agentplane/tasks/202605090922-Y5MBV3/README.md
+++ b/.agentplane/tasks/202605090922-Y5MBV3/README.md
@@ -1,7 +1,8 @@
 ---
 id: "202605090922-Y5MBV3"
 title: "Remove compiler hotspot allowlist"
-status: "DOING"
+result_summary: "Closed stale lifecycle state after merged implementation commit cce1235df."
+status: "DONE"
 priority: "med"
 owner: "CODER"
 revision: 1
@@ -17,15 +18,20 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
-commit: null
+  state: "ok"
+  updated_at: "2026-05-09T15:26:19.271Z"
+  updated_by: "CODER"
+  note: "Compiler hotspot allowlist removal verified on current main."
+commit:
+  hash: "cce1235dfbab70d1e5208a794582c42180220146"
+  message: "🚧 Y5MBV3 hotspots: remove compiler allowlist"
 comments:
   -
     author: "CODER"
     body: "Start: remove the remaining hotspot allow-list entry after confirming compiler.ts is below the oversized threshold."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: compiler hotspot allowlist removal is present on current main, compiler tests, hotspot check, and typecheck evidence are recorded."
 events:
   -
     type: "status"
@@ -34,9 +40,22 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: remove the remaining hotspot allow-list entry after confirming compiler.ts is below the oversized threshold."
+  -
+    type: "verify"
+    at: "2026-05-09T15:26:19.271Z"
+    author: "CODER"
+    state: "ok"
+    note: "Compiler hotspot allowlist removal verified on current main."
+  -
+    type: "status"
+    at: "2026-05-09T15:28:09.988Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: compiler hotspot allowlist removal is present on current main, compiler tests, hotspot check, and typecheck evidence are recorded."
 doc_version: 3
-doc_updated_at: "2026-05-09T09:22:51.102Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-09T15:28:09.992Z"
+doc_updated_by: "INTEGRATOR"
 description: "Remove prompt-modules/compiler.ts from hotspots:check allow-list when the file is below the oversized threshold, leaving hotspot guardrails without runtime allow-list entries."
 sections:
   Summary: |-
@@ -56,6 +75,28 @@ sections:
     3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-09T15:26:19.271Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Compiler hotspot allowlist removal verified on current main.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T09:22:51.102Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    Command: bunx vitest run packages/agentplane/src/runtime/prompt-modules/compiler.test.ts --pool=forks --maxWorkers 2 --testTimeout 120000 --hookTimeout 120000 | Result: pass | Evidence: 12 tests passed. Scope: prompt module compiler behavior.
+    Command: bun run hotspots:check | Result: pass | Evidence: threshold check passed; compiler.ts is 441 lines and no allow-list is configured. Scope: hotspot guard.
+    Command: bun run typecheck | Result: pass | Evidence: tsc -b completed. Scope: workspace TypeScript contracts.
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tasks/202605090922-Y5MBV3/blueprint/resolved-snapshot.json
+    - old_digest: 64f8b2fd54de3a2a02bf6e52c98fe806e5d75a35bc3144235429de950f854bb6
+    - current_digest: 64f8b2fd54de3a2a02bf6e52c98fe806e5d75a35bc3144235429de950f854bb6
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605090922-Y5MBV3
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).

--- a/.agentplane/tasks/202605090922-Y5MBV3/acr.json
+++ b/.agentplane/tasks/202605090922-Y5MBV3/acr.json
@@ -1,0 +1,219 @@
+{
+  "acr_version": "0.1.0",
+  "record_type": "agent_change_record",
+  "record_id": "acr_202605090922-Y5MBV3",
+  "created_at": "2026-05-09T15:28:11.571Z",
+  "producer": {
+    "name": "agentplane",
+    "version": "0.4.2"
+  },
+  "repository": {
+    "vcs": "git",
+    "remote": "https://github.com/basilisk-labs/agentplane.git",
+    "base_ref": "main",
+    "base_commit": "cce1235dfbab70d1e5208a794582c42180220146",
+    "work_ref": "main",
+    "work_commit": "cce1235dfbab70d1e5208a794582c42180220146"
+  },
+  "task": {
+    "task_id": "202605090922-Y5MBV3",
+    "title": "Remove compiler hotspot allowlist",
+    "intent": "Remove prompt-modules/compiler.ts from hotspots:check allow-list when the file is below the oversized threshold, leaving hotspot guardrails without runtime allow-list entries.",
+    "requested_by": {
+      "type": "agentplane_role",
+      "id": "ORCHESTRATOR"
+    }
+  },
+  "agent": {
+    "id": "INTEGRATOR",
+    "name": "INTEGRATOR",
+    "agent_type": "coding_agent",
+    "model": {
+      "provider": "unknown",
+      "name": "unknown",
+      "version": "unknown"
+    },
+    "toolchain": [
+      {
+        "name": "agentplane",
+        "version": "0.4.2"
+      }
+    ]
+  },
+  "plan": {
+    "status": "approved",
+    "artifact": {
+      "path": ".agentplane/tasks/202605090922-Y5MBV3/README.md",
+      "sha256": "sha256:3904bb19544d6d34e737b0b3e6e0025b3b43ebea224f5b27c88728f8f4ef4483"
+    },
+    "approved_at": "2026-05-09T09:22:41.393Z",
+    "approved_by": {
+      "type": "agentplane_role",
+      "id": "ORCHESTRATOR"
+    }
+  },
+  "permissions": {
+    "network": {
+      "mode": "unknown"
+    },
+    "secrets": {
+      "access": "none"
+    },
+    "tools": [
+      {
+        "name": "shell",
+        "allowed": true
+      }
+    ]
+  },
+  "policy": {
+    "policy_version": "0.1.0",
+    "decisions": [
+      {
+        "rule_id": "plan.required",
+        "decision": "pass",
+        "reason": "Approved plan exists."
+      },
+      {
+        "rule_id": "verification.required",
+        "decision": "pass",
+        "reason": "Verification is recorded as ok."
+      }
+    ]
+  },
+  "changes": {
+    "summary": "Closed stale lifecycle state after merged implementation commit cce1235df.",
+    "diff_stats": {
+      "files_changed": 0,
+      "insertions": 0,
+      "deletions": 0
+    },
+    "files": [],
+    "risk": {
+      "level": "medium",
+      "categories": [],
+      "protected_paths_touched": false
+    }
+  },
+  "verification": {
+    "status": "passed",
+    "checks": []
+  },
+  "approvals": [
+    {
+      "approval_id": "approval_202605090922-Y5MBV3_plan",
+      "type": "plan_approval",
+      "decision": "approved",
+      "approved_by": {
+        "type": "agentplane_role",
+        "id": "ORCHESTRATOR"
+      },
+      "approved_at": "2026-05-09T09:22:41.393Z",
+      "scope": "task"
+    }
+  ],
+  "evidence": [
+    {
+      "type": "task",
+      "path": ".agentplane/tasks/202605090922-Y5MBV3/README.md",
+      "sha256": "sha256:3904bb19544d6d34e737b0b3e6e0025b3b43ebea224f5b27c88728f8f4ef4483"
+    },
+    {
+      "type": "plan",
+      "path": ".agentplane/tasks/202605090922-Y5MBV3/README.md",
+      "sha256": "sha256:3904bb19544d6d34e737b0b3e6e0025b3b43ebea224f5b27c88728f8f4ef4483"
+    },
+    {
+      "type": "verification_log",
+      "path": ".agentplane/tasks/202605090922-Y5MBV3/README.md",
+      "sha256": "sha256:3904bb19544d6d34e737b0b3e6e0025b3b43ebea224f5b27c88728f8f4ef4483"
+    },
+    {
+      "type": "other",
+      "path": ".agentplane/tasks/202605090922-Y5MBV3/blueprint/resolved-snapshot.json",
+      "sha256": "sha256:d06a6a2f75505d50039f42e0438d276cbe6abdafd7f0d7b161b91b9e65f98a43"
+    }
+  ],
+  "result": {
+    "status": "finished",
+    "merge_ready": false,
+    "residual_risks": [
+      "Passed verification has no checks."
+    ],
+    "rollback": {
+      "available": true,
+      "notes": "Revert work_commit cce1235dfbab70d1e5208a794582c42180220146 if downstream validation fails."
+    }
+  },
+  "integrity": {
+    "digest_algorithm": "sha256",
+    "record_digest": "sha256:0c420ba7b9ecacfb64d5b78395bc0706da131a23412b1999476c4ea8c2b45870",
+    "canonicalization": "rfc8785-jcs",
+    "signatures": []
+  },
+  "extensions": {
+    "agentplane.blueprint": {
+      "blueprint_id": "code.branch_pr",
+      "blueprint_version": 1,
+      "workflow_mode": "branch_pr",
+      "route": [
+        "intake",
+        "scope",
+        "approval_gate",
+        "context_resolve",
+        "worktree_start",
+        "work_unit",
+        "fast_local_checks",
+        "pr_artifact",
+        "hosted_checks",
+        "publish_or_integrate",
+        "verify_record",
+        "finish"
+      ],
+      "required_evidence": [
+        {
+          "id": "code_pr.paths",
+          "kind": "changed_paths",
+          "produced_by": "work_unit",
+          "required": true
+        },
+        {
+          "id": "code_pr.fast_checks",
+          "kind": "check_result",
+          "produced_by": "fast_local_checks",
+          "required": true
+        },
+        {
+          "id": "code_pr.pr",
+          "kind": "external_link",
+          "produced_by": "pr_artifact",
+          "required": true
+        },
+        {
+          "id": "code_pr.hosted",
+          "kind": "check_result",
+          "produced_by": "hosted_checks",
+          "required": true
+        },
+        {
+          "id": "code_pr.commit",
+          "kind": "commit",
+          "produced_by": "publish_or_integrate",
+          "required": true
+        }
+      ],
+      "accepted_recipe_extensions": [],
+      "rejected_recipe_extensions": [],
+      "stop_reasons": [],
+      "snapshot": {
+        "state": "current",
+        "path": ".agentplane/tasks/202605090922-Y5MBV3/blueprint/resolved-snapshot.json",
+        "digest": "64f8b2fd54de3a2a02bf6e52c98fe806e5d75a35bc3144235429de950f854bb6",
+        "current_digest": "64f8b2fd54de3a2a02bf6e52c98fe806e5d75a35bc3144235429de950f854bb6",
+        "route_changed": false,
+        "artifact_sha256": "sha256:d06a6a2f75505d50039f42e0438d276cbe6abdafd7f0d7b161b91b9e65f98a43",
+        "safe_command": "agentplane blueprint snapshot 202605090922-Y5MBV3"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- closes six stale release/refactor AgentPlane tasks that were already implemented and merged into main
- records fresh verification evidence for cloud sync hardening, ACR split tasks, and hotspot allow-list removal
- adds generated ACR artifacts for the closed tasks

## Verification
- ap backend sync cloud --direction pull --conflict=diff
- bunx vitest run packages/agentplane/src/backends/task-backend.cloud.test.ts packages/agentplane/src/backends/task-backend/cloud-backend-utils.test.ts --pool=forks --maxWorkers 2 --testTimeout 120000 --hookTimeout 120000
- bunx vitest run packages/agentplane/src/commands/acr/acr.command.test.ts packages/agentplane/src/runtime/prompt-modules/compiler.test.ts --pool=forks --maxWorkers 2 --testTimeout 120000 --hookTimeout 120000
- bun run hotspots:check
- bun run typecheck
- pre-push fast CI