### PR TITLE
✅ 68KKFW follow-up: Honor FORCE_COLOR=0

### DIFF
--- a/packages/agentplane/src/cli/output.test.ts
+++ b/packages/agentplane/src/cli/output.test.ts
@@ -98,6 +98,17 @@ describe("cli/output", () => {
     expect(stdout.text()).toBe(["task_id: TASK-2", "status: ready"].join("\n") + "\n");
   });
 
+  it("treats FORCE_COLOR=0 as disabled", () => {
+    delete process.env.NO_COLOR;
+    delete process.env.AGENTPLANE_COLOR;
+
+    process.env.FORCE_COLOR = "1";
+    expect(successMessage("done")).toBe("\u001B[32m✅\u001B[0m done");
+
+    process.env.FORCE_COLOR = "0";
+    expect(successMessage("done")).toBe("✅ done");
+  });
+
   it("formats workflow mode messages", () => {
     expect(workflowModeMessage("direct", "branch_pr")).toBe(
       "Invalid workflow_mode: direct (expected branch_pr)",

--- a/packages/agentplane/src/cli/output.ts
+++ b/packages/agentplane/src/cli/output.ts
@@ -84,6 +84,11 @@ function isTruthyEnv(value: string | undefined): boolean {
   return normalized === "1" || normalized === "true" || normalized === "yes";
 }
 
+function isForceColorEnabled(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  return value.trim() !== "" && value.trim() !== "0";
+}
+
 export function resolveCliPresentationMode(
   env: NodeJS.ProcessEnv = process.env,
 ): CliPresentationMode {
@@ -105,7 +110,7 @@ function shouldUseColor(opts?: {
   ) {
     return false;
   }
-  if (env.AGENTPLANE_COLOR === "always" || env.FORCE_COLOR) return true;
+  if (env.AGENTPLANE_COLOR === "always" || isForceColorEnabled(env.FORCE_COLOR)) return true;
   const writer = opts?.writer ?? (opts?.stream === "stderr" ? process.stderr : process.stdout);
   return Boolean((writer as { isTTY?: boolean }).isTTY);
 }


### PR DESCRIPTION
## Summary

- Follow-up to #3629 after Codex review feedback.
- Treat FORCE_COLOR=0 as disabled instead of enabling ANSI output.
- Add focused regression coverage in packages/agentplane/src/cli/output.test.ts.

## Verification

- bunx prettier --check packages/agentplane/src/cli/output.ts packages/agentplane/src/cli/output.test.ts
- bunx eslint packages/agentplane/src/cli/output.ts packages/agentplane/src/cli/output.test.ts
- bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/cli/output.test.ts
- bun run --filter=agentplane build
- git push pre-push full-fast: 296 test files passed; critical E2E 14 passed

Task: 202605131125-68KKFW
