### PR TITLE
✅ MG1QB4 close: record target-root cached catalog lookup [202605120952-MG1QB4]

### DIFF
--- a/.agentplane/tasks/202605120952-MG1QB4/README.md
+++ b/.agentplane/tasks/202605120952-MG1QB4/README.md
@@ -1,7 +1,8 @@
 ---
 id: "202605120952-MG1QB4"
 title: "Resolve init cached catalogs from target root"
-status: "DOING"
+result_summary: "Resolved init recipe/blueprint catalog lookup through the target root path and verified in the RFQ init test slice before merge."
+status: "DONE"
 priority: "med"
 owner: "CODER"
 revision: 1
@@ -22,11 +23,16 @@ verification:
   updated_by: "CODER"
   note: "Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bunx eslint packages/agentplane/src/cli/run-cli/commands/init; bun run typecheck. Result: pass. Evidence: init tests 32 passed; eslint/typecheck OK. Scope: init recipe/blueprint listing and validation now receive target root, and blueprint install loads catalog from rootOverride when provided."
   attempts: 0
-commit: null
+commit:
+  hash: "06d67d932eec362dfe3081742e4f633061bfca95"
+  message: "🚧 JT6FWR task: Implement init mode and tool RFQ controls [202605120952-JT6FWR] (#3596)"
 comments:
   -
     author: "CODER"
     body: "Start: implementing target-root-aware cached recipe and blueprint lookup inside the approved JT6FWR batch worktree, with focused init coverage."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: PR #3596 merged target-root-aware init cached catalog lookup. Blueprint catalog listing/validation now accepts the init target cwd and cached install uses rootOverride when present."
 events:
   -
     type: "status"
@@ -41,9 +47,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli.core.init.branch-pr.test.ts; bunx eslint packages/agentplane/src/cli/run-cli/commands/init; bun run typecheck. Result: pass. Evidence: init tests 32 passed; eslint/typecheck OK. Scope: init recipe/blueprint listing and validation now receive target root, and blueprint install loads catalog from rootOverride when provided."
+  -
+    type: "status"
+    at: "2026-05-12T10:32:10.192Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: PR #3596 merged target-root-aware init cached catalog lookup. Blueprint catalog listing/validation now accepts the init target cwd and cached install uses rootOverride when present."
 doc_version: 3
-doc_updated_at: "2026-05-12T10:02:57.871Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-12T10:32:10.192Z"
+doc_updated_by: "INTEGRATOR"
 description: "Make init recipes and blueprints discovery/validation use the selected target root instead of process.cwd()."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605120952-MG1QB4/acr.json
+++ b/.agentplane/tasks/202605120952-MG1QB4/acr.json
@@ -1,0 +1,219 @@
+{
+  "acr_version": "0.1.0",
+  "record_type": "agent_change_record",
+  "record_id": "acr_202605120952-MG1QB4",
+  "created_at": "2026-05-12T10:32:10.520Z",
+  "producer": {
+    "name": "agentplane",
+    "version": "0.4.2"
+  },
+  "repository": {
+    "vcs": "git",
+    "remote": "https://github.com/basilisk-labs/agentplane.git",
+    "base_ref": "main",
+    "base_commit": "06d67d932eec362dfe3081742e4f633061bfca95",
+    "work_ref": "main",
+    "work_commit": "06d67d932eec362dfe3081742e4f633061bfca95"
+  },
+  "task": {
+    "task_id": "202605120952-MG1QB4",
+    "title": "Resolve init cached catalogs from target root",
+    "intent": "Make init recipes and blueprints discovery/validation use the selected target root instead of process.cwd().",
+    "requested_by": {
+      "type": "agentplane_role",
+      "id": "ORCHESTRATOR"
+    }
+  },
+  "agent": {
+    "id": "INTEGRATOR",
+    "name": "INTEGRATOR",
+    "agent_type": "coding_agent",
+    "model": {
+      "provider": "unknown",
+      "name": "unknown",
+      "version": "unknown"
+    },
+    "toolchain": [
+      {
+        "name": "agentplane",
+        "version": "0.4.2"
+      }
+    ]
+  },
+  "plan": {
+    "status": "approved",
+    "artifact": {
+      "path": ".agentplane/tasks/202605120952-MG1QB4/README.md",
+      "sha256": "sha256:e1cac27ae12bd918fc45798c76652b3995feaf30ee60cfc33cfa8b3cd46ce7ac"
+    },
+    "approved_at": "2026-05-12T09:52:23.884Z",
+    "approved_by": {
+      "type": "agentplane_role",
+      "id": "ORCHESTRATOR"
+    }
+  },
+  "permissions": {
+    "network": {
+      "mode": "unknown"
+    },
+    "secrets": {
+      "access": "none"
+    },
+    "tools": [
+      {
+        "name": "shell",
+        "allowed": true
+      }
+    ]
+  },
+  "policy": {
+    "policy_version": "0.1.0",
+    "decisions": [
+      {
+        "rule_id": "plan.required",
+        "decision": "pass",
+        "reason": "Approved plan exists."
+      },
+      {
+        "rule_id": "verification.required",
+        "decision": "pass",
+        "reason": "Verification is recorded as ok."
+      }
+    ]
+  },
+  "changes": {
+    "summary": "Resolved init recipe/blueprint catalog lookup through the target root path and verified in the RFQ init test slice before merge.",
+    "diff_stats": {
+      "files_changed": 0,
+      "insertions": 0,
+      "deletions": 0
+    },
+    "files": [],
+    "risk": {
+      "level": "medium",
+      "categories": [],
+      "protected_paths_touched": false
+    }
+  },
+  "verification": {
+    "status": "passed",
+    "checks": []
+  },
+  "approvals": [
+    {
+      "approval_id": "approval_202605120952-MG1QB4_plan",
+      "type": "plan_approval",
+      "decision": "approved",
+      "approved_by": {
+        "type": "agentplane_role",
+        "id": "ORCHESTRATOR"
+      },
+      "approved_at": "2026-05-12T09:52:23.884Z",
+      "scope": "task"
+    }
+  ],
+  "evidence": [
+    {
+      "type": "task",
+      "path": ".agentplane/tasks/202605120952-MG1QB4/README.md",
+      "sha256": "sha256:e1cac27ae12bd918fc45798c76652b3995feaf30ee60cfc33cfa8b3cd46ce7ac"
+    },
+    {
+      "type": "plan",
+      "path": ".agentplane/tasks/202605120952-MG1QB4/README.md",
+      "sha256": "sha256:e1cac27ae12bd918fc45798c76652b3995feaf30ee60cfc33cfa8b3cd46ce7ac"
+    },
+    {
+      "type": "verification_log",
+      "path": ".agentplane/tasks/202605120952-MG1QB4/README.md",
+      "sha256": "sha256:e1cac27ae12bd918fc45798c76652b3995feaf30ee60cfc33cfa8b3cd46ce7ac"
+    },
+    {
+      "type": "other",
+      "path": ".agentplane/tasks/202605120952-MG1QB4/blueprint/resolved-snapshot.json",
+      "sha256": "sha256:0b1ee1b9263dd6c55bc332061a5d3ddfe559a47e4e01ce42f0cbf40625173047"
+    }
+  ],
+  "result": {
+    "status": "finished",
+    "merge_ready": false,
+    "residual_risks": [
+      "Passed verification has no checks."
+    ],
+    "rollback": {
+      "available": true,
+      "notes": "Revert work_commit 06d67d932eec362dfe3081742e4f633061bfca95 if downstream validation fails."
+    }
+  },
+  "integrity": {
+    "digest_algorithm": "sha256",
+    "record_digest": "sha256:787e9b4adcdb429da274e57bea8d0ea91cea04da053a9a62e25dcdba2c55b129",
+    "canonicalization": "rfc8785-jcs",
+    "signatures": []
+  },
+  "extensions": {
+    "agentplane.blueprint": {
+      "blueprint_id": "code.branch_pr",
+      "blueprint_version": 1,
+      "workflow_mode": "branch_pr",
+      "route": [
+        "intake",
+        "scope",
+        "approval_gate",
+        "context_resolve",
+        "worktree_start",
+        "work_unit",
+        "fast_local_checks",
+        "pr_artifact",
+        "hosted_checks",
+        "publish_or_integrate",
+        "verify_record",
+        "finish"
+      ],
+      "required_evidence": [
+        {
+          "id": "code_pr.paths",
+          "kind": "changed_paths",
+          "produced_by": "work_unit",
+          "required": true
+        },
+        {
+          "id": "code_pr.fast_checks",
+          "kind": "check_result",
+          "produced_by": "fast_local_checks",
+          "required": true
+        },
+        {
+          "id": "code_pr.pr",
+          "kind": "external_link",
+          "produced_by": "pr_artifact",
+          "required": true
+        },
+        {
+          "id": "code_pr.hosted",
+          "kind": "check_result",
+          "produced_by": "hosted_checks",
+          "required": true
+        },
+        {
+          "id": "code_pr.commit",
+          "kind": "commit",
+          "produced_by": "publish_or_integrate",
+          "required": true
+        }
+      ],
+      "accepted_recipe_extensions": [],
+      "rejected_recipe_extensions": [],
+      "stop_reasons": [],
+      "snapshot": {
+        "state": "current",
+        "path": ".agentplane/tasks/202605120952-MG1QB4/blueprint/resolved-snapshot.json",
+        "digest": "02159580e41a3ae38886fed30dd21168c4675d368d9069599d3c1dbf5fb3a7f2",
+        "current_digest": "02159580e41a3ae38886fed30dd21168c4675d368d9069599d3c1dbf5fb3a7f2",
+        "route_changed": false,
+        "artifact_sha256": "sha256:0b1ee1b9263dd6c55bc332061a5d3ddfe559a47e4e01ce42f0cbf40625173047",
+        "safe_command": "agentplane blueprint snapshot 202605120952-MG1QB4"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Task: 202605120952-MG1QB4\n\nRecords final closure for target-root-aware init cached catalog lookup. The merged implementation routes cached blueprint listing and validation through the init target cwd and uses rootOverride when installing cached blueprints, so init planning no longer depends on the ambient shell cwd for those catalog reads.\n\nVerification:\n- PR #3596 merged the target-root-aware cached catalog changes.\n- Pre-push close gate passed: format, schema/policy/release parity, build, docs freshness, fast unit suite, and critical CLI E2E.