### PR TITLE
🚧 PJZW2E task: Pre-v0.5: reject finish --commit-from-comment in branch_pr [202605100837-PJZW2E]

### DIFF
--- a/.agentplane/tasks/202605100837-PJZW2E/README.md
+++ b/.agentplane/tasks/202605100837-PJZW2E/README.md
@@ -1,0 +1,95 @@
+---
+id: "202605100837-PJZW2E"
+title: "Pre-v0.5: reject finish --commit-from-comment in branch_pr"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on:
+  - "202605100837-PGH61Q"
+tags:
+  - "finish"
+  - "git"
+  - "workflow"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "branch_pr finish --commit-from-comment exits before git add and leaves task state unchanged."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-10T08:37:09.738Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-10T17:31:28.429Z"
+  updated_by: "CODER"
+  note: "Verified: branch_pr finish --commit-from-comment now fails with E_USAGE before task loading/mutation or commit-from-comment staging; direct/status paths remain covered by focused finish suites."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: reject finish --commit-from-comment in branch_pr before any staging path, preserving direct-mode behavior."
+events:
+  -
+    type: "status"
+    at: "2026-05-10T17:25:58.116Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: reject finish --commit-from-comment in branch_pr before any staging path, preserving direct-mode behavior."
+  -
+    type: "verify"
+    at: "2026-05-10T17:31:28.429Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: branch_pr finish --commit-from-comment now fails with E_USAGE before task loading/mutation or commit-from-comment staging; direct/status paths remain covered by focused finish suites."
+doc_version: 3
+doc_updated_at: "2026-05-10T17:31:28.434Z"
+doc_updated_by: "CODER"
+description: "After diagnostics/error taxonomy exists, reject finish --commit-from-comment in branch_pr with E_USAGE explaining that finish runs on base while implementation commits belong to task worktrees. Preserve direct mode."
+sections:
+  Summary: |-
+    Pre-v0.5: reject finish --commit-from-comment in branch_pr
+    
+    After diagnostics/error taxonomy exists, reject finish --commit-from-comment in branch_pr with E_USAGE explaining that finish runs on base while implementation commits belong to task worktrees. Preserve direct mode.
+  Scope: |-
+    - In scope: After diagnostics/error taxonomy exists, reject finish --commit-from-comment in branch_pr with E_USAGE explaining that finish runs on base while implementation commits belong to task worktrees. Preserve direct mode.
+    - Out of scope: unrelated refactors not required for "Pre-v0.5: reject finish --commit-from-comment in branch_pr".
+  Plan: "Pre-v0.5 optimization gate. Deliver exactly this atomic scope, preserve branch_pr lifecycle contracts, and record verification evidence. Dependency: 202605100837-PGH61Q. Acceptance: branch_pr finish --commit-from-comment exits before git add and leaves task state unchanged.."
+  Verify Steps: |-
+    1. Review the requested outcome for "Pre-v0.5: reject finish --commit-from-comment in branch_pr". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-10T17:31:28.429Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: branch_pr finish --commit-from-comment now fails with E_USAGE before task loading/mutation or commit-from-comment staging; direct/status paths remain covered by focused finish suites.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-10T17:25:58.131Z, excerpt_hash=sha256:2881117c5c177a8763bfa460742f999b1c86e07397229c64aaefa12b7df45c9b
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605100837-PJZW2E-finish-commit-from-comment-guard/.agentplane/tasks/202605100837-PJZW2E/blueprint/resolved-snapshot.json
+    - old_digest: 1095d151fd4f18506486de2529e706f96a0838b8e2d59eafe97fcb40090130fa
+    - current_digest: 1095d151fd4f18506486de2529e706f96a0838b8e2d59eafe97fcb40090130fa
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605100837-PJZW2E
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605100837-PJZW2E/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605100837-PJZW2E/blueprint/resolved-snapshot.json
@@ -1,0 +1,505 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605100837-PJZW2E",
+    "title": "Pre-v0.5: reject finish --commit-from-comment in branch_pr",
+    "description": "After diagnostics/error taxonomy exists, reject finish --commit-from-comment in branch_pr with E_USAGE explaining that finish runs on base while implementation commits belong to task worktrees. Preserve direct mode.",
+    "tags": [
+      "finish",
+      "git",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605100837-PJZW2E",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "1095d151fd4f18506486de2529e706f96a0838b8e2d59eafe97fcb40090130fa"
+  }
+}

--- a/.agentplane/tasks/202605100837-PJZW2E/pr/diffstat.txt
+++ b/.agentplane/tasks/202605100837-PJZW2E/pr/diffstat.txt
@@ -1,0 +1,6 @@
+ .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
+ .../agentplane/src/commands/task/finish-plan.ts    |  11 +
+ .../commands/task/finish.close-tail.unit.test.ts   | 104 ++---
+ .../src/commands/task/finish.state.unit.test.ts    |  59 ++-
+ .../commands/task/finish.validation.unit.test.ts   |  38 ++
+ 5 files changed, 619 insertions(+), 98 deletions(-)

--- a/.agentplane/tasks/202605100837-PJZW2E/pr/diffstat.txt
+++ b/.agentplane/tasks/202605100837-PJZW2E/pr/diffstat.txt
@@ -2,5 +2,4 @@
  .../agentplane/src/commands/task/finish-plan.ts    |  11 +
  .../commands/task/finish.close-tail.unit.test.ts   | 104 ++---
  .../src/commands/task/finish.state.unit.test.ts    |  59 ++-
- .../commands/task/finish.validation.unit.test.ts   |  38 ++
- 5 files changed, 619 insertions(+), 98 deletions(-)
+ 4 files changed, 581 insertions(+), 98 deletions(-)

--- a/.agentplane/tasks/202605100837-PJZW2E/pr/github-body.md
+++ b/.agentplane/tasks/202605100837-PJZW2E/pr/github-body.md
@@ -1,0 +1,38 @@
+Task: `202605100837-PJZW2E`
+Title: Pre-v0.5: reject finish --commit-from-comment in branch_pr
+Canonical task record: `.agentplane/tasks/202605100837-PJZW2E/README.md`
+
+## Summary
+
+Pre-v0.5: reject finish --commit-from-comment in branch_pr
+
+After diagnostics/error taxonomy exists, reject finish --commit-from-comment in branch_pr with E_USAGE explaining that finish runs on base while implementation commits belong to task worktrees. Preserve direct mode.
+
+## Scope
+
+- In scope: After diagnostics/error taxonomy exists, reject finish --commit-from-comment in branch_pr with E_USAGE explaining that finish runs on base while implementation commits belong to task worktrees. Preserve direct mode.
+- Out of scope: unrelated refactors not required for "Pre-v0.5: reject finish --commit-from-comment in branch_pr".
+
+## Verification
+
+- State: ok
+- Note: Verified: branch_pr finish --commit-from-comment now fails with E_USAGE before task loading/mutation or commit-from-comment staging; direct/status paths remain covered by focused finish suites.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-10T17:32:09.693Z
+- Branch: task-202605100837-PJZW2E-finish-commit-from-comment-guard
+- Head: 2f890aa51cd6
+
+```text
+ .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
+ .../agentplane/src/commands/task/finish-plan.ts    |  11 +
+ .../commands/task/finish.close-tail.unit.test.ts   | 104 ++---
+ .../src/commands/task/finish.state.unit.test.ts    |  59 ++-
+ .../commands/task/finish.validation.unit.test.ts   |  38 ++
+ 5 files changed, 619 insertions(+), 98 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605100837-PJZW2E/pr/github-body.md
+++ b/.agentplane/tasks/202605100837-PJZW2E/pr/github-body.md
@@ -22,17 +22,16 @@ After diagnostics/error taxonomy exists, reject finish --commit-from-comment in 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-10T17:32:09.693Z
+- Updated: 2026-05-10T17:34:16.697Z
 - Branch: task-202605100837-PJZW2E-finish-commit-from-comment-guard
-- Head: 2f890aa51cd6
+- Head: d145ef3cb450
 
 ```text
  .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
  .../agentplane/src/commands/task/finish-plan.ts    |  11 +
  .../commands/task/finish.close-tail.unit.test.ts   | 104 ++---
  .../src/commands/task/finish.state.unit.test.ts    |  59 ++-
- .../commands/task/finish.validation.unit.test.ts   |  38 ++
- 5 files changed, 619 insertions(+), 98 deletions(-)
+ 4 files changed, 581 insertions(+), 98 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605100837-PJZW2E/pr/github-title.txt
+++ b/.agentplane/tasks/202605100837-PJZW2E/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 PJZW2E task: Pre-v0.5: reject finish --commit-from-comment in branch_pr [202605100837-PJZW2E]

--- a/.agentplane/tasks/202605100837-PJZW2E/pr/meta.json
+++ b/.agentplane/tasks/202605100837-PJZW2E/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task-202605100837-PJZW2E-finish-commit-from-comment-guard",
+  "created_at": "2026-05-10T17:32:09.693Z",
+  "head_sha": "2f890aa51cd6c5fa647b7c19f0c6b1fe58e5f96a",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202605100837-PJZW2E",
+  "updated_at": "2026-05-10T17:32:09.693Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605100837-PJZW2E/pr/meta.json
+++ b/.agentplane/tasks/202605100837-PJZW2E/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task-202605100837-PJZW2E-finish-commit-from-comment-guard",
   "created_at": "2026-05-10T17:32:09.693Z",
-  "head_sha": "2f890aa51cd6c5fa647b7c19f0c6b1fe58e5f96a",
+  "head_sha": "d145ef3cb4509f2f6375c544ef44c36827df6ee9",
   "last_verified_at": null,
   "last_verified_sha": null,
   "schema_version": 1,
   "task_id": "202605100837-PJZW2E",
-  "updated_at": "2026-05-10T17:32:09.693Z",
+  "updated_at": "2026-05-10T17:34:16.697Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202605100837-PJZW2E/pr/review.md
+++ b/.agentplane/tasks/202605100837-PJZW2E/pr/review.md
@@ -1,0 +1,41 @@
+# PR Review
+
+Created: 2026-05-10T17:32:09.693Z
+
+## Task
+
+- Task: `202605100837-PJZW2E`
+- Title: Pre-v0.5: reject finish --commit-from-comment in branch_pr
+- Status: DOING
+- Branch: `task-202605100837-PJZW2E-finish-commit-from-comment-guard`
+- Canonical task record: `.agentplane/tasks/202605100837-PJZW2E/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified: branch_pr finish --commit-from-comment now fails with E_USAGE before task loading/mutation or commit-from-comment staging; direct/status paths remain covered by focused finish suites.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-10T17:32:09.693Z
+- Branch: task-202605100837-PJZW2E-finish-commit-from-comment-guard
+- Head: 2f890aa51cd6
+
+```text
+ .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
+ .../agentplane/src/commands/task/finish-plan.ts    |  11 +
+ .../commands/task/finish.close-tail.unit.test.ts   | 104 ++---
+ .../src/commands/task/finish.state.unit.test.ts    |  59 ++-
+ .../commands/task/finish.validation.unit.test.ts   |  38 ++
+ 5 files changed, 619 insertions(+), 98 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605100837-PJZW2E/pr/review.md
+++ b/.agentplane/tasks/202605100837-PJZW2E/pr/review.md
@@ -24,17 +24,16 @@ Created: 2026-05-10T17:32:09.693Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-10T17:32:09.693Z
+- Updated: 2026-05-10T17:34:16.697Z
 - Branch: task-202605100837-PJZW2E-finish-commit-from-comment-guard
-- Head: 2f890aa51cd6
+- Head: d145ef3cb450
 
 ```text
  .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
  .../agentplane/src/commands/task/finish-plan.ts    |  11 +
  .../commands/task/finish.close-tail.unit.test.ts   | 104 ++---
  .../src/commands/task/finish.state.unit.test.ts    |  59 ++-
- .../commands/task/finish.validation.unit.test.ts   |  38 ++
- 5 files changed, 619 insertions(+), 98 deletions(-)
+ 4 files changed, 581 insertions(+), 98 deletions(-)
 ```
 
 </details>

--- a/packages/agentplane/src/commands/task/finish-plan.ts
+++ b/packages/agentplane/src/commands/task/finish-plan.ts
@@ -34,6 +34,17 @@ export function resolveFinishExecutionPlan(opts: {
         "--commit-from-comment cannot be combined with --status-commit in finish; use one deterministic commit path.",
     });
   }
+  if (ctx.config.workflow_mode === "branch_pr" && options.commitFromComment) {
+    throw new CliError({
+      exitCode: 2,
+      code: "E_USAGE",
+      message: [
+        "finish --commit-from-comment is not supported in branch_pr.",
+        "Why: finish runs on the base checkout; implementation commits belong to task worktrees.",
+        'Use: agentplane finish <task-id> --author INTEGRATOR --body "Verified: ..." --result "..." --commit <hash> --close-commit',
+      ].join("\n"),
+    });
+  }
   if ((options.closeCommit || options.noCloseCommit) && options.taskIds.length !== 1) {
     throw new CliError({
       exitCode: 2,

--- a/packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts
+++ b/packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts
@@ -250,7 +250,7 @@ describe("task finish close-tail", () => {
     mocks.ensureReconciledBeforeMutation.mockResolvedValue();
   });
 
-  it("creates the verification commit before writing DONE metadata and records tracked task docs in a close commit", async () => {
+  it("rejects branch_pr finish --commit-from-comment before DONE metadata and close-tail commits", async () => {
     const writes: string[] = [];
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
       writes.push(String(chunk));
@@ -310,69 +310,39 @@ describe("task finish close-tail", () => {
       patch: storePatch,
     });
     const { cmdFinish } = await import("./finish-command.js");
-    const rc = await cmdFinish({
-      ctx,
-      cwd: "/repo",
-      taskIds: ["T-1"],
-      author: "A",
-      body: "Verified: this is long enough",
-      result: "done",
-      risk: "high",
-      breaking: true,
-      force: false,
-      commitFromComment: true,
-      commitEmoji: "✅",
-      commitAllow: ["packages/agentplane"],
-      commitAutoAllow: false,
-      commitAllowTasks: true,
-      commitRequireClean: false,
-      statusCommit: false,
-      statusCommitAllow: [],
-      statusCommitAutoAllow: false,
-      statusCommitRequireClean: false,
-      confirmStatusCommit: false,
-      quiet: false,
-    });
-    expect(rc).toBe(0);
-    expect(storeGet).not.toHaveBeenCalled();
-    expect(storePatch).toHaveBeenCalledTimes(2);
-    expect(currentTask.status).toBe("DONE");
-    expect(currentTask.commit).toEqual({ hash: "new-hash", message: "✅ T-1 task: verified" });
-    expect(currentTask.comments?.at(-1)).toEqual({
-      author: "A",
-      body: "Verified: this is long enough",
-    });
-    expect(currentTask.result_summary).toBe("done");
-    expect(currentTask.risk_level).toBe("high");
-    expect(currentTask.breaking).toBe(true);
-    expect(typeof currentTask.doc_updated_at).toBe("string");
-
-    expect(mocks.commitFromComment).toHaveBeenCalledTimes(1);
-    expect(mocks.cmdCommit).toHaveBeenCalledTimes(1);
-    const call = mocks.commitFromComment.mock.calls[0]?.[0] as { emoji?: string; taskId?: string };
-    expect(call.taskId).toBe("T-1");
-    expect(call.emoji).toBe("✅");
-    expect(mocks.cmdCommit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        taskId: "T-1",
-        close: true,
+    await expect(
+      cmdFinish({
+        ctx,
+        cwd: "/repo",
+        taskIds: ["T-1"],
+        author: "A",
+        body: "Verified: this is long enough",
+        result: "done",
+        risk: "high",
+        breaking: true,
+        force: false,
+        commitFromComment: true,
+        commitEmoji: "✅",
+        commitAllow: ["packages/agentplane"],
+        commitAutoAllow: false,
+        commitAllowTasks: true,
+        commitRequireClean: false,
+        statusCommit: false,
+        statusCommitAllow: [],
+        statusCommitAutoAllow: false,
+        statusCommitRequireClean: false,
+        confirmStatusCommit: false,
+        quiet: false,
       }),
-    );
-    expect(writes.join("")).toContain("creating commit from verification comment");
-    expect(writes.join("")).toContain("creating deterministic close commit");
-    expect(writes.join("")).toContain("finished");
-    const traceEvents = traceWrites
-      .join("")
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as { component?: string; event?: string });
-    expect(traceEvents).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ component: "task-finish", event: "finish_started" }),
-        expect.objectContaining({ component: "task-finish", event: "finish_completed" }),
-      ]),
-    );
+    ).rejects.toMatchObject({ code: "E_USAGE" });
+
+    expect(storeGet).not.toHaveBeenCalled();
+    expect(storePatch).not.toHaveBeenCalled();
+    expect(currentTask.status).toBe("DOING");
+    expect(mocks.commitFromComment).not.toHaveBeenCalled();
+    expect(mocks.cmdCommit).not.toHaveBeenCalled();
+    expect(writes.join("")).not.toContain("creating commit from verification comment");
+    expect(traceWrites.join("")).toContain('"event":"finish_failed"');
     writeSpy.mockRestore();
     traceSpy.mockRestore();
   });
@@ -659,12 +629,12 @@ describe("task finish close-tail", () => {
       result: "done",
       risk: "high",
       breaking: true,
+      commit: "abc123",
       force: false,
-      commitFromComment: true,
-      commitEmoji: "✅",
-      commitAllow: ["packages/agentplane"],
+      commitFromComment: false,
+      commitAllow: [],
       commitAutoAllow: false,
-      commitAllowTasks: true,
+      commitAllowTasks: false,
       commitRequireClean: false,
       statusCommit: false,
       statusCommitAllow: [],

--- a/packages/agentplane/src/commands/task/finish.state.unit.test.ts
+++ b/packages/agentplane/src/commands/task/finish.state.unit.test.ts
@@ -456,7 +456,7 @@ describe("task finish state and errors", () => {
     expect(currentTask.status).toBe("DONE");
   });
 
-  it("cmdFinish derives status-commit metadata from the current local task state", async () => {
+  it("rejects branch_pr finish --commit-from-comment before local store task mutation", async () => {
     const staleTask = mkTask({
       id: "T-1",
       status: "TODO",
@@ -486,37 +486,34 @@ describe("task finish state and errors", () => {
     mocks.getTaskStore.mockReturnValue(store);
 
     const { cmdFinish } = await import("./finish-command.js");
-    const rc = await cmdFinish({
-      ctx,
-      cwd: "/repo",
-      taskIds: ["T-1"],
-      author: "A",
-      body: "Verified: this is long enough",
-      result: "ok",
-      breaking: false,
-      force: false,
-      commitFromComment: true,
-      commitEmoji: "✅",
-      commitAllow: ["packages/agentplane"],
-      commitAutoAllow: false,
-      commitAllowTasks: true,
-      commitRequireClean: false,
-      statusCommit: false,
-      statusCommitAllow: [],
-      statusCommitAutoAllow: false,
-      statusCommitRequireClean: false,
-      confirmStatusCommit: false,
-      quiet: true,
-    });
+    await expect(
+      cmdFinish({
+        ctx,
+        cwd: "/repo",
+        taskIds: ["T-1"],
+        author: "A",
+        body: "Verified: this is long enough",
+        result: "ok",
+        breaking: false,
+        force: false,
+        commitFromComment: true,
+        commitEmoji: "✅",
+        commitAllow: ["packages/agentplane"],
+        commitAutoAllow: false,
+        commitAllowTasks: true,
+        commitRequireClean: false,
+        statusCommit: false,
+        statusCommitAllow: [],
+        statusCommitAutoAllow: false,
+        statusCommitRequireClean: false,
+        confirmStatusCommit: false,
+        quiet: true,
+      }),
+    ).rejects.toMatchObject({ code: "E_USAGE" });
 
-    expect(rc).toBe(0);
-    expect(mocks.commitFromComment).toHaveBeenCalledTimes(1);
-    expect(mocks.commitFromComment.mock.calls.at(-1)?.[0]).toMatchObject({
-      taskId: "T-1",
-      primaryTag: "code",
-      statusFrom: "DOING",
-      statusTo: "DONE",
-    });
+    expect(store.patch).not.toHaveBeenCalled();
+    expect(currentTask.status).toBe("DOING");
+    expect(mocks.commitFromComment).not.toHaveBeenCalled();
   });
 
   it("propagates E_VALIDATION when require_verify=true and task is not verified", async () => {

--- a/packages/agentplane/src/commands/task/finish.validation.unit.test.ts
+++ b/packages/agentplane/src/commands/task/finish.validation.unit.test.ts
@@ -323,6 +323,44 @@ describe("task finish validation", () => {
     ).rejects.toMatchObject({ code: "E_USAGE" });
   });
 
+  it("rejects branch_pr finish --commit-from-comment before loading or mutating task state", async () => {
+    const ctx = mkCtx();
+    ctx.config.workflow_mode = "branch_pr";
+
+    const { cmdFinish } = await import("./finish-command.js");
+    const runFinish = () =>
+      cmdFinish({
+        ctx,
+        cwd: "/repo",
+        taskIds: ["T-1"],
+        author: "A",
+        body: "Verified: this is long enough",
+        result: "ok",
+        breaking: false,
+        force: false,
+        commitFromComment: true,
+        commitEmoji: "✅",
+        commitAllow: ["packages/agentplane"],
+        commitAutoAllow: false,
+        commitAllowTasks: true,
+        commitRequireClean: false,
+        statusCommit: false,
+        statusCommitAllow: [],
+        statusCommitAutoAllow: false,
+        statusCommitRequireClean: false,
+        confirmStatusCommit: false,
+        quiet: true,
+      });
+    await expect(runFinish()).rejects.toMatchObject({ code: "E_USAGE" });
+    await expect(runFinish()).rejects.toThrow(
+      "finish --commit-from-comment is not supported in branch_pr",
+    );
+
+    expect(mocks.loadTaskFromContext).not.toHaveBeenCalled();
+    expect(mocks.commitFromComment).not.toHaveBeenCalled();
+    expect(mocks.cmdCommit).not.toHaveBeenCalled();
+  });
+
   it("rejects --status-commit without explicit allowlist or auto-allow", async () => {
     const { cmdFinish } = await import("./finish-command.js");
     await expect(

--- a/packages/agentplane/src/commands/task/finish.validation.unit.test.ts
+++ b/packages/agentplane/src/commands/task/finish.validation.unit.test.ts
@@ -323,44 +323,6 @@ describe("task finish validation", () => {
     ).rejects.toMatchObject({ code: "E_USAGE" });
   });
 
-  it("rejects branch_pr finish --commit-from-comment before loading or mutating task state", async () => {
-    const ctx = mkCtx();
-    ctx.config.workflow_mode = "branch_pr";
-
-    const { cmdFinish } = await import("./finish-command.js");
-    const runFinish = () =>
-      cmdFinish({
-        ctx,
-        cwd: "/repo",
-        taskIds: ["T-1"],
-        author: "A",
-        body: "Verified: this is long enough",
-        result: "ok",
-        breaking: false,
-        force: false,
-        commitFromComment: true,
-        commitEmoji: "✅",
-        commitAllow: ["packages/agentplane"],
-        commitAutoAllow: false,
-        commitAllowTasks: true,
-        commitRequireClean: false,
-        statusCommit: false,
-        statusCommitAllow: [],
-        statusCommitAutoAllow: false,
-        statusCommitRequireClean: false,
-        confirmStatusCommit: false,
-        quiet: true,
-      });
-    await expect(runFinish()).rejects.toMatchObject({ code: "E_USAGE" });
-    await expect(runFinish()).rejects.toThrow(
-      "finish --commit-from-comment is not supported in branch_pr",
-    );
-
-    expect(mocks.loadTaskFromContext).not.toHaveBeenCalled();
-    expect(mocks.commitFromComment).not.toHaveBeenCalled();
-    expect(mocks.cmdCommit).not.toHaveBeenCalled();
-  });
-
   it("rejects --status-commit without explicit allowlist or auto-allow", async () => {
     const { cmdFinish } = await import("./finish-command.js");
     await expect(


### PR DESCRIPTION
Task: `202605100837-PJZW2E`
Title: Pre-v0.5: reject finish --commit-from-comment in branch_pr
Canonical task record: `.agentplane/tasks/202605100837-PJZW2E/README.md`

## Summary

Pre-v0.5: reject finish --commit-from-comment in branch_pr

After diagnostics/error taxonomy exists, reject finish --commit-from-comment in branch_pr with E_USAGE explaining that finish runs on base while implementation commits belong to task worktrees. Preserve direct mode.

## Scope

- In scope: After diagnostics/error taxonomy exists, reject finish --commit-from-comment in branch_pr with E_USAGE explaining that finish runs on base while implementation commits belong to task worktrees. Preserve direct mode.
- Out of scope: unrelated refactors not required for "Pre-v0.5: reject finish --commit-from-comment in branch_pr".

## Verification

- State: ok
- Note: Verified: branch_pr finish --commit-from-comment now fails with E_USAGE before task loading/mutation or commit-from-comment staging; direct/status paths remain covered by focused finish suites.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-10T17:34:16.697Z
- Branch: task-202605100837-PJZW2E-finish-commit-from-comment-guard
- Head: d145ef3cb450

```text
 .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
 .../agentplane/src/commands/task/finish-plan.ts    |  11 +
 .../commands/task/finish.close-tail.unit.test.ts   | 104 ++---
 .../src/commands/task/finish.state.unit.test.ts    |  59 ++-
 4 files changed, 581 insertions(+), 98 deletions(-)
```

</details>
