### PR TITLE
🚧 2K392S task: Defer init base branch creation until apply [202605120837-2K392S]

### DIFF
--- a/.agentplane/tasks/202605120837-2K392S/README.md
+++ b/.agentplane/tasks/202605120837-2K392S/README.md
@@ -1,0 +1,95 @@
+---
+id: "202605120837-2K392S"
+title: "Defer init base branch creation until apply"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-12T08:38:03.095Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Fix init so interactive base-branch creation is deferred until confirmed apply, with regression coverage for cancel-before-apply behavior."
+events:
+  -
+    type: "status"
+    at: "2026-05-12T08:38:30.968Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Fix init so interactive base-branch creation is deferred until confirmed apply, with regression coverage for cancel-before-apply behavior."
+doc_version: 3
+doc_updated_at: "2026-05-12T08:38:30.968Z"
+doc_updated_by: "CODER"
+description: "Fix init so interactive base-branch creation is planned before confirmation and only performs git mutations during apply."
+sections:
+  Summary: |-
+    Defer init base branch creation until apply
+    
+    Fix init so interactive base-branch creation is planned before confirmation and only performs git mutations during apply.
+  Scope: |-
+    - In scope: Fix init so interactive base-branch creation is planned before confirmation and only performs git mutations during apply.
+    - Out of scope: unrelated refactors not required for "Defer init base branch creation until apply".
+  Plan: "Fix init base-branch planning boundary. 1. Move interactive base-branch mutation choice out of pre-confirm planning. 2. Preserve dry-run and non-interactive base-branch resolution as read-only planning. 3. Apply branch creation only after init apply confirmation. 4. Add a regression test proving cancellation before apply leaves no created branch. 5. Run focused init tests, exact-file lint, type/docs policy checks as applicable."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Defer init base branch creation until apply
+
+Fix init so interactive base-branch creation is planned before confirmation and only performs git mutations during apply.
+
+## Scope
+
+- In scope: Fix init so interactive base-branch creation is planned before confirmation and only performs git mutations during apply.
+- Out of scope: unrelated refactors not required for "Defer init base branch creation until apply".
+
+## Plan
+
+Fix init base-branch planning boundary. 1. Move interactive base-branch mutation choice out of pre-confirm planning. 2. Preserve dry-run and non-interactive base-branch resolution as read-only planning. 3. Apply branch creation only after init apply confirmation. 4. Add a regression test proving cancellation before apply leaves no created branch. 5. Run focused init tests, exact-file lint, type/docs policy checks as applicable.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605120837-2K392S/README.md
+++ b/.agentplane/tasks/202605120837-2K392S/README.md
@@ -17,10 +17,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-12T08:50:07.121Z"
+  updated_by: "CODER"
+  note: "Verified init base-branch creation is deferred until confirmed apply."
   attempts: 0
 commit: null
 comments:
@@ -35,8 +35,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: Fix init so interactive base-branch creation is deferred until confirmed apply, with regression coverage for cancel-before-apply behavior."
+  -
+    type: "verify"
+    at: "2026-05-12T08:50:07.121Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified init base-branch creation is deferred until confirmed apply."
 doc_version: 3
-doc_updated_at: "2026-05-12T08:38:30.968Z"
+doc_updated_at: "2026-05-12T08:50:07.146Z"
 doc_updated_by: "CODER"
 description: "Fix init so interactive base-branch creation is planned before confirmation and only performs git mutations during apply."
 sections:
@@ -54,11 +60,33 @@ sections:
     3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-12T08:50:07.121Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified init base-branch creation is deferred until confirmed apply.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-12T08:38:30.968Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605120837-2K392S-defer-init-base-branch-apply/.agentplane/tasks/202605120837-2K392S/blueprint/resolved-snapshot.json
+    - old_digest: db98449531758f004d23e73a3c07eebe294d456ef269a10ae6f8ca6e1ca21682
+    - current_digest: db98449531758f004d23e73a3c07eebe294d456ef269a10ae6f8ca6e1ca21682
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605120837-2K392S
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
     - Re-run required checks to confirm rollback safety.
-  Findings: ""
+  Findings: |-
+    - Observation: Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init-base-branch.test.ts; Result: pass; Evidence: 2 files passed, 22 tests passed. Command: bunx eslint touched files; Result: pass. Command: bun run typecheck; Result: pass. Command: bun run format:check; Result: pass. Command: node .agentplane/policy/check-routing.mjs; Result: pass. Command: ap doctor; Result: pass with info-only findings.
+      Impact: The interactive init path no longer creates a base branch during planning or before the apply confirmation.
+      Resolution: resolveInitBaseBranchForInit now returns a deferred branch creation selection, and applyInitPlan applies it only after confirmation.
 id_source: "generated"
 ---
 ## Summary
@@ -85,6 +113,25 @@ Fix init base-branch planning boundary. 1. Move interactive base-branch mutation
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-12T08:50:07.121Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified init base-branch creation is deferred until confirmed apply.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-12T08:38:30.968Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605120837-2K392S-defer-init-base-branch-apply/.agentplane/tasks/202605120837-2K392S/blueprint/resolved-snapshot.json
+- old_digest: db98449531758f004d23e73a3c07eebe294d456ef269a10ae6f8ca6e1ca21682
+- current_digest: db98449531758f004d23e73a3c07eebe294d456ef269a10ae6f8ca6e1ca21682
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605120837-2K392S
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -93,3 +140,7 @@ Fix init base-branch planning boundary. 1. Move interactive base-branch mutation
 - Re-run required checks to confirm rollback safety.
 
 ## Findings
+
+- Observation: Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init-base-branch.test.ts; Result: pass; Evidence: 2 files passed, 22 tests passed. Command: bunx eslint touched files; Result: pass. Command: bun run typecheck; Result: pass. Command: bun run format:check; Result: pass. Command: node .agentplane/policy/check-routing.mjs; Result: pass. Command: ap doctor; Result: pass with info-only findings.
+  Impact: The interactive init path no longer creates a base branch during planning or before the apply confirmation.
+  Resolution: resolveInitBaseBranchForInit now returns a deferred branch creation selection, and applyInitPlan applies it only after confirmation.

--- a/.agentplane/tasks/202605120837-2K392S/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605120837-2K392S/blueprint/resolved-snapshot.json
@@ -1,0 +1,512 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605120837-2K392S",
+    "title": "Defer init base branch creation until apply",
+    "description": "Fix init so interactive base-branch creation is planned before confirmation and only performs git mutations during apply.",
+    "tags": [
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605120837-2K392S",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "db98449531758f004d23e73a3c07eebe294d456ef269a10ae6f8ca6e1ca21682"
+  }
+}

--- a/.agentplane/tasks/202605120837-2K392S/pr/diffstat.txt
+++ b/.agentplane/tasks/202605120837-2K392S/pr/diffstat.txt
@@ -1,0 +1,6 @@
+ .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
+ .../src/cli/run-cli.core.init-base-branch.test.ts  |  51 ++
+ .../src/cli/run-cli/commands/init/base-branch.ts   | 102 +++-
+ .../src/cli/run-cli/commands/init/execution.ts     |  11 +-
+ .../src/cli/run-cli/commands/init/orchestrate.ts   |   4 +-
+ 5 files changed, 669 insertions(+), 11 deletions(-)

--- a/.agentplane/tasks/202605120837-2K392S/pr/github-body.md
+++ b/.agentplane/tasks/202605120837-2K392S/pr/github-body.md
@@ -22,12 +22,17 @@ Fix init so interactive base-branch creation is planned before confirmation and 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-12T08:38:31.207Z
+- Updated: 2026-05-12T08:49:23.593Z
 - Branch: task/202605120837-2K392S/defer-init-base-branch-apply
-- Head: a42e0cd9f2de
+- Head: 27540f93715f
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
+ .../src/cli/run-cli.core.init-base-branch.test.ts  |  51 ++
+ .../src/cli/run-cli/commands/init/base-branch.ts   | 102 +++-
+ .../src/cli/run-cli/commands/init/execution.ts     |  11 +-
+ .../src/cli/run-cli/commands/init/orchestrate.ts   |   4 +-
+ 5 files changed, 669 insertions(+), 11 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605120837-2K392S/pr/github-body.md
+++ b/.agentplane/tasks/202605120837-2K392S/pr/github-body.md
@@ -15,8 +15,8 @@ Fix init so interactive base-branch creation is planned before confirmation and 
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified init base-branch creation is deferred until confirmed apply.
 - Canonical workflow state lives in the task README.
 
 <details>

--- a/.agentplane/tasks/202605120837-2K392S/pr/github-body.md
+++ b/.agentplane/tasks/202605120837-2K392S/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605120837-2K392S`
+Title: Defer init base branch creation until apply
+Canonical task record: `.agentplane/tasks/202605120837-2K392S/README.md`
+
+## Summary
+
+Defer init base branch creation until apply
+
+Fix init so interactive base-branch creation is planned before confirmation and only performs git mutations during apply.
+
+## Scope
+
+- In scope: Fix init so interactive base-branch creation is planned before confirmation and only performs git mutations during apply.
+- Out of scope: unrelated refactors not required for "Defer init base branch creation until apply".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-12T08:38:31.207Z
+- Branch: task/202605120837-2K392S/defer-init-base-branch-apply
+- Head: a42e0cd9f2de
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605120837-2K392S/pr/github-title.txt
+++ b/.agentplane/tasks/202605120837-2K392S/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 2K392S task: Defer init base branch creation until apply [202605120837-2K392S]

--- a/.agentplane/tasks/202605120837-2K392S/pr/meta.json
+++ b/.agentplane/tasks/202605120837-2K392S/pr/meta.json
@@ -3,12 +3,12 @@
   "branch": "task/202605120837-2K392S/defer-init-base-branch-apply",
   "created_at": "2026-05-12T08:38:31.207Z",
   "head_sha": "27540f93715fd2a30cb7c666a0ada1a84362c862",
-  "last_verified_at": null,
-  "last_verified_sha": null,
+  "last_verified_at": "2026-05-12T08:50:07.121Z",
+  "last_verified_sha": "27540f93715fd2a30cb7c666a0ada1a84362c862",
   "schema_version": 1,
   "task_id": "202605120837-2K392S",
   "updated_at": "2026-05-12T08:49:23.593Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605120837-2K392S/pr/meta.json
+++ b/.agentplane/tasks/202605120837-2K392S/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605120837-2K392S/defer-init-base-branch-apply",
+  "created_at": "2026-05-12T08:38:31.207Z",
+  "head_sha": "a42e0cd9f2de67e3799486ebdc214550672f0550",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202605120837-2K392S",
+  "updated_at": "2026-05-12T08:38:31.207Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605120837-2K392S/pr/meta.json
+++ b/.agentplane/tasks/202605120837-2K392S/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605120837-2K392S/defer-init-base-branch-apply",
   "created_at": "2026-05-12T08:38:31.207Z",
-  "head_sha": "a42e0cd9f2de67e3799486ebdc214550672f0550",
+  "head_sha": "27540f93715fd2a30cb7c666a0ada1a84362c862",
   "last_verified_at": null,
   "last_verified_sha": null,
   "schema_version": 1,
   "task_id": "202605120837-2K392S",
-  "updated_at": "2026-05-12T08:38:31.207Z",
+  "updated_at": "2026-05-12T08:49:23.593Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202605120837-2K392S/pr/review.md
+++ b/.agentplane/tasks/202605120837-2K392S/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-12T08:38:31.207Z
+
+## Task
+
+- Task: `202605120837-2K392S`
+- Title: Defer init base branch creation until apply
+- Status: DOING
+- Branch: `task/202605120837-2K392S/defer-init-base-branch-apply`
+- Canonical task record: `.agentplane/tasks/202605120837-2K392S/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-12T08:38:31.207Z
+- Branch: task/202605120837-2K392S/defer-init-base-branch-apply
+- Head: a42e0cd9f2de
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605120837-2K392S/pr/review.md
+++ b/.agentplane/tasks/202605120837-2K392S/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-05-12T08:38:31.207Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified init base-branch creation is deferred until confirmed apply.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes

--- a/.agentplane/tasks/202605120837-2K392S/pr/review.md
+++ b/.agentplane/tasks/202605120837-2K392S/pr/review.md
@@ -24,12 +24,17 @@ Created: 2026-05-12T08:38:31.207Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-12T08:38:31.207Z
+- Updated: 2026-05-12T08:49:23.593Z
 - Branch: task/202605120837-2K392S/defer-init-base-branch-apply
-- Head: a42e0cd9f2de
+- Head: 27540f93715f
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
+ .../src/cli/run-cli.core.init-base-branch.test.ts  |  51 ++
+ .../src/cli/run-cli/commands/init/base-branch.ts   | 102 +++-
+ .../src/cli/run-cli/commands/init/execution.ts     |  11 +-
+ .../src/cli/run-cli/commands/init/orchestrate.ts   |   4 +-
+ 5 files changed, 669 insertions(+), 11 deletions(-)
 ```
 
 </details>

--- a/packages/agentplane/src/cli/run-cli.core.init-base-branch.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.init-base-branch.test.ts
@@ -1,0 +1,51 @@
+import { execFileAsync } from "@agentplaneorg/core/process";
+import { commitAll, configureGitUser, mkGitRepoRoot } from "@agentplane/testkit";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import * as prompts from "./prompts.js";
+import {
+  applyInitBaseBranchSelection,
+  resolveInitBaseBranchForInit,
+} from "./run-cli/commands/init/base-branch.js";
+
+describe("init base branch selection", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("plans interactive base branch creation without mutating git before apply", async () => {
+    const root = await mkGitRepoRoot();
+    await configureGitUser(root);
+    await writeFile(path.join(root, "seed.txt"), "seed\n", "utf8");
+    await commitAll(root, "chore: seed");
+
+    vi.spyOn(prompts, "selectPrompt").mockResolvedValue("Create new branch");
+    vi.spyOn(prompts, "textPrompt").mockResolvedValue("planned-base");
+
+    const selection = await resolveInitBaseBranchForInit({
+      gitRoot: root,
+      baseBranchFallback: "main",
+      isInteractive: true,
+      workflow: "branch_pr",
+      gitRootExisted: true,
+    });
+
+    expect(selection).toEqual({
+      baseBranch: "planned-base",
+      createBranch: { name: "planned-base", mode: "branch" },
+    });
+    const beforeApply = await execFileAsync("git", ["branch", "--list", "planned-base"], {
+      cwd: root,
+    });
+    expect(beforeApply.stdout.trim()).toBe("");
+
+    await applyInitBaseBranchSelection({ gitRoot: root, selection });
+
+    const afterApply = await execFileAsync("git", ["branch", "--list", "planned-base"], {
+      cwd: root,
+    });
+    expect(afterApply.stdout.trim()).toContain("planned-base");
+  });
+});

--- a/packages/agentplane/src/cli/run-cli/commands/init/base-branch.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/base-branch.ts
@@ -1,5 +1,73 @@
 import type { WorkflowMode } from "../../../../agents/agents-template.js";
-import { promptInitBaseBranch, resolveInitBaseBranch } from "../../../../commands/workflow.js";
+import { resolveInitBaseBranch } from "../../../../commands/workflow.js";
+import { execFileAsync } from "@agentplaneorg/core/process";
+import {
+  gitBranchExists,
+  gitCurrentBranch,
+  gitEnv,
+  gitListBranches,
+} from "@agentplaneorg/core/git";
+import { exitCodeForError } from "../../../exit-codes.js";
+import { selectPrompt, textPrompt } from "../../../prompts.js";
+import { CliError } from "../../../../shared/errors.js";
+
+export type InitBaseBranchSelection = {
+  baseBranch: string;
+  createBranch?: {
+    name: string;
+    mode: "branch" | "checkout";
+  };
+};
+
+async function promptInitBaseBranchSelection(opts: {
+  gitRoot: string;
+  fallback: string;
+}): Promise<InitBaseBranchSelection> {
+  const branches = await gitListBranches(opts.gitRoot);
+  let current: string | null = null;
+  try {
+    current = await gitCurrentBranch(opts.gitRoot);
+  } catch {
+    current = null;
+  }
+
+  const promptNewBranch = async (hasBranches: boolean): Promise<InitBaseBranchSelection> => {
+    const raw = await textPrompt(`Enter new base branch name (default ${opts.fallback}): `);
+    const candidate = raw.trim() || opts.fallback;
+    if (!candidate) {
+      throw new CliError({
+        exitCode: exitCodeForError("E_USAGE"),
+        code: "E_USAGE",
+        message: "Base branch name cannot be empty",
+      });
+    }
+    if (await gitBranchExists(opts.gitRoot, candidate)) return { baseBranch: candidate };
+    return {
+      baseBranch: candidate,
+      createBranch: {
+        name: candidate,
+        mode: hasBranches ? "branch" : "checkout",
+      },
+    };
+  };
+
+  if (branches.length === 0) {
+    return await promptNewBranch(false);
+  }
+
+  const createLabel = "Create new branch";
+  const defaultChoice =
+    current && branches.includes(current) ? current : (branches[0] ?? opts.fallback);
+  const choice = await selectPrompt(
+    "Select base branch",
+    [...branches, createLabel],
+    defaultChoice,
+  );
+  if (choice === createLabel) {
+    return await promptNewBranch(true);
+  }
+  return { baseBranch: choice };
+}
 
 export async function resolveInitBaseBranchForInit(opts: {
   gitRoot: string;
@@ -7,16 +75,38 @@ export async function resolveInitBaseBranchForInit(opts: {
   isInteractive: boolean;
   workflow: WorkflowMode;
   gitRootExisted: boolean;
-}): Promise<string> {
+}): Promise<InitBaseBranchSelection> {
   if (!opts.gitRootExisted) {
-    return opts.baseBranchFallback;
+    return { baseBranch: opts.baseBranchFallback };
   }
-  let initBaseBranch = await resolveInitBaseBranch(opts.gitRoot, opts.baseBranchFallback);
+  const initBaseBranch = await resolveInitBaseBranch(opts.gitRoot, opts.baseBranchFallback);
   if (opts.isInteractive && opts.workflow === "branch_pr" && opts.gitRootExisted) {
-    initBaseBranch = await promptInitBaseBranch({
+    return await promptInitBaseBranchSelection({
       gitRoot: opts.gitRoot,
       fallback: initBaseBranch,
     });
   }
-  return initBaseBranch;
+  return { baseBranch: initBaseBranch };
+}
+
+export async function applyInitBaseBranchSelection(opts: {
+  gitRoot: string;
+  selection: InitBaseBranchSelection;
+}): Promise<void> {
+  const createBranch = opts.selection.createBranch;
+  if (!createBranch) return;
+  if (await gitBranchExists(opts.gitRoot, createBranch.name)) return;
+  try {
+    await execFileAsync(
+      "git",
+      createBranch.mode === "branch"
+        ? ["branch", createBranch.name]
+        : ["checkout", "-q", "-b", createBranch.name],
+      { cwd: opts.gitRoot, env: gitEnv() },
+    );
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : `Failed to create branch ${createBranch.name}`;
+    throw new CliError({ exitCode: exitCodeForError("E_GIT"), code: "E_GIT", message });
+  }
 }

--- a/packages/agentplane/src/cli/run-cli/commands/init/execution.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/execution.ts
@@ -10,6 +10,7 @@ import { getPathKind } from "../../../fs-utils.js";
 import { InitAborted, type InitClackPrompts } from "./prompts.js";
 import type { InitEffect, InitFlags, InitParsed, InitPlan } from "./model.js";
 import type { InitAnswers } from "./answers.js";
+import { applyInitBaseBranchSelection, type InitBaseBranchSelection } from "./base-branch.js";
 import { collectInitConflicts, handleInitConflicts } from "./conflicts.js";
 import { maybeSyncIde } from "./ide-sync.js";
 import { promptConflictResolverStep, applyInitWithProgress } from "./steps/index.js";
@@ -314,7 +315,7 @@ export async function applyInitPlan(opts: {
   clack: InitClackPrompts | null;
   answers: InitAnswers;
   paths: ResolvedInitPaths;
-  initBaseBranch: string;
+  initBaseBranchSelection: InitBaseBranchSelection;
   conflictMode: { backup: boolean; force: boolean };
   conflicts: string[];
   ensureGitRoot: (opts: {
@@ -327,6 +328,10 @@ export async function applyInitPlan(opts: {
     baseBranchFallback: "main",
   });
   const paths = { ...opts.paths, gitRoot: ensured.gitRoot, gitRootExisted: ensured.gitRootExisted };
+  await applyInitBaseBranchSelection({
+    gitRoot: paths.gitRoot,
+    selection: opts.initBaseBranchSelection,
+  });
   await handleInitConflicts({
     gitRoot: paths.gitRoot,
     conflicts: opts.conflicts,
@@ -360,7 +365,7 @@ export async function applyInitPlan(opts: {
           await setPinnedBaseBranch({
             cwd: paths.gitRoot,
             rootOverride: paths.gitRoot,
-            value: opts.initBaseBranch,
+            value: opts.initBaseBranchSelection.baseBranch,
           });
         }
       },
@@ -442,7 +447,7 @@ export async function applyInitPlan(opts: {
       installCommit: async (installPaths) => {
         await ensureInitCommit({
           gitRoot: paths.gitRoot,
-          baseBranch: opts.initBaseBranch,
+          baseBranch: opts.initBaseBranchSelection.baseBranch,
           installPaths: [...installPaths],
           version: getVersion(),
           skipHooks: true,

--- a/packages/agentplane/src/cli/run-cli/commands/init/orchestrate.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/orchestrate.ts
@@ -98,7 +98,7 @@ export async function cmdInit(opts: {
       rootOverride: opts.rootOverride,
       backend: answers.backend,
     });
-    const initBaseBranch = await resolveInitBaseBranchForInit({
+    const initBaseBranchSelection = await resolveInitBaseBranchForInit({
       gitRoot: paths.gitRoot,
       baseBranchFallback: "main",
       isInteractive: interactive,
@@ -136,7 +136,7 @@ export async function cmdInit(opts: {
       clack,
       answers,
       paths,
-      initBaseBranch,
+      initBaseBranchSelection,
       conflictMode,
       conflicts,
       ensureGitRoot,


### PR DESCRIPTION
Task: `202605120837-2K392S`
Title: Defer init base branch creation until apply
Canonical task record: `.agentplane/tasks/202605120837-2K392S/README.md`

## Summary

Defer init base branch creation until apply

Fix init so interactive base-branch creation is planned before confirmation and only performs git mutations during apply.

## Scope

- In scope: Fix init so interactive base-branch creation is planned before confirmation and only performs git mutations during apply.
- Out of scope: unrelated refactors not required for "Defer init base branch creation until apply".

## Verification

- State: ok
- Note: Verified init base-branch creation is deferred until confirmed apply.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-12T08:49:23.593Z
- Branch: task/202605120837-2K392S/defer-init-base-branch-apply
- Head: 27540f93715f

```text
 .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
 .../src/cli/run-cli.core.init-base-branch.test.ts  |  51 ++
 .../src/cli/run-cli/commands/init/base-branch.ts   | 102 +++-
 .../src/cli/run-cli/commands/init/execution.ts     |  11 +-
 .../src/cli/run-cli/commands/init/orchestrate.ts   |   4 +-
 5 files changed, 669 insertions(+), 11 deletions(-)
```

</details>
