### PR TITLE
🚧 GS3HB0 task: Create agentic context extraction tasks [202605131449-GS3HB0]

### DIFF
--- a/.agentplane/tasks/202605131449-GS3HB0/README.md
+++ b/.agentplane/tasks/202605131449-GS3HB0/README.md
@@ -19,9 +19,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-13T15:01:58.818Z"
+  updated_at: "2026-05-13T15:03:27.015Z"
   updated_by: "CODER"
-  note: "Verified agentic context extraction task generation: focused harvest/task-new tests pass; eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live dry-run smoke pass. Release-readiness was rerun with Vitest because Bun lacks node:sqlite in this environment."
+  note: "Verified committed implementation e237c64f2: focused harvest/task-new tests, eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live create-extraction-tasks dry-run all pass. Release-readiness passes under Vitest; Bun test lacks node:sqlite in this environment."
   attempts: 0
 commit: null
 comments:
@@ -42,8 +42,14 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified agentic context extraction task generation: focused harvest/task-new tests pass; eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live dry-run smoke pass. Release-readiness was rerun with Vitest because Bun lacks node:sqlite in this environment."
+  -
+    type: "verify"
+    at: "2026-05-13T15:03:27.015Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified committed implementation e237c64f2: focused harvest/task-new tests, eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live create-extraction-tasks dry-run all pass. Release-readiness passes under Vitest; Bun test lacks node:sqlite in this environment."
 doc_version: 3
-doc_updated_at: "2026-05-13T15:01:58.829Z"
+doc_updated_at: "2026-05-13T15:03:27.026Z"
 doc_updated_by: "CODER"
 description: "Add a context harvest mode that creates standard AgentPlane extraction tasks for batchwise semantic knowledge extraction from completed task history, with modular prompt context and provenance requirements."
 sections:
@@ -80,6 +86,25 @@ sections:
     - route_changed: no
     - safe_command: agentplane blueprint snapshot 202605131449-GS3HB0
     
+    ### 2026-05-13T15:03:27.015Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified committed implementation e237c64f2: focused harvest/task-new tests, eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live create-extraction-tasks dry-run all pass. Release-readiness passes under Vitest; Bun test lacks node:sqlite in this environment.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-13T15:01:58.829Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605131449-GS3HB0-agentic-context-extraction/.agentplane/tasks/202605131449-GS3HB0/blueprint/resolved-snapshot.json
+    - old_digest: 26f4bf4ba1a7d77364547c7ee3496140e1efe1148c468b4acd413e9806fd3388
+    - current_digest: 26f4bf4ba1a7d77364547c7ee3496140e1efe1148c468b4acd413e9806fd3388
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605131449-GS3HB0
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -88,6 +113,10 @@ sections:
     - Observation: Implemented --create-extraction-tasks and --batch-size for context harvest tasks. Generated CURATOR tasks carry README/ACR source packs, allowed outputs, provenance rules, queued source markers, and a replaceable prompt module address.
       Impact: Completed task history can now be processed oldest-first by standard AgentPlane tasks instead of a single deterministic wiki proposal.
       Resolution: Keep deterministic --write-proposals/--promote behavior unchanged; use --create-extraction-tasks for semantic extraction batches.
+    
+    - Observation: PR #3638 opened for the committed branch after implementing agentic extraction task batches.
+      Impact: PR metadata and task verification now refer to the committed implementation head.
+      Resolution: Proceed with PR update, push, and hosted checks.
 id_source: "generated"
 ---
 ## Summary
@@ -133,6 +162,25 @@ BlueprintSnapshotRef:
 - route_changed: no
 - safe_command: agentplane blueprint snapshot 202605131449-GS3HB0
 
+### 2026-05-13T15:03:27.015Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified committed implementation e237c64f2: focused harvest/task-new tests, eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live create-extraction-tasks dry-run all pass. Release-readiness passes under Vitest; Bun test lacks node:sqlite in this environment.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-13T15:01:58.829Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605131449-GS3HB0-agentic-context-extraction/.agentplane/tasks/202605131449-GS3HB0/blueprint/resolved-snapshot.json
+- old_digest: 26f4bf4ba1a7d77364547c7ee3496140e1efe1148c468b4acd413e9806fd3388
+- current_digest: 26f4bf4ba1a7d77364547c7ee3496140e1efe1148c468b4acd413e9806fd3388
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605131449-GS3HB0
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -145,3 +193,7 @@ BlueprintSnapshotRef:
 - Observation: Implemented --create-extraction-tasks and --batch-size for context harvest tasks. Generated CURATOR tasks carry README/ACR source packs, allowed outputs, provenance rules, queued source markers, and a replaceable prompt module address.
   Impact: Completed task history can now be processed oldest-first by standard AgentPlane tasks instead of a single deterministic wiki proposal.
   Resolution: Keep deterministic --write-proposals/--promote behavior unchanged; use --create-extraction-tasks for semantic extraction batches.
+
+- Observation: PR #3638 opened for the committed branch after implementing agentic extraction task batches.
+  Impact: PR metadata and task verification now refer to the committed implementation head.
+  Resolution: Proceed with PR update, push, and hosted checks.

--- a/.agentplane/tasks/202605131449-GS3HB0/README.md
+++ b/.agentplane/tasks/202605131449-GS3HB0/README.md
@@ -19,9 +19,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-13T15:03:27.015Z"
+  updated_at: "2026-05-13T15:42:11.003Z"
   updated_by: "CODER"
-  note: "Verified committed implementation e237c64f2: focused harvest/task-new tests, eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live create-extraction-tasks dry-run all pass. Release-readiness passes under Vitest; Bun test lacks node:sqlite in this environment."
+  note: "Verified review-thread fix 96adf5697: combined --write-proposals and --create-extraction-tasks now preserves context_harvest while adding context_task_extraction; bun test packages/agentplane/src/commands/context/harvest-tasks.test.ts passes 11/11."
   attempts: 0
 commit: null
 comments:
@@ -48,8 +48,14 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified committed implementation e237c64f2: focused harvest/task-new tests, eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live create-extraction-tasks dry-run all pass. Release-readiness passes under Vitest; Bun test lacks node:sqlite in this environment."
+  -
+    type: "verify"
+    at: "2026-05-13T15:42:11.003Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified review-thread fix 96adf5697: combined --write-proposals and --create-extraction-tasks now preserves context_harvest while adding context_task_extraction; bun test packages/agentplane/src/commands/context/harvest-tasks.test.ts passes 11/11."
 doc_version: 3
-doc_updated_at: "2026-05-13T15:03:27.026Z"
+doc_updated_at: "2026-05-13T15:42:11.021Z"
 doc_updated_by: "CODER"
 description: "Add a context harvest mode that creates standard AgentPlane extraction tasks for batchwise semantic knowledge extraction from completed task history, with modular prompt context and provenance requirements."
 sections:
@@ -105,6 +111,25 @@ sections:
     - route_changed: no
     - safe_command: agentplane blueprint snapshot 202605131449-GS3HB0
     
+    ### 2026-05-13T15:42:11.003Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified review-thread fix 96adf5697: combined --write-proposals and --create-extraction-tasks now preserves context_harvest while adding context_task_extraction; bun test packages/agentplane/src/commands/context/harvest-tasks.test.ts passes 11/11.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-13T15:03:27.026Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605131449-GS3HB0-agentic-context-extraction/.agentplane/tasks/202605131449-GS3HB0/blueprint/resolved-snapshot.json
+    - old_digest: 26f4bf4ba1a7d77364547c7ee3496140e1efe1148c468b4acd413e9806fd3388
+    - current_digest: 26f4bf4ba1a7d77364547c7ee3496140e1efe1148c468b4acd413e9806fd3388
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605131449-GS3HB0
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -117,6 +142,10 @@ sections:
     - Observation: PR #3638 opened for the committed branch after implementing agentic extraction task batches.
       Impact: PR metadata and task verification now refer to the committed implementation head.
       Resolution: Proceed with PR update, push, and hosted checks.
+    
+    - Observation: Resolved PR #3638 P1 review finding by writing extraction markers against the latest backend task state after harvest marker writes.
+      Impact: Combined harvest modes no longer drop ingestion provenance markers, so later harvest runs can still detect already ingested tasks.
+      Resolution: Added regression coverage for the combined mode and de-duplicated reported changed paths.
 id_source: "generated"
 ---
 ## Summary
@@ -181,6 +210,25 @@ BlueprintSnapshotRef:
 - route_changed: no
 - safe_command: agentplane blueprint snapshot 202605131449-GS3HB0
 
+### 2026-05-13T15:42:11.003Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified review-thread fix 96adf5697: combined --write-proposals and --create-extraction-tasks now preserves context_harvest while adding context_task_extraction; bun test packages/agentplane/src/commands/context/harvest-tasks.test.ts passes 11/11.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-13T15:03:27.026Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605131449-GS3HB0-agentic-context-extraction/.agentplane/tasks/202605131449-GS3HB0/blueprint/resolved-snapshot.json
+- old_digest: 26f4bf4ba1a7d77364547c7ee3496140e1efe1148c468b4acd413e9806fd3388
+- current_digest: 26f4bf4ba1a7d77364547c7ee3496140e1efe1148c468b4acd413e9806fd3388
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605131449-GS3HB0
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -197,3 +245,7 @@ BlueprintSnapshotRef:
 - Observation: PR #3638 opened for the committed branch after implementing agentic extraction task batches.
   Impact: PR metadata and task verification now refer to the committed implementation head.
   Resolution: Proceed with PR update, push, and hosted checks.
+
+- Observation: Resolved PR #3638 P1 review finding by writing extraction markers against the latest backend task state after harvest marker writes.
+  Impact: Combined harvest modes no longer drop ingestion provenance markers, so later harvest runs can still detect already ingested tasks.
+  Resolution: Added regression coverage for the combined mode and de-duplicated reported changed paths.

--- a/.agentplane/tasks/202605131449-GS3HB0/README.md
+++ b/.agentplane/tasks/202605131449-GS3HB0/README.md
@@ -1,0 +1,147 @@
+---
+id: "202605131449-GS3HB0"
+title: "Create agentic context extraction tasks"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "context"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-13T14:50:04.657Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-13T15:01:58.818Z"
+  updated_by: "CODER"
+  note: "Verified agentic context extraction task generation: focused harvest/task-new tests pass; eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live dry-run smoke pass. Release-readiness was rerun with Vitest because Bun lacks node:sqlite in this environment."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Implementing agentic context extraction task generation as a bounded extension of context harvest, using standard task lifecycle records and focused verification in the task worktree."
+events:
+  -
+    type: "status"
+    at: "2026-05-13T14:50:25.367Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Implementing agentic context extraction task generation as a bounded extension of context harvest, using standard task lifecycle records and focused verification in the task worktree."
+  -
+    type: "verify"
+    at: "2026-05-13T15:01:58.818Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified agentic context extraction task generation: focused harvest/task-new tests pass; eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live dry-run smoke pass. Release-readiness was rerun with Vitest because Bun lacks node:sqlite in this environment."
+doc_version: 3
+doc_updated_at: "2026-05-13T15:01:58.829Z"
+doc_updated_by: "CODER"
+description: "Add a context harvest mode that creates standard AgentPlane extraction tasks for batchwise semantic knowledge extraction from completed task history, with modular prompt context and provenance requirements."
+sections:
+  Summary: |-
+    Create agentic context extraction tasks
+    
+    Add a context harvest mode that creates standard AgentPlane extraction tasks for batchwise semantic knowledge extraction from completed task history, with modular prompt context and provenance requirements.
+  Scope: |-
+    - In scope: Add a context harvest mode that creates standard AgentPlane extraction tasks for batchwise semantic knowledge extraction from completed task history, with modular prompt context and provenance requirements.
+    - Out of scope: unrelated refactors not required for "Create agentic context extraction tasks".
+  Plan: "Implement an agentic context extraction task creation layer for context harvest tasks. Scope: add CLI options for creating standard extraction tasks in oldest-first batches; build README/ACR-aware source packs rather than treating raw JSON as the semantic source; include a modular extraction prompt contract that can be improved later; keep existing deterministic write-proposals/promote behavior intact; add tests and user/developer docs. Verification: focused context harvest tests, task lifecycle tests as needed, CLI docs freshness, lint/typecheck for touched files, policy routing, doctor, and a live dry-run/create-task smoke in a temporary project or mocked backend."
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-13T15:01:58.818Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified agentic context extraction task generation: focused harvest/task-new tests pass; eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live dry-run smoke pass. Release-readiness was rerun with Vitest because Bun lacks node:sqlite in this environment.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-13T14:50:25.367Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605131449-GS3HB0-agentic-context-extraction/.agentplane/tasks/202605131449-GS3HB0/blueprint/resolved-snapshot.json
+    - old_digest: 26f4bf4ba1a7d77364547c7ee3496140e1efe1148c468b4acd413e9806fd3388
+    - current_digest: 26f4bf4ba1a7d77364547c7ee3496140e1efe1148c468b4acd413e9806fd3388
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605131449-GS3HB0
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Implemented --create-extraction-tasks and --batch-size for context harvest tasks. Generated CURATOR tasks carry README/ACR source packs, allowed outputs, provenance rules, queued source markers, and a replaceable prompt module address.
+      Impact: Completed task history can now be processed oldest-first by standard AgentPlane tasks instead of a single deterministic wiki proposal.
+      Resolution: Keep deterministic --write-proposals/--promote behavior unchanged; use --create-extraction-tasks for semantic extraction batches.
+id_source: "generated"
+---
+## Summary
+
+Create agentic context extraction tasks
+
+Add a context harvest mode that creates standard AgentPlane extraction tasks for batchwise semantic knowledge extraction from completed task history, with modular prompt context and provenance requirements.
+
+## Scope
+
+- In scope: Add a context harvest mode that creates standard AgentPlane extraction tasks for batchwise semantic knowledge extraction from completed task history, with modular prompt context and provenance requirements.
+- Out of scope: unrelated refactors not required for "Create agentic context extraction tasks".
+
+## Plan
+
+Implement an agentic context extraction task creation layer for context harvest tasks. Scope: add CLI options for creating standard extraction tasks in oldest-first batches; build README/ACR-aware source packs rather than treating raw JSON as the semantic source; include a modular extraction prompt contract that can be improved later; keep existing deterministic write-proposals/promote behavior intact; add tests and user/developer docs. Verification: focused context harvest tests, task lifecycle tests as needed, CLI docs freshness, lint/typecheck for touched files, policy routing, doctor, and a live dry-run/create-task smoke in a temporary project or mocked backend.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-13T15:01:58.818Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified agentic context extraction task generation: focused harvest/task-new tests pass; eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live dry-run smoke pass. Release-readiness was rerun with Vitest because Bun lacks node:sqlite in this environment.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-13T14:50:25.367Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605131449-GS3HB0-agentic-context-extraction/.agentplane/tasks/202605131449-GS3HB0/blueprint/resolved-snapshot.json
+- old_digest: 26f4bf4ba1a7d77364547c7ee3496140e1efe1148c468b4acd413e9806fd3388
+- current_digest: 26f4bf4ba1a7d77364547c7ee3496140e1efe1148c468b4acd413e9806fd3388
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605131449-GS3HB0
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Implemented --create-extraction-tasks and --batch-size for context harvest tasks. Generated CURATOR tasks carry README/ACR source packs, allowed outputs, provenance rules, queued source markers, and a replaceable prompt module address.
+  Impact: Completed task history can now be processed oldest-first by standard AgentPlane tasks instead of a single deterministic wiki proposal.
+  Resolution: Keep deterministic --write-proposals/--promote behavior unchanged; use --create-extraction-tasks for semantic extraction batches.

--- a/.agentplane/tasks/202605131449-GS3HB0/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605131449-GS3HB0/blueprint/resolved-snapshot.json
@@ -1,0 +1,513 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605131449-GS3HB0",
+    "title": "Create agentic context extraction tasks",
+    "description": "Add a context harvest mode that creates standard AgentPlane extraction tasks for batchwise semantic knowledge extraction from completed task history, with modular prompt context and provenance requirements.",
+    "tags": [
+      "code",
+      "context"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605131449-GS3HB0",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "26f4bf4ba1a7d77364547c7ee3496140e1efe1148c468b4acd413e9806fd3388"
+  }
+}

--- a/.agentplane/tasks/202605131449-GS3HB0/pr/diffstat.txt
+++ b/.agentplane/tasks/202605131449-GS3HB0/pr/diffstat.txt
@@ -5,9 +5,9 @@
  docs/user/local-context.mdx                        |  13 +
  .../src/commands/context/context.spec.ts           |  24 +-
  .../commands/context/harvest-tasks-extraction.ts   |   1 +
- .../src/commands/context/harvest-tasks.test.ts     | 182 +++++++-
- .../src/commands/context/harvest-tasks.ts          | 110 ++++-
+ .../src/commands/context/harvest-tasks.test.ts     | 233 +++++++++-
+ .../src/commands/context/harvest-tasks.ts          | 124 ++++-
  packages/agentplane/src/commands/task/new.ts       |   3 +-
  .../src/context/harvest-tasks-artifacts.ts         |  18 +-
  .../src/context/harvest-tasks-extraction.ts        | 317 +++++++++++++
- 12 files changed, 1217 insertions(+), 22 deletions(-)
+ 12 files changed, 1282 insertions(+), 22 deletions(-)

--- a/.agentplane/tasks/202605131449-GS3HB0/pr/diffstat.txt
+++ b/.agentplane/tasks/202605131449-GS3HB0/pr/diffstat.txt
@@ -1,0 +1,13 @@
+ .../blueprint/resolved-snapshot.json               | 513 +++++++++++++++++++++
+ docs/developer/local-context.mdx                   |  34 +-
+ docs/user/cli-reference.generated.mdx              |  10 +-
+ docs/user/commands.mdx                             |  14 +-
+ docs/user/local-context.mdx                        |  13 +
+ .../src/commands/context/context.spec.ts           |  24 +-
+ .../commands/context/harvest-tasks-extraction.ts   |   1 +
+ .../src/commands/context/harvest-tasks.test.ts     | 182 +++++++-
+ .../src/commands/context/harvest-tasks.ts          | 110 ++++-
+ packages/agentplane/src/commands/task/new.ts       |   3 +-
+ .../src/context/harvest-tasks-artifacts.ts         |  18 +-
+ .../src/context/harvest-tasks-extraction.ts        | 317 +++++++++++++
+ 12 files changed, 1217 insertions(+), 22 deletions(-)

--- a/.agentplane/tasks/202605131449-GS3HB0/pr/github-body.md
+++ b/.agentplane/tasks/202605131449-GS3HB0/pr/github-body.md
@@ -16,15 +16,15 @@ Add a context harvest mode that creates standard AgentPlane extraction tasks for
 ## Verification
 
 - State: ok
-- Note: Verified committed implementation e237c64f2: focused harvest/task-new tests, eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live create-extraction-tasks dry-run all pass. Release-readiness passes under Vitest; Bun test lacks node:sqlite in this environment.
+- Note: Verified review-thread fix 96adf5697: combined --write-proposals and --create-extraction-tasks now preserves context_harvest while adding context_task_extraction; bun test packages/agentplane/src/commands/context/harvest-tasks.test.ts passes 11/11.
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-13T15:03:05.862Z
+- Updated: 2026-05-13T15:42:11.065Z
 - Branch: task/202605131449-GS3HB0/agentic-context-extraction
-- Head: e237c64f2d50
+- Head: 96adf5697296
 
 ```text
  .../blueprint/resolved-snapshot.json               | 513 +++++++++++++++++++++
@@ -34,12 +34,12 @@ Add a context harvest mode that creates standard AgentPlane extraction tasks for
  docs/user/local-context.mdx                        |  13 +
  .../src/commands/context/context.spec.ts           |  24 +-
  .../commands/context/harvest-tasks-extraction.ts   |   1 +
- .../src/commands/context/harvest-tasks.test.ts     | 182 +++++++-
- .../src/commands/context/harvest-tasks.ts          | 110 ++++-
+ .../src/commands/context/harvest-tasks.test.ts     | 233 +++++++++-
+ .../src/commands/context/harvest-tasks.ts          | 124 ++++-
  packages/agentplane/src/commands/task/new.ts       |   3 +-
  .../src/context/harvest-tasks-artifacts.ts         |  18 +-
  .../src/context/harvest-tasks-extraction.ts        | 317 +++++++++++++
- 12 files changed, 1217 insertions(+), 22 deletions(-)
+ 12 files changed, 1282 insertions(+), 22 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605131449-GS3HB0/pr/github-body.md
+++ b/.agentplane/tasks/202605131449-GS3HB0/pr/github-body.md
@@ -16,13 +16,13 @@ Add a context harvest mode that creates standard AgentPlane extraction tasks for
 ## Verification
 
 - State: ok
-- Note: Verified agentic context extraction task generation: focused harvest/task-new tests pass; eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live dry-run smoke pass. Release-readiness was rerun with Vitest because Bun lacks node:sqlite in this environment.
+- Note: Verified committed implementation e237c64f2: focused harvest/task-new tests, eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live create-extraction-tasks dry-run all pass. Release-readiness passes under Vitest; Bun test lacks node:sqlite in this environment.
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-13T15:03:01.411Z
+- Updated: 2026-05-13T15:03:05.862Z
 - Branch: task/202605131449-GS3HB0/agentic-context-extraction
 - Head: e237c64f2d50
 

--- a/.agentplane/tasks/202605131449-GS3HB0/pr/github-body.md
+++ b/.agentplane/tasks/202605131449-GS3HB0/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605131449-GS3HB0`
+Title: Create agentic context extraction tasks
+Canonical task record: `.agentplane/tasks/202605131449-GS3HB0/README.md`
+
+## Summary
+
+Create agentic context extraction tasks
+
+Add a context harvest mode that creates standard AgentPlane extraction tasks for batchwise semantic knowledge extraction from completed task history, with modular prompt context and provenance requirements.
+
+## Scope
+
+- In scope: Add a context harvest mode that creates standard AgentPlane extraction tasks for batchwise semantic knowledge extraction from completed task history, with modular prompt context and provenance requirements.
+- Out of scope: unrelated refactors not required for "Create agentic context extraction tasks".
+
+## Verification
+
+- State: ok
+- Note: Verified agentic context extraction task generation: focused harvest/task-new tests pass; eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live dry-run smoke pass. Release-readiness was rerun with Vitest because Bun lacks node:sqlite in this environment.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-13T14:50:25.406Z
+- Branch: task/202605131449-GS3HB0/agentic-context-extraction
+- Head: 5f62ee4395aa
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605131449-GS3HB0/pr/github-body.md
+++ b/.agentplane/tasks/202605131449-GS3HB0/pr/github-body.md
@@ -22,12 +22,24 @@ Add a context harvest mode that creates standard AgentPlane extraction tasks for
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-13T14:50:25.406Z
+- Updated: 2026-05-13T15:03:01.411Z
 - Branch: task/202605131449-GS3HB0/agentic-context-extraction
-- Head: 5f62ee4395aa
+- Head: e237c64f2d50
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 513 +++++++++++++++++++++
+ docs/developer/local-context.mdx                   |  34 +-
+ docs/user/cli-reference.generated.mdx              |  10 +-
+ docs/user/commands.mdx                             |  14 +-
+ docs/user/local-context.mdx                        |  13 +
+ .../src/commands/context/context.spec.ts           |  24 +-
+ .../commands/context/harvest-tasks-extraction.ts   |   1 +
+ .../src/commands/context/harvest-tasks.test.ts     | 182 +++++++-
+ .../src/commands/context/harvest-tasks.ts          | 110 ++++-
+ packages/agentplane/src/commands/task/new.ts       |   3 +-
+ .../src/context/harvest-tasks-artifacts.ts         |  18 +-
+ .../src/context/harvest-tasks-extraction.ts        | 317 +++++++++++++
+ 12 files changed, 1217 insertions(+), 22 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605131449-GS3HB0/pr/github-title.txt
+++ b/.agentplane/tasks/202605131449-GS3HB0/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 GS3HB0 task: Create agentic context extraction tasks [202605131449-GS3HB0]

--- a/.agentplane/tasks/202605131449-GS3HB0/pr/meta.json
+++ b/.agentplane/tasks/202605131449-GS3HB0/pr/meta.json
@@ -3,11 +3,14 @@
   "branch": "task/202605131449-GS3HB0/agentic-context-extraction",
   "created_at": "2026-05-13T14:50:25.406Z",
   "head_sha": "e237c64f2d50504e7f855cefb7a982d67bd62135",
-  "last_verified_at": "2026-05-13T15:01:58.818Z",
-  "last_verified_sha": "5f62ee4395aaecdd9edb0479d6f89c3d61f4ddab",
+  "last_verified_at": "2026-05-13T15:03:27.015Z",
+  "last_verified_sha": "e237c64f2d50504e7f855cefb7a982d67bd62135",
+  "pr_number": 3638,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3638",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605131449-GS3HB0",
-  "updated_at": "2026-05-13T15:03:01.411Z",
+  "updated_at": "2026-05-13T15:03:05.862Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605131449-GS3HB0/pr/meta.json
+++ b/.agentplane/tasks/202605131449-GS3HB0/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605131449-GS3HB0/agentic-context-extraction",
+  "created_at": "2026-05-13T14:50:25.406Z",
+  "head_sha": "5f62ee4395aaecdd9edb0479d6f89c3d61f4ddab",
+  "last_verified_at": "2026-05-13T15:01:58.818Z",
+  "last_verified_sha": "5f62ee4395aaecdd9edb0479d6f89c3d61f4ddab",
+  "schema_version": 1,
+  "task_id": "202605131449-GS3HB0",
+  "updated_at": "2026-05-13T14:50:25.406Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605131449-GS3HB0/pr/meta.json
+++ b/.agentplane/tasks/202605131449-GS3HB0/pr/meta.json
@@ -2,15 +2,15 @@
   "base": "main",
   "branch": "task/202605131449-GS3HB0/agentic-context-extraction",
   "created_at": "2026-05-13T14:50:25.406Z",
-  "head_sha": "e237c64f2d50504e7f855cefb7a982d67bd62135",
-  "last_verified_at": "2026-05-13T15:03:27.015Z",
-  "last_verified_sha": "e237c64f2d50504e7f855cefb7a982d67bd62135",
+  "head_sha": "96adf5697296acbe55341471c0530e71387de694",
+  "last_verified_at": "2026-05-13T15:42:11.003Z",
+  "last_verified_sha": "96adf5697296acbe55341471c0530e71387de694",
   "pr_number": 3638,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3638",
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202605131449-GS3HB0",
-  "updated_at": "2026-05-13T15:03:05.862Z",
+  "updated_at": "2026-05-13T15:42:11.065Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605131449-GS3HB0/pr/meta.json
+++ b/.agentplane/tasks/202605131449-GS3HB0/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605131449-GS3HB0/agentic-context-extraction",
   "created_at": "2026-05-13T14:50:25.406Z",
-  "head_sha": "5f62ee4395aaecdd9edb0479d6f89c3d61f4ddab",
+  "head_sha": "e237c64f2d50504e7f855cefb7a982d67bd62135",
   "last_verified_at": "2026-05-13T15:01:58.818Z",
   "last_verified_sha": "5f62ee4395aaecdd9edb0479d6f89c3d61f4ddab",
   "schema_version": 1,
   "task_id": "202605131449-GS3HB0",
-  "updated_at": "2026-05-13T14:50:25.406Z",
+  "updated_at": "2026-05-13T15:03:01.411Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605131449-GS3HB0/pr/review.md
+++ b/.agentplane/tasks/202605131449-GS3HB0/pr/review.md
@@ -24,12 +24,24 @@ Created: 2026-05-13T14:50:25.406Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-13T14:50:25.406Z
+- Updated: 2026-05-13T15:03:01.411Z
 - Branch: task/202605131449-GS3HB0/agentic-context-extraction
-- Head: 5f62ee4395aa
+- Head: e237c64f2d50
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 513 +++++++++++++++++++++
+ docs/developer/local-context.mdx                   |  34 +-
+ docs/user/cli-reference.generated.mdx              |  10 +-
+ docs/user/commands.mdx                             |  14 +-
+ docs/user/local-context.mdx                        |  13 +
+ .../src/commands/context/context.spec.ts           |  24 +-
+ .../commands/context/harvest-tasks-extraction.ts   |   1 +
+ .../src/commands/context/harvest-tasks.test.ts     | 182 +++++++-
+ .../src/commands/context/harvest-tasks.ts          | 110 ++++-
+ packages/agentplane/src/commands/task/new.ts       |   3 +-
+ .../src/context/harvest-tasks-artifacts.ts         |  18 +-
+ .../src/context/harvest-tasks-extraction.ts        | 317 +++++++++++++
+ 12 files changed, 1217 insertions(+), 22 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605131449-GS3HB0/pr/review.md
+++ b/.agentplane/tasks/202605131449-GS3HB0/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-05-13T14:50:25.406Z
 ## Verification
 
 - State: ok
-- Note: Verified agentic context extraction task generation: focused harvest/task-new tests pass; eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live dry-run smoke pass. Release-readiness was rerun with Vitest because Bun lacks node:sqlite in this environment.
+- Note: Verified committed implementation e237c64f2: focused harvest/task-new tests, eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live create-extraction-tasks dry-run all pass. Release-readiness passes under Vitest; Bun test lacks node:sqlite in this environment.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,7 +24,7 @@ Created: 2026-05-13T14:50:25.406Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-13T15:03:01.411Z
+- Updated: 2026-05-13T15:03:05.862Z
 - Branch: task/202605131449-GS3HB0/agentic-context-extraction
 - Head: e237c64f2d50
 

--- a/.agentplane/tasks/202605131449-GS3HB0/pr/review.md
+++ b/.agentplane/tasks/202605131449-GS3HB0/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-05-13T14:50:25.406Z
 ## Verification
 
 - State: ok
-- Note: Verified committed implementation e237c64f2: focused harvest/task-new tests, eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live create-extraction-tasks dry-run all pass. Release-readiness passes under Vitest; Bun test lacks node:sqlite in this environment.
+- Note: Verified review-thread fix 96adf5697: combined --write-proposals and --create-extraction-tasks now preserves context_harvest while adding context_task_extraction; bun test packages/agentplane/src/commands/context/harvest-tasks.test.ts passes 11/11.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,9 +24,9 @@ Created: 2026-05-13T14:50:25.406Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-13T15:03:05.862Z
+- Updated: 2026-05-13T15:42:11.065Z
 - Branch: task/202605131449-GS3HB0/agentic-context-extraction
-- Head: e237c64f2d50
+- Head: 96adf5697296
 
 ```text
  .../blueprint/resolved-snapshot.json               | 513 +++++++++++++++++++++
@@ -36,12 +36,12 @@ Created: 2026-05-13T14:50:25.406Z
  docs/user/local-context.mdx                        |  13 +
  .../src/commands/context/context.spec.ts           |  24 +-
  .../commands/context/harvest-tasks-extraction.ts   |   1 +
- .../src/commands/context/harvest-tasks.test.ts     | 182 +++++++-
- .../src/commands/context/harvest-tasks.ts          | 110 ++++-
+ .../src/commands/context/harvest-tasks.test.ts     | 233 +++++++++-
+ .../src/commands/context/harvest-tasks.ts          | 124 ++++-
  packages/agentplane/src/commands/task/new.ts       |   3 +-
  .../src/context/harvest-tasks-artifacts.ts         |  18 +-
  .../src/context/harvest-tasks-extraction.ts        | 317 +++++++++++++
- 12 files changed, 1217 insertions(+), 22 deletions(-)
+ 12 files changed, 1282 insertions(+), 22 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605131449-GS3HB0/pr/review.md
+++ b/.agentplane/tasks/202605131449-GS3HB0/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-13T14:50:25.406Z
+
+## Task
+
+- Task: `202605131449-GS3HB0`
+- Title: Create agentic context extraction tasks
+- Status: DOING
+- Branch: `task/202605131449-GS3HB0/agentic-context-extraction`
+- Canonical task record: `.agentplane/tasks/202605131449-GS3HB0/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified agentic context extraction task generation: focused harvest/task-new tests pass; eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live dry-run smoke pass. Release-readiness was rerun with Vitest because Bun lacks node:sqlite in this environment.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-13T14:50:25.406Z
+- Branch: task/202605131449-GS3HB0/agentic-context-extraction
+- Head: 5f62ee4395aa
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/docs/developer/local-context.mdx
+++ b/docs/developer/local-context.mdx
@@ -20,14 +20,32 @@ it no longer owns the SQLite file.
 
 ## Owning code paths
 
-| Surface                  | Code path                                                                                               |
-| ------------------------ | ------------------------------------------------------------------------------------------------------- |
-| Command specs            | `packages/agentplane/src/commands/context/*.spec.ts`                                                    |
-| CLI handlers             | `packages/agentplane/src/commands/context/*.ts`                                                         |
-| Shared parsing and refs  | `packages/agentplane/src/commands/context/context-utils.ts`                                             |
-| SQLite driver/projection | `packages/agentplane/src/shared/sqlite-driver.ts`, `packages/agentplane/src/commands/context/sqlite.ts` |
-| ACR context extension    | `packages/agentplane/src/commands/acr/**`                                                               |
-| Runner handoff           | `packages/agentplane/src/commands/context/ingest.ts`, `packages/agentplane/src/commands/task/run/**`    |
+| Surface                  | Code path                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Command specs            | `packages/agentplane/src/commands/context/*.spec.ts`                                                                                                                |
+| CLI handlers             | `packages/agentplane/src/commands/context/*.ts`                                                                                                                     |
+| Shared parsing and refs  | `packages/agentplane/src/commands/context/context-utils.ts`                                                                                                         |
+| SQLite driver/projection | `packages/agentplane/src/shared/sqlite-driver.ts`, `packages/agentplane/src/commands/context/sqlite.ts`                                                             |
+| ACR context extension    | `packages/agentplane/src/commands/acr/**`                                                                                                                           |
+| Runner handoff           | `packages/agentplane/src/commands/context/ingest.ts`, `packages/agentplane/src/context/harvest-tasks-extraction.ts`, `packages/agentplane/src/commands/task/run/**` |
+
+## Task-history extraction
+
+`context harvest tasks --create-extraction-tasks` is the agentic layer for completed task history.
+It does not treat the deterministic `context/raw/tasks/*.json` snapshot as the semantic source.
+Instead, it creates standard `CURATOR` tasks whose context extension names the source task READMEs,
+ACR files, source digests, allowed outputs, and a replaceable prompt module.
+
+The generated prompt module uses the normal prompt-module schema with a stable address:
+
+```text
+framework/template/generated.artifact/context_task_extraction/v1
+```
+
+This keeps task-history extraction improvable through the same module/mutation model as other
+AgentPlane prompts. The generated task remains the execution boundary: a CURATOR agent reads the
+source pack, searches existing wiki/facts/graph rows, writes sourced updates, records stale/conflict
+markers, and verifies through context gates before promotion.
 
 ## Projection contract
 

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -3776,7 +3776,7 @@ agentplane context harvest [<cmd> ...]
 
 Harvest completed task evidence into wiki, fact, and graph proposals.
 
-Selects completed tasks in oldest-first order, skips unchanged tasks with matching ingestion markers, and separates source indexing, knowledge extraction, wiki synthesis, promotion-gate state, and task README markers. Write modes require an initialized context workspace.
+Selects completed tasks in oldest-first order, skips unchanged tasks with matching ingestion markers, and separates source indexing, agentic extraction task creation, wiki synthesis, promotion-gate state, and task README markers. Write modes require an initialized context workspace.
 
 Usage:
 
@@ -3794,6 +3794,8 @@ Options:
 - `--after-task <task-id>`: Continue after a previously harvested task id.
 - `--limit <n>`: Maximum number of oldest matching tasks to harvest.
 - `--write-proposals`: Write raw evidence, derived facts/graph rows, report, and wiki proposal. (default=false)
+- `--create-extraction-tasks`: Create standard CURATOR tasks for batchwise semantic extraction from task README/ACR sources. (default=false)
+- `--batch-size <n>`: Number of selected completed tasks per generated extraction task. (default=25)
 - `--promote`: Promote the wiki proposal to semi-canonical only if the promotion gate passes. (default=false)
 - `--dry-run`: Preview selection and gate state without writing artifacts. (default=false)
 - `--format <text|json>`: Output format. (choices=text|json, default=text)
@@ -3811,6 +3813,12 @@ agentplane context harvest tasks --tag branch_pr --write-proposals
 ```
 
 - Write source-backed reusable context proposals from completed branch_pr tasks.
+
+```sh
+agentplane context harvest tasks --tag branch_pr --create-extraction-tasks --batch-size 25
+```
+
+- Create CURATOR tasks that extract semantic wiki/fact/graph knowledge in bounded oldest-first batches.
 
 ### context ingest
 

--- a/docs/user/commands.mdx
+++ b/docs/user/commands.mdx
@@ -226,6 +226,7 @@ agentplane context show context/wiki/page.md#section=section-slug
 agentplane context ingest --changed
 agentplane context ingest ./notes.md --run
 agentplane context harvest tasks --tag release --limit 20 --dry-run
+agentplane context harvest tasks --tag branch_pr --create-extraction-tasks --batch-size 25
 agentplane context harvest tasks --tag branch_pr --write-proposals
 agentplane context verify-task <task-id>
 ```
@@ -234,11 +235,14 @@ Source artifacts live under `context/**`. Derived context artifacts live under
 `.agentplane/context/derived/**`, and the fast SQLite projection is stored in the shared cache
 database at `.agentplane/cache.sqlite`. Use `context harvest tasks` to convert completed task
 history into raw evidence, facts, graph rows, wiki proposals, and promotion-gate reports before
-promoting reusable knowledge. Write modes also mark harvested task READMEs with
-`extensions.context_harvest` and maintain `.agentplane/context/derived/ingestion/tasks.jsonl`, so
-later broad runs can skip unchanged ingested tasks by source digest instead of guessing from wiki
-files. Write modes require `agentplane context init` first. Use `context verify-task` before
-closing work that creates or relies on context artifacts. See [Local context](local-context).
+promoting reusable knowledge. For semantic extraction, `--create-extraction-tasks` creates standard
+`CURATOR` tasks that read task READMEs and ACR evidence in bounded oldest-first batches, then update
+wiki/facts/graph outputs through the normal task lifecycle. Write modes also mark harvested task
+READMEs with `extensions.context_harvest` for raw ingestion and
+`extensions.context_task_extraction` for queued semantic extraction, so later broad runs can skip
+unchanged ingested or queued tasks by source digest instead of guessing from wiki files. Write modes
+require `agentplane context init` first. Use `context verify-task` before closing work that creates
+or relies on context artifacts. See [Local context](local-context).
 
 ## Backend sync (remote backends)
 

--- a/docs/user/local-context.mdx
+++ b/docs/user/local-context.mdx
@@ -54,6 +54,7 @@ runner adapter instead of only preparing the request.
 
 ```bash
 agentplane context harvest tasks --tag release --limit 20 --dry-run
+agentplane context harvest tasks --tag branch_pr --create-extraction-tasks --batch-size 25
 agentplane context harvest tasks --tag branch_pr --write-proposals
 agentplane context harvest tasks --task 202605100837-PJZW2E --write-proposals
 ```
@@ -77,6 +78,18 @@ refs. Later broad runs skip tasks whose marker digest still matches the README e
 `--task` selection and `--promote` can still revisit a marked task when needed. Write modes require
 an initialized context workspace from `agentplane context init`; dry-run mode can be used before
 initialization.
+
+Use `--create-extraction-tasks` when completed task history needs agentic semantic extraction rather
+than deterministic one-claim-per-task proposals. It creates standard `CURATOR` tasks in oldest-first
+batches controlled by `--batch-size`. Each generated task carries an
+`extensions.agentplane.context` source pack with the selected task README paths, ACR paths, source
+digests, allowed outputs, provenance requirements, and a replaceable prompt module for extracting
+wiki pages, facts, entities, relations, stale markers, and conflict markers. This mode does not write
+`context/raw/tasks/*.json` by itself; the source of semantic truth is the task README and ACR
+evidence named in the generated task. It also marks source tasks with
+`extensions.context_task_extraction` so later broad runs do not create duplicate extraction tasks
+while the README digest is unchanged. Raw-ingestion markers from `--write-proposals` do not count as
+semantic extraction completion.
 
 ## Verify task context
 

--- a/packages/agentplane/src/commands/context/context.spec.ts
+++ b/packages/agentplane/src/commands/context/context.spec.ts
@@ -189,6 +189,8 @@ export const contextHarvestTasksSpec: CommandSpec<{
   afterTask: string;
   limit: string;
   writeProposals: boolean;
+  createExtractionTasks: boolean;
+  batchSize: string;
   promote: boolean;
   dryRun: boolean;
   format: "text" | "json";
@@ -197,7 +199,7 @@ export const contextHarvestTasksSpec: CommandSpec<{
   group: "Context",
   summary: "Harvest completed task evidence into wiki, fact, and graph proposals.",
   description:
-    "Selects completed tasks in oldest-first order, skips unchanged tasks with matching ingestion markers, and separates source indexing, knowledge extraction, wiki synthesis, promotion-gate state, and task README markers. Write modes require an initialized context workspace.",
+    "Selects completed tasks in oldest-first order, skips unchanged tasks with matching ingestion markers, and separates source indexing, agentic extraction task creation, wiki synthesis, promotion-gate state, and task README markers. Write modes require an initialized context workspace.",
   options: [
     {
       kind: "string",
@@ -252,6 +254,20 @@ export const contextHarvestTasksSpec: CommandSpec<{
     },
     {
       kind: "boolean",
+      name: "create-extraction-tasks",
+      default: false,
+      description:
+        "Create standard CURATOR tasks for batchwise semantic extraction from task README/ACR sources.",
+    },
+    {
+      kind: "string",
+      name: "batch-size",
+      default: "25",
+      valueHint: "<n>",
+      description: "Number of selected completed tasks per generated extraction task.",
+    },
+    {
+      kind: "boolean",
       name: "promote",
       default: false,
       description: "Promote the wiki proposal to semi-canonical only if the promotion gate passes.",
@@ -280,6 +296,10 @@ export const contextHarvestTasksSpec: CommandSpec<{
       cmd: "agentplane context harvest tasks --tag branch_pr --write-proposals",
       why: "Write source-backed reusable context proposals from completed branch_pr tasks.",
     },
+    {
+      cmd: "agentplane context harvest tasks --tag branch_pr --create-extraction-tasks --batch-size 25",
+      why: "Create CURATOR tasks that extract semantic wiki/fact/graph knowledge in bounded oldest-first batches.",
+    },
   ],
   parse: (raw) => ({
     status: toStringList(raw.opts.status),
@@ -290,6 +310,8 @@ export const contextHarvestTasksSpec: CommandSpec<{
     afterTask: typeof raw.opts["after-task"] === "string" ? raw.opts["after-task"] : "",
     limit: typeof raw.opts.limit === "string" ? raw.opts.limit : "",
     writeProposals: raw.opts["write-proposals"] === true,
+    createExtractionTasks: raw.opts["create-extraction-tasks"] === true,
+    batchSize: typeof raw.opts["batch-size"] === "string" ? raw.opts["batch-size"] : "25",
     promote: raw.opts.promote === true,
     dryRun: raw.opts["dry-run"] === true,
     format: (raw.opts.format as "text" | "json") ?? "text",

--- a/packages/agentplane/src/commands/context/harvest-tasks-extraction.ts
+++ b/packages/agentplane/src/commands/context/harvest-tasks-extraction.ts
@@ -1,0 +1,1 @@
+export * from "../../context/harvest-tasks-extraction.js";

--- a/packages/agentplane/src/commands/context/harvest-tasks.test.ts
+++ b/packages/agentplane/src/commands/context/harvest-tasks.test.ts
@@ -370,6 +370,57 @@ describe("context harvest tasks", () => {
     ).rejects.toThrow();
   });
 
+  it("preserves harvest markers when proposal writing and extraction task creation are combined", async () => {
+    const root = await tempRoot();
+    await initContextWorkspace(root);
+    const tasks = [
+      task({
+        id: "202604010900-FIRST1",
+        title: "First context task",
+        tags: ["workflow"],
+      }),
+    ];
+    const commandCtx = ctx(root, tasks);
+
+    await cmdContextHarvestTasks({
+      ctx: commandCtx,
+      cwd: root,
+      parsed: parsed({
+        tag: ["workflow"],
+        writeProposals: true,
+        createExtractionTasks: true,
+        format: "json",
+      }),
+      createTask: async ({ ctx, parsed }) => {
+        await ctx.taskBackend.writeTask({
+          id: "202604040900-CURAT1",
+          title: parsed.title,
+          status: "TODO",
+          owner: parsed.owner,
+          priority: parsed.priority,
+          tags: parsed.tags,
+          description: parsed.description,
+          extensions: parsed.extensions,
+        } as TaskData);
+        return 0;
+      },
+    });
+
+    expect(tasks.find((row) => row.id === "202604010900-FIRST1")?.extensions).toMatchObject({
+      context_harvest: {
+        pipeline: "context.harvest.tasks",
+        state: "ingested",
+        raw_evidence_path: "context/raw/tasks/202604010900-FIRST1.json",
+        wiki_proposal_path: "context/wiki/proposals/task-harvest/done-workflow.md",
+      },
+      context_task_extraction: {
+        pipeline: "context.harvest.tasks",
+        state: "queued",
+        extraction_task_id: "202604040900-CURAT1",
+      },
+    });
+  });
+
   it("does not treat raw harvest markers as semantic extraction completion", async () => {
     const root = await tempRoot();
     await initContextWorkspace(root);

--- a/packages/agentplane/src/commands/context/harvest-tasks.test.ts
+++ b/packages/agentplane/src/commands/context/harvest-tasks.test.ts
@@ -72,6 +72,8 @@ function parsed(input: Partial<ContextHarvestTasksParsed> = {}): ContextHarvestT
     afterTask: input.afterTask ?? "",
     limit: input.limit ?? "",
     writeProposals: input.writeProposals ?? false,
+    createExtractionTasks: input.createExtractionTasks ?? false,
+    batchSize: input.batchSize ?? "25",
     promote: input.promote ?? false,
     dryRun: input.dryRun ?? false,
     format: input.format ?? "text",
@@ -86,7 +88,8 @@ function ctx(root: string, tasks: TaskData[]): CommandContext {
       listTasks: () => Promise.resolve(tasks),
       writeTask: (updated: TaskData) => {
         const index = tasks.findIndex((task) => task.id === updated.id);
-        if (index !== -1) tasks[index] = updated;
+        if (index === -1) tasks.push(updated);
+        else tasks[index] = updated;
         return Promise.resolve();
       },
     },
@@ -266,6 +269,183 @@ describe("context harvest tasks", () => {
         parsed: parsed({ tag: ["release"], writeProposals: true }),
       }),
     ).rejects.toThrow(/context init/u);
+  });
+
+  it("creates CURATOR extraction tasks in oldest-first batches without writing raw evidence", async () => {
+    const root = await tempRoot();
+    await initContextWorkspace(root);
+    const createdParsed: unknown[] = [];
+    const tasks = [
+      task({ id: "202604030900-THIRD3", title: "Third context task", tags: ["workflow"] }),
+      task({ id: "202604010900-FIRST1", title: "First context task", tags: ["workflow"] }),
+      task({ id: "202604020900-SECOND", title: "Second context task", tags: ["workflow"] }),
+    ];
+    const commandCtx = ctx(root, tasks);
+    let createdCount = 0;
+
+    await cmdContextHarvestTasks({
+      ctx: commandCtx,
+      cwd: root,
+      parsed: parsed({
+        tag: ["workflow"],
+        createExtractionTasks: true,
+        batchSize: "2",
+        format: "json",
+      }),
+      createTask: async ({ ctx, parsed }) => {
+        createdCount += 1;
+        createdParsed.push(parsed);
+        await ctx.taskBackend.writeTask({
+          id: `202604040900-CURAT${createdCount}`,
+          title: parsed.title,
+          status: "TODO",
+          owner: parsed.owner,
+          priority: parsed.priority,
+          tags: parsed.tags,
+          description: parsed.description,
+          extensions: parsed.extensions,
+        } as TaskData);
+        return 0;
+      },
+    });
+
+    expect(createdParsed).toHaveLength(2);
+    expect(createdParsed[0]).toMatchObject({
+      owner: "CURATOR",
+      tags: ["context", "assimilation", "task-harvest"],
+      taskKind: "context",
+      mutationScope: "context",
+      blueprintRequest: "context.assimilation",
+    });
+    const first = createdParsed[0] as {
+      extensions: {
+        "agentplane.context": {
+          source_set: { sources: { id: string; readme_path: string; acr_path: string }[] };
+          prompt_modules: { address: { value: string }; content: string }[];
+        };
+      };
+    };
+    expect(first.extensions["agentplane.context"].source_set.sources).toMatchObject([
+      {
+        id: "202604010900-FIRST1",
+        title: "First context task",
+        status: "DONE",
+        tags: ["workflow"],
+        readme_path: ".agentplane/tasks/202604010900-FIRST1/README.md",
+        acr_path: ".agentplane/tasks/202604010900-FIRST1/acr.json",
+        existing_harvest_marker: null,
+      },
+      {
+        id: "202604020900-SECOND",
+        title: "Second context task",
+        status: "DONE",
+        tags: ["workflow"],
+        readme_path: ".agentplane/tasks/202604020900-SECOND/README.md",
+        acr_path: ".agentplane/tasks/202604020900-SECOND/acr.json",
+        existing_harvest_marker: null,
+      },
+    ]);
+    expect(first.extensions["agentplane.context"].source_set.sources[0]?.source_digest).toMatch(
+      /^sha256:/,
+    );
+    expect(first.extensions["agentplane.context"].source_set.sources[1]?.source_digest).toMatch(
+      /^sha256:/,
+    );
+    expect(first.extensions["agentplane.context"].prompt_modules[0]?.address.value).toBe(
+      "framework/template/generated.artifact/context_task_extraction/v1",
+    );
+    expect(first.extensions["agentplane.context"].prompt_modules[0]?.content).toContain(
+      "Read each source task README first",
+    );
+    expect(tasks.find((row) => row.id === "202604010900-FIRST1")?.extensions).toMatchObject({
+      context_task_extraction: {
+        pipeline: "context.harvest.tasks",
+        state: "queued",
+        extraction_task_id: "202604040900-CURAT1",
+        prompt_module_ref: "framework/template/generated.artifact/context_task_extraction/v1",
+      },
+    });
+    await expect(
+      readFile(path.join(root, "context/raw/tasks/202604010900-FIRST1.json")),
+    ).rejects.toThrow();
+  });
+
+  it("does not treat raw harvest markers as semantic extraction completion", async () => {
+    const root = await tempRoot();
+    await initContextWorkspace(root);
+    const out = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const tasks = [
+      task({
+        id: "202604010900-REL001",
+        title: "Release gate hardening",
+        tags: ["release", "code"],
+      }),
+    ];
+
+    await cmdContextHarvestTasks({
+      ctx: ctx(root, tasks),
+      cwd: root,
+      parsed: parsed({ tag: ["release"], writeProposals: true }),
+    });
+    out.mockClear();
+    await cmdContextHarvestTasks({
+      ctx: ctx(root, tasks),
+      cwd: root,
+      parsed: parsed({
+        tag: ["release"],
+        createExtractionTasks: true,
+        dryRun: true,
+        format: "json",
+      }),
+    });
+
+    const payload = JSON.parse(out.mock.calls.map((call) => String(call[0])).join("")) as {
+      selected_task_ids: string[];
+      extraction_task_batches: { source_task_ids: string[] }[];
+    };
+    expect(payload.selected_task_ids).toEqual(["202604010900-REL001"]);
+    expect(payload.extraction_task_batches[0]?.source_task_ids).toEqual(["202604010900-REL001"]);
+  });
+
+  it("previews extraction task batches on dry-run without creating tasks", async () => {
+    const root = await tempRoot();
+    const out = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await cmdContextHarvestTasks({
+      ctx: ctx(root, [
+        task({ id: "202604010900-FIRST1", title: "First context task", tags: ["workflow"] }),
+        task({ id: "202604020900-SECOND", title: "Second context task", tags: ["workflow"] }),
+      ]),
+      cwd: root,
+      parsed: parsed({
+        tag: ["workflow"],
+        createExtractionTasks: true,
+        batchSize: "1",
+        dryRun: true,
+        format: "json",
+      }),
+      createTask: () => Promise.reject(new Error("dry-run must not create tasks")),
+    });
+
+    const payload = JSON.parse(out.mock.calls.map((call) => String(call[0])).join("")) as {
+      extraction_task_batches: { source_task_ids: string[]; created_task_id: string | null }[];
+      created_extraction_task_ids: string[];
+    };
+    expect(payload.extraction_task_batches).toEqual([
+      {
+        batch_index: 1,
+        batch_count: 2,
+        source_task_ids: ["202604010900-FIRST1"],
+        created_task_id: null,
+      },
+      {
+        batch_index: 2,
+        batch_count: 2,
+        source_task_ids: ["202604020900-SECOND"],
+        created_task_id: null,
+      },
+    ]);
+    expect(payload.created_extraction_task_ids).toEqual([]);
   });
 
   it("sanitizes explicit task filters before deriving proposal paths", async () => {

--- a/packages/agentplane/src/commands/context/harvest-tasks.ts
+++ b/packages/agentplane/src/commands/context/harvest-tasks.ts
@@ -98,11 +98,25 @@ async function createExtractionTasks(opts: {
   }
   const sourceChangedPaths: string[] = [];
   const queuedAt = new Date().toISOString();
+  const latestTasks = await opts.ctx.taskBackend.listTasks();
+  const latestById = new Map(
+    latestTasks
+      .filter((task): task is TaskData & { id: string; title: string; status: string } => {
+        return (
+          typeof task.id === "string" &&
+          typeof task.title === "string" &&
+          typeof task.status === "string"
+        );
+      })
+      .map((task) => [task.id, task]),
+  );
   for (const plan of plans) {
     const extractionTaskId = createdTaskIds[plan.batch_index - 1];
     if (!extractionTaskId) continue;
     for (const sourceTaskId of plan.source_task_ids) {
-      const task = opts.output.selected.find((candidate) => candidate.id === sourceTaskId);
+      const task =
+        latestById.get(sourceTaskId) ??
+        opts.output.selected.find((candidate) => candidate.id === sourceTaskId);
       if (!task) continue;
       const marker = buildTaskExtractionMarker({
         task,
@@ -180,7 +194,7 @@ export async function cmdContextHarvestTasks(opts: {
           parsed: opts.parsed,
           createTask: opts.createTask,
         });
-  const changed = [...written, ...extraction.changedPaths];
+  const changed = [...new Set([...written, ...extraction.changedPaths])];
   const payload = {
     ...output.report,
     selected_task_ids: selected.map((task) => task.id),

--- a/packages/agentplane/src/commands/context/harvest-tasks.ts
+++ b/packages/agentplane/src/commands/context/harvest-tasks.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { TaskData } from "../../backends/task-backend.js";
 import { CliError } from "../../shared/errors.js";
 import { loadCommandContext, type CommandContext } from "../shared/task-backend.js";
+import { runTaskNewParsed } from "../task/new.js";
 import { fileExists, isRecord } from "./context-utils.js";
 import {
   buildOutput,
@@ -11,6 +12,7 @@ import {
   writeOutputs,
   type ContextHarvestTasksParsed,
 } from "./harvest-tasks-artifacts.js";
+import { buildExtractionTaskPlans, buildTaskExtractionMarker } from "./harvest-tasks-extraction.js";
 import type { TaskHarvestMarker } from "./harvest-tasks-markers.js";
 
 export { readHarvestReport, type ContextHarvestTasksParsed } from "./harvest-tasks-artifacts.js";
@@ -64,11 +66,82 @@ async function writeTaskMarkers(ctx: CommandContext, output: ReturnType<typeof b
   return changed;
 }
 
+async function createExtractionTasks(opts: {
+  ctx: CommandContext;
+  cwd: string;
+  rootOverride?: string;
+  output: ReturnType<typeof buildOutput>;
+  parsed: ContextHarvestTasksParsed;
+  createTask?: typeof runTaskNewParsed;
+}) {
+  const beforeTasks = await opts.ctx.taskBackend.listTasks();
+  const knownTaskIds = new Set(beforeTasks.map((task) => task.id));
+  const plans = buildExtractionTaskPlans(opts.output.selected, opts.parsed);
+  const createTask = opts.createTask ?? runTaskNewParsed;
+  const createdTaskIds: string[] = [];
+  for (const plan of plans) {
+    await createTask({
+      ctx: opts.ctx,
+      cwd: opts.cwd,
+      rootOverride: opts.rootOverride,
+      parsed: plan.parsed,
+      printTaskId: false,
+    });
+    const afterPlan = await opts.ctx.taskBackend.listTasks();
+    const createdForPlan = afterPlan
+      .filter((task) => !knownTaskIds.has(task.id))
+      .toSorted((a, b) => a.id.localeCompare(b.id));
+    const createdTaskId = createdForPlan[0]?.id;
+    if (!createdTaskId) continue;
+    createdTaskIds.push(createdTaskId);
+    for (const task of createdForPlan) knownTaskIds.add(task.id);
+  }
+  const sourceChangedPaths: string[] = [];
+  const queuedAt = new Date().toISOString();
+  for (const plan of plans) {
+    const extractionTaskId = createdTaskIds[plan.batch_index - 1];
+    if (!extractionTaskId) continue;
+    for (const sourceTaskId of plan.source_task_ids) {
+      const task = opts.output.selected.find((candidate) => candidate.id === sourceTaskId);
+      if (!task) continue;
+      const marker = buildTaskExtractionMarker({
+        task,
+        queuedAt,
+        extractionTaskId,
+        batchIndex: plan.batch_index,
+        batchCount: plan.batch_count,
+      });
+      const extensions = isRecord(task.extensions) ? task.extensions : {};
+      if (isRecord(extensions.context_task_extraction)) {
+        const current = JSON.stringify(extensions.context_task_extraction);
+        if (current === JSON.stringify(marker)) continue;
+      }
+      await opts.ctx.taskBackend.writeTask({
+        ...task,
+        extensions: {
+          ...extensions,
+          context_task_extraction: marker,
+        },
+      });
+      sourceChangedPaths.push(`.agentplane/tasks/${task.id}/README.md`);
+    }
+  }
+  return {
+    plans,
+    taskIds: createdTaskIds,
+    changedPaths: [
+      ...createdTaskIds.map((taskId) => `.agentplane/tasks/${taskId}/README.md`),
+      ...sourceChangedPaths,
+    ],
+  };
+}
+
 export async function cmdContextHarvestTasks(opts: {
   ctx?: CommandContext;
   cwd: string;
   rootOverride?: string;
   parsed: ContextHarvestTasksParsed;
+  createTask?: typeof runTaskNewParsed;
 }): Promise<number> {
   const ctx =
     opts.ctx ??
@@ -77,28 +150,59 @@ export async function cmdContextHarvestTasks(opts: {
   const selected = selectTasks(await readAllTasks(ctx), opts.parsed);
   const output = buildOutput(opts.parsed, selected);
   const shouldWrite = opts.parsed.writeProposals || opts.parsed.promote;
+  const shouldCreateExtractionTasks = opts.parsed.createExtractionTasks;
 
-  if (!opts.parsed.dryRun && shouldWrite) {
+  if (!opts.parsed.dryRun && (shouldWrite || shouldCreateExtractionTasks)) {
     await assertContextWorkspaceReady(root);
   }
 
-  const changed =
+  const written =
     opts.parsed.dryRun || !shouldWrite
       ? []
       : [
           ...(await writeOutputs(root, output, opts.parsed.promote)),
           ...(await writeTaskMarkers(ctx, output)),
         ];
+  const extraction =
+    opts.parsed.dryRun || !shouldCreateExtractionTasks
+      ? {
+          plans: shouldCreateExtractionTasks
+            ? buildExtractionTaskPlans(output.selected, opts.parsed)
+            : [],
+          taskIds: [],
+          changedPaths: [],
+        }
+      : await createExtractionTasks({
+          ctx,
+          cwd: opts.cwd,
+          rootOverride: opts.rootOverride,
+          output,
+          parsed: opts.parsed,
+          createTask: opts.createTask,
+        });
+  const changed = [...written, ...extraction.changedPaths];
   const payload = {
     ...output.report,
     selected_task_ids: selected.map((task) => task.id),
+    extraction_task_batches: extraction.plans.map((plan) => ({
+      batch_index: plan.batch_index,
+      batch_count: plan.batch_count,
+      source_task_ids: plan.source_task_ids,
+      created_task_id: extraction.taskIds[plan.batch_index - 1] ?? null,
+    })),
+    created_extraction_task_ids: extraction.taskIds,
     changed_paths: changed,
   };
 
   if (opts.parsed.format === "json") {
     process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
   } else {
-    process.stdout.write(`${renderText(output, changed)}\n`);
+    process.stdout.write(
+      `${renderText(output, changed, {
+        planned: extraction.plans.length,
+        created: extraction.taskIds,
+      })}\n`,
+    );
   }
 
   if (opts.parsed.promote && output.report.promotion_gate.state === "blocked") {

--- a/packages/agentplane/src/commands/task/new.ts
+++ b/packages/agentplane/src/commands/task/new.ts
@@ -272,6 +272,7 @@ export async function runTaskNewParsed(opts: {
   cwd: string;
   rootOverride?: string;
   parsed: TaskNewParsed;
+  printTaskId?: boolean;
 }): Promise<number> {
   const p = sanitizeTaskNewParsed(opts.parsed);
   try {
@@ -410,7 +411,7 @@ export async function runTaskNewParsed(opts: {
     }
 
     await ctx.taskBackend.writeTask(task);
-    process.stdout.write(`${taskId}\n`);
+    if (opts.printTaskId !== false) process.stdout.write(`${taskId}\n`);
     if (p.showBlueprint) {
       const summary = await resolveTaskBlueprintLifecycleSummary({
         task,

--- a/packages/agentplane/src/context/harvest-tasks-artifacts.ts
+++ b/packages/agentplane/src/context/harvest-tasks-artifacts.ts
@@ -7,6 +7,7 @@ import type { TaskData } from "../backends/task-backend.js";
 import { CliError } from "../shared/errors.js";
 import { writeJsonStableIfChanged, writeTextIfChanged } from "../shared/write-if-changed.js";
 import { fileExists, isRecord, parseJsonlLines, readText } from "./context-utils.js";
+import { alreadyQueuedForExtractionUnchanged } from "./harvest-tasks-extraction.js";
 import {
   alreadyHarvestedUnchanged,
   buildTaskHarvestLedgerRows,
@@ -26,6 +27,8 @@ export type ContextHarvestTasksParsed = {
   afterTask: string;
   limit: string;
   writeProposals: boolean;
+  createExtractionTasks: boolean;
+  batchSize: string;
   promote: boolean;
   dryRun: boolean;
   format: "text" | "json";
@@ -436,7 +439,11 @@ export function selectTasks(tasks: TaskData[], parsed: ContextHarvestTasksParsed
   const limit = parseLimit(parsed.limit);
   const selected = asTaskList(tasks)
     .filter((task) => taskMatches(task, parsed))
-    .filter((task) => !alreadyHarvestedUnchanged(task, parsed))
+    .filter((task) =>
+      parsed.createExtractionTasks
+        ? !alreadyQueuedForExtractionUnchanged(task, parsed)
+        : !alreadyHarvestedUnchanged(task, parsed),
+    )
     .sort((a, b) => a.id.localeCompare(b.id));
   return limit === null ? selected : selected.slice(0, limit);
 }
@@ -542,7 +549,11 @@ export async function writeOutputs(
   return changed;
 }
 
-export function renderText(output: HarvestOutput, changed: string[]): string {
+export function renderText(
+  output: HarvestOutput,
+  changed: string[],
+  extraction?: { planned: number; created: string[] },
+): string {
   return [
     "context harvest tasks",
     `- selected tasks: ${output.report.counts.selected_tasks}`,
@@ -552,6 +563,9 @@ export function renderText(output: HarvestOutput, changed: string[]): string {
     `- stale candidates: ${output.report.counts.stale_candidates}`,
     `- conflict candidates: ${output.report.counts.conflict_candidates}`,
     `- promotion gate: ${output.report.promotion_gate.state}`,
+    `- extraction task batches: ${extraction?.planned ?? 0}`,
+    `- created extraction tasks: ${extraction?.created.length ?? 0}`,
+    ...(extraction?.created ?? []).map((item) => `  - ${item}`),
     `- proposal: ${output.wikiPath}`,
     `- promoted: ${output.report.promotion_gate.promoted_path ?? "not promoted"}`,
     `- changed paths: ${changed.length}`,

--- a/packages/agentplane/src/context/harvest-tasks-extraction.ts
+++ b/packages/agentplane/src/context/harvest-tasks-extraction.ts
@@ -1,0 +1,317 @@
+import type { TaskData } from "../backends/task-backend.js";
+import type { TaskNewParsed } from "../commands/task/new.js";
+import type { PromptModule } from "../runtime/prompt-modules/index.js";
+import { PROMPT_MODULE_CONTRACT_SCHEMA_VERSION } from "../runtime/prompt-modules/index.js";
+import { CliError } from "../shared/errors.js";
+import { isRecord } from "./context-utils.js";
+import { taskTextDigest } from "./harvest-tasks-markers.js";
+import type { ContextHarvestTasksParsed } from "./harvest-tasks-artifacts.js";
+
+type ExtractionTask = TaskData & { id: string; title: string; status: string };
+
+type ExtractionTaskPlan = {
+  batch_index: number;
+  batch_count: number;
+  source_task_ids: string[];
+  parsed: TaskNewParsed;
+};
+
+const CONTEXT_TASK_EXTRACTION_PROMPT_ADDRESS =
+  "framework/template/generated.artifact/context_task_extraction/v1";
+
+type TaskExtractionMarker = {
+  schema_version: 1;
+  pipeline: "context.harvest.tasks";
+  state: "queued";
+  queued_at: string;
+  source_digest: string;
+  extraction_task_id: string;
+  extraction_task_readme_path: string;
+  batch_index: number;
+  batch_count: number;
+  prompt_module_ref: string;
+};
+
+function parseBatchSize(value: string): number {
+  if (!value.trim()) return 25;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new CliError({
+      exitCode: 3,
+      code: "E_VALIDATION",
+      message: `Invalid --batch-size value: ${value}`,
+    });
+  }
+  return parsed;
+}
+
+function normalizeTags(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value
+        .map(String)
+        .map((tag) => tag.trim())
+        .filter(Boolean)
+    : [];
+}
+
+function sourceTaskRef(task: ExtractionTask) {
+  const acrPath = `.agentplane/tasks/${task.id}/acr.json`;
+  const readmePath = `.agentplane/tasks/${task.id}/README.md`;
+  const extensions = isRecord(task.extensions) ? task.extensions : {};
+  const marker = isRecord(extensions.context_harvest) ? extensions.context_harvest : null;
+  return {
+    id: task.id,
+    title: task.title,
+    status: task.status,
+    tags: normalizeTags(task.tags),
+    readme_path: readmePath,
+    acr_path: acrPath,
+    source_digest: taskTextDigest(task),
+    existing_harvest_marker: marker
+      ? {
+          source_digest:
+            typeof marker.source_digest === "string" ? marker.source_digest : undefined,
+          raw_evidence_path:
+            typeof marker.raw_evidence_path === "string" ? marker.raw_evidence_path : undefined,
+          wiki_proposal_path:
+            typeof marker.wiki_proposal_path === "string" ? marker.wiki_proposal_path : undefined,
+          promotion_state:
+            typeof marker.promotion_state === "string" ? marker.promotion_state : undefined,
+        }
+      : null,
+  };
+}
+
+function existingExtractionMarker(task: ExtractionTask): TaskExtractionMarker | null {
+  const extensions = isRecord(task.extensions) ? task.extensions : {};
+  const marker = extensions.context_task_extraction;
+  if (!isRecord(marker) || marker.pipeline !== "context.harvest.tasks") return null;
+  return marker as TaskExtractionMarker;
+}
+
+export function alreadyQueuedForExtractionUnchanged(
+  task: ExtractionTask,
+  parsed: Pick<ContextHarvestTasksParsed, "task">,
+): boolean {
+  const marker = existingExtractionMarker(task);
+  if (marker?.source_digest !== taskTextDigest(task)) return false;
+  if (parsed.task.includes(task.id)) return false;
+  return true;
+}
+
+export function buildTaskExtractionMarker(opts: {
+  task: ExtractionTask;
+  queuedAt: string;
+  extractionTaskId: string;
+  batchIndex: number;
+  batchCount: number;
+}): TaskExtractionMarker {
+  return {
+    schema_version: 1,
+    pipeline: "context.harvest.tasks",
+    state: "queued",
+    queued_at: opts.queuedAt,
+    source_digest: taskTextDigest(opts.task),
+    extraction_task_id: opts.extractionTaskId,
+    extraction_task_readme_path: `.agentplane/tasks/${opts.extractionTaskId}/README.md`,
+    batch_index: opts.batchIndex,
+    batch_count: opts.batchCount,
+    prompt_module_ref: CONTEXT_TASK_EXTRACTION_PROMPT_ADDRESS,
+  };
+}
+
+function buildExtractionPromptModule(): PromptModule {
+  return {
+    schema_version: PROMPT_MODULE_CONTRACT_SCHEMA_VERSION,
+    address: {
+      value: CONTEXT_TASK_EXTRACTION_PROMPT_ADDRESS,
+      namespace: "framework",
+      surface: "template",
+      target: "generated.artifact",
+      slot: "body",
+      name: "context_task_extraction_v1",
+    },
+    owner: {
+      kind: "framework",
+      package_name: "agentplane",
+    },
+    title: "Context task-history extraction prompt",
+    summary:
+      "Reusable CURATOR prompt module for extracting sourced wiki, facts, and graph updates from completed task READMEs and ACR evidence.",
+    content_kind: "markdown",
+    content: [
+      "# Context Task Extraction",
+      "",
+      "You are CURATOR processing a bounded batch of completed AgentPlane tasks.",
+      "",
+      "Read each source task README first. Read ACR evidence when present. Treat generated raw JSON, search rows, and caches as supporting indexes, not as semantic truth.",
+      "",
+      "Extract durable knowledge only when it is backed by source_refs. Prefer small, reusable facts over task-summary restatement.",
+      "",
+      "Required extraction classes:",
+      "- components, commands, policies, and workflow surfaces touched by the tasks;",
+      "- decisions and invariants that should guide future agents;",
+      "- known failures, mitigations, stale assumptions, and conflict candidates;",
+      "- graph relations between tasks, components, commands, facts, decisions, and wiki pages.",
+      "",
+      "Before writing, search existing wiki/facts/graph rows for matching entities. Update or append with provenance; do not silently overwrite unrelated knowledge.",
+      "",
+      "Write only allowed outputs from the task extension. Keep source_refs on every factual claim. Mark contradictions, stale candidates, and open questions instead of promoting them.",
+    ].join("\n"),
+    mutability: "replaceable",
+    merge: {
+      mode: "pick_one",
+      conflict: "error",
+      precedence: 100,
+    },
+    load: {
+      roles: ["CURATOR"],
+      commands: ["context harvest tasks"],
+      task_tags_any: ["context", "assimilation", "task-harvest"],
+    },
+    provenance: {
+      source_kind: "framework_builtin",
+      source_ref: "context.harvest.tasks#create-extraction-tasks",
+      generated_by: "context.harvest.tasks",
+    },
+  };
+}
+
+function buildDescription(opts: {
+  batchIndex: number;
+  batchCount: number;
+  first: ExtractionTask;
+  last: ExtractionTask;
+  count: number;
+}): string {
+  return [
+    `Semantically extract reusable context from completed task history batch ${opts.batchIndex}/${opts.batchCount}.`,
+    `Source range: ${opts.first.id} -> ${opts.last.id}; source tasks: ${opts.count}.`,
+    "Read task READMEs and ACR evidence, then update sourced wiki proposals, facts, graph rows, stale markers, and conflict markers with provenance.",
+  ].join(" ");
+}
+
+function buildVerifySteps(): string[] {
+  return [
+    "agentplane context doctor",
+    "agentplane context graph summary",
+    "agentplane context graph validate",
+    "agentplane context verify-task <task-id>",
+  ];
+}
+
+export function buildExtractionTaskPlans(
+  tasks: ExtractionTask[],
+  parsed: ContextHarvestTasksParsed,
+): ExtractionTaskPlan[] {
+  const batchSize = parseBatchSize(parsed.batchSize);
+  const batches: ExtractionTask[][] = [];
+  for (let index = 0; index < tasks.length; index += batchSize) {
+    batches.push(tasks.slice(index, index + batchSize));
+  }
+  const promptModule = buildExtractionPromptModule();
+  return batches.map((batch, index) => {
+    const first = batch[0];
+    const last = batch.at(-1);
+    if (!first || !last) {
+      throw new CliError({
+        exitCode: 3,
+        code: "E_VALIDATION",
+        message: "Cannot create an empty extraction task batch.",
+      });
+    }
+    const batchIndex = index + 1;
+    const batchCount = batches.length;
+    const sourceTasks = batch.map((task) => sourceTaskRef(task));
+    return {
+      batch_index: batchIndex,
+      batch_count: batchCount,
+      source_task_ids: batch.map((task) => task.id),
+      parsed: {
+        title: `Extract task-history context ${first.id}..${last.id}`,
+        description: buildDescription({
+          batchIndex,
+          batchCount,
+          first,
+          last,
+          count: batch.length,
+        }),
+        owner: "CURATOR",
+        priority: "med",
+        tags: ["context", "assimilation", "task-harvest"],
+        taskKind: "context",
+        mutationScope: "context",
+        blueprintRequest: "context.assimilation",
+        extensions: {
+          "agentplane.context": {
+            schema_version: 1,
+            task_type: "context_task_extraction",
+            pipeline: "context.harvest.tasks",
+            workspace: "context",
+            mode: "task_history_batch",
+            order: "oldest_first",
+            batch: {
+              index: batchIndex,
+              count: batchCount,
+              size: batch.length,
+              batch_size: batchSize,
+              first_task_id: first.id,
+              last_task_id: last.id,
+            },
+            source_set: {
+              kind: "completed_tasks",
+              selection: {
+                statuses: parsed.status.length > 0 ? parsed.status : ["DONE"],
+                tags: parsed.tag,
+                tasks: parsed.task,
+                since: parsed.since || null,
+                until: parsed.until || null,
+                after_task: parsed.afterTask || null,
+              },
+              sources: sourceTasks,
+            },
+            prompt_modules: [promptModule],
+            prompt_module_ref: promptModule.address.value,
+            allowed_outputs: [
+              "context/wiki/**",
+              ".agentplane/context/derived/facts/**",
+              ".agentplane/context/derived/graph/**",
+              ".agentplane/context/derived/reports/**",
+              ".agentplane/tasks/${taskId}/README.md",
+              ".agentplane/tasks/${taskId}/acr.json",
+            ],
+            forbidden_outputs: [
+              "context/raw/**",
+              "context/raw/private/**",
+              ".agentplane/cache.sqlite",
+              ".agentplane/context/service/**",
+            ],
+            extraction: {
+              read_readme_first: true,
+              read_acr_when_present: true,
+              extract_entities: true,
+              extract_facts: true,
+              extract_relations: true,
+              update_wiki: true,
+              detect_contradictions: true,
+              detect_stale_claims: true,
+              detect_open_questions: true,
+              require_source_refs: true,
+              allow_raw_mutation: false,
+            },
+            policies: {
+              context_rules: ".agentplane/context/policies/context.rules.md",
+              wiki_rules: ".agentplane/context/policies/wiki.rules.md",
+              redaction: ".agentplane/context/policies/redaction.rules.yaml",
+            },
+          },
+        },
+        dependsOn: [],
+        verify: buildVerifySteps(),
+        showBlueprint: false,
+        allowDuplicate: true,
+        riskFlags: [],
+      },
+    };
+  });
+}


### PR DESCRIPTION
Task: `202605131449-GS3HB0`
Title: Create agentic context extraction tasks
Canonical task record: `.agentplane/tasks/202605131449-GS3HB0/README.md`

## Summary

Create agentic context extraction tasks

Add a context harvest mode that creates standard AgentPlane extraction tasks for batchwise semantic knowledge extraction from completed task history, with modular prompt context and provenance requirements.

## Scope

- In scope: Add a context harvest mode that creates standard AgentPlane extraction tasks for batchwise semantic knowledge extraction from completed task history, with modular prompt context and provenance requirements.
- Out of scope: unrelated refactors not required for "Create agentic context extraction tasks".

## Verification

- State: ok
- Note: Verified agentic context extraction task generation: focused harvest/task-new tests pass; eslint, typecheck, docs CLI freshness, format, knip, hotspot, policy routing, docs IA, doctor, diff whitespace, and live dry-run smoke pass. Release-readiness was rerun with Vitest because Bun lacks node:sqlite in this environment.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-13T15:03:01.411Z
- Branch: task/202605131449-GS3HB0/agentic-context-extraction
- Head: e237c64f2d50

```text
 .../blueprint/resolved-snapshot.json               | 513 +++++++++++++++++++++
 docs/developer/local-context.mdx                   |  34 +-
 docs/user/cli-reference.generated.mdx              |  10 +-
 docs/user/commands.mdx                             |  14 +-
 docs/user/local-context.mdx                        |  13 +
 .../src/commands/context/context.spec.ts           |  24 +-
 .../commands/context/harvest-tasks-extraction.ts   |   1 +
 .../src/commands/context/harvest-tasks.test.ts     | 182 +++++++-
 .../src/commands/context/harvest-tasks.ts          | 110 ++++-
 packages/agentplane/src/commands/task/new.ts       |   3 +-
 .../src/context/harvest-tasks-artifacts.ts         |  18 +-
 .../src/context/harvest-tasks-extraction.ts        | 317 +++++++++++++
 12 files changed, 1217 insertions(+), 22 deletions(-)
```

</details>
