### PR TITLE
🧩 3X3KVC task: Fix git lock diagnostics and merge tests [202605111510-3X3KVC]

### DIFF
--- a/.agentplane/tasks/202605111510-3X3KVC/README.md
+++ b/.agentplane/tasks/202605111510-3X3KVC/README.md
@@ -1,0 +1,55 @@
+---
+id: "202605111510-3X3KVC"
+title: "Fix git lock diagnostics and merge tests"
+status: "TODO"
+priority: "med"
+owner: "INTEGRATOR"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "cli"
+  - "code"
+blueprint_request: "quality.regression"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-11T15:10:11.957Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-11T15:10:11.962Z"
+doc_updated_by: "INTEGRATOR"
+description: "Resolve git lock diagnostics and merge integration regressions for v0.5 branch_pr flow"
+sections:
+  Summary: |-
+    Fix git lock diagnostics and merge tests
+    
+    Resolve git lock diagnostics and merge integration regressions for v0.5 branch_pr flow
+  Scope: |-
+    - In scope: Resolve git lock diagnostics and merge integration regressions for v0.5 branch_pr flow.
+    - Out of scope: unrelated refactors not required for "Fix git lock diagnostics and merge tests".
+  Plan: "1) Use existing validated changes from git commit 15beff2ae on task/202605111458-VT7114/fix-git-locking. 2) Apply those changes to new task branch, run verify commands and branch_pr lifecycle checks. 3) Prepare docs/doctor/blueprint/recipe checks and close task."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605111510-3X3KVC/pr/diffstat.txt
+++ b/.agentplane/tasks/202605111510-3X3KVC/pr/diffstat.txt
@@ -1,0 +1,19 @@
+ docs/user/cli-reference.generated.mdx              |  29 +++
+ docs/user/task-lifecycle.mdx                       |  13 +-
+ docs/workflow-guides/branch-pr.mdx                 |  14 +-
+ .../src/cli/run-cli/command-catalog/core.ts        |   5 +
+ .../src/cli/run-cli/command-loaders/core.ts        |   3 +
+ .../src/commands/doctor-git-locks.run.ts           |  45 +++++
+ .../src/commands/doctor-git-locks.spec.ts          |  17 ++
+ .../impl/commands.commit-non-close.unit.test.ts    |  19 +-
+ .../src/commands/guard/impl/comment-commit.ts      | 111 ++++++++++-
+ .../src/commands/guard/impl/commit-diagnostics.ts  |  11 +-
+ .../agentplane/src/commands/guard/impl/commit.ts   | 220 ++++++++++++++++++++-
+ .../src/commands/hooks/capabilities.test.ts        |   6 +-
+ .../agentplane/src/commands/hooks/capabilities.ts  |   2 +-
+ packages/agentplane/src/commands/hooks/run.ts      |  23 ++-
+ .../commands/pr/integrate/internal/merge.test.ts   | 118 ++++++-----
+ .../src/commands/pr/integrate/internal/merge.ts    | 215 +++++++++++++++++---
+ .../src/shared/git-index-lock-guard.test.ts        |   8 +
+ packages/agentplane/src/shared/git-mutation.ts     |  30 ++-
+ 18 files changed, 768 insertions(+), 121 deletions(-)

--- a/.agentplane/tasks/202605111510-3X3KVC/pr/github-body.md
+++ b/.agentplane/tasks/202605111510-3X3KVC/pr/github-body.md
@@ -1,0 +1,51 @@
+Task: `202605111510-3X3KVC`
+Title: Fix git lock diagnostics and merge tests
+Canonical task record: `.agentplane/tasks/202605111510-3X3KVC/README.md`
+
+## Summary
+
+Fix git lock diagnostics and merge tests
+
+Resolve git lock diagnostics and merge integration regressions for v0.5 branch_pr flow
+
+## Scope
+
+- In scope: Resolve git lock diagnostics and merge integration regressions for v0.5 branch_pr flow.
+- Out of scope: unrelated refactors not required for "Fix git lock diagnostics and merge tests".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-11T15:10:35.637Z
+- Branch: task/202605111510-3X3KVC/fix-git-locks-v2
+- Head: df6e4e8fdab2
+
+```text
+ docs/user/cli-reference.generated.mdx              |  29 +++
+ docs/user/task-lifecycle.mdx                       |  13 +-
+ docs/workflow-guides/branch-pr.mdx                 |  14 +-
+ .../src/cli/run-cli/command-catalog/core.ts        |   5 +
+ .../src/cli/run-cli/command-loaders/core.ts        |   3 +
+ .../src/commands/doctor-git-locks.run.ts           |  45 +++++
+ .../src/commands/doctor-git-locks.spec.ts          |  17 ++
+ .../impl/commands.commit-non-close.unit.test.ts    |  19 +-
+ .../src/commands/guard/impl/comment-commit.ts      | 111 ++++++++++-
+ .../src/commands/guard/impl/commit-diagnostics.ts  |  11 +-
+ .../agentplane/src/commands/guard/impl/commit.ts   | 220 ++++++++++++++++++++-
+ .../src/commands/hooks/capabilities.test.ts        |   6 +-
+ .../agentplane/src/commands/hooks/capabilities.ts  |   2 +-
+ packages/agentplane/src/commands/hooks/run.ts      |  23 ++-
+ .../commands/pr/integrate/internal/merge.test.ts   | 118 ++++++-----
+ .../src/commands/pr/integrate/internal/merge.ts    | 215 +++++++++++++++++---
+ .../src/shared/git-index-lock-guard.test.ts        |   8 +
+ packages/agentplane/src/shared/git-mutation.ts     |  30 ++-
+ 18 files changed, 768 insertions(+), 121 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605111510-3X3KVC/pr/github-title.txt
+++ b/.agentplane/tasks/202605111510-3X3KVC/pr/github-title.txt
@@ -1,0 +1,1 @@
+🧩 3X3KVC task: Fix git lock diagnostics and merge tests [202605111510-3X3KVC]

--- a/.agentplane/tasks/202605111510-3X3KVC/pr/meta.json
+++ b/.agentplane/tasks/202605111510-3X3KVC/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605111510-3X3KVC/fix-git-locks-v2",
+  "created_at": "2026-05-11T15:10:35.637Z",
+  "head_sha": "df6e4e8fdab2b62b428652251f9fba98f9cef579",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202605111510-3X3KVC",
+  "updated_at": "2026-05-11T15:10:35.637Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605111510-3X3KVC/pr/review.md
+++ b/.agentplane/tasks/202605111510-3X3KVC/pr/review.md
@@ -1,0 +1,54 @@
+# PR Review
+
+Created: 2026-05-11T15:10:35.637Z
+
+## Task
+
+- Task: `202605111510-3X3KVC`
+- Title: Fix git lock diagnostics and merge tests
+- Status: TODO
+- Branch: `task/202605111510-3X3KVC/fix-git-locks-v2`
+- Canonical task record: `.agentplane/tasks/202605111510-3X3KVC/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-11T15:10:35.637Z
+- Branch: task/202605111510-3X3KVC/fix-git-locks-v2
+- Head: df6e4e8fdab2
+
+```text
+ docs/user/cli-reference.generated.mdx              |  29 +++
+ docs/user/task-lifecycle.mdx                       |  13 +-
+ docs/workflow-guides/branch-pr.mdx                 |  14 +-
+ .../src/cli/run-cli/command-catalog/core.ts        |   5 +
+ .../src/cli/run-cli/command-loaders/core.ts        |   3 +
+ .../src/commands/doctor-git-locks.run.ts           |  45 +++++
+ .../src/commands/doctor-git-locks.spec.ts          |  17 ++
+ .../impl/commands.commit-non-close.unit.test.ts    |  19 +-
+ .../src/commands/guard/impl/comment-commit.ts      | 111 ++++++++++-
+ .../src/commands/guard/impl/commit-diagnostics.ts  |  11 +-
+ .../agentplane/src/commands/guard/impl/commit.ts   | 220 ++++++++++++++++++++-
+ .../src/commands/hooks/capabilities.test.ts        |   6 +-
+ .../agentplane/src/commands/hooks/capabilities.ts  |   2 +-
+ packages/agentplane/src/commands/hooks/run.ts      |  23 ++-
+ .../commands/pr/integrate/internal/merge.test.ts   | 118 ++++++-----
+ .../src/commands/pr/integrate/internal/merge.ts    | 215 +++++++++++++++++---
+ .../src/shared/git-index-lock-guard.test.ts        |   8 +
+ packages/agentplane/src/shared/git-mutation.ts     |  30 ++-
+ 18 files changed, 768 insertions(+), 121 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -82,6 +82,7 @@ This page is generated from the CLI command specs. Do not edit it by hand; edit 
   - [upgrade](#upgrade)
 - Quality
   - [doctor](#doctor)
+  - [doctor git-locks](#doctor-git-locks)
 - Diagnostics
   - [runtime](#runtime)
   - [runtime explain](#runtime-explain)
@@ -2248,6 +2249,34 @@ agentplane doctor --fix
 ```
 
 - Apply safe-only fixes (idempotent).
+
+### doctor git-locks
+
+Check Git index lock state for this repository and suggest cleanup.
+
+Usage:
+
+```text
+agentplane doctor git-locks [options]
+```
+
+Options:
+
+- `--fix`: Remove stale index.lock when safe. (default=false)
+
+Examples:
+
+```sh
+agentplane doctor git-locks
+```
+
+- Inspect current git index lock status.
+
+```sh
+agentplane doctor git-locks --fix
+```
+
+- Remove stale git index.lock after inspection.
 
 ## Diagnostics
 

--- a/docs/user/task-lifecycle.mdx
+++ b/docs/user/task-lifecycle.mdx
@@ -11,11 +11,12 @@ This repository is configured for `branch_pr`, so the normal guarded route is:
 
 1. Preflight.
 2. Create the task and approve the plan.
-3. `work start ... --worktree`.
-4. Implement changes on the task branch and keep local PR artifacts current.
-5. Push the task branch, open a hosted PR, and wait for required remote checks.
-6. `verify` on the task branch, then `integrate` on the base branch only after remote green.
-7. `finish` on the base branch with `--result` and `--commit`.
+3. `work start ... --worktree` on base, then execute implementation on the task branch/worktree.
+4. Run `task start-ready`, implement, and commit implementation changes in the task worktree.
+5. Keep PR artifacts current, push the task branch, open a hosted PR, and wait for required remote checks.
+6. Run `verify` on the task branch, then `integrate` on the base branch only after remote checks pass.
+7. `finish` on the base branch with `--commit <git-rev>` and `--close-commit`.
+8. Clean up the task worktree/branch after hosted merge closure.
 
 ```bash
 agentplane config show
@@ -23,6 +24,7 @@ agentplane quickstart
 agentplane task list
 git status --short --untracked-files=no
 agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree
+agentplane task start-ready <task-id> --author <ROLE> --body "Start: ..."
 agentplane pr open <task-id> --branch task/<task-id>/<slug> --author <ROLE>
 agentplane pr update <task-id>
 git push -u origin task/<task-id>/<slug>
@@ -31,6 +33,7 @@ bun run workflow:wait-remote-checks
 agentplane verify <task-id> --ok|--rework --by <ROLE> --note "..."
 agentplane integrate <task-id> --branch task/<task-id>/<slug> --run-verify
 agentplane finish <task-id> --author INTEGRATOR --body "Verified: ..." --result "..." --commit <git-rev> --close-commit
+agentplane work end <task-id>
 ```
 
 `direct` remains supported, but here it is an explicit alternative rather than the default guarded route.

--- a/docs/workflow-guides/branch-pr.mdx
+++ b/docs/workflow-guides/branch-pr.mdx
@@ -25,31 +25,35 @@ agentplane task plan approve <task-id> --by ORCHESTRATOR
 agentplane work start <task-id> --agent CODER --slug cli-help-copy --worktree
 ```
 
-From the task worktree:
+In the task worktree:
 
 ```bash
 agentplane task start-ready <task-id> --author CODER --body "Start: branch_pr CLI help copy update with focused verification."
-# edit files
+# implement + commit implementation changes
 agentplane task verify-show <task-id>
-# run listed checks
 agentplane pr open <task-id> --branch task/<task-id>/cli-help-copy --author CODER
 agentplane pr update <task-id>
 agentplane verify <task-id> --ok --by CODER --note "Focused checks passed on the task branch."
 ```
 
-From the base checkout after review:
+Back on base checkout:
 
 ```bash
 agentplane integrate <task-id> --branch task/<task-id>/cli-help-copy --run-verify
+# optionally run remote-gate if repository policy requires it
 agentplane finish <task-id> --author INTEGRATOR --body "Verified: branch integrated after review and verification." --result "CLI help copy updated" --commit <git-rev> --close-commit
+agentplane work end <task-id>
 ```
+
+Lifecycle/status checkpoint commits (`start-ready`/`verify`/`set-status` with `--commit-from-comment`) are not implementation commits; they record lifecycle state in task artifacts and should not be used as the base-side `finish` mutation.
 
 ## Expected repo artifacts
 
-- task branch or worktree
+- task branch in the dedicated worktree
 - `.agentplane/tasks/<task-id>/pr/` PR title/body/diffstat artifacts
 - task README verification evidence
 - base-branch finish record after integration
+- worktree branch cleanup via `agentplane work end <task-id>`
 
 ## Limitations
 

--- a/packages/agentplane/src/cli/run-cli/command-catalog/core.ts
+++ b/packages/agentplane/src/cli/run-cli/command-catalog/core.ts
@@ -1,4 +1,5 @@
 import { doctorSpec } from "../../../commands/doctor.spec.js";
+import { doctorGitLocksSpec } from "../../../commands/doctor-git-locks.spec.js";
 import { runtimeExplainSpec, runtimeSpec } from "../../../commands/runtime.spec.js";
 import { upgradeSpec } from "../../../commands/upgrade.spec.js";
 import { workflowBuildSpec } from "../../../commands/workflow-build.command.js";
@@ -45,6 +46,7 @@ import {
   fromCommandsIncidentsIncidentsCommand,
   fromCommandsCoreRole,
   fromCommandsDoctorRun,
+  fromCommandsDoctorGitLocksCommand,
   fromCommandsWorkflowCommand,
   fromCommandsWorkflowBuildCommand,
   fromCommandsWorkflowRestoreCommand,
@@ -113,6 +115,9 @@ export const CORE_COMMANDS = [
   }),
   fromCommandsRuntimeCommand(runtimeSpec, "runRuntime", { needs: "none" }),
   fromCommandsRuntimeCommand(runtimeExplainSpec, "runRuntimeExplain", { needs: "none" }),
+  fromCommandsDoctorGitLocksCommand(doctorGitLocksSpec, "runDoctorGitLocks", {
+    needs: "project",
+  }),
   fromCommandsIncidentsIncidentsCommand(incidentsSpec, "runIncidents", { needs: "none" }),
   declareCommand(incidentsCollectSpec, { load: loadIncidentsCollectSpec }),
   declareCommand(incidentsAdviseSpec, { load: loadIncidentsAdviseSpec }),

--- a/packages/agentplane/src/cli/run-cli/command-loaders/core.ts
+++ b/packages/agentplane/src/cli/run-cli/command-loaders/core.ts
@@ -28,6 +28,9 @@ export const fromCommandsIncidentsIncidentsCommand = commandModule(
 );
 export const fromCommandsCoreRole = commandModule(() => import("../commands/core/role.js"));
 export const fromCommandsDoctorRun = commandModule(() => import("../../../commands/doctor.run.js"));
+export const fromCommandsDoctorGitLocksCommand = commandModule(
+  () => import("../../../commands/doctor-git-locks.run.js"),
+);
 export const fromCommandsWorkflowCommand = commandModule(
   () => import("../../../commands/workflow.command.js"),
 );

--- a/packages/agentplane/src/commands/doctor-git-locks.run.ts
+++ b/packages/agentplane/src/commands/doctor-git-locks.run.ts
@@ -1,0 +1,45 @@
+import { rm } from "node:fs/promises";
+
+import { exitCodeForError } from "../cli/exit-codes.js";
+import { warnMessage, successMessage } from "../cli/output.js";
+import type { CommandHandler } from "../cli/spec/spec.js";
+import { resolveProject } from "@agentplaneorg/core/project";
+import { resolveGitIndexLockInfo } from "../shared/git-mutation.js";
+
+export type DoctorGitLocksParsed = {
+  fix: boolean;
+};
+
+export const runDoctorGitLocks: CommandHandler<DoctorGitLocksParsed> = async (ctx, flags) => {
+  const project = (await resolveProject({
+    cwd: ctx.cwd,
+    rootOverride: ctx.rootOverride ?? null,
+  })) as { gitRoot: string };
+  const lockInfo = (await resolveGitIndexLockInfo({
+    repoRoot: project.gitRoot,
+  })) as { lockPath: string; ageMs: number } | null;
+
+  if (!lockInfo) {
+    process.stdout.write(`${successMessage("doctor git-locks", undefined, "no index.lock detected")}\n`);
+    return 0;
+  }
+
+  const message = `index.lock detected at ${lockInfo.lockPath}; ageMs=${lockInfo.ageMs}`;
+  if (!flags.fix) {
+    process.stderr.write(`${warnMessage(`doctor git-locks: ${message}`)}\n`);
+    process.stderr.write(
+      `${warnMessage("run `agentplane doctor git-locks --fix` only if no git process owns the lock")}\n`,
+    );
+    return exitCodeForError("E_GIT_LOCKED");
+  }
+
+  try {
+    await rm(lockInfo.lockPath, { force: true });
+  } catch (err: unknown) {
+    const errorMessage = err instanceof Error ? err.message : "unknown error";
+    throw new Error(`doctor git-locks --fix failed to remove lock: ${errorMessage}`);
+  }
+
+  process.stdout.write(`${successMessage("doctor git-locks", undefined, `${message} removed`)}\n`);
+  return 0;
+};

--- a/packages/agentplane/src/commands/doctor-git-locks.spec.ts
+++ b/packages/agentplane/src/commands/doctor-git-locks.spec.ts
@@ -1,0 +1,17 @@
+import type { CommandSpec } from "../cli/spec/spec.js";
+
+export const doctorGitLocksSpec: CommandSpec<{ fix: boolean }> = {
+  id: ["doctor", "git-locks"],
+  group: "Quality",
+  summary: "Check Git index lock state for this repository and suggest cleanup.",
+  options: [
+    { kind: "boolean", name: "fix", default: false, description: "Remove stale index.lock when safe." },
+  ],
+  examples: [
+    { cmd: "agentplane doctor git-locks", why: "Inspect current git index lock status." },
+    { cmd: "agentplane doctor git-locks --fix", why: "Remove stale git index.lock after inspection." },
+  ],
+  parse: (raw) => ({
+    fix: raw.opts.fix === true,
+  }),
+};

--- a/packages/agentplane/src/commands/guard/impl/commands.commit-non-close.unit.test.ts
+++ b/packages/agentplane/src/commands/guard/impl/commands.commit-non-close.unit.test.ts
@@ -467,16 +467,19 @@ describe("guard command implementations: commit non-close", () => {
     });
   });
 
-  it("cmdCommit maps unknown errors via mapCoreError when not git-commit shaped", async () => {
+  it("cmdCommit maps unknown git-commit failures to git-commit diagnostics", async () => {
     const { cmdCommit } = await import("./commit.js");
     const ctx = mkCtx();
     ctx.git.statusStagedPaths.mockResolvedValue(["src/app.ts"]);
-    const mapped = new CliError({
-      exitCode: exitCodeForError("E_IO"),
-      code: "E_IO",
-      message: "mapped",
-    });
-    mocks.mapCoreError.mockReturnValue(mapped);
+    const errorMatcher = {
+      exitCode: exitCodeForError("E_GIT"),
+      code: "E_GIT",
+      message: "git commit failed: boom",
+      context: expect.objectContaining({
+        diagnostic_state: "git commit failed",
+        diagnostic_likely_cause: expect.stringContaining("The commit pre-conditions"),
+      }),
+    };
     ctx.git.commit.mockRejectedValue(new Error("boom"));
     await expect(
       cmdCommit({
@@ -496,7 +499,7 @@ describe("guard command implementations: commit non-close", () => {
         requireClean: false,
         quiet: true,
       }),
-    ).rejects.toBe(mapped);
+    ).rejects.toMatchObject(errorMatcher);
   });
 
   it("cmdCommit preserves salient linter failure lines in git-commit-shaped errors", async () => {

--- a/packages/agentplane/src/commands/guard/impl/comment-commit.ts
+++ b/packages/agentplane/src/commands/guard/impl/comment-commit.ts
@@ -1,8 +1,16 @@
 import type { AgentplaneConfig } from "@agentplaneorg/core/config";
 import { extractTaskSuffix } from "@agentplaneorg/core/commit";
 
+import { exitCodeForError } from "../../../cli/exit-codes.js";
 import { invalidValueMessage, successMessage } from "../../../cli/output.js";
 import { CliError } from "../../../shared/errors.js";
+import {
+  resolveGitIndexLockInfo,
+  resolveGitMutationDiagnosticContext,
+  withGitMutationMutex,
+  type GitMutationKind,
+} from "../../../shared/git-mutation.js";
+import { asCommitFailure } from "./commit-diagnostics.js";
 import {
   formatCommentBodyForCommit,
   normalizeCommentBodyForCommit,
@@ -13,6 +21,95 @@ import { appendDcoSignoff } from "./dco.js";
 import { buildGitCommitEnv, resolveCanonicalGitIdentity } from "./env.js";
 import { stageAllowlist } from "./allow.js";
 import { guardCommitCheck } from "./policy.js";
+
+const GIT_COMMIT_LOCK_REMEDIATION =
+  "Wait for the active AgentPlane or external git process to release index lock, then retry.";
+
+async function commitFromCommentWithLock(opts: {
+  ctx: CommandContext;
+  taskId: string;
+  message: string;
+  body: string;
+  env?: NodeJS.ProcessEnv;
+  allowPrefixes: string[];
+  changedPaths: string[];
+  stagedPaths: string[];
+  mutationKind: GitMutationKind;
+}): Promise<void> {
+  const lockInfo = await resolveGitIndexLockInfo({ repoRoot: opts.ctx.resolvedProject.gitRoot });
+  if (lockInfo) {
+    throw new CliError({
+      exitCode: exitCodeForError("E_GIT_LOCKED"),
+      code: "E_GIT_LOCKED",
+      message: `Git index is locked; refusing comment-driven commit: ${lockInfo.lockPath}`,
+      context: {
+        ...(await resolveGitMutationDiagnosticContext({
+          command: "git commit",
+          cwd: opts.ctx.resolvedProject.gitRoot,
+          repoRoot: opts.ctx.resolvedProject.gitRoot,
+          workflowMode: opts.ctx.config.workflow_mode,
+          mutationKind: opts.mutationKind,
+          taskId: opts.taskId,
+          allowPrefixes: opts.allowPrefixes,
+          changedPaths: opts.changedPaths,
+          stagedPaths: opts.stagedPaths,
+        })),
+        remediation: GIT_COMMIT_LOCK_REMEDIATION,
+        git_index_lock_path: lockInfo.lockPath,
+        git_index_lock_age_ms: lockInfo.ageMs,
+      },
+    });
+  }
+
+  await withGitMutationMutex(
+    {
+      repoRoot: opts.ctx.resolvedProject.gitRoot,
+      operation: "git-commit",
+      workflowMode: opts.ctx.config.workflow_mode,
+      mutationKind: opts.mutationKind,
+      taskId: opts.taskId,
+    },
+    async () => {
+      try {
+        await opts.ctx.git.commit({ message: opts.message, body: opts.body, env: opts.env });
+      } catch (err) {
+        const failureContext = await resolveGitMutationDiagnosticContext({
+          command: "git commit",
+          cwd: opts.ctx.resolvedProject.gitRoot,
+          repoRoot: opts.ctx.resolvedProject.gitRoot,
+          workflowMode: opts.ctx.config.workflow_mode,
+          mutationKind: opts.mutationKind,
+          taskId: opts.taskId,
+          allowPrefixes: opts.allowPrefixes,
+          changedPaths: opts.changedPaths,
+          stagedPaths: opts.stagedPaths,
+        });
+
+        const failure = asCommitFailure(err, "task_commit", failureContext);
+        if (failure) throw failure;
+
+        const message = err instanceof Error ? err.message : "git commit failed";
+        const errorContext = await resolveGitMutationDiagnosticContext({
+          command: "git commit",
+          cwd: opts.ctx.resolvedProject.gitRoot,
+          repoRoot: opts.ctx.resolvedProject.gitRoot,
+          workflowMode: opts.ctx.config.workflow_mode,
+          mutationKind: opts.mutationKind,
+          taskId: opts.taskId,
+          allowPrefixes: opts.allowPrefixes,
+          changedPaths: opts.changedPaths,
+          stagedPaths: opts.stagedPaths,
+        });
+        throw new CliError({
+          exitCode: exitCodeForError("E_GIT"),
+          code: "E_GIT",
+          message,
+          context: errorContext,
+        });
+      }
+    },
+  );
+}
 
 function deriveCommitMessageFromComment(opts: {
   taskId: string;
@@ -172,10 +269,20 @@ export async function commitFromComment(opts: {
     allowCI: false,
     gitIdentity: await resolveCanonicalGitIdentity(),
   });
-  await ctx.git.commit({
+  const [changedPaths, stagedPaths] = await Promise.all([
+    ctx.git.statusChangedPaths(),
+    ctx.git.statusStagedPaths(),
+  ]);
+  await commitFromCommentWithLock({
+    ctx,
+    taskId: opts.taskId,
     message,
-    body: appendDcoSignoff({ config: opts.config, body }),
+    body: appendDcoSignoff({ config: opts.config, body }) ?? body,
     env,
+    allowPrefixes: allowPrefixes,
+    changedPaths,
+    stagedPaths,
+    mutationKind: "lifecycle_commit",
   });
 
   const { hash, subject } = await ctx.git.headHashSubject();

--- a/packages/agentplane/src/commands/guard/impl/commit-diagnostics.ts
+++ b/packages/agentplane/src/commands/guard/impl/commit-diagnostics.ts
@@ -147,7 +147,11 @@ function commitFailureDiagnostic(
   };
 }
 
-export function asCommitFailure(err: unknown, phase: CommitFailurePhase): CliError | null {
+export function asCommitFailure(
+  err: unknown,
+  phase: CommitFailurePhase,
+  context?: Record<string, unknown>,
+): CliError | null {
   if (!(err instanceof Error)) return null;
   const e = err as ExecFileLikeError;
   const shortMessage = typeof e.shortMessage === "string" ? e.shortMessage : "";
@@ -177,6 +181,9 @@ export function asCommitFailure(err: unknown, phase: CommitFailurePhase): CliErr
     exitCode: 5,
     code: "E_GIT",
     message: lines.join("\n"),
-    context: withDiagnosticContext({ command: "commit" }, commitFailureDiagnostic(phase, output)),
+    context: {
+      ...(context ? context : {}),
+      ...withDiagnosticContext({ command: "commit" }, commitFailureDiagnostic(phase, output)),
+    },
   });
 }

--- a/packages/agentplane/src/commands/guard/impl/commit.ts
+++ b/packages/agentplane/src/commands/guard/impl/commit.ts
@@ -1,8 +1,15 @@
 import { mapCoreError } from "../../../cli/error-map.js";
 import { infoMessage, successMessage } from "../../../cli/output.js";
+import { exitCodeForError } from "../../../cli/exit-codes.js";
 import { withDiagnosticContext } from "../../shared/diagnostics.js";
-import { CliError } from "../../../shared/errors.js";
+import { CliError, type ErrorCode } from "../../../shared/errors.js";
 import { refreshBranchPrArtifactsAfterTaskCommit } from "../../shared/post-commit-pr-artifacts.js";
+import {
+  resolveGitIndexLockInfo,
+  resolveGitMutationDiagnosticContext,
+  withGitMutationMutex,
+  type GitMutationKind,
+} from "../../../shared/git-mutation.js";
 import {
   loadCommandContext,
   loadTaskFromContext,
@@ -29,6 +36,144 @@ import {
   stageCloseCommitPaths,
 } from "./commit-stage.js";
 import { guardCommitCheck } from "./policy.js";
+
+const GIT_COMMIT_LOCK_REMEDIATION =
+  "Wait for the active AgentPlane or external git process to release index lock, then retry.";
+const GIT_COMMIT_PERMISSION_REMEDIATION =
+  "Check repository permissions (uid/gid and write access for .git/*), fix ownership, then retry.";
+const GIT_COMMIT_RACE_REMEDIATION =
+  "A conflicting git writer was detected. Retry when merge/rebase/commit operations are not running.";
+
+function classifyGitCommitFailure(message: string): ErrorCode {
+  if (message.includes("index.lock") || /could not lock|unable to create .*lock/.test(message)) {
+    return "E_GIT_LOCKED";
+  }
+  if (/\b(EACCES|EPERM)\b|operation not permitted|permission denied/i.test(message)) {
+    return "E_GIT_PERMISSION";
+  }
+  if (/another git process|concurrent|already running|is locked/i.test(message)) {
+    return "E_GIT_RACE";
+  }
+  return "E_GIT";
+}
+
+async function runCommitWithLock(opts: {
+  ctx: CommandContext;
+  taskId: string;
+  message: string;
+  body?: string;
+  env?: NodeJS.ProcessEnv;
+  allowPrefixes?: string[];
+  changedPaths: string[];
+  stagedPaths: string[];
+  mutationKind: GitMutationKind;
+  phase: "task_commit" | "close_commit";
+}): Promise<void> {
+  const lockInfo = await resolveGitIndexLockInfo({ repoRoot: opts.ctx.resolvedProject.gitRoot });
+  if (lockInfo) {
+    const lockDiagnosticContext = await resolveGitMutationDiagnosticContext({
+      command: "git commit",
+      cwd: opts.ctx.resolvedProject.gitRoot,
+      repoRoot: opts.ctx.resolvedProject.gitRoot,
+      workflowMode: opts.ctx.config.workflow_mode,
+      mutationKind: opts.mutationKind,
+      taskId: opts.taskId,
+      allowPrefixes: opts.allowPrefixes,
+      changedPaths: opts.changedPaths,
+      stagedPaths: opts.stagedPaths,
+    });
+    throw new CliError({
+      exitCode: exitCodeForError("E_GIT_LOCKED"),
+      code: "E_GIT_LOCKED",
+      message: `Git index is locked; refusing git commit: ${lockInfo.lockPath}`,
+      context: {
+        ...lockDiagnosticContext,
+        remediation: GIT_COMMIT_LOCK_REMEDIATION,
+        git_index_lock_path: lockInfo.lockPath,
+        git_index_lock_age_ms: lockInfo.ageMs,
+      },
+    });
+  }
+
+  await withGitMutationMutex(
+    {
+      repoRoot: opts.ctx.resolvedProject.gitRoot,
+      operation: "git-commit",
+      workflowMode: opts.ctx.config.workflow_mode,
+      mutationKind: opts.mutationKind,
+      taskId: opts.taskId,
+    },
+    async () => {
+      try {
+        await opts.ctx.git.commit({
+          message: opts.message,
+          body: opts.body,
+          env: opts.env,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "git commit failed";
+        const code = classifyGitCommitFailure(message);
+        if (code === "E_GIT") {
+          const failureContext = await resolveGitMutationDiagnosticContext({
+            command: "git commit",
+            cwd: opts.ctx.resolvedProject.gitRoot,
+            repoRoot: opts.ctx.resolvedProject.gitRoot,
+            workflowMode: opts.ctx.config.workflow_mode,
+            mutationKind: opts.mutationKind,
+            taskId: opts.taskId,
+            allowPrefixes: opts.allowPrefixes,
+            changedPaths: opts.changedPaths,
+            stagedPaths: opts.stagedPaths,
+          });
+          const failure = asCommitFailure(err, opts.phase, failureContext);
+          if (failure) throw failure;
+        }
+
+        const remediation =
+          code === "E_GIT_LOCKED"
+            ? GIT_COMMIT_LOCK_REMEDIATION
+            : code === "E_GIT_PERMISSION"
+              ? GIT_COMMIT_PERMISSION_REMEDIATION
+              : code === "E_GIT_RACE"
+                ? GIT_COMMIT_RACE_REMEDIATION
+                : "Retry once local git writers are idle and git state is readable.";
+        throw new CliError({
+          exitCode: exitCodeForError(code),
+          code,
+          message: `git commit failed: ${message}`,
+          context: withDiagnosticContext(
+            {
+              ...(await resolveGitMutationDiagnosticContext({
+                command: "git commit",
+                cwd: opts.ctx.resolvedProject.gitRoot,
+                repoRoot: opts.ctx.resolvedProject.gitRoot,
+                workflowMode: opts.ctx.config.workflow_mode,
+                mutationKind: opts.mutationKind,
+                taskId: opts.taskId,
+                allowPrefixes: opts.allowPrefixes,
+                changedPaths: opts.changedPaths,
+                stagedPaths: opts.stagedPaths,
+              })),
+              remediation,
+            },
+            {
+              state: code === "E_GIT_LOCKED" ? "Git index lock blocked commit" : "git commit failed",
+              likelyCause:
+                code === "E_GIT_LOCKED"
+                  ? "A git index lock file is present or another process is actively writing git index."
+                  : "The commit pre-conditions or hook/policy checks failed while writing repository state.",
+              nextAction: {
+                command: "agentplane doctor git-locks",
+                reason: "inspect lock owner and safe recovery path before retry",
+                reasonCode: "git_lock_diagnosis",
+              },
+            },
+          ),
+        });
+      }
+    },
+  );
+}
 
 export async function cmdCommit(opts: {
   ctx?: CommandContext;
@@ -149,10 +294,21 @@ export async function cmdCommit(opts: {
       allowCI: opts.allowCI,
       gitIdentity: await resolveCanonicalGitIdentity(),
     });
-    await ctx.git.commit({
+    const [changedPaths, stagedPaths] = await Promise.all([
+      ctx.git.statusChangedPaths(),
+      ctx.git.statusStagedPaths(),
+    ]);
+    await runCommitWithLock({
+      ctx,
+      taskId: opts.taskId,
       message: opts.message,
       body: appendDcoSignoff({ config: ctx.config }),
       env,
+      allowPrefixes: opts.allow,
+      changedPaths,
+      stagedPaths,
+      mutationKind: "implementation_commit",
+      phase: "task_commit",
     });
     const primaryCommit = await ctx.git.headHashSubject();
     await refreshBranchPrArtifactsAfterTaskCommit({
@@ -208,10 +364,51 @@ async function cmdCloseCommit(
   let staged = await opts.ctx.git.statusStagedPaths();
   if (staged.length > 0 && opts.closeUnstageOthers) {
     if (!opts.closeCheckOnly) {
-      await execFileAsync("git", ["restore", "--staged", "--", "."], {
-        cwd: opts.ctx.resolvedProject.gitRoot,
-        env: gitEnv(),
+      const [changedPaths, stagedPaths] = await Promise.all([
+        opts.ctx.git.statusChangedPaths(),
+        opts.ctx.git.statusStagedPaths(),
+      ]);
+      await withGitMutationMutex(
+        {
+          repoRoot: opts.ctx.resolvedProject.gitRoot,
+          operation: "git-restore",
+          workflowMode: opts.ctx.config.workflow_mode,
+          mutationKind: "close_tail",
+          taskId: opts.taskId,
+        },
+        async () => {
+          await execFileAsync("git", ["restore", "--staged", "--", "."], {
+            cwd: opts.ctx.resolvedProject.gitRoot,
+            env: gitEnv(),
+          });
+        },
+      );
+      staged = await opts.ctx.git.statusStagedPaths();
+      const lockInfo = await resolveGitIndexLockInfo({
+        repoRoot: opts.ctx.resolvedProject.gitRoot,
       });
+      if (lockInfo) {
+        throw new CliError({
+          exitCode: exitCodeForError("E_GIT_LOCKED"),
+          code: "E_GIT_LOCKED",
+          message: `Git index is locked; refusing close-commit restore: ${lockInfo.lockPath}`,
+          context: {
+            ...(await resolveGitMutationDiagnosticContext({
+              command: "git restore",
+              cwd: opts.ctx.resolvedProject.gitRoot,
+              repoRoot: opts.ctx.resolvedProject.gitRoot,
+              workflowMode: opts.ctx.config.workflow_mode,
+              mutationKind: "close_tail",
+              taskId: opts.taskId,
+              changedPaths,
+              stagedPaths,
+            })),
+            remediation: GIT_COMMIT_LOCK_REMEDIATION,
+            git_index_lock_path: lockInfo.lockPath,
+            git_index_lock_age_ms: lockInfo.ageMs,
+          },
+        });
+      }
     }
     staged = opts.closeCheckOnly ? staged : await opts.ctx.git.statusStagedPaths();
   }
@@ -324,10 +521,21 @@ async function cmdCloseCommit(
     allowStaleDist: true,
     gitIdentity: await resolveCanonicalGitIdentity(),
   });
-  await opts.ctx.git.commit({
+  const [closeChangedPaths, closeStagedPaths] = await Promise.all([
+    opts.ctx.git.statusChangedPaths(),
+    opts.ctx.git.statusStagedPaths(),
+  ]);
+  await runCommitWithLock({
+    ctx: opts.ctx,
+    taskId: opts.taskId,
     message: msg.subject,
     body: appendDcoSignoff({ config: opts.ctx.config, body: msg.body }),
     env,
+    allowPrefixes: opts.allow,
+    changedPaths: closeChangedPaths,
+    stagedPaths: closeStagedPaths,
+    mutationKind: "close_tail",
+    phase: "close_commit",
   });
 
   if (!opts.quiet) {

--- a/packages/agentplane/src/commands/hooks/capabilities.test.ts
+++ b/packages/agentplane/src/commands/hooks/capabilities.test.ts
@@ -28,19 +28,19 @@ describe("hook capabilities", () => {
     }
   });
 
-  it("declares write-capable hooks as outside-Git-index hook checks", () => {
+  it("declares write-capable hooks as requiring worktree mutex", () => {
     const capability = resolveHookCapability("post-merge");
 
     expect(capability).toMatchObject({
       mode: "write_capable",
-      gitIndexWriteIntent: "forbidden",
+      gitIndexWriteIntent: "worktree_mutex_required",
       mutationKind: "hook_check",
       lockContext: "outside_git_index",
     });
     expect(hookCapabilityDiagnosticContext(capability)).toMatchObject({
       hook: "post-merge",
       hook_capability_mode: "write_capable",
-      hook_git_index_write_intent: "forbidden",
+      hook_git_index_write_intent: "worktree_mutex_required",
       mutation_kind: "hook_check",
       hook_lock_context: "outside_git_index",
     });

--- a/packages/agentplane/src/commands/hooks/capabilities.ts
+++ b/packages/agentplane/src/commands/hooks/capabilities.ts
@@ -38,7 +38,7 @@ const HOOK_CAPABILITIES: Readonly<Record<HookName, HookCapability>> = {
   "post-merge": {
     hook: "post-merge",
     mode: "write_capable",
-    gitIndexWriteIntent: "forbidden",
+    gitIndexWriteIntent: "worktree_mutex_required",
     mutationKind: "hook_check",
     lockContext: "outside_git_index",
   },

--- a/packages/agentplane/src/commands/hooks/run.ts
+++ b/packages/agentplane/src/commands/hooks/run.ts
@@ -1,5 +1,6 @@
 import { mapBackendError } from "../../cli/error-map.js";
 import { CliError } from "../../shared/errors.js";
+import { withGitMutationMutex } from "../../shared/git-mutation.js";
 import {
   hookCapabilityDiagnosticContext,
   resolveHookCapability,
@@ -35,10 +36,30 @@ async function runHook(opts: HooksRunOptions): Promise<number> {
   }
 }
 
+async function runHookWithGitMutationMutex(
+  capability: ReturnType<typeof resolveHookCapability>,
+  opts: HooksRunOptions,
+): Promise<number> {
+  if (capability.gitIndexWriteIntent !== "worktree_mutex_required") {
+    return withHookCapabilityEnvironment(capability, () => runHook(opts));
+  }
+
+  return withGitMutationMutex(
+    {
+      repoRoot: opts.rootOverride ?? opts.cwd,
+      operation: `git-hook-${opts.hook}`,
+      mutationKind: capability.mutationKind,
+      workflowMode: process.env.AGENTPLANE_WORKFLOW_MODE,
+      taskId: (process.env.AGENTPLANE_TASK_ID ?? "").trim() || undefined,
+    },
+    () => withHookCapabilityEnvironment(capability, () => runHook(opts)),
+  );
+}
+
 export async function cmdHooksRun(opts: HooksRunOptions): Promise<number> {
   const capability = resolveHookCapability(opts.hook);
   try {
-    return await withHookCapabilityEnvironment(capability, () => runHook(opts));
+    return await runHookWithGitMutationMutex(capability, opts);
   } catch (err) {
     const status = (err as { status?: unknown } | null)?.status;
     const stdout = (err as { stdout?: unknown } | null)?.stdout;

--- a/packages/agentplane/src/commands/pr/integrate/internal/merge.test.ts
+++ b/packages/agentplane/src/commands/pr/integrate/internal/merge.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { CliError } from "../../../../shared/errors.js";
@@ -14,6 +17,8 @@ vi.mock("@agentplaneorg/core/process", () => ({
 }));
 vi.mock("@agentplaneorg/core/git", () => ({
   gitEnv: () => ({}),
+  gitRevParse: (cwd: string, args: string[]) =>
+    args.includes("--git-common-dir") || args.includes("--git-dir") ? ".git" : `${cwd}/.git`,
 }));
 vi.mock("../../../shared/git-ops.js", () => ({
   gitRevParse: mocks.gitRevParse,
@@ -24,6 +29,15 @@ vi.mock("@agentplaneorg/core/commit", () => ({
 }));
 
 describe("pr/integrate/internal/merge", () => {
+  const withTempGitRoot = async <T>(run: (gitRoot: string) => Promise<T>): Promise<T> => {
+    const gitRoot = await mkdtemp(path.join(tmpdir(), "agentplane-merge-test-"));
+    try {
+      return await run(gitRoot);
+    } finally {
+      await rm(gitRoot, { recursive: true, force: true }).catch(() => null);
+    }
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -39,8 +53,9 @@ describe("pr/integrate/internal/merge", () => {
     mocks.extractTaskSuffix.mockReturnValue("ABC123");
     mocks.gitRevParse.mockResolvedValue("deadbeefcafebabe");
 
-    const hash = await runSquashMerge({
-      gitRoot: "/repo",
+    const hash = await withTempGitRoot((gitRoot) =>
+      runSquashMerge({
+      gitRoot,
       base: "main",
       branch: "task/T-1",
       headBeforeMerge: "before",
@@ -50,13 +65,14 @@ describe("pr/integrate/internal/merge", () => {
       workflowDir: ".agentplane/tasks",
       changedPaths: [],
       genericTokens: ["wip"],
-    });
+      }),
+    );
     expect(hash).toBe("deadbeefcafebabe");
     const commitCall = mocks.execFileAsync.mock.calls.at(-1);
     expect(commitCall?.[0]).toBe("git");
     expect(commitCall?.[1]).toEqual(["commit", "-m", "🧩 ABC123 integrate: Improve PR UX"]);
     expect(commitCall?.[2]).toMatchObject({
-      cwd: "/repo",
+      cwd: expect.stringMatching(/agentplane-merge-test-/),
       env: {
         AGENTPLANE_TASK_ID: "202602111653-X32XPT",
         AGENTPLANE_ALLOW_BASE: "1",
@@ -84,8 +100,9 @@ describe("pr/integrate/internal/merge", () => {
     mocks.extractTaskSuffix.mockReturnValue("X32XPT");
     mocks.gitRevParse.mockResolvedValue("deadbeefcafebabe");
 
-    const hash = await runSquashMerge({
-      gitRoot: "/repo",
+    const hash = await withTempGitRoot((gitRoot) =>
+      runSquashMerge({
+      gitRoot,
       base: "main",
       branch: "task/T-1",
       headBeforeMerge: "before",
@@ -95,13 +112,14 @@ describe("pr/integrate/internal/merge", () => {
       workflowDir: ".agentplane/tasks",
       changedPaths: [],
       genericTokens: ["wip"],
-    });
+      }),
+    );
     expect(hash).toBe("deadbeefcafebabe");
     const commitCall = mocks.execFileAsync.mock.calls.at(-1);
     expect(commitCall?.[0]).toBe("git");
     expect(commitCall?.[1]).toEqual(["commit", "-m", "🧩 X32XPT integrate: Improve PR UX"]);
     expect(commitCall?.[2]).toMatchObject({
-      cwd: "/repo",
+      cwd: expect.stringMatching(/agentplane-merge-test-/),
       env: {
         AGENTPLANE_TASK_ID: "202602111653-X32XPT",
         AGENTPLANE_ALLOW_BASE: "1",
@@ -119,25 +137,27 @@ describe("pr/integrate/internal/merge", () => {
       .mockResolvedValueOnce({ stdout: "  \n" }) // diff --cached empty
       .mockResolvedValueOnce({}); // reset --hard
 
-    await expect(
-      runSquashMerge({
-        gitRoot: "/repo",
-        base: "main",
-        branch: "task/T-2",
-        headBeforeMerge: "before",
-        taskId: "202602111653-X32XPT",
-        taskTitle: "Improve PR UX",
-        taskTags: ["workflow", "cli"],
-        workflowDir: ".agentplane/tasks",
-        changedPaths: [],
-        genericTokens: ["wip"],
-      }),
-    ).rejects.toMatchObject<CliError>({ code: "E_USAGE" });
-    expect(mocks.execFileAsync).toHaveBeenCalledWith(
-      "git",
-      ["reset", "--hard", "before"],
-      expect.objectContaining({ cwd: "/repo" }),
-    );
+    await withTempGitRoot(async (gitRoot) => {
+      await expect(
+        runSquashMerge({
+          gitRoot,
+          base: "main",
+          branch: "task/T-2",
+          headBeforeMerge: "before",
+          taskId: "202602111653-X32XPT",
+          taskTitle: "Improve PR UX",
+          taskTags: ["workflow", "cli"],
+          workflowDir: ".agentplane/tasks",
+          changedPaths: [],
+          genericTokens: ["wip"],
+        }),
+      ).rejects.toMatchObject<CliError>({ code: "E_USAGE" });
+      expect(mocks.execFileAsync).toHaveBeenCalledWith(
+        "git",
+        ["reset", "--hard", "before"],
+        expect.objectContaining({ cwd: gitRoot }),
+      );
+    });
   });
 
   it("runMergeCommit aborts merge and raises E_GIT on failure", async () => {
@@ -145,22 +165,24 @@ describe("pr/integrate/internal/merge", () => {
     mocks.extractTaskSuffix.mockReturnValue("ABC123");
     mocks.execFileAsync.mockRejectedValueOnce(new Error("merge failed")).mockResolvedValueOnce({});
 
-    await expect(
-      runMergeCommit({
-        gitRoot: "/repo",
-        branch: "task/T-3",
-        taskId: "202602111653-X32XPT",
-        taskTitle: "Improve PR UX",
-        taskTags: ["workflow", "cli"],
-        workflowDir: ".agentplane/tasks",
-        changedPaths: [],
-      }),
-    ).rejects.toMatchObject<CliError>({ code: "E_GIT" });
-    expect(mocks.execFileAsync).toHaveBeenCalledWith(
-      "git",
-      ["merge", "--abort"],
-      expect.objectContaining({ cwd: "/repo" }),
-    );
+    await withTempGitRoot(async (gitRoot) => {
+      await expect(
+        runMergeCommit({
+          gitRoot,
+          branch: "task/T-3",
+          taskId: "202602111653-X32XPT",
+          taskTitle: "Improve PR UX",
+          taskTags: ["workflow", "cli"],
+          workflowDir: ".agentplane/tasks",
+          changedPaths: [],
+        }),
+      ).rejects.toMatchObject<CliError>({ code: "E_GIT" });
+      expect(mocks.execFileAsync).toHaveBeenCalledWith(
+        "git",
+        ["merge", "--abort"],
+        expect.objectContaining({ cwd: gitRoot }),
+      );
+    });
   });
 
   it("runMergeCommit allows tracked task state updates on the base commit path", async () => {
@@ -169,15 +191,17 @@ describe("pr/integrate/internal/merge", () => {
     mocks.execFileAsync.mockResolvedValueOnce({}).mockResolvedValueOnce({});
     mocks.gitRevParse.mockResolvedValue("deadbeefcafebabe");
 
-    const hash = await runMergeCommit({
-      gitRoot: "/repo",
+    const hash = await withTempGitRoot((gitRoot) =>
+      runMergeCommit({
+      gitRoot,
       branch: "task/T-3",
       taskId: "202602111653-X32XPT",
       taskTitle: "Improve PR UX",
       taskTags: ["workflow", "cli"],
       workflowDir: ".agentplane/tasks",
       changedPaths: [],
-    });
+      }),
+    );
 
     expect(hash).toBe("deadbeefcafebabe");
     const mergeCall = mocks.execFileAsync.mock.calls[0];
@@ -191,7 +215,7 @@ describe("pr/integrate/internal/merge", () => {
       "🔀 ABC123 integrate: Improve PR UX",
     ]);
     expect(mergeCall?.[2]).toMatchObject({
-      cwd: "/repo",
+      cwd: expect.stringMatching(/agentplane-merge-test-/),
       env: {
         AGENTPLANE_TASK_ID: "202602111653-X32XPT",
         AGENTPLANE_ALLOW_BASE: "1",

--- a/packages/agentplane/src/commands/pr/integrate/internal/merge.ts
+++ b/packages/agentplane/src/commands/pr/integrate/internal/merge.ts
@@ -6,6 +6,13 @@ import { exitCodeForError } from "../../../../cli/exit-codes.js";
 import { CliError } from "../../../../shared/errors.js";
 import { execFileAsync } from "@agentplaneorg/core/process";
 import { gitEnv } from "@agentplaneorg/core/git";
+import {
+  resolveGitIndexLockInfo,
+  resolveGitMutationDiagnosticContext,
+  withGitMutationMutex,
+  type GitMutationKind,
+} from "../../../../shared/git-mutation.js";
+import { withDiagnosticContext } from "../../../shared/diagnostics.js";
 import { gitRevParse } from "../../../shared/git-ops.js";
 import type { PrMeta } from "../../../shared/pr-meta.js";
 import { computeVerifyState, runVerifyCommands } from "../verify.js";
@@ -16,6 +23,110 @@ type MovedTaskArtifact = {
 };
 
 const noopPromise = (): Promise<void> => Promise.resolve();
+
+const GIT_INTEGRATE_LOCK_REMEDIATION =
+  "Wait for the active AgentPlane write operation in this worktree, then retry integration.";
+
+function classifyGitMutationFailure(message: string): "E_GIT_LOCKED" | "E_GIT_PERMISSION" | "E_GIT_RACE" | "E_GIT" {
+  if (message.includes("index.lock") || /could not lock|unable to create .*lock/.test(message)) {
+    return "E_GIT_LOCKED";
+  }
+  if (/\b(EACCES|EPERM)\b|operation not permitted|permission denied/i.test(message)) {
+    return "E_GIT_PERMISSION";
+  }
+  if (/another git process|concurrent|already running|is locked/i.test(message)) {
+    return "E_GIT_RACE";
+  }
+  return "E_GIT";
+}
+
+async function runWithIntegrationMutation<T>(opts: {
+  repoRoot: string;
+  command: string;
+  workflowMode: string;
+  taskId: string;
+  changedPaths: string[];
+  run: () => Promise<T>;
+}): Promise<T> {
+  const lockInfo = await resolveGitIndexLockInfo({ repoRoot: opts.repoRoot });
+  if (lockInfo) {
+    throw new CliError({
+      exitCode: exitCodeForError("E_GIT_LOCKED"),
+      code: "E_GIT_LOCKED",
+      message: `Git index is locked before ${opts.command}: ${lockInfo.lockPath}`,
+      context: {
+        ...(await resolveGitMutationDiagnosticContext({
+          command: opts.command,
+          cwd: opts.repoRoot,
+          repoRoot: opts.repoRoot,
+          workflowMode: opts.workflowMode,
+          mutationKind: "integration" as GitMutationKind,
+          taskId: opts.taskId,
+          changedPaths: opts.changedPaths,
+          stagedPaths: [],
+        })),
+        remediation: GIT_INTEGRATE_LOCK_REMEDIATION,
+        git_index_lock_path: lockInfo.lockPath,
+        git_index_lock_age_ms: lockInfo.ageMs,
+      },
+    });
+  }
+
+  return withGitMutationMutex(
+    {
+      repoRoot: opts.repoRoot,
+      operation: `git-${opts.command.replaceAll(/[^A-Za-z0-9_-]/g, "-")}`,
+      workflowMode: opts.workflowMode,
+      mutationKind: "integration" as GitMutationKind,
+      taskId: opts.taskId,
+    },
+    async () => {
+      try {
+        return await opts.run();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : `${opts.command} failed`;
+        const code = classifyGitMutationFailure(message);
+        const remediation =
+          code === "E_GIT_LOCKED"
+            ? GIT_INTEGRATE_LOCK_REMEDIATION
+            : code === "E_GIT_PERMISSION"
+              ? "Check repository ownership and writable permissions for worktree metadata."
+              : code === "E_GIT_RACE"
+                ? "A conflicting integration writer is active; retry after it finishes."
+                : "Inspect git error output and retry integration.";
+        throw new CliError({
+          exitCode: exitCodeForError(code),
+          code,
+          message: `${opts.command} failed: ${message}`,
+          context: withDiagnosticContext(
+            {
+                ...(await resolveGitMutationDiagnosticContext({
+                  command: opts.command,
+                  cwd: opts.repoRoot,
+                  repoRoot: opts.repoRoot,
+                  workflowMode: opts.workflowMode,
+                  mutationKind: "integration" as GitMutationKind,
+                  taskId: opts.taskId,
+                  changedPaths: opts.changedPaths,
+                  stagedPaths: [],
+                })),
+                remediation,
+            },
+            {
+              state: `${opts.command} failed during integration mutation`,
+              likelyCause: "A git mutation failed while handling the integration worktree.",
+              nextAction: {
+                command: "agentplane doctor git-locks",
+                reason: "inspect active locks and retry in a clean worktree context",
+                reasonCode: "git_lock_diagnosis",
+              },
+            },
+          ),
+        });
+      }
+    },
+  );
+}
 
 function integrateCommitEnv(taskId: string): NodeJS.ProcessEnv {
   return {
@@ -175,9 +286,18 @@ export async function runSquashMerge(opts: {
     changedPaths: opts.changedPaths,
   });
   try {
-    await execFileAsync("git", ["merge", "--squash", opts.branch], {
-      cwd: opts.gitRoot,
-      env: gitEnv(),
+    await runWithIntegrationMutation({
+      repoRoot: opts.gitRoot,
+      command: "git merge --squash",
+      workflowMode: "branch_pr",
+      taskId: opts.taskId,
+      changedPaths: opts.changedPaths,
+      run: async () => {
+        await execFileAsync("git", ["merge", "--squash", opts.branch], {
+          cwd: opts.gitRoot,
+          env: gitEnv(),
+        });
+      },
     });
   } catch (err) {
     await execFileAsync("git", ["reset", "--hard", opts.headBeforeMerge], {
@@ -185,8 +305,7 @@ export async function runSquashMerge(opts: {
       env: gitEnv(),
     });
     await movedArtifacts.restore();
-    const message = err instanceof Error ? err.message : "git merge --squash failed";
-    throw new CliError({ exitCode: exitCodeForError("E_GIT"), code: "E_GIT", message });
+    throw err;
   }
 
   const { stdout: staged } = await execFileAsync("git", ["diff", "--cached", "--name-only"], {
@@ -236,9 +355,18 @@ export async function runSquashMerge(opts: {
 
   const env = integrateCommitEnv(opts.taskId);
   try {
-    await execFileAsync("git", ["commit", "-m", subject], {
-      cwd: opts.gitRoot,
-      env,
+    await runWithIntegrationMutation({
+      repoRoot: opts.gitRoot,
+      command: "git commit",
+      workflowMode: "branch_pr",
+      taskId: opts.taskId,
+      changedPaths: opts.changedPaths,
+      run: async () => {
+        await execFileAsync("git", ["commit", "-m", subject], {
+          cwd: opts.gitRoot,
+          env,
+        });
+      },
     });
   } catch (err) {
     await execFileAsync("git", ["reset", "--hard", opts.headBeforeMerge], {
@@ -246,8 +374,7 @@ export async function runSquashMerge(opts: {
       env: gitEnv(),
     });
     await movedArtifacts.restore();
-    const message = err instanceof Error ? err.message : "git commit failed";
-    throw new CliError({ exitCode: exitCodeForError("E_GIT"), code: "E_GIT", message });
+    throw err;
   }
 
   await movedArtifacts.cleanup();
@@ -272,23 +399,31 @@ export async function runMergeCommit(opts: {
   });
   const env = integrateCommitEnv(opts.taskId);
   try {
-    await execFileAsync(
-      "git",
-      [
-        "merge",
-        "--no-ff",
-        "--signoff",
-        opts.branch,
-        "-m",
-        `🔀 ${suffix} integrate: ${fallbackIntegrateSummary(opts)}`,
-      ],
-      { cwd: opts.gitRoot, env },
-    );
+    await runWithIntegrationMutation({
+      repoRoot: opts.gitRoot,
+      command: "git merge --no-ff",
+      workflowMode: "branch_pr",
+      taskId: opts.taskId,
+      changedPaths: opts.changedPaths,
+      run: async () => {
+        await execFileAsync(
+          "git",
+          [
+            "merge",
+            "--no-ff",
+            "--signoff",
+            opts.branch,
+            "-m",
+            `🔀 ${suffix} integrate: ${fallbackIntegrateSummary(opts)}`,
+          ],
+          { cwd: opts.gitRoot, env },
+        );
+      },
+    });
   } catch (err) {
     await execFileAsync("git", ["merge", "--abort"], { cwd: opts.gitRoot, env: gitEnv() });
     await movedArtifacts.restore();
-    const message = err instanceof Error ? err.message : "git merge failed";
-    throw new CliError({ exitCode: exitCodeForError("E_GIT"), code: "E_GIT", message });
+    throw err;
   }
   await movedArtifacts.cleanup();
   return await gitRevParse(opts.gitRoot, ["HEAD"]);
@@ -319,11 +454,19 @@ export async function runRebaseFastForward(opts: {
   shouldRunVerify: boolean;
 }> {
   try {
-    await execFileAsync("git", ["rebase", opts.base], { cwd: opts.worktreePath, env: gitEnv() });
+    await runWithIntegrationMutation({
+      repoRoot: opts.worktreePath,
+      command: "git rebase",
+      workflowMode: "branch_pr",
+      taskId: opts.taskId,
+      changedPaths: opts.changedPaths,
+      run: async () => {
+        await execFileAsync("git", ["rebase", opts.base], { cwd: opts.worktreePath, env: gitEnv() });
+      },
+    });
   } catch (err) {
     await execFileAsync("git", ["rebase", "--abort"], { cwd: opts.worktreePath, env: gitEnv() });
-    const message = err instanceof Error ? err.message : "git rebase failed";
-    throw new CliError({ exitCode: exitCodeForError("E_GIT"), code: "E_GIT", message });
+    throw err;
   }
 
   let branchHeadSha = await gitRevParse(opts.gitRoot, [opts.branch]);
@@ -360,9 +503,18 @@ export async function runRebaseFastForward(opts: {
     changedPaths: opts.changedPaths,
   });
   try {
-    await execFileAsync("git", ["merge", "--ff-only", opts.branch], {
-      cwd: opts.gitRoot,
-      env: gitEnv(),
+    await runWithIntegrationMutation({
+      repoRoot: opts.gitRoot,
+      command: "git merge --ff-only",
+      workflowMode: "branch_pr",
+      taskId: opts.taskId,
+      changedPaths: opts.changedPaths,
+      run: async () => {
+        await execFileAsync("git", ["merge", "--ff-only", opts.branch], {
+          cwd: opts.gitRoot,
+          env: gitEnv(),
+        });
+      },
     });
   } catch (err) {
     await execFileAsync("git", ["reset", "--hard", opts.headBeforeMerge], {
@@ -370,8 +522,7 @@ export async function runRebaseFastForward(opts: {
       env: gitEnv(),
     }).catch(() => null);
     await movedArtifacts.restore();
-    const message = err instanceof Error ? err.message : "git merge --ff-only failed";
-    throw new CliError({ exitCode: exitCodeForError("E_GIT"), code: "E_GIT", message });
+    throw err;
   }
 
   const mergeHash = await gitRevParse(opts.gitRoot, ["HEAD"]);

--- a/packages/agentplane/src/shared/git-index-lock-guard.test.ts
+++ b/packages/agentplane/src/shared/git-index-lock-guard.test.ts
@@ -19,6 +19,14 @@ const allowedIndexLockFiles = new Map<string, string>([
     "creates a fake Git index lock to verify E_GIT_LOCKED",
   ],
   [
+    "packages/agentplane/src/commands/guard/impl/commit.ts",
+    "checks for pre-commit git index lock state before commit",
+  ],
+  [
+    "packages/agentplane/src/commands/pr/integrate/internal/merge.ts",
+    "checks for pre-integration git index lock state",
+  ],
+  [
     "packages/agentplane/src/shared/git-index-lock-guard.test.ts",
     "enforces the Git index lock ownership guard",
   ],

--- a/packages/agentplane/src/shared/git-mutation.ts
+++ b/packages/agentplane/src/shared/git-mutation.ts
@@ -66,12 +66,20 @@ export async function resolveGitMutationDiagnosticContext(opts: {
   stagedPaths?: string[];
 }): Promise<Record<string, unknown>> {
   const [gitDir, branch] = await Promise.all([
-    gitRevParse(opts.repoRoot, ["--git-dir"]).catch((err: unknown) =>
-      err instanceof Error ? `unresolved:${err.message}` : "unresolved",
-    ),
-    gitCurrentBranch(opts.repoRoot).catch((err: unknown) =>
-      err instanceof Error ? `unresolved:${err.message}` : "unresolved",
-    ),
+    (async () => {
+      try {
+        return await gitRevParse(opts.repoRoot, ["--git-dir"]);
+      } catch (err: unknown) {
+        return err instanceof Error ? `unresolved:${err.message}` : "unresolved";
+      }
+    })(),
+    (async () => {
+      try {
+        return await gitCurrentBranch(opts.repoRoot);
+      } catch (err: unknown) {
+        return err instanceof Error ? `unresolved:${err.message}` : "unresolved";
+      }
+    })(),
   ]);
 
   return gitMutationDiagnosticContext({
@@ -126,9 +134,12 @@ export async function resolveGitMutationMutexContext(opts: {
   operation: string;
 }): Promise<GitMutationMutexContext> {
   const rawGitDir = await gitRevParse(opts.repoRoot, ["--git-dir"]);
-  const rawCommonDir = await gitRevParse(opts.repoRoot, ["--git-common-dir"]).catch(
-    () => rawGitDir,
-  );
+  let rawCommonDir: string;
+  try {
+    rawCommonDir = await gitRevParse(opts.repoRoot, ["--git-common-dir"]);
+  } catch {
+    rawCommonDir = rawGitDir;
+  }
   const gitDir = resolveGitPath(opts.repoRoot, rawGitDir);
   const gitCommonDir = resolveGitPath(opts.repoRoot, rawCommonDir);
   const operation = sanitizeLockOperation(opts.operation);
@@ -208,6 +219,7 @@ export async function withGitMutationMutex<T>(
         pid: process.pid,
         host: hostname(),
         acquired_at: new Date().toISOString(),
+        uid: typeof process.getuid === "function" ? process.getuid() : null,
         repo_root: mutex.repoRoot,
         git_dir: mutex.gitDir,
         git_common_dir: mutex.gitCommonDir,


### PR DESCRIPTION
Task: `202605111510-3X3KVC`
Title: Fix git lock diagnostics and merge tests
Canonical task record: `.agentplane/tasks/202605111510-3X3KVC/README.md`

## Summary

Fix git lock diagnostics and merge tests

Resolve git lock diagnostics and merge integration regressions for v0.5 branch_pr flow

## Scope

- In scope: Resolve git lock diagnostics and merge integration regressions for v0.5 branch_pr flow.
- Out of scope: unrelated refactors not required for "Fix git lock diagnostics and merge tests".

## Verification

- State: pending
- Note: Not recorded yet.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-11T15:10:35.637Z
- Branch: task/202605111510-3X3KVC/fix-git-locks-v2
- Head: df6e4e8fdab2

```text
 docs/user/cli-reference.generated.mdx              |  29 +++
 docs/user/task-lifecycle.mdx                       |  13 +-
 docs/workflow-guides/branch-pr.mdx                 |  14 +-
 .../src/cli/run-cli/command-catalog/core.ts        |   5 +
 .../src/cli/run-cli/command-loaders/core.ts        |   3 +
 .../src/commands/doctor-git-locks.run.ts           |  45 +++++
 .../src/commands/doctor-git-locks.spec.ts          |  17 ++
 .../impl/commands.commit-non-close.unit.test.ts    |  19 +-
 .../src/commands/guard/impl/comment-commit.ts      | 111 ++++++++++-
 .../src/commands/guard/impl/commit-diagnostics.ts  |  11 +-
 .../agentplane/src/commands/guard/impl/commit.ts   | 220 ++++++++++++++++++++-
 .../src/commands/hooks/capabilities.test.ts        |   6 +-
 .../agentplane/src/commands/hooks/capabilities.ts  |   2 +-
 packages/agentplane/src/commands/hooks/run.ts      |  23 ++-
 .../commands/pr/integrate/internal/merge.test.ts   | 118 ++++++-----
 .../src/commands/pr/integrate/internal/merge.ts    | 215 +++++++++++++++++---
 .../src/shared/git-index-lock-guard.test.ts        |   8 +
 packages/agentplane/src/shared/git-mutation.ts     |  30 ++-
 18 files changed, 768 insertions(+), 121 deletions(-)
```

</details>
