### PR TITLE
🚧 F6FWTH task: Harden wait-remote-pr-checks argument parsing [202605111536-F6FWTH]

### DIFF
--- a/.agentplane/tasks/202605111536-F6FWTH/README.md
+++ b/.agentplane/tasks/202605111536-F6FWTH/README.md
@@ -1,0 +1,91 @@
+---
+id: "202605111536-F6FWTH"
+title: "Harden wait-remote-pr-checks argument parsing"
+status: "DOING"
+priority: "med"
+owner: "INTEGRATOR"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "cli"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-11T15:36:49.565Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-11T15:36:53.765Z"
+  updated_by: "INTEGRATOR"
+  note: "Fixed unknown --* option handling in scripts/wait-remote-pr-checks.mjs and added regression coverage in packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts; no behavior change beyond CLI validation."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "INTEGRATOR"
+    body: "Start: owner executing requested CLI rough-edge fix. Scope is script argument validation guard + regression test. Evidence from targeted CLI test suite and docs checks will be recorded in verify step."
+events:
+  -
+    type: "status"
+    at: "2026-05-11T15:36:50.662Z"
+    author: "INTEGRATOR"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: owner executing requested CLI rough-edge fix. Scope is script argument validation guard + regression test. Evidence from targeted CLI test suite and docs checks will be recorded in verify step."
+  -
+    type: "verify"
+    at: "2026-05-11T15:36:53.765Z"
+    author: "INTEGRATOR"
+    state: "ok"
+    note: "Fixed unknown --* option handling in scripts/wait-remote-pr-checks.mjs and added regression coverage in packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts; no behavior change beyond CLI validation."
+doc_version: 3
+doc_updated_at: "2026-05-11T15:36:53.778Z"
+doc_updated_by: "INTEGRATOR"
+description: "Unknown --* option should fail fast with explicit error and no GitHub calls; add regression test and keep parse behavior stable."
+sections:
+  Summary: |-
+    Harden wait-remote-pr-checks argument parsing
+    
+    Unknown --* option should fail fast with explicit error and no GitHub calls; add regression test and keep parse behavior stable.
+  Scope: |-
+    - In scope: Unknown --* option should fail fast with explicit error and no GitHub calls; add regression test and keep parse behavior stable.
+    - Out of scope: unrelated refactors not required for "Harden wait-remote-pr-checks argument parsing".
+  Plan: "Fix parseArgs in scripts/wait-remote-pr-checks.mjs to reject unknown --* args; add regression tests and keep script behavior deterministic."
+  Verify Steps: |-
+    1. Review the requested outcome for "Harden wait-remote-pr-checks argument parsing". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-11T15:36:53.765Z — VERIFY — ok
+    
+    By: INTEGRATOR
+    
+    Note: Fixed unknown --* option handling in scripts/wait-remote-pr-checks.mjs and added regression coverage in packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts; no behavior change beyond CLI validation.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-11T15:36:50.676Z, excerpt_hash=sha256:5bd873274e8cee03bc0f5f842d759bb6f9ada289ff597053bea70dfb81e647bf
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tasks/202605111536-F6FWTH/blueprint/resolved-snapshot.json
+    - old_digest: eaefbf69d06b32fc0f70f948502112ce5a45976f3142719f1e6a3e9b20f45a9e
+    - current_digest: eaefbf69d06b32fc0f70f948502112ce5a45976f3142719f1e6a3e9b20f45a9e
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605111536-F6FWTH
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Discovered that full CLI suite (packages/agentplane/src/cli) has existing unrelated failures in finish/upgrade/init and pr lifecycle areas under this environment.
+      Impact: No direct user-facing regressions in script behavior; deterministic fast-fail for malformed flags.
+      Resolution: Added parse guard and regression test; execution checks pass for targeted suites.
+id_source: "generated"
+---

--- a/.agentplane/tasks/202605111536-F6FWTH/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605111536-F6FWTH/blueprint/resolved-snapshot.json
@@ -1,0 +1,552 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605111536-F6FWTH",
+    "title": "Harden wait-remote-pr-checks argument parsing",
+    "description": "Unknown --* option should fail fast with explicit error and no GitHub calls; add regression test and keep parse behavior stable.",
+    "tags": [
+      "cli"
+    ],
+    "owner": "INTEGRATOR",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "quality.regression",
+    "version": 1,
+    "title": "Quality regression",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "quality.regression",
+    "blueprintVersion": 1,
+    "title": "Quality regression",
+    "taskId": "202605111536-F6FWTH",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to quality.regression",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest",
+          "artifact"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "check_result"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "weak_links"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "regression.original_failure",
+        "kind": "artifact",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Original failure log or check output."
+      },
+      {
+        "id": "regression.reproduction",
+        "kind": "check_result",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Local reproduction or explicit non-reproduction result."
+      },
+      {
+        "id": "regression.focused_check",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Focused regression check."
+      },
+      {
+        "id": "regression.matrix_or_scope",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Affected test/check matrix or bounded scope."
+      },
+      {
+        "id": "regression.full_gate",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Full relevant gate or hosted check evidence."
+      },
+      {
+        "id": "regression.flake_classification",
+        "kind": "weak_links",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Flake classification or residual risk."
+      },
+      {
+        "id": "regression.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "affected matrix or full relevant gate",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "failure reproduction command",
+      "focused regression check",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest",
+        "artifact"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "check_result"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "weak_links"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "regression.original_failure",
+      "kind": "artifact",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Original failure log or check output."
+    },
+    {
+      "id": "regression.reproduction",
+      "kind": "check_result",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Local reproduction or explicit non-reproduction result."
+    },
+    {
+      "id": "regression.focused_check",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Focused regression check."
+    },
+    {
+      "id": "regression.matrix_or_scope",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Affected test/check matrix or bounded scope."
+    },
+    {
+      "id": "regression.full_gate",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Full relevant gate or hosted check evidence."
+    },
+    {
+      "id": "regression.flake_classification",
+      "kind": "weak_links",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Flake classification or residual risk."
+    },
+    {
+      "id": "regression.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "affected matrix or full relevant gate",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "failure reproduction command",
+    "focused regression check",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to quality.regression",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "eaefbf69d06b32fc0f70f948502112ce5a45976f3142719f1e6a3e9b20f45a9e"
+  }
+}

--- a/.agentplane/tasks/202605111536-F6FWTH/pr/diffstat.txt
+++ b/.agentplane/tasks/202605111536-F6FWTH/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ .../blueprint/resolved-snapshot.json               | 552 +++++++++++++++++++++
+ .../src/cli/wait-remote-pr-checks-script.test.ts   |  14 +
+ scripts/wait-remote-pr-checks.mjs                  |   3 +
+ 3 files changed, 569 insertions(+)

--- a/.agentplane/tasks/202605111536-F6FWTH/pr/github-body.md
+++ b/.agentplane/tasks/202605111536-F6FWTH/pr/github-body.md
@@ -1,0 +1,36 @@
+Task: `202605111536-F6FWTH`
+Title: Harden wait-remote-pr-checks argument parsing
+Canonical task record: `.agentplane/tasks/202605111536-F6FWTH/README.md`
+
+## Summary
+
+Harden wait-remote-pr-checks argument parsing
+
+Unknown --* option should fail fast with explicit error and no GitHub calls; add regression test and keep parse behavior stable.
+
+## Scope
+
+- In scope: Unknown --* option should fail fast with explicit error and no GitHub calls; add regression test and keep parse behavior stable.
+- Out of scope: unrelated refactors not required for "Harden wait-remote-pr-checks argument parsing".
+
+## Verification
+
+- State: ok
+- Note: Fixed unknown --* option handling in scripts/wait-remote-pr-checks.mjs and added regression coverage in packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts; no behavior change beyond CLI validation.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-12T09:40:55.625Z
+- Branch: task/202605111536-F6FWTH/harden-wait-script
+- Head: fd0a5eca08d9
+
+```text
+ .../blueprint/resolved-snapshot.json               | 552 +++++++++++++++++++++
+ .../src/cli/wait-remote-pr-checks-script.test.ts   |  14 +
+ scripts/wait-remote-pr-checks.mjs                  |   3 +
+ 3 files changed, 569 insertions(+)
+```
+
+</details>

--- a/.agentplane/tasks/202605111536-F6FWTH/pr/github-title.txt
+++ b/.agentplane/tasks/202605111536-F6FWTH/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 F6FWTH task: Harden wait-remote-pr-checks argument parsing [202605111536-F6FWTH]

--- a/.agentplane/tasks/202605111536-F6FWTH/pr/meta.json
+++ b/.agentplane/tasks/202605111536-F6FWTH/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605111536-F6FWTH/harden-wait-script",
+  "created_at": "2026-05-12T09:40:55.625Z",
+  "head_sha": "fd0a5eca08d9d3b4d3b4be9940be93b7f5b722b2",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202605111536-F6FWTH",
+  "updated_at": "2026-05-12T09:40:55.625Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605111536-F6FWTH/pr/review.md
+++ b/.agentplane/tasks/202605111536-F6FWTH/pr/review.md
@@ -1,0 +1,39 @@
+# PR Review
+
+Created: 2026-05-12T09:40:55.625Z
+
+## Task
+
+- Task: `202605111536-F6FWTH`
+- Title: Harden wait-remote-pr-checks argument parsing
+- Status: DOING
+- Branch: `task/202605111536-F6FWTH/harden-wait-script`
+- Canonical task record: `.agentplane/tasks/202605111536-F6FWTH/README.md`
+
+## Verification
+
+- State: ok
+- Note: Fixed unknown --* option handling in scripts/wait-remote-pr-checks.mjs and added regression coverage in packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts; no behavior change beyond CLI validation.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-12T09:40:55.625Z
+- Branch: task/202605111536-F6FWTH/harden-wait-script
+- Head: fd0a5eca08d9
+
+```text
+ .../blueprint/resolved-snapshot.json               | 552 +++++++++++++++++++++
+ .../src/cli/wait-remote-pr-checks-script.test.ts   |  14 +
+ scripts/wait-remote-pr-checks.mjs                  |   3 +
+ 3 files changed, 569 insertions(+)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts
+++ b/packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts
@@ -292,6 +292,20 @@ describe("wait-remote-pr-checks script", () => {
     expect(callLogText).not.toContain(`["pr","view","--pr"`);
   });
 
+  it("rejects unknown dashed options before contacting GitHub", async () => {
+    const root = await makeTempRoot();
+
+    const result = await runScript(["--mystery"], {
+      env: {
+        PATH: `${path.join(root, "bin")}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Unknown option: --mystery");
+    expect(result.stderr).not.toContain("required checks passed");
+  });
+
   it(
     "waits for multiple PRs in input order and caches shared protection lookups",
     { timeout: 120_000 },

--- a/scripts/wait-remote-pr-checks.mjs
+++ b/scripts/wait-remote-pr-checks.mjs
@@ -95,6 +95,9 @@ function parseArgs(argv) {
     if (IGNORED_LEGACY_FLAGS.has(arg)) {
       continue;
     }
+    if (arg.startsWith("--")) {
+      throw new Error(`Unknown option: ${arg}`);
+    }
     options.targetArgs.push(arg);
   }
 


### PR DESCRIPTION
Task: `202605111536-F6FWTH`
Title: Harden wait-remote-pr-checks argument parsing
Canonical task record: `.agentplane/tasks/202605111536-F6FWTH/README.md`

## Summary

Harden wait-remote-pr-checks argument parsing

Unknown --* option should fail fast with explicit error and no GitHub calls; add regression test and keep parse behavior stable.

## Scope

- In scope: Unknown --* option should fail fast with explicit error and no GitHub calls; add regression test and keep parse behavior stable.
- Out of scope: unrelated refactors not required for "Harden wait-remote-pr-checks argument parsing".

## Verification

- State: ok
- Note: Fixed unknown --* option handling in scripts/wait-remote-pr-checks.mjs and added regression coverage in packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts; no behavior change beyond CLI validation.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-12T09:40:55.625Z
- Branch: task/202605111536-F6FWTH/harden-wait-script
- Head: fd0a5eca08d9

```text
 .../blueprint/resolved-snapshot.json               | 552 +++++++++++++++++++++
 .../src/cli/wait-remote-pr-checks-script.test.ts   |  14 +
 scripts/wait-remote-pr-checks.mjs                  |   3 +
 3 files changed, 569 insertions(+)
```

</details>
