### PR TITLE
🚧 A8PGWA task: Pre-v0.5: feed workflow Git capabilities into blueprint planner [202605100837-A8PGWA]

### DIFF
--- a/.agentplane/tasks/202605100837-A8PGWA/README.md
+++ b/.agentplane/tasks/202605100837-A8PGWA/README.md
@@ -1,0 +1,95 @@
+---
+id: "202605100837-A8PGWA"
+title: "Pre-v0.5: feed workflow Git capabilities into blueprint planner"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on:
+  - "202605100837-6FTSE2"
+tags:
+  - "blueprints"
+  - "release"
+  - "workflow"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "Blueprint route snapshots include workflow Git capabilities for branch_pr and direct modes."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-10T08:37:13.946Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-11T07:31:27.170Z"
+  updated_by: "CODER"
+  note: "Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/blueprints/resolve.test.ts packages/agentplane/src/blueprints/snapshot.test.ts packages/agentplane/src/cli/run-cli.core.tasks.create.test.ts --reporter dot; Result: pass, 3 files / 46 tests. Command: bunx eslint touched blueprint/task preview files; Result: pass. Command: bunx prettier --check touched files; Result: pass. Command: bun run --filter=agentplane build; Result: pass. Command: bun run hotspots:check; Result: pass, oversized baseline OK. Command: ap blueprint snapshot 202605100837-A8PGWA && ap task verify-show 202605100837-A8PGWA; Result: pass, workflow_git capabilities visible and snapshot current."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: feed workflow Git capabilities into blueprint planner and route snapshots so branch_pr guidance avoids finish --commit-from-comment and direct mode retains its lifecycle commit behavior."
+events:
+  -
+    type: "status"
+    at: "2026-05-11T07:26:38.891Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: feed workflow Git capabilities into blueprint planner and route snapshots so branch_pr guidance avoids finish --commit-from-comment and direct mode retains its lifecycle commit behavior."
+  -
+    type: "verify"
+    at: "2026-05-11T07:31:27.170Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/blueprints/resolve.test.ts packages/agentplane/src/blueprints/snapshot.test.ts packages/agentplane/src/cli/run-cli.core.tasks.create.test.ts --reporter dot; Result: pass, 3 files / 46 tests. Command: bunx eslint touched blueprint/task preview files; Result: pass. Command: bunx prettier --check touched files; Result: pass. Command: bun run --filter=agentplane build; Result: pass. Command: bun run hotspots:check; Result: pass, oversized baseline OK. Command: ap blueprint snapshot 202605100837-A8PGWA && ap task verify-show 202605100837-A8PGWA; Result: pass, workflow_git capabilities visible and snapshot current."
+doc_version: 3
+doc_updated_at: "2026-05-11T07:31:27.179Z"
+doc_updated_by: "CODER"
+description: "Expose workflow capabilities to blueprint planning: workflowMode, implementationCommitLocation, finishCommitSource, closeTailRequired, and related branch_pr constraints."
+sections:
+  Summary: |-
+    Pre-v0.5: feed workflow Git capabilities into blueprint planner
+    
+    Expose workflow capabilities to blueprint planning: workflowMode, implementationCommitLocation, finishCommitSource, closeTailRequired, and related branch_pr constraints.
+  Scope: |-
+    - In scope: Expose workflow capabilities to blueprint planning: workflowMode, implementationCommitLocation, finishCommitSource, closeTailRequired, and related branch_pr constraints.
+    - Out of scope: unrelated refactors not required for "Pre-v0.5: feed workflow Git capabilities into blueprint planner".
+  Plan: "Pre-v0.5 optimization gate. Deliver exactly this atomic scope, preserve branch_pr lifecycle contracts, and record verification evidence. Dependency: 202605100837-6FTSE2. Acceptance: Blueprint route snapshots include workflow Git capabilities for branch_pr and direct modes.."
+  Verify Steps: |-
+    1. Review the requested outcome for "Pre-v0.5: feed workflow Git capabilities into blueprint planner". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-11T07:31:27.170Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/blueprints/resolve.test.ts packages/agentplane/src/blueprints/snapshot.test.ts packages/agentplane/src/cli/run-cli.core.tasks.create.test.ts --reporter dot; Result: pass, 3 files / 46 tests. Command: bunx eslint touched blueprint/task preview files; Result: pass. Command: bunx prettier --check touched files; Result: pass. Command: bun run --filter=agentplane build; Result: pass. Command: bun run hotspots:check; Result: pass, oversized baseline OK. Command: ap blueprint snapshot 202605100837-A8PGWA && ap task verify-show 202605100837-A8PGWA; Result: pass, workflow_git capabilities visible and snapshot current.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-11T07:26:38.907Z, excerpt_hash=sha256:66e08f03b9ef46a3c4cf6983d44521d3ad11221dca86ff8b8b1e2b348b88a99f
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605100837-A8PGWA-blueprint-git-capabilities/.agentplane/tasks/202605100837-A8PGWA/blueprint/resolved-snapshot.json
+    - old_digest: 77a354420f9d921329361adbb08fcb5030a1db929c79be3aa0411dfa20fc80fb
+    - current_digest: 77a354420f9d921329361adbb08fcb5030a1db929c79be3aa0411dfa20fc80fb
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605100837-A8PGWA
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605100837-A8PGWA/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605100837-A8PGWA/blueprint/resolved-snapshot.json
@@ -1,0 +1,521 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605100837-A8PGWA",
+    "title": "Pre-v0.5: feed workflow Git capabilities into blueprint planner",
+    "description": "Expose workflow capabilities to blueprint planning: workflowMode, implementationCommitLocation, finishCommitSource, closeTailRequired, and related branch_pr constraints.",
+    "tags": [
+      "blueprints",
+      "release",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605100837-A8PGWA",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "77a354420f9d921329361adbb08fcb5030a1db929c79be3aa0411dfa20fc80fb"
+  }
+}

--- a/.agentplane/tasks/202605100837-A8PGWA/pr/diffstat.txt
+++ b/.agentplane/tasks/202605100837-A8PGWA/pr/diffstat.txt
@@ -1,0 +1,10 @@
+ .../blueprint/resolved-snapshot.json               | 521 +++++++++++++++++++++
+ packages/agentplane/src/blueprints/explain.ts      |  16 +-
+ packages/agentplane/src/blueprints/model.ts        |  12 +
+ packages/agentplane/src/blueprints/plan.ts         |  34 +-
+ packages/agentplane/src/blueprints/resolve.test.ts |  36 ++
+ .../agentplane/src/blueprints/snapshot.test.ts     |  11 +
+ packages/agentplane/src/blueprints/snapshot.ts     |   4 +-
+ .../src/cli/run-cli.core.tasks.create.test.ts      |   3 +
+ .../src/commands/task/blueprint-summary.ts         |  12 +
+ 9 files changed, 643 insertions(+), 6 deletions(-)

--- a/.agentplane/tasks/202605100837-A8PGWA/pr/github-body.md
+++ b/.agentplane/tasks/202605100837-A8PGWA/pr/github-body.md
@@ -1,0 +1,42 @@
+Task: `202605100837-A8PGWA`
+Title: Pre-v0.5: feed workflow Git capabilities into blueprint planner
+Canonical task record: `.agentplane/tasks/202605100837-A8PGWA/README.md`
+
+## Summary
+
+Pre-v0.5: feed workflow Git capabilities into blueprint planner
+
+Expose workflow capabilities to blueprint planning: workflowMode, implementationCommitLocation, finishCommitSource, closeTailRequired, and related branch_pr constraints.
+
+## Scope
+
+- In scope: Expose workflow capabilities to blueprint planning: workflowMode, implementationCommitLocation, finishCommitSource, closeTailRequired, and related branch_pr constraints.
+- Out of scope: unrelated refactors not required for "Pre-v0.5: feed workflow Git capabilities into blueprint planner".
+
+## Verification
+
+- State: ok
+- Note: Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/blueprints/resolve.test.ts packages/agentplane/src/blueprints/snapshot.test.ts packages/agentplane/src/cli/run-cli.core.tasks.create.test.ts --reporter dot; Result: pass, 3 files / 46 tests. Command: bunx eslint touched blueprint/task preview files; Result: pass. Command: bunx prettier --check touched files; Result: pass. Command: bun run --filter=agentplane build; Result: pass. Command: bun run hotspots:check; Result: pass, oversized baseline OK. Command: ap blueprint snapshot 202605100837-A8PGWA && ap task verify-show 202605100837-A8PGWA; Result: pass, workflow_git capabilities visible and snapshot current.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-11T07:43:58.910Z
+- Branch: task-202605100837-A8PGWA-blueprint-git-capabilities
+- Head: 4cd946f85a30
+
+```text
+ .../blueprint/resolved-snapshot.json               | 521 +++++++++++++++++++++
+ packages/agentplane/src/blueprints/explain.ts      |  16 +-
+ packages/agentplane/src/blueprints/model.ts        |  12 +
+ packages/agentplane/src/blueprints/plan.ts         |  34 +-
+ packages/agentplane/src/blueprints/resolve.test.ts |  36 ++
+ .../agentplane/src/blueprints/snapshot.test.ts     |  11 +
+ packages/agentplane/src/blueprints/snapshot.ts     |   4 +-
+ .../src/cli/run-cli.core.tasks.create.test.ts      |   3 +
+ .../src/commands/task/blueprint-summary.ts         |  12 +
+ 9 files changed, 643 insertions(+), 6 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605100837-A8PGWA/pr/github-title.txt
+++ b/.agentplane/tasks/202605100837-A8PGWA/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 A8PGWA task: Pre-v0.5: feed workflow Git capabilities into blueprint planner [202605100837-A8PGWA]

--- a/.agentplane/tasks/202605100837-A8PGWA/pr/meta.json
+++ b/.agentplane/tasks/202605100837-A8PGWA/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task-202605100837-A8PGWA-blueprint-git-capabilities",
+  "created_at": "2026-05-11T07:43:58.910Z",
+  "head_sha": "4cd946f85a3087dda2ba09548b58db6a40bcdfbf",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202605100837-A8PGWA",
+  "updated_at": "2026-05-11T07:43:58.910Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605100837-A8PGWA/pr/review.md
+++ b/.agentplane/tasks/202605100837-A8PGWA/pr/review.md
@@ -1,0 +1,45 @@
+# PR Review
+
+Created: 2026-05-11T07:43:58.910Z
+
+## Task
+
+- Task: `202605100837-A8PGWA`
+- Title: Pre-v0.5: feed workflow Git capabilities into blueprint planner
+- Status: DOING
+- Branch: `task-202605100837-A8PGWA-blueprint-git-capabilities`
+- Canonical task record: `.agentplane/tasks/202605100837-A8PGWA/README.md`
+
+## Verification
+
+- State: ok
+- Note: Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/blueprints/resolve.test.ts packages/agentplane/src/blueprints/snapshot.test.ts packages/agentplane/src/cli/run-cli.core.tasks.create.test.ts --reporter dot; Result: pass, 3 files / 46 tests. Command: bunx eslint touched blueprint/task preview files; Result: pass. Command: bunx prettier --check touched files; Result: pass. Command: bun run --filter=agentplane build; Result: pass. Command: bun run hotspots:check; Result: pass, oversized baseline OK. Command: ap blueprint snapshot 202605100837-A8PGWA && ap task verify-show 202605100837-A8PGWA; Result: pass, workflow_git capabilities visible and snapshot current.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-11T07:43:58.910Z
+- Branch: task-202605100837-A8PGWA-blueprint-git-capabilities
+- Head: 4cd946f85a30
+
+```text
+ .../blueprint/resolved-snapshot.json               | 521 +++++++++++++++++++++
+ packages/agentplane/src/blueprints/explain.ts      |  16 +-
+ packages/agentplane/src/blueprints/model.ts        |  12 +
+ packages/agentplane/src/blueprints/plan.ts         |  34 +-
+ packages/agentplane/src/blueprints/resolve.test.ts |  36 ++
+ .../agentplane/src/blueprints/snapshot.test.ts     |  11 +
+ packages/agentplane/src/blueprints/snapshot.ts     |   4 +-
+ .../src/cli/run-cli.core.tasks.create.test.ts      |   3 +
+ .../src/commands/task/blueprint-summary.ts         |  12 +
+ 9 files changed, 643 insertions(+), 6 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/blueprints/explain.ts
+++ b/packages/agentplane/src/blueprints/explain.ts
@@ -5,7 +5,11 @@ import type {
   ResolvedBlueprint,
   WorkflowMode,
 } from "./model.js";
-import { blueprintPlanEvidence, buildBlueprintPlanArtifact } from "./plan.js";
+import {
+  blueprintPlanEvidence,
+  buildBlueprintPlanArtifact,
+  workflowGitCapabilitiesForMode,
+} from "./plan.js";
 
 function recipeContributionId(item: {
   recipeId: string;
@@ -36,11 +40,14 @@ export function explainResolvedBlueprint(opts: {
   workflowMode?: WorkflowMode;
 }): BlueprintExplainOutput {
   const plan = buildBlueprintPlanArtifact(opts);
+  const workflowMode = opts.workflowMode ?? opts.input?.workflowMode;
+  const workflowGitCapabilities = workflowGitCapabilitiesForMode(workflowMode);
   return {
     blueprintId: opts.resolved.blueprint.id,
     blueprintVersion: opts.resolved.blueprint.version,
     title: opts.resolved.blueprint.title,
-    ...(opts.workflowMode ? { workflowMode: opts.workflowMode } : {}),
+    ...(workflowMode ? { workflowMode } : {}),
+    ...(workflowGitCapabilities ? { workflowGitCapabilities } : {}),
     route: opts.resolved.activeNodes.map((node) => explainNode(node)),
     skippedNodes: [...opts.resolved.skippedNodes],
     requiredEvidence: opts.resolved.requiredEvidence.map((evidence) =>
@@ -59,6 +66,11 @@ export function formatBlueprintExplain(output: BlueprintExplainOutput): string {
     `blueprint_id: ${output.blueprintId}`,
     `blueprint_version: ${output.blueprintVersion}`,
     ...(output.workflowMode ? [`workflow_mode: ${output.workflowMode}`] : []),
+    ...(output.workflowGitCapabilities
+      ? [
+          `workflow_git: implementation_commit_location=${output.workflowGitCapabilities.implementationCommitLocation} finish_commit_source=${output.workflowGitCapabilities.finishCommitSource} close_tail_required=${output.workflowGitCapabilities.closeTailRequired ? "yes" : "no"} lifecycle_comment_commit_location=${output.workflowGitCapabilities.lifecycleCommentCommitLocation} finish_commit_from_comment=${output.workflowGitCapabilities.finishCommitFromComment ? "yes" : "no"}`,
+        ]
+      : []),
     `route: ${output.route.map((node) => node.kind).join(" -> ")}`,
     `selection_reasons: ${output.selectionReasons.join("; ") || "none"}`,
     `policy_modules: ${output.plan.policyModules.join(", ") || "none"}`,

--- a/packages/agentplane/src/blueprints/model.ts
+++ b/packages/agentplane/src/blueprints/model.ts
@@ -17,6 +17,15 @@ export type TaskKind = "analysis" | "content" | "docs" | "code" | "release" | "o
 
 export type WorkflowMode = "direct" | "branch_pr";
 
+export type WorkflowGitCapabilities = {
+  workflowMode: WorkflowMode;
+  implementationCommitLocation: "current_checkout" | "task_worktree";
+  finishCommitSource: "explicit_hash_or_comment_commit" | "explicit_hash";
+  closeTailRequired: boolean;
+  lifecycleCommentCommitLocation: "current_checkout" | "task_worktree";
+  finishCommitFromComment: boolean;
+};
+
 export type BlueprintNodeKind =
   | "intake"
   | "scope"
@@ -298,6 +307,7 @@ export type BlueprintPlanArtifact = {
   title: string;
   taskId?: string;
   workflowMode?: WorkflowMode;
+  workflowGitCapabilities?: WorkflowGitCapabilities;
   taskIntent: BlueprintTaskIntent;
   whySelected: readonly string[];
   states: readonly BlueprintPlanState[];
@@ -442,6 +452,7 @@ export type BlueprintSnapshotResolverInput = {
   owner?: string;
   taskKind?: TaskKind;
   workflowMode?: WorkflowMode;
+  workflowGitCapabilities?: WorkflowGitCapabilities;
   mutation: MutationKind;
   mutationScope?: MutationKind;
   touchedPaths: readonly string[];
@@ -522,6 +533,7 @@ export type BlueprintExplainOutput = {
   blueprintVersion: 1;
   title: string;
   workflowMode?: WorkflowMode;
+  workflowGitCapabilities?: WorkflowGitCapabilities;
   route: readonly BlueprintExplainNode[];
   skippedNodes: readonly SkippedNode[];
   requiredEvidence: readonly BlueprintExplainEvidence[];

--- a/packages/agentplane/src/blueprints/plan.ts
+++ b/packages/agentplane/src/blueprints/plan.ts
@@ -6,6 +6,7 @@ import type {
   BlueprintResolveInput,
   BlueprintTaskIntent,
   ResolvedBlueprint,
+  WorkflowGitCapabilities,
   WorkflowMode,
 } from "./model.js";
 import { validateBlueprintPlanArtifact } from "./validate.js";
@@ -26,6 +27,32 @@ function taskIntentFromInput(input?: BlueprintResolveInput): BlueprintTaskIntent
       ? { blueprintRequest: input.blueprintRequest ?? input.explicitBlueprintId }
       : {}),
   };
+}
+
+export function workflowGitCapabilitiesForMode(
+  workflowMode: WorkflowMode | undefined,
+): WorkflowGitCapabilities | undefined {
+  if (workflowMode === "branch_pr") {
+    return {
+      workflowMode,
+      implementationCommitLocation: "task_worktree",
+      finishCommitSource: "explicit_hash",
+      closeTailRequired: true,
+      lifecycleCommentCommitLocation: "task_worktree",
+      finishCommitFromComment: false,
+    };
+  }
+  if (workflowMode === "direct") {
+    return {
+      workflowMode,
+      implementationCommitLocation: "current_checkout",
+      finishCommitSource: "explicit_hash_or_comment_commit",
+      closeTailRequired: false,
+      lifecycleCommentCommitLocation: "current_checkout",
+      finishCommitFromComment: true,
+    };
+  }
+  return undefined;
 }
 
 export function blueprintPlanState(
@@ -63,15 +90,16 @@ export function buildBlueprintPlanArtifact(opts: {
 }): BlueprintPlanArtifact {
   const statePolicyModules = opts.resolved.activeNodes.flatMap((node) => node.policyModules ?? []);
   const stateCommands = opts.resolved.activeNodes.flatMap((node) => node.allowedCommands ?? []);
+  const workflowMode = opts.workflowMode ?? opts.input?.workflowMode;
+  const workflowGitCapabilities = workflowGitCapabilitiesForMode(workflowMode);
   const plan: BlueprintPlanArtifact = {
     schemaVersion: 1,
     blueprintId: opts.resolved.blueprint.id,
     blueprintVersion: opts.resolved.blueprint.version,
     title: opts.resolved.blueprint.title,
     ...(opts.input?.taskId ? { taskId: opts.input.taskId } : {}),
-    ...((opts.workflowMode ?? opts.input?.workflowMode)
-      ? { workflowMode: opts.workflowMode ?? opts.input?.workflowMode }
-      : {}),
+    ...(workflowMode ? { workflowMode } : {}),
+    ...(workflowGitCapabilities ? { workflowGitCapabilities } : {}),
     taskIntent: taskIntentFromInput(opts.input),
     whySelected: [...opts.resolved.selectionReasons],
     states: opts.resolved.activeNodes.map((node) => blueprintPlanState(node)),

--- a/packages/agentplane/src/blueprints/resolve.test.ts
+++ b/packages/agentplane/src/blueprints/resolve.test.ts
@@ -437,11 +437,47 @@ describe("resolveBlueprint", () => {
     expect(output.plan.allowedCommands).toContain(
       "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
     );
+    expect(output.plan.workflowGitCapabilities).toEqual({
+      workflowMode: "branch_pr",
+      implementationCommitLocation: "task_worktree",
+      finishCommitSource: "explicit_hash",
+      closeTailRequired: true,
+      lifecycleCommentCommitLocation: "task_worktree",
+      finishCommitFromComment: false,
+    });
+    expect(formatBlueprintExplain(output)).toContain(
+      "workflow_git: implementation_commit_location=task_worktree finish_commit_source=explicit_hash close_tail_required=yes lifecycle_comment_commit_location=task_worktree finish_commit_from_comment=no",
+    );
     expect(
       output.plan.states
         .find((state) => state.kind === "context_resolve")
         ?.policyModules.includes(".agentplane/policy/workflow.branch_pr.md"),
     ).toBe(true);
+  });
+
+  it("builds direct workflow Git capabilities without branch_pr close-tail semantics", () => {
+    const input: BlueprintResolveInput = {
+      tags: ["code"],
+      taskKind: "code",
+      mutation: "code",
+      mutationScope: "code",
+      workflowMode: "direct",
+    };
+    const output = explainResolvedBlueprint({
+      resolved: resolve(input),
+      input,
+      workflowMode: "direct",
+    });
+
+    expect(output.plan.blueprintId).toBe("code.direct");
+    expect(output.plan.workflowGitCapabilities).toEqual({
+      workflowMode: "direct",
+      implementationCommitLocation: "current_checkout",
+      finishCommitSource: "explicit_hash_or_comment_commit",
+      closeTailRequired: false,
+      lifecycleCommentCommitLocation: "current_checkout",
+      finishCommitFromComment: true,
+    });
   });
 
   it("builds executable plan metadata for specialized benchmark routes", () => {

--- a/packages/agentplane/src/blueprints/snapshot.test.ts
+++ b/packages/agentplane/src/blueprints/snapshot.test.ts
@@ -59,6 +59,17 @@ describe("blueprint resolved snapshots", () => {
       }),
     );
     expect(snapshot.selectedBlueprint.id).toBe("code.branch_pr");
+    expect(snapshot.resolverInput.workflowGitCapabilities).toEqual({
+      workflowMode: "branch_pr",
+      implementationCommitLocation: "task_worktree",
+      finishCommitSource: "explicit_hash",
+      closeTailRequired: true,
+      lifecycleCommentCommitLocation: "task_worktree",
+      finishCommitFromComment: false,
+    });
+    expect(snapshot.plan.workflowGitCapabilities).toEqual(
+      snapshot.resolverInput.workflowGitCapabilities,
+    );
     expect(snapshot.nodes.map((node) => node.kind)).toContain("fast_local_checks");
     expect(snapshot.requiredEvidence.map((item) => item.id)).toContain("code_pr.commit");
     expect(snapshot.policyModules).toContain(".agentplane/policy/workflow.branch_pr.md");

--- a/packages/agentplane/src/blueprints/snapshot.ts
+++ b/packages/agentplane/src/blueprints/snapshot.ts
@@ -12,7 +12,7 @@ import type {
   WorkflowMode,
 } from "./model.js";
 import { isRecord } from "../shared/guards.js";
-import { buildBlueprintPlanArtifact } from "./plan.js";
+import { buildBlueprintPlanArtifact, workflowGitCapabilitiesForMode } from "./plan.js";
 
 function sortJson(input: unknown): unknown {
   if (Array.isArray(input)) return input.map((item) => sortJson(item));
@@ -36,6 +36,7 @@ export function blueprintSnapshotDigest(input: unknown): BlueprintSnapshotDigest
 }
 
 function normalizedResolverInput(input: BlueprintResolveInput): BlueprintSnapshotResolverInput {
+  const workflowGitCapabilities = workflowGitCapabilitiesForMode(input.workflowMode);
   return {
     ...(input.taskId ? { taskId: input.taskId } : {}),
     ...(input.title ? { title: input.title } : {}),
@@ -44,6 +45,7 @@ function normalizedResolverInput(input: BlueprintResolveInput): BlueprintSnapsho
     ...(input.owner ? { owner: input.owner } : {}),
     ...(input.taskKind ? { taskKind: input.taskKind } : {}),
     ...(input.workflowMode ? { workflowMode: input.workflowMode } : {}),
+    ...(workflowGitCapabilities ? { workflowGitCapabilities } : {}),
     mutation: input.mutation,
     ...(input.mutationScope ? { mutationScope: input.mutationScope } : {}),
     touchedPaths: [...(input.touchedPaths ?? [])],

--- a/packages/agentplane/src/cli/run-cli.core.tasks.create.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.tasks.create.test.ts
@@ -306,6 +306,9 @@ describe("runCli", { timeout: TASKS_CLI_TIMEOUT_MS }, () => {
       expect(io.stderr).toContain("Blueprint route preview:");
       expect(io.stderr).toContain("blueprint_id: analysis.light");
       expect(io.stderr).toContain(
+        "workflow_git: implementation_commit_location=current_checkout finish_commit_source=explicit_hash_or_comment_commit close_tail_required=no finish_commit_from_comment=yes",
+      );
+      expect(io.stderr).toContain(
         "route: intake -> scope -> context_resolve -> work_unit -> artifact_write -> verify_record -> finish",
       );
       expect(io.stderr).toContain(

--- a/packages/agentplane/src/commands/task/blueprint-summary.ts
+++ b/packages/agentplane/src/commands/task/blueprint-summary.ts
@@ -13,6 +13,7 @@ export type TaskBlueprintLifecycleSummary = {
   blueprint_id?: string;
   blueprint_version?: string | number;
   workflow_mode?: string;
+  workflow_git?: string;
   route?: string[];
   selection_reasons?: string[];
   required_evidence?: string[];
@@ -30,6 +31,16 @@ function lifecycleSummaryFromExplain(
     blueprint_id: output.blueprintId,
     blueprint_version: output.blueprintVersion,
     ...(output.workflowMode ? { workflow_mode: output.workflowMode } : {}),
+    ...(output.workflowGitCapabilities
+      ? {
+          workflow_git: [
+            `implementation_commit_location=${output.workflowGitCapabilities.implementationCommitLocation}`,
+            `finish_commit_source=${output.workflowGitCapabilities.finishCommitSource}`,
+            `close_tail_required=${output.workflowGitCapabilities.closeTailRequired ? "yes" : "no"}`,
+            `finish_commit_from_comment=${output.workflowGitCapabilities.finishCommitFromComment ? "yes" : "no"}`,
+          ].join(" "),
+        }
+      : {}),
     route: output.route.map((node) => node.kind),
     selection_reasons: [...output.selectionReasons],
     required_evidence: output.requiredEvidence.map((item) => item.id),
@@ -90,6 +101,7 @@ export function formatTaskBlueprintCreationPreview(summary: TaskBlueprintLifecyc
           ? []
           : [`blueprint_version: ${summary.blueprint_version}`]),
         ...(summary.workflow_mode ? [`workflow_mode: ${summary.workflow_mode}`] : []),
+        ...(summary.workflow_git ? [`workflow_git: ${summary.workflow_git}`] : []),
         `route: ${joinOrNone(summary.route, " -> ")}`,
         `selection_reasons: ${joinOrNone(summary.selection_reasons, "; ")}`,
         `required_evidence: ${joinOrNone(summary.required_evidence, ", ")}`,


### PR DESCRIPTION
Task: `202605100837-A8PGWA`
Title: Pre-v0.5: feed workflow Git capabilities into blueprint planner
Canonical task record: `.agentplane/tasks/202605100837-A8PGWA/README.md`

## Summary

Pre-v0.5: feed workflow Git capabilities into blueprint planner

Expose workflow capabilities to blueprint planning: workflowMode, implementationCommitLocation, finishCommitSource, closeTailRequired, and related branch_pr constraints.

## Scope

- In scope: Expose workflow capabilities to blueprint planning: workflowMode, implementationCommitLocation, finishCommitSource, closeTailRequired, and related branch_pr constraints.
- Out of scope: unrelated refactors not required for "Pre-v0.5: feed workflow Git capabilities into blueprint planner".

## Verification

- State: ok
- Note: Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/blueprints/resolve.test.ts packages/agentplane/src/blueprints/snapshot.test.ts packages/agentplane/src/cli/run-cli.core.tasks.create.test.ts --reporter dot; Result: pass, 3 files / 46 tests. Command: bunx eslint touched blueprint/task preview files; Result: pass. Command: bunx prettier --check touched files; Result: pass. Command: bun run --filter=agentplane build; Result: pass. Command: bun run hotspots:check; Result: pass, oversized baseline OK. Command: ap blueprint snapshot 202605100837-A8PGWA && ap task verify-show 202605100837-A8PGWA; Result: pass, workflow_git capabilities visible and snapshot current.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-11T07:43:58.910Z
- Branch: task-202605100837-A8PGWA-blueprint-git-capabilities
- Head: 4cd946f85a30

```text
 .../blueprint/resolved-snapshot.json               | 521 +++++++++++++++++++++
 packages/agentplane/src/blueprints/explain.ts      |  16 +-
 packages/agentplane/src/blueprints/model.ts        |  12 +
 packages/agentplane/src/blueprints/plan.ts         |  34 +-
 packages/agentplane/src/blueprints/resolve.test.ts |  36 ++
 .../agentplane/src/blueprints/snapshot.test.ts     |  11 +
 packages/agentplane/src/blueprints/snapshot.ts     |   4 +-
 .../src/cli/run-cli.core.tasks.create.test.ts      |   3 +
 .../src/commands/task/blueprint-summary.ts         |  12 +
 9 files changed, 643 insertions(+), 6 deletions(-)
```

</details>
