### PR TITLE
🚧 VEENHF task: Pre-v0.5: add worktree-aware Git context diagnostics [202605100836-VEENHF]

### DIFF
--- a/.agentplane/tasks/202605100836-VEENHF/README.md
+++ b/.agentplane/tasks/202605100836-VEENHF/README.md
@@ -1,0 +1,98 @@
+---
+id: "202605100836-VEENHF"
+title: "Pre-v0.5: add worktree-aware Git context diagnostics"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on:
+  - "202605100836-R13PHK"
+tags:
+  - "diagnostics"
+  - "git"
+  - "workflow"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "Focused tests assert Git errors include worktree/gitdir/task context."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-10T08:36:52.433Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-10T10:55:06.800Z"
+  updated_by: "CODER"
+  note: "Verified worktree-aware Git context diagnostics for staging failures."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: add worktree-aware diagnostic context to internal Git mutation failures."
+events:
+  -
+    type: "status"
+    at: "2026-05-10T10:48:31.514Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: add worktree-aware diagnostic context to internal Git mutation failures."
+  -
+    type: "verify"
+    at: "2026-05-10T10:55:06.800Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified worktree-aware Git context diagnostics for staging failures."
+doc_version: 3
+doc_updated_at: "2026-05-10T10:55:06.810Z"
+doc_updated_by: "CODER"
+description: "Capture command, cwd, repo root, gitdir, branch, workflow mode, mutation kind, task id, allow prefixes, changed paths, and staged paths for internal git add/commit/checkout failures."
+sections:
+  Summary: |-
+    Pre-v0.5: add worktree-aware Git context diagnostics
+    
+    Capture command, cwd, repo root, gitdir, branch, workflow mode, mutation kind, task id, allow prefixes, changed paths, and staged paths for internal git add/commit/checkout failures.
+  Scope: |-
+    - In scope: Capture command, cwd, repo root, gitdir, branch, workflow mode, mutation kind, task id, allow prefixes, changed paths, and staged paths for internal git add/commit/checkout failures.
+    - Out of scope: unrelated refactors not required for "Pre-v0.5: add worktree-aware Git context diagnostics".
+  Plan: "Pre-v0.5 optimization gate. Deliver exactly this atomic scope, preserve branch_pr lifecycle contracts, and record verification evidence. Dependency: 202605100836-R13PHK. Acceptance: Focused tests assert Git errors include worktree/gitdir/task context.."
+  Verify Steps: |-
+    1. Review the requested outcome for "Pre-v0.5: add worktree-aware Git context diagnostics". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-10T10:55:06.800Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified worktree-aware Git context diagnostics for staging failures.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-10T10:48:31.531Z, excerpt_hash=sha256:0af906d6e0c18712313d5a37ebe9995a0857e03318a72c79e7e98ba8c54daf84
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605100836-VEENHF-worktree-git-context/.agentplane/tasks/202605100836-VEENHF/blueprint/resolved-snapshot.json
+    - old_digest: 95304f5e44b3fa8ee64da3c6e9b3199cddf513e9dfccdf0a5676e7d29c244a77
+    - current_digest: 95304f5e44b3fa8ee64da3c6e9b3199cddf513e9dfccdf0a5676e7d29c244a77
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605100836-VEENHF
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Added resolver-backed Git mutation diagnostic context with cwd, repo root, git dir, branch, workflow mode, task id, mutation kind, allow prefixes, changed paths, and staged paths on stageAllowlist git add failures. Checks: check:types-files for touched files, Vitest allow.test.ts, Prettier check, lint:core, policy routing, ap doctor.
+      Impact: Internal git add failures now include actionable worktree context without changing successful staging behavior.
+      Resolution: Ready for PR review and merge.
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605100836-VEENHF/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605100836-VEENHF/blueprint/resolved-snapshot.json
@@ -1,0 +1,505 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605100836-VEENHF",
+    "title": "Pre-v0.5: add worktree-aware Git context diagnostics",
+    "description": "Capture command, cwd, repo root, gitdir, branch, workflow mode, mutation kind, task id, allow prefixes, changed paths, and staged paths for internal git add/commit/checkout failures.",
+    "tags": [
+      "diagnostics",
+      "git",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605100836-VEENHF",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "95304f5e44b3fa8ee64da3c6e9b3199cddf513e9dfccdf0a5676e7d29c244a77"
+  }
+}

--- a/.agentplane/tasks/202605100836-VEENHF/pr/diffstat.txt
+++ b/.agentplane/tasks/202605100836-VEENHF/pr/diffstat.txt
@@ -1,0 +1,5 @@
+ .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
+ .../src/commands/guard/impl/allow.test.ts          |  56 ++-
+ .../agentplane/src/commands/guard/impl/allow.ts    |  23 +-
+ packages/agentplane/src/shared/git-mutation.ts     |  39 ++
+ 4 files changed, 621 insertions(+), 2 deletions(-)

--- a/.agentplane/tasks/202605100836-VEENHF/pr/github-body.md
+++ b/.agentplane/tasks/202605100836-VEENHF/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605100836-VEENHF`
+Title: Pre-v0.5: add worktree-aware Git context diagnostics
+Canonical task record: `.agentplane/tasks/202605100836-VEENHF/README.md`
+
+## Summary
+
+Pre-v0.5: add worktree-aware Git context diagnostics
+
+Capture command, cwd, repo root, gitdir, branch, workflow mode, mutation kind, task id, allow prefixes, changed paths, and staged paths for internal git add/commit/checkout failures.
+
+## Scope
+
+- In scope: Capture command, cwd, repo root, gitdir, branch, workflow mode, mutation kind, task id, allow prefixes, changed paths, and staged paths for internal git add/commit/checkout failures.
+- Out of scope: unrelated refactors not required for "Pre-v0.5: add worktree-aware Git context diagnostics".
+
+## Verification
+
+- State: ok
+- Note: Verified worktree-aware Git context diagnostics for staging failures.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-10T10:48:31.590Z
+- Branch: task/202605100836-VEENHF/worktree-git-context
+- Head: 425b437e08f8
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605100836-VEENHF/pr/github-body.md
+++ b/.agentplane/tasks/202605100836-VEENHF/pr/github-body.md
@@ -22,12 +22,16 @@ Capture command, cwd, repo root, gitdir, branch, workflow mode, mutation kind, t
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-10T10:48:31.590Z
+- Updated: 2026-05-10T10:56:25.496Z
 - Branch: task/202605100836-VEENHF/worktree-git-context
-- Head: 425b437e08f8
+- Head: 2c2fec156a9b
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
+ .../src/commands/guard/impl/allow.test.ts          |  56 ++-
+ .../agentplane/src/commands/guard/impl/allow.ts    |  23 +-
+ packages/agentplane/src/shared/git-mutation.ts     |  39 ++
+ 4 files changed, 621 insertions(+), 2 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605100836-VEENHF/pr/github-title.txt
+++ b/.agentplane/tasks/202605100836-VEENHF/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 VEENHF task: Pre-v0.5: add worktree-aware Git context diagnostics [202605100836-VEENHF]

--- a/.agentplane/tasks/202605100836-VEENHF/pr/meta.json
+++ b/.agentplane/tasks/202605100836-VEENHF/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605100836-VEENHF/worktree-git-context",
   "created_at": "2026-05-10T10:48:31.590Z",
-  "head_sha": "425b437e08f84eb2a43fb509813107365fe86323",
+  "head_sha": "2c2fec156a9b3e6b0c897883ab40eca7571184a9",
   "last_verified_at": "2026-05-10T10:55:06.800Z",
   "last_verified_sha": "425b437e08f84eb2a43fb509813107365fe86323",
   "schema_version": 1,
   "task_id": "202605100836-VEENHF",
-  "updated_at": "2026-05-10T10:48:31.590Z",
+  "updated_at": "2026-05-10T10:56:25.496Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605100836-VEENHF/pr/meta.json
+++ b/.agentplane/tasks/202605100836-VEENHF/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605100836-VEENHF/worktree-git-context",
+  "created_at": "2026-05-10T10:48:31.590Z",
+  "head_sha": "425b437e08f84eb2a43fb509813107365fe86323",
+  "last_verified_at": "2026-05-10T10:55:06.800Z",
+  "last_verified_sha": "425b437e08f84eb2a43fb509813107365fe86323",
+  "schema_version": 1,
+  "task_id": "202605100836-VEENHF",
+  "updated_at": "2026-05-10T10:48:31.590Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605100836-VEENHF/pr/review.md
+++ b/.agentplane/tasks/202605100836-VEENHF/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-10T10:48:31.590Z
+
+## Task
+
+- Task: `202605100836-VEENHF`
+- Title: Pre-v0.5: add worktree-aware Git context diagnostics
+- Status: DOING
+- Branch: `task/202605100836-VEENHF/worktree-git-context`
+- Canonical task record: `.agentplane/tasks/202605100836-VEENHF/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified worktree-aware Git context diagnostics for staging failures.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-10T10:48:31.590Z
+- Branch: task/202605100836-VEENHF/worktree-git-context
+- Head: 425b437e08f8
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605100836-VEENHF/pr/review.md
+++ b/.agentplane/tasks/202605100836-VEENHF/pr/review.md
@@ -24,12 +24,16 @@ Created: 2026-05-10T10:48:31.590Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-10T10:48:31.590Z
+- Updated: 2026-05-10T10:56:25.496Z
 - Branch: task/202605100836-VEENHF/worktree-git-context
-- Head: 425b437e08f8
+- Head: 2c2fec156a9b
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
+ .../src/commands/guard/impl/allow.test.ts          |  56 ++-
+ .../agentplane/src/commands/guard/impl/allow.ts    |  23 +-
+ packages/agentplane/src/shared/git-mutation.ts     |  39 ++
+ 4 files changed, 621 insertions(+), 2 deletions(-)
 ```
 
 </details>

--- a/packages/agentplane/src/commands/guard/impl/allow.test.ts
+++ b/packages/agentplane/src/commands/guard/impl/allow.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { CliError } from "../../../shared/errors.js";
 
 const mocks = vi.hoisted(() => ({
   resolveProject: vi.fn(),
   statusChangedPaths: vi.fn(),
+  gitRevParse: vi.fn(),
+  gitCurrentBranch: vi.fn(),
   loadCommandContext: vi.fn(),
 }));
 
@@ -12,6 +14,8 @@ vi.mock("@agentplaneorg/core/project", () => ({
   resolveProject: mocks.resolveProject,
 }));
 vi.mock("@agentplaneorg/core/git", () => ({
+  gitCurrentBranch: mocks.gitCurrentBranch,
+  gitRevParse: mocks.gitRevParse,
   GitContext: class {
     constructor(opts: { gitRoot: string }) {
       void opts.gitRoot;
@@ -24,6 +28,12 @@ vi.mock("../../shared/task-backend.js", () => ({
 }));
 
 describe("guard/impl/allow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.gitRevParse.mockResolvedValue("/repo/.git/worktrees/task-worktree");
+    mocks.gitCurrentBranch.mockResolvedValue("task/202601010101-ABCDEF/example");
+  });
+
   it("suggestAllowPrefixes returns sorted unique prefixes", async () => {
     const { suggestAllowPrefixes } = await import("./allow.js");
     const out = suggestAllowPrefixes([
@@ -313,5 +323,49 @@ describe("guard/impl/allow", () => {
       },
     });
     expect(ctx.git.stage).not.toHaveBeenCalled();
+  });
+
+  it("stageAllowlist includes worktree git context when staging fails", async () => {
+    const { stageAllowlist } = await import("./allow.js");
+    const ctx = {
+      resolvedProject: {
+        gitRoot: "/repo/worktrees/task-worktree",
+      },
+      config: {
+        workflow_mode: "branch_pr",
+      },
+      git: {
+        statusChangedPaths: vi.fn().mockResolvedValue(["src/app.ts"]),
+        stage: vi.fn().mockRejectedValue(new Error("index lock denied")),
+      },
+    };
+
+    await expect(
+      stageAllowlist({
+        ctx: ctx as never,
+        allow: ["src"],
+        allowTasks: false,
+        tasksPath: ".agentplane/tasks.json",
+        workflowDir: ".agentplane/tasks",
+        taskId: "202601010101-ABCDEF",
+        mutationKind: "implementation_commit",
+      }),
+    ).rejects.toMatchObject<CliError>({
+      code: "E_GIT",
+      message: "Failed to stage allowed paths: index lock denied",
+      context: {
+        command: "git add",
+        cwd: "/repo/worktrees/task-worktree",
+        git_repo_root: "/repo/worktrees/task-worktree",
+        git_dir: "/repo/.git/worktrees/task-worktree",
+        git_branch: "task/202601010101-ABCDEF/example",
+        workflow_mode: "branch_pr",
+        mutation_kind: "implementation_commit",
+        task_id: "202601010101-ABCDEF",
+        allow_prefixes: ["src"],
+        changed_paths: ["src/app.ts"],
+        staged_paths: ["src/app.ts"],
+      },
+    });
   });
 });

--- a/packages/agentplane/src/commands/guard/impl/allow.ts
+++ b/packages/agentplane/src/commands/guard/impl/allow.ts
@@ -3,6 +3,7 @@ import { resolveProject } from "@agentplaneorg/core/project";
 import { exitCodeForError } from "../../../cli/exit-codes.js";
 import {
   gitMutationDiagnosticContext,
+  resolveGitMutationDiagnosticContext,
   type GitMutationKind,
 } from "../../../shared/git-mutation.js";
 import { gitPathIsUnderPrefix, normalizeGitPathPrefix } from "../../../shared/git-path.js";
@@ -195,6 +196,26 @@ export async function stageAllowlist(opts: {
 
   // `git add <pathspec>` is not reliable for staging deletes/renames across versions/configs.
   // `-A -- <pathspec...>` makes the allowlist staging semantics deterministic.
-  await opts.ctx.git.stage(unique);
+  try {
+    await opts.ctx.git.stage(unique);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new CliError({
+      exitCode: exitCodeForError("E_GIT"),
+      code: "E_GIT",
+      message: `Failed to stage allowed paths: ${message}`,
+      context: await resolveGitMutationDiagnosticContext({
+        command: "git add",
+        cwd: opts.ctx.resolvedProject.gitRoot,
+        repoRoot: opts.ctx.resolvedProject.gitRoot,
+        workflowMode: opts.ctx.config.workflow_mode,
+        mutationKind: opts.mutationKind,
+        taskId: opts.taskId,
+        allowPrefixes: effectiveAllow,
+        changedPaths: changed,
+        stagedPaths: unique,
+      }),
+    });
+  }
   return unique;
 }

--- a/packages/agentplane/src/shared/git-mutation.ts
+++ b/packages/agentplane/src/shared/git-mutation.ts
@@ -1,3 +1,5 @@
+import { gitCurrentBranch, gitRevParse } from "@agentplaneorg/core/git";
+
 export const GIT_MUTATION_KINDS = [
   "implementation_commit",
   "lifecycle_commit",
@@ -11,6 +13,11 @@ export type GitMutationKind = (typeof GIT_MUTATION_KINDS)[number];
 
 export function gitMutationDiagnosticContext(opts: {
   command: string;
+  cwd?: string;
+  repoRoot?: string;
+  gitDir?: string;
+  branch?: string;
+  workflowMode?: string;
   mutationKind?: GitMutationKind;
   taskId?: string;
   allowPrefixes?: string[];
@@ -19,10 +26,42 @@ export function gitMutationDiagnosticContext(opts: {
 }): Record<string, unknown> {
   return {
     command: opts.command,
+    ...(opts.cwd ? { cwd: opts.cwd } : {}),
+    ...(opts.repoRoot ? { git_repo_root: opts.repoRoot } : {}),
+    ...(opts.gitDir ? { git_dir: opts.gitDir } : {}),
+    ...(opts.branch ? { git_branch: opts.branch } : {}),
+    ...(opts.workflowMode ? { workflow_mode: opts.workflowMode } : {}),
     ...(opts.mutationKind ? { mutation_kind: opts.mutationKind } : {}),
     ...(opts.taskId ? { task_id: opts.taskId } : {}),
     ...(opts.allowPrefixes ? { allow_prefixes: opts.allowPrefixes } : {}),
     ...(opts.changedPaths ? { changed_paths: opts.changedPaths } : {}),
     ...(opts.stagedPaths ? { staged_paths: opts.stagedPaths } : {}),
   };
+}
+
+export async function resolveGitMutationDiagnosticContext(opts: {
+  command: string;
+  cwd: string;
+  repoRoot: string;
+  workflowMode?: string;
+  mutationKind?: GitMutationKind;
+  taskId?: string;
+  allowPrefixes?: string[];
+  changedPaths?: string[];
+  stagedPaths?: string[];
+}): Promise<Record<string, unknown>> {
+  const [gitDir, branch] = await Promise.all([
+    gitRevParse(opts.repoRoot, ["--git-dir"]).catch((err: unknown) =>
+      err instanceof Error ? `unresolved:${err.message}` : "unresolved",
+    ),
+    gitCurrentBranch(opts.repoRoot).catch((err: unknown) =>
+      err instanceof Error ? `unresolved:${err.message}` : "unresolved",
+    ),
+  ]);
+
+  return gitMutationDiagnosticContext({
+    ...opts,
+    gitDir,
+    branch,
+  });
 }


### PR DESCRIPTION
Task: `202605100836-VEENHF`
Title: Pre-v0.5: add worktree-aware Git context diagnostics
Canonical task record: `.agentplane/tasks/202605100836-VEENHF/README.md`

## Summary

Pre-v0.5: add worktree-aware Git context diagnostics

Capture command, cwd, repo root, gitdir, branch, workflow mode, mutation kind, task id, allow prefixes, changed paths, and staged paths for internal git add/commit/checkout failures.

## Scope

- In scope: Capture command, cwd, repo root, gitdir, branch, workflow mode, mutation kind, task id, allow prefixes, changed paths, and staged paths for internal git add/commit/checkout failures.
- Out of scope: unrelated refactors not required for "Pre-v0.5: add worktree-aware Git context diagnostics".

## Verification

- State: ok
- Note: Verified worktree-aware Git context diagnostics for staging failures.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-10T10:56:25.496Z
- Branch: task/202605100836-VEENHF/worktree-git-context
- Head: 2c2fec156a9b

```text
 .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
 .../src/commands/guard/impl/allow.test.ts          |  56 ++-
 .../agentplane/src/commands/guard/impl/allow.ts    |  23 +-
 packages/agentplane/src/shared/git-mutation.ts     |  39 ++
 4 files changed, 621 insertions(+), 2 deletions(-)
```

</details>
