### PR TITLE
🚧 4FB61V task: Fix release notes template leakage [202605130758-4FB61V]

### DIFF
--- a/.agentplane/tasks/202605130758-4FB61V/README.md
+++ b/.agentplane/tasks/202605130758-4FB61V/README.md
@@ -1,0 +1,95 @@
+---
+id: "202605130758-4FB61V"
+title: "Fix release notes template leakage"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "release"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-13T07:59:05.437Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: fixing the leaked v0.5.0 release-note template block and adding a focused validation guard for placeholders, duplicate sections, and published writing rules."
+events:
+  -
+    type: "status"
+    at: "2026-05-13T08:09:10.034Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: fixing the leaked v0.5.0 release-note template block and adding a focused validation guard for placeholders, duplicate sections, and published writing rules."
+doc_version: 3
+doc_updated_at: "2026-05-13T08:09:10.034Z"
+doc_updated_by: "CODER"
+description: "Remove template placeholders from v0.5.0 release notes and harden release notes validation against placeholder leakage."
+sections:
+  Summary: |-
+    Fix release notes template leakage
+    
+    Remove template placeholders from v0.5.0 release notes and harden release notes validation against placeholder leakage.
+  Scope: |-
+    - In scope: Remove template placeholders from v0.5.0 release notes and harden release notes validation against placeholder leakage.
+    - Out of scope: unrelated refactors not required for "Fix release notes template leakage".
+  Plan: "1. Create a branch_pr worktree for CODER. 2. Replace the leaked v0.5.0 template block with real release summary/categories without duplicate sections. 3. Harden release note validation to reject template placeholders, published Writing Rules blocks, and duplicate release sections. 4. Add focused tests for placeholder rejection and valid notes. 5. Run targeted release-note tests, check-release-notes for v0.5.0, routing check, and doctor; record verification."
+  Verify Steps: |-
+    1. Review the requested outcome for "Fix release notes template leakage". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Fix release notes template leakage
+
+Remove template placeholders from v0.5.0 release notes and harden release notes validation against placeholder leakage.
+
+## Scope
+
+- In scope: Remove template placeholders from v0.5.0 release notes and harden release notes validation against placeholder leakage.
+- Out of scope: unrelated refactors not required for "Fix release notes template leakage".
+
+## Plan
+
+1. Create a branch_pr worktree for CODER. 2. Replace the leaked v0.5.0 template block with real release summary/categories without duplicate sections. 3. Harden release note validation to reject template placeholders, published Writing Rules blocks, and duplicate release sections. 4. Add focused tests for placeholder rejection and valid notes. 5. Run targeted release-note tests, check-release-notes for v0.5.0, routing check, and doctor; record verification.
+
+## Verify Steps
+
+1. Review the requested outcome for "Fix release notes template leakage". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605130758-4FB61V/README.md
+++ b/.agentplane/tasks/202605130758-4FB61V/README.md
@@ -17,10 +17,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-13T09:54:05.898Z"
+  updated_by: "CODER"
+  note: "Verified release notes template leakage fix: v0.5.0 placeholders removed; release notes validators reject template placeholders, Writing Rules blocks, and duplicate section headings. Checks passed: bun test packages/agentplane/src/commands/release/apply.preflight.test.ts; bunx eslint scripts/check-release-notes.mjs packages/agentplane/src/commands/release/apply.preflight.package.ts packages/agentplane/src/commands/release/apply.preflight.test.ts; node scripts/check-release-notes.mjs --tag v0.5.0; node .agentplane/policy/check-routing.mjs; ap doctor; git diff --check."
   attempts: 0
 commit: null
 comments:
@@ -35,8 +35,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: fixing the leaked v0.5.0 release-note template block and adding a focused validation guard for placeholders, duplicate sections, and published writing rules."
+  -
+    type: "verify"
+    at: "2026-05-13T09:54:05.898Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified release notes template leakage fix: v0.5.0 placeholders removed; release notes validators reject template placeholders, Writing Rules blocks, and duplicate section headings. Checks passed: bun test packages/agentplane/src/commands/release/apply.preflight.test.ts; bunx eslint scripts/check-release-notes.mjs packages/agentplane/src/commands/release/apply.preflight.package.ts packages/agentplane/src/commands/release/apply.preflight.test.ts; node scripts/check-release-notes.mjs --tag v0.5.0; node .agentplane/policy/check-routing.mjs; ap doctor; git diff --check."
 doc_version: 3
-doc_updated_at: "2026-05-13T08:09:10.034Z"
+doc_updated_at: "2026-05-13T09:54:05.903Z"
 doc_updated_by: "CODER"
 description: "Remove template placeholders from v0.5.0 release notes and harden release notes validation against placeholder leakage."
 sections:
@@ -54,6 +60,25 @@ sections:
     3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-13T09:54:05.898Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified release notes template leakage fix: v0.5.0 placeholders removed; release notes validators reject template placeholders, Writing Rules blocks, and duplicate section headings. Checks passed: bun test packages/agentplane/src/commands/release/apply.preflight.test.ts; bunx eslint scripts/check-release-notes.mjs packages/agentplane/src/commands/release/apply.preflight.package.ts packages/agentplane/src/commands/release/apply.preflight.test.ts; node scripts/check-release-notes.mjs --tag v0.5.0; node .agentplane/policy/check-routing.mjs; ap doctor; git diff --check.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-13T08:09:10.034Z, excerpt_hash=sha256:4ce5acdba341738551e924ae56fe237cecb172ad2ab47aa81ecdbf9d4771f32c
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605130758-4FB61V-release-notes-template-guard/.agentplane/tasks/202605130758-4FB61V/blueprint/resolved-snapshot.json
+    - old_digest: 635a98e00703d73845f4676cd40ee2164795af185a09d0e0b7dd4b3f4f0faa03
+    - current_digest: 635a98e00703d73845f4676cd40ee2164795af185a09d0e0b7dd4b3f4f0faa03
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605130758-4FB61V
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -85,6 +110,25 @@ Remove template placeholders from v0.5.0 release notes and harden release notes 
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-13T09:54:05.898Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified release notes template leakage fix: v0.5.0 placeholders removed; release notes validators reject template placeholders, Writing Rules blocks, and duplicate section headings. Checks passed: bun test packages/agentplane/src/commands/release/apply.preflight.test.ts; bunx eslint scripts/check-release-notes.mjs packages/agentplane/src/commands/release/apply.preflight.package.ts packages/agentplane/src/commands/release/apply.preflight.test.ts; node scripts/check-release-notes.mjs --tag v0.5.0; node .agentplane/policy/check-routing.mjs; ap doctor; git diff --check.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-13T08:09:10.034Z, excerpt_hash=sha256:4ce5acdba341738551e924ae56fe237cecb172ad2ab47aa81ecdbf9d4771f32c
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605130758-4FB61V-release-notes-template-guard/.agentplane/tasks/202605130758-4FB61V/blueprint/resolved-snapshot.json
+- old_digest: 635a98e00703d73845f4676cd40ee2164795af185a09d0e0b7dd4b3f4f0faa03
+- current_digest: 635a98e00703d73845f4676cd40ee2164795af185a09d0e0b7dd4b3f4f0faa03
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605130758-4FB61V
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605130758-4FB61V/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605130758-4FB61V/blueprint/resolved-snapshot.json
@@ -1,0 +1,415 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605130758-4FB61V",
+    "title": "Fix release notes template leakage",
+    "description": "Remove template placeholders from v0.5.0 release notes and harden release notes validation against placeholder leakage.",
+    "tags": [
+      "release"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "release",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "release.strict",
+    "version": 1,
+    "title": "Strict release",
+    "taskKinds": [
+      "release"
+    ],
+    "workflowModes": [
+      "direct",
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "release.strict",
+    "blueprintVersion": 1,
+    "title": "Strict release",
+    "taskId": "202605130758-4FB61V",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "release"
+    },
+    "whySelected": [
+      "task kind resolved to release",
+      "workflow mode: branch_pr",
+      "mutation scope: release"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.release.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "deterministic_check",
+        "kind": "deterministic_check",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "release.approval",
+        "kind": "approval",
+        "producedBy": "approval_gate",
+        "required": true,
+        "description": "Release approval."
+      },
+      {
+        "id": "release.plan",
+        "kind": "artifact",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Release plan or candidate artifact."
+      },
+      {
+        "id": "release.check",
+        "kind": "check_result",
+        "producedBy": "deterministic_check",
+        "required": true,
+        "description": "Release gates."
+      },
+      {
+        "id": "release.publish",
+        "kind": "external_link",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Publish evidence."
+      },
+      {
+        "id": "release.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Release commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.release.md"
+    ],
+    "allowedCommands": [
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "publish commands after approval",
+      "release gates"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Release work needs strict release policy, approval evidence, and rollback context."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.release.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "deterministic_check",
+      "kind": "deterministic_check",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "release.approval",
+      "kind": "approval",
+      "producedBy": "approval_gate",
+      "required": true,
+      "description": "Release approval."
+    },
+    {
+      "id": "release.plan",
+      "kind": "artifact",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Release plan or candidate artifact."
+    },
+    {
+      "id": "release.check",
+      "kind": "check_result",
+      "producedBy": "deterministic_check",
+      "required": true,
+      "description": "Release gates."
+    },
+    {
+      "id": "release.publish",
+      "kind": "external_link",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Publish evidence."
+    },
+    {
+      "id": "release.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Release commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.release.md"
+  ],
+  "allowedCommands": [
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "publish commands after approval",
+    "release gates"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Release work needs strict release policy, approval evidence, and rollback context."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to release",
+    "workflow mode: branch_pr",
+    "mutation scope: release"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "635a98e00703d73845f4676cd40ee2164795af185a09d0e0b7dd4b3f4f0faa03"
+  }
+}

--- a/.agentplane/tasks/202605130758-4FB61V/pr/diffstat.txt
+++ b/.agentplane/tasks/202605130758-4FB61V/pr/diffstat.txt
@@ -1,0 +1,5 @@
+ docs/releases/v0.5.0.md                            | 32 ++---------
+ .../commands/release/apply.preflight.package.ts    | 50 ++++++++++++++++
+ .../src/commands/release/apply.preflight.test.ts   | 66 +++++++++++++++++++++-
+ scripts/check-release-notes.mjs                    | 42 ++++++++++++++
+ 4 files changed, 161 insertions(+), 29 deletions(-)

--- a/.agentplane/tasks/202605130758-4FB61V/pr/diffstat.txt
+++ b/.agentplane/tasks/202605130758-4FB61V/pr/diffstat.txt
@@ -1,5 +1,6 @@
- docs/releases/v0.5.0.md                            | 32 ++---------
- .../commands/release/apply.preflight.package.ts    | 50 ++++++++++++++++
- .../src/commands/release/apply.preflight.test.ts   | 66 +++++++++++++++++++++-
- scripts/check-release-notes.mjs                    | 42 ++++++++++++++
- 4 files changed, 161 insertions(+), 29 deletions(-)
+ .../blueprint/resolved-snapshot.json               | 415 +++++++++++++++++++++
+ docs/releases/v0.5.0.md                            |  32 +-
+ .../commands/release/apply.preflight.package.ts    |  50 +++
+ .../src/commands/release/apply.preflight.test.ts   |  66 +++-
+ scripts/check-release-notes.mjs                    |  42 +++
+ 5 files changed, 576 insertions(+), 29 deletions(-)

--- a/.agentplane/tasks/202605130758-4FB61V/pr/diffstat.txt
+++ b/.agentplane/tasks/202605130758-4FB61V/pr/diffstat.txt
@@ -1,6 +1,6 @@
  .../blueprint/resolved-snapshot.json               | 415 +++++++++++++++++++++
  docs/releases/v0.5.0.md                            |  32 +-
- .../commands/release/apply.preflight.package.ts    |  50 +++
- .../src/commands/release/apply.preflight.test.ts   |  66 +++-
- scripts/check-release-notes.mjs                    |  42 +++
- 5 files changed, 576 insertions(+), 29 deletions(-)
+ .../commands/release/apply.preflight.package.ts    |  72 ++++
+ .../src/commands/release/apply.preflight.test.ts   |  91 ++++-
+ scripts/check-release-notes.mjs                    |  64 ++++
+ 5 files changed, 645 insertions(+), 29 deletions(-)

--- a/.agentplane/tasks/202605130758-4FB61V/pr/github-body.md
+++ b/.agentplane/tasks/202605130758-4FB61V/pr/github-body.md
@@ -1,0 +1,37 @@
+Task: `202605130758-4FB61V`
+Title: Fix release notes template leakage
+Canonical task record: `.agentplane/tasks/202605130758-4FB61V/README.md`
+
+## Summary
+
+Fix release notes template leakage
+
+Remove template placeholders from v0.5.0 release notes and harden release notes validation against placeholder leakage.
+
+## Scope
+
+- In scope: Remove template placeholders from v0.5.0 release notes and harden release notes validation against placeholder leakage.
+- Out of scope: unrelated refactors not required for "Fix release notes template leakage".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-13T09:53:33.482Z
+- Branch: task/202605130758-4FB61V/release-notes-template-guard
+- Head: 24b1dc2ed0f2
+
+```text
+ docs/releases/v0.5.0.md                            | 32 ++---------
+ .../commands/release/apply.preflight.package.ts    | 50 ++++++++++++++++
+ .../src/commands/release/apply.preflight.test.ts   | 66 +++++++++++++++++++++-
+ scripts/check-release-notes.mjs                    | 42 ++++++++++++++
+ 4 files changed, 161 insertions(+), 29 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605130758-4FB61V/pr/github-body.md
+++ b/.agentplane/tasks/202605130758-4FB61V/pr/github-body.md
@@ -22,17 +22,17 @@ Remove template placeholders from v0.5.0 release notes and harden release notes 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-13T09:53:33.482Z
+- Updated: 2026-05-13T10:14:41.383Z
 - Branch: task/202605130758-4FB61V/release-notes-template-guard
-- Head: 24b1dc2ed0f2
+- Head: 0698e414f6ce
 
 ```text
  .../blueprint/resolved-snapshot.json               | 415 +++++++++++++++++++++
  docs/releases/v0.5.0.md                            |  32 +-
- .../commands/release/apply.preflight.package.ts    |  50 +++
- .../src/commands/release/apply.preflight.test.ts   |  66 +++-
- scripts/check-release-notes.mjs                    |  42 +++
- 5 files changed, 576 insertions(+), 29 deletions(-)
+ .../commands/release/apply.preflight.package.ts    |  72 ++++
+ .../src/commands/release/apply.preflight.test.ts   |  91 ++++-
+ scripts/check-release-notes.mjs                    |  64 ++++
+ 5 files changed, 645 insertions(+), 29 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605130758-4FB61V/pr/github-body.md
+++ b/.agentplane/tasks/202605130758-4FB61V/pr/github-body.md
@@ -15,8 +15,8 @@ Remove template placeholders from v0.5.0 release notes and harden release notes 
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified release notes template leakage fix: v0.5.0 placeholders removed; release notes validators reject template placeholders, Writing Rules blocks, and duplicate section headings. Checks passed: bun test packages/agentplane/src/commands/release/apply.preflight.test.ts; bunx eslint scripts/check-release-notes.mjs packages/agentplane/src/commands/release/apply.preflight.package.ts packages/agentplane/src/commands/release/apply.preflight.test.ts; node scripts/check-release-notes.mjs --tag v0.5.0; node .agentplane/policy/check-routing.mjs; ap doctor; git diff --check.
 - Canonical workflow state lives in the task README.
 
 <details>

--- a/.agentplane/tasks/202605130758-4FB61V/pr/github-body.md
+++ b/.agentplane/tasks/202605130758-4FB61V/pr/github-body.md
@@ -27,11 +27,12 @@ Remove template placeholders from v0.5.0 release notes and harden release notes 
 - Head: 24b1dc2ed0f2
 
 ```text
- docs/releases/v0.5.0.md                            | 32 ++---------
- .../commands/release/apply.preflight.package.ts    | 50 ++++++++++++++++
- .../src/commands/release/apply.preflight.test.ts   | 66 +++++++++++++++++++++-
- scripts/check-release-notes.mjs                    | 42 ++++++++++++++
- 4 files changed, 161 insertions(+), 29 deletions(-)
+ .../blueprint/resolved-snapshot.json               | 415 +++++++++++++++++++++
+ docs/releases/v0.5.0.md                            |  32 +-
+ .../commands/release/apply.preflight.package.ts    |  50 +++
+ .../src/commands/release/apply.preflight.test.ts   |  66 +++-
+ scripts/check-release-notes.mjs                    |  42 +++
+ 5 files changed, 576 insertions(+), 29 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605130758-4FB61V/pr/github-title.txt
+++ b/.agentplane/tasks/202605130758-4FB61V/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 4FB61V task: Fix release notes template leakage [202605130758-4FB61V]

--- a/.agentplane/tasks/202605130758-4FB61V/pr/meta.json
+++ b/.agentplane/tasks/202605130758-4FB61V/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605130758-4FB61V/release-notes-template-guard",
+  "created_at": "2026-05-13T08:09:10.107Z",
+  "head_sha": "24b1dc2ed0f276aa7b95f94ac4a098e07864595e",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202605130758-4FB61V",
+  "updated_at": "2026-05-13T09:53:33.482Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605130758-4FB61V/pr/meta.json
+++ b/.agentplane/tasks/202605130758-4FB61V/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605130758-4FB61V/release-notes-template-guard",
   "created_at": "2026-05-13T08:09:10.107Z",
-  "head_sha": "24b1dc2ed0f276aa7b95f94ac4a098e07864595e",
+  "head_sha": "0698e414f6ced818c0aa3b5568d9e057fa02860f",
   "last_verified_at": "2026-05-13T09:54:05.898Z",
   "last_verified_sha": "24b1dc2ed0f276aa7b95f94ac4a098e07864595e",
   "schema_version": 1,
   "task_id": "202605130758-4FB61V",
-  "updated_at": "2026-05-13T09:53:33.482Z",
+  "updated_at": "2026-05-13T10:14:41.383Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605130758-4FB61V/pr/meta.json
+++ b/.agentplane/tasks/202605130758-4FB61V/pr/meta.json
@@ -3,12 +3,12 @@
   "branch": "task/202605130758-4FB61V/release-notes-template-guard",
   "created_at": "2026-05-13T08:09:10.107Z",
   "head_sha": "24b1dc2ed0f276aa7b95f94ac4a098e07864595e",
-  "last_verified_at": null,
-  "last_verified_sha": null,
+  "last_verified_at": "2026-05-13T09:54:05.898Z",
+  "last_verified_sha": "24b1dc2ed0f276aa7b95f94ac4a098e07864595e",
   "schema_version": 1,
   "task_id": "202605130758-4FB61V",
   "updated_at": "2026-05-13T09:53:33.482Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605130758-4FB61V/pr/review.md
+++ b/.agentplane/tasks/202605130758-4FB61V/pr/review.md
@@ -24,17 +24,17 @@ Created: 2026-05-13T08:09:10.107Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-13T09:53:33.482Z
+- Updated: 2026-05-13T10:14:41.383Z
 - Branch: task/202605130758-4FB61V/release-notes-template-guard
-- Head: 24b1dc2ed0f2
+- Head: 0698e414f6ce
 
 ```text
  .../blueprint/resolved-snapshot.json               | 415 +++++++++++++++++++++
  docs/releases/v0.5.0.md                            |  32 +-
- .../commands/release/apply.preflight.package.ts    |  50 +++
- .../src/commands/release/apply.preflight.test.ts   |  66 +++-
- scripts/check-release-notes.mjs                    |  42 +++
- 5 files changed, 576 insertions(+), 29 deletions(-)
+ .../commands/release/apply.preflight.package.ts    |  72 ++++
+ .../src/commands/release/apply.preflight.test.ts   |  91 ++++-
+ scripts/check-release-notes.mjs                    |  64 ++++
+ 5 files changed, 645 insertions(+), 29 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605130758-4FB61V/pr/review.md
+++ b/.agentplane/tasks/202605130758-4FB61V/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-05-13T08:09:10.107Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified release notes template leakage fix: v0.5.0 placeholders removed; release notes validators reject template placeholders, Writing Rules blocks, and duplicate section headings. Checks passed: bun test packages/agentplane/src/commands/release/apply.preflight.test.ts; bunx eslint scripts/check-release-notes.mjs packages/agentplane/src/commands/release/apply.preflight.package.ts packages/agentplane/src/commands/release/apply.preflight.test.ts; node scripts/check-release-notes.mjs --tag v0.5.0; node .agentplane/policy/check-routing.mjs; ap doctor; git diff --check.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes

--- a/.agentplane/tasks/202605130758-4FB61V/pr/review.md
+++ b/.agentplane/tasks/202605130758-4FB61V/pr/review.md
@@ -29,11 +29,12 @@ Created: 2026-05-13T08:09:10.107Z
 - Head: 24b1dc2ed0f2
 
 ```text
- docs/releases/v0.5.0.md                            | 32 ++---------
- .../commands/release/apply.preflight.package.ts    | 50 ++++++++++++++++
- .../src/commands/release/apply.preflight.test.ts   | 66 +++++++++++++++++++++-
- scripts/check-release-notes.mjs                    | 42 ++++++++++++++
- 4 files changed, 161 insertions(+), 29 deletions(-)
+ .../blueprint/resolved-snapshot.json               | 415 +++++++++++++++++++++
+ docs/releases/v0.5.0.md                            |  32 +-
+ .../commands/release/apply.preflight.package.ts    |  50 +++
+ .../src/commands/release/apply.preflight.test.ts   |  66 +++-
+ scripts/check-release-notes.mjs                    |  42 +++
+ 5 files changed, 576 insertions(+), 29 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605130758-4FB61V/pr/review.md
+++ b/.agentplane/tasks/202605130758-4FB61V/pr/review.md
@@ -1,0 +1,40 @@
+# PR Review
+
+Created: 2026-05-13T08:09:10.107Z
+
+## Task
+
+- Task: `202605130758-4FB61V`
+- Title: Fix release notes template leakage
+- Status: DOING
+- Branch: `task/202605130758-4FB61V/release-notes-template-guard`
+- Canonical task record: `.agentplane/tasks/202605130758-4FB61V/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-13T09:53:33.482Z
+- Branch: task/202605130758-4FB61V/release-notes-template-guard
+- Head: 24b1dc2ed0f2
+
+```text
+ docs/releases/v0.5.0.md                            | 32 ++---------
+ .../commands/release/apply.preflight.package.ts    | 50 ++++++++++++++++
+ .../src/commands/release/apply.preflight.test.ts   | 66 +++++++++++++++++++++-
+ scripts/check-release-notes.mjs                    | 42 ++++++++++++++
+ 4 files changed, 161 insertions(+), 29 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -2,34 +2,10 @@
 
 ## Summary
 
-- 2-4 bullets with the main release outcomes in plain language.
-
-## Added
-
-- New features or capabilities.
-
-## Improved
-
-- Behavior/UX improvements that users will notice.
-
-## Fixed
-
-- Bug fixes and regressions.
-
-## Upgrade Notes
-
-- Breaking changes, migration steps, or "none".
-
-## Verification
-
-- Release checks completed (for example: release:prepublish, parity, publish gates).
-
-## Writing Rules
-
-- Cover all differences from the release plan (`changes.md`/`changes.json`).
-- Use detailed, human-readable language, not raw commit log text.
-- Keep concrete bullets with explicit outcomes.
-- Keep at least one bullet per listed change from `changes.md`/`changes.json`.
+- v0.5.0 turns blueprints and recipes into first-class task routing surfaces, including plan dry-runs, compatibility checks, evidence projection, and recipe contribution diagnostics.
+- The release hardens branch-pr, Git mutation, lock, hook, and close-flow behavior so agents get clearer failure modes instead of ambiguous dirty-index or lifecycle states.
+- Release readiness now covers package parity, generated references, ACR examples, npm availability, publish manifests, and hosted release evidence as one coupled gate.
+- Init, cloud backend, and local task workflows received targeted fixes that keep project setup, catalog lookup, and release recovery aligned with the new v0.5 contracts.
 
 ## Added
 

--- a/packages/agentplane/src/commands/release/apply.preflight.package.ts
+++ b/packages/agentplane/src/commands/release/apply.preflight.package.ts
@@ -83,6 +83,29 @@ function duplicateSectionHeadings(content: string): string[] {
   return [...duplicates].toSorted((a, b) => a.localeCompare(b));
 }
 
+function releaseNoteLinesOutsideCodeFences(content: string): string[] {
+  const lines = content.split(/\r?\n/u);
+  let inFence = false;
+  const visibleLines: string[] = [];
+  for (const line of lines) {
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (!inFence) visibleLines.push(line);
+  }
+  return visibleLines;
+}
+
+function unreplacedTemplateBullet(content: string): string | null {
+  const placeholders: ReadonlySet<string> = new Set(RELEASE_NOTE_TEMPLATE_PLACEHOLDERS);
+  for (const line of releaseNoteLinesOutsideCodeFences(content)) {
+    const match = /^\s*[-*]\s+(.+?)\s*$/u.exec(line);
+    if (match?.[1] && placeholders.has(match[1])) return match[1];
+  }
+  return null;
+}
+
 export async function validateReleaseNotes(notesPath: string, minBullets: number): Promise<void> {
   const content = await readFile(notesPath, "utf8");
   if (!/release\s+notes/i.test(content)) {
@@ -99,14 +122,13 @@ export async function validateReleaseNotes(notesPath: string, minBullets: number
       message: `Release notes must not include template writing instructions in ${notesPath}.`,
     });
   }
-  for (const placeholder of RELEASE_NOTE_TEMPLATE_PLACEHOLDERS) {
-    if (content.includes(placeholder)) {
-      throw new CliError({
-        exitCode: exitCodeForError("E_VALIDATION"),
-        code: "E_VALIDATION",
-        message: `Release notes must replace template placeholder text in ${notesPath}: ${placeholder}`,
-      });
-    }
+  const templateBullet = unreplacedTemplateBullet(content);
+  if (templateBullet) {
+    throw new CliError({
+      exitCode: exitCodeForError("E_VALIDATION"),
+      code: "E_VALIDATION",
+      message: `Release notes must replace template placeholder bullet in ${notesPath}: ${templateBullet}`,
+    });
   }
   const duplicateHeadings = duplicateSectionHeadings(content);
   if (duplicateHeadings.length > 0) {

--- a/packages/agentplane/src/commands/release/apply.preflight.package.ts
+++ b/packages/agentplane/src/commands/release/apply.preflight.package.ts
@@ -57,6 +57,32 @@ export async function readOptionalAgentplaneDependencyVersion(
   return version || null;
 }
 
+const RELEASE_NOTE_TEMPLATE_PLACEHOLDERS = [
+  "2-4 bullets with the main release outcomes in plain language.",
+  "New features or capabilities.",
+  "Behavior/UX improvements that users will notice.",
+  "Bug fixes and regressions.",
+  'Breaking changes, migration steps, or "none".',
+  "Release checks completed (for example: release:prepublish, parity, publish gates).",
+  "Cover all differences from the release plan (`changes.md`/`changes.json`).",
+  "Use detailed, human-readable language, not raw commit log text.",
+  "Keep concrete bullets with explicit outcomes.",
+  "Keep at least one bullet per listed change from `changes.md`/`changes.json`.",
+] as const;
+
+function duplicateSectionHeadings(content: string): string[] {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const match of content.matchAll(/^##\s+(.+?)\s*$/gmu)) {
+    const heading = match[1]?.trim();
+    if (!heading) continue;
+    const key = heading.toLowerCase();
+    if (seen.has(key)) duplicates.add(heading);
+    seen.add(key);
+  }
+  return [...duplicates].toSorted((a, b) => a.localeCompare(b));
+}
+
 export async function validateReleaseNotes(notesPath: string, minBullets: number): Promise<void> {
   const content = await readFile(notesPath, "utf8");
   if (!/release\s+notes/i.test(content)) {
@@ -64,6 +90,30 @@ export async function validateReleaseNotes(notesPath: string, minBullets: number
       exitCode: exitCodeForError("E_VALIDATION"),
       code: "E_VALIDATION",
       message: `Release notes must include a "Release Notes" heading in ${notesPath}.`,
+    });
+  }
+  if (/^##\s+Writing Rules\s*$/mu.test(content)) {
+    throw new CliError({
+      exitCode: exitCodeForError("E_VALIDATION"),
+      code: "E_VALIDATION",
+      message: `Release notes must not include template writing instructions in ${notesPath}.`,
+    });
+  }
+  for (const placeholder of RELEASE_NOTE_TEMPLATE_PLACEHOLDERS) {
+    if (content.includes(placeholder)) {
+      throw new CliError({
+        exitCode: exitCodeForError("E_VALIDATION"),
+        code: "E_VALIDATION",
+        message: `Release notes must replace template placeholder text in ${notesPath}: ${placeholder}`,
+      });
+    }
+  }
+  const duplicateHeadings = duplicateSectionHeadings(content);
+  if (duplicateHeadings.length > 0) {
+    throw new CliError({
+      exitCode: exitCodeForError("E_VALIDATION"),
+      code: "E_VALIDATION",
+      message: `Release notes must not include duplicate section headings in ${notesPath}: ${duplicateHeadings.join(", ")}`,
     });
   }
   const bulletCount = content.split(/\r?\n/u).filter((line) => /^\s*[-*]\s+\S+/u.test(line)).length;

--- a/packages/agentplane/src/commands/release/apply.preflight.test.ts
+++ b/packages/agentplane/src/commands/release/apply.preflight.test.ts
@@ -82,17 +82,42 @@ describeWhenNotHook(
           "",
           "- New features or capabilities.",
           "",
-          "## Writing Rules",
-          "",
-          "- Cover all differences from the release plan (`changes.md`/`changes.json`).",
-          "",
         ].join("\n"),
         "utf8",
       );
 
       await expect(validateReleaseNotes(notesPath, 1)).rejects.toThrow(
-        /template writing instructions/u,
+        /template placeholder bullet/u,
       );
+    });
+
+    it("allows release notes to mention old template bullets inside fenced examples", async () => {
+      const root = await mkGitRepoRoot();
+      const notesPath = path.join(root, "docs", "releases", "v0.2.7.md");
+      await mkdir(path.dirname(notesPath), { recursive: true });
+      await writeFile(
+        notesPath,
+        [
+          "# Release Notes - v0.2.7",
+          "",
+          "## Summary",
+          "",
+          "- Release notes validation now rejects unreplaced template bullets.",
+          "- The check still allows historical examples in fenced snippets.",
+          "",
+          "## Fixed",
+          "",
+          "- The old template looked like this:",
+          "",
+          "```md",
+          "- 2-4 bullets with the main release outcomes in plain language.",
+          "```",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      await expect(validateReleaseNotes(notesPath, 1)).resolves.toBeUndefined();
     });
 
     it("rejects release notes with duplicate section headings", async () => {

--- a/packages/agentplane/src/commands/release/apply.preflight.test.ts
+++ b/packages/agentplane/src/commands/release/apply.preflight.test.ts
@@ -20,7 +20,10 @@ import {
 import { runReleasePlan } from "./plan.command.js";
 import { runReleaseApply, runReleaseCandidate } from "./apply.command.js";
 import { cleanHookEnv, packageDependencyExists } from "./apply.mutation.js";
-import { readOptionalAgentplaneDependencyVersion } from "./apply.preflight.package.js";
+import {
+  readOptionalAgentplaneDependencyVersion,
+  validateReleaseNotes,
+} from "./apply.preflight.package.js";
 
 const execFileAsync = promisify(execFile);
 const RELEASE_APPLY_LONG_TIMEOUT_MS = 120_000;
@@ -60,6 +63,67 @@ describeWhenNotHook(
 
       await expect(readOptionalAgentplaneDependencyVersion(pkgPath)).resolves.toBeNull();
       await expect(packageDependencyExists(pkgPath, "agentplane")).resolves.toBe(false);
+    });
+
+    it("rejects release notes that still contain template placeholder text", async () => {
+      const root = await mkGitRepoRoot();
+      const notesPath = path.join(root, "docs", "releases", "v0.2.7.md");
+      await mkdir(path.dirname(notesPath), { recursive: true });
+      await writeFile(
+        notesPath,
+        [
+          "# Release Notes - v0.2.7",
+          "",
+          "## Summary",
+          "",
+          "- 2-4 bullets with the main release outcomes in plain language.",
+          "",
+          "## Added",
+          "",
+          "- New features or capabilities.",
+          "",
+          "## Writing Rules",
+          "",
+          "- Cover all differences from the release plan (`changes.md`/`changes.json`).",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      await expect(validateReleaseNotes(notesPath, 1)).rejects.toThrow(
+        /template writing instructions/u,
+      );
+    });
+
+    it("rejects release notes with duplicate section headings", async () => {
+      const root = await mkGitRepoRoot();
+      const notesPath = path.join(root, "docs", "releases", "v0.2.7.md");
+      await mkdir(path.dirname(notesPath), { recursive: true });
+      await writeFile(
+        notesPath,
+        [
+          "# Release Notes - v0.2.7",
+          "",
+          "## Summary",
+          "",
+          "- Agents now get deterministic release evidence.",
+          "- Publish checks now cover package parity.",
+          "",
+          "## Added",
+          "",
+          "- Added release evidence checks.",
+          "",
+          "## Added",
+          "",
+          "- Added package parity checks.",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      await expect(validateReleaseNotes(notesPath, 1)).rejects.toThrow(
+        /duplicate section headings.*Added/u,
+      );
     });
 
     it(

--- a/scripts/check-release-notes.mjs
+++ b/scripts/check-release-notes.mjs
@@ -98,6 +98,29 @@ function duplicateSectionHeadings(content) {
   return [...duplicates].toSorted((a, b) => a.localeCompare(b));
 }
 
+function releaseNoteLinesOutsideCodeFences(content) {
+  const lines = content.split(/\r?\n/u);
+  let inFence = false;
+  const visibleLines = [];
+  for (const line of lines) {
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (!inFence) visibleLines.push(line);
+  }
+  return visibleLines;
+}
+
+function unreplacedTemplateBullet(content) {
+  const placeholders = new Set(RELEASE_NOTE_TEMPLATE_PLACEHOLDERS);
+  for (const line of releaseNoteLinesOutsideCodeFences(content)) {
+    const match = /^\s*[-*]\s+(.+?)\s*$/u.exec(line);
+    if (match?.[1] && placeholders.has(match[1])) return match[1];
+  }
+  return null;
+}
+
 const main = defineCheck({
   name: "check-release-notes",
   parseArgs,
@@ -147,12 +170,11 @@ const main = defineCheck({
       if (/^##\s+Writing Rules\s*$/mu.test(content)) {
         errors.push(`Release notes must not include template writing instructions in ${relPath}.`);
       }
-      for (const placeholder of RELEASE_NOTE_TEMPLATE_PLACEHOLDERS) {
-        if (content.includes(placeholder)) {
-          errors.push(
-            `Release notes must replace template placeholder text in ${relPath}: ${placeholder}`,
-          );
-        }
+      const templateBullet = unreplacedTemplateBullet(content);
+      if (templateBullet) {
+        errors.push(
+          `Release notes must replace template placeholder bullet in ${relPath}: ${templateBullet}`,
+        );
       }
       const duplicateHeadings = duplicateSectionHeadings(content);
       if (duplicateHeadings.length > 0) {

--- a/scripts/check-release-notes.mjs
+++ b/scripts/check-release-notes.mjs
@@ -72,6 +72,32 @@ const parseArgs = (argv) => {
   };
 };
 
+const RELEASE_NOTE_TEMPLATE_PLACEHOLDERS = [
+  "2-4 bullets with the main release outcomes in plain language.",
+  "New features or capabilities.",
+  "Behavior/UX improvements that users will notice.",
+  "Bug fixes and regressions.",
+  'Breaking changes, migration steps, or "none".',
+  "Release checks completed (for example: release:prepublish, parity, publish gates).",
+  "Cover all differences from the release plan (`changes.md`/`changes.json`).",
+  "Use detailed, human-readable language, not raw commit log text.",
+  "Keep concrete bullets with explicit outcomes.",
+  "Keep at least one bullet per listed change from `changes.md`/`changes.json`.",
+];
+
+function duplicateSectionHeadings(content) {
+  const seen = new Set();
+  const duplicates = new Set();
+  for (const match of content.matchAll(/^##\s+(.+?)\s*$/gmu)) {
+    const heading = String(match[1] ?? "").trim();
+    if (!heading) continue;
+    const key = heading.toLowerCase();
+    if (seen.has(key)) duplicates.add(heading);
+    seen.add(key);
+  }
+  return [...duplicates].toSorted((a, b) => a.localeCompare(b));
+}
+
 const main = defineCheck({
   name: "check-release-notes",
   parseArgs,
@@ -117,6 +143,22 @@ const main = defineCheck({
       const content = fs.readFileSync(fullPath, "utf8");
       if (!/release\s+notes/i.test(content)) {
         errors.push(`Release notes must include a "Release Notes" heading in ${relPath}.`);
+      }
+      if (/^##\s+Writing Rules\s*$/mu.test(content)) {
+        errors.push(`Release notes must not include template writing instructions in ${relPath}.`);
+      }
+      for (const placeholder of RELEASE_NOTE_TEMPLATE_PLACEHOLDERS) {
+        if (content.includes(placeholder)) {
+          errors.push(
+            `Release notes must replace template placeholder text in ${relPath}: ${placeholder}`,
+          );
+        }
+      }
+      const duplicateHeadings = duplicateSectionHeadings(content);
+      if (duplicateHeadings.length > 0) {
+        errors.push(
+          `Release notes must not include duplicate section headings in ${relPath}: ${duplicateHeadings.join(", ")}`,
+        );
       }
       const minBullets = Math.max(
         minBulletsOverride ?? 0,


### PR DESCRIPTION
Task: `202605130758-4FB61V`
Title: Fix release notes template leakage
Canonical task record: `.agentplane/tasks/202605130758-4FB61V/README.md`

## Summary

Fix release notes template leakage

Remove template placeholders from v0.5.0 release notes and harden release notes validation against placeholder leakage.

## Scope

- In scope: Remove template placeholders from v0.5.0 release notes and harden release notes validation against placeholder leakage.
- Out of scope: unrelated refactors not required for "Fix release notes template leakage".

## Verification

- State: pending
- Note: Not recorded yet.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-13T09:53:33.482Z
- Branch: task/202605130758-4FB61V/release-notes-template-guard
- Head: 24b1dc2ed0f2

```text
 .../blueprint/resolved-snapshot.json               | 415 +++++++++++++++++++++
 docs/releases/v0.5.0.md                            |  32 +-
 .../commands/release/apply.preflight.package.ts    |  50 +++
 .../src/commands/release/apply.preflight.test.ts   |  66 +++-
 scripts/check-release-notes.mjs                    |  42 +++
 5 files changed, 576 insertions(+), 29 deletions(-)
```

</details>
