### PR TITLE
🚧 RQ5BHG task: Pre-v0.5: separate integration queue from worktree mutex [202605100837-RQ5BHG]

### DIFF
--- a/.agentplane/tasks/202605100837-RQ5BHG/README.md
+++ b/.agentplane/tasks/202605100837-RQ5BHG/README.md
@@ -1,0 +1,98 @@
+---
+id: "202605100837-RQ5BHG"
+title: "Pre-v0.5: separate integration queue from worktree mutex"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on:
+  - "202605100837-SAJN9F"
+tags:
+  - "git"
+  - "queue"
+  - "workflow"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "Tests show integration operations serialize while independent task worktree commits can proceed."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-10T08:37:04.971Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-10T16:45:11.438Z"
+  updated_by: "CODER"
+  note: "Implemented a dedicated integration queue mutex under .agentplane/cache/locks/integration-queue.lock and wrapped enqueue/claim/release/run-next queue mutations with it. The queue lane serializes integration state changes, while per-worktree Git mutation mutexes remain independent. Checks passed: queue-state/queue-mutex Vitest 9 tests, scoped ESLint, Prettier, and agentplane package build."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: separate base integration queue coordination from per-worktree Git mutation mutex semantics and add regression evidence."
+events:
+  -
+    type: "status"
+    at: "2026-05-10T16:40:15.885Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: separate base integration queue coordination from per-worktree Git mutation mutex semantics and add regression evidence."
+  -
+    type: "verify"
+    at: "2026-05-10T16:45:11.438Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented a dedicated integration queue mutex under .agentplane/cache/locks/integration-queue.lock and wrapped enqueue/claim/release/run-next queue mutations with it. The queue lane serializes integration state changes, while per-worktree Git mutation mutexes remain independent. Checks passed: queue-state/queue-mutex Vitest 9 tests, scoped ESLint, Prettier, and agentplane package build."
+doc_version: 3
+doc_updated_at: "2026-05-10T16:45:11.448Z"
+doc_updated_by: "CODER"
+description: "Make the model and code paths distinguish base-branch integration queue from per-worktree Git write mutex. Do not serialize independent task worktrees globally."
+sections:
+  Summary: |-
+    Pre-v0.5: separate integration queue from worktree mutex
+    
+    Make the model and code paths distinguish base-branch integration queue from per-worktree Git write mutex. Do not serialize independent task worktrees globally.
+  Scope: |-
+    - In scope: Make the model and code paths distinguish base-branch integration queue from per-worktree Git write mutex. Do not serialize independent task worktrees globally.
+    - Out of scope: unrelated refactors not required for "Pre-v0.5: separate integration queue from worktree mutex".
+  Plan: "Pre-v0.5 optimization gate. Deliver exactly this atomic scope, preserve branch_pr lifecycle contracts, and record verification evidence. Dependency: 202605100837-SAJN9F. Acceptance: Tests show integration operations serialize while independent task worktree commits can proceed.."
+  Verify Steps: |-
+    1. Review the requested outcome for "Pre-v0.5: separate integration queue from worktree mutex". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-10T16:45:11.438Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Implemented a dedicated integration queue mutex under .agentplane/cache/locks/integration-queue.lock and wrapped enqueue/claim/release/run-next queue mutations with it. The queue lane serializes integration state changes, while per-worktree Git mutation mutexes remain independent. Checks passed: queue-state/queue-mutex Vitest 9 tests, scoped ESLint, Prettier, and agentplane package build.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-10T16:40:15.900Z, excerpt_hash=sha256:c272a59efae44703efcc8a8a3f9019d0b016d0a192af92bf5ef210deeb5c97ed
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605100837-RQ5BHG-integration-queue-mutex/.agentplane/tasks/202605100837-RQ5BHG/blueprint/resolved-snapshot.json
+    - old_digest: b5fc21179a3802d656c6f3bf246a9f3a7fef176e8cf640e1f628793e2b82b1ea
+    - current_digest: b5fc21179a3802d656c6f3bf246a9f3a7fef176e8cf640e1f628793e2b82b1ea
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605100837-RQ5BHG
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Integration queue write operations now use a queue-owned mutex, while Git index writes still use worktree-id mutexes.
+      Impact: Base integration claims serialize without globally blocking independent task worktree commits.
+      Resolution: Keep queue coordination in integrate queue code paths and Git index coordination in shared git mutation mutex paths.
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605100837-RQ5BHG/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605100837-RQ5BHG/blueprint/resolved-snapshot.json
@@ -1,0 +1,505 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605100837-RQ5BHG",
+    "title": "Pre-v0.5: separate integration queue from worktree mutex",
+    "description": "Make the model and code paths distinguish base-branch integration queue from per-worktree Git write mutex. Do not serialize independent task worktrees globally.",
+    "tags": [
+      "git",
+      "queue",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605100837-RQ5BHG",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "b5fc21179a3802d656c6f3bf246a9f3a7fef176e8cf640e1f628793e2b82b1ea"
+  }
+}

--- a/.agentplane/tasks/202605100837-RQ5BHG/pr/diffstat.txt
+++ b/.agentplane/tasks/202605100837-RQ5BHG/pr/diffstat.txt
@@ -1,0 +1,5 @@
+ .../src/commands/integrate-queue.command.ts        | 171 ++++++++++++---------
+ .../src/commands/pr/integrate/queue-mutex.test.ts  | 101 ++++++++++++
+ .../src/commands/pr/integrate/queue-state.test.ts  |  56 +++++++
+ .../src/commands/pr/integrate/queue-state.ts       |  90 ++++++++++-
+ 4 files changed, 344 insertions(+), 74 deletions(-)

--- a/.agentplane/tasks/202605100837-RQ5BHG/pr/github-body.md
+++ b/.agentplane/tasks/202605100837-RQ5BHG/pr/github-body.md
@@ -1,0 +1,37 @@
+Task: `202605100837-RQ5BHG`
+Title: Pre-v0.5: separate integration queue from worktree mutex
+Canonical task record: `.agentplane/tasks/202605100837-RQ5BHG/README.md`
+
+## Summary
+
+Pre-v0.5: separate integration queue from worktree mutex
+
+Make the model and code paths distinguish base-branch integration queue from per-worktree Git write mutex. Do not serialize independent task worktrees globally.
+
+## Scope
+
+- In scope: Make the model and code paths distinguish base-branch integration queue from per-worktree Git write mutex. Do not serialize independent task worktrees globally.
+- Out of scope: unrelated refactors not required for "Pre-v0.5: separate integration queue from worktree mutex".
+
+## Verification
+
+- State: ok
+- Note: Implemented a dedicated integration queue mutex under .agentplane/cache/locks/integration-queue.lock and wrapped enqueue/claim/release/run-next queue mutations with it. The queue lane serializes integration state changes, while per-worktree Git mutation mutexes remain independent. Checks passed: queue-state/queue-mutex Vitest 9 tests, scoped ESLint, Prettier, and agentplane package build.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-10T16:45:50.123Z
+- Branch: task-202605100837-RQ5BHG-integration-queue-mutex
+- Head: 7a29b6de0d8d
+
+```text
+ .../src/commands/integrate-queue.command.ts        | 171 ++++++++++++---------
+ .../src/commands/pr/integrate/queue-mutex.test.ts  | 101 ++++++++++++
+ .../src/commands/pr/integrate/queue-state.test.ts  |  56 +++++++
+ .../src/commands/pr/integrate/queue-state.ts       |  90 ++++++++++-
+ 4 files changed, 344 insertions(+), 74 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605100837-RQ5BHG/pr/github-title.txt
+++ b/.agentplane/tasks/202605100837-RQ5BHG/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 RQ5BHG task: Pre-v0.5: separate integration queue from worktree mutex [202605100837-RQ5BHG]

--- a/.agentplane/tasks/202605100837-RQ5BHG/pr/meta.json
+++ b/.agentplane/tasks/202605100837-RQ5BHG/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task-202605100837-RQ5BHG-integration-queue-mutex",
+  "created_at": "2026-05-10T16:45:50.123Z",
+  "head_sha": "7a29b6de0d8d5ca2fc4a56712c110dc23fa8cf7e",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202605100837-RQ5BHG",
+  "updated_at": "2026-05-10T16:45:50.123Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605100837-RQ5BHG/pr/review.md
+++ b/.agentplane/tasks/202605100837-RQ5BHG/pr/review.md
@@ -1,0 +1,40 @@
+# PR Review
+
+Created: 2026-05-10T16:45:50.123Z
+
+## Task
+
+- Task: `202605100837-RQ5BHG`
+- Title: Pre-v0.5: separate integration queue from worktree mutex
+- Status: DOING
+- Branch: `task-202605100837-RQ5BHG-integration-queue-mutex`
+- Canonical task record: `.agentplane/tasks/202605100837-RQ5BHG/README.md`
+
+## Verification
+
+- State: ok
+- Note: Implemented a dedicated integration queue mutex under .agentplane/cache/locks/integration-queue.lock and wrapped enqueue/claim/release/run-next queue mutations with it. The queue lane serializes integration state changes, while per-worktree Git mutation mutexes remain independent. Checks passed: queue-state/queue-mutex Vitest 9 tests, scoped ESLint, Prettier, and agentplane package build.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-10T16:45:50.123Z
+- Branch: task-202605100837-RQ5BHG-integration-queue-mutex
+- Head: 7a29b6de0d8d
+
+```text
+ .../src/commands/integrate-queue.command.ts        | 171 ++++++++++++---------
+ .../src/commands/pr/integrate/queue-mutex.test.ts  | 101 ++++++++++++
+ .../src/commands/pr/integrate/queue-state.test.ts  |  56 +++++++
+ .../src/commands/pr/integrate/queue-state.ts       |  90 ++++++++++-
+ 4 files changed, 344 insertions(+), 74 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/integrate-queue.command.ts
+++ b/packages/agentplane/src/commands/integrate-queue.command.ts
@@ -19,6 +19,7 @@ import {
   queueBaseConflictReason,
   readIntegrationQueue,
   upsertQueuedEntry,
+  withIntegrationQueueMutex,
   writeIntegrationQueue,
   type IntegrationQueueEntry,
 } from "./pr/integrate/queue-state.js";
@@ -126,22 +127,27 @@ export function makeRunIntegrateQueueEnqueueHandler(
       runVerify: false,
     });
     const baseSha = await gitRevParse(prepared.resolved.gitRoot, [prepared.base]);
-    const queue = await readIntegrationQueue(prepared.resolved.gitRoot);
-    await writeIntegrationQueue(
-      prepared.resolved.gitRoot,
-      upsertQueuedEntry(queue, {
-        task_id: prepared.task.id,
-        branch: prepared.branch,
-        base: prepared.base,
-        head_sha: prepared.branchHeadSha,
-        base_sha: baseSha,
-        changed_paths: prepared.changedPaths,
-        pr_number:
-          typeof prepared.metaSource.pr_number === "number" ? prepared.metaSource.pr_number : null,
-        pr_url: typeof prepared.metaSource.pr_url === "string" ? prepared.metaSource.pr_url : null,
-        priority: p.priority,
-      }),
-    );
+    await withIntegrationQueueMutex(prepared.resolved.gitRoot, async () => {
+      const queue = await readIntegrationQueue(prepared.resolved.gitRoot);
+      await writeIntegrationQueue(
+        prepared.resolved.gitRoot,
+        upsertQueuedEntry(queue, {
+          task_id: prepared.task.id,
+          branch: prepared.branch,
+          base: prepared.base,
+          head_sha: prepared.branchHeadSha,
+          base_sha: baseSha,
+          changed_paths: prepared.changedPaths,
+          pr_number:
+            typeof prepared.metaSource.pr_number === "number"
+              ? prepared.metaSource.pr_number
+              : null,
+          pr_url:
+            typeof prepared.metaSource.pr_url === "string" ? prepared.metaSource.pr_url : null,
+          priority: p.priority,
+        }),
+      );
+    });
     createCliEmitter().success("queued integration", prepared.task.id, `branch=${prepared.branch}`);
     return 0;
   };
@@ -172,25 +178,31 @@ export function makeRunIntegrateQueueClaimHandler(
   return async (_ctx: CommandCtx, p: IntegrateQueueClaimParsed): Promise<number> => {
     const commandCtx = await getCtx("integrate queue claim");
     const gitRoot = commandCtx.resolvedProject.gitRoot;
-    const queue = await readIntegrationQueue(gitRoot);
-    const claimed = claimNextQueuedEntry(queue, {
-      worker: p.worker ?? defaultWorker(),
-      ...(p.leaseMs === null ? {} : { leaseMs: p.leaseMs }),
+    const claimed = await withIntegrationQueueMutex(gitRoot, async () => {
+      const queue = await readIntegrationQueue(gitRoot);
+      const next = claimNextQueuedEntry(queue, {
+        worker: p.worker ?? defaultWorker(),
+        ...(p.leaseMs === null ? {} : { leaseMs: p.leaseMs }),
+      });
+      if (!next.entry) {
+        await writeIntegrationQueue(gitRoot, next.state);
+        return next;
+      }
+      const stale = await rejectIfQueuedEntryIsStale({ gitRoot, entry: next.entry });
+      if (stale) {
+        await writeIntegrationQueue(
+          gitRoot,
+          markQueueEntry(next.state, stale.task_id, "rework", stale.reason),
+        );
+        throw new CliError({ code: "E_VALIDATION", message: stale.reason ?? "queued entry stale" });
+      }
+      await writeIntegrationQueue(gitRoot, next.state);
+      return next;
     });
     if (!claimed.entry) {
       createCliEmitter().line(emptyStateMessage("queued integration entries"));
-      await writeIntegrationQueue(gitRoot, claimed.state);
       return 0;
     }
-    const stale = await rejectIfQueuedEntryIsStale({ gitRoot, entry: claimed.entry });
-    if (stale) {
-      await writeIntegrationQueue(
-        gitRoot,
-        markQueueEntry(claimed.state, stale.task_id, "rework", stale.reason),
-      );
-      throw new CliError({ code: "E_VALIDATION", message: stale.reason ?? "queued entry stale" });
-    }
-    await writeIntegrationQueue(gitRoot, claimed.state);
     const output = createCliEmitter();
     if (p.json) output.json(claimed.entry);
     else
@@ -209,11 +221,13 @@ export function makeRunIntegrateQueueReleaseHandler(
   return async (_ctx: CommandCtx, p: IntegrateQueueReleaseParsed): Promise<number> => {
     const commandCtx = await getCtx("integrate queue release");
     const gitRoot = commandCtx.resolvedProject.gitRoot;
-    const queue = await readIntegrationQueue(gitRoot);
-    await writeIntegrationQueue(
-      gitRoot,
-      markQueueEntry(queue, p.taskId, p.status, p.reason ?? undefined),
-    );
+    await withIntegrationQueueMutex(gitRoot, async () => {
+      const queue = await readIntegrationQueue(gitRoot);
+      await writeIntegrationQueue(
+        gitRoot,
+        markQueueEntry(queue, p.taskId, p.status, p.reason ?? undefined),
+      );
+    });
     createCliEmitter().success("queue entry", p.taskId, `status=${p.status}`);
     return 0;
   };
@@ -225,62 +239,73 @@ export function makeRunIntegrateQueueRunNextHandler(
   return async (ctx: CommandCtx, p: IntegrateQueueRunNextParsed): Promise<number> => {
     const commandCtx = await getCtx("integrate queue run-next");
     const gitRoot = commandCtx.resolvedProject.gitRoot;
-    const queue = await readIntegrationQueue(gitRoot);
-    const claimed = claimNextQueuedEntry(queue, {
-      worker: p.worker ?? defaultWorker(),
-      ...(p.leaseMs === null ? {} : { leaseMs: p.leaseMs }),
+    const claimed = await withIntegrationQueueMutex(gitRoot, async () => {
+      const queue = await readIntegrationQueue(gitRoot);
+      const next = claimNextQueuedEntry(queue, {
+        worker: p.worker ?? defaultWorker(),
+        ...(p.leaseMs === null ? {} : { leaseMs: p.leaseMs }),
+      });
+      if (!next.entry) {
+        await writeIntegrationQueue(gitRoot, next.state);
+        return next;
+      }
+
+      const stale = await rejectIfQueuedEntryIsStale({ gitRoot, entry: next.entry });
+      if (stale) {
+        await writeIntegrationQueue(
+          gitRoot,
+          markQueueEntry(next.state, stale.task_id, "rework", stale.reason),
+        );
+        throw new CliError({ code: "E_VALIDATION", message: stale.reason ?? "queued entry stale" });
+      }
+
+      await writeIntegrationQueue(gitRoot, next.state);
+      return next;
     });
     if (!claimed.entry) {
       createCliEmitter().line(emptyStateMessage("queued integration entries"));
-      await writeIntegrationQueue(gitRoot, claimed.state);
       return 0;
     }
-
-    const stale = await rejectIfQueuedEntryIsStale({ gitRoot, entry: claimed.entry });
-    if (stale) {
-      await writeIntegrationQueue(
-        gitRoot,
-        markQueueEntry(claimed.state, stale.task_id, "rework", stale.reason),
-      );
-      throw new CliError({ code: "E_VALIDATION", message: stale.reason ?? "queued entry stale" });
-    }
-
-    await writeIntegrationQueue(gitRoot, claimed.state);
+    const claimedEntry = claimed.entry;
     try {
       const result = await cmdIntegrate({
         ctx: commandCtx,
         cwd: ctx.cwd,
         rootOverride: ctx.rootOverride,
-        taskId: claimed.entry.task_id,
-        branch: claimed.entry.branch,
-        base: claimed.entry.base,
+        taskId: claimedEntry.task_id,
+        branch: claimedEntry.branch,
+        base: claimedEntry.base,
         mergeStrategy: "merge",
         runVerify: p.runVerify,
         dryRun: p.dryRun,
         quiet: p.quiet,
       });
-      const nextQueue = await readIntegrationQueue(gitRoot);
-      await writeIntegrationQueue(
-        gitRoot,
-        markQueueEntry(nextQueue, claimed.entry.task_id, p.dryRun ? "queued" : "done"),
-      );
+      await withIntegrationQueueMutex(gitRoot, async () => {
+        const nextQueue = await readIntegrationQueue(gitRoot);
+        await writeIntegrationQueue(
+          gitRoot,
+          markQueueEntry(nextQueue, claimedEntry.task_id, p.dryRun ? "queued" : "done"),
+        );
+      });
       return result;
     } catch (err) {
-      const nextQueue = await readIntegrationQueue(gitRoot);
       const handoff = err instanceof CliError && err.code === "E_HANDOFF";
-      await writeIntegrationQueue(
-        gitRoot,
-        markQueueEntry(
-          nextQueue,
-          claimed.entry.task_id,
-          handoff ? "handoff" : "rework",
-          handoff
-            ? "protected base handoff recorded; wait for hosted merge/close before releasing lane"
-            : err instanceof Error
-              ? err.message
-              : String(err),
-        ),
-      );
+      await withIntegrationQueueMutex(gitRoot, async () => {
+        const nextQueue = await readIntegrationQueue(gitRoot);
+        await writeIntegrationQueue(
+          gitRoot,
+          markQueueEntry(
+            nextQueue,
+            claimedEntry.task_id,
+            handoff ? "handoff" : "rework",
+            handoff
+              ? "protected base handoff recorded; wait for hosted merge/close before releasing lane"
+              : err instanceof Error
+                ? err.message
+                : String(err),
+          ),
+        );
+      });
       throw err;
     }
   };

--- a/packages/agentplane/src/commands/pr/integrate/queue-mutex.test.ts
+++ b/packages/agentplane/src/commands/pr/integrate/queue-mutex.test.ts
@@ -1,0 +1,101 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { withGitMutationMutex } from "../../../shared/git-mutation.js";
+import { withIntegrationQueueMutex } from "./queue-state.js";
+
+const mocks = vi.hoisted(() => ({
+  gitCurrentBranch: vi.fn(),
+  gitRevParse: vi.fn(),
+}));
+
+vi.mock("@agentplaneorg/core/git", () => ({
+  gitCurrentBranch: mocks.gitCurrentBranch,
+  gitRevParse: mocks.gitRevParse,
+}));
+
+type GitIdentity = {
+  gitDir: string;
+  gitCommonDir: string;
+};
+
+const roots: string[] = [];
+let identities: Map<string, GitIdentity>;
+
+async function makeRoot(name: string, identity?: GitIdentity): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), `agentplane-${name}-`));
+  roots.push(root);
+  if (identity) identities.set(root, identity);
+  return root;
+}
+
+describe("integration queue mutex coordination", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    identities = new Map();
+    mocks.gitCurrentBranch.mockResolvedValue("main");
+    mocks.gitRevParse.mockImplementation((cwd: string, args: string[]) => {
+      const identity = identities.get(cwd);
+      if (!identity) throw new Error(`missing identity for ${cwd}`);
+      if (args[0] === "--git-dir") return Promise.resolve(identity.gitDir);
+      if (args[0] === "--git-common-dir") return Promise.resolve(identity.gitCommonDir);
+      throw new Error(`unexpected rev-parse args: ${args.join(" ")}`);
+    });
+  });
+
+  afterEach(async () => {
+    for (const root of roots.splice(0)) {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the integration queue lane independent from task worktree Git writers", async () => {
+    const commonDir = path.join(tmpdir(), "agentplane-common.git");
+    const baseRoot = await makeRoot("base");
+    const taskRootA = await makeRoot("task-a", {
+      gitCommonDir: commonDir,
+      gitDir: path.join(commonDir, "worktrees", "task-a"),
+    });
+    const taskRootB = await makeRoot("task-b", {
+      gitCommonDir: commonDir,
+      gitDir: path.join(commonDir, "worktrees", "task-b"),
+    });
+
+    let release!: () => void;
+    const queueHolder = withIntegrationQueueMutex(baseRoot, async () => {
+      await new Promise<void>((resolve) => {
+        release = resolve;
+      });
+    });
+
+    const results = await Promise.all([
+      withGitMutationMutex(
+        {
+          repoRoot: taskRootA,
+          operation: "git-add",
+          workflowMode: "branch_pr",
+          mutationKind: "implementation_commit",
+          taskId: "202601010101-TASKA",
+        },
+        () => Promise.resolve("task-a"),
+      ),
+      withGitMutationMutex(
+        {
+          repoRoot: taskRootB,
+          operation: "git-add",
+          workflowMode: "branch_pr",
+          mutationKind: "implementation_commit",
+          taskId: "202601010101-TASKB",
+        },
+        () => Promise.resolve("task-b"),
+      ),
+    ]);
+
+    expect(results).toEqual(["task-a", "task-b"]);
+    release();
+    await queueHolder;
+  });
+});

--- a/packages/agentplane/src/commands/pr/integrate/queue-state.test.ts
+++ b/packages/agentplane/src/commands/pr/integrate/queue-state.test.ts
@@ -1,11 +1,17 @@
+import { mkdtemp, readdir, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
 import { describe, expect, it } from "vitest";
 
+import type { CliError } from "../../../shared/errors.js";
 import {
   claimNextQueuedEntry,
   emptyIntegrationQueue,
   expireClaimedEntries,
   markQueueEntry,
   queueBaseConflictReason,
+  withIntegrationQueueMutex,
   upsertQueuedEntry,
   type QueueClock,
 } from "./queue-state.js";
@@ -26,6 +32,25 @@ function enqueue(taskId: string, priority = 0) {
     pr_url: null,
     priority,
   };
+}
+
+async function makeRoot(name: string): Promise<string> {
+  return mkdtemp(path.join(tmpdir(), `agentplane-${name}-`));
+}
+
+async function waitForQueueLock(root: string): Promise<string> {
+  const locksDir = path.join(root, ".agentplane", "cache", "locks");
+  for (let attempt = 0; attempt < 50; attempt++) {
+    try {
+      const entries = await readdir(locksDir);
+      const lock = entries.find((entry) => entry === "integration-queue.lock");
+      if (lock) return path.join(locksDir, lock);
+    } catch {
+      // keep polling until the holder creates the lock directory
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("Timed out waiting for integration queue mutex");
 }
 
 describe("integration queue state", () => {
@@ -183,5 +208,36 @@ describe("integration queue state", () => {
         baseChangedPaths: ["src/shared.ts"],
       }),
     ).toBeNull();
+  });
+
+  it("serializes integration queue writers with a queue-owned mutex", async () => {
+    const root = await makeRoot("integration-queue");
+    try {
+      let release!: () => void;
+      const holder = withIntegrationQueueMutex(root, async () => {
+        await new Promise<void>((resolve) => {
+          release = resolve;
+        });
+      });
+
+      const lockPath = await waitForQueueLock(root);
+      await expect(
+        withIntegrationQueueMutex(root, () => Promise.resolve(null)),
+      ).rejects.toMatchObject<CliError>({
+        code: "E_GIT_RACE",
+        context: {
+          mutation_kind: "integration",
+          integration_queue_lock_path: lockPath,
+          remediation:
+            "Wait for the active integration queue operation to finish, then retry. Worktree Git mutation mutexes remain independent.",
+        },
+      });
+
+      release();
+      await holder;
+      await expect(stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/agentplane/src/commands/pr/integrate/queue-state.ts
+++ b/packages/agentplane/src/commands/pr/integrate/queue-state.ts
@@ -1,5 +1,9 @@
 import path from "node:path";
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { hostname } from "node:os";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+
+import { CliError } from "../../../shared/errors.js";
+import { gitMutationDiagnosticContext } from "../../../shared/git-mutation.js";
 
 export type IntegrationQueueStatus = "queued" | "claimed" | "handoff" | "done" | "rework";
 
@@ -27,6 +31,13 @@ type IntegrationQueueState = {
   entries: IntegrationQueueEntry[];
 };
 
+export type IntegrationQueueMutexContext = {
+  gitRoot: string;
+  locksDir: string;
+  lockPath: string;
+  queuePath: string;
+};
+
 export type QueueClock = {
   now: () => Date;
 };
@@ -36,6 +47,16 @@ const DEFAULT_QUEUE_CLOCK: QueueClock = { now: () => new Date() };
 
 function integrationQueuePath(gitRoot: string): string {
   return path.join(gitRoot, ".agentplane", "cache", "integration-queue.json");
+}
+
+export function resolveIntegrationQueueMutexContext(gitRoot: string): IntegrationQueueMutexContext {
+  const locksDir = path.join(gitRoot, ".agentplane", "cache", "locks");
+  return {
+    gitRoot,
+    locksDir,
+    lockPath: path.join(locksDir, "integration-queue.lock"),
+    queuePath: integrationQueuePath(gitRoot),
+  };
 }
 
 export function emptyIntegrationQueue(): IntegrationQueueState {
@@ -85,6 +106,73 @@ export async function writeIntegrationQueue(
   const tmpPath = `${queuePath}.${process.pid}.tmp`;
   await writeFile(tmpPath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
   await rename(tmpPath, queuePath);
+}
+
+async function readQueueMutexOwner(lockPath: string): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(path.join(lockPath, "owner.json"), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export async function withIntegrationQueueMutex<T>(
+  gitRoot: string,
+  run: (ctx: IntegrationQueueMutexContext) => Promise<T>,
+): Promise<T> {
+  const mutex = resolveIntegrationQueueMutexContext(gitRoot);
+  await mkdir(mutex.locksDir, { recursive: true });
+
+  try {
+    await mkdir(mutex.lockPath);
+  } catch (err) {
+    const code = (err as { code?: unknown } | null)?.code;
+    if (code !== "EEXIST") throw err;
+    const owner = await readQueueMutexOwner(mutex.lockPath);
+    throw new CliError({
+      code: "E_GIT_RACE",
+      message: `Integration queue mutex is already held: ${mutex.lockPath}`,
+      context: {
+        ...gitMutationDiagnosticContext({
+          command: "agentplane integration queue mutex",
+          cwd: gitRoot,
+          repoRoot: gitRoot,
+          workflowMode: "branch_pr",
+          mutationKind: "integration",
+          remediation:
+            "Wait for the active integration queue operation to finish, then retry. Worktree Git mutation mutexes remain independent.",
+        }),
+        integration_queue_path: mutex.queuePath,
+        integration_queue_lock_path: mutex.lockPath,
+        integration_queue_lock_owner: owner,
+      },
+    });
+  }
+
+  await writeFile(
+    path.join(mutex.lockPath, "owner.json"),
+    JSON.stringify(
+      {
+        pid: process.pid,
+        host: hostname(),
+        acquired_at: new Date().toISOString(),
+        git_root: mutex.gitRoot,
+        queue_path: mutex.queuePath,
+        operation: "integration-queue",
+        workflow_mode: "branch_pr",
+        mutation_kind: "integration",
+      },
+      null,
+      2,
+    ) + "\n",
+    "utf8",
+  );
+
+  try {
+    return await run(mutex);
+  } finally {
+    await rm(mutex.lockPath, { recursive: true, force: true });
+  }
 }
 
 export function upsertQueuedEntry(


### PR DESCRIPTION
Task: `202605100837-RQ5BHG`
Title: Pre-v0.5: separate integration queue from worktree mutex
Canonical task record: `.agentplane/tasks/202605100837-RQ5BHG/README.md`

## Summary

Pre-v0.5: separate integration queue from worktree mutex

Make the model and code paths distinguish base-branch integration queue from per-worktree Git write mutex. Do not serialize independent task worktrees globally.

## Scope

- In scope: Make the model and code paths distinguish base-branch integration queue from per-worktree Git write mutex. Do not serialize independent task worktrees globally.
- Out of scope: unrelated refactors not required for "Pre-v0.5: separate integration queue from worktree mutex".

## Verification

- State: ok
- Note: Implemented a dedicated integration queue mutex under .agentplane/cache/locks/integration-queue.lock and wrapped enqueue/claim/release/run-next queue mutations with it. The queue lane serializes integration state changes, while per-worktree Git mutation mutexes remain independent. Checks passed: queue-state/queue-mutex Vitest 9 tests, scoped ESLint, Prettier, and agentplane package build.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-10T16:45:50.123Z
- Branch: task-202605100837-RQ5BHG-integration-queue-mutex
- Head: 7a29b6de0d8d

```text
 .../src/commands/integrate-queue.command.ts        | 171 ++++++++++++---------
 .../src/commands/pr/integrate/queue-mutex.test.ts  | 101 ++++++++++++
 .../src/commands/pr/integrate/queue-state.test.ts  |  56 +++++++
 .../src/commands/pr/integrate/queue-state.ts       |  90 ++++++++++-
 4 files changed, 344 insertions(+), 74 deletions(-)
```

</details>
