### PR TITLE
🚧 4FFAY9 task: Extract shared task doc section parser [202605091754-4FFAY9]

### DIFF
--- a/.agentplane/tasks/202605091754-4FFAY9/README.md
+++ b/.agentplane/tasks/202605091754-4FFAY9/README.md
@@ -1,0 +1,99 @@
+---
+id: "202605091754-4FFAY9"
+title: "Extract shared task doc section parser"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "core"
+  - "refactor"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "bun run clone:check"
+  - "bun run test:project -- packages/core/src/tasks"
+  - "bun run typecheck"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-09T17:55:13.528Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-09T18:52:34.181Z"
+  updated_by: "CODER"
+  note: "Verified: extracted shared task doc section parser; focused core task-doc/readme/store tests passed (4 files, 58 tests), typecheck passed, Prettier passed, clone:report improved metrics to 83 clones / 1384 duplicated lines / 14705 duplicated tokens, and clone:check passed without baseline update."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: extract a shared task doc section parser and reuse it from normalization, ensure-section, and section-map helpers."
+events:
+  -
+    type: "status"
+    at: "2026-05-09T18:46:47.086Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: extract a shared task doc section parser and reuse it from normalization, ensure-section, and section-map helpers."
+  -
+    type: "verify"
+    at: "2026-05-09T18:52:34.181Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: extracted shared task doc section parser; focused core task-doc/readme/store tests passed (4 files, 58 tests), typecheck passed, Prettier passed, clone:report improved metrics to 83 clones / 1384 duplicated lines / 14705 duplicated tokens, and clone:check passed without baseline update."
+doc_version: 3
+doc_updated_at: "2026-05-09T18:52:34.206Z"
+doc_updated_by: "CODER"
+description: "Unify the duplicated section parsing logic in core task document normalization so normalizeTaskDoc and normalizeDocSections share one parser."
+sections:
+  Summary: |-
+    Extract shared task doc section parser
+    
+    Unify the duplicated section parsing logic in core task document normalization so normalizeTaskDoc and normalizeDocSections share one parser.
+  Scope: |-
+    - In scope: Unify the duplicated section parsing logic in core task document normalization so normalizeTaskDoc and normalizeDocSections share one parser.
+    - Out of scope: unrelated refactors not required for "Extract shared task doc section parser".
+  Plan: "Extract a shared parser for task document sections in core task-doc handling. Reuse it from normalizeTaskDoc and normalizeDocSections while preserving ordering, duplicate-section separator behavior, and required-section behavior. Verify with core task tests, typecheck, and clone check."
+  Verify Steps: |-
+    1. Run `bun run test:project -- core packages/core/src/tasks/task-doc.test.ts packages/core/src/tasks/task-doc-mutation.test.ts packages/core/src/tasks/task-readme.test.ts packages/core/src/tasks/task-store.test.ts`. Expected: task document parsing, mutation, README rendering, and store behavior remain green.
+    2. Run `bun run typecheck`. Expected: TypeScript project references compile.
+    3. Run `bunx prettier --check packages/core/src/tasks/task-doc.ts`. Expected: changed source is formatted.
+    4. Run `bun run clone:report`. Expected: task-doc section parser duplicate cluster is gone and clone metrics decrease versus the pre-task report.
+    5. Run `bun run clone:check`. Expected: clone baseline guard passes without updating the baseline.
+    6. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-09T18:52:34.181Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: extracted shared task doc section parser; focused core task-doc/readme/store tests passed (4 files, 58 tests), typecheck passed, Prettier passed, clone:report improved metrics to 83 clones / 1384 duplicated lines / 14705 duplicated tokens, and clone:check passed without baseline update.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T18:46:47.106Z, excerpt_hash=sha256:93bb97b97fca27990952f5958b92342d641cfa12159e222be6628989d756a6d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605091754-4FFAY9-task-doc-parser/.agentplane/tasks/202605091754-4FFAY9/blueprint/resolved-snapshot.json
+    - old_digest: e42fc5b22ff69e1a97a3ab0b1b9de53d3f97385bbd2ac38e9f0f856e92c44633
+    - current_digest: e42fc5b22ff69e1a97a3ab0b1b9de53d3f97385bbd2ac38e9f0f856e92c44633
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605091754-4FFAY9
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605091754-4FFAY9/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605091754-4FFAY9/blueprint/resolved-snapshot.json
@@ -1,0 +1,505 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605091754-4FFAY9",
+    "title": "Extract shared task doc section parser",
+    "description": "Unify the duplicated section parsing logic in core task document normalization so normalizeTaskDoc and normalizeDocSections share one parser.",
+    "tags": [
+      "code",
+      "core",
+      "refactor"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605091754-4FFAY9",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "e42fc5b22ff69e1a97a3ab0b1b9de53d3f97385bbd2ac38e9f0f856e92c44633"
+  }
+}

--- a/.agentplane/tasks/202605091754-4FFAY9/pr/diffstat.txt
+++ b/.agentplane/tasks/202605091754-4FFAY9/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
+ packages/core/src/tasks/task-doc.ts                | 152 +++----
+ 2 files changed, 562 insertions(+), 95 deletions(-)

--- a/.agentplane/tasks/202605091754-4FFAY9/pr/github-body.md
+++ b/.agentplane/tasks/202605091754-4FFAY9/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605091754-4FFAY9`
+Title: Extract shared task doc section parser
+Canonical task record: `.agentplane/tasks/202605091754-4FFAY9/README.md`
+
+## Summary
+
+Extract shared task doc section parser
+
+Unify the duplicated section parsing logic in core task document normalization so normalizeTaskDoc and normalizeDocSections share one parser.
+
+## Scope
+
+- In scope: Unify the duplicated section parsing logic in core task document normalization so normalizeTaskDoc and normalizeDocSections share one parser.
+- Out of scope: unrelated refactors not required for "Extract shared task doc section parser".
+
+## Verification
+
+- State: ok
+- Note: Verified: extracted shared task doc section parser; focused core task-doc/readme/store tests passed (4 files, 58 tests), typecheck passed, Prettier passed, clone:report improved metrics to 83 clones / 1384 duplicated lines / 14705 duplicated tokens, and clone:check passed without baseline update.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-09T18:46:47.225Z
+- Branch: task/202605091754-4FFAY9/task-doc-parser
+- Head: f8395196d2a2
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605091754-4FFAY9/pr/github-body.md
+++ b/.agentplane/tasks/202605091754-4FFAY9/pr/github-body.md
@@ -22,12 +22,14 @@ Unify the duplicated section parsing logic in core task document normalization s
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-09T18:46:47.225Z
+- Updated: 2026-05-09T18:53:16.677Z
 - Branch: task/202605091754-4FFAY9/task-doc-parser
-- Head: f8395196d2a2
+- Head: 90f3f6953a17
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
+ packages/core/src/tasks/task-doc.ts                | 152 +++----
+ 2 files changed, 562 insertions(+), 95 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605091754-4FFAY9/pr/github-title.txt
+++ b/.agentplane/tasks/202605091754-4FFAY9/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 4FFAY9 task: Extract shared task doc section parser [202605091754-4FFAY9]

--- a/.agentplane/tasks/202605091754-4FFAY9/pr/meta.json
+++ b/.agentplane/tasks/202605091754-4FFAY9/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605091754-4FFAY9/task-doc-parser",
   "created_at": "2026-05-09T18:46:47.225Z",
-  "head_sha": "f8395196d2a23facd7a802015ad9fb08520f17b2",
+  "head_sha": "90f3f6953a17a8ed538c04d2f92d88a6534e1f20",
   "last_verified_at": "2026-05-09T18:52:34.181Z",
   "last_verified_sha": "f8395196d2a23facd7a802015ad9fb08520f17b2",
   "schema_version": 1,
   "task_id": "202605091754-4FFAY9",
-  "updated_at": "2026-05-09T18:46:47.225Z",
+  "updated_at": "2026-05-09T18:53:16.677Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605091754-4FFAY9/pr/meta.json
+++ b/.agentplane/tasks/202605091754-4FFAY9/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605091754-4FFAY9/task-doc-parser",
+  "created_at": "2026-05-09T18:46:47.225Z",
+  "head_sha": "f8395196d2a23facd7a802015ad9fb08520f17b2",
+  "last_verified_at": "2026-05-09T18:52:34.181Z",
+  "last_verified_sha": "f8395196d2a23facd7a802015ad9fb08520f17b2",
+  "schema_version": 1,
+  "task_id": "202605091754-4FFAY9",
+  "updated_at": "2026-05-09T18:46:47.225Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605091754-4FFAY9/pr/review.md
+++ b/.agentplane/tasks/202605091754-4FFAY9/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-09T18:46:47.225Z
+
+## Task
+
+- Task: `202605091754-4FFAY9`
+- Title: Extract shared task doc section parser
+- Status: DOING
+- Branch: `task/202605091754-4FFAY9/task-doc-parser`
+- Canonical task record: `.agentplane/tasks/202605091754-4FFAY9/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified: extracted shared task doc section parser; focused core task-doc/readme/store tests passed (4 files, 58 tests), typecheck passed, Prettier passed, clone:report improved metrics to 83 clones / 1384 duplicated lines / 14705 duplicated tokens, and clone:check passed without baseline update.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-09T18:46:47.225Z
+- Branch: task/202605091754-4FFAY9/task-doc-parser
+- Head: f8395196d2a2
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605091754-4FFAY9/pr/review.md
+++ b/.agentplane/tasks/202605091754-4FFAY9/pr/review.md
@@ -24,12 +24,14 @@ Created: 2026-05-09T18:46:47.225Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-09T18:46:47.225Z
+- Updated: 2026-05-09T18:53:16.677Z
 - Branch: task/202605091754-4FFAY9/task-doc-parser
-- Head: f8395196d2a2
+- Head: 90f3f6953a17
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
+ packages/core/src/tasks/task-doc.ts                | 152 +++----
+ 2 files changed, 562 insertions(+), 95 deletions(-)
 ```
 
 </details>

--- a/packages/core/src/tasks/task-doc.ts
+++ b/packages/core/src/tasks/task-doc.ts
@@ -3,6 +3,8 @@ const DOC_SECTION_HEADER_RE = /^##\s+Summary(?:\s|$|#)/;
 const AUTO_SUMMARY_HEADER = "## Changes Summary (auto)";
 import { TASK_DOC_SECTION_ORDER } from "./task-doc-contract.js";
 
+type ParsedDocSection = { title: string; lines: string[] };
+
 export function normalizeDocSectionName(section: string): string {
   return section.trim().replaceAll(/\s+/g, " ").toLowerCase();
 }
@@ -48,6 +50,55 @@ export function splitCombinedHeadingLines(doc: string): string[] {
   }
 
   return out;
+}
+
+function parseDocSectionsInternal(
+  doc: string,
+  opts: { separateDuplicateSections?: boolean } = {},
+): {
+  sections: Map<string, ParsedDocSection>;
+  order: string[];
+} {
+  const lines = splitCombinedHeadingLines(doc);
+  const sections = new Map<string, ParsedDocSection>();
+  const order: string[] = [];
+  const pendingSeparator = new Set<string>();
+  let currentKey: string | null = null;
+
+  for (const line of lines) {
+    const match = /^##\s+(.*)$/.exec(line.trim());
+    if (match) {
+      const title = match[1]?.trim() ?? "";
+      const key = normalizeDocSectionName(title);
+      if (key) {
+        const existing = sections.get(key);
+        if (existing) {
+          if (
+            opts.separateDuplicateSections === true &&
+            existing.lines.some((entry) => entry.trim() !== "")
+          ) {
+            pendingSeparator.add(key);
+          }
+        } else {
+          sections.set(key, { title, lines: [] });
+          order.push(key);
+        }
+        currentKey = key;
+        continue;
+      }
+    }
+    if (currentKey) {
+      const entry = sections.get(currentKey);
+      if (!entry) continue;
+      if (pendingSeparator.has(currentKey) && line.trim() !== "") {
+        entry.lines.push("");
+        pendingSeparator.delete(currentKey);
+      }
+      entry.lines.push(line);
+    }
+  }
+
+  return { sections, order };
 }
 
 function normalizeSectionLines(lines: string[]): string[] {
@@ -96,41 +147,9 @@ export function normalizeTaskDoc(doc: string): string {
   const trimmed = normalized.replaceAll(/^\n+|\n+$/g, "");
   if (!trimmed) return "";
 
-  const lines = splitCombinedHeadingLines(trimmed);
-  const sections = new Map<string, { title: string; lines: string[] }>();
-  const order: string[] = [];
-  const pendingSeparator = new Set<string>();
-  let currentKey: string | null = null;
-
-  for (const line of lines) {
-    const match = /^##\s+(.*)$/.exec(line.trim());
-    if (match) {
-      const title = match[1]?.trim() ?? "";
-      const key = normalizeDocSectionName(title);
-      if (key) {
-        const existing = sections.get(key);
-        if (existing) {
-          if (existing.lines.some((entry) => entry.trim() !== "")) {
-            pendingSeparator.add(key);
-          }
-        } else {
-          sections.set(key, { title, lines: [] });
-          order.push(key);
-        }
-        currentKey = key;
-        continue;
-      }
-    }
-    if (currentKey) {
-      const entry = sections.get(currentKey);
-      if (!entry) continue;
-      if (pendingSeparator.has(currentKey) && line.trim() !== "") {
-        entry.lines.push("");
-        pendingSeparator.delete(currentKey);
-      }
-      entry.lines.push(line);
-    }
-  }
+  const { sections, order } = parseDocSectionsInternal(trimmed, {
+    separateDuplicateSections: true,
+  });
 
   if (order.length === 0) return trimmed;
 
@@ -249,41 +268,7 @@ export function setMarkdownSection(body: string, section: string, text: string):
 }
 
 function normalizeDocSections(doc: string, required: string[]): string {
-  const lines = splitCombinedHeadingLines(doc);
-  const sections = new Map<string, { title: string; lines: string[] }>();
-  const order: string[] = [];
-  const pendingSeparator = new Set<string>();
-  let currentKey: string | null = null;
-
-  for (const line of lines) {
-    const match = /^##\s+(.*)$/.exec(line.trim());
-    if (match) {
-      const title = match[1]?.trim() ?? "";
-      const key = normalizeDocSectionName(title);
-      if (key) {
-        const existing = sections.get(key);
-        if (existing) {
-          if (existing.lines.some((entry) => entry.trim() !== "")) {
-            pendingSeparator.add(key);
-          }
-        } else {
-          sections.set(key, { title, lines: [] });
-          order.push(key);
-        }
-        currentKey = key;
-        continue;
-      }
-    }
-    if (currentKey) {
-      const entry = sections.get(currentKey);
-      if (!entry) continue;
-      if (pendingSeparator.has(currentKey) && line.trim() !== "") {
-        entry.lines.push("");
-        pendingSeparator.delete(currentKey);
-      }
-      entry.lines.push(line);
-    }
-  }
+  const { sections, order } = parseDocSectionsInternal(doc, { separateDuplicateSections: true });
 
   const out: string[] = [];
   const seen = new Set(order);
@@ -319,33 +304,10 @@ export function ensureDocSections(doc: string, required: string[]): string {
 }
 
 export function parseDocSections(doc: string): {
-  sections: Map<string, { title: string; lines: string[] }>;
+  sections: Map<string, ParsedDocSection>;
   order: string[];
 } {
-  const lines = splitCombinedHeadingLines(doc);
-  const sections = new Map<string, { title: string; lines: string[] }>();
-  const order: string[] = [];
-  let currentKey: string | null = null;
-  for (const line of lines) {
-    const match = /^##\s+(.*)$/.exec(line.trim());
-    if (match) {
-      const title = match[1]?.trim() ?? "";
-      const key = normalizeDocSectionName(title);
-      if (key) {
-        if (!sections.has(key)) {
-          sections.set(key, { title, lines: [] });
-          order.push(key);
-        }
-        currentKey = key;
-        continue;
-      }
-    }
-    if (currentKey) {
-      const entry = sections.get(currentKey);
-      if (entry) entry.lines.push(line);
-    }
-  }
-  return { sections, order };
+  return parseDocSectionsInternal(doc);
 }
 
 function orderedTaskSectionTitles(sections: Record<string, string>): string[] {


### PR DESCRIPTION
Task: `202605091754-4FFAY9`
Title: Extract shared task doc section parser
Canonical task record: `.agentplane/tasks/202605091754-4FFAY9/README.md`

## Summary

Extract shared task doc section parser

Unify the duplicated section parsing logic in core task document normalization so normalizeTaskDoc and normalizeDocSections share one parser.

## Scope

- In scope: Unify the duplicated section parsing logic in core task document normalization so normalizeTaskDoc and normalizeDocSections share one parser.
- Out of scope: unrelated refactors not required for "Extract shared task doc section parser".

## Verification

- State: ok
- Note: Verified: extracted shared task doc section parser; focused core task-doc/readme/store tests passed (4 files, 58 tests), typecheck passed, Prettier passed, clone:report improved metrics to 83 clones / 1384 duplicated lines / 14705 duplicated tokens, and clone:check passed without baseline update.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-09T18:53:16.677Z
- Branch: task/202605091754-4FFAY9/task-doc-parser
- Head: 90f3f6953a17

```text
 .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
 packages/core/src/tasks/task-doc.ts                | 152 +++----
 2 files changed, 562 insertions(+), 95 deletions(-)
```

</details>
