### PR TITLE
🚧 PGH61Q task: Pre-v0.5: split hook capabilities and declare write intent [202605100837-PGH61Q]

### DIFF
--- a/.agentplane/tasks/202605100837-PGH61Q/README.md
+++ b/.agentplane/tasks/202605100837-PGH61Q/README.md
@@ -1,0 +1,98 @@
+---
+id: "202605100837-PGH61Q"
+title: "Pre-v0.5: split hook capabilities and declare write intent"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on:
+  - "202605100837-RQ5BHG"
+tags:
+  - "git"
+  - "hooks"
+  - "workflow"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "Hook tests assert read-only mode does not write the index and write-capable mode declares mutation kind and lock context."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-10T08:37:07.444Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-10T17:02:57.220Z"
+  updated_by: "CODER"
+  note: "Added explicit hook capability declarations: commit-msg/pre-commit/pre-push run as read-only hook_check paths with GIT_OPTIONAL_LOCKS=0 and forbidden Git index write intent; post-merge is declared write-capable but outside the Git index with hook_check lock context. Checks passed: hook capabilities + hook-run Vitest 26 tests, scoped ESLint, Prettier, and agentplane package build."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: classify hook execution capabilities, keep read-only hooks index-free, and require lock/context for write-capable hook behavior."
+events:
+  -
+    type: "status"
+    at: "2026-05-10T16:59:26.662Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: classify hook execution capabilities, keep read-only hooks index-free, and require lock/context for write-capable hook behavior."
+  -
+    type: "verify"
+    at: "2026-05-10T17:02:57.220Z"
+    author: "CODER"
+    state: "ok"
+    note: "Added explicit hook capability declarations: commit-msg/pre-commit/pre-push run as read-only hook_check paths with GIT_OPTIONAL_LOCKS=0 and forbidden Git index write intent; post-merge is declared write-capable but outside the Git index with hook_check lock context. Checks passed: hook capabilities + hook-run Vitest 26 tests, scoped ESLint, Prettier, and agentplane package build."
+doc_version: 3
+doc_updated_at: "2026-05-10T17:02:57.230Z"
+doc_updated_by: "CODER"
+description: "Classify hooks into read-only checks and write-capable enforcement. Read-only hooks should avoid index writes; write-capable hooks must take the worktree mutex or write outside the Git index. Push hooks must not create lifecycle/status commits implicitly."
+sections:
+  Summary: |-
+    Pre-v0.5: split hook capabilities and declare write intent
+    
+    Classify hooks into read-only checks and write-capable enforcement. Read-only hooks should avoid index writes; write-capable hooks must take the worktree mutex or write outside the Git index. Push hooks must not create lifecycle/status commits implicitly.
+  Scope: |-
+    - In scope: Classify hooks into read-only checks and write-capable enforcement. Read-only hooks should avoid index writes; write-capable hooks must take the worktree mutex or write outside the Git index. Push hooks must not create lifecycle/status commits implicitly.
+    - Out of scope: unrelated refactors not required for "Pre-v0.5: split hook capabilities and declare write intent".
+  Plan: "Pre-v0.5 optimization gate. Deliver exactly this atomic scope, preserve branch_pr lifecycle contracts, and record verification evidence. Dependency: 202605100837-RQ5BHG. Acceptance: Hook tests assert read-only mode does not write the index and write-capable mode declares mutation kind and lock context.."
+  Verify Steps: |-
+    1. Review the requested outcome for "Pre-v0.5: split hook capabilities and declare write intent". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-10T17:02:57.220Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Added explicit hook capability declarations: commit-msg/pre-commit/pre-push run as read-only hook_check paths with GIT_OPTIONAL_LOCKS=0 and forbidden Git index write intent; post-merge is declared write-capable but outside the Git index with hook_check lock context. Checks passed: hook capabilities + hook-run Vitest 26 tests, scoped ESLint, Prettier, and agentplane package build.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-10T16:59:26.677Z, excerpt_hash=sha256:c0effbf92ae1a8e8b82ed19a08f61ca8eea83c563cdde42a212e634cbad7c94c
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605100837-PGH61Q-hook-capabilities/.agentplane/tasks/202605100837-PGH61Q/blueprint/resolved-snapshot.json
+    - old_digest: 52a2193fb26878659c02c219c03b5cbdde497bab4c7829606af79645094a835c
+    - current_digest: 52a2193fb26878659c02c219c03b5cbdde497bab4c7829606af79645094a835c
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605100837-PGH61Q
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Hook execution now exposes capability mode, Git index write intent, mutation kind, and lock context through a shared contract.
+      Impact: Read-only hooks avoid Git index writes, while write-capable hook behavior is explicit instead of hidden.
+      Resolution: Keep hook write intent in capabilities.ts and enrich hook CLI errors with the same diagnostic context.
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605100837-PGH61Q/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605100837-PGH61Q/blueprint/resolved-snapshot.json
@@ -1,0 +1,505 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605100837-PGH61Q",
+    "title": "Pre-v0.5: split hook capabilities and declare write intent",
+    "description": "Classify hooks into read-only checks and write-capable enforcement. Read-only hooks should avoid index writes; write-capable hooks must take the worktree mutex or write outside the Git index. Push hooks must not create lifecycle/status commits implicitly.",
+    "tags": [
+      "git",
+      "hooks",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605100837-PGH61Q",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "52a2193fb26878659c02c219c03b5cbdde497bab4c7829606af79645094a835c"
+  }
+}

--- a/.agentplane/tasks/202605100837-PGH61Q/pr/diffstat.txt
+++ b/.agentplane/tasks/202605100837-PGH61Q/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ .../src/commands/hooks/capabilities.test.ts        | 48 +++++++++++
+ .../agentplane/src/commands/hooks/capabilities.ts  | 93 ++++++++++++++++++++++
+ packages/agentplane/src/commands/hooks/run.ts      | 19 ++++-
+ 3 files changed, 158 insertions(+), 2 deletions(-)

--- a/.agentplane/tasks/202605100837-PGH61Q/pr/github-body.md
+++ b/.agentplane/tasks/202605100837-PGH61Q/pr/github-body.md
@@ -1,0 +1,36 @@
+Task: `202605100837-PGH61Q`
+Title: Pre-v0.5: split hook capabilities and declare write intent
+Canonical task record: `.agentplane/tasks/202605100837-PGH61Q/README.md`
+
+## Summary
+
+Pre-v0.5: split hook capabilities and declare write intent
+
+Classify hooks into read-only checks and write-capable enforcement. Read-only hooks should avoid index writes; write-capable hooks must take the worktree mutex or write outside the Git index. Push hooks must not create lifecycle/status commits implicitly.
+
+## Scope
+
+- In scope: Classify hooks into read-only checks and write-capable enforcement. Read-only hooks should avoid index writes; write-capable hooks must take the worktree mutex or write outside the Git index. Push hooks must not create lifecycle/status commits implicitly.
+- Out of scope: unrelated refactors not required for "Pre-v0.5: split hook capabilities and declare write intent".
+
+## Verification
+
+- State: ok
+- Note: Added explicit hook capability declarations: commit-msg/pre-commit/pre-push run as read-only hook_check paths with GIT_OPTIONAL_LOCKS=0 and forbidden Git index write intent; post-merge is declared write-capable but outside the Git index with hook_check lock context. Checks passed: hook capabilities + hook-run Vitest 26 tests, scoped ESLint, Prettier, and agentplane package build.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-10T17:03:20.977Z
+- Branch: task-202605100837-PGH61Q-hook-capabilities
+- Head: 81090060d212
+
+```text
+ .../src/commands/hooks/capabilities.test.ts        | 48 +++++++++++
+ .../agentplane/src/commands/hooks/capabilities.ts  | 93 ++++++++++++++++++++++
+ packages/agentplane/src/commands/hooks/run.ts      | 19 ++++-
+ 3 files changed, 158 insertions(+), 2 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605100837-PGH61Q/pr/github-title.txt
+++ b/.agentplane/tasks/202605100837-PGH61Q/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 PGH61Q task: Pre-v0.5: split hook capabilities and declare write intent [202605100837-PGH61Q]

--- a/.agentplane/tasks/202605100837-PGH61Q/pr/meta.json
+++ b/.agentplane/tasks/202605100837-PGH61Q/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task-202605100837-PGH61Q-hook-capabilities",
+  "created_at": "2026-05-10T17:03:20.977Z",
+  "head_sha": "81090060d2129258556d9eadf27837868702cf2e",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202605100837-PGH61Q",
+  "updated_at": "2026-05-10T17:03:20.977Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605100837-PGH61Q/pr/review.md
+++ b/.agentplane/tasks/202605100837-PGH61Q/pr/review.md
@@ -1,0 +1,39 @@
+# PR Review
+
+Created: 2026-05-10T17:03:20.977Z
+
+## Task
+
+- Task: `202605100837-PGH61Q`
+- Title: Pre-v0.5: split hook capabilities and declare write intent
+- Status: DOING
+- Branch: `task-202605100837-PGH61Q-hook-capabilities`
+- Canonical task record: `.agentplane/tasks/202605100837-PGH61Q/README.md`
+
+## Verification
+
+- State: ok
+- Note: Added explicit hook capability declarations: commit-msg/pre-commit/pre-push run as read-only hook_check paths with GIT_OPTIONAL_LOCKS=0 and forbidden Git index write intent; post-merge is declared write-capable but outside the Git index with hook_check lock context. Checks passed: hook capabilities + hook-run Vitest 26 tests, scoped ESLint, Prettier, and agentplane package build.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-10T17:03:20.977Z
+- Branch: task-202605100837-PGH61Q-hook-capabilities
+- Head: 81090060d212
+
+```text
+ .../src/commands/hooks/capabilities.test.ts        | 48 +++++++++++
+ .../agentplane/src/commands/hooks/capabilities.ts  | 93 ++++++++++++++++++++++
+ packages/agentplane/src/commands/hooks/run.ts      | 19 ++++-
+ 3 files changed, 158 insertions(+), 2 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/hooks/capabilities.test.ts
+++ b/packages/agentplane/src/commands/hooks/capabilities.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  hookCapabilityDiagnosticContext,
+  resolveHookCapability,
+  withHookCapabilityEnvironment,
+} from "./capabilities.js";
+
+describe("hook capabilities", () => {
+  it("runs read-only hooks with Git optional locks disabled and no index write intent", async () => {
+    const previous = process.env.GIT_OPTIONAL_LOCKS;
+    delete process.env.GIT_OPTIONAL_LOCKS;
+    try {
+      const capability = resolveHookCapability("pre-commit");
+      await withHookCapabilityEnvironment(capability, () => {
+        expect(process.env.GIT_OPTIONAL_LOCKS).toBe("0");
+        expect(process.env.AGENTPLANE_HOOK_CAPABILITY_MODE).toBe("read_only");
+        expect(process.env.AGENTPLANE_HOOK_GIT_INDEX_WRITE_INTENT).toBe("forbidden");
+        expect(process.env.AGENTPLANE_HOOK_MUTATION_KIND).toBe("hook_check");
+        expect(process.env.AGENTPLANE_HOOK_LOCK_CONTEXT).toBe("git_optional_locks_disabled");
+        return Promise.resolve();
+      });
+
+      expect(process.env.GIT_OPTIONAL_LOCKS).toBeUndefined();
+    } finally {
+      if (previous === undefined) delete process.env.GIT_OPTIONAL_LOCKS;
+      else process.env.GIT_OPTIONAL_LOCKS = previous;
+    }
+  });
+
+  it("declares write-capable hooks as outside-Git-index hook checks", () => {
+    const capability = resolveHookCapability("post-merge");
+
+    expect(capability).toMatchObject({
+      mode: "write_capable",
+      gitIndexWriteIntent: "forbidden",
+      mutationKind: "hook_check",
+      lockContext: "outside_git_index",
+    });
+    expect(hookCapabilityDiagnosticContext(capability)).toMatchObject({
+      hook: "post-merge",
+      hook_capability_mode: "write_capable",
+      hook_git_index_write_intent: "forbidden",
+      mutation_kind: "hook_check",
+      hook_lock_context: "outside_git_index",
+    });
+  });
+});

--- a/packages/agentplane/src/commands/hooks/capabilities.ts
+++ b/packages/agentplane/src/commands/hooks/capabilities.ts
@@ -1,0 +1,93 @@
+import type { GitMutationKind } from "../../shared/git-mutation.js";
+import type { HookName } from "./shared.js";
+
+export type HookCapabilityMode = "read_only" | "write_capable";
+export type HookGitIndexWriteIntent = "forbidden" | "worktree_mutex_required";
+export type HookLockContext = "git_optional_locks_disabled" | "outside_git_index";
+
+export type HookCapability = {
+  hook: HookName;
+  mode: HookCapabilityMode;
+  gitIndexWriteIntent: HookGitIndexWriteIntent;
+  mutationKind: GitMutationKind;
+  lockContext: HookLockContext;
+};
+
+const HOOK_CAPABILITIES: Readonly<Record<HookName, HookCapability>> = {
+  "commit-msg": {
+    hook: "commit-msg",
+    mode: "read_only",
+    gitIndexWriteIntent: "forbidden",
+    mutationKind: "hook_check",
+    lockContext: "git_optional_locks_disabled",
+  },
+  "pre-commit": {
+    hook: "pre-commit",
+    mode: "read_only",
+    gitIndexWriteIntent: "forbidden",
+    mutationKind: "hook_check",
+    lockContext: "git_optional_locks_disabled",
+  },
+  "pre-push": {
+    hook: "pre-push",
+    mode: "read_only",
+    gitIndexWriteIntent: "forbidden",
+    mutationKind: "hook_check",
+    lockContext: "git_optional_locks_disabled",
+  },
+  "post-merge": {
+    hook: "post-merge",
+    mode: "write_capable",
+    gitIndexWriteIntent: "forbidden",
+    mutationKind: "hook_check",
+    lockContext: "outside_git_index",
+  },
+};
+
+export function resolveHookCapability(hook: HookName): HookCapability {
+  return HOOK_CAPABILITIES[hook];
+}
+
+export function hookCapabilityDiagnosticContext(
+  capability: HookCapability,
+): Record<string, unknown> {
+  return {
+    hook: capability.hook,
+    hook_capability_mode: capability.mode,
+    hook_git_index_write_intent: capability.gitIndexWriteIntent,
+    mutation_kind: capability.mutationKind,
+    hook_lock_context: capability.lockContext,
+  };
+}
+
+export async function withHookCapabilityEnvironment<T>(
+  capability: HookCapability,
+  run: () => Promise<T>,
+): Promise<T> {
+  const previous = {
+    AGENTPLANE_HOOK_CAPABILITY_MODE: process.env.AGENTPLANE_HOOK_CAPABILITY_MODE,
+    AGENTPLANE_HOOK_GIT_INDEX_WRITE_INTENT: process.env.AGENTPLANE_HOOK_GIT_INDEX_WRITE_INTENT,
+    AGENTPLANE_HOOK_LOCK_CONTEXT: process.env.AGENTPLANE_HOOK_LOCK_CONTEXT,
+    AGENTPLANE_HOOK_MUTATION_KIND: process.env.AGENTPLANE_HOOK_MUTATION_KIND,
+    GIT_OPTIONAL_LOCKS: process.env.GIT_OPTIONAL_LOCKS,
+  };
+
+  process.env.AGENTPLANE_HOOK_CAPABILITY_MODE = capability.mode;
+  process.env.AGENTPLANE_HOOK_GIT_INDEX_WRITE_INTENT = capability.gitIndexWriteIntent;
+  process.env.AGENTPLANE_HOOK_LOCK_CONTEXT = capability.lockContext;
+  process.env.AGENTPLANE_HOOK_MUTATION_KIND = capability.mutationKind;
+  if (capability.mode === "read_only") process.env.GIT_OPTIONAL_LOCKS = "0";
+
+  try {
+    return await run();
+  } finally {
+    restoreEnv(previous);
+  }
+}
+
+function restoreEnv(values: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(values)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}

--- a/packages/agentplane/src/commands/hooks/run.ts
+++ b/packages/agentplane/src/commands/hooks/run.ts
@@ -1,5 +1,10 @@
 import { mapBackendError } from "../../cli/error-map.js";
 import { CliError } from "../../shared/errors.js";
+import {
+  hookCapabilityDiagnosticContext,
+  resolveHookCapability,
+  withHookCapabilityEnvironment,
+} from "./capabilities.js";
 import type { HookName } from "./shared.js";
 import { runCommitMsgHook } from "./run.commit-msg.js";
 import { runPostMergeHook } from "./run.post-merge.js";
@@ -31,8 +36,9 @@ async function runHook(opts: HooksRunOptions): Promise<number> {
 }
 
 export async function cmdHooksRun(opts: HooksRunOptions): Promise<number> {
+  const capability = resolveHookCapability(opts.hook);
   try {
-    return await runHook(opts);
+    return await withHookCapabilityEnvironment(capability, () => runHook(opts));
   } catch (err) {
     const status = (err as { status?: unknown } | null)?.status;
     const stdout = (err as { stdout?: unknown } | null)?.stdout;
@@ -42,7 +48,16 @@ export async function cmdHooksRun(opts: HooksRunOptions): Promise<number> {
     if (typeof status === "number" && Number.isInteger(status) && status >= 0) {
       return status;
     }
-    if (err instanceof CliError) throw err;
+    if (err instanceof CliError) {
+      const context = hookCapabilityDiagnosticContext(capability);
+      if (err.context) Object.assign(context, err.context);
+      throw new CliError({
+        exitCode: err.exitCode,
+        code: err.code,
+        message: err.message,
+        context,
+      });
+    }
     throw mapBackendError(err, {
       command: `hooks run ${opts.hook}`,
       root: opts.rootOverride ?? null,


### PR DESCRIPTION
Task: `202605100837-PGH61Q`
Title: Pre-v0.5: split hook capabilities and declare write intent
Canonical task record: `.agentplane/tasks/202605100837-PGH61Q/README.md`

## Summary

Pre-v0.5: split hook capabilities and declare write intent

Classify hooks into read-only checks and write-capable enforcement. Read-only hooks should avoid index writes; write-capable hooks must take the worktree mutex or write outside the Git index. Push hooks must not create lifecycle/status commits implicitly.

## Scope

- In scope: Classify hooks into read-only checks and write-capable enforcement. Read-only hooks should avoid index writes; write-capable hooks must take the worktree mutex or write outside the Git index. Push hooks must not create lifecycle/status commits implicitly.
- Out of scope: unrelated refactors not required for "Pre-v0.5: split hook capabilities and declare write intent".

## Verification

- State: ok
- Note: Added explicit hook capability declarations: commit-msg/pre-commit/pre-push run as read-only hook_check paths with GIT_OPTIONAL_LOCKS=0 and forbidden Git index write intent; post-merge is declared write-capable but outside the Git index with hook_check lock context. Checks passed: hook capabilities + hook-run Vitest 26 tests, scoped ESLint, Prettier, and agentplane package build.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-10T17:03:20.977Z
- Branch: task-202605100837-PGH61Q-hook-capabilities
- Head: 81090060d212

```text
 .../src/commands/hooks/capabilities.test.ts        | 48 +++++++++++
 .../agentplane/src/commands/hooks/capabilities.ts  | 93 ++++++++++++++++++++++
 packages/agentplane/src/commands/hooks/run.ts      | 19 ++++-
 3 files changed, 158 insertions(+), 2 deletions(-)
```

</details>
