### PR TITLE
🚧 R13PHK task: Pre-v0.5: add Git mutation kind diagnostics type [202605100836-R13PHK]

### DIFF
--- a/.agentplane/tasks/202605100836-R13PHK/README.md
+++ b/.agentplane/tasks/202605100836-R13PHK/README.md
@@ -1,0 +1,98 @@
+---
+id: "202605100836-R13PHK"
+title: "Pre-v0.5: add Git mutation kind diagnostics type"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on:
+  - "202605100836-NKKQEH"
+tags:
+  - "diagnostics"
+  - "git"
+  - "workflow"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "Typecheck passes and at least one commit/stage diagnostic path carries mutation kind metadata."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-10T08:36:49.130Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-10T10:26:01.602Z"
+  updated_by: "CODER"
+  note: "Verified GitMutationKind diagnostics type and staging metadata path."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: add internal GitMutationKind diagnostics vocabulary without behavior changes."
+events:
+  -
+    type: "status"
+    at: "2026-05-10T10:21:30.554Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: add internal GitMutationKind diagnostics vocabulary without behavior changes."
+  -
+    type: "verify"
+    at: "2026-05-10T10:26:01.602Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified GitMutationKind diagnostics type and staging metadata path."
+doc_version: 3
+doc_updated_at: "2026-05-10T10:26:01.608Z"
+doc_updated_by: "CODER"
+description: "Introduce a GitMutationKind type for implementation_commit, lifecycle_commit, pr_artifact_update, close_tail, integration, and hook_check. Use it initially for diagnostics/logging without behavior changes."
+sections:
+  Summary: |-
+    Pre-v0.5: add Git mutation kind diagnostics type
+    
+    Introduce a GitMutationKind type for implementation_commit, lifecycle_commit, pr_artifact_update, close_tail, integration, and hook_check. Use it initially for diagnostics/logging without behavior changes.
+  Scope: |-
+    - In scope: Introduce a GitMutationKind type for implementation_commit, lifecycle_commit, pr_artifact_update, close_tail, integration, and hook_check. Use it initially for diagnostics/logging without behavior changes.
+    - Out of scope: unrelated refactors not required for "Pre-v0.5: add Git mutation kind diagnostics type".
+  Plan: "Pre-v0.5 optimization gate. Deliver exactly this atomic scope, preserve branch_pr lifecycle contracts, and record verification evidence. Dependency: 202605100836-NKKQEH. Acceptance: Typecheck passes and at least one commit/stage diagnostic path carries mutation kind metadata.."
+  Verify Steps: |-
+    1. Review the requested outcome for "Pre-v0.5: add Git mutation kind diagnostics type". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-10T10:26:01.602Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified GitMutationKind diagnostics type and staging metadata path.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-10T10:21:30.564Z, excerpt_hash=sha256:af2885dc4405fb341d03470f3b319c8ce6d2fac039a4da814a5a303983a92d4e
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605100836-R13PHK-git-mutation-kind/.agentplane/tasks/202605100836-R13PHK/blueprint/resolved-snapshot.json
+    - old_digest: e0df736e70ab54b197b697768ab7a629bdc0c2d668b9ca1c4685a9120df94f54
+    - current_digest: e0df736e70ab54b197b697768ab7a629bdc0c2d668b9ca1c4685a9120df94f54
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605100836-R13PHK
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Added shared GitMutationKind vocabulary and passed mutation kind metadata through stageAllowlist diagnostics for lifecycle, implementation, PR-artifact, and close-tail commit paths. Checks: check:types-files for touched files, Vitest agentplane allow.test.ts, Prettier check, lint:core, policy routing, ap doctor.
+      Impact: Commit/stage diagnostics can now classify the internal Git mutation kind without changing runtime behavior.
+      Resolution: Ready for PR review and merge.
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605100836-R13PHK/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605100836-R13PHK/blueprint/resolved-snapshot.json
@@ -1,0 +1,505 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605100836-R13PHK",
+    "title": "Pre-v0.5: add Git mutation kind diagnostics type",
+    "description": "Introduce a GitMutationKind type for implementation_commit, lifecycle_commit, pr_artifact_update, close_tail, integration, and hook_check. Use it initially for diagnostics/logging without behavior changes.",
+    "tags": [
+      "diagnostics",
+      "git",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605100836-R13PHK",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "e0df736e70ab54b197b697768ab7a629bdc0c2d668b9ca1c4685a9120df94f54"
+  }
+}

--- a/.agentplane/tasks/202605100836-R13PHK/pr/diffstat.txt
+++ b/.agentplane/tasks/202605100836-R13PHK/pr/diffstat.txt
@@ -1,0 +1,8 @@
+ .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
+ .../src/commands/guard/impl/allow.test.ts          |  37 ++
+ .../agentplane/src/commands/guard/impl/allow.ts    |  33 ++
+ .../src/commands/guard/impl/comment-commit.ts      |   1 +
+ .../src/commands/guard/impl/commit-refresh.ts      |   1 +
+ .../agentplane/src/commands/guard/impl/commit.ts   |   2 +
+ packages/agentplane/src/shared/git-mutation.ts     |  28 ++
+ 7 files changed, 607 insertions(+)

--- a/.agentplane/tasks/202605100836-R13PHK/pr/github-body.md
+++ b/.agentplane/tasks/202605100836-R13PHK/pr/github-body.md
@@ -22,12 +22,19 @@ Introduce a GitMutationKind type for implementation_commit, lifecycle_commit, pr
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-10T10:21:30.595Z
+- Updated: 2026-05-10T10:32:39.718Z
 - Branch: task/202605100836-R13PHK/git-mutation-kind
-- Head: 90ff3c323e29
+- Head: 164524bc59f9
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
+ .../src/commands/guard/impl/allow.test.ts          |  37 ++
+ .../agentplane/src/commands/guard/impl/allow.ts    |  33 ++
+ .../src/commands/guard/impl/comment-commit.ts      |   1 +
+ .../src/commands/guard/impl/commit-refresh.ts      |   1 +
+ .../agentplane/src/commands/guard/impl/commit.ts   |   2 +
+ packages/agentplane/src/shared/git-mutation.ts     |  28 ++
+ 7 files changed, 607 insertions(+)
 ```
 
 </details>

--- a/.agentplane/tasks/202605100836-R13PHK/pr/github-body.md
+++ b/.agentplane/tasks/202605100836-R13PHK/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605100836-R13PHK`
+Title: Pre-v0.5: add Git mutation kind diagnostics type
+Canonical task record: `.agentplane/tasks/202605100836-R13PHK/README.md`
+
+## Summary
+
+Pre-v0.5: add Git mutation kind diagnostics type
+
+Introduce a GitMutationKind type for implementation_commit, lifecycle_commit, pr_artifact_update, close_tail, integration, and hook_check. Use it initially for diagnostics/logging without behavior changes.
+
+## Scope
+
+- In scope: Introduce a GitMutationKind type for implementation_commit, lifecycle_commit, pr_artifact_update, close_tail, integration, and hook_check. Use it initially for diagnostics/logging without behavior changes.
+- Out of scope: unrelated refactors not required for "Pre-v0.5: add Git mutation kind diagnostics type".
+
+## Verification
+
+- State: ok
+- Note: Verified GitMutationKind diagnostics type and staging metadata path.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-10T10:21:30.595Z
+- Branch: task/202605100836-R13PHK/git-mutation-kind
+- Head: 90ff3c323e29
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605100836-R13PHK/pr/github-title.txt
+++ b/.agentplane/tasks/202605100836-R13PHK/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 R13PHK task: Pre-v0.5: add Git mutation kind diagnostics type [202605100836-R13PHK]

--- a/.agentplane/tasks/202605100836-R13PHK/pr/meta.json
+++ b/.agentplane/tasks/202605100836-R13PHK/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605100836-R13PHK/git-mutation-kind",
+  "created_at": "2026-05-10T10:21:30.595Z",
+  "head_sha": "90ff3c323e2987b3a6ad32658d8a8fbd4e024637",
+  "last_verified_at": "2026-05-10T10:26:01.602Z",
+  "last_verified_sha": "90ff3c323e2987b3a6ad32658d8a8fbd4e024637",
+  "schema_version": 1,
+  "task_id": "202605100836-R13PHK",
+  "updated_at": "2026-05-10T10:21:30.595Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605100836-R13PHK/pr/meta.json
+++ b/.agentplane/tasks/202605100836-R13PHK/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605100836-R13PHK/git-mutation-kind",
   "created_at": "2026-05-10T10:21:30.595Z",
-  "head_sha": "90ff3c323e2987b3a6ad32658d8a8fbd4e024637",
+  "head_sha": "164524bc59f93e0c95f81b8203ad3709ddfe8585",
   "last_verified_at": "2026-05-10T10:26:01.602Z",
   "last_verified_sha": "90ff3c323e2987b3a6ad32658d8a8fbd4e024637",
   "schema_version": 1,
   "task_id": "202605100836-R13PHK",
-  "updated_at": "2026-05-10T10:21:30.595Z",
+  "updated_at": "2026-05-10T10:32:39.718Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605100836-R13PHK/pr/review.md
+++ b/.agentplane/tasks/202605100836-R13PHK/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-10T10:21:30.595Z
+
+## Task
+
+- Task: `202605100836-R13PHK`
+- Title: Pre-v0.5: add Git mutation kind diagnostics type
+- Status: DOING
+- Branch: `task/202605100836-R13PHK/git-mutation-kind`
+- Canonical task record: `.agentplane/tasks/202605100836-R13PHK/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified GitMutationKind diagnostics type and staging metadata path.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-10T10:21:30.595Z
+- Branch: task/202605100836-R13PHK/git-mutation-kind
+- Head: 90ff3c323e29
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605100836-R13PHK/pr/review.md
+++ b/.agentplane/tasks/202605100836-R13PHK/pr/review.md
@@ -24,12 +24,19 @@ Created: 2026-05-10T10:21:30.595Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-10T10:21:30.595Z
+- Updated: 2026-05-10T10:32:39.718Z
 - Branch: task/202605100836-R13PHK/git-mutation-kind
-- Head: 90ff3c323e29
+- Head: 164524bc59f9
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
+ .../src/commands/guard/impl/allow.test.ts          |  37 ++
+ .../agentplane/src/commands/guard/impl/allow.ts    |  33 ++
+ .../src/commands/guard/impl/comment-commit.ts      |   1 +
+ .../src/commands/guard/impl/commit-refresh.ts      |   1 +
+ .../agentplane/src/commands/guard/impl/commit.ts   |   2 +
+ packages/agentplane/src/shared/git-mutation.ts     |  28 ++
+ 7 files changed, 607 insertions(+)
 ```
 
 </details>

--- a/packages/agentplane/src/commands/guard/impl/allow.test.ts
+++ b/packages/agentplane/src/commands/guard/impl/allow.test.ts
@@ -277,4 +277,41 @@ describe("guard/impl/allow", () => {
     expect(staged).toEqual([".github/workflows/publish.yml"]);
     expect(ctx.git.stage).toHaveBeenCalledWith([".github/workflows/publish.yml"]);
   });
+
+  it("stageAllowlist includes Git mutation kind metadata in staging diagnostics", async () => {
+    const { stageAllowlist } = await import("./allow.js");
+    const ctx = {
+      git: {
+        statusChangedPaths: vi.fn().mockResolvedValue(["docs/readme.md"]),
+        stage: vi.fn(),
+      },
+    };
+
+    let err: unknown;
+    try {
+      await stageAllowlist({
+        ctx: ctx as never,
+        allow: ["src"],
+        allowTasks: false,
+        tasksPath: ".agentplane/tasks.json",
+        workflowDir: ".agentplane/tasks",
+        taskId: "202601010101-ABCDEF",
+        mutationKind: "lifecycle_commit",
+      });
+    } catch (caught) {
+      err = caught;
+    }
+
+    expect(err).toMatchObject<CliError>({
+      code: "E_USAGE",
+      context: {
+        command: "stage-allowlist",
+        mutation_kind: "lifecycle_commit",
+        task_id: "202601010101-ABCDEF",
+        allow_prefixes: ["src"],
+        changed_paths: ["docs/readme.md"],
+      },
+    });
+    expect(ctx.git.stage).not.toHaveBeenCalled();
+  });
 });

--- a/packages/agentplane/src/commands/guard/impl/allow.ts
+++ b/packages/agentplane/src/commands/guard/impl/allow.ts
@@ -1,6 +1,10 @@
 import { resolveProject } from "@agentplaneorg/core/project";
 
 import { exitCodeForError } from "../../../cli/exit-codes.js";
+import {
+  gitMutationDiagnosticContext,
+  type GitMutationKind,
+} from "../../../shared/git-mutation.js";
 import { gitPathIsUnderPrefix, normalizeGitPathPrefix } from "../../../shared/git-path.js";
 import { CliError } from "../../../shared/errors.js";
 import {
@@ -96,6 +100,7 @@ export async function stageAllowlist(opts: {
   allowTaskOnly?: boolean;
   emptyAllowMessage?: string;
   noMatchMessage?: string;
+  mutationKind?: GitMutationKind;
 }): Promise<string[]> {
   const changed = await opts.ctx.git.statusChangedPaths();
   if (changed.length === 0) {
@@ -103,6 +108,13 @@ export async function stageAllowlist(opts: {
       exitCode: 2,
       code: "E_USAGE",
       message: "No changes to stage (working tree clean)",
+      context: gitMutationDiagnosticContext({
+        command: "stage-allowlist",
+        mutationKind: opts.mutationKind,
+        taskId: opts.taskId,
+        allowPrefixes: opts.allow,
+        changedPaths: changed,
+      }),
     });
   }
 
@@ -113,6 +125,13 @@ export async function stageAllowlist(opts: {
       code: "E_USAGE",
       message:
         "Repo-wide allowlist ('.') is not allowed; choose minimal prefixes (tip: `agentplane guard suggest-allow --format args`).",
+      context: gitMutationDiagnosticContext({
+        command: "stage-allowlist",
+        mutationKind: opts.mutationKind,
+        taskId: opts.taskId,
+        allowPrefixes: allow,
+        changedPaths: changed,
+      }),
     });
   }
   const taskAllow = taskArtifactPrefixes({
@@ -139,6 +158,13 @@ export async function stageAllowlist(opts: {
       exitCode: 2,
       code: "E_USAGE",
       message: opts.emptyAllowMessage ?? "Provide at least one allowed prefix",
+      context: gitMutationDiagnosticContext({
+        command: "stage-allowlist",
+        mutationKind: opts.mutationKind,
+        taskId: opts.taskId,
+        allowPrefixes: effectiveAllow,
+        changedPaths: changed,
+      }),
     });
   }
   const denied = opts.allowTasks ? [] : taskAllow;
@@ -157,6 +183,13 @@ export async function stageAllowlist(opts: {
       exitCode: 2,
       code: "E_USAGE",
       message: opts.noMatchMessage ?? "No changes matched allowed prefixes (update --commit-allow)",
+      context: gitMutationDiagnosticContext({
+        command: "stage-allowlist",
+        mutationKind: opts.mutationKind,
+        taskId: opts.taskId,
+        allowPrefixes: effectiveAllow,
+        changedPaths: changed,
+      }),
     });
   }
 

--- a/packages/agentplane/src/commands/guard/impl/comment-commit.ts
+++ b/packages/agentplane/src/commands/guard/impl/comment-commit.ts
@@ -119,6 +119,7 @@ export async function commitFromComment(opts: {
     tasksPath: opts.config.paths.tasks_path,
     workflowDir: opts.config.paths.workflow_dir,
     taskId: opts.taskId,
+    mutationKind: "lifecycle_commit",
   });
 
   const message = deriveCommitMessageFromComment({

--- a/packages/agentplane/src/commands/guard/impl/commit-refresh.ts
+++ b/packages/agentplane/src/commands/guard/impl/commit-refresh.ts
@@ -85,6 +85,7 @@ export async function commitRefreshedTaskArtifacts(opts: {
       "PR artifact refresh produced no task-local files to stage for the follow-up commit.",
     noMatchMessage:
       "PR artifact refresh produced changes outside the active task artifact scope; inspect the working tree before retrying the commit flow.",
+    mutationKind: "pr_artifact_update",
   });
 
   const message = buildTaskArtifactRefreshCommitSubject({

--- a/packages/agentplane/src/commands/guard/impl/commit.ts
+++ b/packages/agentplane/src/commands/guard/impl/commit.ts
@@ -99,6 +99,7 @@ export async function cmdCommit(opts: {
           "No staged files and no commit allowlist. Pass --allow <path-prefix>, use --allow-tasks for active task artifacts, or stage files manually.",
         noMatchMessage:
           "No changed files matched the commit allowlist (adjust --allow, protected allow flags, or --allow-tasks; otherwise stage files manually).",
+        mutationKind: "implementation_commit",
       });
       if (!opts.quiet) {
         process.stdout.write(
@@ -280,6 +281,7 @@ async function cmdCloseCommit(
         emptyAllowMessage: "No changed task artifacts to stage for the deterministic close commit.",
         noMatchMessage:
           "No changed files matched the active task artifact scope for the deterministic close commit.",
+        mutationKind: "close_tail",
       })
     : stageCloseCommitPaths({
         ctx: opts.ctx,

--- a/packages/agentplane/src/shared/git-mutation.ts
+++ b/packages/agentplane/src/shared/git-mutation.ts
@@ -1,0 +1,28 @@
+export const GIT_MUTATION_KINDS = [
+  "implementation_commit",
+  "lifecycle_commit",
+  "pr_artifact_update",
+  "close_tail",
+  "integration",
+  "hook_check",
+] as const;
+
+export type GitMutationKind = (typeof GIT_MUTATION_KINDS)[number];
+
+export function gitMutationDiagnosticContext(opts: {
+  command: string;
+  mutationKind?: GitMutationKind;
+  taskId?: string;
+  allowPrefixes?: string[];
+  changedPaths?: string[];
+  stagedPaths?: string[];
+}): Record<string, unknown> {
+  return {
+    command: opts.command,
+    ...(opts.mutationKind ? { mutation_kind: opts.mutationKind } : {}),
+    ...(opts.taskId ? { task_id: opts.taskId } : {}),
+    ...(opts.allowPrefixes ? { allow_prefixes: opts.allowPrefixes } : {}),
+    ...(opts.changedPaths ? { changed_paths: opts.changedPaths } : {}),
+    ...(opts.stagedPaths ? { staged_paths: opts.stagedPaths } : {}),
+  };
+}


### PR DESCRIPTION
Task: `202605100836-R13PHK`
Title: Pre-v0.5: add Git mutation kind diagnostics type
Canonical task record: `.agentplane/tasks/202605100836-R13PHK/README.md`

## Summary

Pre-v0.5: add Git mutation kind diagnostics type

Introduce a GitMutationKind type for implementation_commit, lifecycle_commit, pr_artifact_update, close_tail, integration, and hook_check. Use it initially for diagnostics/logging without behavior changes.

## Scope

- In scope: Introduce a GitMutationKind type for implementation_commit, lifecycle_commit, pr_artifact_update, close_tail, integration, and hook_check. Use it initially for diagnostics/logging without behavior changes.
- Out of scope: unrelated refactors not required for "Pre-v0.5: add Git mutation kind diagnostics type".

## Verification

- State: ok
- Note: Verified GitMutationKind diagnostics type and staging metadata path.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-10T10:32:39.718Z
- Branch: task/202605100836-R13PHK/git-mutation-kind
- Head: 164524bc59f9

```text
 .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
 .../src/commands/guard/impl/allow.test.ts          |  37 ++
 .../agentplane/src/commands/guard/impl/allow.ts    |  33 ++
 .../src/commands/guard/impl/comment-commit.ts      |   1 +
 .../src/commands/guard/impl/commit-refresh.ts      |   1 +
 .../agentplane/src/commands/guard/impl/commit.ts   |   2 +
 packages/agentplane/src/shared/git-mutation.ts     |  28 ++
 7 files changed, 607 insertions(+)
```

</details>
