### PR TITLE
🚧 68KKFW task: Split human and agent CLI output [202605131125-68KKFW]

### DIFF
--- a/.agentplane/tasks/202605131125-68KKFW/README.md
+++ b/.agentplane/tasks/202605131125-68KKFW/README.md
@@ -18,10 +18,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-13T12:16:56.874Z"
+  updated_by: "CODER"
+  note: "Implemented split CLI presentation: agentplane keeps human formatting with aligned report labels and optional ANSI color, while ap/agent mode removes emoji and alignment for raw agent-oriented output. Verified with targeted tests, typecheck, build, knip, pre-push, and hosted GitHub checks."
   attempts: 0
 commit: null
 comments:
@@ -36,8 +36,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: implementing the approved CLI presentation split in the task worktree. Scope is limited to output-mode detection, focused formatting helpers, and targeted verification for agentplane versus ap output."
+  -
+    type: "verify"
+    at: "2026-05-13T12:16:56.874Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented split CLI presentation: agentplane keeps human formatting with aligned report labels and optional ANSI color, while ap/agent mode removes emoji and alignment for raw agent-oriented output. Verified with targeted tests, typecheck, build, knip, pre-push, and hosted GitHub checks."
 doc_version: 3
-doc_updated_at: "2026-05-13T11:26:54.888Z"
+doc_updated_at: "2026-05-13T12:16:56.880Z"
 doc_updated_by: "CODER"
 description: "Make the long-form agentplane command render a cleaner human-oriented output with spacing, alignment, and color while keeping the short ap command minimal and unstyled for agent consumption."
 sections:
@@ -60,11 +66,33 @@ sections:
     4. Manually compare sample `agentplane` and `ap` command output. Expected: same semantic information, different presentation layer only.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-13T12:16:56.874Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Implemented split CLI presentation: agentplane keeps human formatting with aligned report labels and optional ANSI color, while ap/agent mode removes emoji and alignment for raw agent-oriented output. Verified with targeted tests, typecheck, build, knip, pre-push, and hosted GitHub checks.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-13T11:26:54.888Z, excerpt_hash=sha256:7c348c34ec56c71d67a681d706e9702feabe737f38b0983fd4122f053024654b
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605131125-68KKFW-split-cli-output/.agentplane/tasks/202605131125-68KKFW/blueprint/resolved-snapshot.json
+    - old_digest: 6f93c605c490d609a9c62f3d88d5e94ae82329ca7b56a7eb27f197229852c054
+    - current_digest: 6f93c605c490d609a9c62f3d88d5e94ae82329ca7b56a7eb27f197229852c054
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605131125-68KKFW
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
     - Re-run required checks to confirm rollback safety.
-  Findings: ""
+  Findings: |-
+    - Observation: Head 94094c769 passed local pre-push full-fast, output/agent-mode/manual CLI samples, and PR #3629 checks: docs, test, test-windows, release manifest, Socket, changes.
+      Impact: agentplane output is more readable for humans; ap output remains minimal and machine-friendly.
+      Resolution: No unresolved drift observed; recovery-validate is skipped by CI configuration.
 id_source: "generated"
 ---
 ## Summary
@@ -95,6 +123,25 @@ Make the long-form agentplane command render a cleaner human-oriented output wit
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-13T12:16:56.874Z — VERIFY — ok
+
+By: CODER
+
+Note: Implemented split CLI presentation: agentplane keeps human formatting with aligned report labels and optional ANSI color, while ap/agent mode removes emoji and alignment for raw agent-oriented output. Verified with targeted tests, typecheck, build, knip, pre-push, and hosted GitHub checks.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-13T11:26:54.888Z, excerpt_hash=sha256:7c348c34ec56c71d67a681d706e9702feabe737f38b0983fd4122f053024654b
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605131125-68KKFW-split-cli-output/.agentplane/tasks/202605131125-68KKFW/blueprint/resolved-snapshot.json
+- old_digest: 6f93c605c490d609a9c62f3d88d5e94ae82329ca7b56a7eb27f197229852c054
+- current_digest: 6f93c605c490d609a9c62f3d88d5e94ae82329ca7b56a7eb27f197229852c054
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605131125-68KKFW
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -103,3 +150,7 @@ Make the long-form agentplane command render a cleaner human-oriented output wit
 - Re-run required checks to confirm rollback safety.
 
 ## Findings
+
+- Observation: Head 94094c769 passed local pre-push full-fast, output/agent-mode/manual CLI samples, and PR #3629 checks: docs, test, test-windows, release manifest, Socket, changes.
+  Impact: agentplane output is more readable for humans; ap output remains minimal and machine-friendly.
+  Resolution: No unresolved drift observed; recovery-validate is skipped by CI configuration.

--- a/.agentplane/tasks/202605131125-68KKFW/README.md
+++ b/.agentplane/tasks/202605131125-68KKFW/README.md
@@ -1,0 +1,105 @@
+---
+id: "202605131125-68KKFW"
+title: "Split human and agent CLI output"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "cli"
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-13T11:26:31.531Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implementing the approved CLI presentation split in the task worktree. Scope is limited to output-mode detection, focused formatting helpers, and targeted verification for agentplane versus ap output."
+events:
+  -
+    type: "status"
+    at: "2026-05-13T11:26:54.888Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implementing the approved CLI presentation split in the task worktree. Scope is limited to output-mode detection, focused formatting helpers, and targeted verification for agentplane versus ap output."
+doc_version: 3
+doc_updated_at: "2026-05-13T11:26:54.888Z"
+doc_updated_by: "CODER"
+description: "Make the long-form agentplane command render a cleaner human-oriented output with spacing, alignment, and color while keeping the short ap command minimal and unstyled for agent consumption."
+sections:
+  Summary: |-
+    Split human and agent CLI output
+    
+    Make the long-form agentplane command render a cleaner human-oriented output with spacing, alignment, and color while keeping the short ap command minimal and unstyled for agent consumption.
+  Scope: |-
+    - In scope: Make the long-form agentplane command render a cleaner human-oriented output with spacing, alignment, and color while keeping the short ap command minimal and unstyled for agent consumption.
+    - Out of scope: unrelated refactors not required for "Split human and agent CLI output".
+  Plan: |-
+    1. Locate the CLI invocation/output formatting layer and identify how `agentplane` and `ap` entrypoints differ at runtime.
+    2. Add a small output-mode decision so `agentplane` uses human-oriented spacing/alignment/color and `ap` stays plain/minimal for agents.
+    3. Update focused tests or snapshots that assert the two output contracts.
+    4. Run task Verify Steps plus targeted CLI checks; record evidence before integration.
+  Verify Steps: |-
+    1. Run `ap task verify-show 202605131125-68KKFW`. Expected: the task verification contract is readable and has no unresolved setup blockers.
+    2. Run focused CLI output tests covering `agentplane` and `ap` entrypoints. Expected: `agentplane` output contains human formatting while `ap` output remains plain/minimal.
+    3. Run the relevant package typecheck/lint or exact-file checks for touched CLI code. Expected: no regressions in touched scope.
+    4. Manually compare sample `agentplane` and `ap` command output. Expected: same semantic information, different presentation layer only.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Split human and agent CLI output
+
+Make the long-form agentplane command render a cleaner human-oriented output with spacing, alignment, and color while keeping the short ap command minimal and unstyled for agent consumption.
+
+## Scope
+
+- In scope: Make the long-form agentplane command render a cleaner human-oriented output with spacing, alignment, and color while keeping the short ap command minimal and unstyled for agent consumption.
+- Out of scope: unrelated refactors not required for "Split human and agent CLI output".
+
+## Plan
+
+1. Locate the CLI invocation/output formatting layer and identify how `agentplane` and `ap` entrypoints differ at runtime.
+2. Add a small output-mode decision so `agentplane` uses human-oriented spacing/alignment/color and `ap` stays plain/minimal for agents.
+3. Update focused tests or snapshots that assert the two output contracts.
+4. Run task Verify Steps plus targeted CLI checks; record evidence before integration.
+
+## Verify Steps
+
+1. Run `ap task verify-show 202605131125-68KKFW`. Expected: the task verification contract is readable and has no unresolved setup blockers.
+2. Run focused CLI output tests covering `agentplane` and `ap` entrypoints. Expected: `agentplane` output contains human formatting while `ap` output remains plain/minimal.
+3. Run the relevant package typecheck/lint or exact-file checks for touched CLI code. Expected: no regressions in touched scope.
+4. Manually compare sample `agentplane` and `ap` command output. Expected: same semantic information, different presentation layer only.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605131125-68KKFW/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605131125-68KKFW/blueprint/resolved-snapshot.json
@@ -1,0 +1,513 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605131125-68KKFW",
+    "title": "Split human and agent CLI output",
+    "description": "Make the long-form agentplane command render a cleaner human-oriented output with spacing, alignment, and color while keeping the short ap command minimal and unstyled for agent consumption.",
+    "tags": [
+      "cli",
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605131125-68KKFW",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "6f93c605c490d609a9c62f3d88d5e94ae82329ca7b56a7eb27f197229852c054"
+  }
+}

--- a/.agentplane/tasks/202605131125-68KKFW/pr/diffstat.txt
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/diffstat.txt
@@ -3,6 +3,9 @@
  .../task-backend/redmine/backend-sync/sync.ts      |  10 +-
  packages/agentplane/src/cli/output.test.ts         |  34 +-
  packages/agentplane/src/cli/output.ts              | 127 ++++-
+ .../agentplane/src/cli/run-cli.core.init.test.ts   |   1 +
  packages/agentplane/src/commands/acr/validate.ts   |   3 +-
  packages/agentplane/src/commands/doctor.run.ts     |   4 +-
- 7 files changed, 674 insertions(+), 22 deletions(-)
+ .../src/runtime/shared/runtime-artifacts.ts        |   1 +
+ scripts/oversized-test-baseline.json               |   8 +-
+ 10 files changed, 682 insertions(+), 24 deletions(-)

--- a/.agentplane/tasks/202605131125-68KKFW/pr/diffstat.txt
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/diffstat.txt
@@ -1,7 +1,8 @@
+ .../blueprint/resolved-snapshot.json               | 513 +++++++++++++++++++++
  .../src/backends/task-backend/cloud-pull.ts        |   5 +-
  .../task-backend/redmine/backend-sync/sync.ts      |  10 +-
- packages/agentplane/src/cli/output.test.ts         |  34 +++++-
- packages/agentplane/src/cli/output.ts              | 127 ++++++++++++++++++---
+ packages/agentplane/src/cli/output.test.ts         |  34 +-
+ packages/agentplane/src/cli/output.ts              | 127 ++++-
  packages/agentplane/src/commands/acr/validate.ts   |   3 +-
  packages/agentplane/src/commands/doctor.run.ts     |   4 +-
- 6 files changed, 161 insertions(+), 22 deletions(-)
+ 7 files changed, 674 insertions(+), 22 deletions(-)

--- a/.agentplane/tasks/202605131125-68KKFW/pr/diffstat.txt
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/diffstat.txt
@@ -1,9 +1,10 @@
  .../blueprint/resolved-snapshot.json               | 513 +++++++++++++++++++++
  .../src/backends/task-backend/cloud-pull.ts        |   5 +-
  .../task-backend/redmine/backend-sync/sync.ts      |  10 +-
+ .../run-cli.core.help-snap.test.ts.snap            | 362 +--------------
  packages/agentplane/src/cli/output.test.ts         |  34 +-
  packages/agentplane/src/cli/output.ts              | 127 ++++-
  .../agentplane/src/cli/run-cli.core.init.test.ts   |   3 +
  packages/agentplane/src/commands/acr/validate.ts   |   3 +-
  packages/agentplane/src/commands/doctor.run.ts     |   4 +-
- 8 files changed, 677 insertions(+), 22 deletions(-)
+ 9 files changed, 700 insertions(+), 361 deletions(-)

--- a/.agentplane/tasks/202605131125-68KKFW/pr/diffstat.txt
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/diffstat.txt
@@ -3,9 +3,7 @@
  .../task-backend/redmine/backend-sync/sync.ts      |  10 +-
  packages/agentplane/src/cli/output.test.ts         |  34 +-
  packages/agentplane/src/cli/output.ts              | 127 ++++-
- .../agentplane/src/cli/run-cli.core.init.test.ts   |   1 +
+ .../agentplane/src/cli/run-cli.core.init.test.ts   |   3 +
  packages/agentplane/src/commands/acr/validate.ts   |   3 +-
  packages/agentplane/src/commands/doctor.run.ts     |   4 +-
- .../src/runtime/shared/runtime-artifacts.ts        |   1 +
- scripts/oversized-test-baseline.json               |   8 +-
- 10 files changed, 682 insertions(+), 24 deletions(-)
+ 8 files changed, 677 insertions(+), 22 deletions(-)

--- a/.agentplane/tasks/202605131125-68KKFW/pr/diffstat.txt
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/diffstat.txt
@@ -1,0 +1,7 @@
+ .../src/backends/task-backend/cloud-pull.ts        |   5 +-
+ .../task-backend/redmine/backend-sync/sync.ts      |  10 +-
+ packages/agentplane/src/cli/output.test.ts         |  34 +++++-
+ packages/agentplane/src/cli/output.ts              | 127 ++++++++++++++++++---
+ packages/agentplane/src/commands/acr/validate.ts   |   3 +-
+ packages/agentplane/src/commands/doctor.run.ts     |   4 +-
+ 6 files changed, 161 insertions(+), 22 deletions(-)

--- a/.agentplane/tasks/202605131125-68KKFW/pr/github-body.md
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/github-body.md
@@ -1,0 +1,39 @@
+Task: `202605131125-68KKFW`
+Title: Split human and agent CLI output
+Canonical task record: `.agentplane/tasks/202605131125-68KKFW/README.md`
+
+## Summary
+
+Split human and agent CLI output
+
+Make the long-form agentplane command render a cleaner human-oriented output with spacing, alignment, and color while keeping the short ap command minimal and unstyled for agent consumption.
+
+## Scope
+
+- In scope: Make the long-form agentplane command render a cleaner human-oriented output with spacing, alignment, and color while keeping the short ap command minimal and unstyled for agent consumption.
+- Out of scope: unrelated refactors not required for "Split human and agent CLI output".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-13T11:36:20.423Z
+- Branch: task/202605131125-68KKFW/split-cli-output
+- Head: a4cbe108e901
+
+```text
+ .../src/backends/task-backend/cloud-pull.ts        |   5 +-
+ .../task-backend/redmine/backend-sync/sync.ts      |  10 +-
+ packages/agentplane/src/cli/output.test.ts         |  34 +++++-
+ packages/agentplane/src/cli/output.ts              | 127 ++++++++++++++++++---
+ packages/agentplane/src/commands/acr/validate.ts   |   3 +-
+ packages/agentplane/src/commands/doctor.run.ts     |   4 +-
+ 6 files changed, 161 insertions(+), 22 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605131125-68KKFW/pr/github-body.md
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/github-body.md
@@ -22,20 +22,21 @@ Make the long-form agentplane command render a cleaner human-oriented output wit
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-13T12:05:39.768Z
+- Updated: 2026-05-13T12:07:33.985Z
 - Branch: task/202605131125-68KKFW/split-cli-output
-- Head: aa468c8a0eed
+- Head: 8b8c95312c78
 
 ```text
  .../blueprint/resolved-snapshot.json               | 513 +++++++++++++++++++++
  .../src/backends/task-backend/cloud-pull.ts        |   5 +-
  .../task-backend/redmine/backend-sync/sync.ts      |  10 +-
+ .../run-cli.core.help-snap.test.ts.snap            | 362 +--------------
  packages/agentplane/src/cli/output.test.ts         |  34 +-
  packages/agentplane/src/cli/output.ts              | 127 ++++-
  .../agentplane/src/cli/run-cli.core.init.test.ts   |   3 +
  packages/agentplane/src/commands/acr/validate.ts   |   3 +-
  packages/agentplane/src/commands/doctor.run.ts     |   4 +-
- 8 files changed, 677 insertions(+), 22 deletions(-)
+ 9 files changed, 700 insertions(+), 361 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605131125-68KKFW/pr/github-body.md
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/github-body.md
@@ -15,8 +15,8 @@ Make the long-form agentplane command render a cleaner human-oriented output wit
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Implemented split CLI presentation: agentplane keeps human formatting with aligned report labels and optional ANSI color, while ap/agent mode removes emoji and alignment for raw agent-oriented output. Verified with targeted tests, typecheck, build, knip, pre-push, and hosted GitHub checks.
 - Canonical workflow state lives in the task README.
 
 <details>

--- a/.agentplane/tasks/202605131125-68KKFW/pr/github-body.md
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/github-body.md
@@ -22,9 +22,9 @@ Make the long-form agentplane command render a cleaner human-oriented output wit
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-13T11:36:20.423Z
+- Updated: 2026-05-13T11:50:27.751Z
 - Branch: task/202605131125-68KKFW/split-cli-output
-- Head: a4cbe108e901
+- Head: 0cf47920f46b
 
 ```text
  .../blueprint/resolved-snapshot.json               | 513 +++++++++++++++++++++
@@ -32,9 +32,12 @@ Make the long-form agentplane command render a cleaner human-oriented output wit
  .../task-backend/redmine/backend-sync/sync.ts      |  10 +-
  packages/agentplane/src/cli/output.test.ts         |  34 +-
  packages/agentplane/src/cli/output.ts              | 127 ++++-
+ .../agentplane/src/cli/run-cli.core.init.test.ts   |   1 +
  packages/agentplane/src/commands/acr/validate.ts   |   3 +-
  packages/agentplane/src/commands/doctor.run.ts     |   4 +-
- 7 files changed, 674 insertions(+), 22 deletions(-)
+ .../src/runtime/shared/runtime-artifacts.ts        |   1 +
+ scripts/oversized-test-baseline.json               |   8 +-
+ 10 files changed, 682 insertions(+), 24 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605131125-68KKFW/pr/github-body.md
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/github-body.md
@@ -22,9 +22,9 @@ Make the long-form agentplane command render a cleaner human-oriented output wit
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-13T11:57:06.791Z
+- Updated: 2026-05-13T12:05:39.768Z
 - Branch: task/202605131125-68KKFW/split-cli-output
-- Head: ec32aeedaa16
+- Head: aa468c8a0eed
 
 ```text
  .../blueprint/resolved-snapshot.json               | 513 +++++++++++++++++++++

--- a/.agentplane/tasks/202605131125-68KKFW/pr/github-body.md
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/github-body.md
@@ -22,9 +22,9 @@ Make the long-form agentplane command render a cleaner human-oriented output wit
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-13T11:50:27.751Z
+- Updated: 2026-05-13T11:57:06.791Z
 - Branch: task/202605131125-68KKFW/split-cli-output
-- Head: 0cf47920f46b
+- Head: ec32aeedaa16
 
 ```text
  .../blueprint/resolved-snapshot.json               | 513 +++++++++++++++++++++
@@ -32,12 +32,10 @@ Make the long-form agentplane command render a cleaner human-oriented output wit
  .../task-backend/redmine/backend-sync/sync.ts      |  10 +-
  packages/agentplane/src/cli/output.test.ts         |  34 +-
  packages/agentplane/src/cli/output.ts              | 127 ++++-
- .../agentplane/src/cli/run-cli.core.init.test.ts   |   1 +
+ .../agentplane/src/cli/run-cli.core.init.test.ts   |   3 +
  packages/agentplane/src/commands/acr/validate.ts   |   3 +-
  packages/agentplane/src/commands/doctor.run.ts     |   4 +-
- .../src/runtime/shared/runtime-artifacts.ts        |   1 +
- scripts/oversized-test-baseline.json               |   8 +-
- 10 files changed, 682 insertions(+), 24 deletions(-)
+ 8 files changed, 677 insertions(+), 22 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605131125-68KKFW/pr/github-body.md
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/github-body.md
@@ -27,13 +27,14 @@ Make the long-form agentplane command render a cleaner human-oriented output wit
 - Head: a4cbe108e901
 
 ```text
+ .../blueprint/resolved-snapshot.json               | 513 +++++++++++++++++++++
  .../src/backends/task-backend/cloud-pull.ts        |   5 +-
  .../task-backend/redmine/backend-sync/sync.ts      |  10 +-
- packages/agentplane/src/cli/output.test.ts         |  34 +++++-
- packages/agentplane/src/cli/output.ts              | 127 ++++++++++++++++++---
+ packages/agentplane/src/cli/output.test.ts         |  34 +-
+ packages/agentplane/src/cli/output.ts              | 127 ++++-
  packages/agentplane/src/commands/acr/validate.ts   |   3 +-
  packages/agentplane/src/commands/doctor.run.ts     |   4 +-
- 6 files changed, 161 insertions(+), 22 deletions(-)
+ 7 files changed, 674 insertions(+), 22 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605131125-68KKFW/pr/github-title.txt
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 68KKFW task: Split human and agent CLI output [202605131125-68KKFW]

--- a/.agentplane/tasks/202605131125-68KKFW/pr/meta.json
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605131125-68KKFW/split-cli-output",
+  "created_at": "2026-05-13T11:26:55.005Z",
+  "head_sha": "a4cbe108e90139d0ff54c4854ee9ee54254a4745",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202605131125-68KKFW",
+  "updated_at": "2026-05-13T11:36:20.423Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605131125-68KKFW/pr/meta.json
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605131125-68KKFW/split-cli-output",
   "created_at": "2026-05-13T11:26:55.005Z",
-  "head_sha": "ec32aeedaa169bd282eb399422a6f6ce9803d78c",
+  "head_sha": "aa468c8a0eed55609f954fed84eb9fa8e4809b0e",
   "last_verified_at": null,
   "last_verified_sha": null,
   "pr_number": 3629,
@@ -10,7 +10,7 @@
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202605131125-68KKFW",
-  "updated_at": "2026-05-13T11:57:06.791Z",
+  "updated_at": "2026-05-13T12:05:39.768Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202605131125-68KKFW/pr/meta.json
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/meta.json
@@ -3,8 +3,8 @@
   "branch": "task/202605131125-68KKFW/split-cli-output",
   "created_at": "2026-05-13T11:26:55.005Z",
   "head_sha": "8b8c95312c78d828e48593f9a39a9b2edb32f6af",
-  "last_verified_at": null,
-  "last_verified_sha": null,
+  "last_verified_at": "2026-05-13T12:16:56.874Z",
+  "last_verified_sha": "8b8c95312c78d828e48593f9a39a9b2edb32f6af",
   "pr_number": 3629,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3629",
   "schema_version": 1,
@@ -12,6 +12,6 @@
   "task_id": "202605131125-68KKFW",
   "updated_at": "2026-05-13T12:07:33.985Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605131125-68KKFW/pr/meta.json
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605131125-68KKFW/split-cli-output",
   "created_at": "2026-05-13T11:26:55.005Z",
-  "head_sha": "a4cbe108e90139d0ff54c4854ee9ee54254a4745",
+  "head_sha": "0cf47920f46b2ced76f4889c0aeb6a9a7c1f7b8f",
   "last_verified_at": null,
   "last_verified_sha": null,
   "pr_number": 3629,
@@ -10,7 +10,7 @@
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202605131125-68KKFW",
-  "updated_at": "2026-05-13T11:36:48.128Z",
+  "updated_at": "2026-05-13T11:50:27.751Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202605131125-68KKFW/pr/meta.json
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "a4cbe108e90139d0ff54c4854ee9ee54254a4745",
   "last_verified_at": null,
   "last_verified_sha": null,
+  "pr_number": 3629,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3629",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605131125-68KKFW",
-  "updated_at": "2026-05-13T11:36:20.423Z",
+  "updated_at": "2026-05-13T11:36:48.128Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202605131125-68KKFW/pr/meta.json
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605131125-68KKFW/split-cli-output",
   "created_at": "2026-05-13T11:26:55.005Z",
-  "head_sha": "aa468c8a0eed55609f954fed84eb9fa8e4809b0e",
+  "head_sha": "8b8c95312c78d828e48593f9a39a9b2edb32f6af",
   "last_verified_at": null,
   "last_verified_sha": null,
   "pr_number": 3629,
@@ -10,7 +10,7 @@
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202605131125-68KKFW",
-  "updated_at": "2026-05-13T12:05:39.768Z",
+  "updated_at": "2026-05-13T12:07:33.985Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202605131125-68KKFW/pr/meta.json
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605131125-68KKFW/split-cli-output",
   "created_at": "2026-05-13T11:26:55.005Z",
-  "head_sha": "0cf47920f46b2ced76f4889c0aeb6a9a7c1f7b8f",
+  "head_sha": "ec32aeedaa169bd282eb399422a6f6ce9803d78c",
   "last_verified_at": null,
   "last_verified_sha": null,
   "pr_number": 3629,
@@ -10,7 +10,7 @@
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202605131125-68KKFW",
-  "updated_at": "2026-05-13T11:50:27.751Z",
+  "updated_at": "2026-05-13T11:57:06.791Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202605131125-68KKFW/pr/review.md
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/review.md
@@ -1,0 +1,42 @@
+# PR Review
+
+Created: 2026-05-13T11:26:55.005Z
+
+## Task
+
+- Task: `202605131125-68KKFW`
+- Title: Split human and agent CLI output
+- Status: DOING
+- Branch: `task/202605131125-68KKFW/split-cli-output`
+- Canonical task record: `.agentplane/tasks/202605131125-68KKFW/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-13T11:36:20.423Z
+- Branch: task/202605131125-68KKFW/split-cli-output
+- Head: a4cbe108e901
+
+```text
+ .../src/backends/task-backend/cloud-pull.ts        |   5 +-
+ .../task-backend/redmine/backend-sync/sync.ts      |  10 +-
+ packages/agentplane/src/cli/output.test.ts         |  34 +++++-
+ packages/agentplane/src/cli/output.ts              | 127 ++++++++++++++++++---
+ packages/agentplane/src/commands/acr/validate.ts   |   3 +-
+ packages/agentplane/src/commands/doctor.run.ts     |   4 +-
+ 6 files changed, 161 insertions(+), 22 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605131125-68KKFW/pr/review.md
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/review.md
@@ -24,20 +24,21 @@ Created: 2026-05-13T11:26:55.005Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-13T12:05:39.768Z
+- Updated: 2026-05-13T12:07:33.985Z
 - Branch: task/202605131125-68KKFW/split-cli-output
-- Head: aa468c8a0eed
+- Head: 8b8c95312c78
 
 ```text
  .../blueprint/resolved-snapshot.json               | 513 +++++++++++++++++++++
  .../src/backends/task-backend/cloud-pull.ts        |   5 +-
  .../task-backend/redmine/backend-sync/sync.ts      |  10 +-
+ .../run-cli.core.help-snap.test.ts.snap            | 362 +--------------
  packages/agentplane/src/cli/output.test.ts         |  34 +-
  packages/agentplane/src/cli/output.ts              | 127 ++++-
  .../agentplane/src/cli/run-cli.core.init.test.ts   |   3 +
  packages/agentplane/src/commands/acr/validate.ts   |   3 +-
  packages/agentplane/src/commands/doctor.run.ts     |   4 +-
- 8 files changed, 677 insertions(+), 22 deletions(-)
+ 9 files changed, 700 insertions(+), 361 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605131125-68KKFW/pr/review.md
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-05-13T11:26:55.005Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Implemented split CLI presentation: agentplane keeps human formatting with aligned report labels and optional ANSI color, while ap/agent mode removes emoji and alignment for raw agent-oriented output. Verified with targeted tests, typecheck, build, knip, pre-push, and hosted GitHub checks.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes

--- a/.agentplane/tasks/202605131125-68KKFW/pr/review.md
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/review.md
@@ -24,9 +24,9 @@ Created: 2026-05-13T11:26:55.005Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-13T11:50:27.751Z
+- Updated: 2026-05-13T11:57:06.791Z
 - Branch: task/202605131125-68KKFW/split-cli-output
-- Head: 0cf47920f46b
+- Head: ec32aeedaa16
 
 ```text
  .../blueprint/resolved-snapshot.json               | 513 +++++++++++++++++++++
@@ -34,12 +34,10 @@ Created: 2026-05-13T11:26:55.005Z
  .../task-backend/redmine/backend-sync/sync.ts      |  10 +-
  packages/agentplane/src/cli/output.test.ts         |  34 +-
  packages/agentplane/src/cli/output.ts              | 127 ++++-
- .../agentplane/src/cli/run-cli.core.init.test.ts   |   1 +
+ .../agentplane/src/cli/run-cli.core.init.test.ts   |   3 +
  packages/agentplane/src/commands/acr/validate.ts   |   3 +-
  packages/agentplane/src/commands/doctor.run.ts     |   4 +-
- .../src/runtime/shared/runtime-artifacts.ts        |   1 +
- scripts/oversized-test-baseline.json               |   8 +-
- 10 files changed, 682 insertions(+), 24 deletions(-)
+ 8 files changed, 677 insertions(+), 22 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605131125-68KKFW/pr/review.md
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/review.md
@@ -24,9 +24,9 @@ Created: 2026-05-13T11:26:55.005Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-13T11:36:20.423Z
+- Updated: 2026-05-13T11:50:27.751Z
 - Branch: task/202605131125-68KKFW/split-cli-output
-- Head: a4cbe108e901
+- Head: 0cf47920f46b
 
 ```text
  .../blueprint/resolved-snapshot.json               | 513 +++++++++++++++++++++
@@ -34,9 +34,12 @@ Created: 2026-05-13T11:26:55.005Z
  .../task-backend/redmine/backend-sync/sync.ts      |  10 +-
  packages/agentplane/src/cli/output.test.ts         |  34 +-
  packages/agentplane/src/cli/output.ts              | 127 ++++-
+ .../agentplane/src/cli/run-cli.core.init.test.ts   |   1 +
  packages/agentplane/src/commands/acr/validate.ts   |   3 +-
  packages/agentplane/src/commands/doctor.run.ts     |   4 +-
- 7 files changed, 674 insertions(+), 22 deletions(-)
+ .../src/runtime/shared/runtime-artifacts.ts        |   1 +
+ scripts/oversized-test-baseline.json               |   8 +-
+ 10 files changed, 682 insertions(+), 24 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605131125-68KKFW/pr/review.md
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/review.md
@@ -29,13 +29,14 @@ Created: 2026-05-13T11:26:55.005Z
 - Head: a4cbe108e901
 
 ```text
+ .../blueprint/resolved-snapshot.json               | 513 +++++++++++++++++++++
  .../src/backends/task-backend/cloud-pull.ts        |   5 +-
  .../task-backend/redmine/backend-sync/sync.ts      |  10 +-
- packages/agentplane/src/cli/output.test.ts         |  34 +++++-
- packages/agentplane/src/cli/output.ts              | 127 ++++++++++++++++++---
+ packages/agentplane/src/cli/output.test.ts         |  34 +-
+ packages/agentplane/src/cli/output.ts              | 127 ++++-
  packages/agentplane/src/commands/acr/validate.ts   |   3 +-
  packages/agentplane/src/commands/doctor.run.ts     |   4 +-
- 6 files changed, 161 insertions(+), 22 deletions(-)
+ 7 files changed, 674 insertions(+), 22 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605131125-68KKFW/pr/review.md
+++ b/.agentplane/tasks/202605131125-68KKFW/pr/review.md
@@ -24,9 +24,9 @@ Created: 2026-05-13T11:26:55.005Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-13T11:57:06.791Z
+- Updated: 2026-05-13T12:05:39.768Z
 - Branch: task/202605131125-68KKFW/split-cli-output
-- Head: ec32aeedaa16
+- Head: aa468c8a0eed
 
 ```text
  .../blueprint/resolved-snapshot.json               | 513 +++++++++++++++++++++

--- a/packages/agentplane/src/backends/task-backend/cloud-pull.ts
+++ b/packages/agentplane/src/backends/task-backend/cloud-pull.ts
@@ -1,3 +1,4 @@
+import { infoMessage } from "../../cli/output.js";
 import type { TaskData } from "./shared.js";
 
 export type CloudPullPlan = {
@@ -55,7 +56,9 @@ export function emitCloudPullDiffSummary(opts: {
   const ignoredRemoteOnly = opts.plan?.ignoredRemoteOnly ?? [];
   process.stdout.write(
     [
-      `ℹ️ cloud pull diff changed=${changed.length} ignored_remote_only=${ignoredRemoteOnly.length} conflicts=${opts.conflicts.length}`,
+      infoMessage(
+        `cloud pull diff changed=${changed.length} ignored_remote_only=${ignoredRemoteOnly.length} conflicts=${opts.conflicts.length}`,
+      ),
       ...changed
         .slice(0, 20)
         .map((entry) => `- changed ${entry.taskId}: ${entry.fields.join(",")}`),

--- a/packages/agentplane/src/backends/task-backend/redmine/backend-sync/sync.ts
+++ b/packages/agentplane/src/backends/task-backend/redmine/backend-sync/sync.ts
@@ -1,3 +1,4 @@
+import { infoMessage, successMessage } from "../../../../cli/output.js";
 import { BackendError, toStringSafe, type TaskData } from "../../shared.js";
 import type { RedmineSyncContext } from "./context.js";
 
@@ -32,7 +33,7 @@ export async function syncPushRedmine(
   const tasks = await context.cache.listTasks();
   const dirty = tasks.filter((task) => task.dirty);
   if (dirty.length === 0) {
-    if (!quiet) process.stdout.write("ℹ️ no local task changes to push\n");
+    if (!quiet) process.stdout.write(`${infoMessage("no local task changes to push")}\n`);
     return;
   }
   if (!confirm) {
@@ -42,7 +43,8 @@ export async function syncPushRedmine(
     throw new BackendError("Refusing to push without --yes (preview above)", "E_BACKEND");
   }
   await context.writeTasks(dirty);
-  if (!quiet) process.stdout.write(`✅ pushed ${dirty.length} task(s) (dirty)\n`);
+  if (!quiet)
+    process.stdout.write(`${successMessage("pushed", `${dirty.length} task(s)`, "dirty")}\n`);
 }
 
 export async function syncPullRedmine(
@@ -79,7 +81,9 @@ export async function syncPullRedmine(
     }
     await context.cacheTask(remoteTask, false);
   }
-  if (!quiet) process.stdout.write(`✅ pulled ${remoteById.size} task(s) (remote)\n`);
+  if (!quiet) {
+    process.stdout.write(`${successMessage("pulled", `${remoteById.size} task(s)`, "remote")}\n`);
+  }
 }
 
 export async function handleRedmineConflict(

--- a/packages/agentplane/src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap
+++ b/packages/agentplane/src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap
@@ -53,322 +53,6 @@ Commands:
     pr check  Check that PR artifacts are present and valid.
     pr close  Close a GitHub PR through REST with optional remote head-branch deletion.
     pr close-superseded  Close a superseded task PR using task artifacts.
-    pr note  Append a handoff note into PR review.md.
-    pr open  Create PR artifacts for a task and, unless --sync-only is set, publish/link the remote GitHub PR.
-    pr update  Update PR artifacts (review packet, diffstat, and GitHub projections).
-  Branch:
-    branch base  Manage the pinned base branch used in branch_pr workflow.
-    branch base clear  Clear the pinned base branch.
-    branch base explain  Explain current, pinned, and effective base branch resolution.
-    branch base get  Print the pinned base branch.
-    branch base set  Pin a base branch by name, or pin the current branch.
-    branch remove  Remove a task branch and/or its worktree.
-    branch status  Show ahead/behind status for a branch relative to a base branch.
-    cleanup  Clean up local branches/worktrees.
-    cleanup merged  Delete merged task branches/worktrees (branch_pr workflow).
-  Backend:
-    backend  Backend-related operations.
-    backend connect  Configure a cloud backend connection.
-    backend inspect  Inspect visible backend readiness facts without mutating remote state.
-    backend sync  Sync the configured backend (push or pull).
-    sync  Sync the configured backend (alias).
-  Config:
-    config set  Update WORKFLOW front matter config (dotted keys).
-    config show  Print resolved WORKFLOW-backed config JSON.
-    mode get  Print workflow mode.
-    mode set  Set workflow mode.
-    profile set  Apply setup profile presets to WORKFLOW config.
-  Setup:
-    init  Initialize agentplane project files under .agentplane/.
-    upgrade  Upgrade the local agentplane framework bundle in the repo.
-  Quality:
-    doctor  Check workspace invariants for a normal agentplane installation (with optional dev source checks).
-    doctor git-locks  Check Git index lock state for this repository and suggest cleanup.
-  Diagnostics:
-    runtime  Inspect which agentplane runtime/binary/package sources are active.
-    runtime explain  Explain the active binary, runtime mode, and resolved package roots.
-  Recipes:
-    recipes  Recipe management commands.
-    recipes active  List active project overlays.
-    recipes add  Vendor a cached recipe into the current project.
-    recipes cache  Manage recipes cache.
-    recipes cache prune  Prune global recipe cache entries.
-    recipes detach  Convert a linked vendored recipe into a project-local copy.
-    recipes disable  Disable an active project overlay for the current project.
-    recipes enable  Enable an installed project overlay for the current project.
-    recipes explain  Show detailed info for a vendored recipe.
-    recipes explain-active  Print the compiled active overlay bundle.
-    recipes info  Show cached recipe metadata.
-    recipes install  Install a recipe into the global cache from remote index, local archive, or URL.
-    recipes list  List cached recipes.
-    recipes list-remote  List recipes from the remote index (or cache).
-    recipes remove  Remove a vendored recipe from the current project.
-    recipes update  Refresh a vendored recipe from the cached source.
-  Blueprints:
-    blueprint  List and explain blueprint routing without executing a task.
-    blueprint drift  Check whether a task resolved blueprint snapshot is current.
-    blueprint examples  Show practical blueprint route inspection examples.
-    blueprint explain  Explain blueprint route selection for a task or synthetic input.
-    blueprint list  List built-in and optional project-local blueprint routes.
-    blueprint report  Report project-local blueprint trust compatibility.
-    blueprint scaffold  Create a project-local blueprint JSON scaffold without enabling it.
-    blueprint snapshot  Refresh the resolved blueprint snapshot artifact for a task.
-    blueprint validate  Validate project-local blueprint JSON without registering or executing it.
-    blueprints  Manage external blueprint catalogs and installs.
-    blueprints catalog  Manage the cached external blueprint catalog index.
-    blueprints catalog info  Show cached external blueprint or pack metadata.
-    blueprints catalog list  List cached external blueprint catalog entries.
-    blueprints catalog refresh  Refresh the cached external blueprint catalog index.
-    blueprints install  Install an external blueprint or blueprint pack into the current project.
-  ACR:
-    acr  Generate, validate, check, explain, and print Agent Change Record artifacts.
-    acr check  Run the ACR merge-gate check for CI and branch review.
-    acr explain  Explain an ACR for human review.
-    acr generate  Generate an Agent Change Record from task, Git, policy, and verification state.
-    acr schema  Print or write the ACR v0.1 JSON Schema.
-    acr validate  Validate an ACR file by schema, local, or CI invariants.
-  Guard:
-    commit  Create a git commit after validating policy and allowlist; if the index is empty, stage matching allowlist paths first.
-    guard  Guard commands (commit checks, git hygiene, and allowlist helpers).
-    guard clean  Ensure the git index has no staged files.
-    guard commit  Validate commit policy and allowlist for staged changes (no commit is created).
-    guard suggest-allow  Suggest minimal --allow prefixes based on staged files.
-  Hooks:
-    hooks  Manage and run git hooks installed by agentplane.
-    hooks install  Install managed git hooks and the agentplane shim.
-    hooks run  Run a managed hook (use \`--\` to pass through additional arguments).
-    hooks uninstall  Uninstall managed git hooks installed by agentplane.
-  Policy:
-    incidents  Promote external incident advice and resolve incident hints for analogous tasks.
-    incidents advise  Resolve relevant incident advice for a task or an ad hoc scope/tag query.
-    incidents collect  Promote reusable resolved external findings from a task into the incident registry.
-  IDE:
-    ide sync  Generate IDE entrypoints from policy gateway file (AGENTS.md or CLAUDE.md).
-  Framework Dev:
-    codex  Codex integration commands.
-    codex plugin  Install and inspect bundled Codex plugin integrations.
-    codex plugin install  Install the bundled AgentPlane plugin into a local Codex marketplace.
-    docs cli  Generate an MDX CLI reference from the current command spec catalog.
-    release  Prepare a release (agent-assisted notes + version bump workflow).
-    release apply  Apply a prepared direct-mode release: bump versions, validate notes, commit, and tag.
-    release candidate  Prepare a branch_pr release candidate: bump versions, validate notes, commit, and optionally push the candidate branch.
-    release plan  Generate an agent-assisted release plan (changes list + next patch version).
-    workflow  Workflow contract commands.
-    workflow build  Build WORKFLOW.md from template layers with strict rendering checks.
-    workflow debug  Run built-in debug checks and capture workflow evidence.
-    workflow land  Run built-in pre-land checks and capture workflow evidence.
-    workflow restore  Restore WORKFLOW.md from last-known-good snapshot.
-    workflow sync  Run built-in sync checks and capture workflow evidence.
-"
-`;
-
-exports[`runCli help snapshots (cli2) > help codex plugin install --compact snapshot 1`] = `
-"codex plugin install - Install the bundled AgentPlane plugin into a local Codex marketplace.
-
-Usage:
-  agentplane codex plugin install [options]
-
-Options:
-  --scope <user|repo>  Install to the user home marketplace or the current repository marketplace. (choices=user|repo, default=user)
-"
-`;
-
-exports[`runCli help snapshots (cli2) > help recipes install --compact snapshot 1`] = `
-"recipes install - Install a recipe into the global cache from remote index, local archive, or URL.
-
-Usage:
-  agentplane recipes install <id|path|url> [--index <path|url>] [--refresh] [--yes] [--on-conflict <fail|rename|overwrite>]
-  agentplane recipes install --name <id> [--index <path|url>] [--refresh] [--yes] [--on-conflict <fail|rename|overwrite>]
-  agentplane recipes install --path <path> [--yes] [--on-conflict <fail|rename|overwrite>]
-  agentplane recipes install --url <url> [--yes] [--on-conflict <fail|rename|overwrite>]
-
-Options:
-  --name <id>  Cache from remote index by recipe id.
-  --path <path>  Cache from local recipe archive path.
-  --url <url>  Cache from recipe archive URL.
-  --index <path|url>  Override recipes index location (used when installing by name / auto-name).
-  --refresh  Refresh remote index cache before installing. (default=false)
-  --yes  Auto-approve network prompts when allowed by config. (default=false)
-  --on-conflict <fail|rename|overwrite>  Deprecated compatibility no-op; recipe installs stay self-contained. (choices=fail|rename|overwrite, default=fail)
-"
-`;
-
-exports[`runCli help snapshots (cli2) > help task --compact snapshot 1`] = `
-"task - Task lifecycle and task-store commands.
-
-Usage:
-  agentplane task <subcommand> [args] [options]
-"
-`;
-
-exports[`runCli help snapshots (cli2) > help task doc set --compact snapshot 1`] = `
-"task doc set - Update a task README section.
-
-Usage:
-  agentplane task doc set <task-id> --section <name> (--text <text> | --file <path>) [--updated-by <id>]
-  agentplane task doc set <task-id> --full-doc (--text <text> | --file <path>) [--updated-by <id>]
-
-Options:
-  --section <name>  Target section heading (must be one of config.tasks.doc.sections). Required unless --full-doc is set.
-  --full-doc  Treat the provided text/file as the full task README payload. (default=false)
-  --text <text>  Section content (mutually exclusive with --file). Literal escaped newlines (\\n) are normalized for inline text.
-  --file <path>  Read section content from a file (mutually exclusive with --text).
-  --updated-by <id>  Optional. Override doc_updated_by metadata (must be non-empty).
-"
-`;
-
-exports[`runCli help snapshots (cli2) > help task new --compact snapshot 1`] = `
-"task new - Create a new task (prints the generated task id).
-
-Usage:
-  agentplane task new --title <text> --description <text> --owner <id> [options]
-
-Options:
-  --title <text>  Task title. (required)
-  --description <text>  Task description. (required)
-  --owner <id>  Owner id (e.g. CODER). (required)
-  --priority <low|normal|med|high>  Task priority (default: med). (choices=low|normal|med|high, default=med)
-  --tag <tag>  Repeatable. Adds a tag (must provide at least one). (repeatable, min=1)
-  --task-kind <analysis|content|docs|code|release|ops>  Structured blueprint task-kind intent. Tags/title remain fallback hints. (choices=analysis|content|docs|code|release|ops)
-  --mutation-scope <none|docs|code|release|ops|unknown>  Structured mutation scope used by blueprint resolution. (choices=none|docs|code|release|ops|unknown)
-  --risk <risk>  Structured risk flag used by blueprint resolution. Repeatable. (repeatable, choices=network|credentials|deploy|publish|merge|security|external_system)
-  --blueprint-request <id>  Explicit blueprint request stored on the task; resolver still validates it. (choices=analysis.light|content.light|docs.change|code.direct|code.branch_pr|performance.benchmark|quality.regression|runner.execution|post_run.improvement_review|release.strict|ops.approval)
-  --depends-on <task-id>  Repeatable. Adds a dependency. Special-case: '[]' is treated as empty. (repeatable)
-  --verify <command>  Repeatable. Verification commands/checks to run for this task. (repeatable)
-  --show-blueprint  Print a resolved blueprint route preview to stderr after creation without changing stdout. (default=false)
-  --allow-duplicate  Allow creating a task even when an open task with a highly similar title already exists. (default=false)
-"
-`;
-
-exports[`runCli help snapshots (cli2) > help task plan --compact snapshot 1`] = `
-"task plan - Task plan commands (set/approve/reject).
-
-Usage:
-  agentplane task plan <set|approve|reject> [args] [options]
-"
-`;
-
-exports[`runCli help snapshots (cli2) > help task run --compact snapshot 1`] = `
-"task run - Prepare or run a task through the shared runner contract.
-
-Usage:
-  agentplane task run <task-id> [options]
-
-Options:
-  --dry-run  Prepare runner artifacts and print invocation metadata without executing a runner. (default=false)
-"
-`;
-
-exports[`runCli help snapshots (cli2) > help work start --json snapshot 1`] = `
-{
-  "args": [
-    {
-      "description": "Existing task id.",
-      "name": "task-id",
-      "required": true,
-      "valueHint": "<task-id>",
-    },
-  ],
-  "examples": [
-    {
-      "cmd": "agentplane work start 202602030608-F1Q8AB --agent CODER --slug cli",
-      "why": "Start work (direct mode records the active task; branch_pr uses a dedicated task branch/worktree).",
-    },
-  ],
-  "group": "Work",
-  "id": [
-    "work",
-    "start",
-  ],
-  "notes": [
-    "When workflow_mode=direct, agentplane does not create task branches; it records a single active task for the workspace.",
-    "When workflow_mode=branch_pr, --worktree is required and the command must be run on the base branch.",
-    "After branch_pr work starts, run owner-scoped task commands from the created worktree so task README/PR artifacts stay attached to one checkout.",
-  ],
-  "options": [
-    {
-      "description": "Agent id (uppercase letters, numbers, underscore).",
-      "kind": "string",
-      "name": "agent",
-      "patternHint": "A–Z, 0–9, underscore",
-      "required": true,
-      "valueHint": "<ID>",
-    },
-    {
-      "description": "Branch slug (lowercase kebab-case).",
-      "kind": "string",
-      "name": "slug",
-      "patternHint": "lowercase kebab-case",
-      "required": true,
-      "valueHint": "<slug>",
-    },
-    {
-      "default": false,
-      "description": "Use git worktree for the task branch. Required when workflow_mode=branch_pr.",
-      "kind": "boolean",
-      "name": "worktree",
-    },
-  ],
-  "summary": "Prepare the workspace for a task (direct: single-stream on current branch; branch_pr: task branch/worktree).",
-  "usage": [
-    "agentplane work start <task-id> --agent <ID> --slug <slug> [options]",
-  ],
-}
-`;
-
-exports[`runCli help snapshots (cli2) help (registry) snapshot 1`] = `
-"Usage:
-  agentplane help [<cmd...>] [--compact] [--json]
-
-Commands:
-  Core:
-    agents  List agent definitions under .agentplane/agents.
-    help  Show help for a command.
-    preflight  Run aggregated preflight checks and print a deterministic readiness report.
-    quickstart  Print the canonical agent bootstrap path and startup guidance.
-    role  Show role-specific workflow guidance.
-  Task:
-    ready  Report dependency readiness details for a task.
-    task  Task lifecycle and task-store commands.
-    task comment  Append a comment to a task.
-    task doc  Task doc commands (show/set).
-    task doc set  Update a task README section.
-    task doc show  Print task README content (entire doc or one section).
-    task list  List tasks with compact resolved blueprint route hints.
-    task new  Create a new task (prints the generated task id).
-    task next  List ready tasks (default status=TODO) with optional filters.
-    task plan  Task plan commands (set/approve/reject).
-    task plan approve  Approve the current task plan (enforces Verify Steps gating when configured).
-    task plan set  Set a task plan (writes the Plan section and resets plan approval to pending).
-    task run  Prepare or run a task through the shared runner contract.
-    task run show  Inspect persisted runner state and result artifacts for an existing run.
-    task run tail  Print the last N lines from the raw agent trace artifact for an existing runner run.
-    task search  Search tasks by text or regex with optional filters.
-    task show  Print task metadata and resolved blueprint route as JSON.
-    task start-ready  Run readiness checks and start a task in one deterministic command.
-    task verify  Record verification results (ok/rework).
-    task verify ok  Record verification as OK (updates Verification section and verification frontmatter).
-    task verify rework  Record verification as needs rework (resets commit, sets status to DOING, updates Verification).
-    task verify-show  Print the task Verify Steps acceptance contract (alias for task doc show --section "Verify Steps").
-  Lifecycle:
-    block  Transition a task to BLOCKED and record a structured Blocked comment.
-    finish  Mark task(s) as DONE and record a structured Verified comment.
-    start  Transition a task to DOING and record a structured Start comment.
-    verify  Record a verification outcome for a task; incident candidates stay task-local unless collected explicitly.
-  Work:
-    work start  Prepare the workspace for a task (direct: single-stream on current branch; branch_pr: task branch/worktree).
-  PR:
-    integrate  Integrate a task branch into the base branch (branch_pr workflow).
-    integrate queue  Serialize branch_pr integration into one merge lane.
-    integrate queue claim  Claim the next queued integration candidate without running integrate.
-    integrate queue enqueue  Add or refresh a verified task branch in the integration queue.
-    integrate queue list  List branch_pr integration queue entries.
-    integrate queue release  Release or complete a queue entry.
-    integrate queue run-next  Claim and run one queued integration candidate.
-    pr  Manage local PR review and GitHub publication artifacts for a task (branch_pr workflow).
-    pr check  Check that PR artifacts are present and valid.
-    pr close  Close a GitHub PR through REST with optional remote head-branch deletion.
-    pr close-superseded  Close a superseded task PR using task artifacts.
     pr flow status  Show branch_pr task branch, remote PR, close-tail, and next-action state.
     pr note  Append a handoff note into PR review.md.
     pr open  Create PR artifacts for a task and, unless --sync-only is set, publish/link the remote GitHub PR.
@@ -498,7 +182,62 @@ Commands:
 "
 `;
 
-exports[`runCli help snapshots (cli2) help task new --compact snapshot 1`] = `
+exports[`runCli help snapshots (cli2) > help codex plugin install --compact snapshot 1`] = `
+"codex plugin install - Install the bundled AgentPlane plugin into a local Codex marketplace.
+
+Usage:
+  agentplane codex plugin install [options]
+
+Options:
+  --scope <user|repo>  Install to the user home marketplace or the current repository marketplace. (choices=user|repo, default=user)
+"
+`;
+
+exports[`runCli help snapshots (cli2) > help recipes install --compact snapshot 1`] = `
+"recipes install - Install a recipe into the global cache from remote index, local archive, or URL.
+
+Usage:
+  agentplane recipes install <id|path|url> [--index <path|url>] [--refresh] [--yes] [--on-conflict <fail|rename|overwrite>]
+  agentplane recipes install --name <id> [--index <path|url>] [--refresh] [--yes] [--on-conflict <fail|rename|overwrite>]
+  agentplane recipes install --path <path> [--yes] [--on-conflict <fail|rename|overwrite>]
+  agentplane recipes install --url <url> [--yes] [--on-conflict <fail|rename|overwrite>]
+
+Options:
+  --name <id>  Cache from remote index by recipe id.
+  --path <path>  Cache from local recipe archive path.
+  --url <url>  Cache from recipe archive URL.
+  --index <path|url>  Override recipes index location (used when installing by name / auto-name).
+  --refresh  Refresh remote index cache before installing. (default=false)
+  --yes  Auto-approve network prompts when allowed by config. (default=false)
+  --on-conflict <fail|rename|overwrite>  Deprecated compatibility no-op; recipe installs stay self-contained. (choices=fail|rename|overwrite, default=fail)
+"
+`;
+
+exports[`runCli help snapshots (cli2) > help task --compact snapshot 1`] = `
+"task - Task lifecycle and task-store commands.
+
+Usage:
+  agentplane task <subcommand> [args] [options]
+"
+`;
+
+exports[`runCli help snapshots (cli2) > help task doc set --compact snapshot 1`] = `
+"task doc set - Update a task README section.
+
+Usage:
+  agentplane task doc set <task-id> --section <name> (--text <text> | --file <path>) [--updated-by <id>]
+  agentplane task doc set <task-id> --full-doc (--text <text> | --file <path>) [--updated-by <id>]
+
+Options:
+  --section <name>  Target section heading (must be one of config.tasks.doc.sections). Required unless --full-doc is set.
+  --full-doc  Treat the provided text/file as the full task README payload. (default=false)
+  --text <text>  Section content (mutually exclusive with --file). Literal escaped newlines (\\n) are normalized for inline text.
+  --file <path>  Read section content from a file (mutually exclusive with --text).
+  --updated-by <id>  Optional. Override doc_updated_by metadata (must be non-empty).
+"
+`;
+
+exports[`runCli help snapshots (cli2) > help task new --compact snapshot 1`] = `
 "task new - Create a new task (prints the generated task id).
 
 Usage:
@@ -521,15 +260,15 @@ Options:
 "
 `;
 
-exports[`runCli help snapshots (cli2) help task --compact snapshot 1`] = `
-"task - Task lifecycle and task-store commands.
+exports[`runCli help snapshots (cli2) > help task plan --compact snapshot 1`] = `
+"task plan - Task plan commands (set/approve/reject).
 
 Usage:
-  agentplane task <subcommand> [args] [options]
+  agentplane task plan <set|approve|reject> [args] [options]
 "
 `;
 
-exports[`runCli help snapshots (cli2) help task run --compact snapshot 1`] = `
+exports[`runCli help snapshots (cli2) > help task run --compact snapshot 1`] = `
 "task run - Prepare or run a task through the shared runner contract.
 
 Usage:
@@ -540,62 +279,7 @@ Options:
 "
 `;
 
-exports[`runCli help snapshots (cli2) help task plan --compact snapshot 1`] = `
-"task plan - Task plan commands (set/approve/reject).
-
-Usage:
-  agentplane task plan <set|approve|reject> [args] [options]
-"
-`;
-
-exports[`runCli help snapshots (cli2) help task doc set --compact snapshot 1`] = `
-"task doc set - Update a task README section.
-
-Usage:
-  agentplane task doc set <task-id> --section <name> (--text <text> | --file <path>) [--updated-by <id>]
-  agentplane task doc set <task-id> --full-doc (--text <text> | --file <path>) [--updated-by <id>]
-
-Options:
-  --section <name>  Target section heading (must be one of config.tasks.doc.sections). Required unless --full-doc is set.
-  --full-doc  Treat the provided text/file as the full task README payload. (default=false)
-  --text <text>  Section content (mutually exclusive with --file). Literal escaped newlines (\\n) are normalized for inline text.
-  --file <path>  Read section content from a file (mutually exclusive with --text).
-  --updated-by <id>  Optional. Override doc_updated_by metadata (must be non-empty).
-"
-`;
-
-exports[`runCli help snapshots (cli2) help recipes install --compact snapshot 1`] = `
-"recipes install - Install a recipe into the global cache from remote index, local archive, or URL.
-
-Usage:
-  agentplane recipes install <id|path|url> [--index <path|url>] [--refresh] [--yes] [--on-conflict <fail|rename|overwrite>]
-  agentplane recipes install --name <id> [--index <path|url>] [--refresh] [--yes] [--on-conflict <fail|rename|overwrite>]
-  agentplane recipes install --path <path> [--yes] [--on-conflict <fail|rename|overwrite>]
-  agentplane recipes install --url <url> [--yes] [--on-conflict <fail|rename|overwrite>]
-
-Options:
-  --name <id>  Cache from remote index by recipe id.
-  --path <path>  Cache from local recipe archive path.
-  --url <url>  Cache from recipe archive URL.
-  --index <path|url>  Override recipes index location (used when installing by name / auto-name).
-  --refresh  Refresh remote index cache before installing. (default=false)
-  --yes  Auto-approve network prompts when allowed by config. (default=false)
-  --on-conflict <fail|rename|overwrite>  Deprecated compatibility no-op; recipe installs stay self-contained. (choices=fail|rename|overwrite, default=fail)
-"
-`;
-
-exports[`runCli help snapshots (cli2) help codex plugin install --compact snapshot 1`] = `
-"codex plugin install - Install the bundled AgentPlane plugin into a local Codex marketplace.
-
-Usage:
-  agentplane codex plugin install [options]
-
-Options:
-  --scope <user|repo>  Install to the user home marketplace or the current repository marketplace. (choices=user|repo, default=user)
-"
-`;
-
-exports[`runCli help snapshots (cli2) help work start --json snapshot 1`] = `
+exports[`runCli help snapshots (cli2) > help work start --json snapshot 1`] = `
 {
   "args": [
     {

--- a/packages/agentplane/src/cli/output.test.ts
+++ b/packages/agentplane/src/cli/output.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   backendNotSupportedMessage,
@@ -14,6 +14,7 @@ import {
   missingFileMessage,
   missingValueMessage,
   requiredFieldMessage,
+  resolveCliPresentationMode,
   successMessage,
   usageMessage,
   warnMessage,
@@ -32,6 +33,18 @@ function createMemoryWriter(): { text: () => string; write: (chunk: string) => u
 }
 
 describe("cli/output", () => {
+  const envSnapshot = { ...process.env };
+
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in envSnapshot)) delete process.env[key];
+    }
+    for (const [key, value] of Object.entries(envSnapshot)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
   it("formats success and info messages", () => {
     expect(successMessage("done")).toBe("✅ done");
     expect(successMessage("saved", "file.txt")).toBe("✅ saved file.txt");
@@ -66,6 +79,23 @@ describe("cli/output", () => {
     expect(missingFileMessage("file.txt", "root")).toBe("Missing file.txt at root");
     expect(emptyStateMessage("tasks")).toBe("No tasks found.");
     expect(emptyStateMessage("tasks", "Create one.")).toBe("No tasks found. Create one.");
+  });
+
+  it("renders ap/agent-mode messages without human decoration", () => {
+    process.env.AGENTPLANE_CLI_ALIAS = "ap";
+
+    expect(resolveCliPresentationMode()).toBe("agent");
+    expect(successMessage("saved", "file.txt", "ok")).toBe("saved file.txt (ok)");
+    expect(infoMessage("note")).toBe("note");
+    expect(warnMessage("careful")).toBe("warning: careful");
+
+    const stdout = createMemoryWriter();
+    const emitter = createCliEmitter({ stdout, stderr: createMemoryWriter() });
+    emitter.report([
+      { label: "task_id", value: "TASK-2" },
+      { label: "status", value: "ready" },
+    ]);
+    expect(stdout.text()).toBe(["task_id: TASK-2", "status: ready"].join("\n") + "\n");
   });
 
   it("formats workflow mode messages", () => {
@@ -113,7 +143,7 @@ describe("cli/output", () => {
         "  ]",
         "ℹ️ task inspect: TASK-2",
         "task_id: TASK-2",
-        "status: ready",
+        "status:  ready",
         "✅ saved TASK-2",
       ].join("\n") + "\n",
     );

--- a/packages/agentplane/src/cli/output.ts
+++ b/packages/agentplane/src/cli/output.ts
@@ -20,7 +20,7 @@ export type CliReportOptions = {
   stream?: CliEmitterStream;
 };
 
-export type CliPresentationMode = "agent" | "human";
+type CliPresentationMode = "agent" | "human";
 
 export type CliEmitter = {
   line: (text: string, stream?: CliEmitterStream) => void;

--- a/packages/agentplane/src/cli/output.ts
+++ b/packages/agentplane/src/cli/output.ts
@@ -1,5 +1,6 @@
 import type { Logger, LoggerMode } from "@agentplaneorg/core/logger";
 import { createLogger } from "@agentplaneorg/core/logger";
+import { visibleLen } from "../shared/ansi.js";
 
 export type CliOutputWriter = {
   write: (chunk: string) => unknown;
@@ -18,6 +19,8 @@ export type CliReportOptions = {
   header?: string;
   stream?: CliEmitterStream;
 };
+
+export type CliPresentationMode = "agent" | "human";
 
 export type CliEmitter = {
   line: (text: string, stream?: CliEmitterStream) => void;
@@ -75,24 +78,90 @@ function ensureTrailingNewline(text: string): string {
   return text.endsWith("\n") ? text : `${text}\n`;
 }
 
-function renderReportLine(entry: CliReportEntry): string {
+function isTruthyEnv(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
+export function resolveCliPresentationMode(
+  env: NodeJS.ProcessEnv = process.env,
+): CliPresentationMode {
+  const alias = env.AGENTPLANE_CLI_ALIAS?.trim().toLowerCase();
+  if (alias === "ap" || isTruthyEnv(env.AGENTPLANE_AGENT_MODE)) return "agent";
+  return "human";
+}
+
+function shouldUseColor(opts?: {
+  stream?: CliEmitterStream;
+  writer?: CliOutputWriter;
+  env?: NodeJS.ProcessEnv;
+}): boolean {
+  const env = opts?.env ?? process.env;
+  if (
+    env.NO_COLOR !== undefined ||
+    env.AGENTPLANE_COLOR === "0" ||
+    env.AGENTPLANE_COLOR === "never"
+  ) {
+    return false;
+  }
+  if (env.AGENTPLANE_COLOR === "always" || env.FORCE_COLOR) return true;
+  const writer = opts?.writer ?? (opts?.stream === "stderr" ? process.stderr : process.stdout);
+  return Boolean((writer as { isTTY?: boolean }).isTTY);
+}
+
+function color(code: number, text: string, enabled: boolean): string {
+  return enabled ? `\u001B[${code}m${text}\u001B[0m` : text;
+}
+
+function dim(text: string, enabled: boolean): string {
+  return color(2, text, enabled);
+}
+
+function cyan(text: string, enabled: boolean): string {
+  return color(36, text, enabled);
+}
+
+function green(text: string, enabled: boolean): string {
+  return color(32, text, enabled);
+}
+
+function yellow(text: string, enabled: boolean): string {
+  return color(33, text, enabled);
+}
+
+function renderReportLine(
+  entry: CliReportEntry,
+  labelWidth?: number,
+  colorEnabled = false,
+): string {
   if (typeof entry === "string") return entry;
   if (entry.value === undefined || entry.value === null) return `${entry.label}:`;
-  return `${entry.label}: ${String(entry.value)}`;
+  const label = `${entry.label}:`;
+  const alignedLabel = labelWidth ? label.padEnd(labelWidth + 1) : label;
+  return `${cyan(alignedLabel, colorEnabled)} ${String(entry.value)}`;
+}
+
+function plainSuccessMessage(action: string, target?: string, details?: string): string {
+  const base = target ? `${action} ${target}` : action;
+  const suffix = details ? ` (${details})` : "";
+  return `${base}${suffix}`;
 }
 
 export function successMessage(action: string, target?: string, details?: string): string {
-  const base = target ? `${action} ${target}` : action;
-  const suffix = details ? ` (${details})` : "";
-  return `✅ ${base}${suffix}`;
+  const text = plainSuccessMessage(action, target, details);
+  if (resolveCliPresentationMode() === "agent") return text;
+  return `${green("✅", shouldUseColor())} ${text}`;
 }
 
 export function infoMessage(message: string): string {
-  return `ℹ️ ${message}`;
+  if (resolveCliPresentationMode() === "agent") return message;
+  return `${cyan("ℹ️", shouldUseColor())} ${message}`;
 }
 
 export function warnMessage(message: string): string {
-  return `⚠️ ${message}`;
+  if (resolveCliPresentationMode() === "agent") return `warning: ${message}`;
+  return `${yellow("⚠️", shouldUseColor({ stream: "stderr" }))} ${message}`;
 }
 
 export function usageMessage(usage: string, example?: string): string {
@@ -152,13 +221,30 @@ function renderTextLine(text: string): string {
 }
 
 function renderTextLines(lines: Iterable<string>): string {
-  return Array.from(lines, renderTextLine).join("");
+  return [...lines].map((line) => renderTextLine(line)).join("");
 }
 
-function renderReportBlock(entries: Iterable<CliReportEntry>, options?: CliReportOptions): string {
-  const lines = options?.header ? [options.header] : [];
-  for (const entry of entries) {
-    lines.push(renderReportLine(entry));
+function renderReportBlock(
+  entries: Iterable<CliReportEntry>,
+  options?: CliReportOptions & {
+    mode?: CliPresentationMode;
+    color?: boolean;
+  },
+): string {
+  const mode = options?.mode ?? resolveCliPresentationMode();
+  const values = [...entries];
+  const labelWidth =
+    mode === "human"
+      ? Math.max(
+          0,
+          ...values.map((entry) => (typeof entry === "string" ? 0 : visibleLen(entry.label))),
+        )
+      : undefined;
+  const lines = options?.header
+    ? [mode === "human" ? dim(options.header, options.color ?? false) : options.header]
+    : [];
+  for (const entry of values) {
+    lines.push(renderReportLine(entry, labelWidth, mode === "human" && (options?.color ?? false)));
   }
   return renderTextLines(lines);
 }
@@ -174,10 +260,20 @@ export function createCliEmitter(streams?: {
   stderr?: CliOutputWriter;
   loggerMode?: LoggerMode;
   logger?: Logger;
+  presentationMode?: CliPresentationMode;
+  color?: boolean;
 }): CliEmitter {
   const stdout = streams?.stdout ?? process.stdout;
   const stderr = streams?.stderr ?? process.stderr;
   const logger = streams?.logger ?? createLogger({ mode: streams?.loggerMode, stdout, stderr });
+  const presentationMode = streams?.presentationMode ?? resolveCliPresentationMode();
+  const colorForStream = (stream: CliEmitterStream): boolean =>
+    streams?.color ??
+    (presentationMode === "human" &&
+      shouldUseColor({
+        stream,
+        writer: stream === "stderr" ? stderr : stdout,
+      }));
 
   const line = (text: string, stream: CliEmitterStream = "stdout"): void => {
     logger.write({ kind: "line", text, stream });
@@ -209,9 +305,14 @@ export function createCliEmitter(streams?: {
   };
 
   const report = (entries: Iterable<CliReportEntry>, options?: CliReportOptions): void => {
-    const block = renderReportBlock(entries, options);
+    const stream = options?.stream ?? "stdout";
+    const block = renderReportBlock(entries, {
+      ...options,
+      mode: presentationMode,
+      color: colorForStream(stream),
+    });
     for (const valueLine of block.trimEnd().split("\n")) {
-      logger.write({ kind: "line", text: valueLine, stream: options?.stream ?? "stdout" });
+      logger.write({ kind: "line", text: valueLine, stream });
     }
   };
 

--- a/packages/agentplane/src/cli/run-cli.core.init.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.init.test.ts
@@ -277,7 +277,9 @@ describe("runCli", () => {
     expect(gitignore).toContain(".env");
     expect(gitignore).toContain(".agentplane/worktrees");
     expect(gitignore).toContain(".agentplane/cache");
-    expect(gitignore).toContain(".agentplane/cache.sqlite*");
+    expect(gitignore).toContain(".agentplane/cache.sqlite");
+    expect(gitignore).toContain(".agentplane/cache.sqlite-wal");
+    expect(gitignore).toContain(".agentplane/cache.sqlite-shm");
     expect(gitignore).toContain(".agentplane/recipes-cache");
     expect(gitignore).toContain(".agentplane/.upgrade");
     expect(gitignore).toContain(".agentplane/.release");

--- a/packages/agentplane/src/cli/run-cli.core.init.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.init.test.ts
@@ -277,6 +277,7 @@ describe("runCli", () => {
     expect(gitignore).toContain(".env");
     expect(gitignore).toContain(".agentplane/worktrees");
     expect(gitignore).toContain(".agentplane/cache");
+    expect(gitignore).toContain(".agentplane/cache.sqlite*");
     expect(gitignore).toContain(".agentplane/recipes-cache");
     expect(gitignore).toContain(".agentplane/.upgrade");
     expect(gitignore).toContain(".agentplane/.release");

--- a/packages/agentplane/src/commands/acr/validate.ts
+++ b/packages/agentplane/src/commands/acr/validate.ts
@@ -8,6 +8,7 @@ import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
+import { successMessage } from "../../cli/output.js";
 import type { CommandContext } from "../shared/task-backend.js";
 import { loadTaskFromContext } from "../shared/task-backend.js";
 import { acrValidationError } from "./remediation.js";
@@ -198,7 +199,7 @@ export function emitValidationResult(
     process.stdout.write(`${JSON.stringify({ command, ...result }, null, 2)}\n`);
     return;
   }
-  process.stdout.write(`✅ ${command} ${path.basename(result.acr_path)}\n`);
+  process.stdout.write(`${successMessage(command, path.basename(result.acr_path))}\n`);
 }
 
 export function defaultAcrPath(ctx: CommandContext, taskId: string): string {

--- a/packages/agentplane/src/commands/doctor.run.ts
+++ b/packages/agentplane/src/commands/doctor.run.ts
@@ -2,7 +2,7 @@ import { loadConfig } from "@agentplaneorg/core/config";
 import { resolveProject } from "@agentplaneorg/core/project";
 
 import type { CommandHandler } from "../cli/spec/spec.js";
-import { warnMessage, successMessage } from "../cli/output.js";
+import { infoMessage, successMessage, warnMessage } from "../cli/output.js";
 import type { DoctorParsed } from "./doctor.spec.js";
 import { loadCommandContext } from "./shared/task-backend.js";
 import { checkDoneTaskCommitInvariants } from "./doctor/archive.js";
@@ -35,7 +35,7 @@ export const runDoctor: CommandHandler<DoctorParsed> = async (ctx, p) => {
   });
 
   const reportProgress = (message: string): void => {
-    process.stderr.write(`ℹ️ doctor: ${message}\n`);
+    process.stderr.write(`${infoMessage(`doctor: ${message}`)}\n`);
   };
 
   const runChecks = async (): Promise<string[]> => {

--- a/scripts/oversized-test-baseline.json
+++ b/scripts/oversized-test-baseline.json
@@ -2,8 +2,8 @@
   "schema_version": 2,
   "threshold_lines": 1000,
   "budgets": {
-    "max_entries": 12,
-    "max_total_lines": 13575,
+    "max_entries": 13,
+    "max_total_lines": 14579,
     "max_file_lines": 1300
   },
   "entries": [
@@ -38,6 +38,10 @@
     {
       "file": "packages/agentplane/src/backends/task-backend.cloud.test.ts",
       "lines": 1028
+    },
+    {
+      "file": "packages/agentplane/src/backends/task-backend.local.test.ts",
+      "lines": 1006
     },
     {
       "file": "packages/agentplane/src/commands/doctor.command.open-pr.test.ts",

--- a/scripts/oversized-test-baseline.json
+++ b/scripts/oversized-test-baseline.json
@@ -2,8 +2,8 @@
   "schema_version": 2,
   "threshold_lines": 1000,
   "budgets": {
-    "max_entries": 13,
-    "max_total_lines": 14579,
+    "max_entries": 12,
+    "max_total_lines": 13575,
     "max_file_lines": 1300
   },
   "entries": [
@@ -38,10 +38,6 @@
     {
       "file": "packages/agentplane/src/backends/task-backend.cloud.test.ts",
       "lines": 1028
-    },
-    {
-      "file": "packages/agentplane/src/backends/task-backend.local.test.ts",
-      "lines": 1006
     },
     {
       "file": "packages/agentplane/src/commands/doctor.command.open-pr.test.ts",


### PR DESCRIPTION
Task: `202605131125-68KKFW`
Title: Split human and agent CLI output
Canonical task record: `.agentplane/tasks/202605131125-68KKFW/README.md`

## Summary

Split human and agent CLI output

Make the long-form agentplane command render a cleaner human-oriented output with spacing, alignment, and color while keeping the short ap command minimal and unstyled for agent consumption.

## Scope

- In scope: Make the long-form agentplane command render a cleaner human-oriented output with spacing, alignment, and color while keeping the short ap command minimal and unstyled for agent consumption.
- Out of scope: unrelated refactors not required for "Split human and agent CLI output".

## Verification

- State: pending
- Note: Not recorded yet.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-13T11:36:20.423Z
- Branch: task/202605131125-68KKFW/split-cli-output
- Head: a4cbe108e901

```text
 .../blueprint/resolved-snapshot.json               | 513 +++++++++++++++++++++
 .../src/backends/task-backend/cloud-pull.ts        |   5 +-
 .../task-backend/redmine/backend-sync/sync.ts      |  10 +-
 packages/agentplane/src/cli/output.test.ts         |  34 +-
 packages/agentplane/src/cli/output.ts              | 127 ++++-
 packages/agentplane/src/commands/acr/validate.ts   |   3 +-
 packages/agentplane/src/commands/doctor.run.ts     |   4 +-
 7 files changed, 674 insertions(+), 22 deletions(-)
```

</details>
