### PR TITLE
🚧 JT6FWR task: Implement init mode and tool RFQ controls [202605120952-JT6FWR]

### DIFF
--- a/.agentplane/tasks/202605120952-D2F8VR/README.md
+++ b/.agentplane/tasks/202605120952-D2F8VR/README.md
@@ -1,0 +1,95 @@
+---
+id: "202605120952-D2F8VR"
+title: "Block ambiguous nested init roots"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-12T09:52:23.674Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implementing parent Git ambiguity detection inside the approved JT6FWR batch worktree, with no-write regression coverage for nested non-interactive init."
+events:
+  -
+    type: "status"
+    at: "2026-05-12T09:53:35.247Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implementing parent Git ambiguity detection inside the approved JT6FWR batch worktree, with no-write regression coverage for nested non-interactive init."
+doc_version: 3
+doc_updated_at: "2026-05-12T09:53:35.247Z"
+doc_updated_by: "CODER"
+description: "Detect parent Git repositories before init writes and fail non-interactive init without an explicit root to avoid accidental nested repositories."
+sections:
+  Summary: |-
+    Block ambiguous nested init roots
+    
+    Detect parent Git repositories before init writes and fail non-interactive init without an explicit root to avoid accidental nested repositories.
+  Scope: |-
+    - In scope: Detect parent Git repositories before init writes and fail non-interactive init without an explicit root to avoid accidental nested repositories.
+    - Out of scope: unrelated refactors not required for "Block ambiguous nested init roots".
+  Plan: "In the JT6FWR batch worktree, add pure parent Git detection before init writes. Non-interactive init from a nested directory without explicit --root must fail with actionable guidance and no writes; explicit --root remains allowed. Verify with focused init test coverage."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Block ambiguous nested init roots
+
+Detect parent Git repositories before init writes and fail non-interactive init without an explicit root to avoid accidental nested repositories.
+
+## Scope
+
+- In scope: Detect parent Git repositories before init writes and fail non-interactive init without an explicit root to avoid accidental nested repositories.
+- Out of scope: unrelated refactors not required for "Block ambiguous nested init roots".
+
+## Plan
+
+In the JT6FWR batch worktree, add pure parent Git detection before init writes. Non-interactive init from a nested directory without explicit --root must fail with actionable guidance and no writes; explicit --root remains allowed. Verify with focused init test coverage.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605120952-D2F8VR/README.md
+++ b/.agentplane/tasks/202605120952-D2F8VR/README.md
@@ -17,10 +17,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-12T10:02:56.613Z"
+  updated_by: "CODER"
+  note: "Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bun run typecheck; node .agentplane/policy/check-routing.mjs; ap doctor. Result: pass. Evidence: regression 'init refuses ambiguous nested non-interactive roots without explicit --root' passed and asserted no .git/.agentplane writes; typecheck/routing/doctor OK. Scope: parent Git detection and non-interactive nested init guard."
   attempts: 0
 commit: null
 comments:
@@ -35,8 +35,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: implementing parent Git ambiguity detection inside the approved JT6FWR batch worktree, with no-write regression coverage for nested non-interactive init."
+  -
+    type: "verify"
+    at: "2026-05-12T10:02:56.613Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bun run typecheck; node .agentplane/policy/check-routing.mjs; ap doctor. Result: pass. Evidence: regression 'init refuses ambiguous nested non-interactive roots without explicit --root' passed and asserted no .git/.agentplane writes; typecheck/routing/doctor OK. Scope: parent Git detection and non-interactive nested init guard."
 doc_version: 3
-doc_updated_at: "2026-05-12T09:53:35.247Z"
+doc_updated_at: "2026-05-12T10:02:56.619Z"
 doc_updated_by: "CODER"
 description: "Detect parent Git repositories before init writes and fail non-interactive init without an explicit root to avoid accidental nested repositories."
 sections:
@@ -54,6 +60,25 @@ sections:
     3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-12T10:02:56.613Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bun run typecheck; node .agentplane/policy/check-routing.mjs; ap doctor. Result: pass. Evidence: regression 'init refuses ambiguous nested non-interactive roots without explicit --root' passed and asserted no .git/.agentplane writes; typecheck/routing/doctor OK. Scope: parent Git detection and non-interactive nested init guard.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-12T09:53:35.247Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605120952-JT6FWR-init-rfq-controls/.agentplane/tasks/202605120952-D2F8VR/blueprint/resolved-snapshot.json
+    - old_digest: d005506d7dde5366cef55c2aa25cd0b09fd2e8b39090bacf565fa46597965ce7
+    - current_digest: d005506d7dde5366cef55c2aa25cd0b09fd2e8b39090bacf565fa46597965ce7
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605120952-D2F8VR
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -85,6 +110,25 @@ In the JT6FWR batch worktree, add pure parent Git detection before init writes. 
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-12T10:02:56.613Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bun run typecheck; node .agentplane/policy/check-routing.mjs; ap doctor. Result: pass. Evidence: regression 'init refuses ambiguous nested non-interactive roots without explicit --root' passed and asserted no .git/.agentplane writes; typecheck/routing/doctor OK. Scope: parent Git detection and non-interactive nested init guard.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-12T09:53:35.247Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605120952-JT6FWR-init-rfq-controls/.agentplane/tasks/202605120952-D2F8VR/blueprint/resolved-snapshot.json
+- old_digest: d005506d7dde5366cef55c2aa25cd0b09fd2e8b39090bacf565fa46597965ce7
+- current_digest: d005506d7dde5366cef55c2aa25cd0b09fd2e8b39090bacf565fa46597965ce7
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605120952-D2F8VR
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605120952-D2F8VR/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605120952-D2F8VR/blueprint/resolved-snapshot.json
@@ -1,0 +1,512 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605120952-D2F8VR",
+    "title": "Block ambiguous nested init roots",
+    "description": "Detect parent Git repositories before init writes and fail non-interactive init without an explicit root to avoid accidental nested repositories.",
+    "tags": [
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605120952-D2F8VR",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "d005506d7dde5366cef55c2aa25cd0b09fd2e8b39090bacf565fa46597965ce7"
+  }
+}

--- a/.agentplane/tasks/202605120952-JT6FWR/README.md
+++ b/.agentplane/tasks/202605120952-JT6FWR/README.md
@@ -17,10 +17,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-12T10:02:54.382Z"
+  updated_by: "CODER"
+  note: "Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bunx eslint packages/agentplane/src/cli/run-cli/commands/init packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bunx prettier --check packages/agentplane/src/cli/run-cli/commands/init packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts docs/user/cli-reference.generated.mdx; bun run docs:cli:check; bun run typecheck; node .agentplane/policy/check-routing.mjs; ap doctor. Result: pass. Evidence: init tests 32 passed; CLI reference fresh; typecheck/routing/doctor OK. Scope: --init-mode/--quick/--advanced, --tool mapping, InitPlan mode/profile fields, generated CLI docs."
   attempts: 0
 commit: null
 comments:
@@ -35,8 +35,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: implementing the RFQ init mode/tool controls as the primary batch worktree owner, including plan schema compatibility and focused init tests."
+  -
+    type: "verify"
+    at: "2026-05-12T10:02:54.382Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bunx eslint packages/agentplane/src/cli/run-cli/commands/init packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bunx prettier --check packages/agentplane/src/cli/run-cli/commands/init packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts docs/user/cli-reference.generated.mdx; bun run docs:cli:check; bun run typecheck; node .agentplane/policy/check-routing.mjs; ap doctor. Result: pass. Evidence: init tests 32 passed; CLI reference fresh; typecheck/routing/doctor OK. Scope: --init-mode/--quick/--advanced, --tool mapping, InitPlan mode/profile fields, generated CLI docs."
 doc_version: 3
-doc_updated_at: "2026-05-12T09:52:47.338Z"
+doc_updated_at: "2026-05-12T10:02:54.388Z"
 doc_updated_by: "CODER"
 description: "Add user-facing init mode/tool flags and expose mode/profile in the init plan while preserving legacy init flags."
 sections:
@@ -54,6 +60,25 @@ sections:
     3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-12T10:02:54.382Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bunx eslint packages/agentplane/src/cli/run-cli/commands/init packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bunx prettier --check packages/agentplane/src/cli/run-cli/commands/init packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts docs/user/cli-reference.generated.mdx; bun run docs:cli:check; bun run typecheck; node .agentplane/policy/check-routing.mjs; ap doctor. Result: pass. Evidence: init tests 32 passed; CLI reference fresh; typecheck/routing/doctor OK. Scope: --init-mode/--quick/--advanced, --tool mapping, InitPlan mode/profile fields, generated CLI docs.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-12T09:52:47.338Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605120952-JT6FWR-init-rfq-controls/.agentplane/tasks/202605120952-JT6FWR/blueprint/resolved-snapshot.json
+    - old_digest: 794134d89a4018e4371412fa46e63797450ce359101beb6169d0bcb887adcc74
+    - current_digest: 794134d89a4018e4371412fa46e63797450ce359101beb6169d0bcb887adcc74
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605120952-JT6FWR
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -85,6 +110,25 @@ Batch primary for RFQ init v2 remaining controls. Implement --init-mode/--quick/
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-12T10:02:54.382Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bunx eslint packages/agentplane/src/cli/run-cli/commands/init packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bunx prettier --check packages/agentplane/src/cli/run-cli/commands/init packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts docs/user/cli-reference.generated.mdx; bun run docs:cli:check; bun run typecheck; node .agentplane/policy/check-routing.mjs; ap doctor. Result: pass. Evidence: init tests 32 passed; CLI reference fresh; typecheck/routing/doctor OK. Scope: --init-mode/--quick/--advanced, --tool mapping, InitPlan mode/profile fields, generated CLI docs.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-12T09:52:47.338Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605120952-JT6FWR-init-rfq-controls/.agentplane/tasks/202605120952-JT6FWR/blueprint/resolved-snapshot.json
+- old_digest: 794134d89a4018e4371412fa46e63797450ce359101beb6169d0bcb887adcc74
+- current_digest: 794134d89a4018e4371412fa46e63797450ce359101beb6169d0bcb887adcc74
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605120952-JT6FWR
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605120952-JT6FWR/README.md
+++ b/.agentplane/tasks/202605120952-JT6FWR/README.md
@@ -1,0 +1,95 @@
+---
+id: "202605120952-JT6FWR"
+title: "Implement init mode and tool RFQ controls"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-12T09:52:23.471Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implementing the RFQ init mode/tool controls as the primary batch worktree owner, including plan schema compatibility and focused init tests."
+events:
+  -
+    type: "status"
+    at: "2026-05-12T09:52:47.338Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implementing the RFQ init mode/tool controls as the primary batch worktree owner, including plan schema compatibility and focused init tests."
+doc_version: 3
+doc_updated_at: "2026-05-12T09:52:47.338Z"
+doc_updated_by: "CODER"
+description: "Add user-facing init mode/tool flags and expose mode/profile in the init plan while preserving legacy init flags."
+sections:
+  Summary: |-
+    Implement init mode and tool RFQ controls
+    
+    Add user-facing init mode/tool flags and expose mode/profile in the init plan while preserving legacy init flags.
+  Scope: |-
+    - In scope: Add user-facing init mode/tool flags and expose mode/profile in the init plan while preserving legacy init flags.
+    - Out of scope: unrelated refactors not required for "Implement init mode and tool RFQ controls".
+  Plan: "Batch primary for RFQ init v2 remaining controls. Implement --init-mode/--quick/--advanced, --tool mapping, user-facing mode/profile fields in InitPlan, and compatibility tests. Batch includes dependent tasks 202605120952-D2F8VR and 202605120952-MG1QB4 in the same worktree because all edits share init parsing/orchestration surfaces. Verify with focused init tests, lint for touched init files, policy routing, and doctor."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Implement init mode and tool RFQ controls
+
+Add user-facing init mode/tool flags and expose mode/profile in the init plan while preserving legacy init flags.
+
+## Scope
+
+- In scope: Add user-facing init mode/tool flags and expose mode/profile in the init plan while preserving legacy init flags.
+- Out of scope: unrelated refactors not required for "Implement init mode and tool RFQ controls".
+
+## Plan
+
+Batch primary for RFQ init v2 remaining controls. Implement --init-mode/--quick/--advanced, --tool mapping, user-facing mode/profile fields in InitPlan, and compatibility tests. Batch includes dependent tasks 202605120952-D2F8VR and 202605120952-MG1QB4 in the same worktree because all edits share init parsing/orchestration surfaces. Verify with focused init tests, lint for touched init files, policy routing, and doctor.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605120952-JT6FWR/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605120952-JT6FWR/blueprint/resolved-snapshot.json
@@ -1,0 +1,512 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605120952-JT6FWR",
+    "title": "Implement init mode and tool RFQ controls",
+    "description": "Add user-facing init mode/tool flags and expose mode/profile in the init plan while preserving legacy init flags.",
+    "tags": [
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605120952-JT6FWR",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "794134d89a4018e4371412fa46e63797450ce359101beb6169d0bcb887adcc74"
+  }
+}

--- a/.agentplane/tasks/202605120952-JT6FWR/pr/diffstat.txt
+++ b/.agentplane/tasks/202605120952-JT6FWR/pr/diffstat.txt
@@ -1,0 +1,17 @@
+ .agentplane/tasks/202605120952-D2F8VR/README.md    |  95 ++++
+ .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
+ .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
+ .agentplane/tasks/202605120952-MG1QB4/README.md    |  95 ++++
+ .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |  10 +
+ .../agentplane/src/cli/run-cli.core.init.test.ts   |  58 +++
+ .../src/cli/run-cli/commands/init/answers.ts       |  27 +-
+ .../src/cli/run-cli/commands/init/blueprints.ts    |  15 +-
+ .../src/cli/run-cli/commands/init/execution.ts     |  20 +-
+ .../src/cli/run-cli/commands/init/git.ts           |  15 +
+ .../src/cli/run-cli/commands/init/model.ts         |  12 +-
+ .../src/cli/run-cli/commands/init/modes.ts         |  48 ++
+ .../src/cli/run-cli/commands/init/orchestrate.ts   |  23 +-
+ .../src/cli/run-cli/commands/init/recipes.ts       |   9 +-
+ .../src/cli/run-cli/commands/init/spec.ts          |  50 ++
+ 16 files changed, 1992 insertions(+), 21 deletions(-)

--- a/.agentplane/tasks/202605120952-JT6FWR/pr/diffstat.txt
+++ b/.agentplane/tasks/202605120952-JT6FWR/pr/diffstat.txt
@@ -1,7 +1,7 @@
- .agentplane/tasks/202605120952-D2F8VR/README.md    |  95 ++++
+ .agentplane/tasks/202605120952-D2F8VR/README.md    | 139 ++++++
  .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
  .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
- .agentplane/tasks/202605120952-MG1QB4/README.md    |  95 ++++
+ .agentplane/tasks/202605120952-MG1QB4/README.md    | 139 ++++++
  .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
  docs/user/cli-reference.generated.mdx              |  10 +
  .../agentplane/src/cli/run-cli.core.init.test.ts   |  58 +++
@@ -14,4 +14,4 @@
  .../src/cli/run-cli/commands/init/orchestrate.ts   |  23 +-
  .../src/cli/run-cli/commands/init/recipes.ts       |   9 +-
  .../src/cli/run-cli/commands/init/spec.ts          |  50 ++
- 16 files changed, 1992 insertions(+), 21 deletions(-)
+ 16 files changed, 2080 insertions(+), 21 deletions(-)

--- a/.agentplane/tasks/202605120952-JT6FWR/pr/github-body.md
+++ b/.agentplane/tasks/202605120952-JT6FWR/pr/github-body.md
@@ -22,15 +22,15 @@ Add user-facing init mode/tool flags and expose mode/profile in the init plan wh
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-12T10:02:54.412Z
+- Updated: 2026-05-12T10:03:15.025Z
 - Branch: task/202605120952-JT6FWR/init-rfq-controls
-- Head: b52b4f106e97
+- Head: eaf139fac6fc
 
 ```text
- .agentplane/tasks/202605120952-D2F8VR/README.md    |  95 ++++
+ .agentplane/tasks/202605120952-D2F8VR/README.md    | 139 ++++++
  .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
  .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
- .agentplane/tasks/202605120952-MG1QB4/README.md    |  95 ++++
+ .agentplane/tasks/202605120952-MG1QB4/README.md    | 139 ++++++
  .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
  docs/user/cli-reference.generated.mdx              |  10 +
  .../agentplane/src/cli/run-cli.core.init.test.ts   |  58 +++
@@ -43,7 +43,7 @@ Add user-facing init mode/tool flags and expose mode/profile in the init plan wh
  .../src/cli/run-cli/commands/init/orchestrate.ts   |  23 +-
  .../src/cli/run-cli/commands/init/recipes.ts       |   9 +-
  .../src/cli/run-cli/commands/init/spec.ts          |  50 ++
- 16 files changed, 1992 insertions(+), 21 deletions(-)
+ 16 files changed, 2080 insertions(+), 21 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605120952-JT6FWR/pr/github-body.md
+++ b/.agentplane/tasks/202605120952-JT6FWR/pr/github-body.md
@@ -15,19 +15,35 @@ Add user-facing init mode/tool flags and expose mode/profile in the init plan wh
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bunx eslint packages/agentplane/src/cli/run-cli/commands/init packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bunx prettier --check packages/agentplane/src/cli/run-cli/commands/init packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts docs/user/cli-reference.generated.mdx; bun run docs:cli:check; bun run typecheck; node .agentplane/policy/check-routing.mjs; ap doctor. Result: pass. Evidence: init tests 32 passed; CLI reference fresh; typecheck/routing/doctor OK. Scope: --init-mode/--quick/--advanced, --tool mapping, InitPlan mode/profile fields, generated CLI docs.
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-12T09:52:47.377Z
+- Updated: 2026-05-12T10:02:54.412Z
 - Branch: task/202605120952-JT6FWR/init-rfq-controls
-- Head: 324e9ee7238b
+- Head: b52b4f106e97
 
 ```text
-No changes detected.
+ .agentplane/tasks/202605120952-D2F8VR/README.md    |  95 ++++
+ .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
+ .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
+ .agentplane/tasks/202605120952-MG1QB4/README.md    |  95 ++++
+ .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |  10 +
+ .../agentplane/src/cli/run-cli.core.init.test.ts   |  58 +++
+ .../src/cli/run-cli/commands/init/answers.ts       |  27 +-
+ .../src/cli/run-cli/commands/init/blueprints.ts    |  15 +-
+ .../src/cli/run-cli/commands/init/execution.ts     |  20 +-
+ .../src/cli/run-cli/commands/init/git.ts           |  15 +
+ .../src/cli/run-cli/commands/init/model.ts         |  12 +-
+ .../src/cli/run-cli/commands/init/modes.ts         |  48 ++
+ .../src/cli/run-cli/commands/init/orchestrate.ts   |  23 +-
+ .../src/cli/run-cli/commands/init/recipes.ts       |   9 +-
+ .../src/cli/run-cli/commands/init/spec.ts          |  50 ++
+ 16 files changed, 1992 insertions(+), 21 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605120952-JT6FWR/pr/github-body.md
+++ b/.agentplane/tasks/202605120952-JT6FWR/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605120952-JT6FWR`
+Title: Implement init mode and tool RFQ controls
+Canonical task record: `.agentplane/tasks/202605120952-JT6FWR/README.md`
+
+## Summary
+
+Implement init mode and tool RFQ controls
+
+Add user-facing init mode/tool flags and expose mode/profile in the init plan while preserving legacy init flags.
+
+## Scope
+
+- In scope: Add user-facing init mode/tool flags and expose mode/profile in the init plan while preserving legacy init flags.
+- Out of scope: unrelated refactors not required for "Implement init mode and tool RFQ controls".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-12T09:52:47.377Z
+- Branch: task/202605120952-JT6FWR/init-rfq-controls
+- Head: 324e9ee7238b
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605120952-JT6FWR/pr/github-title.txt
+++ b/.agentplane/tasks/202605120952-JT6FWR/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 JT6FWR task: Implement init mode and tool RFQ controls [202605120952-JT6FWR]

--- a/.agentplane/tasks/202605120952-JT6FWR/pr/meta.json
+++ b/.agentplane/tasks/202605120952-JT6FWR/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605120952-JT6FWR/init-rfq-controls",
   "created_at": "2026-05-12T09:52:47.377Z",
-  "head_sha": "b52b4f106e97a425dc16c05652697c3f2b93ed1d",
+  "head_sha": "eaf139fac6fcb1f1098e6b02b2f3da859d0f215a",
   "last_verified_at": "2026-05-12T10:02:54.382Z",
   "last_verified_sha": "b52b4f106e97a425dc16c05652697c3f2b93ed1d",
   "schema_version": 1,
   "task_id": "202605120952-JT6FWR",
-  "updated_at": "2026-05-12T10:02:54.412Z",
+  "updated_at": "2026-05-12T10:03:15.025Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605120952-JT6FWR/pr/meta.json
+++ b/.agentplane/tasks/202605120952-JT6FWR/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605120952-JT6FWR/init-rfq-controls",
+  "created_at": "2026-05-12T09:52:47.377Z",
+  "head_sha": "324e9ee7238bd2ea39f34a80468f322a9f64db9f",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202605120952-JT6FWR",
+  "updated_at": "2026-05-12T09:52:47.377Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605120952-JT6FWR/pr/meta.json
+++ b/.agentplane/tasks/202605120952-JT6FWR/pr/meta.json
@@ -2,13 +2,13 @@
   "base": "main",
   "branch": "task/202605120952-JT6FWR/init-rfq-controls",
   "created_at": "2026-05-12T09:52:47.377Z",
-  "head_sha": "324e9ee7238bd2ea39f34a80468f322a9f64db9f",
-  "last_verified_at": null,
-  "last_verified_sha": null,
+  "head_sha": "b52b4f106e97a425dc16c05652697c3f2b93ed1d",
+  "last_verified_at": "2026-05-12T10:02:54.382Z",
+  "last_verified_sha": "b52b4f106e97a425dc16c05652697c3f2b93ed1d",
   "schema_version": 1,
   "task_id": "202605120952-JT6FWR",
-  "updated_at": "2026-05-12T09:52:47.377Z",
+  "updated_at": "2026-05-12T10:02:54.412Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605120952-JT6FWR/pr/review.md
+++ b/.agentplane/tasks/202605120952-JT6FWR/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-05-12T09:52:47.377Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bunx eslint packages/agentplane/src/cli/run-cli/commands/init packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bunx prettier --check packages/agentplane/src/cli/run-cli/commands/init packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts docs/user/cli-reference.generated.mdx; bun run docs:cli:check; bun run typecheck; node .agentplane/policy/check-routing.mjs; ap doctor. Result: pass. Evidence: init tests 32 passed; CLI reference fresh; typecheck/routing/doctor OK. Scope: --init-mode/--quick/--advanced, --tool mapping, InitPlan mode/profile fields, generated CLI docs.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,12 +24,28 @@ Created: 2026-05-12T09:52:47.377Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-12T09:52:47.377Z
+- Updated: 2026-05-12T10:02:54.412Z
 - Branch: task/202605120952-JT6FWR/init-rfq-controls
-- Head: 324e9ee7238b
+- Head: b52b4f106e97
 
 ```text
-No changes detected.
+ .agentplane/tasks/202605120952-D2F8VR/README.md    |  95 ++++
+ .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
+ .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
+ .agentplane/tasks/202605120952-MG1QB4/README.md    |  95 ++++
+ .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |  10 +
+ .../agentplane/src/cli/run-cli.core.init.test.ts   |  58 +++
+ .../src/cli/run-cli/commands/init/answers.ts       |  27 +-
+ .../src/cli/run-cli/commands/init/blueprints.ts    |  15 +-
+ .../src/cli/run-cli/commands/init/execution.ts     |  20 +-
+ .../src/cli/run-cli/commands/init/git.ts           |  15 +
+ .../src/cli/run-cli/commands/init/model.ts         |  12 +-
+ .../src/cli/run-cli/commands/init/modes.ts         |  48 ++
+ .../src/cli/run-cli/commands/init/orchestrate.ts   |  23 +-
+ .../src/cli/run-cli/commands/init/recipes.ts       |   9 +-
+ .../src/cli/run-cli/commands/init/spec.ts          |  50 ++
+ 16 files changed, 1992 insertions(+), 21 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605120952-JT6FWR/pr/review.md
+++ b/.agentplane/tasks/202605120952-JT6FWR/pr/review.md
@@ -24,15 +24,15 @@ Created: 2026-05-12T09:52:47.377Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-12T10:02:54.412Z
+- Updated: 2026-05-12T10:03:15.025Z
 - Branch: task/202605120952-JT6FWR/init-rfq-controls
-- Head: b52b4f106e97
+- Head: eaf139fac6fc
 
 ```text
- .agentplane/tasks/202605120952-D2F8VR/README.md    |  95 ++++
+ .agentplane/tasks/202605120952-D2F8VR/README.md    | 139 ++++++
  .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
  .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
- .agentplane/tasks/202605120952-MG1QB4/README.md    |  95 ++++
+ .agentplane/tasks/202605120952-MG1QB4/README.md    | 139 ++++++
  .../blueprint/resolved-snapshot.json               | 512 +++++++++++++++++++++
  docs/user/cli-reference.generated.mdx              |  10 +
  .../agentplane/src/cli/run-cli.core.init.test.ts   |  58 +++
@@ -45,7 +45,7 @@ Created: 2026-05-12T09:52:47.377Z
  .../src/cli/run-cli/commands/init/orchestrate.ts   |  23 +-
  .../src/cli/run-cli/commands/init/recipes.ts       |   9 +-
  .../src/cli/run-cli/commands/init/spec.ts          |  50 ++
- 16 files changed, 1992 insertions(+), 21 deletions(-)
+ 16 files changed, 2080 insertions(+), 21 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605120952-JT6FWR/pr/review.md
+++ b/.agentplane/tasks/202605120952-JT6FWR/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-12T09:52:47.377Z
+
+## Task
+
+- Task: `202605120952-JT6FWR`
+- Title: Implement init mode and tool RFQ controls
+- Status: DOING
+- Branch: `task/202605120952-JT6FWR/init-rfq-controls`
+- Canonical task record: `.agentplane/tasks/202605120952-JT6FWR/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-12T09:52:47.377Z
+- Branch: task/202605120952-JT6FWR/init-rfq-controls
+- Head: 324e9ee7238b
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605120952-MG1QB4/README.md
+++ b/.agentplane/tasks/202605120952-MG1QB4/README.md
@@ -17,10 +17,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-12T10:02:57.866Z"
+  updated_by: "CODER"
+  note: "Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bunx eslint packages/agentplane/src/cli/run-cli/commands/init; bun run typecheck. Result: pass. Evidence: init tests 32 passed; eslint/typecheck OK. Scope: init recipe/blueprint listing and validation now receive target root, and blueprint install loads catalog from rootOverride when provided."
   attempts: 0
 commit: null
 comments:
@@ -35,8 +35,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: implementing target-root-aware cached recipe and blueprint lookup inside the approved JT6FWR batch worktree, with focused init coverage."
+  -
+    type: "verify"
+    at: "2026-05-12T10:02:57.866Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bunx eslint packages/agentplane/src/cli/run-cli/commands/init; bun run typecheck. Result: pass. Evidence: init tests 32 passed; eslint/typecheck OK. Scope: init recipe/blueprint listing and validation now receive target root, and blueprint install loads catalog from rootOverride when provided."
 doc_version: 3
-doc_updated_at: "2026-05-12T09:53:35.533Z"
+doc_updated_at: "2026-05-12T10:02:57.871Z"
 doc_updated_by: "CODER"
 description: "Make init recipes and blueprints discovery/validation use the selected target root instead of process.cwd()."
 sections:
@@ -54,6 +60,25 @@ sections:
     3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-12T10:02:57.866Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bunx eslint packages/agentplane/src/cli/run-cli/commands/init; bun run typecheck. Result: pass. Evidence: init tests 32 passed; eslint/typecheck OK. Scope: init recipe/blueprint listing and validation now receive target root, and blueprint install loads catalog from rootOverride when provided.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-12T09:53:35.533Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605120952-JT6FWR-init-rfq-controls/.agentplane/tasks/202605120952-MG1QB4/blueprint/resolved-snapshot.json
+    - old_digest: 02159580e41a3ae38886fed30dd21168c4675d368d9069599d3c1dbf5fb3a7f2
+    - current_digest: 02159580e41a3ae38886fed30dd21168c4675d368d9069599d3c1dbf5fb3a7f2
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605120952-MG1QB4
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -85,6 +110,25 @@ In the JT6FWR batch worktree, route init cached recipe/blueprint listing and val
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-12T10:02:57.866Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bunx eslint packages/agentplane/src/cli/run-cli/commands/init; bun run typecheck. Result: pass. Evidence: init tests 32 passed; eslint/typecheck OK. Scope: init recipe/blueprint listing and validation now receive target root, and blueprint install loads catalog from rootOverride when provided.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-12T09:53:35.533Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605120952-JT6FWR-init-rfq-controls/.agentplane/tasks/202605120952-MG1QB4/blueprint/resolved-snapshot.json
+- old_digest: 02159580e41a3ae38886fed30dd21168c4675d368d9069599d3c1dbf5fb3a7f2
+- current_digest: 02159580e41a3ae38886fed30dd21168c4675d368d9069599d3c1dbf5fb3a7f2
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605120952-MG1QB4
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605120952-MG1QB4/README.md
+++ b/.agentplane/tasks/202605120952-MG1QB4/README.md
@@ -1,0 +1,95 @@
+---
+id: "202605120952-MG1QB4"
+title: "Resolve init cached catalogs from target root"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-12T09:52:23.884Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implementing target-root-aware cached recipe and blueprint lookup inside the approved JT6FWR batch worktree, with focused init coverage."
+events:
+  -
+    type: "status"
+    at: "2026-05-12T09:53:35.533Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implementing target-root-aware cached recipe and blueprint lookup inside the approved JT6FWR batch worktree, with focused init coverage."
+doc_version: 3
+doc_updated_at: "2026-05-12T09:53:35.533Z"
+doc_updated_by: "CODER"
+description: "Make init recipes and blueprints discovery/validation use the selected target root instead of process.cwd()."
+sections:
+  Summary: |-
+    Resolve init cached catalogs from target root
+    
+    Make init recipes and blueprints discovery/validation use the selected target root instead of process.cwd().
+  Scope: |-
+    - In scope: Make init recipes and blueprints discovery/validation use the selected target root instead of process.cwd().
+    - Out of scope: unrelated refactors not required for "Resolve init cached catalogs from target root".
+  Plan: "In the JT6FWR batch worktree, route init cached recipe/blueprint listing and validation through the selected target root instead of process.cwd(). Preserve existing flags and plain fallback behavior. Verify with focused init catalog tests or targeted init tests."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Resolve init cached catalogs from target root
+
+Make init recipes and blueprints discovery/validation use the selected target root instead of process.cwd().
+
+## Scope
+
+- In scope: Make init recipes and blueprints discovery/validation use the selected target root instead of process.cwd().
+- Out of scope: unrelated refactors not required for "Resolve init cached catalogs from target root".
+
+## Plan
+
+In the JT6FWR batch worktree, route init cached recipe/blueprint listing and validation through the selected target root instead of process.cwd(). Preserve existing flags and plain fallback behavior. Verify with focused init catalog tests or targeted init tests.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605120952-MG1QB4/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605120952-MG1QB4/blueprint/resolved-snapshot.json
@@ -1,0 +1,512 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605120952-MG1QB4",
+    "title": "Resolve init cached catalogs from target root",
+    "description": "Make init recipes and blueprints discovery/validation use the selected target root instead of process.cwd().",
+    "tags": [
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605120952-MG1QB4",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "02159580e41a3ae38886fed30dd21168c4675d368d9069599d3c1dbf5fb3a7f2"
+  }
+}

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -2075,6 +2075,10 @@ agentplane init [options]
 
 Options:
 
+- `--init-mode <quick|guided|advanced|ci>`: User-facing init route. TTY defaults to guided; --yes defaults to ci for automation. (choices=quick|guided|advanced|ci)
+- `--quick`: Alias for --init-mode quick. (default=false)
+- `--advanced`: Alias for --init-mode advanced. (default=false)
+- `--tool <codex|claude|cursor|windsurf|multiple|manual>`: AI surface that should read project instructions. Granular --policy-gateway/--ide flags override this mapping. (choices=codex|claude|cursor|windsurf|multiple|manual)
 - `--setup-profile <light|normal|full-harness>`: Setup profile preset. Preferred values: light, normal, full-harness. (choices=light|normal|full-harness|developer|vibecoder|manager|enterprise)
 - `--policy-gateway <codex|claude>`: Policy gateway file to install (codex -&gt; AGENTS.md, claude -&gt; CLAUDE.md). (choices=codex|claude)
 - `--ide <codex|cursor|windsurf>`: IDE rules integration target (default: codex). (choices=codex|cursor|windsurf)
@@ -2140,6 +2144,12 @@ agentplane init --dry-run --yes --output json
 ```
 
 - Print a machine-readable init plan without writing files.
+
+```sh
+agentplane init --quick --tool cursor
+```
+
+- Use the quick first-run route and install AGENTS.md plus Cursor rules.
 
 ### upgrade
 

--- a/packages/agentplane/src/cli/run-cli.core.init.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.init.test.ts
@@ -674,6 +674,64 @@ describe("runCli", () => {
     expect(await pathExists(path.join(root, ".agentplane"))).toBe(false);
   });
 
+  it("init --quick --tool cursor maps to guided plan fields and Cursor rules", async () => {
+    const root = await mkTempDir();
+    const io = captureStdIO();
+    try {
+      const code = await runCli([
+        "init",
+        "--dry-run",
+        "--yes",
+        "--quick",
+        "--tool",
+        "cursor",
+        "--root",
+        root,
+        "--output",
+        "json",
+      ]);
+      expect(code).toBe(0);
+      const envelope = JSON.parse(io.stdout) as {
+        data?: {
+          mode?: string;
+          profile?: string;
+          internalSetupProfile?: string;
+          answers?: { policyGateway?: string; ide?: string };
+        };
+      };
+      expect(envelope.data?.mode).toBe("quick");
+      expect(envelope.data?.profile).toBe("team");
+      expect(envelope.data?.internalSetupProfile).toBe("normal");
+      expect(envelope.data?.answers).toMatchObject({ policyGateway: "codex", ide: "cursor" });
+    } finally {
+      io.restore();
+    }
+
+    expect(await pathExists(path.join(root, ".git"))).toBe(false);
+    expect(await pathExists(path.join(root, ".agentplane"))).toBe(false);
+  });
+
+  it("init refuses ambiguous nested non-interactive roots without explicit --root", async () => {
+    const parent = await mkGitRepoRoot();
+    const nested = path.join(parent, "packages", "api");
+    await mkdir(nested, { recursive: true });
+    const originalCwd = process.cwd();
+    process.chdir(nested);
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["init", "--yes"]);
+      expect(code).toBe(2);
+      expect(io.stderr).toContain("Refusing to initialize nested git repository");
+      expect(io.stderr).toContain("Pass --root");
+    } finally {
+      io.restore();
+      process.chdir(originalCwd);
+    }
+
+    expect(await pathExists(path.join(nested, ".git"))).toBe(false);
+    expect(await pathExists(path.join(nested, ".agentplane"))).toBe(false);
+  });
+
   it("init --no-input is an alias for --yes", async () => {
     const root = await mkGitRepoRoot();
     await configureGitUser(root);

--- a/packages/agentplane/src/cli/run-cli/commands/init/answers.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/answers.ts
@@ -20,6 +20,11 @@ import {
 } from "./steps/index.js";
 import type { InitPromptClack } from "./steps/contracts.js";
 import { introLogo, section } from "./ui.js";
+import {
+  resolveIdeFromFlags,
+  resolvePolicyGatewayFromFlags,
+  resolveToolDefaults,
+} from "./modes.js";
 
 export type InitAnswers = {
   setupProfile: SetupProfilePreset;
@@ -53,8 +58,8 @@ export function buildNonInteractiveAnswers(flags: InitParsed): InitAnswers {
   return {
     setupProfile: setupProfilePreset,
     setupProfileDescription: preset.description,
-    policyGateway: flags.policyGateway ?? INIT_DEFAULTS.policyGateway,
-    ide: flags.ide ?? INIT_DEFAULTS.ide,
+    policyGateway: resolvePolicyGatewayFromFlags(flags, INIT_DEFAULTS.policyGateway),
+    ide: resolveIdeFromFlags(flags, INIT_DEFAULTS.ide),
     workflow: flags.workflow ?? INIT_DEFAULTS.workflow,
     directCloseDirtyPolicy: flags.directCloseDirtyPolicy ?? INIT_DEFAULTS.directCloseDirtyPolicy,
     backend: flags.backend ?? INIT_DEFAULTS.backend,
@@ -72,6 +77,7 @@ export function buildNonInteractiveAnswers(flags: InitParsed): InitAnswers {
 export async function promptInteractiveAnswers(opts: {
   flags: InitParsed;
   clack: InitClackPrompts;
+  targetRoot: string;
 }): Promise<InitAnswers> {
   const promptClack = opts.clack as InitPromptClack & Pick<InitClackPrompts, "note">;
   opts.clack.intro("AgentPlane init");
@@ -83,8 +89,17 @@ export async function promptInteractiveAnswers(opts: {
     defaultProfile: "normal",
   });
   const selectedPreset = setupProfilePresets[setup.setupProfilePreset];
-  const policy = await promptPolicyGatewayStep({ clack: promptClack, flags: opts.flags });
-  const ide = await promptIdeStep({ clack: promptClack, flags: opts.flags });
+  const toolDefaults = resolveToolDefaults(opts.flags.tool);
+  const policy = await promptPolicyGatewayStep({
+    clack: promptClack,
+    flags: {
+      policyGateway: opts.flags.policyGateway ?? toolDefaults.policyGateway,
+    },
+  });
+  const ide = await promptIdeStep({
+    clack: promptClack,
+    flags: { ide: opts.flags.ide ?? toolDefaults.ide },
+  });
   const workflow = await promptWorkflowStep({
     clack: promptClack,
     flags: opts.flags,
@@ -97,7 +112,7 @@ export async function promptInteractiveAnswers(opts: {
     setupProfilePreset: setup.setupProfilePreset,
     setupProfileMode: setup.setupProfileMode,
   });
-  const cachedRecipes = await listCachedRecipes();
+  const cachedRecipes = await listCachedRecipes({ cwd: opts.targetRoot });
   const recipeSelection = await promptRecipeSelectionStep({
     clack: promptClack,
     flags: opts.flags,
@@ -105,7 +120,7 @@ export async function promptInteractiveAnswers(opts: {
     setupProfileMode: setup.setupProfileMode,
     cachedRecipes,
   });
-  const cachedBlueprints = await listCachedBlueprintCatalogItems();
+  const cachedBlueprints = await listCachedBlueprintCatalogItems({ cwd: opts.targetRoot });
   const blueprintSelection = await promptBlueprintSelectionStep({
     clack: promptClack,
     flags: opts.flags,

--- a/packages/agentplane/src/cli/run-cli/commands/init/blueprints.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/blueprints.ts
@@ -41,9 +41,11 @@ function parseBlueprintRef(value: string): BlueprintRef {
   return { id: trimmed };
 }
 
-export async function listCachedBlueprintCatalogItems(): Promise<CachedBlueprintCatalogItem[]> {
+export async function listCachedBlueprintCatalogItems(opts?: {
+  cwd?: string;
+}): Promise<CachedBlueprintCatalogItem[]> {
   try {
-    const catalog = await loadCatalog({ cwd: process.cwd() });
+    const catalog = await loadCatalog({ cwd: opts?.cwd ?? process.cwd() });
     return [
       ...catalog.index.blueprints.map((entry) => ({
         id: entry.id,
@@ -81,9 +83,12 @@ async function gitStatusPaths(cwd: string): Promise<string[]> {
     .filter(Boolean);
 }
 
-export async function validateCachedBlueprintSelection(selection: string[]): Promise<void> {
+export async function validateCachedBlueprintSelection(
+  selection: string[],
+  opts?: { cwd?: string },
+): Promise<void> {
   if (selection.length === 0) return;
-  const catalog = await loadCatalog({ cwd: process.cwd() });
+  const catalog = await loadCatalog({ cwd: opts?.cwd ?? process.cwd() });
   const cached = [
     ...catalog.index.blueprints.map((entry) => ({
       id: entry.id,
@@ -120,7 +125,7 @@ export async function maybeInstallCachedBlueprints(opts: {
     rootOverride: opts.rootOverride ?? null,
   });
   const before = new Set(await gitStatusPaths(project.gitRoot));
-  const catalog = await loadCatalog({ cwd: opts.cwd });
+  const catalog = await loadCatalog({ cwd: opts.rootOverride ?? opts.cwd });
   const allowedIds: string[] = [];
 
   for (const value of opts.blueprints) {

--- a/packages/agentplane/src/cli/run-cli/commands/init/execution.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/execution.ts
@@ -22,10 +22,13 @@ import { ensureInitCloudEnvTemplate, ensureInitRedmineEnvTemplate } from "./writ
 import { ensureInitGitignore } from "./write-gitignore.js";
 import { ensureInitWorkflow } from "./write-workflow.js";
 import { assertConfirmed } from "./answers.js";
+import { setupProfileToUserFacingProfile } from "./modes.js";
+import { detectParentGitRoot } from "./git.js";
 
 export type ResolvedInitPaths = {
   gitRoot: string;
   gitRootExisted: boolean;
+  parentGitRoot: string | null;
   agentplaneDir: string;
   workflowPath: string;
   legacyConfigPath: string;
@@ -40,6 +43,7 @@ export async function resolveInitPaths(opts: {
   const initRoot = path.resolve(opts.rootOverride ?? opts.cwd);
   const gitRoot = initRoot;
   const gitRootExisted = (await getPathKind(path.join(gitRoot, ".git"))) === "dir";
+  const parentGitRoot = gitRootExisted ? null : await detectParentGitRoot(gitRoot);
   const agentplaneDir = path.join(gitRoot, ".agentplane");
   const workflowPath = path.join(agentplaneDir, "WORKFLOW.md");
   const legacyConfigPath = path.join(agentplaneDir, "config.json");
@@ -52,7 +56,15 @@ export async function resolveInitPaths(opts: {
       : opts.backend === "cloud"
         ? cloudBackendPath
         : localBackendPath;
-  return { gitRoot, gitRootExisted, agentplaneDir, workflowPath, legacyConfigPath, backendPath };
+  return {
+    gitRoot,
+    gitRootExisted,
+    parentGitRoot,
+    agentplaneDir,
+    workflowPath,
+    legacyConfigPath,
+    backendPath,
+  };
 }
 
 export async function collectInitAndHookConflicts(opts: {
@@ -193,6 +205,7 @@ export function buildInitPlan(opts: {
   conflictMode: { backup: boolean; force: boolean };
   outputMode: "text" | "json";
   includeInstallCommit: boolean;
+  initMode: InitPlan["mode"];
 }): InitPlan {
   const hasConflictStrategy = opts.conflictMode.backup || opts.conflictMode.force;
   const conflictEffects: InitEffect[] = hasConflictStrategy
@@ -224,7 +237,9 @@ export function buildInitPlan(opts: {
     schemaVersion: "init-plan/v1",
     agentplaneVersion: getVersion(),
     root: opts.paths.gitRoot,
-    profile: opts.answers.setupProfile,
+    mode: opts.initMode,
+    profile: setupProfileToUserFacingProfile(opts.answers.setupProfile),
+    internalSetupProfile: opts.answers.setupProfile,
     answers: {
       policyGateway: opts.answers.policyGateway,
       ide: opts.answers.ide,
@@ -241,6 +256,7 @@ export function buildInitPlan(opts: {
     },
     context: {
       gitRootExisted: opts.paths.gitRootExisted,
+      parentGitRoot: opts.paths.parentGitRoot,
       outputMode: opts.outputMode,
     },
     effects,

--- a/packages/agentplane/src/cli/run-cli/commands/init/git.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/git.ts
@@ -2,6 +2,21 @@ import path from "node:path";
 
 import { gitInitRepo } from "../../../../commands/workflow.js";
 import { getPathKind } from "../../../fs-utils.js";
+import { execFileAsync } from "@agentplaneorg/core/process";
+import { gitEnv } from "@agentplaneorg/core/git";
+
+export async function detectParentGitRoot(initRoot: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["rev-parse", "--show-toplevel"], {
+      cwd: initRoot,
+      env: gitEnv(),
+    });
+    const discovered = path.resolve(stdout.trim());
+    return discovered === path.resolve(initRoot) ? null : discovered;
+  } catch {
+    return null;
+  }
+}
 
 export async function ensureGitRoot(opts: {
   initRoot: string;

--- a/packages/agentplane/src/cli/run-cli/commands/init/model.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/model.ts
@@ -6,9 +6,14 @@ import type { PolicyGatewayFlavor } from "../../../../shared/policy-gateway.js";
 export type InitIde = "codex" | "cursor" | "windsurf";
 
 export type SetupProfilePreset = "light" | "normal" | "full-harness";
+export type InitMode = "quick" | "guided" | "advanced" | "ci";
+export type UserFacingProfile = "solo" | "team" | "strict" | "custom";
+export type InitTool = "codex" | "claude" | "cursor" | "windsurf" | "multiple" | "manual";
 export type InitBackend = "local" | "redmine" | "cloud";
 
 export type InitFlags = {
+  initMode?: InitMode;
+  tool?: InitTool;
   setupProfile?: SetupProfilePreset;
   policyGateway?: PolicyGatewayFlavor;
   ide?: InitIde;
@@ -49,7 +54,9 @@ export type InitDefaults = {
 };
 
 export type InitEffectKind =
+  | "create_dir"
   | "write_file"
+  | "update_file"
   | "backup_path"
   | "delete_path"
   | "git_init"
@@ -75,7 +82,9 @@ export type InitPlan = {
   schemaVersion: "init-plan/v1";
   agentplaneVersion: string;
   root: string;
-  profile: SetupProfilePreset;
+  mode: InitMode;
+  profile: UserFacingProfile;
+  internalSetupProfile: SetupProfilePreset;
   answers: {
     policyGateway: PolicyGatewayFlavor;
     ide: InitIde;
@@ -92,6 +101,7 @@ export type InitPlan = {
   };
   context: {
     gitRootExisted: boolean;
+    parentGitRoot: string | null;
     outputMode: "text" | "json";
   };
   effects: InitEffect[];

--- a/packages/agentplane/src/cli/run-cli/commands/init/modes.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/modes.ts
@@ -1,0 +1,48 @@
+import type {
+  InitFlags,
+  InitIde,
+  InitMode,
+  InitParsed,
+  InitTool,
+  SetupProfilePreset,
+  UserFacingProfile,
+} from "./model.js";
+import type { PolicyGatewayFlavor } from "../../../../shared/policy-gateway.js";
+
+export function resolveInitMode(opts: { flags: InitParsed; interactive: boolean }): InitMode {
+  if (opts.flags.initMode) return opts.flags.initMode;
+  if (opts.flags.yes) return "ci";
+  if (!opts.interactive) return "ci";
+  return "guided";
+}
+
+export function setupProfileToUserFacingProfile(profile: SetupProfilePreset): UserFacingProfile {
+  if (profile === "light") return "solo";
+  if (profile === "full-harness") return "strict";
+  return "team";
+}
+
+export function resolveToolDefaults(tool: InitTool | undefined): {
+  policyGateway?: PolicyGatewayFlavor;
+  ide?: InitIde;
+} {
+  if (!tool || tool === "multiple" || tool === "manual") return {};
+  if (tool === "claude") return { policyGateway: "claude", ide: "codex" };
+  if (tool === "cursor") return { policyGateway: "codex", ide: "cursor" };
+  if (tool === "windsurf") return { policyGateway: "codex", ide: "windsurf" };
+  return { policyGateway: "codex", ide: "codex" };
+}
+
+export function resolvePolicyGatewayFromFlags(
+  flags: Pick<InitFlags, "policyGateway" | "tool">,
+  fallback: PolicyGatewayFlavor,
+): PolicyGatewayFlavor {
+  return flags.policyGateway ?? resolveToolDefaults(flags.tool).policyGateway ?? fallback;
+}
+
+export function resolveIdeFromFlags(
+  flags: Pick<InitFlags, "ide" | "tool">,
+  fallback: InitIde,
+): InitIde {
+  return flags.ide ?? resolveToolDefaults(flags.tool).ide ?? fallback;
+}

--- a/packages/agentplane/src/cli/run-cli/commands/init/orchestrate.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/orchestrate.ts
@@ -22,6 +22,7 @@ import {
 } from "./execution.js";
 import { buildNonInteractiveAnswers, promptInteractiveAnswers } from "./answers.js";
 import { outroError, outroSuccess } from "./ui.js";
+import { resolveInitMode } from "./modes.js";
 
 function shouldRunInteractiveInit(flags: InitParsed): boolean {
   if (flags.yes || flags.dryRun || process.env.AGENTPLANE_PROMPTS === "plain") return false;
@@ -48,10 +49,12 @@ function renderDryRunPlanText(plan: ReturnType<typeof buildInitPlan>): string {
   const lines = [
     "AgentPlane init plan",
     `Root: ${plan.root}`,
-    `Profile: ${plan.profile}`,
+    `Mode: ${plan.mode}`,
+    `Profile: ${plan.profile} (${plan.internalSetupProfile})`,
     `Workflow: ${plan.answers.workflow}`,
     `Backend: ${plan.answers.backend}`,
     `Git init: ${String(!plan.context.gitRootExisted)}`,
+    `Parent Git: ${plan.context.parentGitRoot ?? "none"}`,
     `Conflicts: ${plan.conflicts.length === 0 ? "none" : plan.conflicts.join(", ")}`,
     "Effects:",
     ...plan.effects.map((effect) => {
@@ -84,20 +87,31 @@ export async function cmdInit(opts: {
   spec: CommandSpec<InitParsed>;
 }): Promise<number> {
   const interactive = shouldRunInteractiveInit(opts.flags);
+  const initMode = resolveInitMode({ flags: opts.flags, interactive });
   assertNonInteractiveInitAllowed({ flags: opts.flags, spec: opts.spec, interactive });
   const clack = interactive ? requireInitClack(await loadInitClackPrompts(), opts.spec) : null;
+  const targetRoot = path.resolve(opts.rootOverride ?? opts.cwd);
 
   try {
     const answers = clack
-      ? await promptInteractiveAnswers({ flags: opts.flags, clack })
+      ? await promptInteractiveAnswers({ flags: opts.flags, clack, targetRoot })
       : buildNonInteractiveAnswers(opts.flags);
-    await validateCachedRecipesSelection(answers.recipes);
-    await validateCachedBlueprintSelection(answers.blueprints);
+    await validateCachedRecipesSelection(answers.recipes, { cwd: targetRoot });
+    await validateCachedBlueprintSelection(answers.blueprints, { cwd: targetRoot });
     const paths = await resolveInitPaths({
       cwd: opts.cwd,
       rootOverride: opts.rootOverride,
       backend: answers.backend,
     });
+    if (!interactive && !opts.rootOverride && !paths.gitRootExisted && paths.parentGitRoot) {
+      throw usageError({
+        spec: opts.spec,
+        command: "init",
+        message:
+          `Refusing to initialize nested git repository at ${paths.gitRoot}; parent repository detected at ${paths.parentGitRoot}. ` +
+          "Pass --root to select the intended repository root or run from the target root.",
+      });
+    }
     const initBaseBranchSelection = await resolveInitBaseBranchForInit({
       gitRoot: paths.gitRoot,
       baseBranchFallback: "main",
@@ -119,6 +133,7 @@ export async function cmdInit(opts: {
       conflictMode,
       outputMode: opts.outputMode ?? "text",
       includeInstallCommit: !opts.flags.gitignoreAgents,
+      initMode,
     });
     if (opts.flags.dryRun) {
       if ((opts.outputMode ?? "text") === "json") {

--- a/packages/agentplane/src/cli/run-cli/commands/init/recipes.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/recipes.ts
@@ -14,7 +14,7 @@ type CachedRecipeInfo = {
   version: string;
 };
 
-export async function listCachedRecipes(): Promise<CachedRecipeInfo[]> {
+export async function listCachedRecipes(_opts?: { cwd?: string }): Promise<CachedRecipeInfo[]> {
   const cached = await readAndMigrateInstalledRecipesFile(resolveInstalledRecipesPath(), {
     dropInvalidEntries: true,
   });
@@ -46,9 +46,12 @@ async function gitStatusPaths(cwd: string): Promise<string[]> {
     .filter(Boolean);
 }
 
-export async function validateCachedRecipesSelection(recipes: string[]): Promise<void> {
+export async function validateCachedRecipesSelection(
+  recipes: string[],
+  opts?: { cwd?: string },
+): Promise<void> {
   if (recipes.length === 0) return;
-  const cached = await listCachedRecipes();
+  const cached = await listCachedRecipes(opts);
   const available = new Set(cached.map((entry) => entry.id));
   const missing = recipes.filter((recipe) => !available.has(recipe));
   if (missing.length === 0) return;

--- a/packages/agentplane/src/cli/run-cli/commands/init/spec.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/spec.ts
@@ -20,6 +20,36 @@ export const initSpec: CommandSpec<InitParsed> = {
   options: [
     {
       kind: "string",
+      name: "init-mode",
+      valueHint: "<quick|guided|advanced|ci>",
+      choices: ["quick", "guided", "advanced", "ci"],
+      coerce: (raw) => raw.trim().toLowerCase(),
+      description:
+        "User-facing init route. TTY defaults to guided; --yes defaults to ci for automation.",
+    },
+    {
+      kind: "boolean",
+      name: "quick",
+      default: false,
+      description: "Alias for --init-mode quick.",
+    },
+    {
+      kind: "boolean",
+      name: "advanced",
+      default: false,
+      description: "Alias for --init-mode advanced.",
+    },
+    {
+      kind: "string",
+      name: "tool",
+      valueHint: "<codex|claude|cursor|windsurf|multiple|manual>",
+      choices: ["codex", "claude", "cursor", "windsurf", "multiple", "manual"],
+      coerce: (raw) => raw.trim().toLowerCase(),
+      description:
+        "AI surface that should read project instructions. Granular --policy-gateway/--ide flags override this mapping.",
+    },
+    {
+      kind: "string",
       name: "setup-profile",
       valueHint: "<light|normal|full-harness>",
       choices: [
@@ -194,6 +224,10 @@ export const initSpec: CommandSpec<InitParsed> = {
       cmd: "agentplane init --dry-run --yes --output json",
       why: "Print a machine-readable init plan without writing files.",
     },
+    {
+      cmd: "agentplane init --quick --tool cursor",
+      why: "Use the quick first-run route and install AGENTS.md plus Cursor rules.",
+    },
   ],
   validateRaw: (raw) => {
     if (raw.extra.length > 0) {
@@ -212,7 +246,16 @@ export const initSpec: CommandSpec<InitParsed> = {
     const recipesRaw = raw.opts.recipes as string | undefined;
     const blueprintsRaw = raw.opts.blueprints as string | undefined;
 
+    const initModeFlag =
+      raw.opts.quick === true
+        ? "quick"
+        : raw.opts.advanced === true
+          ? "advanced"
+          : (raw.opts["init-mode"] as InitFlags["initMode"]);
+
     return {
+      initMode: initModeFlag,
+      tool: raw.opts.tool as InitFlags["tool"],
       setupProfile: normalizeSetupProfile(raw.opts["setup-profile"] as string | undefined),
       policyGateway: raw.opts["policy-gateway"] as InitFlags["policyGateway"],
       ide: raw.opts.ide as InitFlags["ide"],
@@ -270,6 +313,13 @@ export const initSpec: CommandSpec<InitParsed> = {
         spec: initSpec,
         command: "init",
         message: "Use either --force or --backup (not both).",
+      });
+    }
+    if (p.initMode === "quick" && p.setupProfile === "full-harness") {
+      throw usageError({
+        spec: initSpec,
+        command: "init",
+        message: "--init-mode quick cannot be combined with --setup-profile full-harness.",
       });
     }
   },


### PR DESCRIPTION
## Summary

Adds the remaining init v2 RFQ controls that were not covered by the earlier planning-boundary work:

- Adds user-facing init route flags: `--init-mode <quick|guided|advanced|ci>`, `--quick`, and `--advanced`.
- Adds `--tool <codex|claude|cursor|windsurf|multiple|manual>` as a first-run AI surface shortcut while preserving explicit `--policy-gateway` and `--ide` precedence.
- Extends `InitPlan` with user-facing `mode`, `profile`, `internalSetupProfile`, and `context.parentGitRoot` fields for dry-run JSON and text previews.
- Blocks non-interactive init from accidentally creating a nested Git repository when the current directory is inside a parent Git repo and no explicit `--root` was supplied.
- Routes init blueprint catalog listing/validation and install lookup through the selected target root instead of ambient `process.cwd()`.
- Refreshes generated CLI reference for the new init flags.

## Included tasks

- `202605120952-JT6FWR`: init mode/tool controls and plan fields.
- `202605120952-D2F8VR`: parent Git ambiguity guard.
- `202605120952-MG1QB4`: target-root-aware cached recipe/blueprint lookup.

## Verification

- `bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts` -> 32 passed.
- `bunx eslint packages/agentplane/src/cli/run-cli/commands/init packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts` -> passed.
- `bunx prettier --check packages/agentplane/src/cli/run-cli/commands/init packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts docs/user/cli-reference.generated.mdx` -> passed.
- `bun run docs:cli:check` -> generated CLI reference is fresh.
- `bun run typecheck` -> passed.
- `node .agentplane/policy/check-routing.mjs` -> passed.
- `ap doctor` -> OK.
