### PR TITLE
🚧 JY4YSA task: Support packaged blueprint catalogs [202605091906-JY4YSA]

### DIFF
--- a/.agentplane/tasks/202605091906-JY4YSA/README.md
+++ b/.agentplane/tasks/202605091906-JY4YSA/README.md
@@ -1,0 +1,96 @@
+---
+id: "202605091906-JY4YSA"
+title: "Support packaged blueprint catalogs"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-09T19:06:25.601Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-09T19:15:46.664Z"
+  updated_by: "CODER"
+  note: "Packaged blueprint catalog support verified."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implementing package-style blueprint catalog parsing and install support in the task worktree while preserving existing source catalog behavior."
+events:
+  -
+    type: "status"
+    at: "2026-05-09T19:07:04.212Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implementing package-style blueprint catalog parsing and install support in the task worktree while preserving existing source catalog behavior."
+  -
+    type: "verify"
+    at: "2026-05-09T19:15:46.664Z"
+    author: "CODER"
+    state: "ok"
+    note: "Packaged blueprint catalog support verified."
+doc_version: 3
+doc_updated_at: "2026-05-09T19:15:46.696Z"
+doc_updated_by: "CODER"
+description: "Teach AgentPlane CLI to consume recipes-like blueprint release indexes with versioned package tarballs and checksums while preserving existing source catalog compatibility."
+sections:
+  Summary: |-
+    Support packaged blueprint catalogs
+    
+    Teach AgentPlane CLI to consume recipes-like blueprint release indexes with versioned package tarballs and checksums while preserving existing source catalog compatibility.
+  Scope: |-
+    - In scope: Teach AgentPlane CLI to consume recipes-like blueprint release indexes with versioned package tarballs and checksums while preserving existing source catalog compatibility.
+    - Out of scope: unrelated refactors not required for "Support packaged blueprint catalogs".
+  Plan: "Add package-style blueprint catalog support while preserving source catalog compatibility: parse remote release indexes with versions/url/sha256, display package metadata in catalog list/info, install selected blueprint packages by downloading tarballs and verifying checksums, keep existing path-based catalog installs working, and cover behavior with focused CLI tests."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-09T19:15:46.664Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Packaged blueprint catalog support verified.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T19:07:04.250Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    Command: bun vitest packages/agentplane/src/cli/run-cli.core.blueprint.test.ts. Result: pass. Evidence: 23 tests passed, including packaged blueprint install test. Scope: blueprint catalog refresh/install CLI behavior.
+    
+    Command: bun --filter agentplane typecheck. Result: pass. Evidence: agentplane typecheck exited with code 0. Scope: TypeScript signatures for AgentPlane package.
+    
+    Command: node .agentplane/policy/check-routing.mjs && ap doctor. Result: pass. Evidence: policy routing OK; doctor OK with errors=0 warnings=0. Scope: policy routing and repo-local runtime health.
+    
+    Command: published package E2E using AGENTPLANE_HOME inside worktree and index https://raw.githubusercontent.com/basilisk-labs/agentplane-blueprints/ed6021b/index.json. Result: pass. Evidence: catalog sees coding-twitter 0.1.1; install wrote coding.twitter and project-local blueprint-catalog provenance. Scope: release-index parsing, tarball checksum verification, archive extraction, install, and provenance copy.
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605091906-JY4YSA-packaged-blueprint-catalog/.agentplane/tasks/202605091906-JY4YSA/blueprint/resolved-snapshot.json
+    - old_digest: 39ecd490d3342aec503d5dbb350e30eed2dfa3594cffe2712e1df396361825ed
+    - current_digest: 39ecd490d3342aec503d5dbb350e30eed2dfa3594cffe2712e1df396361825ed
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605091906-JY4YSA
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605091906-JY4YSA/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605091906-JY4YSA/blueprint/resolved-snapshot.json
@@ -1,0 +1,496 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605091906-JY4YSA",
+    "title": "Support packaged blueprint catalogs",
+    "description": "Teach AgentPlane CLI to consume recipes-like blueprint release indexes with versioned package tarballs and checksums while preserving existing source catalog compatibility.",
+    "tags": [
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605091906-JY4YSA",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "39ecd490d3342aec503d5dbb350e30eed2dfa3594cffe2712e1df396361825ed"
+  }
+}

--- a/.agentplane/tasks/202605091906-JY4YSA/pr/diffstat.txt
+++ b/.agentplane/tasks/202605091906-JY4YSA/pr/diffstat.txt
@@ -1,0 +1,5 @@
+ .../blueprint/resolved-snapshot.json               | 496 +++++++++++++++++++++
+ .../src/cli/run-cli.core.blueprint.test.ts         | 119 +++++
+ .../src/commands/blueprints/blueprints.command.ts  |   6 +-
+ .../agentplane/src/commands/blueprints/catalog.ts  | 252 +++++++++--
+ 4 files changed, 825 insertions(+), 48 deletions(-)

--- a/.agentplane/tasks/202605091906-JY4YSA/pr/github-body.md
+++ b/.agentplane/tasks/202605091906-JY4YSA/pr/github-body.md
@@ -22,12 +22,16 @@ Teach AgentPlane CLI to consume recipes-like blueprint release indexes with vers
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-09T19:07:04.570Z
+- Updated: 2026-05-09T19:16:57.571Z
 - Branch: task/202605091906-JY4YSA/packaged-blueprint-catalog
-- Head: 8d509525d621
+- Head: 8575da6dfc4d
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 496 +++++++++++++++++++++
+ .../src/cli/run-cli.core.blueprint.test.ts         | 119 +++++
+ .../src/commands/blueprints/blueprints.command.ts  |   6 +-
+ .../agentplane/src/commands/blueprints/catalog.ts  | 252 +++++++++--
+ 4 files changed, 825 insertions(+), 48 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605091906-JY4YSA/pr/github-body.md
+++ b/.agentplane/tasks/202605091906-JY4YSA/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605091906-JY4YSA`
+Title: Support packaged blueprint catalogs
+Canonical task record: `.agentplane/tasks/202605091906-JY4YSA/README.md`
+
+## Summary
+
+Support packaged blueprint catalogs
+
+Teach AgentPlane CLI to consume recipes-like blueprint release indexes with versioned package tarballs and checksums while preserving existing source catalog compatibility.
+
+## Scope
+
+- In scope: Teach AgentPlane CLI to consume recipes-like blueprint release indexes with versioned package tarballs and checksums while preserving existing source catalog compatibility.
+- Out of scope: unrelated refactors not required for "Support packaged blueprint catalogs".
+
+## Verification
+
+- State: ok
+- Note: Packaged blueprint catalog support verified.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-09T19:07:04.570Z
+- Branch: task/202605091906-JY4YSA/packaged-blueprint-catalog
+- Head: 8d509525d621
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605091906-JY4YSA/pr/github-title.txt
+++ b/.agentplane/tasks/202605091906-JY4YSA/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 JY4YSA task: Support packaged blueprint catalogs [202605091906-JY4YSA]

--- a/.agentplane/tasks/202605091906-JY4YSA/pr/meta.json
+++ b/.agentplane/tasks/202605091906-JY4YSA/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605091906-JY4YSA/packaged-blueprint-catalog",
   "created_at": "2026-05-09T19:07:04.570Z",
-  "head_sha": "8d509525d621ee4ac306fbf71d9040335ada084f",
+  "head_sha": "8575da6dfc4d70ef8fbfccd37b31de0bc5b96ee9",
   "last_verified_at": "2026-05-09T19:15:46.664Z",
   "last_verified_sha": "8d509525d621ee4ac306fbf71d9040335ada084f",
   "schema_version": 1,
   "task_id": "202605091906-JY4YSA",
-  "updated_at": "2026-05-09T19:07:04.570Z",
+  "updated_at": "2026-05-09T19:16:57.571Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605091906-JY4YSA/pr/meta.json
+++ b/.agentplane/tasks/202605091906-JY4YSA/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605091906-JY4YSA/packaged-blueprint-catalog",
+  "created_at": "2026-05-09T19:07:04.570Z",
+  "head_sha": "8d509525d621ee4ac306fbf71d9040335ada084f",
+  "last_verified_at": "2026-05-09T19:15:46.664Z",
+  "last_verified_sha": "8d509525d621ee4ac306fbf71d9040335ada084f",
+  "schema_version": 1,
+  "task_id": "202605091906-JY4YSA",
+  "updated_at": "2026-05-09T19:07:04.570Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605091906-JY4YSA/pr/review.md
+++ b/.agentplane/tasks/202605091906-JY4YSA/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-09T19:07:04.570Z
+
+## Task
+
+- Task: `202605091906-JY4YSA`
+- Title: Support packaged blueprint catalogs
+- Status: DOING
+- Branch: `task/202605091906-JY4YSA/packaged-blueprint-catalog`
+- Canonical task record: `.agentplane/tasks/202605091906-JY4YSA/README.md`
+
+## Verification
+
+- State: ok
+- Note: Packaged blueprint catalog support verified.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-09T19:07:04.570Z
+- Branch: task/202605091906-JY4YSA/packaged-blueprint-catalog
+- Head: 8d509525d621
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605091906-JY4YSA/pr/review.md
+++ b/.agentplane/tasks/202605091906-JY4YSA/pr/review.md
@@ -24,12 +24,16 @@ Created: 2026-05-09T19:07:04.570Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-09T19:07:04.570Z
+- Updated: 2026-05-09T19:16:57.571Z
 - Branch: task/202605091906-JY4YSA/packaged-blueprint-catalog
-- Head: 8d509525d621
+- Head: 8575da6dfc4d
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 496 +++++++++++++++++++++
+ .../src/cli/run-cli.core.blueprint.test.ts         | 119 +++++
+ .../src/commands/blueprints/blueprints.command.ts  |   6 +-
+ .../agentplane/src/commands/blueprints/catalog.ts  | 252 +++++++++--
+ 4 files changed, 825 insertions(+), 48 deletions(-)
 ```
 
 </details>

--- a/packages/agentplane/src/cli/run-cli.core.blueprint.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.blueprint.test.ts
@@ -1,11 +1,16 @@
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { promisify } from "node:util";
 
 import { requireBlueprint } from "../blueprints/registry.js";
 import { captureStdIO, mkTempDir } from "@agentplane/testkit";
 import { describe, expect, it } from "vitest";
 
 import { runCli } from "./run-cli.js";
+
+const execFileAsync = promisify(execFile);
 
 async function mkProject(): Promise<string> {
   const root = await mkTempDir();
@@ -98,6 +103,67 @@ async function mkBlueprintCatalogFixture(): Promise<{ root: string; indexPath: s
     "utf8",
   );
   return { root, indexPath: path.join(root, "catalog", "index.json") };
+}
+
+async function mkPackagedBlueprintCatalogFixture(): Promise<{ root: string; indexPath: string }> {
+  const fixture = await mkBlueprintCatalogFixture();
+  const distDir = path.join(fixture.root, "dist");
+  await mkdir(distDir, { recursive: true });
+  const archivePath = path.join(distDir, "external-analysis-0.1.0.tar.gz");
+  await execFileAsync("tar", [
+    "-czf",
+    archivePath,
+    "-C",
+    path.join(fixture.root, "blueprints"),
+    "external-analysis",
+  ]);
+  const sha256 = createHash("sha256").update(await readFile(archivePath)).digest("hex");
+  const releaseIndexPath = path.join(fixture.root, "index.json");
+  await writeFile(
+    releaseIndexPath,
+    `${JSON.stringify(
+      {
+        schema_version: 1,
+        catalog_id: "test-blueprints",
+        name: "Test Blueprints",
+        blueprints: [
+          {
+            id: "external-analysis",
+            name: "External Analysis",
+            summary: "External analysis route.",
+            activation: {
+              recommended_allowed_ids: ["analysis.external"],
+            },
+            versions: [
+              {
+                version: "0.1.0",
+                url: archivePath,
+                sha256,
+                min_agentplane_version: "0.5.0-rc.1",
+                tags: ["analysis"],
+              },
+            ],
+          },
+        ],
+        packs: [
+          {
+            id: "baseline",
+            version: "0.1.0",
+            name: "Baseline",
+            summary: "Baseline blueprint pack.",
+            blueprints: [{ id: "external-analysis", required: true }],
+            activation: {
+              recommended_allowed_ids: ["analysis.external"],
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+  return { root: fixture.root, indexPath: releaseIndexPath };
 }
 
 describe("runCli blueprint commands", () => {
@@ -349,6 +415,59 @@ describe("runCli blueprint commands", () => {
         ),
       ) as { id?: string };
       expect(installed.id).toBe("analysis.external");
+    } finally {
+      io.restore();
+      if (originalHome === undefined) delete process.env.AGENTPLANE_HOME;
+      else process.env.AGENTPLANE_HOME = originalHome;
+    }
+  });
+
+  it("blueprints install writes a packaged blueprint after checksum verification", async () => {
+    const home = await mkTempDir();
+    const originalHome = process.env.AGENTPLANE_HOME;
+    process.env.AGENTPLANE_HOME = home;
+    const fixture = await mkPackagedBlueprintCatalogFixture();
+    const root = await mkProject();
+    const io = captureStdIO();
+    try {
+      const code = await runCli([
+        "--root",
+        root,
+        "blueprints",
+        "install",
+        "external-analysis",
+        "--index",
+        fixture.indexPath,
+        "--activate",
+        "--json",
+      ]);
+      expect(code).toBe(0);
+      const payload = JSON.parse(io.stdout) as {
+        activated: boolean;
+        installed: { blueprintId: string; projectPath: string }[];
+        allowed_ids: string[];
+      };
+      expect(payload.activated).toBe(true);
+      expect(payload.allowed_ids).toEqual(["analysis.external"]);
+      expect(payload.installed).toEqual([
+        expect.objectContaining({
+          blueprintId: "analysis.external",
+          projectPath: ".agentplane/blueprints/analysis.external.json",
+        }),
+      ]);
+      const installed = JSON.parse(
+        await readFile(
+          path.join(root, ".agentplane", "blueprints", "analysis.external.json"),
+          "utf8",
+        ),
+      ) as { id?: string };
+      expect(installed.id).toBe("analysis.external");
+      await expect(
+        readFile(
+          path.join(root, ".agentplane", "blueprint-catalog", "external-analysis", "blueprint.json"),
+          "utf8",
+        ),
+      ).resolves.toContain('"external-analysis"');
     } finally {
       io.restore();
       if (originalHome === undefined) delete process.env.AGENTPLANE_HOME;

--- a/packages/agentplane/src/commands/blueprints/blueprints.command.ts
+++ b/packages/agentplane/src/commands/blueprints/blueprints.command.ts
@@ -221,9 +221,11 @@ export const runBlueprintsCatalogInfo: CommandHandler<BlueprintsCatalogInfoParse
   const catalog = await loadCatalog({ cwd: ctx.cwd });
   const found = findEntry(catalog.index, p.id, p.kind);
   const loaded =
-    found.kind === "blueprint"
+    found.kind === "blueprint" && found.entry.path
       ? await loadBlueprintManifest({ catalogSource: catalog.source, entry: found.entry })
-      : await loadPackManifest({ catalogSource: catalog.source, entry: found.entry });
+      : found.kind === "pack"
+        ? await loadPackManifest({ catalogSource: catalog.source, entry: found.entry })
+        : { manifest: found.entry };
   const output = { kind: found.kind, manifest: loaded.manifest };
   if (p.json) process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
   else

--- a/packages/agentplane/src/commands/blueprints/catalog.ts
+++ b/packages/agentplane/src/commands/blueprints/catalog.ts
@@ -1,8 +1,10 @@
-import { mkdir, cp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, cp, mkdtemp, readFile, rm, writeFile, readdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { fetchText } from "../../cli/http.js";
+import { extractArchive } from "../../cli/archive.js";
+import { sha256File } from "../../cli/checksum.js";
+import { downloadToFile, fetchText } from "../../cli/http.js";
 import { validateProjectBlueprintFile } from "../../blueprints/index.js";
 import { CliError, ValidationError } from "../../shared/errors.js";
 import { isRecord } from "../../shared/guards.js";
@@ -12,7 +14,26 @@ export type CatalogKind = "blueprint" | "pack";
 
 export type CatalogEntry = {
   id: string;
-  path: string;
+  path?: string;
+  name?: string;
+  summary?: string;
+  version?: string;
+  tags?: string[];
+  activation?: {
+    recommended_allowed_ids?: string[];
+  };
+  versions?: {
+    version: string;
+    url: string;
+    sha256: string;
+    min_agentplane_version?: string;
+    tags?: string[];
+  }[];
+  blueprints?: {
+    id: string;
+    version?: string;
+    required?: boolean;
+  }[];
 };
 
 export type BlueprintCatalogIndex = {
@@ -125,11 +146,72 @@ async function readText(source: string): Promise<string> {
 function parseCatalogEntry(raw: unknown, field: string): CatalogEntry {
   if (!isRecord(raw)) throw new ValidationError({ message: `${field} entry must be an object.` });
   const id = typeof raw.id === "string" ? raw.id.trim() : "";
-  const entryPath = typeof raw.path === "string" ? raw.path.trim() : "";
-  if (!id || !entryPath) {
-    throw new ValidationError({ message: `${field} entry must contain id and path.` });
+  const entryPath = typeof raw.path === "string" ? raw.path.trim() : undefined;
+  const versions = Array.isArray(raw.versions)
+    ? raw.versions.map((version) => {
+        if (!isRecord(version)) {
+          throw new ValidationError({ message: `${field} versions entries must be objects.` });
+        }
+        const versionId = typeof version.version === "string" ? version.version.trim() : "";
+        const url = typeof version.url === "string" ? version.url.trim() : "";
+        const sha256 = typeof version.sha256 === "string" ? version.sha256.trim() : "";
+        if (!versionId || !url || !sha256) {
+          throw new ValidationError({
+            message: `${field} versions entries must contain version, url, and sha256.`,
+          });
+        }
+        return {
+          version: versionId,
+          url,
+          sha256,
+          min_agentplane_version:
+            typeof version.min_agentplane_version === "string"
+              ? version.min_agentplane_version
+              : undefined,
+          tags: Array.isArray(version.tags)
+            ? version.tags.filter((tag): tag is string => typeof tag === "string")
+            : undefined,
+        };
+      })
+    : undefined;
+  const blueprints = Array.isArray(raw.blueprints)
+    ? raw.blueprints.map((entry) => {
+        if (!isRecord(entry) || typeof entry.id !== "string" || !entry.id.trim()) {
+          throw new ValidationError({ message: `${field} blueprint entries must contain id.` });
+        }
+        return {
+          id: entry.id.trim(),
+          version: typeof entry.version === "string" ? entry.version.trim() : undefined,
+          required: entry.required === true,
+        };
+      })
+    : undefined;
+  if (!id || (!entryPath && !versions && !blueprints)) {
+    throw new ValidationError({
+      message: `${field} entry must contain id plus path, versions, or blueprints.`,
+    });
   }
-  return { id, path: entryPath };
+  return {
+    id,
+    path: entryPath,
+    name: typeof raw.name === "string" ? raw.name : undefined,
+    summary: typeof raw.summary === "string" ? raw.summary : undefined,
+    version: typeof raw.version === "string" ? raw.version : undefined,
+    tags: Array.isArray(raw.tags)
+      ? raw.tags.filter((tag): tag is string => typeof tag === "string")
+      : undefined,
+    activation: isRecord(raw.activation)
+      ? {
+          recommended_allowed_ids: Array.isArray(raw.activation.recommended_allowed_ids)
+            ? raw.activation.recommended_allowed_ids.filter(
+                (allowedId): allowedId is string => typeof allowedId === "string",
+              )
+            : undefined,
+        }
+      : undefined,
+    versions,
+    blueprints,
+  };
 }
 
 function parseCatalogIndex(raw: unknown): BlueprintCatalogIndex {
@@ -337,10 +419,44 @@ function parsePackManifest(raw: unknown): CatalogPackManifest {
   return pack;
 }
 
+function pickLatestVersion(entry: CatalogEntry): NonNullable<CatalogEntry["versions"]>[number] {
+  const versions = entry.versions ?? [];
+  if (versions.length === 0) {
+    throw new ValidationError({ message: `Blueprint ${entry.id} has no installable versions.` });
+  }
+  return versions.toSorted((a, b) => a.version.localeCompare(b.version, undefined, { numeric: true })).at(-1)!;
+}
+
+async function resolvePackageRoot(extractedDir: string): Promise<string> {
+  const rootManifest = path.join(extractedDir, "blueprint.json");
+  try {
+    await readFile(rootManifest, "utf8");
+    return extractedDir;
+  } catch (err) {
+    const code = (err as { code?: string } | null)?.code;
+    if (code !== "ENOENT") throw err;
+  }
+  const entries = await readdir(extractedDir, { withFileTypes: true });
+  const dirs = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+  if (dirs.length !== 1) {
+    throw new ValidationError({
+      message: "Blueprint package archive must contain blueprint.json at root or exactly one root directory.",
+    });
+  }
+  const candidate = path.join(extractedDir, dirs[0]);
+  await readFile(path.join(candidate, "blueprint.json"), "utf8");
+  return candidate;
+}
+
 export async function loadBlueprintManifest(opts: {
   catalogSource: string;
   entry: CatalogEntry;
 }): Promise<{ manifest: CatalogBlueprintManifest; manifestSource: string }> {
+  if (!opts.entry.path) {
+    throw new ValidationError({
+      message: `Blueprint ${opts.entry.id} is packaged; install it to inspect its full manifest.`,
+    });
+  }
   const manifestSource = resolveCatalogEntrySource(opts.catalogSource, opts.entry.path);
   return {
     manifest: parseBlueprintManifest(JSON.parse(await readText(manifestSource)) as unknown),
@@ -352,6 +468,18 @@ export async function loadPackManifest(opts: {
   catalogSource: string;
   entry: CatalogEntry;
 }): Promise<{ manifest: CatalogPackManifest; manifestSource: string }> {
+  if (!opts.entry.path) {
+    const pack = {
+      schema_version: 1,
+      id: opts.entry.id,
+      version: opts.entry.version ?? "0.0.0",
+      name: opts.entry.name ?? opts.entry.id,
+      summary: opts.entry.summary ?? "",
+      blueprints: opts.entry.blueprints ?? [],
+      activation: opts.entry.activation,
+    } satisfies CatalogPackManifest;
+    return { manifest: parsePackManifest(pack), manifestSource: opts.catalogSource };
+  }
   const manifestSource = resolveCatalogEntrySource(opts.catalogSource, opts.entry.path);
   return {
     manifest: parsePackManifest(JSON.parse(await readText(manifestSource)) as unknown),
@@ -390,45 +518,77 @@ export async function installBlueprint(opts: {
   catalogSource: string;
   entry: CatalogEntry;
 }): Promise<InstalledBlueprint> {
-  const { manifest, manifestSource } = await loadBlueprintManifest({
-    catalogSource: opts.catalogSource,
-    entry: opts.entry,
-  });
-  assertSafeCatalogPathSegment(manifest.definition.id, "Catalog blueprint definition.id");
-  if (!isHttpUrl(manifestSource)) {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "agentplane-blueprint-"));
+  try {
+    let manifestSource = "";
+    let manifest: CatalogBlueprintManifest;
+    if (opts.entry.path) {
+      const loaded = await loadBlueprintManifest({
+        catalogSource: opts.catalogSource,
+        entry: opts.entry,
+      });
+      manifest = loaded.manifest;
+      manifestSource = loaded.manifestSource;
+    } else {
+      const latest = pickLatestVersion(opts.entry);
+      const archiveUrl = isHttpUrl(latest.url)
+        ? latest.url
+        : isHttpUrl(opts.catalogSource)
+          ? new URL(latest.url, opts.catalogSource).toString()
+          : path.resolve(path.dirname(opts.catalogSource), latest.url);
+      const archiveName =
+        path.basename(isHttpUrl(archiveUrl) ? new URL(archiveUrl).pathname : archiveUrl) ||
+        "blueprint.tar.gz";
+      const archivePath = path.join(tempRoot, archiveName);
+      if (isHttpUrl(archiveUrl)) await downloadToFile(archiveUrl, archivePath);
+      else await cp(archiveUrl, archivePath);
+      const actualSha = await sha256File(archivePath);
+      if (actualSha !== latest.sha256) {
+        throw new ValidationError({
+          message: `Blueprint checksum mismatch for ${opts.entry.id}@${latest.version}`,
+        });
+      }
+      await extractArchive({ archivePath, destDir: tempRoot });
+      const packageRoot = await resolvePackageRoot(tempRoot);
+      manifestSource = path.join(packageRoot, "blueprint.json");
+      manifest = parseBlueprintManifest(JSON.parse(await readFile(manifestSource, "utf8")) as unknown);
+    }
+    assertSafeCatalogPathSegment(manifest.definition.id, "Catalog blueprint definition.id");
     assertSafeCatalogPathSegment(manifest.id, "Catalog blueprint manifest id");
+    const definitionSource = resolveNearSource(manifestSource, manifest.definition.path);
+    const definitionText = await readText(definitionSource);
+    const targetDir = path.join(opts.projectRoot, ".agentplane", "blueprints");
+    const targetPath = path.join(targetDir, `${manifest.definition.id}.json`);
+    await mkdir(targetDir, { recursive: true });
+    await writeFile(targetPath, definitionText, "utf8");
+    const validation = await validateProjectBlueprintFile(targetPath);
+    if (!validation.ok) {
+      throw new ValidationError({
+        message: `Installed blueprint definition is invalid: ${validation.errors
+          .map((error) => `${error.code}: ${error.message}`)
+          .join("; ")}`,
+        context: { path: targetPath },
+      });
+    }
+    if (!isHttpUrl(manifestSource)) {
+      const packageRoot = path.dirname(manifestSource);
+      const catalogTarget = path.join(
+        opts.projectRoot,
+        ".agentplane",
+        "blueprint-catalog",
+        manifest.id,
+      );
+      await rm(catalogTarget, { recursive: true, force: true });
+      await mkdir(path.dirname(catalogTarget), { recursive: true });
+      await cp(packageRoot, catalogTarget, { recursive: true });
+    }
+    return {
+      catalogId: manifest.id,
+      blueprintId: manifest.definition.id,
+      projectPath: path.relative(opts.projectRoot, targetPath),
+      recommendedAllowedIds: manifest.activation?.recommended_allowed_ids ?? [manifest.definition.id],
+    };
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
   }
-  const definitionSource = resolveNearSource(manifestSource, manifest.definition.path);
-  const definitionText = await readText(definitionSource);
-  const targetDir = path.join(opts.projectRoot, ".agentplane", "blueprints");
-  const targetPath = path.join(targetDir, `${manifest.definition.id}.json`);
-  await mkdir(targetDir, { recursive: true });
-  await writeFile(targetPath, definitionText, "utf8");
-  const validation = await validateProjectBlueprintFile(targetPath);
-  if (!validation.ok) {
-    throw new ValidationError({
-      message: `Installed blueprint definition is invalid: ${validation.errors
-        .map((error) => `${error.code}: ${error.message}`)
-        .join("; ")}`,
-      context: { path: targetPath },
-    });
-  }
-  if (!isHttpUrl(manifestSource)) {
-    const packageRoot = path.dirname(manifestSource);
-    const catalogTarget = path.join(
-      opts.projectRoot,
-      ".agentplane",
-      "blueprint-catalog",
-      manifest.id,
-    );
-    await rm(catalogTarget, { recursive: true, force: true });
-    await mkdir(path.dirname(catalogTarget), { recursive: true });
-    await cp(packageRoot, catalogTarget, { recursive: true });
-  }
-  return {
-    catalogId: manifest.id,
-    blueprintId: manifest.definition.id,
-    projectPath: path.relative(opts.projectRoot, targetPath),
-    recommendedAllowedIds: manifest.activation?.recommended_allowed_ids ?? [manifest.definition.id],
-  };
 }


### PR DESCRIPTION
Task: `202605091906-JY4YSA`
Title: Support packaged blueprint catalogs
Canonical task record: `.agentplane/tasks/202605091906-JY4YSA/README.md`

## Summary

Support packaged blueprint catalogs

Teach AgentPlane CLI to consume recipes-like blueprint release indexes with versioned package tarballs and checksums while preserving existing source catalog compatibility.

## Scope

- In scope: Teach AgentPlane CLI to consume recipes-like blueprint release indexes with versioned package tarballs and checksums while preserving existing source catalog compatibility.
- Out of scope: unrelated refactors not required for "Support packaged blueprint catalogs".

## Verification

- State: ok
- Note: Packaged blueprint catalog support verified.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-09T19:16:57.571Z
- Branch: task/202605091906-JY4YSA/packaged-blueprint-catalog
- Head: 8575da6dfc4d

```text
 .../blueprint/resolved-snapshot.json               | 496 +++++++++++++++++++++
 .../src/cli/run-cli.core.blueprint.test.ts         | 119 +++++
 .../src/commands/blueprints/blueprints.command.ts  |   6 +-
 .../agentplane/src/commands/blueprints/catalog.ts  | 252 +++++++++--
 4 files changed, 825 insertions(+), 48 deletions(-)
```

</details>
