### PR TITLE
🚧 6FTSE2 task: Pre-v0.5: enforce lifecycle commit-from-comment command matrix [202605100837-6FTSE2]

### DIFF
--- a/.agentplane/tasks/202605100837-6FTSE2/README.md
+++ b/.agentplane/tasks/202605100837-6FTSE2/README.md
@@ -1,0 +1,95 @@
+---
+id: "202605100837-6FTSE2"
+title: "Pre-v0.5: enforce lifecycle commit-from-comment command matrix"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on:
+  - "202605100837-PJZW2E"
+tags:
+  - "git"
+  - "lifecycle"
+  - "workflow"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "Matrix tests cover allowed and denied command/mode/location combinations."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-10T08:37:11.911Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-11T06:24:37.778Z"
+  updated_by: "CODER"
+  note: "Verified: lifecycle commit-from-comment matrix is enforced by a shared guard; start-ready/set-status are allowed in direct and branch_pr task worktrees but rejected on branch_pr base, finish is rejected in branch_pr, and verify has no commit-from-comment option."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: enforce lifecycle commit-from-comment command matrix across direct and branch_pr locations."
+events:
+  -
+    type: "status"
+    at: "2026-05-11T06:20:43.286Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: enforce lifecycle commit-from-comment command matrix across direct and branch_pr locations."
+  -
+    type: "verify"
+    at: "2026-05-11T06:24:37.778Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: lifecycle commit-from-comment matrix is enforced by a shared guard; start-ready/set-status are allowed in direct and branch_pr task worktrees but rejected on branch_pr base, finish is rejected in branch_pr, and verify has no commit-from-comment option."
+doc_version: 3
+doc_updated_at: "2026-05-11T06:24:37.784Z"
+doc_updated_by: "CODER"
+description: "Define and enforce the command/mode matrix for start-ready, verify, set-status, and finish commit-from-comment behavior across direct, branch_pr task worktree, and branch_pr base checkout."
+sections:
+  Summary: |-
+    Pre-v0.5: enforce lifecycle commit-from-comment command matrix
+    
+    Define and enforce the command/mode matrix for start-ready, verify, set-status, and finish commit-from-comment behavior across direct, branch_pr task worktree, and branch_pr base checkout.
+  Scope: |-
+    - In scope: Define and enforce the command/mode matrix for start-ready, verify, set-status, and finish commit-from-comment behavior across direct, branch_pr task worktree, and branch_pr base checkout.
+    - Out of scope: unrelated refactors not required for "Pre-v0.5: enforce lifecycle commit-from-comment command matrix".
+  Plan: "Pre-v0.5 optimization gate. Deliver exactly this atomic scope, preserve branch_pr lifecycle contracts, and record verification evidence. Dependency: 202605100837-PJZW2E. Acceptance: Matrix tests cover allowed and denied command/mode/location combinations.."
+  Verify Steps: |-
+    1. Review the requested outcome for "Pre-v0.5: enforce lifecycle commit-from-comment command matrix". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-11T06:24:37.778Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: lifecycle commit-from-comment matrix is enforced by a shared guard; start-ready/set-status are allowed in direct and branch_pr task worktrees but rejected on branch_pr base, finish is rejected in branch_pr, and verify has no commit-from-comment option.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-11T06:20:43.296Z, excerpt_hash=sha256:9994c0d9111e0e75254c470d168106ee37246cc35fcd706c6bb071b7504c03c9
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605100837-6FTSE2-lifecycle-commit-matrix/.agentplane/tasks/202605100837-6FTSE2/blueprint/resolved-snapshot.json
+    - old_digest: 3a122939c4e5b065c73ed6d92981576c2a743e8cf1056d501a8afca8302652f6
+    - current_digest: 3a122939c4e5b065c73ed6d92981576c2a743e8cf1056d501a8afca8302652f6
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605100837-6FTSE2
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605100837-6FTSE2/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605100837-6FTSE2/blueprint/resolved-snapshot.json
@@ -1,0 +1,505 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605100837-6FTSE2",
+    "title": "Pre-v0.5: enforce lifecycle commit-from-comment command matrix",
+    "description": "Define and enforce the command/mode matrix for start-ready, verify, set-status, and finish commit-from-comment behavior across direct, branch_pr task worktree, and branch_pr base checkout.",
+    "tags": [
+      "git",
+      "lifecycle",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605100837-6FTSE2",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "3a122939c4e5b065c73ed6d92981576c2a743e8cf1056d501a8afca8302652f6"
+  }
+}

--- a/.agentplane/tasks/202605100837-6FTSE2/pr/diffstat.txt
+++ b/.agentplane/tasks/202605100837-6FTSE2/pr/diffstat.txt
@@ -1,0 +1,7 @@
+ .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
+ .../task/lifecycle-commit-matrix.unit.test.ts      | 141 ++++++
+ .../agentplane/src/commands/task/set-status.ts     |   9 +
+ packages/agentplane/src/commands/task/shared.ts    |   1 +
+ .../src/commands/task/shared/transitions.ts        |  55 +++
+ packages/agentplane/src/commands/task/start.ts     |   9 +
+ 6 files changed, 720 insertions(+)

--- a/.agentplane/tasks/202605100837-6FTSE2/pr/github-body.md
+++ b/.agentplane/tasks/202605100837-6FTSE2/pr/github-body.md
@@ -1,0 +1,39 @@
+Task: `202605100837-6FTSE2`
+Title: Pre-v0.5: enforce lifecycle commit-from-comment command matrix
+Canonical task record: `.agentplane/tasks/202605100837-6FTSE2/README.md`
+
+## Summary
+
+Pre-v0.5: enforce lifecycle commit-from-comment command matrix
+
+Define and enforce the command/mode matrix for start-ready, verify, set-status, and finish commit-from-comment behavior across direct, branch_pr task worktree, and branch_pr base checkout.
+
+## Scope
+
+- In scope: Define and enforce the command/mode matrix for start-ready, verify, set-status, and finish commit-from-comment behavior across direct, branch_pr task worktree, and branch_pr base checkout.
+- Out of scope: unrelated refactors not required for "Pre-v0.5: enforce lifecycle commit-from-comment command matrix".
+
+## Verification
+
+- State: ok
+- Note: Verified: lifecycle commit-from-comment matrix is enforced by a shared guard; start-ready/set-status are allowed in direct and branch_pr task worktrees but rejected on branch_pr base, finish is rejected in branch_pr, and verify has no commit-from-comment option.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-11T06:48:39.662Z
+- Branch: task-202605100837-6FTSE2-lifecycle-commit-matrix
+- Head: 5b4c8defed12
+
+```text
+ .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
+ .../task/lifecycle-commit-matrix.unit.test.ts      | 141 ++++++
+ .../agentplane/src/commands/task/set-status.ts     |   9 +
+ packages/agentplane/src/commands/task/shared.ts    |   1 +
+ .../src/commands/task/shared/transitions.ts        |  55 +++
+ packages/agentplane/src/commands/task/start.ts     |   9 +
+ 6 files changed, 720 insertions(+)
+```
+
+</details>

--- a/.agentplane/tasks/202605100837-6FTSE2/pr/github-title.txt
+++ b/.agentplane/tasks/202605100837-6FTSE2/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 6FTSE2 task: Pre-v0.5: enforce lifecycle commit-from-comment command matrix [202605100837-6FTSE2]

--- a/.agentplane/tasks/202605100837-6FTSE2/pr/meta.json
+++ b/.agentplane/tasks/202605100837-6FTSE2/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task-202605100837-6FTSE2-lifecycle-commit-matrix",
+  "created_at": "2026-05-11T06:48:39.662Z",
+  "head_sha": "5b4c8defed124e056cad7ea513dedeea6109bf76",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202605100837-6FTSE2",
+  "updated_at": "2026-05-11T06:48:39.662Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605100837-6FTSE2/pr/review.md
+++ b/.agentplane/tasks/202605100837-6FTSE2/pr/review.md
@@ -1,0 +1,42 @@
+# PR Review
+
+Created: 2026-05-11T06:48:39.662Z
+
+## Task
+
+- Task: `202605100837-6FTSE2`
+- Title: Pre-v0.5: enforce lifecycle commit-from-comment command matrix
+- Status: DOING
+- Branch: `task-202605100837-6FTSE2-lifecycle-commit-matrix`
+- Canonical task record: `.agentplane/tasks/202605100837-6FTSE2/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified: lifecycle commit-from-comment matrix is enforced by a shared guard; start-ready/set-status are allowed in direct and branch_pr task worktrees but rejected on branch_pr base, finish is rejected in branch_pr, and verify has no commit-from-comment option.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-11T06:48:39.662Z
+- Branch: task-202605100837-6FTSE2-lifecycle-commit-matrix
+- Head: 5b4c8defed12
+
+```text
+ .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
+ .../task/lifecycle-commit-matrix.unit.test.ts      | 141 ++++++
+ .../agentplane/src/commands/task/set-status.ts     |   9 +
+ packages/agentplane/src/commands/task/shared.ts    |   1 +
+ .../src/commands/task/shared/transitions.ts        |  55 +++
+ packages/agentplane/src/commands/task/start.ts     |   9 +
+ 6 files changed, 720 insertions(+)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/task/lifecycle-commit-matrix.unit.test.ts
+++ b/packages/agentplane/src/commands/task/lifecycle-commit-matrix.unit.test.ts
@@ -1,0 +1,141 @@
+import { defaultConfig } from "@agentplaneorg/core/config";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CommandContext } from "../shared/task-backend.js";
+
+const mocks = vi.hoisted(() => ({
+  gitCurrentBranch: vi.fn(),
+  resolveBaseBranch: vi.fn(),
+}));
+
+vi.mock("@agentplaneorg/core/git", async () => {
+  const actualUnknown: unknown = await vi.importActual("@agentplaneorg/core/git");
+  const actual =
+    actualUnknown && typeof actualUnknown === "object"
+      ? (actualUnknown as Record<string, unknown>)
+      : {};
+  return {
+    ...actual,
+    resolveBaseBranch: mocks.resolveBaseBranch,
+  };
+});
+
+vi.mock("../shared/git-ops.js", async (importOriginal) => {
+  const actualUnknown: unknown = await importOriginal();
+  const actual =
+    actualUnknown && typeof actualUnknown === "object"
+      ? (actualUnknown as Record<string, unknown>)
+      : {};
+  return {
+    ...actual,
+    gitCurrentBranch: mocks.gitCurrentBranch,
+  };
+});
+
+function mkCtx(mode: "direct" | "branch_pr"): CommandContext {
+  const config = defaultConfig();
+  config.workflow_mode = mode;
+  return {
+    config,
+    resolvedProject: {
+      gitRoot: "/repo",
+      agentplaneDir: "/repo/.agentplane",
+    },
+  } as CommandContext;
+}
+
+describe("lifecycle commit-from-comment matrix", () => {
+  beforeEach(() => {
+    mocks.gitCurrentBranch.mockReset();
+    mocks.resolveBaseBranch.mockReset();
+  });
+
+  it("allows task lifecycle comment commits in direct mode without branch lookup", async () => {
+    const { ensureLifecycleCommentCommitLocation } = await import("./shared/transitions.js");
+
+    await expect(
+      ensureLifecycleCommentCommitLocation({
+        enabled: true,
+        ctx: mkCtx("direct"),
+        cwd: "/repo",
+        command: "task start-ready",
+        taskId: "T-1",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.resolveBaseBranch).not.toHaveBeenCalled();
+    expect(mocks.gitCurrentBranch).not.toHaveBeenCalled();
+  });
+
+  it("allows start-ready and set-status comment commits from a branch_pr task worktree", async () => {
+    mocks.resolveBaseBranch.mockResolvedValue("main");
+    mocks.gitCurrentBranch.mockResolvedValue("task/T-1/work");
+    const { ensureLifecycleCommentCommitLocation } = await import("./shared/transitions.js");
+
+    await expect(
+      ensureLifecycleCommentCommitLocation({
+        enabled: true,
+        ctx: mkCtx("branch_pr"),
+        cwd: "/repo",
+        command: "task start-ready",
+        taskId: "T-1",
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      ensureLifecycleCommentCommitLocation({
+        enabled: true,
+        ctx: mkCtx("branch_pr"),
+        cwd: "/repo",
+        command: "task set-status",
+        taskId: "T-1",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects start-ready and set-status comment commits from the branch_pr base checkout", async () => {
+    mocks.resolveBaseBranch.mockResolvedValue("main");
+    mocks.gitCurrentBranch.mockResolvedValue("main");
+    const { ensureLifecycleCommentCommitLocation } = await import("./shared/transitions.js");
+
+    const runStartReady = () =>
+      ensureLifecycleCommentCommitLocation({
+        enabled: true,
+        ctx: mkCtx("branch_pr"),
+        cwd: "/repo",
+        command: "task start-ready",
+        taskId: "T-1",
+      });
+    await expect(runStartReady()).rejects.toMatchObject({ code: "E_USAGE" });
+    await expect(runStartReady()).rejects.toThrow("branch_pr base checkout");
+    await expect(
+      ensureLifecycleCommentCommitLocation({
+        enabled: true,
+        ctx: mkCtx("branch_pr"),
+        cwd: "/repo",
+        command: "task set-status",
+        taskId: "T-1",
+      }),
+    ).rejects.toMatchObject({ code: "E_USAGE" });
+  });
+
+  it("rejects finish comment commits anywhere in branch_pr", async () => {
+    const { ensureLifecycleCommentCommitLocation } = await import("./shared/transitions.js");
+
+    const runFinish = () =>
+      ensureLifecycleCommentCommitLocation({
+        enabled: true,
+        ctx: mkCtx("branch_pr"),
+        cwd: "/repo",
+        command: "finish",
+        taskId: "T-1",
+      });
+    await expect(runFinish()).rejects.toMatchObject({ code: "E_USAGE" });
+    await expect(runFinish()).rejects.toThrow("finish --commit-from-comment is not supported");
+  });
+
+  it("keeps verify out of the commit-from-comment surface", async () => {
+    const { verifySpec } = await import("../verify.spec.js");
+
+    expect(verifySpec.options.some((option) => option.name === "commit-from-comment")).toBe(false);
+  });
+});

--- a/packages/agentplane/src/commands/task/set-status.ts
+++ b/packages/agentplane/src/commands/task/set-status.ts
@@ -12,6 +12,7 @@ import {
 import {
   applyTaskStatusTransitionCommand,
   defaultCommitEmojiForStatus,
+  ensureLifecycleCommentCommitLocation,
   normalizeTaskStatus,
   nowIso,
   prepareTaskTransitionComment,
@@ -69,6 +70,14 @@ export async function cmdTaskSetStatus(opts: {
       });
     }
     const resolved = ctx.resolvedProject;
+    await ensureLifecycleCommentCommitLocation({
+      enabled: opts.commitFromComment,
+      ctx,
+      cwd: opts.cwd,
+      rootOverride: opts.rootOverride,
+      command: "task set-status",
+      taskId: opts.taskId,
+    });
 
     const preparedComment =
       opts.author && opts.body

--- a/packages/agentplane/src/commands/task/shared.ts
+++ b/packages/agentplane/src/commands/task/shared.ts
@@ -48,6 +48,7 @@ export {
   ensurePlanApprovedIfRequired,
   ensureVerificationSatisfiedIfRequired,
   ensureCommentCommitAllowed,
+  ensureLifecycleCommentCommitLocation,
   emitTransitionWarnings,
   requireStructuredComment,
   type TaskTransitionCommentCommandOptions,

--- a/packages/agentplane/src/commands/task/shared/transitions.ts
+++ b/packages/agentplane/src/commands/task/shared/transitions.ts
@@ -1,4 +1,5 @@
 import type { AgentplaneConfig } from "@agentplaneorg/core/config";
+import { resolveBaseBranch } from "@agentplaneorg/core/git";
 import { execFileAsync } from "@agentplaneorg/core/process";
 import { normalizeTaskStatus } from "@agentplaneorg/core/tasks";
 
@@ -9,6 +10,7 @@ import { CliError } from "../../../shared/errors.js";
 import { parseGitLogHashSubject } from "./git-log.js";
 import type { TaskData } from "../../../backends/task-backend.js";
 import { commitFromComment } from "../../guard/impl/comment-commit.js";
+import { gitCurrentBranch } from "../../shared/git-ops.js";
 import { refreshBranchPrArtifactsAfterTaskCommit } from "../../shared/post-commit-pr-artifacts.js";
 import type { CommandContext } from "../../shared/task-backend.js";
 import { requiresVerificationByPrimary, toStringArray } from "./tags.js";
@@ -70,6 +72,59 @@ export function ensureCommentCommitAllowed(opts: {
   if (warning) {
     process.stderr.write(`${warnMessage(warning)}\n`);
   }
+}
+
+export async function ensureLifecycleCommentCommitLocation(opts: {
+  enabled: boolean;
+  ctx: CommandContext;
+  cwd: string;
+  rootOverride?: string;
+  command: "task start-ready" | "task set-status" | "finish";
+  taskId: string;
+}): Promise<void> {
+  if (!opts.enabled) return;
+  if (opts.ctx.config.workflow_mode === "direct") return;
+
+  if (opts.command === "finish") {
+    throw new CliError({
+      exitCode: 2,
+      code: "E_USAGE",
+      message: [
+        "finish --commit-from-comment is not supported in branch_pr.",
+        "Why: finish runs on the base checkout; implementation commits belong to task worktrees.",
+        'Use: agentplane finish <task-id> --author INTEGRATOR --body "Verified: ..." --result "..." --commit <hash> --close-commit',
+      ].join("\n"),
+    });
+  }
+
+  const baseBranch = await resolveBaseBranch({
+    cwd: opts.cwd,
+    rootOverride: opts.rootOverride ?? null,
+    cliBaseOpt: null,
+    mode: opts.ctx.config.workflow_mode,
+  });
+  if (!baseBranch) {
+    throw new CliError({
+      exitCode: 2,
+      code: "E_USAGE",
+      message:
+        `${opts.command} --commit-from-comment requires a resolved branch_pr base branch; ` +
+        "run `agentplane branch base set <branch>` first.",
+    });
+  }
+
+  const currentBranch = await gitCurrentBranch(opts.ctx.resolvedProject.gitRoot);
+  if (currentBranch !== baseBranch) return;
+
+  throw new CliError({
+    exitCode: 2,
+    code: "E_USAGE",
+    message: [
+      `${opts.command} --commit-from-comment is not supported on the branch_pr base checkout.`,
+      "Why: lifecycle comment commits for task execution belong to the task worktree.",
+      `Use: agentplane work start ${opts.taskId} --agent <ROLE> --slug <slug> --worktree, then rerun from the task worktree.`,
+    ].join("\n"),
+  });
 }
 
 export function emitTransitionWarnings(warnings: readonly string[], quiet: boolean): void {

--- a/packages/agentplane/src/commands/task/start.ts
+++ b/packages/agentplane/src/commands/task/start.ts
@@ -12,6 +12,7 @@ import {
   applyTaskStatusTransitionCommand,
   assertVerifyStepsFilled,
   ensurePlanApprovedIfRequired,
+  ensureLifecycleCommentCommitLocation,
   extractTaskObservationSection,
   defaultCommitEmojiForStatus,
   extractDocSection,
@@ -80,6 +81,14 @@ export async function cmdStart(opts: TaskTransitionCommentCommandOptions): Promi
 
     const { prefix, min_chars: minChars } = ctx.config.tasks.comments.start;
     requireStructuredComment(opts.body, prefix, minChars);
+    await ensureLifecycleCommentCommitLocation({
+      enabled: opts.commitFromComment,
+      ctx,
+      cwd: opts.cwd,
+      rootOverride: opts.rootOverride,
+      command: "task start-ready",
+      taskId: opts.taskId,
+    });
     const preparedComment = prepareTaskTransitionComment({
       body: opts.body,
       enabled: opts.commitFromComment,


### PR DESCRIPTION
Task: `202605100837-6FTSE2`
Title: Pre-v0.5: enforce lifecycle commit-from-comment command matrix
Canonical task record: `.agentplane/tasks/202605100837-6FTSE2/README.md`

## Summary

Pre-v0.5: enforce lifecycle commit-from-comment command matrix

Define and enforce the command/mode matrix for start-ready, verify, set-status, and finish commit-from-comment behavior across direct, branch_pr task worktree, and branch_pr base checkout.

## Scope

- In scope: Define and enforce the command/mode matrix for start-ready, verify, set-status, and finish commit-from-comment behavior across direct, branch_pr task worktree, and branch_pr base checkout.
- Out of scope: unrelated refactors not required for "Pre-v0.5: enforce lifecycle commit-from-comment command matrix".

## Verification

- State: ok
- Note: Verified: lifecycle commit-from-comment matrix is enforced by a shared guard; start-ready/set-status are allowed in direct and branch_pr task worktrees but rejected on branch_pr base, finish is rejected in branch_pr, and verify has no commit-from-comment option.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-11T06:48:39.662Z
- Branch: task-202605100837-6FTSE2-lifecycle-commit-matrix
- Head: 5b4c8defed12

```text
 .../blueprint/resolved-snapshot.json               | 505 +++++++++++++++++++++
 .../task/lifecycle-commit-matrix.unit.test.ts      | 141 ++++++
 .../agentplane/src/commands/task/set-status.ts     |   9 +
 packages/agentplane/src/commands/task/shared.ts    |   1 +
 .../src/commands/task/shared/transitions.ts        |  55 +++
 packages/agentplane/src/commands/task/start.ts     |   9 +
 6 files changed, 720 insertions(+)
```

</details>
