### PR TITLE
🚧 3V6FMM task: Fix ACR projection checkout collision [202605110703-3V6FMM]

### DIFF
--- a/.agentplane/tasks/202605110703-3V6FMM/README.md
+++ b/.agentplane/tasks/202605110703-3V6FMM/README.md
@@ -1,0 +1,94 @@
+---
+id: "202605110703-3V6FMM"
+title: "Fix ACR projection checkout collision"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "acr"
+  - "code"
+  - "workflow"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-11T07:03:55.565Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-11T07:12:07.838Z"
+  updated_by: "CODER"
+  note: "Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/commands/task/finish.validation.unit.test.ts packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts --reporter dot; Result: pass, 2 files / 33 tests. Command: bunx eslint touched finish files; Result: pass. Command: bunx prettier --check touched finish files; Result: pass. Command: bun run --filter=agentplane build; Result: pass. Command: bun run hotspots:check; Result: pass, oversized baseline OK."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: tracing branch_pr finish and hosted close ACR refresh so local base checkout no longer creates untracked acr.json files that block fast-forward pulls."
+events:
+  -
+    type: "status"
+    at: "2026-05-11T07:04:02.692Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: tracing branch_pr finish and hosted close ACR refresh so local base checkout no longer creates untracked acr.json files that block fast-forward pulls."
+  -
+    type: "verify"
+    at: "2026-05-11T07:12:07.838Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/commands/task/finish.validation.unit.test.ts packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts --reporter dot; Result: pass, 2 files / 33 tests. Command: bunx eslint touched finish files; Result: pass. Command: bunx prettier --check touched finish files; Result: pass. Command: bun run --filter=agentplane build; Result: pass. Command: bun run hotspots:check; Result: pass, oversized baseline OK."
+doc_version: 3
+doc_updated_at: "2026-05-11T07:12:07.847Z"
+doc_updated_by: "CODER"
+description: "Prevent automatic ACR refresh during branch_pr finish/hosted-close from leaving local untracked acr.json files that later block fast-forward pulls after hosted close commits track the same path."
+sections:
+  Summary: |-
+    Fix ACR projection checkout collision
+    
+    Prevent automatic ACR refresh during branch_pr finish/hosted-close from leaving local untracked acr.json files that later block fast-forward pulls after hosted close commits track the same path.
+  Scope: |-
+    - In scope: Prevent automatic ACR refresh during branch_pr finish/hosted-close from leaving local untracked acr.json files that later block fast-forward pulls after hosted close commits track the same path.
+    - Out of scope: unrelated refactors not required for "Fix ACR projection checkout collision".
+  Plan: |-
+    1. Trace automatic ACR refresh during finish, hosted close, and integrate paths to identify why branch_pr base checkout creates untracked task ACR files before remote hosted close commits land.
+    2. Adjust branch_pr close/finish behavior so generated ACR artifacts are either committed in the local close tail or skipped when a hosted close route owns the tracked artifact, avoiding untracked-overwrite fast-forward failures.
+    3. Add focused regression coverage for the collision case.
+    4. Run targeted tests plus formatting/build gates required by the task.
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-11T07:12:07.838Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/commands/task/finish.validation.unit.test.ts packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts --reporter dot; Result: pass, 2 files / 33 tests. Command: bunx eslint touched finish files; Result: pass. Command: bunx prettier --check touched finish files; Result: pass. Command: bun run --filter=agentplane build; Result: pass. Command: bun run hotspots:check; Result: pass, oversized baseline OK.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-11T07:04:02.701Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605110703-3V6FMM-acr-checkout-collision/.agentplane/tasks/202605110703-3V6FMM/blueprint/resolved-snapshot.json
+    - old_digest: 94f3ade92cd1c41ea8d34d87ccc2a43ce6b118d6e007c0d7bcbe06bbb9d86e7c
+    - current_digest: 94f3ade92cd1c41ea8d34d87ccc2a43ce6b118d6e007c0d7bcbe06bbb9d86e7c
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605110703-3V6FMM
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605110703-3V6FMM/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605110703-3V6FMM/blueprint/resolved-snapshot.json
@@ -1,0 +1,498 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605110703-3V6FMM",
+    "title": "Fix ACR projection checkout collision",
+    "description": "Prevent automatic ACR refresh during branch_pr finish/hosted-close from leaving local untracked acr.json files that later block fast-forward pulls after hosted close commits track the same path.",
+    "tags": [
+      "acr",
+      "code",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605110703-3V6FMM",
+    "workflowMode": "branch_pr",
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "94f3ade92cd1c41ea8d34d87ccc2a43ce6b118d6e007c0d7bcbe06bbb9d86e7c"
+  }
+}

--- a/.agentplane/tasks/202605110703-3V6FMM/pr/diffstat.txt
+++ b/.agentplane/tasks/202605110703-3V6FMM/pr/diffstat.txt
@@ -1,0 +1,5 @@
+ .../blueprint/resolved-snapshot.json               | 498 +++++++++++++++++++++
+ .../agentplane/src/commands/task/finish-close.ts   |  38 +-
+ .../agentplane/src/commands/task/finish-execute.ts |  32 +-
+ .../commands/task/finish.validation.unit.test.ts   |  44 +-
+ 4 files changed, 578 insertions(+), 34 deletions(-)

--- a/.agentplane/tasks/202605110703-3V6FMM/pr/github-body.md
+++ b/.agentplane/tasks/202605110703-3V6FMM/pr/github-body.md
@@ -1,0 +1,37 @@
+Task: `202605110703-3V6FMM`
+Title: Fix ACR projection checkout collision
+Canonical task record: `.agentplane/tasks/202605110703-3V6FMM/README.md`
+
+## Summary
+
+Fix ACR projection checkout collision
+
+Prevent automatic ACR refresh during branch_pr finish/hosted-close from leaving local untracked acr.json files that later block fast-forward pulls after hosted close commits track the same path.
+
+## Scope
+
+- In scope: Prevent automatic ACR refresh during branch_pr finish/hosted-close from leaving local untracked acr.json files that later block fast-forward pulls after hosted close commits track the same path.
+- Out of scope: unrelated refactors not required for "Fix ACR projection checkout collision".
+
+## Verification
+
+- State: ok
+- Note: Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/commands/task/finish.validation.unit.test.ts packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts --reporter dot; Result: pass, 2 files / 33 tests. Command: bunx eslint touched finish files; Result: pass. Command: bunx prettier --check touched finish files; Result: pass. Command: bun run --filter=agentplane build; Result: pass. Command: bun run hotspots:check; Result: pass, oversized baseline OK.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-11T07:12:54.165Z
+- Branch: task-202605110703-3V6FMM-acr-checkout-collision
+- Head: 8573b3209341
+
+```text
+ .../blueprint/resolved-snapshot.json               | 498 +++++++++++++++++++++
+ .../agentplane/src/commands/task/finish-close.ts   |  38 +-
+ .../agentplane/src/commands/task/finish-execute.ts |  32 +-
+ .../commands/task/finish.validation.unit.test.ts   |  44 +-
+ 4 files changed, 578 insertions(+), 34 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605110703-3V6FMM/pr/github-title.txt
+++ b/.agentplane/tasks/202605110703-3V6FMM/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 3V6FMM task: Fix ACR projection checkout collision [202605110703-3V6FMM]

--- a/.agentplane/tasks/202605110703-3V6FMM/pr/meta.json
+++ b/.agentplane/tasks/202605110703-3V6FMM/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task-202605110703-3V6FMM-acr-checkout-collision",
+  "created_at": "2026-05-11T07:12:54.165Z",
+  "head_sha": "8573b3209341da36792fc87f3054f64de6342ee5",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202605110703-3V6FMM",
+  "updated_at": "2026-05-11T07:12:54.165Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605110703-3V6FMM/pr/review.md
+++ b/.agentplane/tasks/202605110703-3V6FMM/pr/review.md
@@ -1,0 +1,40 @@
+# PR Review
+
+Created: 2026-05-11T07:12:54.165Z
+
+## Task
+
+- Task: `202605110703-3V6FMM`
+- Title: Fix ACR projection checkout collision
+- Status: DOING
+- Branch: `task-202605110703-3V6FMM-acr-checkout-collision`
+- Canonical task record: `.agentplane/tasks/202605110703-3V6FMM/README.md`
+
+## Verification
+
+- State: ok
+- Note: Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/commands/task/finish.validation.unit.test.ts packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts --reporter dot; Result: pass, 2 files / 33 tests. Command: bunx eslint touched finish files; Result: pass. Command: bunx prettier --check touched finish files; Result: pass. Command: bun run --filter=agentplane build; Result: pass. Command: bun run hotspots:check; Result: pass, oversized baseline OK.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-11T07:12:54.165Z
+- Branch: task-202605110703-3V6FMM-acr-checkout-collision
+- Head: 8573b3209341
+
+```text
+ .../blueprint/resolved-snapshot.json               | 498 +++++++++++++++++++++
+ .../agentplane/src/commands/task/finish-close.ts   |  38 +-
+ .../agentplane/src/commands/task/finish-execute.ts |  32 +-
+ .../commands/task/finish.validation.unit.test.ts   |  44 +-
+ 4 files changed, 578 insertions(+), 34 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/task/finish-close.ts
+++ b/packages/agentplane/src/commands/task/finish-close.ts
@@ -122,16 +122,14 @@ async function closeTailAlreadyHandledRemotely(opts: {
   return observedClosePr?.status === "OPEN" || observedClosePr?.status === "MERGED";
 }
 
-export async function materializeBranchPrCloseTail(opts: {
+export async function resolveBranchPrCloseTailState(opts: {
   ctx: CommandContext;
-  cwd: string;
-  rootOverride?: string;
   taskId: string;
-  baseBranchOverride?: string;
-  quiet: boolean;
-  closeUnstageOthers?: boolean;
-  allowPolicy?: boolean;
-}): Promise<string | null> {
+}): Promise<{
+  baseBranch: string;
+  closeBranch: string | null;
+  alreadyHandled: boolean;
+}> {
   const gitRoot = opts.ctx.resolvedProject.gitRoot;
   const baseBranch = await gitCurrentBranch(gitRoot);
   const alreadyClosedOnBase = await taskCloseAlreadyRecordedOnBase({
@@ -141,7 +139,7 @@ export async function materializeBranchPrCloseTail(opts: {
     baseBranch,
   });
   if (alreadyClosedOnBase) {
-    return null;
+    return { baseBranch, closeBranch: null, alreadyHandled: true };
   }
 
   const headCommitHash = await readHeadCommitHash(gitRoot);
@@ -155,10 +153,30 @@ export async function materializeBranchPrCloseTail(opts: {
     baseBranch,
     closeBranch,
   });
-  if (alreadyHandledRemotely) {
+  return { baseBranch, closeBranch, alreadyHandled: alreadyHandledRemotely };
+}
+
+export async function materializeBranchPrCloseTail(opts: {
+  ctx: CommandContext;
+  cwd: string;
+  rootOverride?: string;
+  taskId: string;
+  baseBranchOverride?: string;
+  quiet: boolean;
+  closeUnstageOthers?: boolean;
+  allowPolicy?: boolean;
+}): Promise<string | null> {
+  const gitRoot = opts.ctx.resolvedProject.gitRoot;
+  const closeTailState = await resolveBranchPrCloseTailState({
+    ctx: opts.ctx,
+    taskId: opts.taskId,
+  });
+  if (closeTailState.alreadyHandled || !closeTailState.closeBranch) {
     return null;
   }
 
+  const baseBranch = closeTailState.baseBranch;
+  const closeBranch = closeTailState.closeBranch;
   const branchExists = await gitBranchExists(gitRoot, closeBranch);
 
   await execFileAsync(

--- a/packages/agentplane/src/commands/task/finish-execute.ts
+++ b/packages/agentplane/src/commands/task/finish-execute.ts
@@ -13,7 +13,11 @@ import {
   type ResolvedCommitInfo,
   writeFinishedTasks,
 } from "./finish-shared.js";
-import { clearDirectWorkLockIfMatches, materializeBranchPrCloseTail } from "./finish-close.js";
+import {
+  clearDirectWorkLockIfMatches,
+  materializeBranchPrCloseTail,
+  resolveBranchPrCloseTailState,
+} from "./finish-close.js";
 import { appendFinishStructuredFinding } from "./finish-findings.js";
 import {
   defaultCommitEmojiForStatus,
@@ -30,6 +34,10 @@ export async function executeFinishPlan(opts: {
   plan: FinishExecutionPlan;
 }): Promise<number> {
   const { ctx, options, plan } = opts;
+  if (await shouldSkipAlreadyHandledBranchPrCloseTail({ ctx, options, plan })) {
+    return 0;
+  }
+
   await appendStructuredFindingIfNeeded({ ctx, options, plan });
 
   const loadedState = await loadFinishTasks({ ctx, options, plan });
@@ -150,6 +158,28 @@ export async function executeFinishPlan(opts: {
   }
 
   return 0;
+}
+
+async function shouldSkipAlreadyHandledBranchPrCloseTail(opts: {
+  ctx: CommandContext;
+  options: FinishOptions;
+  plan: FinishExecutionPlan;
+}): Promise<boolean> {
+  if (opts.ctx.config.workflow_mode !== "branch_pr") return false;
+  if (!opts.plan.shouldCloseCommit || !opts.plan.primaryTaskId) return false;
+
+  const closeTailState = await resolveBranchPrCloseTailState({
+    ctx: opts.ctx,
+    taskId: opts.plan.primaryTaskId,
+  });
+  if (!closeTailState.alreadyHandled) return false;
+
+  if (!opts.options.quiet) {
+    process.stdout.write(
+      "branch_pr close tail already exists on base or hosted close; skipping local task artifact writes.\n",
+    );
+  }
+  return true;
 }
 
 async function appendStructuredFindingIfNeeded(opts: {

--- a/packages/agentplane/src/commands/task/finish.validation.unit.test.ts
+++ b/packages/agentplane/src/commands/task/finish.validation.unit.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   execFileAsync: vi.fn(),
   gitBranchExists: vi.fn(),
   gitCurrentBranch: vi.fn(),
+  tryLookupExistingGithubPrByBranch: vi.fn(),
   generateAcr: vi.fn(),
   writeAcrFile: vi.fn(),
   checkTaskBlueprintSnapshotDrift: vi.fn(),
@@ -44,6 +45,9 @@ vi.mock("../shared/task-backend.js", () => ({
 vi.mock("../shared/git-ops.js", () => ({
   gitBranchExists: mocks.gitBranchExists,
   gitCurrentBranch: mocks.gitCurrentBranch,
+}));
+vi.mock("../pr/internal/sync-github.js", () => ({
+  tryLookupExistingGithubPrByBranch: mocks.tryLookupExistingGithubPrByBranch,
 }));
 vi.mock("../acr/acr.command.js", () => ({
   generateAcr: mocks.generateAcr,
@@ -232,6 +236,7 @@ describe("task finish validation", () => {
     mocks.execFileAsync.mockReset();
     mocks.gitBranchExists.mockReset();
     mocks.gitCurrentBranch.mockReset();
+    mocks.tryLookupExistingGithubPrByBranch.mockReset();
     mocks.generateAcr.mockReset();
     mocks.writeAcrFile.mockReset();
     mocks.checkTaskBlueprintSnapshotDrift.mockReset();
@@ -249,6 +254,7 @@ describe("task finish validation", () => {
     });
     mocks.gitBranchExists.mockResolvedValue(false);
     mocks.gitCurrentBranch.mockResolvedValue("main");
+    mocks.tryLookupExistingGithubPrByBranch.mockResolvedValue(null);
     mocks.generateAcr.mockResolvedValue({
       acrPath: "/repo/.agentplane/tasks/T-1/acr.json",
       record: { record_type: "agent_change_record" },
@@ -872,37 +878,31 @@ describe("task finish validation", () => {
     );
   });
 
-  it("skips branch_pr close-tail materialization when a close commit already exists on base", async () => {
+  it("skips branch_pr task artifact writes when hosted close is already recorded on origin main", async () => {
     const ctx = mkCtx();
     ctx.config.workflow_mode = "branch_pr";
-    const task = mkTask({
-      id: "T-1",
-      tags: ["meta"],
-      commit: { hash: "impl-hash", message: "feat: implement T-1" },
-    });
+    ctx.config.acr.enabled = true;
+    ctx.config.acr.write_on_finish = true;
     const store = {
-      get: vi.fn().mockResolvedValue(task),
-      patch: vi
+      get: vi
         .fn()
-        .mockImplementation(
-          async (_taskId: string, builder: (current: TaskData) => Promise<TaskStorePatch>) => {
-            applyStorePatch(task, await builder(task));
-            return { changed: true, task };
-          },
+        .mockResolvedValue(
+          mkTask({ id: "T-1", commit: { hash: "impl-hash", message: "feat: implement T-1" } }),
         ),
+      patch: vi.fn().mockResolvedValue({ changed: true, task: mkTask({ id: "T-1" }) }),
     };
     mocks.backendIsLocalFileBackend.mockReturnValue(true);
     mocks.getTaskStore.mockReturnValue(store);
     mocks.execFileAsync.mockImplementation((...args: unknown[]) => {
       const [, gitArgs] = args as [string, string[]];
-      if (Array.isArray(gitArgs) && gitArgs[0] === "log") {
-        return Promise.resolve({
-          stdout: "✅ T-1 close: done (T-1)\nseed\n",
-          stderr: "",
-        });
-      }
       if (Array.isArray(gitArgs) && gitArgs[0] === "rev-parse" && gitArgs[1] === "HEAD") {
         return Promise.resolve({ stdout: "base-head-sha\n", stderr: "" });
+      }
+      if (Array.isArray(gitArgs) && gitArgs[0] === "log" && gitArgs[1] === "origin/main") {
+        return Promise.resolve({
+          stdout: "✅ T-1 close: Merged via PR #123. (T-1) [code]\n",
+          stderr: "",
+        });
       }
       return Promise.resolve({ stdout: "", stderr: "" });
     });
@@ -930,11 +930,9 @@ describe("task finish validation", () => {
       quiet: true,
     });
 
-    expect(mocks.execFileAsync).not.toHaveBeenCalledWith(
-      "git",
-      ["checkout", "-b", "task-close/T-1/base-head-sh"],
-      expect.any(Object),
-    );
+    expect(store.patch).not.toHaveBeenCalled();
+    expect(mocks.generateAcr).not.toHaveBeenCalled();
+    expect(mocks.writeAcrFile).not.toHaveBeenCalled();
     expect(mocks.cmdCommit).not.toHaveBeenCalledWith(
       expect.objectContaining({
         taskId: "T-1",


### PR DESCRIPTION
Task: `202605110703-3V6FMM`
Title: Fix ACR projection checkout collision
Canonical task record: `.agentplane/tasks/202605110703-3V6FMM/README.md`

## Summary

Fix ACR projection checkout collision

Prevent automatic ACR refresh during branch_pr finish/hosted-close from leaving local untracked acr.json files that later block fast-forward pulls after hosted close commits track the same path.

## Scope

- In scope: Prevent automatic ACR refresh during branch_pr finish/hosted-close from leaving local untracked acr.json files that later block fast-forward pulls after hosted close commits track the same path.
- Out of scope: unrelated refactors not required for "Fix ACR projection checkout collision".

## Verification

- State: ok
- Note: Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/commands/task/finish.validation.unit.test.ts packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts --reporter dot; Result: pass, 2 files / 33 tests. Command: bunx eslint touched finish files; Result: pass. Command: bunx prettier --check touched finish files; Result: pass. Command: bun run --filter=agentplane build; Result: pass. Command: bun run hotspots:check; Result: pass, oversized baseline OK.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-11T07:12:54.165Z
- Branch: task-202605110703-3V6FMM-acr-checkout-collision
- Head: 8573b3209341

```text
 .../blueprint/resolved-snapshot.json               | 498 +++++++++++++++++++++
 .../agentplane/src/commands/task/finish-close.ts   |  38 +-
 .../agentplane/src/commands/task/finish-execute.ts |  32 +-
 .../commands/task/finish.validation.unit.test.ts   |  44 +-
 4 files changed, 578 insertions(+), 34 deletions(-)
```

</details>
