### PR TITLE
🚧 C49NA0 task: Integrate atomic global reinstall helper [202605091534-C49NA0]

### DIFF
--- a/.agentplane/tasks/202605091534-C49NA0/README.md
+++ b/.agentplane/tasks/202605091534-C49NA0/README.md
@@ -1,0 +1,102 @@
+---
+id: "202605091534-C49NA0"
+title: "Integrate atomic global reinstall helper"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-09T15:34:20.111Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-09T15:35:55.417Z"
+  updated_by: "CODER"
+  note: "Runtime reinstall helper integration verified."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: integrate the existing runtime reinstall helper branch onto current main with focused release-contract and docs verification."
+events:
+  -
+    type: "status"
+    at: "2026-05-09T15:34:32.941Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: integrate the existing runtime reinstall helper branch onto current main with focused release-contract and docs verification."
+  -
+    type: "verify"
+    at: "2026-05-09T15:35:55.417Z"
+    author: "CODER"
+    state: "ok"
+    note: "Runtime reinstall helper integration verified."
+doc_version: 3
+doc_updated_at: "2026-05-09T15:35:55.442Z"
+doc_updated_by: "CODER"
+description: "Integrate the existing local runtime-install-atomic branch changes into current main: make scripts/reinstall-global-agentplane.sh use an atomic npm link workflow, update release contract coverage, and align developer docs."
+sections:
+  Summary: |-
+    Integrate atomic global reinstall helper
+    
+    Integrate the existing local runtime-install-atomic branch changes into current main: make scripts/reinstall-global-agentplane.sh use an atomic npm link workflow, update release contract coverage, and align developer docs.
+  Scope: |-
+    - In scope: Integrate the existing local runtime-install-atomic branch changes into current main: make scripts/reinstall-global-agentplane.sh use an atomic npm link workflow, update release contract coverage, and align developer docs.
+    - Out of scope: unrelated refactors not required for "Integrate atomic global reinstall helper".
+  Plan: |-
+    Plan:
+    1. Start a dedicated branch_pr worktree for the runtime reinstall helper integration.
+    2. Cherry-pick the existing local DM5JTS runtime-install-atomic commit onto current main.
+    3. Resolve any drift against current release-contract tests and docs.
+    4. Verify the focused release CI contract test, typecheck, and fast policy/docs checks.
+    5. Open and merge the PR, then finish the task and remove the stale local branch/worktree if safe.
+    
+    Acceptance:
+    - scripts/reinstall-global-agentplane.sh uses an atomic local npm link workflow and avoids rebuilding @agentplane/testkit.
+    - release-ci-contract has explicit coverage for the reinstall helper's minimal runtime build path.
+    - developer docs describe the helper accurately.
+    - current main contains the integrated change and no stale DOING/TODO tasks remain.
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-09T15:35:55.417Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Runtime reinstall helper integration verified.
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T15:34:32.961Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    Command: bunx vitest run packages/agentplane/src/commands/release/release-ci-contract.test.ts --pool=forks --maxWorkers 2 --testTimeout 120000 --hookTimeout 120000 | Result: pass | Evidence: 8 tests passed. Scope: release CI contract and reinstall helper expectations.
+    Command: bun run typecheck | Result: pass | Evidence: tsc -b completed. Scope: workspace TypeScript contracts.
+    Command: bunx eslint scripts/reinstall-global-agentplane.sh packages/agentplane/src/commands/release/release-ci-contract.test.ts docs/developer/testing-and-quality.mdx | Result: pass | Evidence: no errors; markdown/shell files were ignored by eslint config with warnings. Scope: touched lintable TypeScript path plus config behavior.
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605091534-C49NA0-runtime-reinstall-helper/.agentplane/tasks/202605091534-C49NA0/blueprint/resolved-snapshot.json
+    - old_digest: e2aa4530a91440f132fb460b34bbc5f3e8499caf822b86dfbecf0b545bd7052d
+    - current_digest: e2aa4530a91440f132fb460b34bbc5f3e8499caf822b86dfbecf0b545bd7052d
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605091534-C49NA0
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605091534-C49NA0/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605091534-C49NA0/blueprint/resolved-snapshot.json
@@ -1,0 +1,536 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605091534-C49NA0",
+    "title": "Integrate atomic global reinstall helper",
+    "description": "Integrate the existing local runtime-install-atomic branch changes into current main: make scripts/reinstall-global-agentplane.sh use an atomic npm link workflow, update release contract coverage, and align developer docs.",
+    "tags": [
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "quality.regression",
+    "version": 1,
+    "title": "Quality regression",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "quality.regression",
+    "blueprintVersion": 1,
+    "title": "Quality regression",
+    "taskId": "202605091534-C49NA0",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to quality.regression",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest",
+          "artifact"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "check_result"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "weak_links"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "regression.original_failure",
+        "kind": "artifact",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Original failure log or check output."
+      },
+      {
+        "id": "regression.reproduction",
+        "kind": "check_result",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Local reproduction or explicit non-reproduction result."
+      },
+      {
+        "id": "regression.focused_check",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Focused regression check."
+      },
+      {
+        "id": "regression.matrix_or_scope",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Affected test/check matrix or bounded scope."
+      },
+      {
+        "id": "regression.full_gate",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Full relevant gate or hosted check evidence."
+      },
+      {
+        "id": "regression.flake_classification",
+        "kind": "weak_links",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Flake classification or residual risk."
+      },
+      {
+        "id": "regression.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "affected matrix or full relevant gate",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "failure reproduction command",
+      "focused regression check",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest",
+        "artifact"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "check_result"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "weak_links"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "regression.original_failure",
+      "kind": "artifact",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Original failure log or check output."
+    },
+    {
+      "id": "regression.reproduction",
+      "kind": "check_result",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Local reproduction or explicit non-reproduction result."
+    },
+    {
+      "id": "regression.focused_check",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Focused regression check."
+    },
+    {
+      "id": "regression.matrix_or_scope",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Affected test/check matrix or bounded scope."
+    },
+    {
+      "id": "regression.full_gate",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Full relevant gate or hosted check evidence."
+    },
+    {
+      "id": "regression.flake_classification",
+      "kind": "weak_links",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Flake classification or residual risk."
+    },
+    {
+      "id": "regression.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "affected matrix or full relevant gate",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "failure reproduction command",
+    "focused regression check",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to quality.regression",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "e2aa4530a91440f132fb460b34bbc5f3e8499caf822b86dfbecf0b545bd7052d"
+  }
+}

--- a/.agentplane/tasks/202605091534-C49NA0/pr/diffstat.txt
+++ b/.agentplane/tasks/202605091534-C49NA0/pr/diffstat.txt
@@ -1,4 +1,5 @@
- docs/developer/testing-and-quality.mdx             |  8 +++++---
- .../commands/release/release-ci-contract.test.ts   | 15 ++++++++++++---
- scripts/reinstall-global-agentplane.sh             | 22 +++++++++++++---------
- 3 files changed, 30 insertions(+), 15 deletions(-)
+ .../blueprint/resolved-snapshot.json               | 536 +++++++++++++++++++++
+ docs/developer/testing-and-quality.mdx             |   8 +-
+ .../commands/release/release-ci-contract.test.ts   |  15 +-
+ scripts/reinstall-global-agentplane.sh             |  22 +-
+ 4 files changed, 566 insertions(+), 15 deletions(-)

--- a/.agentplane/tasks/202605091534-C49NA0/pr/diffstat.txt
+++ b/.agentplane/tasks/202605091534-C49NA0/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ docs/developer/testing-and-quality.mdx             |  8 +++++---
+ .../commands/release/release-ci-contract.test.ts   | 15 ++++++++++++---
+ scripts/reinstall-global-agentplane.sh             | 22 +++++++++++++---------
+ 3 files changed, 30 insertions(+), 15 deletions(-)

--- a/.agentplane/tasks/202605091534-C49NA0/pr/github-body.md
+++ b/.agentplane/tasks/202605091534-C49NA0/pr/github-body.md
@@ -22,15 +22,16 @@ Integrate the existing local runtime-install-atomic branch changes into current 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-09T15:35:55.544Z
+- Updated: 2026-05-09T15:36:26.507Z
 - Branch: task/202605091534-C49NA0/runtime-reinstall-helper
-- Head: 769dd0802d2d
+- Head: 24428fa78335
 
 ```text
- docs/developer/testing-and-quality.mdx             |  8 +++++---
- .../commands/release/release-ci-contract.test.ts   | 15 ++++++++++++---
- scripts/reinstall-global-agentplane.sh             | 22 +++++++++++++---------
- 3 files changed, 30 insertions(+), 15 deletions(-)
+ .../blueprint/resolved-snapshot.json               | 536 +++++++++++++++++++++
+ docs/developer/testing-and-quality.mdx             |   8 +-
+ .../commands/release/release-ci-contract.test.ts   |  15 +-
+ scripts/reinstall-global-agentplane.sh             |  22 +-
+ 4 files changed, 566 insertions(+), 15 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605091534-C49NA0/pr/github-body.md
+++ b/.agentplane/tasks/202605091534-C49NA0/pr/github-body.md
@@ -1,0 +1,36 @@
+Task: `202605091534-C49NA0`
+Title: Integrate atomic global reinstall helper
+Canonical task record: `.agentplane/tasks/202605091534-C49NA0/README.md`
+
+## Summary
+
+Integrate atomic global reinstall helper
+
+Integrate the existing local runtime-install-atomic branch changes into current main: make scripts/reinstall-global-agentplane.sh use an atomic npm link workflow, update release contract coverage, and align developer docs.
+
+## Scope
+
+- In scope: Integrate the existing local runtime-install-atomic branch changes into current main: make scripts/reinstall-global-agentplane.sh use an atomic npm link workflow, update release contract coverage, and align developer docs.
+- Out of scope: unrelated refactors not required for "Integrate atomic global reinstall helper".
+
+## Verification
+
+- State: ok
+- Note: Runtime reinstall helper integration verified.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-09T15:35:55.544Z
+- Branch: task/202605091534-C49NA0/runtime-reinstall-helper
+- Head: 769dd0802d2d
+
+```text
+ docs/developer/testing-and-quality.mdx             |  8 +++++---
+ .../commands/release/release-ci-contract.test.ts   | 15 ++++++++++++---
+ scripts/reinstall-global-agentplane.sh             | 22 +++++++++++++---------
+ 3 files changed, 30 insertions(+), 15 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605091534-C49NA0/pr/github-title.txt
+++ b/.agentplane/tasks/202605091534-C49NA0/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 C49NA0 task: Integrate atomic global reinstall helper [202605091534-C49NA0]

--- a/.agentplane/tasks/202605091534-C49NA0/pr/meta.json
+++ b/.agentplane/tasks/202605091534-C49NA0/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605091534-C49NA0/runtime-reinstall-helper",
+  "created_at": "2026-05-09T15:35:55.544Z",
+  "head_sha": "769dd0802d2dab6cb947774939d9dfcd8ff91ba6",
+  "last_verified_at": "2026-05-09T15:35:55.417Z",
+  "last_verified_sha": "769dd0802d2dab6cb947774939d9dfcd8ff91ba6",
+  "schema_version": 1,
+  "task_id": "202605091534-C49NA0",
+  "updated_at": "2026-05-09T15:35:55.544Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605091534-C49NA0/pr/meta.json
+++ b/.agentplane/tasks/202605091534-C49NA0/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605091534-C49NA0/runtime-reinstall-helper",
   "created_at": "2026-05-09T15:35:55.544Z",
-  "head_sha": "769dd0802d2dab6cb947774939d9dfcd8ff91ba6",
+  "head_sha": "24428fa783355c07e03f37d24143d63a710f70f8",
   "last_verified_at": "2026-05-09T15:35:55.417Z",
   "last_verified_sha": "769dd0802d2dab6cb947774939d9dfcd8ff91ba6",
   "schema_version": 1,
   "task_id": "202605091534-C49NA0",
-  "updated_at": "2026-05-09T15:35:55.544Z",
+  "updated_at": "2026-05-09T15:36:26.507Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605091534-C49NA0/pr/review.md
+++ b/.agentplane/tasks/202605091534-C49NA0/pr/review.md
@@ -1,0 +1,39 @@
+# PR Review
+
+Created: 2026-05-09T15:35:55.544Z
+
+## Task
+
+- Task: `202605091534-C49NA0`
+- Title: Integrate atomic global reinstall helper
+- Status: DOING
+- Branch: `task/202605091534-C49NA0/runtime-reinstall-helper`
+- Canonical task record: `.agentplane/tasks/202605091534-C49NA0/README.md`
+
+## Verification
+
+- State: ok
+- Note: Runtime reinstall helper integration verified.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-09T15:35:55.544Z
+- Branch: task/202605091534-C49NA0/runtime-reinstall-helper
+- Head: 769dd0802d2d
+
+```text
+ docs/developer/testing-and-quality.mdx             |  8 +++++---
+ .../commands/release/release-ci-contract.test.ts   | 15 ++++++++++++---
+ scripts/reinstall-global-agentplane.sh             | 22 +++++++++++++---------
+ 3 files changed, 30 insertions(+), 15 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605091534-C49NA0/pr/review.md
+++ b/.agentplane/tasks/202605091534-C49NA0/pr/review.md
@@ -24,15 +24,16 @@ Created: 2026-05-09T15:35:55.544Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-09T15:35:55.544Z
+- Updated: 2026-05-09T15:36:26.507Z
 - Branch: task/202605091534-C49NA0/runtime-reinstall-helper
-- Head: 769dd0802d2d
+- Head: 24428fa78335
 
 ```text
- docs/developer/testing-and-quality.mdx             |  8 +++++---
- .../commands/release/release-ci-contract.test.ts   | 15 ++++++++++++---
- scripts/reinstall-global-agentplane.sh             | 22 +++++++++++++---------
- 3 files changed, 30 insertions(+), 15 deletions(-)
+ .../blueprint/resolved-snapshot.json               | 536 +++++++++++++++++++++
+ docs/developer/testing-and-quality.mdx             |   8 +-
+ .../commands/release/release-ci-contract.test.ts   |  15 +-
+ scripts/reinstall-global-agentplane.sh             |  22 +-
+ 4 files changed, 566 insertions(+), 15 deletions(-)
 ```
 
 </details>

--- a/docs/developer/testing-and-quality.mdx
+++ b/docs/developer/testing-and-quality.mdx
@@ -75,9 +75,11 @@ developer reinstall helper:
 scripts/reinstall-global-agentplane.sh
 ```
 
-It rebuilds local `@agentplaneorg/core` and `agentplane`, reinstalls both packages globally from
-this checkout, and verifies that the global `agentplane` runtime resolves `@agentplaneorg/core`
-from this checkout instead of a published fallback.
+It rebuilds the local `@agentplaneorg/core` and `agentplane` runtime bundles, links local
+`@agentplaneorg/core` and `agentplane` into the global npm prefix from this checkout, and verifies
+that the global `agentplane` runtime resolves `@agentplaneorg/core` from this checkout instead of a
+published fallback. Use `bun run framework:dev:bootstrap` when you also need the full framework
+development layout and `@agentplane/testkit`.
 
 For a full run (including slower CLI integration tests):
 

--- a/packages/agentplane/src/commands/release/release-ci-contract.test.ts
+++ b/packages/agentplane/src/commands/release/release-ci-contract.test.ts
@@ -68,14 +68,13 @@ describe("release CI contract", () => {
       releaseCheck.indexOf("bun run --filter=agentplane build"),
     );
 
-    const [coreCi, prepublish, hostedClose, reinstall] = await Promise.all([
+    const [coreCi, prepublish, hostedClose] = await Promise.all([
       readRootText(".github/workflows/ci.yml"),
       readRootText(".github/workflows/prepublish.yml"),
       readRootText(".github/workflows/task-hosted-close.yml"),
-      readRootText("scripts/reinstall-global-agentplane.sh"),
     ]);
 
-    for (const text of [coreCi, prepublish, hostedClose, reinstall]) {
+    for (const text of [coreCi, prepublish, hostedClose]) {
       expect(text).toContain("bun run --filter=@agentplane/testkit build");
       expect(text.indexOf("bun run --filter=agentplane build")).toBeGreaterThan(
         text.indexOf("bun run --filter=@agentplaneorg/core build"),
@@ -84,6 +83,16 @@ describe("release CI contract", () => {
         text.indexOf("bun run --filter=agentplane build"),
       );
     }
+  });
+
+  it("keeps the developer reinstall helper on the minimal runtime build path", async () => {
+    const reinstall = await readRootText("scripts/reinstall-global-agentplane.sh");
+
+    expect(reinstall).toContain("bun run --filter=@agentplaneorg/core build");
+    expect(reinstall).toContain("bun run --filter=agentplane build:bundle");
+    expect(reinstall).toContain("npm link");
+    expect(reinstall).not.toContain("bun run --filter=@agentplane/testkit build");
+    expect(reinstall).not.toContain("npm install -g ./packages");
   });
 
   it("does not expose repo-private test helpers from the published agentplane package", async () => {

--- a/scripts/reinstall-global-agentplane.sh
+++ b/scripts/reinstall-global-agentplane.sh
@@ -5,9 +5,9 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
   cat <<'USAGE'
 Usage: scripts/reinstall-global-agentplane.sh
 
-Rebuilds local @agentplaneorg/core, agentplane, and @agentplane/testkit packages,
-reinstalls both packages globally from the local checkout,
-and verifies that global agentplane resolves local framework bits.
+Builds local @agentplaneorg/core and agentplane runtime bundles, links both
+packages into the global npm prefix from this checkout, and verifies that global
+agentplane resolves local framework bits.
 USAGE
   exit 0
 fi
@@ -19,13 +19,17 @@ fi
 
 echo "==> Building local packages"
 bun run --filter=@agentplaneorg/core build
-bun run --filter=agentplane build
-bun run --filter=@agentplane/testkit build
+bun run --filter=agentplane build:bundle
 
-echo "==> Reinstalling global framework packages from local source"
-npm uninstall -g agentplane @agentplaneorg/core >/dev/null 2>&1 || true
-npm install -g ./packages/core
-npm install -g ./packages/agentplane
+echo "==> Linking global framework packages from local source"
+(
+  cd packages/core
+  npm link
+)
+(
+  cd packages/agentplane
+  npm link
+)
 
 echo "==> Verifying global install resolves local checkout artifacts"
 node scripts/verify-global-agentplane-install.mjs


### PR DESCRIPTION
Task: `202605091534-C49NA0`
Title: Integrate atomic global reinstall helper
Canonical task record: `.agentplane/tasks/202605091534-C49NA0/README.md`

## Summary

Integrate atomic global reinstall helper

Integrate the existing local runtime-install-atomic branch changes into current main: make scripts/reinstall-global-agentplane.sh use an atomic npm link workflow, update release contract coverage, and align developer docs.

## Scope

- In scope: Integrate the existing local runtime-install-atomic branch changes into current main: make scripts/reinstall-global-agentplane.sh use an atomic npm link workflow, update release contract coverage, and align developer docs.
- Out of scope: unrelated refactors not required for "Integrate atomic global reinstall helper".

## Verification

- State: ok
- Note: Runtime reinstall helper integration verified.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-09T15:36:26.507Z
- Branch: task/202605091534-C49NA0/runtime-reinstall-helper
- Head: 24428fa78335

```text
 .../blueprint/resolved-snapshot.json               | 536 +++++++++++++++++++++
 docs/developer/testing-and-quality.mdx             |   8 +-
 .../commands/release/release-ci-contract.test.ts   |  15 +-
 scripts/reinstall-global-agentplane.sh             |  22 +-
 4 files changed, 566 insertions(+), 15 deletions(-)
```

</details>
