### PR TITLE
🚧 5G5506 task: Deduplicate CLI benchmark script helpers [202605091753-5G5506]

### DIFF
--- a/.agentplane/tasks/202605091753-5G5506/README.md
+++ b/.agentplane/tasks/202605091753-5G5506/README.md
@@ -1,0 +1,105 @@
+---
+id: "202605091753-5G5506"
+title: "Deduplicate CLI benchmark script helpers"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "performance"
+  - "refactor"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "performance.benchmark"
+verify:
+  - "bun run clone:check"
+  - "bun run clone:report"
+  - "bun run test:project -- scripts"
+  - "bun run typecheck"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-09T17:55:08.763Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-09T18:28:03.684Z"
+  updated_by: "CODER"
+  note: "Verified: extracted shared benchmark helper module; help paths, walltime smoke, perf smoke, Prettier, typecheck, clone:report, and clone:check passed. Clone metrics improved from 1546 duplicated lines / 16193 tokens after the previous task to 1465 duplicated lines / 15457 tokens, with clone count 88 -> 85."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: extracting shared CLI benchmark helper code from benchmark runner scripts while preserving command-specific defaults and validating with clone/type/script checks."
+events:
+  -
+    type: "status"
+    at: "2026-05-09T18:22:55.723Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: extracting shared CLI benchmark helper code from benchmark runner scripts while preserving command-specific defaults and validating with clone/type/script checks."
+  -
+    type: "verify"
+    at: "2026-05-09T18:28:03.684Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: extracted shared benchmark helper module; help paths, walltime smoke, perf smoke, Prettier, typecheck, clone:report, and clone:check passed. Clone metrics improved from 1546 duplicated lines / 16193 tokens after the previous task to 1465 duplicated lines / 15457 tokens, with clone count 88 -> 85."
+doc_version: 3
+doc_updated_at: "2026-05-09T18:28:03.704Z"
+doc_updated_by: "CODER"
+description: "Move shared duration statistics, suite argument parsing, config loading, interpolation, and command formatting from benchmark scripts into a script-local helper module without changing benchmark semantics."
+sections:
+  Summary: |-
+    Deduplicate CLI benchmark script helpers
+    
+    Move shared duration statistics, suite argument parsing, config loading, interpolation, and command formatting from benchmark scripts into a script-local helper module without changing benchmark semantics.
+  Scope: |-
+    - In scope: Move shared duration statistics, suite argument parsing, config loading, interpolation, and command formatting from benchmark scripts into a script-local helper module without changing benchmark semantics.
+    - Out of scope: unrelated refactors not required for "Deduplicate CLI benchmark script helpers".
+  Plan: "Extract script-local benchmark helper functions for duration summaries, positive integer parsing, suite config parsing/loading, argument interpolation, and command formatting. Keep command-specific defaults and output semantics in the current scripts. Verify with focused script checks if available, typecheck, clone report, and clone baseline check."
+  Verify Steps: |-
+    1. Run `bun run clone:report`. Expected: benchmark script helper clones are gone and total clone metrics decrease versus the pre-task report.
+    2. Run `node scripts/measure-cli-walltime.mjs --help >/tmp/agentplane-walltime-help.txt && node scripts/measure-cli-perf.mjs --help >/tmp/agentplane-perf-help.txt`. Expected: both help paths render successfully.
+    3. Run `node scripts/measure-cli-walltime.mjs --runs 1 --command-id version`. Expected: JSON payload is emitted with failed_count=0.
+    4. Run `node scripts/measure-cli-perf.mjs --runs 1 --command-id quickstart`. Expected: JSON payload is emitted with failed_count=0.
+    5. Run `bunx prettier --check scripts/lib/cli-benchmark-shared.mjs scripts/cli-benchmark-runner.mjs scripts/measure-cli-walltime.mjs`. Expected: changed files are formatted.
+    6. Run `bun run typecheck`. Expected: TypeScript project references compile.
+    7. Run `bun run clone:check`. Expected: clone baseline guard passes without updating the baseline.
+    8. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-09T18:28:03.684Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: extracted shared benchmark helper module; help paths, walltime smoke, perf smoke, Prettier, typecheck, clone:report, and clone:check passed. Clone metrics improved from 1546 duplicated lines / 16193 tokens after the previous task to 1465 duplicated lines / 15457 tokens, with clone count 88 -> 85.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T18:27:52.838Z, excerpt_hash=sha256:67672282255775ebb2705db21f8fdf331bd0a4df407c230a6976b4f4d0eb3951
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605091753-5G5506-benchmark-helpers/.agentplane/tasks/202605091753-5G5506/blueprint/resolved-snapshot.json
+    - old_digest: 40c43f19f10e2e5299610ae39047253064e701498c2c7dfe085d6be0a223e5cd
+    - current_digest: 40c43f19f10e2e5299610ae39047253064e701498c2c7dfe085d6be0a223e5cd
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605091753-5G5506
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: The originally seeded Verify Steps contained an invalid scripts project test command; replaced it with direct benchmark script smoke checks that exercise the changed surfaces.
+      Impact: The benchmark scripts now share stats, argument parsing, suite config loading, interpolation, and preview formatting without changing command-specific payload semantics.
+      Resolution: Keep remaining clone clusters in the separate hook, task-doc, task transition, and verify spec tasks.
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605091753-5G5506/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605091753-5G5506/blueprint/resolved-snapshot.json
@@ -1,0 +1,541 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605091753-5G5506",
+    "title": "Deduplicate CLI benchmark script helpers",
+    "description": "Move shared duration statistics, suite argument parsing, config loading, interpolation, and command formatting from benchmark scripts into a script-local helper module without changing benchmark semantics.",
+    "tags": [
+      "code",
+      "performance",
+      "refactor"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "performance.benchmark"
+  },
+  "selectedBlueprint": {
+    "id": "performance.benchmark",
+    "version": 1,
+    "title": "Performance benchmark",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "performance.benchmark",
+    "blueprintVersion": 1,
+    "title": "Performance benchmark",
+    "taskId": "202605091753-5G5506",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "performance.benchmark"
+    },
+    "whySelected": [
+      "explicit blueprint requested: performance.benchmark",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "artifact"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "final_output"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "benchmark.baseline",
+        "kind": "artifact",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Baseline measurement artifact."
+      },
+      {
+        "id": "benchmark.method",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Benchmark method, environment, and warm/cold mode."
+      },
+      {
+        "id": "benchmark.runs",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Run count and raw measurement results."
+      },
+      {
+        "id": "benchmark.threshold",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Accepted threshold or noise tolerance."
+      },
+      {
+        "id": "benchmark.comparison",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Before/after comparison result."
+      },
+      {
+        "id": "benchmark.verdict",
+        "kind": "final_output",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Faster, slower, unchanged, or noisy verdict."
+      },
+      {
+        "id": "benchmark.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "benchmark baseline command",
+      "benchmark comparison command",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Benchmark work needs normal branch_pr code policy plus room for baseline and comparison artifacts."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "artifact"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "final_output"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "benchmark.baseline",
+      "kind": "artifact",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Baseline measurement artifact."
+    },
+    {
+      "id": "benchmark.method",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Benchmark method, environment, and warm/cold mode."
+    },
+    {
+      "id": "benchmark.runs",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Run count and raw measurement results."
+    },
+    {
+      "id": "benchmark.threshold",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Accepted threshold or noise tolerance."
+    },
+    {
+      "id": "benchmark.comparison",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Before/after comparison result."
+    },
+    {
+      "id": "benchmark.verdict",
+      "kind": "final_output",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Faster, slower, unchanged, or noisy verdict."
+    },
+    {
+      "id": "benchmark.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "benchmark baseline command",
+    "benchmark comparison command",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Benchmark work needs normal branch_pr code policy plus room for baseline and comparison artifacts."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: performance.benchmark",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "40c43f19f10e2e5299610ae39047253064e701498c2c7dfe085d6be0a223e5cd"
+  }
+}

--- a/.agentplane/tasks/202605091753-5G5506/pr/diffstat.txt
+++ b/.agentplane/tasks/202605091753-5G5506/pr/diffstat.txt
@@ -1,0 +1,5 @@
+ .../blueprint/resolved-snapshot.json               | 541 +++++++++++++++++++++
+ scripts/cli-benchmark-runner.mjs                   | 240 +--------
+ scripts/lib/cli-benchmark-shared.mjs               | 245 ++++++++++
+ scripts/measure-cli-walltime.mjs                   | 229 +--------
+ 4 files changed, 829 insertions(+), 426 deletions(-)

--- a/.agentplane/tasks/202605091753-5G5506/pr/github-body.md
+++ b/.agentplane/tasks/202605091753-5G5506/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605091753-5G5506`
+Title: Deduplicate CLI benchmark script helpers
+Canonical task record: `.agentplane/tasks/202605091753-5G5506/README.md`
+
+## Summary
+
+Deduplicate CLI benchmark script helpers
+
+Move shared duration statistics, suite argument parsing, config loading, interpolation, and command formatting from benchmark scripts into a script-local helper module without changing benchmark semantics.
+
+## Scope
+
+- In scope: Move shared duration statistics, suite argument parsing, config loading, interpolation, and command formatting from benchmark scripts into a script-local helper module without changing benchmark semantics.
+- Out of scope: unrelated refactors not required for "Deduplicate CLI benchmark script helpers".
+
+## Verification
+
+- State: ok
+- Note: Verified: extracted shared benchmark helper module; help paths, walltime smoke, perf smoke, Prettier, typecheck, clone:report, and clone:check passed. Clone metrics improved from 1546 duplicated lines / 16193 tokens after the previous task to 1465 duplicated lines / 15457 tokens, with clone count 88 -> 85.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-09T18:22:55.946Z
+- Branch: task/202605091753-5G5506/benchmark-helpers
+- Head: d25d4ae5fb95
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605091753-5G5506/pr/github-body.md
+++ b/.agentplane/tasks/202605091753-5G5506/pr/github-body.md
@@ -22,12 +22,16 @@ Move shared duration statistics, suite argument parsing, config loading, interpo
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-09T18:22:55.946Z
+- Updated: 2026-05-09T18:28:17.804Z
 - Branch: task/202605091753-5G5506/benchmark-helpers
-- Head: d25d4ae5fb95
+- Head: 621acaa364c2
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 541 +++++++++++++++++++++
+ scripts/cli-benchmark-runner.mjs                   | 240 +--------
+ scripts/lib/cli-benchmark-shared.mjs               | 245 ++++++++++
+ scripts/measure-cli-walltime.mjs                   | 229 +--------
+ 4 files changed, 829 insertions(+), 426 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605091753-5G5506/pr/github-title.txt
+++ b/.agentplane/tasks/202605091753-5G5506/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 5G5506 task: Deduplicate CLI benchmark script helpers [202605091753-5G5506]

--- a/.agentplane/tasks/202605091753-5G5506/pr/meta.json
+++ b/.agentplane/tasks/202605091753-5G5506/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605091753-5G5506/benchmark-helpers",
   "created_at": "2026-05-09T18:22:55.946Z",
-  "head_sha": "d25d4ae5fb957961719455f3b4ade92166a0dd27",
+  "head_sha": "621acaa364c25ac9507d7e01db3d2933b51ecc58",
   "last_verified_at": "2026-05-09T18:28:03.684Z",
   "last_verified_sha": "d25d4ae5fb957961719455f3b4ade92166a0dd27",
   "schema_version": 1,
   "task_id": "202605091753-5G5506",
-  "updated_at": "2026-05-09T18:22:55.946Z",
+  "updated_at": "2026-05-09T18:28:17.804Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605091753-5G5506/pr/meta.json
+++ b/.agentplane/tasks/202605091753-5G5506/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605091753-5G5506/benchmark-helpers",
+  "created_at": "2026-05-09T18:22:55.946Z",
+  "head_sha": "d25d4ae5fb957961719455f3b4ade92166a0dd27",
+  "last_verified_at": "2026-05-09T18:28:03.684Z",
+  "last_verified_sha": "d25d4ae5fb957961719455f3b4ade92166a0dd27",
+  "schema_version": 1,
+  "task_id": "202605091753-5G5506",
+  "updated_at": "2026-05-09T18:22:55.946Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605091753-5G5506/pr/review.md
+++ b/.agentplane/tasks/202605091753-5G5506/pr/review.md
@@ -24,12 +24,16 @@ Created: 2026-05-09T18:22:55.946Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-09T18:22:55.946Z
+- Updated: 2026-05-09T18:28:17.804Z
 - Branch: task/202605091753-5G5506/benchmark-helpers
-- Head: d25d4ae5fb95
+- Head: 621acaa364c2
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 541 +++++++++++++++++++++
+ scripts/cli-benchmark-runner.mjs                   | 240 +--------
+ scripts/lib/cli-benchmark-shared.mjs               | 245 ++++++++++
+ scripts/measure-cli-walltime.mjs                   | 229 +--------
+ 4 files changed, 829 insertions(+), 426 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605091753-5G5506/pr/review.md
+++ b/.agentplane/tasks/202605091753-5G5506/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-09T18:22:55.946Z
+
+## Task
+
+- Task: `202605091753-5G5506`
+- Title: Deduplicate CLI benchmark script helpers
+- Status: DOING
+- Branch: `task/202605091753-5G5506/benchmark-helpers`
+- Canonical task record: `.agentplane/tasks/202605091753-5G5506/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified: extracted shared benchmark helper module; help paths, walltime smoke, perf smoke, Prettier, typecheck, clone:report, and clone:check passed. Clone metrics improved from 1546 duplicated lines / 16193 tokens after the previous task to 1465 duplicated lines / 15457 tokens, with clone count 88 -> 85.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-09T18:22:55.946Z
+- Branch: task/202605091753-5G5506/benchmark-helpers
+- Head: d25d4ae5fb95
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/scripts/cli-benchmark-runner.mjs
+++ b/scripts/cli-benchmark-runner.mjs
@@ -1,9 +1,19 @@
 import { execFile } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+
+import {
+  cliRepoRootFromPath,
+  formatSuiteCommands,
+  interpolateArgs,
+  parseSuiteArgs as parseSharedSuiteArgs,
+  readSuiteConfigMap,
+  roundMs,
+  summarizeDurations,
+} from "./lib/cli-benchmark-shared.mjs";
 
 const execFileAsync = promisify(execFile);
 const MAX_BUFFER_BYTES = 10 * 1024 * 1024;
@@ -15,222 +25,14 @@ const DEFAULT_SUITE_CONFIG_PATH = path.join(
 );
 const DEFAULT_CLI_PATH = path.join(REPO_ROOT, "packages", "agentplane", "bin", "agentplane.js");
 
-export function cliRepoRootFromPath(cliPath) {
-  return path.resolve(path.dirname(cliPath), "..", "..", "..");
-}
-
-function roundMs(value) {
-  return Number(value.toFixed(3));
-}
-
-function sortNumeric(values) {
-  return values.toSorted((left, right) => left - right);
-}
-
-function median(values) {
-  const sorted = sortNumeric(values);
-  const mid = Math.floor(sorted.length / 2);
-  if (sorted.length % 2 === 1) {
-    return sorted[mid];
-  }
-  return (sorted[mid - 1] + sorted[mid]) / 2;
-}
-
-function percentile(values, percentileValue) {
-  const sorted = sortNumeric(values);
-  const index = Math.ceil((percentileValue / 100) * sorted.length) - 1;
-  return sorted[Math.min(Math.max(index, 0), sorted.length - 1)];
-}
-
-function summarizeDurations(durations) {
-  let sum = 0;
-  for (const value of durations) {
-    sum += value;
-  }
-  const average = durations.length === 0 ? 0 : sum / durations.length;
-
-  let totalDiff = 0;
-  for (const value of durations) {
-    const diff = value - average;
-    totalDiff += diff * diff;
-  }
-  const variance = durations.length === 0 ? 0 : totalDiff / durations.length;
-
-  return {
-    min_ms: roundMs(Math.min(...durations)),
-    median_ms: roundMs(median(durations)),
-    max_ms: roundMs(Math.max(...durations)),
-    avg_ms: roundMs(average),
-    p95_ms: roundMs(percentile(durations, 95)),
-    p99_ms: roundMs(percentile(durations, 99)),
-    stddev_ms: roundMs(Math.sqrt(variance)),
-  };
-}
-
-function parsePositiveInt(value, flag) {
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isInteger(parsed) || parsed < 0) {
-    throw new Error(`Invalid value for ${flag}: ${value} (expected integer >= 0)`);
-  }
-  return parsed;
-}
-
 export function parseSuiteArgs(argv) {
-  let suite = null;
-  let suiteConfig = DEFAULT_SUITE_CONFIG_PATH;
-  let root = REPO_ROOT;
-  let cliPath = DEFAULT_CLI_PATH;
-  let runs = 3;
-  let warmups = 0;
-  let timeoutMs = Number.parseInt(process.env.AGENTPLANE_CLI_BENCH_TIMEOUT_MS ?? "0", 10) || 0;
-  let commandId = null;
-  let help = false;
-
-  for (let i = 0; i < argv.length; i += 1) {
-    const arg = argv[i];
-    switch (arg) {
-      case "--help":
-      case "-h": {
-        help = true;
-        break;
-      }
-      case "--suite": {
-        const next = argv[i + 1];
-        if (!next) throw new Error("Missing value after --suite");
-        suite = next;
-        i += 1;
-        break;
-      }
-      case "--suite-config": {
-        const next = argv[i + 1];
-        if (!next) throw new Error("Missing value after --suite-config");
-        suiteConfig = path.resolve(next);
-        i += 1;
-        break;
-      }
-      case "--root": {
-        const next = argv[i + 1];
-        if (!next) throw new Error("Missing value after --root");
-        root = path.resolve(next);
-        i += 1;
-        break;
-      }
-      case "--cli": {
-        const next = argv[i + 1];
-        if (!next) throw new Error("Missing value after --cli");
-        cliPath = path.resolve(next);
-        i += 1;
-        break;
-      }
-      case "--runs": {
-        const next = argv[i + 1];
-        if (!next) throw new Error("Missing value after --runs");
-        runs = parsePositiveInt(next, "--runs");
-        if (runs === 0) {
-          throw new Error("Invalid value for --runs: 0 (expected integer >= 1)");
-        }
-        i += 1;
-        break;
-      }
-      case "--warmups": {
-        const next = argv[i + 1];
-        if (!next) throw new Error("Missing value after --warmups");
-        warmups = parsePositiveInt(next, "--warmups");
-        i += 1;
-        break;
-      }
-      case "--timeout-ms": {
-        const next = argv[i + 1];
-        if (!next) throw new Error("Missing value after --timeout-ms");
-        timeoutMs = parsePositiveInt(next, "--timeout-ms");
-        i += 1;
-        break;
-      }
-      case "--command-id": {
-        const next = argv[i + 1];
-        if (!next) throw new Error("Missing value after --command-id");
-        commandId = next;
-        i += 1;
-        break;
-      }
-      default: {
-        throw new Error(`Unknown argument: ${arg}`);
-      }
-    }
-  }
-
-  return {
-    suite: suite ?? "cli-cold-path",
-    suiteConfig,
-    root,
-    cliPath,
-    runs,
-    warmups,
-    timeoutMs,
-    commandId,
-    help,
-  };
-}
-
-function parseBenchmarkConfig(raw) {
-  if (!raw || raw.schema_version !== 1 || !Array.isArray(raw.suites)) {
-    throw new Error("Invalid suite config payload: expected schema_version=1 and suites");
-  }
-  return raw;
-}
-
-function readSuiteConfig(filePath) {
-  if (!existsSync(filePath)) {
-    throw new Error(`Suite config is missing: ${filePath}`);
-  }
-  const payload = parseBenchmarkConfig(JSON.parse(readFileSync(filePath, "utf8")));
-  const suites = new Map();
-
-  for (const suite of payload.suites ?? []) {
-    if (!suite || typeof suite.id !== "string" || typeof suite.mode !== "string") {
-      throw new Error(`Invalid suite entry in ${filePath}`);
-    }
-    if (!Array.isArray(suite.commands) || suite.commands.length === 0) {
-      throw new Error(`Suite ${suite.id} must contain at least one command`);
-    }
-    suites.set(suite.id, suite);
-  }
-
-  return {
-    suites,
-    defaultSuite: payload.default_suite,
-  };
-}
-
-function interpolateArg(value, vars) {
-  return String(value).replaceAll("{root}", vars.root).replaceAll("{repo_root}", vars.repoRoot);
-}
-
-function interpolateArgs(args, vars) {
-  return args.map((value) => interpolateArg(value, vars));
-}
-
-function formatSuiteCommands(suite) {
-  if (!suite || !Array.isArray(suite.commands)) {
-    return [];
-  }
-  return suite.commands.map((command) => ({
-    id: String(command.id ?? ""),
-    commandLine: `agentplane ${
-      Array.isArray(command.argv)
-        ? command.argv
-            .map((argument) =>
-              typeof argument === "string" &&
-              argument.includes(" ") &&
-              !argument.startsWith('"') &&
-              !argument.endsWith('"')
-                ? `"${argument}"`
-                : String(argument),
-            )
-            .join(" ")
-        : ""
-    }`,
-  }));
+  return parseSharedSuiteArgs(argv, {
+    suite: "cli-cold-path",
+    suiteConfig: DEFAULT_SUITE_CONFIG_PATH,
+    root: REPO_ROOT,
+    cliPath: DEFAULT_CLI_PATH,
+    timeoutEnvVar: "AGENTPLANE_CLI_BENCH_TIMEOUT_MS",
+  });
 }
 
 async function runCommandWithOptions(cliPath, argv, options) {
@@ -303,7 +105,7 @@ async function runCommandGroup(cliPath, argv, parallel, options = {}) {
 }
 
 export async function measureSuite(options) {
-  const raw = readSuiteConfig(options.suiteConfig);
+  const raw = readSuiteConfigMap(options.suiteConfig);
   const selected = raw.suites.get(options.suite) ?? raw.suites.get(raw.defaultSuite);
   if (!selected) {
     throw new Error(`Suite not found: ${options.suite}`);
@@ -421,11 +223,11 @@ export async function runSuiteRunner(
 ) {
   const options = parseSuiteArgs(argv);
   if (options.help) {
-    const suiteConfig = readSuiteConfig(options.suiteConfig);
+    const suiteConfig = readSuiteConfigMap(options.suiteConfig);
     const previewSuite =
       suiteConfig.suites.get(options.suite) ??
       suiteConfig.suites.get(suiteConfig.defaultSuite ?? options.suite);
-    const commandPreview = formatSuiteCommands(previewSuite);
+    const commandPreview = formatSuiteCommands(previewSuite, { commandPrefix: "agentplane" });
     outputStream.write(
       `${printCliPerfHelpText({
         scriptName,

--- a/scripts/lib/cli-benchmark-shared.mjs
+++ b/scripts/lib/cli-benchmark-shared.mjs
@@ -1,0 +1,245 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+export function cliRepoRootFromPath(cliPath) {
+  return path.resolve(path.dirname(cliPath), "..", "..", "..");
+}
+
+export function roundMs(value) {
+  return Number(value.toFixed(3));
+}
+
+function sortNumeric(values) {
+  return values.toSorted((left, right) => left - right);
+}
+
+function median(values) {
+  const sorted = sortNumeric(values);
+  if (sorted.length === 0) return 0;
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) {
+    return sorted[mid];
+  }
+  return (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function percentile(values, percentileValue) {
+  const sorted = sortNumeric(values);
+  if (sorted.length === 0) return 0;
+  const index = Math.ceil((percentileValue / 100) * sorted.length) - 1;
+  return sorted[Math.min(Math.max(index, 0), sorted.length - 1)];
+}
+
+export function summarizeDurations(durations) {
+  if (durations.length === 0) {
+    return {
+      min_ms: 0,
+      median_ms: 0,
+      max_ms: 0,
+      avg_ms: 0,
+      p95_ms: 0,
+      p99_ms: 0,
+      stddev_ms: 0,
+    };
+  }
+
+  let sum = 0;
+  for (const value of durations) {
+    sum += value;
+  }
+  const average = sum / durations.length;
+
+  let totalDiff = 0;
+  for (const value of durations) {
+    const diff = value - average;
+    totalDiff += diff * diff;
+  }
+  const variance = totalDiff / durations.length;
+
+  return {
+    min_ms: roundMs(Math.min(...durations)),
+    median_ms: roundMs(median(durations)),
+    max_ms: roundMs(Math.max(...durations)),
+    avg_ms: roundMs(average),
+    p95_ms: roundMs(percentile(durations, 95)),
+    p99_ms: roundMs(percentile(durations, 99)),
+    stddev_ms: roundMs(Math.sqrt(variance)),
+  };
+}
+
+function parsePositiveInt(value, flag) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid value for ${flag}: ${value} (expected integer >= 0)`);
+  }
+  return parsed;
+}
+
+export function parseSuiteArgs(argv, defaults) {
+  let suite = null;
+  let suiteConfig = defaults.suiteConfig;
+  let root = defaults.root;
+  let cliPath = defaults.cliPath;
+  let runs = 3;
+  let warmups = 0;
+  let timeoutMs =
+    defaults.timeoutEnvVar === undefined
+      ? undefined
+      : Number.parseInt(process.env[defaults.timeoutEnvVar] ?? "0", 10) || 0;
+  let commandId = null;
+  let help = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--help":
+      case "-h": {
+        help = true;
+        break;
+      }
+      case "--suite": {
+        const next = argv[i + 1];
+        if (!next) throw new Error("Missing value after --suite");
+        suite = next;
+        i += 1;
+        break;
+      }
+      case "--suite-config": {
+        const next = argv[i + 1];
+        if (!next) throw new Error("Missing value after --suite-config");
+        suiteConfig = path.resolve(next);
+        i += 1;
+        break;
+      }
+      case "--root": {
+        const next = argv[i + 1];
+        if (!next) throw new Error("Missing value after --root");
+        root = path.resolve(next);
+        i += 1;
+        break;
+      }
+      case "--cli": {
+        const next = argv[i + 1];
+        if (!next) throw new Error("Missing value after --cli");
+        cliPath = path.resolve(next);
+        i += 1;
+        break;
+      }
+      case "--runs": {
+        const next = argv[i + 1];
+        if (!next) throw new Error("Missing value after --runs");
+        runs = parsePositiveInt(next, "--runs");
+        if (runs === 0) {
+          throw new Error("Invalid value for --runs: 0 (expected integer >= 1)");
+        }
+        i += 1;
+        break;
+      }
+      case "--warmups": {
+        const next = argv[i + 1];
+        if (!next) throw new Error("Missing value after --warmups");
+        warmups = parsePositiveInt(next, "--warmups");
+        i += 1;
+        break;
+      }
+      case "--timeout-ms": {
+        if (timeoutMs === undefined) {
+          throw new Error(`Unknown argument: ${arg}`);
+        }
+        const next = argv[i + 1];
+        if (!next) throw new Error("Missing value after --timeout-ms");
+        timeoutMs = parsePositiveInt(next, "--timeout-ms");
+        i += 1;
+        break;
+      }
+      case "--command-id": {
+        const next = argv[i + 1];
+        if (!next) throw new Error("Missing value after --command-id");
+        commandId = next;
+        i += 1;
+        break;
+      }
+      default: {
+        throw new Error(`Unknown argument: ${arg}`);
+      }
+    }
+  }
+
+  return {
+    suite: suite ?? defaults.suite,
+    suiteConfig,
+    root,
+    cliPath,
+    runs,
+    warmups,
+    ...(timeoutMs === undefined ? {} : { timeoutMs }),
+    commandId,
+    help,
+  };
+}
+
+export function parseSuiteConfig(raw) {
+  if (!raw || raw.schema_version !== 1 || !Array.isArray(raw.suites)) {
+    throw new Error("Invalid suite config payload: expected schema_version=1 and suites");
+  }
+  return raw;
+}
+
+export function readSuiteConfig(filePath) {
+  if (!existsSync(filePath)) {
+    throw new Error(`Suite config is missing: ${filePath}`);
+  }
+  return parseSuiteConfig(JSON.parse(readFileSync(filePath, "utf8")));
+}
+
+export function readSuiteConfigMap(filePath) {
+  const payload = readSuiteConfig(filePath);
+  const suites = new Map();
+
+  for (const suite of payload.suites ?? []) {
+    if (!suite || typeof suite.id !== "string" || typeof suite.mode !== "string") {
+      throw new Error(`Invalid suite entry in ${filePath}`);
+    }
+    if (!Array.isArray(suite.commands) || suite.commands.length === 0) {
+      throw new Error(`Suite ${suite.id} must contain at least one command`);
+    }
+    suites.set(suite.id, suite);
+  }
+
+  return {
+    suites,
+    defaultSuite: payload.default_suite,
+  };
+}
+
+function interpolateArg(value, vars) {
+  return String(value).replaceAll("{root}", vars.root).replaceAll("{repo_root}", vars.repoRoot);
+}
+
+export function interpolateArgs(args, vars) {
+  return args.map((value) => interpolateArg(value, vars));
+}
+
+export function formatSuiteCommands(suite, options = {}) {
+  if (!suite || !Array.isArray(suite.commands)) {
+    return [];
+  }
+  const prefix = options.commandPrefix ? `${options.commandPrefix} ` : "";
+  return suite.commands.map((command) => ({
+    id: String(command.id ?? ""),
+    commandLine: `${prefix}${
+      Array.isArray(command.argv)
+        ? command.argv
+            .map((argument) =>
+              typeof argument === "string" &&
+              argument.includes(" ") &&
+              !argument.startsWith('"') &&
+              !argument.endsWith('"')
+                ? `"${argument}"`
+                : String(argument),
+            )
+            .join(" ")
+        : ""
+    }`,
+  }));
+}

--- a/scripts/measure-cli-walltime.mjs
+++ b/scripts/measure-cli-walltime.mjs
@@ -1,9 +1,19 @@
 import { execFile } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+
+import {
+  cliRepoRootFromPath,
+  formatSuiteCommands,
+  interpolateArgs,
+  parseSuiteArgs as parseSharedSuiteArgs,
+  readSuiteConfigMap,
+  roundMs,
+  summarizeDurations,
+} from "./lib/cli-benchmark-shared.mjs";
 
 const execFileAsync = promisify(execFile);
 const MAX_BUFFER_BYTES = 10 * 1024 * 1024;
@@ -15,207 +25,13 @@ const DEFAULT_SUITE_CONFIG_PATH = path.join(
 );
 const DEFAULT_CLI_PATH = path.join(REPO_ROOT, "packages", "agentplane", "bin", "agentplane.js");
 
-function roundMs(value) {
-  return Number(value.toFixed(3));
-}
-
-function sortNumeric(values) {
-  return values.toSorted((left, right) => left - right);
-}
-
-function percentile(values, percentileValue) {
-  const sorted = sortNumeric(values);
-  if (sorted.length === 0) {
-    return 0;
-  }
-  const index = Math.ceil((percentileValue / 100) * sorted.length) - 1;
-  return sorted[Math.min(Math.max(index, 0), sorted.length - 1)];
-}
-
-function median(values) {
-  const sorted = sortNumeric(values);
-  const mid = Math.floor(sorted.length / 2);
-  if (sorted.length % 2 === 1) {
-    return sorted[mid];
-  }
-  if (sorted.length === 0) {
-    return 0;
-  }
-  return (sorted[mid - 1] + sorted[mid]) / 2;
-}
-
-function summarizeDurations(durations) {
-  if (durations.length === 0) {
-    return {
-      min_ms: 0,
-      median_ms: 0,
-      max_ms: 0,
-      avg_ms: 0,
-      p95_ms: 0,
-      p99_ms: 0,
-      stddev_ms: 0,
-    };
-  }
-
-  let sum = 0;
-  for (const value of durations) {
-    sum += value;
-  }
-  const average = sum / durations.length;
-
-  let totalDiff = 0;
-  for (const value of durations) {
-    const diff = value - average;
-    totalDiff += diff * diff;
-  }
-  const variance = totalDiff / durations.length;
-
-  return {
-    min_ms: roundMs(Math.min(...durations)),
-    median_ms: roundMs(median(durations)),
-    max_ms: roundMs(Math.max(...durations)),
-    avg_ms: roundMs(average),
-    p95_ms: roundMs(percentile(durations, 95)),
-    p99_ms: roundMs(percentile(durations, 99)),
-    stddev_ms: roundMs(Math.sqrt(variance)),
-  };
-}
-
-function parsePositiveInt(value, flag) {
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isInteger(parsed) || parsed < 0) {
-    throw new Error(`Invalid value for ${flag}: ${value} (expected integer >= 0)`);
-  }
-  return parsed;
-}
-
 function parseSuiteArgs(argv) {
-  let suite = null;
-  let suiteConfig = DEFAULT_SUITE_CONFIG_PATH;
-  let root = REPO_ROOT;
-  let cliPath = DEFAULT_CLI_PATH;
-  let runs = 3;
-  let warmups = 0;
-  let commandId = null;
-  let help = false;
-
-  for (let i = 0; i < argv.length; i += 1) {
-    const arg = argv[i];
-    switch (arg) {
-      case "--help":
-      case "-h": {
-        return { help: true };
-      }
-      case "--suite": {
-        const next = argv[i + 1];
-        if (!next) throw new Error("Missing value after --suite");
-        suite = next;
-        i += 1;
-        break;
-      }
-      case "--suite-config": {
-        const next = argv[i + 1];
-        if (!next) throw new Error("Missing value after --suite-config");
-        suiteConfig = path.resolve(next);
-        i += 1;
-        break;
-      }
-      case "--root": {
-        const next = argv[i + 1];
-        if (!next) throw new Error("Missing value after --root");
-        root = path.resolve(next);
-        i += 1;
-        break;
-      }
-      case "--cli": {
-        const next = argv[i + 1];
-        if (!next) throw new Error("Missing value after --cli");
-        cliPath = path.resolve(next);
-        i += 1;
-        break;
-      }
-      case "--runs": {
-        const next = argv[i + 1];
-        if (!next) throw new Error("Missing value after --runs");
-        runs = parsePositiveInt(next, "--runs");
-        if (runs === 0) {
-          throw new Error("Invalid value for --runs: 0 (expected integer >= 1)");
-        }
-        i += 1;
-        break;
-      }
-      case "--warmups": {
-        const next = argv[i + 1];
-        if (!next) throw new Error("Missing value after --warmups");
-        warmups = parsePositiveInt(next, "--warmups");
-        i += 1;
-        break;
-      }
-      case "--command-id": {
-        const next = argv[i + 1];
-        if (!next) throw new Error("Missing value after --command-id");
-        commandId = next;
-        i += 1;
-        break;
-      }
-      default: {
-        throw new Error(`Unknown argument: ${arg}`);
-      }
-    }
-  }
-
-  return {
-    suite: suite ?? "cli_walltime_baseline",
-    suiteConfig,
-    root,
-    cliPath,
-    runs,
-    warmups,
-    commandId,
-    help,
-  };
-}
-
-function parseSuiteConfig(raw) {
-  if (!raw || raw.schema_version !== 1 || !Array.isArray(raw.suites)) {
-    throw new Error("Invalid suite config payload: expected schema_version=1 and suites");
-  }
-  return raw;
-}
-
-function readSuiteConfig(filePath) {
-  if (!existsSync(filePath)) {
-    throw new Error(`Suite config is missing: ${filePath}`);
-  }
-  return parseSuiteConfig(JSON.parse(readFileSync(filePath, "utf8")));
-}
-
-function interpolateArg(value, vars) {
-  return String(value).replaceAll("{root}", vars.root).replaceAll("{repo_root}", vars.repoRoot);
-}
-
-function interpolateArgs(args, vars) {
-  return args.map((value) => interpolateArg(value, vars));
-}
-
-function formatSuiteCommands(suite) {
-  if (!suite || !Array.isArray(suite.commands)) {
-    return [];
-  }
-  return suite.commands.map((command) => ({
-    id: String(command.id ?? ""),
-    commandLine: command.argv
-      .map((arg) =>
-        typeof arg === "string" && arg.includes(" ") && !arg.startsWith('"') && !arg.endsWith('"')
-          ? `"${arg}"`
-          : String(arg),
-      )
-      .join(" "),
-  }));
-}
-
-function cliRepoRootFromPath(cliPath) {
-  return path.resolve(path.dirname(cliPath), "..", "..", "..");
+  return parseSharedSuiteArgs(argv, {
+    suite: "cli_walltime_baseline",
+    suiteConfig: DEFAULT_SUITE_CONFIG_PATH,
+    root: REPO_ROOT,
+    cliPath: DEFAULT_CLI_PATH,
+  });
 }
 
 async function runCommand(cliPath, argv) {
@@ -247,9 +63,8 @@ async function runCommand(cliPath, argv) {
 }
 
 async function measureSuite(options) {
-  const raw = readSuiteConfig(options.suiteConfig);
-  const suites = new Map((raw.suites ?? []).map((suite) => [suite.id, suite]));
-  const selected = suites.get(options.suite) ?? suites.get(raw.default_suite);
+  const raw = readSuiteConfigMap(options.suiteConfig);
+  const selected = raw.suites.get(options.suite) ?? raw.suites.get(raw.defaultSuite);
   if (!selected) {
     throw new Error(`Suite not found: ${options.suite}`);
   }
@@ -359,10 +174,10 @@ export async function runWalltimeRunner(
 ) {
   const options = parseSuiteArgs(argv);
   if (options.help) {
-    const suiteConfig = readSuiteConfig(options.suiteConfig);
-    const suites = new Map((suiteConfig.suites ?? []).map((suite) => [suite.id, suite]));
+    const suiteConfig = readSuiteConfigMap(options.suiteConfig);
     const previewSuite =
-      suites.get(options.suite) ?? suites.get(suiteConfig.default_suite ?? options.suite);
+      suiteConfig.suites.get(options.suite) ??
+      suiteConfig.suites.get(suiteConfig.defaultSuite ?? options.suite);
     const commandPreview = formatSuiteCommands(previewSuite);
     outputStream.write(
       `${printWalltimeHelpText({


### PR DESCRIPTION
Task: `202605091753-5G5506`
Title: Deduplicate CLI benchmark script helpers
Canonical task record: `.agentplane/tasks/202605091753-5G5506/README.md`

## Summary

Deduplicate CLI benchmark script helpers

Move shared duration statistics, suite argument parsing, config loading, interpolation, and command formatting from benchmark scripts into a script-local helper module without changing benchmark semantics.

## Scope

- In scope: Move shared duration statistics, suite argument parsing, config loading, interpolation, and command formatting from benchmark scripts into a script-local helper module without changing benchmark semantics.
- Out of scope: unrelated refactors not required for "Deduplicate CLI benchmark script helpers".

## Verification

- State: ok
- Note: Verified: extracted shared benchmark helper module; help paths, walltime smoke, perf smoke, Prettier, typecheck, clone:report, and clone:check passed. Clone metrics improved from 1546 duplicated lines / 16193 tokens after the previous task to 1465 duplicated lines / 15457 tokens, with clone count 88 -> 85.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-09T18:28:17.804Z
- Branch: task/202605091753-5G5506/benchmark-helpers
- Head: 621acaa364c2

```text
 .../blueprint/resolved-snapshot.json               | 541 +++++++++++++++++++++
 scripts/cli-benchmark-runner.mjs                   | 240 +--------
 scripts/lib/cli-benchmark-shared.mjs               | 245 ++++++++++
 scripts/measure-cli-walltime.mjs                   | 229 +--------
 4 files changed, 829 insertions(+), 426 deletions(-)
```

</details>
