### PR TITLE
🚧 S1KM8E task: Create verify command spec factory [202605091754-S1KM8E]

### DIFF
--- a/.agentplane/tasks/202605091754-S1KM8E/README.md
+++ b/.agentplane/tasks/202605091754-S1KM8E/README.md
@@ -1,0 +1,99 @@
+---
+id: "202605091754-S1KM8E"
+title: "Create verify command spec factory"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "refactor"
+  - "verify"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "bun run clone:check"
+  - "bun run test:project -- packages/agentplane/src/commands/task"
+  - "bun run typecheck"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-09T17:55:12.356Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-09T19:18:20.585Z"
+  updated_by: "CODER"
+  note: "Verified: created shared verify command spec/handler factory; verify CLI tests passed (2 files, 17 tests), typecheck passed, Prettier passed, clone:report improved metrics to 81 clones / 1335 duplicated lines / 14279 duplicated tokens, and clone:check passed without baseline update."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: create a shared factory for task verify ok/rework command specs and handlers."
+events:
+  -
+    type: "status"
+    at: "2026-05-09T19:13:38.791Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: create a shared factory for task verify ok/rework command specs and handlers."
+  -
+    type: "verify"
+    at: "2026-05-09T19:18:20.585Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: created shared verify command spec/handler factory; verify CLI tests passed (2 files, 17 tests), typecheck passed, Prettier passed, clone:report improved metrics to 81 clones / 1335 duplicated lines / 14279 duplicated tokens, and clone:check passed without baseline update."
+doc_version: 3
+doc_updated_at: "2026-05-09T19:18:20.599Z"
+doc_updated_by: "CODER"
+description: "Replace the duplicated task verify ok/rework command spec boilerplate with a small factory that keeps verdict-specific summary and runner behavior explicit."
+sections:
+  Summary: |-
+    Create verify command spec factory
+    
+    Replace the duplicated task verify ok/rework command spec boilerplate with a small factory that keeps verdict-specific summary and runner behavior explicit.
+  Scope: |-
+    - In scope: Replace the duplicated task verify ok/rework command spec boilerplate with a small factory that keeps verdict-specific summary and runner behavior explicit.
+    - Out of scope: unrelated refactors not required for "Create verify command spec factory".
+  Plan: "Introduce a small factory for task verify ok/rework command specs and handlers. Parameterize verdict-specific command id, summary/example text, getCtx command name, and runner function. Verify with task command tests, typecheck, and clone check."
+  Verify Steps: |-
+    1. Run `bun run test:project -- cli-core packages/agentplane/src/cli/run-cli.core.lifecycle.verify.test.ts packages/agentplane/src/cli/run-cli.core.tasks.verify-matrix.test.ts`. Expected: verify command behavior remains green.
+    2. Run `bun run typecheck`. Expected: TypeScript project references compile.
+    3. Run `bunx prettier --check packages/agentplane/src/commands/task/verify-command-shared.ts packages/agentplane/src/commands/task/verify-ok.command.ts packages/agentplane/src/commands/task/verify-rework.command.ts`. Expected: changed sources are formatted.
+    4. Run `bun run clone:report`. Expected: verify ok/rework command spec duplicate cluster is gone and clone metrics decrease versus the pre-task report.
+    5. Run `bun run clone:check`. Expected: clone baseline guard passes without updating the baseline.
+    6. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-09T19:18:20.585Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: created shared verify command spec/handler factory; verify CLI tests passed (2 files, 17 tests), typecheck passed, Prettier passed, clone:report improved metrics to 81 clones / 1335 duplicated lines / 14279 duplicated tokens, and clone:check passed without baseline update.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-09T19:13:38.807Z, excerpt_hash=sha256:e6cfa79415826b7b75f1502069d24a5e2301c29e0abdd8edeece3c4996ffac74
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605091754-S1KM8E-verify-spec-factory/.agentplane/tasks/202605091754-S1KM8E/blueprint/resolved-snapshot.json
+    - old_digest: 43a901fa90a54a2ddb018fa303a4f73e7cfb9407bbb8f7006d155ee88efcee1e
+    - current_digest: 43a901fa90a54a2ddb018fa303a4f73e7cfb9407bbb8f7006d155ee88efcee1e
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605091754-S1KM8E
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605091754-S1KM8E/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605091754-S1KM8E/blueprint/resolved-snapshot.json
@@ -1,0 +1,505 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605091754-S1KM8E",
+    "title": "Create verify command spec factory",
+    "description": "Replace the duplicated task verify ok/rework command spec boilerplate with a small factory that keeps verdict-specific summary and runner behavior explicit.",
+    "tags": [
+      "code",
+      "refactor",
+      "verify"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605091754-S1KM8E",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "43a901fa90a54a2ddb018fa303a4f73e7cfb9407bbb8f7006d155ee88efcee1e"
+  }
+}

--- a/.agentplane/tasks/202605091754-S1KM8E/pr/diffstat.txt
+++ b/.agentplane/tasks/202605091754-S1KM8E/pr/diffstat.txt
@@ -1,0 +1,5 @@
+ .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
+ .../src/commands/task/verify-command-shared.ts     |  95 +++-
+ .../src/commands/task/verify-ok.command.ts         |  74 +--
+ .../src/commands/task/verify-rework.command.ts     |  74 +--
+ 4 files changed, 627 insertions(+), 121 deletions(-)

--- a/.agentplane/tasks/202605091754-S1KM8E/pr/github-body.md
+++ b/.agentplane/tasks/202605091754-S1KM8E/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605091754-S1KM8E`
+Title: Create verify command spec factory
+Canonical task record: `.agentplane/tasks/202605091754-S1KM8E/README.md`
+
+## Summary
+
+Create verify command spec factory
+
+Replace the duplicated task verify ok/rework command spec boilerplate with a small factory that keeps verdict-specific summary and runner behavior explicit.
+
+## Scope
+
+- In scope: Replace the duplicated task verify ok/rework command spec boilerplate with a small factory that keeps verdict-specific summary and runner behavior explicit.
+- Out of scope: unrelated refactors not required for "Create verify command spec factory".
+
+## Verification
+
+- State: ok
+- Note: Verified: created shared verify command spec/handler factory; verify CLI tests passed (2 files, 17 tests), typecheck passed, Prettier passed, clone:report improved metrics to 81 clones / 1335 duplicated lines / 14279 duplicated tokens, and clone:check passed without baseline update.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-09T19:13:38.898Z
+- Branch: task/202605091754-S1KM8E/verify-spec-factory
+- Head: 8d79e1d5dff2
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605091754-S1KM8E/pr/github-body.md
+++ b/.agentplane/tasks/202605091754-S1KM8E/pr/github-body.md
@@ -22,12 +22,16 @@ Replace the duplicated task verify ok/rework command spec boilerplate with a sma
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-09T19:13:38.898Z
+- Updated: 2026-05-09T19:18:57.670Z
 - Branch: task/202605091754-S1KM8E/verify-spec-factory
-- Head: 8d79e1d5dff2
+- Head: e76ae07f9f10
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
+ .../src/commands/task/verify-command-shared.ts     |  95 +++-
+ .../src/commands/task/verify-ok.command.ts         |  74 +--
+ .../src/commands/task/verify-rework.command.ts     |  74 +--
+ 4 files changed, 627 insertions(+), 121 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605091754-S1KM8E/pr/github-title.txt
+++ b/.agentplane/tasks/202605091754-S1KM8E/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 S1KM8E task: Create verify command spec factory [202605091754-S1KM8E]

--- a/.agentplane/tasks/202605091754-S1KM8E/pr/meta.json
+++ b/.agentplane/tasks/202605091754-S1KM8E/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605091754-S1KM8E/verify-spec-factory",
   "created_at": "2026-05-09T19:13:38.898Z",
-  "head_sha": "8d79e1d5dff2b2be62db668008898056d9692efe",
+  "head_sha": "e76ae07f9f10f0c945f7a0f275c94d441fb459b6",
   "last_verified_at": "2026-05-09T19:18:20.585Z",
   "last_verified_sha": "8d79e1d5dff2b2be62db668008898056d9692efe",
   "schema_version": 1,
   "task_id": "202605091754-S1KM8E",
-  "updated_at": "2026-05-09T19:13:38.898Z",
+  "updated_at": "2026-05-09T19:18:57.670Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605091754-S1KM8E/pr/meta.json
+++ b/.agentplane/tasks/202605091754-S1KM8E/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605091754-S1KM8E/verify-spec-factory",
+  "created_at": "2026-05-09T19:13:38.898Z",
+  "head_sha": "8d79e1d5dff2b2be62db668008898056d9692efe",
+  "last_verified_at": "2026-05-09T19:18:20.585Z",
+  "last_verified_sha": "8d79e1d5dff2b2be62db668008898056d9692efe",
+  "schema_version": 1,
+  "task_id": "202605091754-S1KM8E",
+  "updated_at": "2026-05-09T19:13:38.898Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605091754-S1KM8E/pr/review.md
+++ b/.agentplane/tasks/202605091754-S1KM8E/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-09T19:13:38.898Z
+
+## Task
+
+- Task: `202605091754-S1KM8E`
+- Title: Create verify command spec factory
+- Status: DOING
+- Branch: `task/202605091754-S1KM8E/verify-spec-factory`
+- Canonical task record: `.agentplane/tasks/202605091754-S1KM8E/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified: created shared verify command spec/handler factory; verify CLI tests passed (2 files, 17 tests), typecheck passed, Prettier passed, clone:report improved metrics to 81 clones / 1335 duplicated lines / 14279 duplicated tokens, and clone:check passed without baseline update.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-09T19:13:38.898Z
+- Branch: task/202605091754-S1KM8E/verify-spec-factory
+- Head: 8d79e1d5dff2
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605091754-S1KM8E/pr/review.md
+++ b/.agentplane/tasks/202605091754-S1KM8E/pr/review.md
@@ -24,12 +24,16 @@ Created: 2026-05-09T19:13:38.898Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-09T19:13:38.898Z
+- Updated: 2026-05-09T19:18:57.670Z
 - Branch: task/202605091754-S1KM8E/verify-spec-factory
-- Head: 8d79e1d5dff2
+- Head: e76ae07f9f10
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
+ .../src/commands/task/verify-command-shared.ts     |  95 +++-
+ .../src/commands/task/verify-ok.command.ts         |  74 +--
+ .../src/commands/task/verify-rework.command.ts     |  74 +--
+ 4 files changed, 627 insertions(+), 121 deletions(-)
 ```
 
 </details>

--- a/packages/agentplane/src/commands/task/verify-command-shared.ts
+++ b/packages/agentplane/src/commands/task/verify-command-shared.ts
@@ -1,5 +1,6 @@
 import { usageError } from "../../cli/spec/errors.js";
-import type { CommandSpec, OptionSpec, ParsedRaw } from "../../cli/spec/spec.js";
+import type { CommandCtx, CommandSpec, OptionSpec, ParsedRaw } from "../../cli/spec/spec.js";
+import type { CommandContext } from "../shared/task-backend.js";
 
 export type VerifyCommonParsed = {
   by: string;
@@ -22,6 +23,36 @@ export type VerifyCommonParsed = {
   incidentAdvice?: string;
   incidentRule?: string;
 };
+
+export type TaskVerifyParsed = VerifyCommonParsed & {
+  taskId: string;
+};
+
+type VerifyRecordRunner = (opts: {
+  ctx: CommandContext;
+  cwd: string;
+  rootOverride?: string;
+  taskId: string;
+  by: string;
+  note: string;
+  noteFile?: string;
+  details?: string;
+  file?: string;
+  collectIncidents: boolean;
+  quiet: boolean;
+  observation?: string;
+  impact?: string;
+  resolution?: string;
+  promote: boolean;
+  external: boolean;
+  localOnly: boolean;
+  repoFixable: boolean;
+  incidentScope?: string;
+  incidentTags: string[];
+  incidentMatch: string[];
+  incidentAdvice?: string;
+  incidentRule?: string;
+}) => Promise<number>;
 
 export const verifyFindingOptions: readonly OptionSpec[] = [
   {
@@ -290,5 +321,67 @@ export function parseVerifyCommonOptions(raw: ParsedRaw): VerifyCommonParsed {
       typeof raw.opts["incident-advice"] === "string" ? raw.opts["incident-advice"] : undefined,
     incidentRule:
       typeof raw.opts["incident-rule"] === "string" ? raw.opts["incident-rule"] : undefined,
+  };
+}
+
+export function createTaskVerifyCommandSpec(opts: {
+  id: ["task", "verify", "ok"] | ["task", "verify", "rework"];
+  summary: string;
+  example: { cmd: string; why: string };
+}): CommandSpec<TaskVerifyParsed> {
+  const spec: CommandSpec<TaskVerifyParsed> = {
+    id: opts.id,
+    group: "Task",
+    summary: opts.summary,
+    args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
+    options: verifyCommonOptions,
+    examples: [opts.example],
+    validateRaw: (raw) => {
+      validateVerifyDetailsFileExclusive(raw, spec, {
+        message: "Provide at most one of --details or --file.",
+      });
+      validateVerifyNonEmptyInput(raw, spec, "by");
+      validateVerifyNoteSource(raw, spec);
+      validateVerifyFindingSource(raw, spec);
+    },
+    parse: (raw) => ({
+      taskId: String(raw.args["task-id"]),
+      ...parseVerifyCommonOptions(raw),
+    }),
+  };
+  return spec;
+}
+
+export function makeRunTaskVerifyHandler(opts: {
+  commandName: string;
+  getCtx: (cmd: string) => Promise<CommandContext>;
+  run: VerifyRecordRunner;
+}) {
+  return async (ctx: CommandCtx, p: TaskVerifyParsed): Promise<number> => {
+    return await opts.run({
+      ctx: await opts.getCtx(opts.commandName),
+      cwd: ctx.cwd,
+      rootOverride: ctx.rootOverride,
+      taskId: p.taskId,
+      by: p.by,
+      note: p.note,
+      noteFile: p.noteFile,
+      details: p.details,
+      file: p.file,
+      collectIncidents: p.collectIncidents,
+      quiet: p.quiet,
+      observation: p.observation,
+      impact: p.impact,
+      resolution: p.resolution,
+      promote: p.promote,
+      external: p.external,
+      localOnly: p.localOnly,
+      repoFixable: p.repoFixable,
+      incidentScope: p.incidentScope,
+      incidentTags: p.incidentTags,
+      incidentMatch: p.incidentMatch,
+      incidentAdvice: p.incidentAdvice,
+      incidentRule: p.incidentRule,
+    });
   };
 }

--- a/packages/agentplane/src/commands/task/verify-ok.command.ts
+++ b/packages/agentplane/src/commands/task/verify-ok.command.ts
@@ -1,73 +1,27 @@
-import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
 import type { CommandContext } from "../shared/task-backend.js";
 
 import { cmdTaskVerifyOk } from "./verify-record.js";
 import {
-  parseVerifyCommonOptions,
-  validateVerifyDetailsFileExclusive,
-  validateVerifyFindingSource,
-  validateVerifyNonEmptyInput,
-  validateVerifyNoteSource,
-  verifyCommonOptions,
-  type VerifyCommonParsed,
+  createTaskVerifyCommandSpec,
+  makeRunTaskVerifyHandler,
+  type TaskVerifyParsed,
 } from "./verify-command-shared.js";
 
-export type TaskVerifyOkParsed = VerifyCommonParsed & {
-  taskId: string;
-};
+export type TaskVerifyOkParsed = TaskVerifyParsed;
 
-export const taskVerifyOkSpec: CommandSpec<TaskVerifyOkParsed> = {
+export const taskVerifyOkSpec = createTaskVerifyCommandSpec({
   id: ["task", "verify", "ok"],
-  group: "Task",
   summary: "Record verification as OK (updates Verification section and verification frontmatter).",
-  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
-  options: verifyCommonOptions,
-  examples: [
-    {
-      cmd: 'agentplane task verify ok 202602030608-F1Q8AB --by REVIEWER --note "Looks good"',
-      why: "Record an OK verification.",
-    },
-  ],
-  validateRaw: (raw) => {
-    validateVerifyDetailsFileExclusive(raw, taskVerifyOkSpec, {
-      message: "Provide at most one of --details or --file.",
-    });
-    validateVerifyNonEmptyInput(raw, taskVerifyOkSpec, "by");
-    validateVerifyNoteSource(raw, taskVerifyOkSpec);
-    validateVerifyFindingSource(raw, taskVerifyOkSpec);
+  example: {
+    cmd: 'agentplane task verify ok 202602030608-F1Q8AB --by REVIEWER --note "Looks good"',
+    why: "Record an OK verification.",
   },
-  parse: (raw) => ({
-    taskId: String(raw.args["task-id"]),
-    ...parseVerifyCommonOptions(raw),
-  }),
-};
+});
 
 export function makeRunTaskVerifyOkHandler(getCtx: (cmd: string) => Promise<CommandContext>) {
-  return async (ctx: CommandCtx, p: TaskVerifyOkParsed): Promise<number> => {
-    return await cmdTaskVerifyOk({
-      ctx: await getCtx("task verify ok"),
-      cwd: ctx.cwd,
-      rootOverride: ctx.rootOverride,
-      taskId: p.taskId,
-      by: p.by,
-      note: p.note,
-      noteFile: p.noteFile,
-      details: p.details,
-      file: p.file,
-      collectIncidents: p.collectIncidents,
-      quiet: p.quiet,
-      observation: p.observation,
-      impact: p.impact,
-      resolution: p.resolution,
-      promote: p.promote,
-      external: p.external,
-      localOnly: p.localOnly,
-      repoFixable: p.repoFixable,
-      incidentScope: p.incidentScope,
-      incidentTags: p.incidentTags,
-      incidentMatch: p.incidentMatch,
-      incidentAdvice: p.incidentAdvice,
-      incidentRule: p.incidentRule,
-    });
-  };
+  return makeRunTaskVerifyHandler({
+    commandName: "task verify ok",
+    getCtx,
+    run: cmdTaskVerifyOk,
+  });
 }

--- a/packages/agentplane/src/commands/task/verify-rework.command.ts
+++ b/packages/agentplane/src/commands/task/verify-rework.command.ts
@@ -1,74 +1,28 @@
-import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
 import type { CommandContext } from "../shared/task-backend.js";
 
 import { cmdTaskVerifyRework } from "./verify-record.js";
 import {
-  parseVerifyCommonOptions,
-  validateVerifyDetailsFileExclusive,
-  validateVerifyFindingSource,
-  validateVerifyNonEmptyInput,
-  validateVerifyNoteSource,
-  verifyCommonOptions,
-  type VerifyCommonParsed,
+  createTaskVerifyCommandSpec,
+  makeRunTaskVerifyHandler,
+  type TaskVerifyParsed,
 } from "./verify-command-shared.js";
 
-export type TaskVerifyReworkParsed = VerifyCommonParsed & {
-  taskId: string;
-};
+export type TaskVerifyReworkParsed = TaskVerifyParsed;
 
-export const taskVerifyReworkSpec: CommandSpec<TaskVerifyReworkParsed> = {
+export const taskVerifyReworkSpec = createTaskVerifyCommandSpec({
   id: ["task", "verify", "rework"],
-  group: "Task",
   summary:
     "Record verification as needs rework (resets commit, sets status to DOING, updates Verification).",
-  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
-  options: verifyCommonOptions,
-  examples: [
-    {
-      cmd: 'agentplane task verify rework 202602030608-F1Q8AB --by REVIEWER --note "Needs changes"',
-      why: "Record a needs-rework verification.",
-    },
-  ],
-  validateRaw: (raw) => {
-    validateVerifyDetailsFileExclusive(raw, taskVerifyReworkSpec, {
-      message: "Provide at most one of --details or --file.",
-    });
-    validateVerifyNonEmptyInput(raw, taskVerifyReworkSpec, "by");
-    validateVerifyNoteSource(raw, taskVerifyReworkSpec);
-    validateVerifyFindingSource(raw, taskVerifyReworkSpec);
+  example: {
+    cmd: 'agentplane task verify rework 202602030608-F1Q8AB --by REVIEWER --note "Needs changes"',
+    why: "Record a needs-rework verification.",
   },
-  parse: (raw) => ({
-    taskId: String(raw.args["task-id"]),
-    ...parseVerifyCommonOptions(raw),
-  }),
-};
+});
 
 export function makeRunTaskVerifyReworkHandler(getCtx: (cmd: string) => Promise<CommandContext>) {
-  return async (ctx: CommandCtx, p: TaskVerifyReworkParsed): Promise<number> => {
-    return await cmdTaskVerifyRework({
-      ctx: await getCtx("task verify rework"),
-      cwd: ctx.cwd,
-      rootOverride: ctx.rootOverride,
-      taskId: p.taskId,
-      by: p.by,
-      note: p.note,
-      noteFile: p.noteFile,
-      details: p.details,
-      file: p.file,
-      collectIncidents: p.collectIncidents,
-      quiet: p.quiet,
-      observation: p.observation,
-      impact: p.impact,
-      resolution: p.resolution,
-      promote: p.promote,
-      external: p.external,
-      localOnly: p.localOnly,
-      repoFixable: p.repoFixable,
-      incidentScope: p.incidentScope,
-      incidentTags: p.incidentTags,
-      incidentMatch: p.incidentMatch,
-      incidentAdvice: p.incidentAdvice,
-      incidentRule: p.incidentRule,
-    });
-  };
+  return makeRunTaskVerifyHandler({
+    commandName: "task verify rework",
+    getCtx,
+    run: cmdTaskVerifyRework,
+  });
 }


### PR DESCRIPTION
Task: `202605091754-S1KM8E`
Title: Create verify command spec factory
Canonical task record: `.agentplane/tasks/202605091754-S1KM8E/README.md`

## Summary

Create verify command spec factory

Replace the duplicated task verify ok/rework command spec boilerplate with a small factory that keeps verdict-specific summary and runner behavior explicit.

## Scope

- In scope: Replace the duplicated task verify ok/rework command spec boilerplate with a small factory that keeps verdict-specific summary and runner behavior explicit.
- Out of scope: unrelated refactors not required for "Create verify command spec factory".

## Verification

- State: ok
- Note: Verified: created shared verify command spec/handler factory; verify CLI tests passed (2 files, 17 tests), typecheck passed, Prettier passed, clone:report improved metrics to 81 clones / 1335 duplicated lines / 14279 duplicated tokens, and clone:check passed without baseline update.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-09T19:18:57.670Z
- Branch: task/202605091754-S1KM8E/verify-spec-factory
- Head: e76ae07f9f10

```text
 .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
 .../src/commands/task/verify-command-shared.ts     |  95 +++-
 .../src/commands/task/verify-ok.command.ts         |  74 +--
 .../src/commands/task/verify-rework.command.ts     |  74 +--
 4 files changed, 627 insertions(+), 121 deletions(-)
```

</details>
