### PR TITLE
🚧 SAJN9F task: Pre-v0.5: introduce worktree-scoped Git mutation mutex [202605100837-SAJN9F]

### DIFF
--- a/.agentplane/tasks/202605100837-SAJN9F/README.md
+++ b/.agentplane/tasks/202605100837-SAJN9F/README.md
@@ -1,0 +1,98 @@
+---
+id: "202605100837-SAJN9F"
+title: "Pre-v0.5: introduce worktree-scoped Git mutation mutex"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on:
+  - "202605100837-X33YYQ"
+tags:
+  - "git"
+  - "locks"
+  - "workflow"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "Concurrent same-worktree writers conflict cleanly; different worktrees do not block each other."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-10T08:37:02.876Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-10T15:50:36.084Z"
+  updated_by: "CODER"
+  note: "Implemented a worktree-scoped AgentPlane Git mutation mutex under .agentplane/cache/locks, keyed from git common dir plus resolved gitdir. Stage paths that write the Git index now take the mutex before git add. Checks passed: targeted Vitest git-mutation+allow suites, prettier check, and scoped eslint for changed files."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement a worktree-scoped Git mutation mutex keyed by repo identity plus gitdir identity, with tests for same-worktree contention and different-worktree independence."
+events:
+  -
+    type: "status"
+    at: "2026-05-10T15:42:56.853Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement a worktree-scoped Git mutation mutex keyed by repo identity plus gitdir identity, with tests for same-worktree contention and different-worktree independence."
+  -
+    type: "verify"
+    at: "2026-05-10T15:50:36.084Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented a worktree-scoped AgentPlane Git mutation mutex under .agentplane/cache/locks, keyed from git common dir plus resolved gitdir. Stage paths that write the Git index now take the mutex before git add. Checks passed: targeted Vitest git-mutation+allow suites, prettier check, and scoped eslint for changed files."
+doc_version: 3
+doc_updated_at: "2026-05-10T15:50:36.106Z"
+doc_updated_by: "CODER"
+description: "Add an AgentPlane-level mutex for write operations that touch the Git index. Key it by gitdir hash plus repo identity, not branch name, so different worktrees can proceed independently."
+sections:
+  Summary: |-
+    Pre-v0.5: introduce worktree-scoped Git mutation mutex
+    
+    Add an AgentPlane-level mutex for write operations that touch the Git index. Key it by gitdir hash plus repo identity, not branch name, so different worktrees can proceed independently.
+  Scope: |-
+    - In scope: Add an AgentPlane-level mutex for write operations that touch the Git index. Key it by gitdir hash plus repo identity, not branch name, so different worktrees can proceed independently.
+    - Out of scope: unrelated refactors not required for "Pre-v0.5: introduce worktree-scoped Git mutation mutex".
+  Plan: "Pre-v0.5 optimization gate. Deliver exactly this atomic scope, preserve branch_pr lifecycle contracts, and record verification evidence. Dependency: 202605100837-X33YYQ. Acceptance: Concurrent same-worktree writers conflict cleanly; different worktrees do not block each other.."
+  Verify Steps: |-
+    1. Review the requested outcome for "Pre-v0.5: introduce worktree-scoped Git mutation mutex". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-10T15:50:36.084Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Implemented a worktree-scoped AgentPlane Git mutation mutex under .agentplane/cache/locks, keyed from git common dir plus resolved gitdir. Stage paths that write the Git index now take the mutex before git add. Checks passed: targeted Vitest git-mutation+allow suites, prettier check, and scoped eslint for changed files.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-10T15:42:56.886Z, excerpt_hash=sha256:b0c1558a3602d347c62e3b2f0d1b3b5f3edaff7b752da93b79e21b3cd14d555f
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605100837-SAJN9F-worktree-mutex/.agentplane/tasks/202605100837-SAJN9F/blueprint/resolved-snapshot.json
+    - old_digest: ffcb856706a38da7b3ad08f98064fc6910ad1ceaacf885ccca30c67ee599ce46
+    - current_digest: ffcb856706a38da7b3ad08f98064fc6910ad1ceaacf885ccca30c67ee599ce46
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605100837-SAJN9F
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Concurrent same-worktree mutex acquisition returns E_GIT_RACE with lock context; different gitdirs produce different worktree ids and run independently.
+      Impact: AgentPlane serializes Git index writers within one worktree without globally blocking independent task worktrees.
+      Resolution: Keep Git-owned .git/**/index.lock as diagnostics only; use .agentplane/cache/locks for AgentPlane coordination.
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605100837-SAJN9F/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605100837-SAJN9F/blueprint/resolved-snapshot.json
@@ -1,0 +1,505 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605100837-SAJN9F",
+    "title": "Pre-v0.5: introduce worktree-scoped Git mutation mutex",
+    "description": "Add an AgentPlane-level mutex for write operations that touch the Git index. Key it by gitdir hash plus repo identity, not branch name, so different worktrees can proceed independently.",
+    "tags": [
+      "git",
+      "locks",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605100837-SAJN9F",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "ffcb856706a38da7b3ad08f98064fc6910ad1ceaacf885ccca30c67ee599ce46"
+  }
+}

--- a/.agentplane/tasks/202605100837-SAJN9F/pr/diffstat.txt
+++ b/.agentplane/tasks/202605100837-SAJN9F/pr/diffstat.txt
@@ -1,0 +1,6 @@
+ .../src/commands/guard/impl/allow.test.ts          |  39 +++---
+ .../agentplane/src/commands/guard/impl/allow.ts    | 118 +++++++++--------
+ .../src/commands/guard/impl/commit-stage.ts        |  27 +++-
+ .../agentplane/src/shared/git-mutation.test.ts     | 144 +++++++++++++++++++++
+ packages/agentplane/src/shared/git-mutation.ts     | 134 ++++++++++++++++++-
+ 5 files changed, 392 insertions(+), 70 deletions(-)

--- a/.agentplane/tasks/202605100837-SAJN9F/pr/github-body.md
+++ b/.agentplane/tasks/202605100837-SAJN9F/pr/github-body.md
@@ -1,0 +1,38 @@
+Task: `202605100837-SAJN9F`
+Title: Pre-v0.5: introduce worktree-scoped Git mutation mutex
+Canonical task record: `.agentplane/tasks/202605100837-SAJN9F/README.md`
+
+## Summary
+
+Pre-v0.5: introduce worktree-scoped Git mutation mutex
+
+Add an AgentPlane-level mutex for write operations that touch the Git index. Key it by gitdir hash plus repo identity, not branch name, so different worktrees can proceed independently.
+
+## Scope
+
+- In scope: Add an AgentPlane-level mutex for write operations that touch the Git index. Key it by gitdir hash plus repo identity, not branch name, so different worktrees can proceed independently.
+- Out of scope: unrelated refactors not required for "Pre-v0.5: introduce worktree-scoped Git mutation mutex".
+
+## Verification
+
+- State: ok
+- Note: Implemented a worktree-scoped AgentPlane Git mutation mutex under .agentplane/cache/locks, keyed from git common dir plus resolved gitdir. Stage paths that write the Git index now take the mutex before git add. Checks passed: targeted Vitest git-mutation+allow suites, prettier check, and scoped eslint for changed files.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-10T15:51:00.275Z
+- Branch: task-202605100837-SAJN9F-worktree-mutex
+- Head: 98f9550499b7
+
+```text
+ .../src/commands/guard/impl/allow.test.ts          |  39 +++---
+ .../agentplane/src/commands/guard/impl/allow.ts    | 118 +++++++++--------
+ .../src/commands/guard/impl/commit-stage.ts        |  27 +++-
+ .../agentplane/src/shared/git-mutation.test.ts     | 144 +++++++++++++++++++++
+ packages/agentplane/src/shared/git-mutation.ts     | 134 ++++++++++++++++++-
+ 5 files changed, 392 insertions(+), 70 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605100837-SAJN9F/pr/github-title.txt
+++ b/.agentplane/tasks/202605100837-SAJN9F/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 SAJN9F task: Pre-v0.5: introduce worktree-scoped Git mutation mutex [202605100837-SAJN9F]

--- a/.agentplane/tasks/202605100837-SAJN9F/pr/meta.json
+++ b/.agentplane/tasks/202605100837-SAJN9F/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task-202605100837-SAJN9F-worktree-mutex",
+  "created_at": "2026-05-10T15:51:00.275Z",
+  "head_sha": "98f9550499b7f237a0b2f1ad55aa4171a20c6b65",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202605100837-SAJN9F",
+  "updated_at": "2026-05-10T15:51:00.275Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605100837-SAJN9F/pr/review.md
+++ b/.agentplane/tasks/202605100837-SAJN9F/pr/review.md
@@ -1,0 +1,41 @@
+# PR Review
+
+Created: 2026-05-10T15:51:00.275Z
+
+## Task
+
+- Task: `202605100837-SAJN9F`
+- Title: Pre-v0.5: introduce worktree-scoped Git mutation mutex
+- Status: DOING
+- Branch: `task-202605100837-SAJN9F-worktree-mutex`
+- Canonical task record: `.agentplane/tasks/202605100837-SAJN9F/README.md`
+
+## Verification
+
+- State: ok
+- Note: Implemented a worktree-scoped AgentPlane Git mutation mutex under .agentplane/cache/locks, keyed from git common dir plus resolved gitdir. Stage paths that write the Git index now take the mutex before git add. Checks passed: targeted Vitest git-mutation+allow suites, prettier check, and scoped eslint for changed files.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-10T15:51:00.275Z
+- Branch: task-202605100837-SAJN9F-worktree-mutex
+- Head: 98f9550499b7
+
+```text
+ .../src/commands/guard/impl/allow.test.ts          |  39 +++---
+ .../agentplane/src/commands/guard/impl/allow.ts    | 118 +++++++++--------
+ .../src/commands/guard/impl/commit-stage.ts        |  27 +++-
+ .../agentplane/src/shared/git-mutation.test.ts     | 144 +++++++++++++++++++++
+ packages/agentplane/src/shared/git-mutation.ts     | 134 ++++++++++++++++++-
+ 5 files changed, 392 insertions(+), 70 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/guard/impl/allow.test.ts
+++ b/packages/agentplane/src/commands/guard/impl/allow.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { CliError } from "../../../shared/errors.js";
 
@@ -13,6 +13,9 @@ const mocks = vi.hoisted(() => ({
   gitCurrentBranch: vi.fn(),
   loadCommandContext: vi.fn(),
 }));
+
+let repoRoot: string;
+let defaultGitDir: string;
 
 vi.mock("@agentplaneorg/core/project", () => ({
   resolveProject: mocks.resolveProject,
@@ -32,10 +35,16 @@ vi.mock("../../shared/task-backend.js", () => ({
 }));
 
 describe("guard/impl/allow", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
-    mocks.gitRevParse.mockResolvedValue("/repo/.git/worktrees/task-worktree");
+    repoRoot = await mkdtemp(path.join(tmpdir(), "agentplane-repo-"));
+    defaultGitDir = path.join(repoRoot, ".git", "worktrees", "task-worktree");
+    mocks.gitRevParse.mockResolvedValue(defaultGitDir);
     mocks.gitCurrentBranch.mockResolvedValue("task/202601010101-ABCDEF/example");
+  });
+
+  afterEach(async () => {
+    await rm(repoRoot, { recursive: true, force: true });
   });
 
   it("suggestAllowPrefixes returns sorted unique prefixes", async () => {
@@ -210,7 +219,7 @@ describe("guard/impl/allow", () => {
 
     const ctxOk = {
       resolvedProject: {
-        gitRoot: "/repo/worktrees/task-worktree",
+        gitRoot: repoRoot,
       },
       config: {
         workflow_mode: "branch_pr",
@@ -236,7 +245,7 @@ describe("guard/impl/allow", () => {
     const { stageAllowlist } = await import("./allow.js");
     const ctx = {
       resolvedProject: {
-        gitRoot: "/repo/worktrees/task-worktree",
+        gitRoot: repoRoot,
       },
       config: {
         workflow_mode: "branch_pr",
@@ -273,7 +282,7 @@ describe("guard/impl/allow", () => {
     const { stageAllowlist } = await import("./allow.js");
     const ctx = {
       resolvedProject: {
-        gitRoot: "/repo/worktrees/task-worktree",
+        gitRoot: repoRoot,
       },
       config: {
         workflow_mode: "branch_pr",
@@ -304,7 +313,7 @@ describe("guard/impl/allow", () => {
     const { stageAllowlist } = await import("./allow.js");
     const ctx = {
       resolvedProject: {
-        gitRoot: "/repo/worktrees/task-worktree",
+        gitRoot: repoRoot,
       },
       config: {
         workflow_mode: "branch_pr",
@@ -374,7 +383,7 @@ describe("guard/impl/allow", () => {
     const { stageAllowlist } = await import("./allow.js");
     const ctx = {
       resolvedProject: {
-        gitRoot: "/repo/worktrees/task-worktree",
+        gitRoot: repoRoot,
       },
       config: {
         workflow_mode: "branch_pr",
@@ -400,9 +409,9 @@ describe("guard/impl/allow", () => {
       message: "Failed to stage allowed paths: index lock denied",
       context: {
         command: "git add",
-        cwd: "/repo/worktrees/task-worktree",
-        git_repo_root: "/repo/worktrees/task-worktree",
-        git_dir: "/repo/.git/worktrees/task-worktree",
+        cwd: repoRoot,
+        git_repo_root: repoRoot,
+        git_dir: defaultGitDir,
         git_branch: "task/202601010101-ABCDEF/example",
         workflow_mode: "branch_pr",
         mutation_kind: "implementation_commit",
@@ -420,7 +429,7 @@ describe("guard/impl/allow", () => {
     const { stageAllowlist } = await import("./allow.js");
     const baseCtx = {
       resolvedProject: {
-        gitRoot: "/repo/worktrees/task-worktree",
+        gitRoot: repoRoot,
       },
       config: {
         workflow_mode: "branch_pr",
@@ -472,7 +481,7 @@ describe("guard/impl/allow", () => {
     mocks.gitRevParse.mockResolvedValue(gitDir);
     const ctx = {
       resolvedProject: {
-        gitRoot: "/repo/worktrees/task-worktree",
+        gitRoot: repoRoot,
       },
       config: {
         workflow_mode: "branch_pr",
@@ -502,8 +511,8 @@ describe("guard/impl/allow", () => {
         )}`,
         context: {
           command: "git add",
-          cwd: "/repo/worktrees/task-worktree",
-          git_repo_root: "/repo/worktrees/task-worktree",
+          cwd: repoRoot,
+          git_repo_root: repoRoot,
           git_dir: gitDir,
           git_branch: "task/202601010101-ABCDEF/example",
           workflow_mode: "branch_pr",

--- a/packages/agentplane/src/commands/guard/impl/allow.ts
+++ b/packages/agentplane/src/commands/guard/impl/allow.ts
@@ -7,6 +7,7 @@ import {
   resolveGitIndexLockInfo,
   resolveGitMutationDiagnosticContext,
   type GitMutationKind,
+  withGitMutationMutex,
 } from "../../../shared/git-mutation.js";
 import { gitPathIsUnderPrefix, normalizeGitPathPrefix } from "../../../shared/git-path.js";
 import { CliError } from "../../../shared/errors.js";
@@ -233,59 +234,72 @@ export async function stageAllowlist(opts: {
     });
   }
 
-  const lockInfo = await resolveGitIndexLockInfo({ repoRoot: opts.ctx.resolvedProject.gitRoot });
-  if (lockInfo) {
-    throw new CliError({
-      exitCode: exitCodeForError("E_GIT_LOCKED"),
-      code: "E_GIT_LOCKED",
-      message: `Git index is locked; refusing to stage allowed paths: ${lockInfo.lockPath}`,
-      context: await resolveGitMutationDiagnosticContext({
-        command: "git add",
-        cwd: opts.ctx.resolvedProject.gitRoot,
+  await withGitMutationMutex(
+    {
+      repoRoot: opts.ctx.resolvedProject.gitRoot,
+      operation: "git-add",
+      workflowMode: opts.ctx.config.workflow_mode,
+      mutationKind: opts.mutationKind,
+      taskId: opts.taskId,
+    },
+    async () => {
+      const lockInfo = await resolveGitIndexLockInfo({
         repoRoot: opts.ctx.resolvedProject.gitRoot,
-        workflowMode: opts.ctx.config.workflow_mode,
-        mutationKind: opts.mutationKind,
-        taskId: opts.taskId,
-        allowPrefixes: effectiveAllow,
-        changedPaths: changed,
-        stagedPaths: unique,
-      }).then((context) => ({
-        ...context,
-        git_dir: lockInfo.gitDir,
-        git_index_lock_path: lockInfo.lockPath,
-        git_index_lock_age_ms: lockInfo.ageMs,
-        remediation:
-          "Wait for the owning git process to finish, then retry. If no git process owns the lock, inspect the lock path and remove it manually.",
-      })),
-    });
-  }
+      });
+      if (lockInfo) {
+        throw new CliError({
+          exitCode: exitCodeForError("E_GIT_LOCKED"),
+          code: "E_GIT_LOCKED",
+          message: `Git index is locked; refusing to stage allowed paths: ${lockInfo.lockPath}`,
+          context: await resolveGitMutationDiagnosticContext({
+            command: "git add",
+            cwd: opts.ctx.resolvedProject.gitRoot,
+            repoRoot: opts.ctx.resolvedProject.gitRoot,
+            workflowMode: opts.ctx.config.workflow_mode,
+            mutationKind: opts.mutationKind,
+            taskId: opts.taskId,
+            allowPrefixes: effectiveAllow,
+            changedPaths: changed,
+            stagedPaths: unique,
+          }).then((context) => ({
+            ...context,
+            git_dir: lockInfo.gitDir,
+            git_index_lock_path: lockInfo.lockPath,
+            git_index_lock_age_ms: lockInfo.ageMs,
+            remediation:
+              "Wait for the owning git process to finish, then retry. If no git process owns the lock, inspect the lock path and remove it manually.",
+          })),
+        });
+      }
 
-  // `git add <pathspec>` is not reliable for staging deletes/renames across versions/configs.
-  // `-A -- <pathspec...>` makes the allowlist staging semantics deterministic.
-  try {
-    await opts.ctx.git.stage(unique);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    const code = classifyGitStageFailure(message);
-    throw new CliError({
-      exitCode: exitCodeForError(code),
-      code,
-      message: `Failed to stage allowed paths: ${message}`,
-      context: {
-        ...(await resolveGitMutationDiagnosticContext({
-          command: "git add",
-          cwd: opts.ctx.resolvedProject.gitRoot,
-          repoRoot: opts.ctx.resolvedProject.gitRoot,
-          workflowMode: opts.ctx.config.workflow_mode,
-          mutationKind: opts.mutationKind,
-          taskId: opts.taskId,
-          allowPrefixes: effectiveAllow,
-          changedPaths: changed,
-          stagedPaths: unique,
-        })),
-        remediation: GIT_STAGE_REMEDIATION,
-      },
-    });
-  }
+      // `git add <pathspec>` is not reliable for staging deletes/renames across versions/configs.
+      // `-A -- <pathspec...>` makes the allowlist staging semantics deterministic.
+      try {
+        await opts.ctx.git.stage(unique);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        const code = classifyGitStageFailure(message);
+        throw new CliError({
+          exitCode: exitCodeForError(code),
+          code,
+          message: `Failed to stage allowed paths: ${message}`,
+          context: {
+            ...(await resolveGitMutationDiagnosticContext({
+              command: "git add",
+              cwd: opts.ctx.resolvedProject.gitRoot,
+              repoRoot: opts.ctx.resolvedProject.gitRoot,
+              workflowMode: opts.ctx.config.workflow_mode,
+              mutationKind: opts.mutationKind,
+              taskId: opts.taskId,
+              allowPrefixes: effectiveAllow,
+              changedPaths: changed,
+              stagedPaths: unique,
+            })),
+            remediation: GIT_STAGE_REMEDIATION,
+          },
+        });
+      }
+    },
+  );
   return unique;
 }

--- a/packages/agentplane/src/commands/guard/impl/commands.commit-close.unit.test.ts
+++ b/packages/agentplane/src/commands/guard/impl/commands.commit-close.unit.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   resolveCanonicalGitIdentity: vi.fn(),
   guardCommitCheck: vi.fn(),
   resolveIgnoredDirectCloseDirtyPaths: vi.fn(),
+  withGitMutationMutex: vi.fn(),
 }));
 
 vi.mock("@agentplaneorg/core/commit", async (importOriginal) => {
@@ -66,6 +67,13 @@ vi.mock("./policy.js", () => ({ guardCommitCheck: mocks.guardCommitCheck }));
 vi.mock("./close-dirt.js", () => ({
   resolveIgnoredDirectCloseDirtyPaths: mocks.resolveIgnoredDirectCloseDirtyPaths,
 }));
+vi.mock("../../../shared/git-mutation.js", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    withGitMutationMutex: mocks.withGitMutationMutex,
+  };
+});
 
 describe("guard command implementations: commit close", () => {
   beforeEach(() => {
@@ -90,6 +98,9 @@ describe("guard command implementations: commit close", () => {
     mocks.gitRevParse.mockResolvedValue(".git");
     mocks.resolveCanonicalGitIdentity.mockResolvedValue(null);
     mocks.resolveIgnoredDirectCloseDirtyPaths.mockResolvedValue([]);
+    mocks.withGitMutationMutex.mockImplementation(
+      async (_opts: unknown, run: (ctx: unknown) => Promise<unknown>) => await run({}),
+    );
   });
 
   it("cmdCommit close path stages absolute README when outside gitRoot", async () => {

--- a/packages/agentplane/src/commands/guard/impl/commands.commit-non-close.unit.test.ts
+++ b/packages/agentplane/src/commands/guard/impl/commands.commit-non-close.unit.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   resolveCanonicalGitIdentity: vi.fn(),
   guardCommitCheck: vi.fn(),
   resolveIgnoredDirectCloseDirtyPaths: vi.fn(),
+  withGitMutationMutex: vi.fn(),
 }));
 
 vi.mock("@agentplaneorg/core/commit", async (importOriginal) => {
@@ -66,6 +67,13 @@ vi.mock("./policy.js", () => ({ guardCommitCheck: mocks.guardCommitCheck }));
 vi.mock("./close-dirt.js", () => ({
   resolveIgnoredDirectCloseDirtyPaths: mocks.resolveIgnoredDirectCloseDirtyPaths,
 }));
+vi.mock("../../../shared/git-mutation.js", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    withGitMutationMutex: mocks.withGitMutationMutex,
+  };
+});
 
 describe("guard command implementations: commit non-close", () => {
   beforeEach(() => {
@@ -90,6 +98,9 @@ describe("guard command implementations: commit non-close", () => {
     mocks.gitRevParse.mockResolvedValue(".git");
     mocks.resolveCanonicalGitIdentity.mockResolvedValue(null);
     mocks.resolveIgnoredDirectCloseDirtyPaths.mockResolvedValue([]);
+    mocks.withGitMutationMutex.mockImplementation(
+      async (_opts: unknown, run: (ctx: unknown) => Promise<unknown>) => await run({}),
+    );
   });
 
   it("cmdCommit non-close path commits with env and provided ctx", async () => {

--- a/packages/agentplane/src/commands/guard/impl/commit-stage.ts
+++ b/packages/agentplane/src/commands/guard/impl/commit-stage.ts
@@ -1,4 +1,5 @@
 import { protectedPathKindForFile } from "../../../shared/protected-paths.js";
+import { withGitMutationMutex } from "../../../shared/git-mutation.js";
 import { isTaskLocalAdvancePath } from "../../shared/task-local-freshness.js";
 import { type CommandContext } from "../../shared/task-backend.js";
 
@@ -43,7 +44,18 @@ export async function stageActiveTaskArtifactsFromAllowTasks(opts: {
     .filter((relPath) => !staged.has(relPath))
     .toSorted((a, b) => a.localeCompare(b));
   if (unique.length === 0) return [];
-  await opts.ctx.git.stage(unique);
+  await withGitMutationMutex(
+    {
+      repoRoot: opts.ctx.resolvedProject.gitRoot,
+      operation: "git-add",
+      workflowMode: opts.ctx.config.workflow_mode,
+      mutationKind: "lifecycle_commit",
+      taskId: opts.taskId,
+    },
+    async () => {
+      await opts.ctx.git.stage(unique);
+    },
+  );
   return unique;
 }
 
@@ -69,5 +81,16 @@ export async function stageCloseCommitPaths(opts: {
       }
     }
   }
-  await opts.ctx.git.stage([...stagePaths].toSorted((a, b) => a.localeCompare(b)));
+  await withGitMutationMutex(
+    {
+      repoRoot: opts.ctx.resolvedProject.gitRoot,
+      operation: "git-add",
+      workflowMode: opts.ctx.config.workflow_mode,
+      mutationKind: "close_tail",
+      taskId: opts.taskId,
+    },
+    async () => {
+      await opts.ctx.git.stage([...stagePaths].toSorted((a, b) => a.localeCompare(b)));
+    },
+  );
 }

--- a/packages/agentplane/src/shared/git-mutation.test.ts
+++ b/packages/agentplane/src/shared/git-mutation.test.ts
@@ -1,0 +1,144 @@
+import { mkdtemp, readdir, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CliError } from "./errors.js";
+
+const mocks = vi.hoisted(() => ({
+  gitCurrentBranch: vi.fn(),
+  gitRevParse: vi.fn(),
+}));
+
+vi.mock("@agentplaneorg/core/git", () => ({
+  gitCurrentBranch: mocks.gitCurrentBranch,
+  gitRevParse: mocks.gitRevParse,
+}));
+
+type GitIdentity = {
+  gitDir: string;
+  gitCommonDir: string;
+};
+
+const roots: string[] = [];
+let identities: Map<string, GitIdentity>;
+
+async function makeRoot(name: string, identity: GitIdentity): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), `agentplane-${name}-`));
+  roots.push(root);
+  identities.set(root, identity);
+  return root;
+}
+
+async function waitForLock(root: string): Promise<string> {
+  const locksDir = path.join(root, ".agentplane", "cache", "locks");
+  for (let attempt = 0; attempt < 50; attempt++) {
+    try {
+      const entries = await readdir(locksDir);
+      const lock = entries.find((entry) => entry.endsWith(".git-add.lock"));
+      if (lock) return path.join(locksDir, lock);
+    } catch {
+      // keep polling until the holder creates the lock directory
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("Timed out waiting for Git mutation mutex");
+}
+
+describe("Git mutation mutex", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    identities = new Map();
+    mocks.gitCurrentBranch.mockResolvedValue("task/202601010101-ABCDEF/example");
+    mocks.gitRevParse.mockImplementation((cwd: string, args: string[]) => {
+      const identity = identities.get(cwd);
+      if (!identity) throw new Error(`missing identity for ${cwd}`);
+      if (args[0] === "--git-dir") return Promise.resolve(identity.gitDir);
+      if (args[0] === "--git-common-dir") return Promise.resolve(identity.gitCommonDir);
+      throw new Error(`unexpected rev-parse args: ${args.join(" ")}`);
+    });
+  });
+
+  afterEach(async () => {
+    for (const root of roots.splice(0)) {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("conflicts cleanly for concurrent writers in the same worktree", async () => {
+    const commonDir = path.join(tmpdir(), "agentplane-common.git");
+    const root = await makeRoot("same-worktree", {
+      gitCommonDir: commonDir,
+      gitDir: path.join(commonDir, "worktrees", "one"),
+    });
+    const { withGitMutationMutex } = await import("./git-mutation.js");
+
+    let release!: () => void;
+    const holder = withGitMutationMutex(
+      {
+        repoRoot: root,
+        operation: "git-add",
+        workflowMode: "branch_pr",
+        mutationKind: "implementation_commit",
+        taskId: "202601010101-ABCDEF",
+      },
+      async () => {
+        await new Promise<void>((resolve) => {
+          release = resolve;
+        });
+      },
+    );
+
+    const lockPath = await waitForLock(root);
+    await expect(
+      withGitMutationMutex(
+        {
+          repoRoot: root,
+          operation: "git-add",
+          workflowMode: "branch_pr",
+          mutationKind: "implementation_commit",
+          taskId: "202601010101-ABCDEF",
+        },
+        () => Promise.resolve(null),
+      ),
+    ).rejects.toMatchObject<CliError>({
+      code: "E_GIT_RACE",
+      context: {
+        git_mutation_lock_path: lockPath,
+        mutation_kind: "implementation_commit",
+        task_id: "202601010101-ABCDEF",
+      },
+    });
+
+    release();
+    await holder;
+    await expect(stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("uses independent mutex keys for different worktree gitdirs", async () => {
+    const commonDir = path.join(tmpdir(), "agentplane-common.git");
+    const rootA = await makeRoot("worktree-a", {
+      gitCommonDir: commonDir,
+      gitDir: path.join(commonDir, "worktrees", "a"),
+    });
+    const rootB = await makeRoot("worktree-b", {
+      gitCommonDir: commonDir,
+      gitDir: path.join(commonDir, "worktrees", "b"),
+    });
+    const { resolveGitMutationMutexContext, withGitMutationMutex } =
+      await import("./git-mutation.js");
+
+    const [ctxA, ctxB] = await Promise.all([
+      resolveGitMutationMutexContext({ repoRoot: rootA, operation: "git-add" }),
+      resolveGitMutationMutexContext({ repoRoot: rootB, operation: "git-add" }),
+    ]);
+    expect(ctxA.worktreeId).not.toBe(ctxB.worktreeId);
+
+    const results = await Promise.all([
+      withGitMutationMutex({ repoRoot: rootA, operation: "git-add" }, () => Promise.resolve("a")),
+      withGitMutationMutex({ repoRoot: rootB, operation: "git-add" }, () => Promise.resolve("b")),
+    ]);
+    expect(results).toEqual(["a", "b"]);
+  });
+});

--- a/packages/agentplane/src/shared/git-mutation.ts
+++ b/packages/agentplane/src/shared/git-mutation.ts
@@ -1,7 +1,11 @@
-import { stat } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { hostname } from "node:os";
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { gitCurrentBranch, gitRevParse } from "@agentplaneorg/core/git";
+
+import { CliError } from "./errors.js";
 
 export const GIT_MUTATION_KINDS = [
   "implementation_commit",
@@ -95,5 +99,133 @@ export async function resolveGitIndexLockInfo(opts: {
     const code = (err as { code?: unknown } | null)?.code;
     if (code === "ENOENT") return null;
     throw err;
+  }
+}
+
+export type GitMutationMutexContext = {
+  repoRoot: string;
+  gitDir: string;
+  gitCommonDir: string;
+  locksDir: string;
+  lockPath: string;
+  worktreeId: string;
+  operation: string;
+};
+
+function resolveGitPath(repoRoot: string, rawPath: string): string {
+  return path.isAbsolute(rawPath) ? rawPath : path.resolve(repoRoot, rawPath);
+}
+
+function sanitizeLockOperation(operation: string): string {
+  const normalized = operation.trim().replaceAll(/[^A-Za-z0-9_.-]/g, "-");
+  return normalized.length > 0 ? normalized : "git-write";
+}
+
+export async function resolveGitMutationMutexContext(opts: {
+  repoRoot: string;
+  operation: string;
+}): Promise<GitMutationMutexContext> {
+  const rawGitDir = await gitRevParse(opts.repoRoot, ["--git-dir"]);
+  const rawCommonDir = await gitRevParse(opts.repoRoot, ["--git-common-dir"]).catch(
+    () => rawGitDir,
+  );
+  const gitDir = resolveGitPath(opts.repoRoot, rawGitDir);
+  const gitCommonDir = resolveGitPath(opts.repoRoot, rawCommonDir);
+  const operation = sanitizeLockOperation(opts.operation);
+  const worktreeIdentity = `${gitCommonDir}\0${gitDir}`;
+  const worktreeId = createHash("sha256").update(worktreeIdentity).digest("hex").slice(0, 16);
+  const locksDir = path.join(opts.repoRoot, ".agentplane", "cache", "locks");
+
+  return {
+    repoRoot: opts.repoRoot,
+    gitDir,
+    gitCommonDir,
+    locksDir,
+    lockPath: path.join(locksDir, `${worktreeId}.${operation}.lock`),
+    worktreeId,
+    operation,
+  };
+}
+
+async function readMutexOwner(lockPath: string): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(path.join(lockPath, "owner.json"), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export async function withGitMutationMutex<T>(
+  opts: {
+    repoRoot: string;
+    operation: string;
+    workflowMode?: string;
+    mutationKind?: GitMutationKind;
+    taskId?: string;
+  },
+  run: (ctx: GitMutationMutexContext) => Promise<T>,
+): Promise<T> {
+  const mutex = await resolveGitMutationMutexContext({
+    repoRoot: opts.repoRoot,
+    operation: opts.operation,
+  });
+  await mkdir(mutex.locksDir, { recursive: true });
+
+  try {
+    await mkdir(mutex.lockPath);
+  } catch (err) {
+    const code = (err as { code?: unknown } | null)?.code;
+    if (code !== "EEXIST") throw err;
+
+    const owner = await readMutexOwner(mutex.lockPath);
+    throw new CliError({
+      code: "E_GIT_RACE",
+      message: `Git mutation mutex is already held for this worktree: ${mutex.lockPath}`,
+      context: {
+        ...gitMutationDiagnosticContext({
+          command: "agentplane git mutation mutex",
+          cwd: opts.repoRoot,
+          repoRoot: opts.repoRoot,
+          gitDir: mutex.gitDir,
+          workflowMode: opts.workflowMode,
+          mutationKind: opts.mutationKind,
+          taskId: opts.taskId,
+          remediation:
+            "Wait for the active AgentPlane Git mutation in this worktree to finish, then retry. Different worktrees use independent mutex keys.",
+        }),
+        git_common_dir: mutex.gitCommonDir,
+        git_worktree_id: mutex.worktreeId,
+        git_mutation_lock_path: mutex.lockPath,
+        git_mutation_lock_owner: owner,
+      },
+    });
+  }
+
+  await writeFile(
+    path.join(mutex.lockPath, "owner.json"),
+    JSON.stringify(
+      {
+        pid: process.pid,
+        host: hostname(),
+        acquired_at: new Date().toISOString(),
+        repo_root: mutex.repoRoot,
+        git_dir: mutex.gitDir,
+        git_common_dir: mutex.gitCommonDir,
+        worktree_id: mutex.worktreeId,
+        operation: mutex.operation,
+        workflow_mode: opts.workflowMode ?? null,
+        mutation_kind: opts.mutationKind ?? null,
+        task_id: opts.taskId ?? null,
+      },
+      null,
+      2,
+    ) + "\n",
+    "utf8",
+  );
+
+  try {
+    return await run(mutex);
+  } finally {
+    await rm(mutex.lockPath, { recursive: true, force: true });
   }
 }


### PR DESCRIPTION
Task: `202605100837-SAJN9F`
Title: Pre-v0.5: introduce worktree-scoped Git mutation mutex
Canonical task record: `.agentplane/tasks/202605100837-SAJN9F/README.md`

## Summary

Pre-v0.5: introduce worktree-scoped Git mutation mutex

Add an AgentPlane-level mutex for write operations that touch the Git index. Key it by gitdir hash plus repo identity, not branch name, so different worktrees can proceed independently.

## Scope

- In scope: Add an AgentPlane-level mutex for write operations that touch the Git index. Key it by gitdir hash plus repo identity, not branch name, so different worktrees can proceed independently.
- Out of scope: unrelated refactors not required for "Pre-v0.5: introduce worktree-scoped Git mutation mutex".

## Verification

- State: ok
- Note: Implemented a worktree-scoped AgentPlane Git mutation mutex under .agentplane/cache/locks, keyed from git common dir plus resolved gitdir. Stage paths that write the Git index now take the mutex before git add. Checks passed: targeted Vitest git-mutation+allow suites, prettier check, and scoped eslint for changed files.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-10T15:51:00.275Z
- Branch: task-202605100837-SAJN9F-worktree-mutex
- Head: 98f9550499b7

```text
 .../src/commands/guard/impl/allow.test.ts          |  39 +++---
 .../agentplane/src/commands/guard/impl/allow.ts    | 118 +++++++++--------
 .../src/commands/guard/impl/commit-stage.ts        |  27 +++-
 .../agentplane/src/shared/git-mutation.test.ts     | 144 +++++++++++++++++++++
 packages/agentplane/src/shared/git-mutation.ts     | 134 ++++++++++++++++++-
 5 files changed, 392 insertions(+), 70 deletions(-)
```

</details>
