### PR TITLE
🚧 JXWHD3 task: Implement RFQ init P0 planning boundary [202605120709-JXWHD3]

### DIFF
--- a/.agentplane/tasks/202605120709-JXWHD3/README.md
+++ b/.agentplane/tasks/202605120709-JXWHD3/README.md
@@ -1,0 +1,141 @@
+---
+id: "202605120709-JXWHD3"
+title: "Implement RFQ init P0 planning boundary"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-12T07:09:23.315Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-12T08:23:52.910Z"
+  updated_by: "CODER"
+  note: "Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts; Result: pass; Evidence: 21 tests passed. Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/cli/run-cli/commands/init/steps/prompt-steps.test.ts packages/agentplane/src/cli/run-cli/commands/init/ui.test.ts packages/agentplane/src/cli/run-cli/commands/init/prompts.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/apply.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/conflict-resolver.test.ts; Result: pass; Evidence: 25 tests passed. Command: exact-file eslint, bun run format:check, bun run typecheck, bun run docs:cli:check, node .agentplane/policy/check-routing.mjs, ap doctor; Result: pass; Evidence: lint clean, Prettier clean, tsc -b OK, CLI reference up to date, policy routing OK, doctor OK."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Implementing the approved P0 init RFQ slice in the dedicated branch_pr worktree, limited to planning/apply safety, dry-run behavior, base-branch interactivity, docs, and focused tests."
+events:
+  -
+    type: "status"
+    at: "2026-05-12T07:09:41.915Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Implementing the approved P0 init RFQ slice in the dedicated branch_pr worktree, limited to planning/apply safety, dry-run behavior, base-branch interactivity, docs, and focused tests."
+  -
+    type: "verify"
+    at: "2026-05-12T08:23:52.910Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts; Result: pass; Evidence: 21 tests passed. Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/cli/run-cli/commands/init/steps/prompt-steps.test.ts packages/agentplane/src/cli/run-cli/commands/init/ui.test.ts packages/agentplane/src/cli/run-cli/commands/init/prompts.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/apply.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/conflict-resolver.test.ts; Result: pass; Evidence: 25 tests passed. Command: exact-file eslint, bun run format:check, bun run typecheck, bun run docs:cli:check, node .agentplane/policy/check-routing.mjs, ap doctor; Result: pass; Evidence: lint clean, Prettier clean, tsc -b OK, CLI reference up to date, policy routing OK, doctor OK."
+doc_version: 3
+doc_updated_at: "2026-05-12T08:23:52.939Z"
+doc_updated_by: "CODER"
+description: "Implement the P0 AgentPlane init RFQ slice: pure planning before apply, dry-run plan output, delayed git/conflict side effects, base-branch interactive fix, docs, and tests."
+sections:
+  Summary: |-
+    Implement RFQ init P0 planning boundary
+    
+    Implement the P0 AgentPlane init RFQ slice: pure planning before apply, dry-run plan output, delayed git/conflict side effects, base-branch interactive fix, docs, and tests.
+  Scope: |-
+    - In scope: Implement the P0 AgentPlane init RFQ slice: pure planning before apply, dry-run plan output, delayed git/conflict side effects, base-branch interactive fix, docs, and tests.
+    - Out of scope: unrelated refactors not required for "Implement RFQ init P0 planning boundary".
+  Plan: "Implement the P0 slice from /Users/densmirnov/Github/agentplane-cloud/0.5/Agentplane RFQ Initialization.md. Scope: init command planning/apply safety only, not the full UX redesign. Steps: (1) inspect current init pipeline and tests; (2) introduce pure path/plan/dry-run behavior so fresh repo Git init and conflict backup/delete happen only after final confirmation; (3) add CLI flags needed for P0 compatibility, especially --dry-run and non-interactive aliases if low-risk; (4) pass real interactivity into base-branch resolution; (5) update docs/generated CLI references where flags or behavior change; (6) add targeted unit/integration tests for no pre-confirm writes, conflict cancel purity, dry-run JSON purity, and existing --yes compatibility; (7) run focused init tests, lint/format for touched files, and routing/doctor as applicable. Drift trigger: if implementation requires full Quick/Guided/Advanced TUI redesign, parent Git ambiguity UI, or multiselect recipes/blueprints, record as follow-up instead of expanding this task."
+  Verify Steps: |-
+    1. Run focused init integration coverage: `bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts`. Expected: all init tests pass, including dry-run purity and alias coverage.
+    2. Run init unit/prompt coverage: `bunx vitest --config vitest.workspace.ts run packages/agentplane/src/cli/run-cli/commands/init/steps/prompt-steps.test.ts packages/agentplane/src/cli/run-cli/commands/init/ui.test.ts packages/agentplane/src/cli/run-cli/commands/init/prompts.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/apply.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/conflict-resolver.test.ts`. Expected: all tests pass.
+    3. Run touched-file lint, format, and typecheck: exact-file `eslint`, `bun run format:check`, `bun run typecheck`. Expected: pass.
+    4. Run docs/policy freshness checks: `bun run docs:cli:check`, `node .agentplane/policy/check-routing.mjs`, `ap doctor`. Expected: pass/OK without errors.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-12T08:23:52.910Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts; Result: pass; Evidence: 21 tests passed. Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/cli/run-cli/commands/init/steps/prompt-steps.test.ts packages/agentplane/src/cli/run-cli/commands/init/ui.test.ts packages/agentplane/src/cli/run-cli/commands/init/prompts.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/apply.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/conflict-resolver.test.ts; Result: pass; Evidence: 25 tests passed. Command: exact-file eslint, bun run format:check, bun run typecheck, bun run docs:cli:check, node .agentplane/policy/check-routing.mjs, ap doctor; Result: pass; Evidence: lint clean, Prettier clean, tsc -b OK, CLI reference up to date, policy routing OK, doctor OK.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-12T08:22:17.779Z, excerpt_hash=sha256:eb1768e72f2ae03b3eea914532713f0ff8dab0c3dac4584083f79fd547670127
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605120709-JXWHD3-init-p0-planning-boundary/.agentplane/tasks/202605120709-JXWHD3/blueprint/resolved-snapshot.json
+    - old_digest: 8132944f1dd255a2da2c8455722552886a5db7dc1db5cefa47a6f49319a0b847
+    - current_digest: 8132944f1dd255a2da2c8455722552886a5db7dc1db5cefa47a6f49319a0b847
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605120709-JXWHD3
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Implement RFQ init P0 planning boundary
+
+Implement the P0 AgentPlane init RFQ slice: pure planning before apply, dry-run plan output, delayed git/conflict side effects, base-branch interactive fix, docs, and tests.
+
+## Scope
+
+- In scope: Implement the P0 AgentPlane init RFQ slice: pure planning before apply, dry-run plan output, delayed git/conflict side effects, base-branch interactive fix, docs, and tests.
+- Out of scope: unrelated refactors not required for "Implement RFQ init P0 planning boundary".
+
+## Plan
+
+Implement the P0 slice from /Users/densmirnov/Github/agentplane-cloud/0.5/Agentplane RFQ Initialization.md. Scope: init command planning/apply safety only, not the full UX redesign. Steps: (1) inspect current init pipeline and tests; (2) introduce pure path/plan/dry-run behavior so fresh repo Git init and conflict backup/delete happen only after final confirmation; (3) add CLI flags needed for P0 compatibility, especially --dry-run and non-interactive aliases if low-risk; (4) pass real interactivity into base-branch resolution; (5) update docs/generated CLI references where flags or behavior change; (6) add targeted unit/integration tests for no pre-confirm writes, conflict cancel purity, dry-run JSON purity, and existing --yes compatibility; (7) run focused init tests, lint/format for touched files, and routing/doctor as applicable. Drift trigger: if implementation requires full Quick/Guided/Advanced TUI redesign, parent Git ambiguity UI, or multiselect recipes/blueprints, record as follow-up instead of expanding this task.
+
+## Verify Steps
+
+1. Run focused init integration coverage: `bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts`. Expected: all init tests pass, including dry-run purity and alias coverage.
+2. Run init unit/prompt coverage: `bunx vitest --config vitest.workspace.ts run packages/agentplane/src/cli/run-cli/commands/init/steps/prompt-steps.test.ts packages/agentplane/src/cli/run-cli/commands/init/ui.test.ts packages/agentplane/src/cli/run-cli/commands/init/prompts.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/apply.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/conflict-resolver.test.ts`. Expected: all tests pass.
+3. Run touched-file lint, format, and typecheck: exact-file `eslint`, `bun run format:check`, `bun run typecheck`. Expected: pass.
+4. Run docs/policy freshness checks: `bun run docs:cli:check`, `node .agentplane/policy/check-routing.mjs`, `ap doctor`. Expected: pass/OK without errors.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-12T08:23:52.910Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts; Result: pass; Evidence: 21 tests passed. Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/cli/run-cli/commands/init/steps/prompt-steps.test.ts packages/agentplane/src/cli/run-cli/commands/init/ui.test.ts packages/agentplane/src/cli/run-cli/commands/init/prompts.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/apply.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/conflict-resolver.test.ts; Result: pass; Evidence: 25 tests passed. Command: exact-file eslint, bun run format:check, bun run typecheck, bun run docs:cli:check, node .agentplane/policy/check-routing.mjs, ap doctor; Result: pass; Evidence: lint clean, Prettier clean, tsc -b OK, CLI reference up to date, policy routing OK, doctor OK.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-12T08:22:17.779Z, excerpt_hash=sha256:eb1768e72f2ae03b3eea914532713f0ff8dab0c3dac4584083f79fd547670127
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605120709-JXWHD3-init-p0-planning-boundary/.agentplane/tasks/202605120709-JXWHD3/blueprint/resolved-snapshot.json
+- old_digest: 8132944f1dd255a2da2c8455722552886a5db7dc1db5cefa47a6f49319a0b847
+- current_digest: 8132944f1dd255a2da2c8455722552886a5db7dc1db5cefa47a6f49319a0b847
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605120709-JXWHD3
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605120709-JXWHD3/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605120709-JXWHD3/blueprint/resolved-snapshot.json
@@ -1,0 +1,512 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605120709-JXWHD3",
+    "title": "Implement RFQ init P0 planning boundary",
+    "description": "Implement the P0 AgentPlane init RFQ slice: pure planning before apply, dry-run plan output, delayed git/conflict side effects, base-branch interactive fix, docs, and tests.",
+    "tags": [
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605120709-JXWHD3",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "8132944f1dd255a2da2c8455722552886a5db7dc1db5cefa47a6f49319a0b847"
+  }
+}

--- a/.agentplane/tasks/202605120709-JXWHD3/pr/diffstat.txt
+++ b/.agentplane/tasks/202605120709-JXWHD3/pr/diffstat.txt
@@ -1,0 +1,14 @@
+ .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |   9 +
+ docs/user/commands.mdx                             |   3 +
+ docs/user/setup.mdx                                |  11 +
+ .../agentplane/src/cli/run-cli.core.init.test.ts   |  97 ++++
+ packages/agentplane/src/cli/run-cli.ts             |   3 +-
+ .../src/cli/run-cli/commands/init/answers.ts       |   3 +
+ .../src/cli/run-cli/commands/init/base-branch.ts   |   3 +
+ .../src/cli/run-cli/commands/init/execution.ts     | 282 ++++++++++--
+ .../src/cli/run-cli/commands/init/model.ts         |  53 +++
+ .../src/cli/run-cli/commands/init/orchestrate.ts   |  52 ++-
+ .../src/cli/run-cli/commands/init/spec.ts          |  37 +-
+ packages/agentplane/src/cli/spec/spec.ts           |   1 +
+ 13 files changed, 1011 insertions(+), 55 deletions(-)

--- a/.agentplane/tasks/202605120709-JXWHD3/pr/github-body.md
+++ b/.agentplane/tasks/202605120709-JXWHD3/pr/github-body.md
@@ -1,0 +1,46 @@
+Task: `202605120709-JXWHD3`
+Title: Implement RFQ init P0 planning boundary
+Canonical task record: `.agentplane/tasks/202605120709-JXWHD3/README.md`
+
+## Summary
+
+Implement RFQ init P0 planning boundary
+
+Implement the P0 AgentPlane init RFQ slice: pure planning before apply, dry-run plan output, delayed git/conflict side effects, base-branch interactive fix, docs, and tests.
+
+## Scope
+
+- In scope: Implement the P0 AgentPlane init RFQ slice: pure planning before apply, dry-run plan output, delayed git/conflict side effects, base-branch interactive fix, docs, and tests.
+- Out of scope: unrelated refactors not required for "Implement RFQ init P0 planning boundary".
+
+## Verification
+
+- State: ok
+- Note: Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts; Result: pass; Evidence: 21 tests passed. Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/cli/run-cli/commands/init/steps/prompt-steps.test.ts packages/agentplane/src/cli/run-cli/commands/init/ui.test.ts packages/agentplane/src/cli/run-cli/commands/init/prompts.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/apply.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/conflict-resolver.test.ts; Result: pass; Evidence: 25 tests passed. Command: exact-file eslint, bun run format:check, bun run typecheck, bun run docs:cli:check, node .agentplane/policy/check-routing.mjs, ap doctor; Result: pass; Evidence: lint clean, Prettier clean, tsc -b OK, CLI reference up to date, policy routing OK, doctor OK.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-12T08:24:27.590Z
+- Branch: task/202605120709-JXWHD3/init-p0-planning-boundary
+- Head: a95645d52dbc
+
+```text
+ .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |   9 +
+ docs/user/commands.mdx                             |   3 +
+ docs/user/setup.mdx                                |  11 +
+ .../agentplane/src/cli/run-cli.core.init.test.ts   |  97 ++++
+ packages/agentplane/src/cli/run-cli.ts             |   3 +-
+ .../src/cli/run-cli/commands/init/answers.ts       |   3 +
+ .../src/cli/run-cli/commands/init/base-branch.ts   |   3 +
+ .../src/cli/run-cli/commands/init/execution.ts     | 282 ++++++++++--
+ .../src/cli/run-cli/commands/init/model.ts         |  53 +++
+ .../src/cli/run-cli/commands/init/orchestrate.ts   |  52 ++-
+ .../src/cli/run-cli/commands/init/spec.ts          |  37 +-
+ packages/agentplane/src/cli/spec/spec.ts           |   1 +
+ 13 files changed, 1011 insertions(+), 55 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605120709-JXWHD3/pr/github-title.txt
+++ b/.agentplane/tasks/202605120709-JXWHD3/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 JXWHD3 task: Implement RFQ init P0 planning boundary [202605120709-JXWHD3]

--- a/.agentplane/tasks/202605120709-JXWHD3/pr/meta.json
+++ b/.agentplane/tasks/202605120709-JXWHD3/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605120709-JXWHD3/init-p0-planning-boundary",
+  "created_at": "2026-05-12T07:09:42.115Z",
+  "head_sha": "a95645d52dbc8ff4792713377e7abae950f1da13",
+  "last_verified_at": "2026-05-12T08:23:52.910Z",
+  "last_verified_sha": "239bf0f612a78e5de83620741418238c2dbf2c93",
+  "schema_version": 1,
+  "task_id": "202605120709-JXWHD3",
+  "updated_at": "2026-05-12T08:24:27.590Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605120709-JXWHD3/pr/review.md
+++ b/.agentplane/tasks/202605120709-JXWHD3/pr/review.md
@@ -1,0 +1,49 @@
+# PR Review
+
+Created: 2026-05-12T07:09:42.115Z
+
+## Task
+
+- Task: `202605120709-JXWHD3`
+- Title: Implement RFQ init P0 planning boundary
+- Status: DOING
+- Branch: `task/202605120709-JXWHD3/init-p0-planning-boundary`
+- Canonical task record: `.agentplane/tasks/202605120709-JXWHD3/README.md`
+
+## Verification
+
+- State: ok
+- Note: Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts; Result: pass; Evidence: 21 tests passed. Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/cli/run-cli/commands/init/steps/prompt-steps.test.ts packages/agentplane/src/cli/run-cli/commands/init/ui.test.ts packages/agentplane/src/cli/run-cli/commands/init/prompts.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/apply.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/conflict-resolver.test.ts; Result: pass; Evidence: 25 tests passed. Command: exact-file eslint, bun run format:check, bun run typecheck, bun run docs:cli:check, node .agentplane/policy/check-routing.mjs, ap doctor; Result: pass; Evidence: lint clean, Prettier clean, tsc -b OK, CLI reference up to date, policy routing OK, doctor OK.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-12T08:24:27.590Z
+- Branch: task/202605120709-JXWHD3/init-p0-planning-boundary
+- Head: a95645d52dbc
+
+```text
+ .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |   9 +
+ docs/user/commands.mdx                             |   3 +
+ docs/user/setup.mdx                                |  11 +
+ .../agentplane/src/cli/run-cli.core.init.test.ts   |  97 ++++
+ packages/agentplane/src/cli/run-cli.ts             |   3 +-
+ .../src/cli/run-cli/commands/init/answers.ts       |   3 +
+ .../src/cli/run-cli/commands/init/base-branch.ts   |   3 +
+ .../src/cli/run-cli/commands/init/execution.ts     | 282 ++++++++++--
+ .../src/cli/run-cli/commands/init/model.ts         |  53 +++
+ .../src/cli/run-cli/commands/init/orchestrate.ts   |  52 ++-
+ .../src/cli/run-cli/commands/init/spec.ts          |  37 +-
+ packages/agentplane/src/cli/spec/spec.ts           |   1 +
+ 13 files changed, 1011 insertions(+), 55 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -2092,6 +2092,9 @@ Options:
 - `--force`: Overwrite init conflicts by deleting existing paths. (default=false)
 - `--backup`: Backup init conflicts before overwriting. (default=false)
 - `--yes`: Non-interactive mode (do not prompt; use defaults for missing flags). (default=false)
+- `--no-input`: Alias for --yes; run init without prompts using defaults for missing flags. (default=false)
+- `--non-interactive`: Alias for --yes; run init without prompts using defaults for missing flags. (default=false)
+- `--dry-run`: Build and print the init plan without writing files, initializing git, or handling conflicts. (default=false)
 - `--gitignore-agents`: Add gateway/agent files (AGENTS.md or CLAUDE.md and .agentplane/agents/) to .gitignore and skip the initial install commit. (default=false)
 
 Examples:
@@ -2131,6 +2134,12 @@ agentplane init --yes --gitignore-agents
 ```
 
 - Initialize without committing and keep agent prompts/templates local (gitignored).
+
+```sh
+agentplane init --dry-run --yes --output json
+```
+
+- Print a machine-readable init plan without writing files.
 
 ### upgrade
 

--- a/docs/user/commands.mdx
+++ b/docs/user/commands.mdx
@@ -56,6 +56,8 @@ agentplane init
 ```
 
 If the directory is not a git repository, `agentplane init` initializes git in that directory.
+Use `agentplane init --dry-run --yes` to preview the setup plan without creating `.git`,
+`.agentplane`, backups, hooks, or commits. Add `--output json` for a machine-readable plan.
 
 Interactive init now starts with a profile menu:
 
@@ -75,6 +77,7 @@ Non-interactive:
 
 ```bash
 agentplane init --setup-profile normal --workflow direct --backend local --execution-profile balanced --strict-unsafe-confirm true --hooks true --require-network-approval true --yes
+agentplane init --dry-run --yes --output json
 ```
 
 Workflow contract operations:

--- a/docs/user/setup.mdx
+++ b/docs/user/setup.mdx
@@ -55,6 +55,17 @@ agentplane init
 
 If `.git` does not exist in that folder, `init` creates a new Git repository there.
 
+To inspect the setup without writes, use dry-run:
+
+```bash
+agentplane init --dry-run --yes
+agentplane init --dry-run --yes --output json
+```
+
+Dry-run builds the same setup plan but does not create `.git`, `.agentplane`, gateway files,
+backups, hooks, or commits. Use it before re-initializing repositories that already contain
+AgentPlane-related files.
+
 ## Create your first task
 
 Use a harmless task first. The goal is to see the artifact shape before giving an agent broad edit

--- a/packages/agentplane/src/cli/run-cli.core.init.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.init.test.ts
@@ -590,4 +590,101 @@ describe("runCli", () => {
     );
     expect(baseBranch.trim()).toBe("main");
   });
+
+  it("init --dry-run --yes is pure for a fresh non-git directory", async () => {
+    const root = await mkTempDir();
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["init", "--dry-run", "--yes", "--root", root]);
+      expect(code).toBe(0);
+      expect(io.stdout).toContain("AgentPlane init plan");
+      expect(io.stdout).toContain("Git init: true");
+    } finally {
+      io.restore();
+    }
+
+    expect(await pathExists(path.join(root, ".git"))).toBe(false);
+    expect(await pathExists(path.join(root, ".agentplane"))).toBe(false);
+    expect(await pathExists(path.join(root, "AGENTS.md"))).toBe(false);
+    expect(await pathExists(path.join(root, ".gitignore"))).toBe(false);
+  });
+
+  it("init --dry-run --backup does not create backups before apply", async () => {
+    const root = await mkGitRepoRoot();
+    await mkdir(path.join(root, ".agentplane"), { recursive: true });
+    const configPath = path.join(root, ".agentplane", "config.json");
+    await writeFile(configPath, '{"existing":true}\n', "utf8");
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["init", "--dry-run", "--yes", "--backup", "--root", root]);
+      expect(code).toBe(0);
+      expect(io.stdout).toContain("backup_path .agentplane/config.json");
+    } finally {
+      io.restore();
+    }
+
+    expect(await readFile(configPath, "utf8")).toBe('{"existing":true}\n');
+    const entries = await readdir(path.join(root, ".agentplane"));
+    expect(entries.some((entry) => entry.includes(".bak"))).toBe(false);
+  });
+
+  it("init --dry-run reports conflicts without requiring a conflict strategy", async () => {
+    const root = await mkGitRepoRoot();
+    await mkdir(path.join(root, ".agentplane"), { recursive: true });
+    const configPath = path.join(root, ".agentplane", "config.json");
+    await writeFile(configPath, '{"existing":true}\n', "utf8");
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["init", "--dry-run", "--yes", "--root", root, "--output", "json"]);
+      expect(code).toBe(0);
+      const envelope = JSON.parse(io.stdout) as {
+        data?: { conflicts?: string[]; warnings?: string[]; effects?: { kind: string }[] };
+      };
+      expect(envelope.data?.conflicts).toContain(".agentplane/config.json");
+      expect(envelope.data?.warnings).toContain(
+        "Conflicts require --backup or --force before apply.",
+      );
+      expect(envelope.data?.effects?.some((effect) => effect.kind === "delete_path")).toBe(false);
+      expect(envelope.data?.effects?.some((effect) => effect.kind === "backup_path")).toBe(false);
+    } finally {
+      io.restore();
+    }
+
+    expect(await readFile(configPath, "utf8")).toBe('{"existing":true}\n');
+  });
+
+  it("init --dry-run --yes --output json emits a stable plan envelope without writes", async () => {
+    const root = await mkTempDir();
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["init", "--dry-run", "--yes", "--root", root, "--output", "json"]);
+      expect(code).toBe(0);
+      const envelope = JSON.parse(io.stdout) as {
+        data?: { schemaVersion?: string; effects?: { kind: string }[] };
+      };
+      expect(envelope.data?.schemaVersion).toBe("init-plan/v1");
+      expect(envelope.data?.effects?.some((effect) => effect.kind === "git_init")).toBe(true);
+    } finally {
+      io.restore();
+    }
+
+    expect(await pathExists(path.join(root, ".git"))).toBe(false);
+    expect(await pathExists(path.join(root, ".agentplane"))).toBe(false);
+  });
+
+  it("init --no-input is an alias for --yes", async () => {
+    const root = await mkGitRepoRoot();
+    await configureGitUser(root);
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["init", "--no-input", "--root", root]);
+      expect(code).toBe(0);
+    } finally {
+      io.restore();
+    }
+
+    expect(await pathExists(path.join(root, ".agentplane", "WORKFLOW.md"))).toBe(true);
+  });
 });

--- a/packages/agentplane/src/cli/run-cli.ts
+++ b/packages/agentplane/src/cli/run-cli.ts
@@ -290,7 +290,8 @@ export async function runCli(argv: string[]): Promise<number> {
       return await runWithOutputMode({
         mode: outputMode,
         command: runtimeEntry.spec.id.join(" "),
-        run: async () => await runtimeEntry.handler({ cwd, rootOverride: globals.root }, parsed),
+        run: async () =>
+          await runtimeEntry.handler({ cwd, rootOverride: globals.root, outputMode }, parsed),
       });
     }
 

--- a/packages/agentplane/src/cli/run-cli/commands/init/answers.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/answers.ts
@@ -22,6 +22,7 @@ import type { InitPromptClack } from "./steps/contracts.js";
 import { introLogo, section } from "./ui.js";
 
 export type InitAnswers = {
+  setupProfile: SetupProfilePreset;
   setupProfileDescription: string;
   policyGateway: PolicyGatewayFlavor;
   ide: InitIde;
@@ -50,6 +51,7 @@ export function buildNonInteractiveAnswers(flags: InitParsed): InitAnswers {
   const setupProfilePreset: SetupProfilePreset = flags.setupProfile ?? "normal";
   const preset = setupProfilePresets[setupProfilePreset];
   return {
+    setupProfile: setupProfilePreset,
     setupProfileDescription: preset.description,
     policyGateway: flags.policyGateway ?? INIT_DEFAULTS.policyGateway,
     ide: flags.ide ?? INIT_DEFAULTS.ide,
@@ -112,6 +114,7 @@ export async function promptInteractiveAnswers(opts: {
     cachedBlueprints,
   });
   return {
+    setupProfile: setup.setupProfilePreset,
     setupProfileDescription: selectedPreset.description,
     policyGateway: policy.policyGateway,
     ide: ide.ide,

--- a/packages/agentplane/src/cli/run-cli/commands/init/base-branch.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/base-branch.ts
@@ -8,6 +8,9 @@ export async function resolveInitBaseBranchForInit(opts: {
   workflow: WorkflowMode;
   gitRootExisted: boolean;
 }): Promise<string> {
+  if (!opts.gitRootExisted) {
+    return opts.baseBranchFallback;
+  }
   let initBaseBranch = await resolveInitBaseBranch(opts.gitRoot, opts.baseBranchFallback);
   if (opts.isInteractive && opts.workflow === "branch_pr" && opts.gitRootExisted) {
     initBaseBranch = await promptInitBaseBranch({

--- a/packages/agentplane/src/cli/run-cli/commands/init/execution.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/execution.ts
@@ -6,10 +6,11 @@ import { setPinnedBaseBranch } from "@agentplaneorg/core/git";
 import { collectHooksInstallConflicts } from "../../../../commands/hooks/install.js";
 import { cmdHooksInstall, ensureInitCommit } from "../../../../commands/workflow.js";
 import { getVersion } from "../../../../meta/version.js";
+import { getPathKind } from "../../../fs-utils.js";
 import { InitAborted, type InitClackPrompts } from "./prompts.js";
-import type { InitFlags, InitParsed } from "./model.js";
+import type { InitEffect, InitFlags, InitParsed, InitPlan } from "./model.js";
 import type { InitAnswers } from "./answers.js";
-import { collectInitConflicts } from "./conflicts.js";
+import { collectInitConflicts, handleInitConflicts } from "./conflicts.js";
 import { maybeSyncIde } from "./ide-sync.js";
 import { promptConflictResolverStep, applyInitWithProgress } from "./steps/index.js";
 import type { InitPromptClack } from "./steps/contracts.js";
@@ -23,6 +24,7 @@ import { assertConfirmed } from "./answers.js";
 
 export type ResolvedInitPaths = {
   gitRoot: string;
+  gitRootExisted: boolean;
   agentplaneDir: string;
   workflowPath: string;
   legacyConfigPath: string;
@@ -33,16 +35,10 @@ export async function resolveInitPaths(opts: {
   cwd: string;
   rootOverride?: string;
   backend: NonNullable<InitFlags["backend"]>;
-  ensureGitRoot: (opts: {
-    initRoot: string;
-    baseBranchFallback: string;
-  }) => Promise<{ gitRoot: string; gitRootExisted: boolean }>;
-}): Promise<ResolvedInitPaths & { gitRootExisted: boolean }> {
+}): Promise<ResolvedInitPaths> {
   const initRoot = path.resolve(opts.rootOverride ?? opts.cwd);
-  const { gitRoot, gitRootExisted } = await opts.ensureGitRoot({
-    initRoot,
-    baseBranchFallback: "main",
-  });
+  const gitRoot = initRoot;
+  const gitRootExisted = (await getPathKind(path.join(gitRoot, ".git"))) === "dir";
   const agentplaneDir = path.join(gitRoot, ".agentplane");
   const workflowPath = path.join(agentplaneDir, "WORKFLOW.md");
   const legacyConfigPath = path.join(agentplaneDir, "config.json");
@@ -72,22 +68,203 @@ export async function collectInitAndHookConflicts(opts: {
   ];
   const initFiles = [opts.paths.workflowPath, opts.paths.legacyConfigPath, opts.paths.backendPath];
   const initConflicts = await collectInitConflicts({ initDirs, initFiles });
-  const hookConflicts = opts.answers.hooks
-    ? await collectHooksInstallConflicts({
-        gitRoot: opts.paths.gitRoot,
-        agentplaneDir: opts.paths.agentplaneDir,
-      })
-    : [];
+  const hookConflicts =
+    opts.answers.hooks && opts.paths.gitRootExisted
+      ? await collectHooksInstallConflicts({
+          gitRoot: opts.paths.gitRoot,
+          agentplaneDir: opts.paths.agentplaneDir,
+        })
+      : [];
   return [...new Set([...initConflicts, ...hookConflicts])];
+}
+
+function rel(root: string, filePath: string): string {
+  return path.relative(root, filePath) || ".";
+}
+
+function initWriteEffects(opts: { paths: ResolvedInitPaths; answers: InitAnswers }): InitEffect[] {
+  const gateway = opts.answers.policyGateway === "claude" ? "CLAUDE.md" : "AGENTS.md";
+  const effects: InitEffect[] = [
+    {
+      kind: "write_file",
+      path: ".agentplane/config.json",
+      summary: "Write legacy compatibility config",
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "low",
+    },
+    {
+      kind: "write_file",
+      path: ".agentplane/WORKFLOW.md",
+      summary: "Write workflow contract",
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "low",
+    },
+    {
+      kind: "write_file",
+      path: rel(opts.paths.gitRoot, opts.paths.backendPath),
+      summary: `Write ${opts.answers.backend} backend stub`,
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "low",
+    },
+    {
+      kind: "write_file",
+      path: gateway,
+      summary: `Write ${opts.answers.policyGateway} policy gateway`,
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "low",
+    },
+    {
+      kind: "write_file",
+      path: ".gitignore",
+      summary: "Update repository ignore rules",
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "low",
+    },
+  ];
+  if (!opts.paths.gitRootExisted) {
+    effects.unshift({
+      kind: "git_init",
+      summary: "Initialize git repository after final confirmation",
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "medium",
+    });
+  }
+  if (opts.answers.hooks) {
+    effects.push({
+      kind: "install_hooks",
+      path: ".git/hooks",
+      summary: "Install managed git hooks",
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "medium",
+    });
+  }
+  if (opts.answers.ide !== "codex") {
+    effects.push({
+      kind: "sync_ide",
+      summary: `Sync ${opts.answers.ide} rules`,
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "low",
+    });
+  }
+  for (const recipe of opts.answers.recipes) {
+    effects.push({
+      kind: "vendor_recipe",
+      summary: `Materialize cached recipe ${recipe}`,
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "low",
+    });
+  }
+  for (const blueprint of opts.answers.blueprints) {
+    effects.push({
+      kind: "install_blueprint",
+      summary: `Install cached blueprint catalog entry ${blueprint}`,
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "low",
+    });
+  }
+  return effects;
+}
+
+export function buildInitPlan(opts: {
+  paths: ResolvedInitPaths;
+  answers: InitAnswers;
+  conflicts: string[];
+  conflictMode: { backup: boolean; force: boolean };
+  outputMode: "text" | "json";
+  includeInstallCommit: boolean;
+}): InitPlan {
+  const hasConflictStrategy = opts.conflictMode.backup || opts.conflictMode.force;
+  const conflictEffects: InitEffect[] = hasConflictStrategy
+    ? opts.conflicts.map((conflict) => ({
+        kind: opts.conflictMode.backup ? "backup_path" : "delete_path",
+        path: rel(opts.paths.gitRoot, conflict),
+        summary: opts.conflictMode.backup ? "Back up conflicting path" : "Delete conflicting path",
+        destructive: opts.conflictMode.force,
+        reversible: opts.conflictMode.backup,
+        requiresNetwork: false,
+        risk: opts.conflictMode.force ? "high" : "medium",
+      }))
+    : [];
+  const effects = [
+    ...conflictEffects,
+    ...initWriteEffects({ paths: opts.paths, answers: opts.answers }),
+  ];
+  if (opts.includeInstallCommit) {
+    effects.push({
+      kind: "git_commit",
+      summary: `Create initial AgentPlane install commit for ${getVersion()}`,
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "medium",
+    });
+  }
+  return {
+    schemaVersion: "init-plan/v1",
+    agentplaneVersion: getVersion(),
+    root: opts.paths.gitRoot,
+    profile: opts.answers.setupProfile,
+    answers: {
+      policyGateway: opts.answers.policyGateway,
+      ide: opts.answers.ide,
+      workflow: opts.answers.workflow,
+      backend: opts.answers.backend,
+      hooks: opts.answers.hooks,
+      requirePlanApproval: opts.answers.requirePlanApproval,
+      requireNetworkApproval: opts.answers.requireNetworkApproval,
+      requireVerifyApproval: opts.answers.requireVerifyApproval,
+      executionProfile: opts.answers.executionProfile,
+      strictUnsafeConfirm: opts.answers.strictUnsafeConfirm,
+      recipes: [...opts.answers.recipes],
+      blueprints: [...opts.answers.blueprints],
+    },
+    context: {
+      gitRootExisted: opts.paths.gitRootExisted,
+      outputMode: opts.outputMode,
+    },
+    effects,
+    conflicts: opts.conflicts.map((conflict) => rel(opts.paths.gitRoot, conflict)),
+    warnings:
+      opts.conflicts.length > 0 && !hasConflictStrategy
+        ? ["Conflicts require --backup or --force before apply."]
+        : [],
+    nextSteps: [
+      "agentplane quickstart",
+      'agentplane task new --title "Trace first AI-assisted change" --owner CODER --tag code',
+    ],
+  };
 }
 
 export async function maybeConfirmInteractiveApply(opts: {
   clack: InitClackPrompts | null;
   flags: InitParsed;
   answers: InitAnswers;
+  paths: ResolvedInitPaths;
+  plan: InitPlan;
 }): Promise<void> {
   if (!opts.clack) return;
   previewInstall(opts.clack, [
+    { label: "Target", value: opts.paths.gitRoot },
     { label: "Profile", value: opts.answers.setupProfileDescription },
     { label: "Gateway", value: opts.answers.policyGateway },
     { label: "Workflow", value: opts.answers.workflow },
@@ -96,6 +273,8 @@ export async function maybeConfirmInteractiveApply(opts: {
     { label: "IDE", value: opts.answers.ide },
     { label: "Recipes", value: opts.answers.recipes.join(", ") || "none" },
     { label: "Blueprints", value: opts.answers.blueprints.join(", ") || "none" },
+    { label: "Git init", value: !opts.paths.gitRootExisted },
+    { label: "Conflicts", value: opts.plan.conflicts.join(", ") || "none" },
     { label: "Install commit", value: !opts.flags.gitignoreAgents },
   ]);
   const confirmed = assertConfirmed(
@@ -136,19 +315,36 @@ export async function applyInitPlan(opts: {
   answers: InitAnswers;
   paths: ResolvedInitPaths;
   initBaseBranch: string;
+  conflictMode: { backup: boolean; force: boolean };
+  conflicts: string[];
+  ensureGitRoot: (opts: {
+    initRoot: string;
+    baseBranchFallback: string;
+  }) => Promise<{ gitRoot: string; gitRootExisted: boolean }>;
 }): Promise<void> {
+  const ensured = await opts.ensureGitRoot({
+    initRoot: opts.paths.gitRoot,
+    baseBranchFallback: "main",
+  });
+  const paths = { ...opts.paths, gitRoot: ensured.gitRoot, gitRootExisted: ensured.gitRootExisted };
+  await handleInitConflicts({
+    gitRoot: paths.gitRoot,
+    conflicts: opts.conflicts,
+    backup: opts.conflictMode.backup,
+    force: opts.conflictMode.force,
+  });
   await applyInitWithProgress({
     clack: opts.clack,
     includeInstallCommit: !opts.flags.gitignoreAgents,
     plan: {
       config: async () => {
-        await ensureAgentplaneDirs(opts.paths.agentplaneDir, opts.answers.backend);
+        await ensureAgentplaneDirs(paths.agentplaneDir, opts.answers.backend);
         await writeInitConfig({
-          agentplaneDir: opts.paths.agentplaneDir,
-          gitRoot: opts.paths.gitRoot,
+          agentplaneDir: paths.agentplaneDir,
+          gitRoot: paths.gitRoot,
           workflow: opts.answers.workflow,
           directCloseDirtyPolicy: opts.answers.directCloseDirtyPolicy,
-          backendConfigPathAbs: opts.paths.backendPath,
+          backendConfigPathAbs: paths.backendPath,
           requirePlanApproval: opts.answers.requirePlanApproval,
           requireNetworkApproval: opts.answers.requireNetworkApproval,
           requireVerifyApproval: opts.answers.requireVerifyApproval,
@@ -158,38 +354,38 @@ export async function applyInitPlan(opts: {
         });
         await writeBackendStubs({
           backend: opts.answers.backend,
-          backendPath: opts.paths.backendPath,
+          backendPath: paths.backendPath,
         });
         if (opts.flags.gitignoreAgents) {
           await setPinnedBaseBranch({
-            cwd: opts.paths.gitRoot,
-            rootOverride: opts.paths.gitRoot,
+            cwd: paths.gitRoot,
+            rootOverride: paths.gitRoot,
             value: opts.initBaseBranch,
           });
         }
       },
       agents: async () => {
         const { installPaths } = await ensureAgentsFiles({
-          gitRoot: opts.paths.gitRoot,
-          agentplaneDir: opts.paths.agentplaneDir,
+          gitRoot: paths.gitRoot,
+          agentplaneDir: paths.agentplaneDir,
           workflow: opts.answers.workflow,
           policyGateway: opts.answers.policyGateway,
-          workflowPathAbs: opts.paths.workflowPath,
-          backendPathAbs: opts.paths.backendPath,
+          workflowPathAbs: paths.workflowPath,
+          backendPathAbs: paths.backendPath,
         });
         if (opts.answers.backend === "redmine") {
-          await ensureInitRedmineEnvTemplate({ gitRoot: opts.paths.gitRoot });
+          await ensureInitRedmineEnvTemplate({ gitRoot: paths.gitRoot });
           installPaths.push(".env.example");
         }
         if (opts.answers.backend === "cloud") {
-          await ensureInitCloudEnvTemplate({ gitRoot: opts.paths.gitRoot });
+          await ensureInitCloudEnvTemplate({ gitRoot: paths.gitRoot });
           installPaths.push(".env.example");
         }
         return installPaths;
       },
       workflow: async () => {
         const workflowInit = await ensureInitWorkflow({
-          gitRoot: opts.paths.gitRoot,
+          gitRoot: paths.gitRoot,
           workflowMode: opts.answers.workflow,
           approvals: {
             requirePlanApproval: opts.answers.requirePlanApproval,
@@ -197,11 +393,11 @@ export async function applyInitPlan(opts: {
             requireNetworkApproval: opts.answers.requireNetworkApproval,
           },
         });
-        return workflowInit.installPaths.map((abs) => path.relative(opts.paths.gitRoot, abs));
+        return workflowInit.installPaths.map((abs) => path.relative(paths.gitRoot, abs));
       },
       gitignore: async () => {
         await ensureInitGitignore({
-          gitRoot: opts.paths.gitRoot,
+          gitRoot: paths.gitRoot,
           includeAgentPromptFiles: opts.flags.gitignoreAgents === true,
         });
         return [".gitignore"];
@@ -209,8 +405,8 @@ export async function applyInitPlan(opts: {
       hooks: opts.answers.hooks
         ? async () => {
             await cmdHooksInstall({
-              cwd: opts.cwd,
-              rootOverride: opts.rootOverride,
+              cwd: paths.gitRoot,
+              rootOverride: paths.gitRoot,
               quiet: true,
             });
             return [".agentplane/bin/agentplane"];
@@ -218,10 +414,10 @@ export async function applyInitPlan(opts: {
         : undefined,
       ideSync: async () => {
         const ideRes = await maybeSyncIde({
-          cwd: opts.cwd,
-          rootOverride: opts.rootOverride,
+          cwd: paths.gitRoot,
+          rootOverride: paths.gitRoot,
           ide: opts.answers.ide,
-          gitRoot: opts.paths.gitRoot,
+          gitRoot: paths.gitRoot,
         });
         return ideRes.installPaths;
       },
@@ -229,8 +425,8 @@ export async function applyInitPlan(opts: {
         return await import("./recipes.js").then((m) =>
           m.maybeAddCachedRecipes({
             recipes: opts.answers.recipes,
-            cwd: opts.cwd,
-            rootOverride: opts.rootOverride,
+            cwd: paths.gitRoot,
+            rootOverride: paths.gitRoot,
           }),
         );
       },
@@ -238,14 +434,14 @@ export async function applyInitPlan(opts: {
         return await import("./blueprints.js").then((m) =>
           m.maybeInstallCachedBlueprints({
             blueprints: opts.answers.blueprints,
-            cwd: opts.cwd,
-            rootOverride: opts.rootOverride,
+            cwd: paths.gitRoot,
+            rootOverride: paths.gitRoot,
           }),
         );
       },
       installCommit: async (installPaths) => {
         await ensureInitCommit({
-          gitRoot: opts.paths.gitRoot,
+          gitRoot: paths.gitRoot,
           baseBranch: opts.initBaseBranch,
           installPaths: [...installPaths],
           version: getVersion(),

--- a/packages/agentplane/src/cli/run-cli/commands/init/model.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/model.ts
@@ -26,6 +26,7 @@ export type InitFlags = {
   blueprints?: string[];
   force?: boolean;
   backup?: boolean;
+  dryRun?: boolean;
   yes: boolean;
 };
 
@@ -45,4 +46,56 @@ export type InitDefaults = {
   executionProfile: ExecutionProfile;
   strictUnsafeConfirm: boolean;
   blueprints: string[];
+};
+
+export type InitEffectKind =
+  | "write_file"
+  | "backup_path"
+  | "delete_path"
+  | "git_init"
+  | "git_commit"
+  | "install_hooks"
+  | "sync_ide"
+  | "vendor_recipe"
+  | "install_blueprint";
+
+export type InitEffectRisk = "none" | "low" | "medium" | "high";
+
+export type InitEffect = {
+  kind: InitEffectKind;
+  path?: string;
+  summary: string;
+  destructive: boolean;
+  reversible: boolean;
+  requiresNetwork: boolean;
+  risk: InitEffectRisk;
+};
+
+export type InitPlan = {
+  schemaVersion: "init-plan/v1";
+  agentplaneVersion: string;
+  root: string;
+  profile: SetupProfilePreset;
+  answers: {
+    policyGateway: PolicyGatewayFlavor;
+    ide: InitIde;
+    workflow: WorkflowMode;
+    backend: InitBackend;
+    hooks: boolean;
+    requirePlanApproval: boolean;
+    requireNetworkApproval: boolean;
+    requireVerifyApproval: boolean;
+    executionProfile: ExecutionProfile;
+    strictUnsafeConfirm: boolean;
+    recipes: string[];
+    blueprints: string[];
+  };
+  context: {
+    gitRootExisted: boolean;
+    outputMode: "text" | "json";
+  };
+  effects: InitEffect[];
+  conflicts: string[];
+  warnings: string[];
+  nextSteps: string[];
 };

--- a/packages/agentplane/src/cli/run-cli/commands/init/orchestrate.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/orchestrate.ts
@@ -6,7 +6,6 @@ import { usageError } from "../../../spec/errors.js";
 import type { CommandSpec } from "../../../spec/spec.js";
 
 import { resolveInitBaseBranchForInit } from "./base-branch.js";
-import { handleInitConflicts } from "./conflicts.js";
 import { ensureGitRoot } from "./git.js";
 import type { InitParsed } from "./model.js";
 import { InitAborted, loadInitClackPrompts, shouldUseInitClackPrompts } from "./prompts.js";
@@ -15,6 +14,7 @@ import { validateCachedRecipesSelection } from "./recipes.js";
 import { validateCachedBlueprintSelection } from "./blueprints.js";
 import {
   applyInitPlan,
+  buildInitPlan,
   collectInitAndHookConflicts,
   maybeConfirmInteractiveApply,
   resolveConflictStrategy,
@@ -24,7 +24,7 @@ import { buildNonInteractiveAnswers, promptInteractiveAnswers } from "./answers.
 import { outroError, outroSuccess } from "./ui.js";
 
 function shouldRunInteractiveInit(flags: InitParsed): boolean {
-  if (flags.yes || process.env.AGENTPLANE_PROMPTS === "plain") return false;
+  if (flags.yes || flags.dryRun || process.env.AGENTPLANE_PROMPTS === "plain") return false;
   return shouldUseInitClackPrompts();
 }
 
@@ -34,6 +34,7 @@ function assertNonInteractiveInitAllowed(opts: {
   interactive: boolean;
 }): void {
   if (opts.interactive || opts.flags.yes || opts.flags.setupProfile) return;
+  if (opts.flags.dryRun) return;
   if (opts.flags.workflow && opts.flags.requireNetworkApproval !== undefined) return;
   throw usageError({
     spec: opts.spec,
@@ -41,6 +42,26 @@ function assertNonInteractiveInitAllowed(opts: {
     message:
       "Non-interactive init requires --yes, --setup-profile, or explicit values for: --workflow, --require-network-approval.",
   });
+}
+
+function renderDryRunPlanText(plan: ReturnType<typeof buildInitPlan>): string {
+  const lines = [
+    "AgentPlane init plan",
+    `Root: ${plan.root}`,
+    `Profile: ${plan.profile}`,
+    `Workflow: ${plan.answers.workflow}`,
+    `Backend: ${plan.answers.backend}`,
+    `Git init: ${String(!plan.context.gitRootExisted)}`,
+    `Conflicts: ${plan.conflicts.length === 0 ? "none" : plan.conflicts.join(", ")}`,
+    "Effects:",
+    ...plan.effects.map((effect) => {
+      const pathSuffix = effect.path ? ` ${effect.path}` : "";
+      return `- ${effect.kind}${pathSuffix}: ${effect.summary}`;
+    }),
+    "Next:",
+    ...plan.nextSteps.map((step, index) => `${index + 1}. ${step}`),
+  ];
+  return `${lines.join("\n")}\n`;
 }
 
 function requireInitClack(
@@ -58,6 +79,7 @@ function requireInitClack(
 export async function cmdInit(opts: {
   cwd: string;
   rootOverride?: string;
+  outputMode?: "text" | "json";
   flags: InitParsed;
   spec: CommandSpec<InitParsed>;
 }): Promise<number> {
@@ -75,12 +97,11 @@ export async function cmdInit(opts: {
       cwd: opts.cwd,
       rootOverride: opts.rootOverride,
       backend: answers.backend,
-      ensureGitRoot,
     });
     const initBaseBranch = await resolveInitBaseBranchForInit({
       gitRoot: paths.gitRoot,
       baseBranchFallback: "main",
-      isInteractive: false,
+      isInteractive: interactive,
       workflow: answers.workflow,
       gitRootExisted: paths.gitRootExisted,
     });
@@ -91,13 +112,23 @@ export async function cmdInit(opts: {
       gitRoot: paths.gitRoot,
       conflicts,
     });
-    await handleInitConflicts({
-      gitRoot: paths.gitRoot,
+    const plan = buildInitPlan({
+      paths,
+      answers,
       conflicts,
-      backup: conflictMode.backup,
-      force: conflictMode.force,
+      conflictMode,
+      outputMode: opts.outputMode ?? "text",
+      includeInstallCommit: !opts.flags.gitignoreAgents,
     });
-    await maybeConfirmInteractiveApply({ clack, flags: opts.flags, answers });
+    if (opts.flags.dryRun) {
+      if ((opts.outputMode ?? "text") === "json") {
+        process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+      } else {
+        process.stdout.write(renderDryRunPlanText(plan));
+      }
+      return 0;
+    }
+    await maybeConfirmInteractiveApply({ clack, flags: opts.flags, answers, paths, plan });
     await applyInitPlan({
       cwd: opts.cwd,
       rootOverride: opts.rootOverride,
@@ -106,6 +137,9 @@ export async function cmdInit(opts: {
       answers,
       paths,
       initBaseBranch,
+      conflictMode,
+      conflicts,
+      ensureGitRoot,
     });
     if (clack) {
       outroSuccess(clack, paths.gitRoot);

--- a/packages/agentplane/src/cli/run-cli/commands/init/spec.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/spec.ts
@@ -143,6 +143,25 @@ export const initSpec: CommandSpec<InitParsed> = {
     },
     {
       kind: "boolean",
+      name: "no-input",
+      default: false,
+      description: "Alias for --yes; run init without prompts using defaults for missing flags.",
+    },
+    {
+      kind: "boolean",
+      name: "non-interactive",
+      default: false,
+      description: "Alias for --yes; run init without prompts using defaults for missing flags.",
+    },
+    {
+      kind: "boolean",
+      name: "dry-run",
+      default: false,
+      description:
+        "Build and print the init plan without writing files, initializing git, or handling conflicts.",
+    },
+    {
+      kind: "boolean",
       name: "gitignore-agents",
       default: false,
       description:
@@ -170,6 +189,10 @@ export const initSpec: CommandSpec<InitParsed> = {
     {
       cmd: "agentplane init --yes --gitignore-agents",
       why: "Initialize without committing and keep agent prompts/templates local (gitignored).",
+    },
+    {
+      cmd: "agentplane init --dry-run --yes --output json",
+      why: "Print a machine-readable init plan without writing files.",
     },
   ],
   validateRaw: (raw) => {
@@ -233,7 +256,11 @@ export const initSpec: CommandSpec<InitParsed> = {
         blueprintsRaw === undefined ? undefined : parseBlueprintsSelectionForInit(blueprintsRaw),
       force: raw.opts.force === true,
       backup: raw.opts.backup === true,
-      yes: raw.opts.yes === true,
+      yes:
+        raw.opts.yes === true ||
+        raw.opts["no-input"] === true ||
+        raw.opts["non-interactive"] === true,
+      dryRun: raw.opts["dry-run"] === true,
       gitignoreAgents: raw.opts["gitignore-agents"] === true,
     };
   },
@@ -249,4 +276,10 @@ export const initSpec: CommandSpec<InitParsed> = {
 };
 
 export const runInit: CommandHandler<InitParsed> = (ctx, flags) =>
-  cmdInit({ cwd: ctx.cwd, rootOverride: ctx.rootOverride, flags, spec: initSpec });
+  cmdInit({
+    cwd: ctx.cwd,
+    rootOverride: ctx.rootOverride,
+    outputMode: ctx.outputMode ?? "text",
+    flags,
+    spec: initSpec,
+  });

--- a/packages/agentplane/src/cli/spec/spec.ts
+++ b/packages/agentplane/src/cli/spec/spec.ts
@@ -79,6 +79,7 @@ export type CommandSpec<TParsed = unknown> = {
 export type CommandCtx = {
   cwd: string;
   rootOverride?: string;
+  outputMode?: "text" | "json";
 };
 
 export type CommandHandler<TParsed = unknown> = (


### PR DESCRIPTION
Task: `202605120709-JXWHD3`
Title: Implement RFQ init P0 planning boundary
Canonical task record: `.agentplane/tasks/202605120709-JXWHD3/README.md`

## Summary

Implement RFQ init P0 planning boundary

Implement the P0 AgentPlane init RFQ slice: pure planning before apply, dry-run plan output, delayed git/conflict side effects, base-branch interactive fix, docs, and tests.

## Scope

- In scope: Implement the P0 AgentPlane init RFQ slice: pure planning before apply, dry-run plan output, delayed git/conflict side effects, base-branch interactive fix, docs, and tests.
- Out of scope: unrelated refactors not required for "Implement RFQ init P0 planning boundary".

## Verification

- State: ok
- Note: Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts; Result: pass; Evidence: 21 tests passed. Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/cli/run-cli/commands/init/steps/prompt-steps.test.ts packages/agentplane/src/cli/run-cli/commands/init/ui.test.ts packages/agentplane/src/cli/run-cli/commands/init/prompts.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/apply.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/conflict-resolver.test.ts; Result: pass; Evidence: 25 tests passed. Command: exact-file eslint, bun run format:check, bun run typecheck, bun run docs:cli:check, node .agentplane/policy/check-routing.mjs, ap doctor; Result: pass; Evidence: lint clean, Prettier clean, tsc -b OK, CLI reference up to date, policy routing OK, doctor OK.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-12T08:24:27.590Z
- Branch: task/202605120709-JXWHD3/init-p0-planning-boundary
- Head: a95645d52dbc

```text
 .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
 docs/user/cli-reference.generated.mdx              |   9 +
 docs/user/commands.mdx                             |   3 +
 docs/user/setup.mdx                                |  11 +
 .../agentplane/src/cli/run-cli.core.init.test.ts   |  97 ++++
 packages/agentplane/src/cli/run-cli.ts             |   3 +-
 .../src/cli/run-cli/commands/init/answers.ts       |   3 +
 .../src/cli/run-cli/commands/init/base-branch.ts   |   3 +
 .../src/cli/run-cli/commands/init/execution.ts     | 282 ++++++++++--
 .../src/cli/run-cli/commands/init/model.ts         |  53 +++
 .../src/cli/run-cli/commands/init/orchestrate.ts   |  52 ++-
 .../src/cli/run-cli/commands/init/spec.ts          |  37 +-
 packages/agentplane/src/cli/spec/spec.ts           |   1 +
 13 files changed, 1011 insertions(+), 55 deletions(-)
```

</details>
