### PR TITLE
🚧 33VQFN task: Add local insights report command [202605131637-33VQFN]

### DIFF
--- a/.agentplane/tasks/202605131637-33VQFN/README.md
+++ b/.agentplane/tasks/202605131637-33VQFN/README.md
@@ -1,0 +1,159 @@
+---
+id: "202605131637-33VQFN"
+title: "Add local insights report command"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 1
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "cli"
+  - "code"
+  - "diagnostics"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-13T16:38:06.111Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-13T17:12:25.652Z"
+  updated_by: "CODER"
+  note: "Verified: implemented local-only insights report CLI with privacy-bounded payload, generated CLI docs, and targeted command coverage. Checks passed: bun test packages/agentplane/src/cli/run-cli/command-catalog.test.ts packages/agentplane/src/cli/run-cli.core.insights-report.test.ts (8 pass); bun run typecheck; bun run lint:core; bun run format:check; node .agentplane/policy/check-routing.mjs; ap doctor; node packages/agentplane/bin/agentplane.js insights report --json --recent-limit 1. Full bun run lint still fails in unrelated website TypeScript/Docusaurus typing files outside this task scope; core lint passes."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement a local-only insights report CLI command in the dedicated task worktree, preserving privacy boundaries and adding targeted command coverage."
+events:
+  -
+    type: "status"
+    at: "2026-05-13T16:38:35.223Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement a local-only insights report CLI command in the dedicated task worktree, preserving privacy boundaries and adding targeted command coverage."
+  -
+    type: "verify"
+    at: "2026-05-13T17:12:25.652Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: implemented local-only insights report CLI with privacy-bounded payload, generated CLI docs, and targeted command coverage. Checks passed: bun test packages/agentplane/src/cli/run-cli/command-catalog.test.ts packages/agentplane/src/cli/run-cli.core.insights-report.test.ts (8 pass); bun run typecheck; bun run lint:core; bun run format:check; node .agentplane/policy/check-routing.mjs; ap doctor; node packages/agentplane/bin/agentplane.js insights report --json --recent-limit 1. Full bun run lint still fails in unrelated website TypeScript/Docusaurus typing files outside this task scope; core lint passes."
+doc_version: 3
+doc_updated_at: "2026-05-13T17:12:25.687Z"
+doc_updated_by: "CODER"
+description: "Implement a local-only agentplane insights report command that summarizes privacy-safe repository and AgentPlane diagnostic state for user-shared support analysis without uploading telemetry."
+sections:
+  Summary: |-
+    Add local insights report command
+    
+    Implement a local-only agentplane insights report command that summarizes privacy-safe repository and AgentPlane diagnostic state for user-shared support analysis without uploading telemetry.
+  Scope: |-
+    - In scope: Implement a local-only agentplane insights report command that summarizes privacy-safe repository and AgentPlane diagnostic state for user-shared support analysis without uploading telemetry.
+    - Out of scope: unrelated refactors not required for "Add local insights report command".
+  Plan: |-
+    1. Inspect existing CLI command registry/spec patterns and task/config store APIs.
+    2. Add agentplane insights report as a local-only command with JSON default output and optional pretty output if existing CLI conventions support it.
+    3. Include bounded diagnostics: AgentPlane version/config summary, workflow mode/backend id, git branch/dirty counts, task status counts, recent error/status evidence from local task metadata, and explicit privacy metadata stating no network/upload and excluded content classes.
+    4. Add focused CLI tests covering command output, no sensitive raw task text exposure, and usage/help wiring.
+    5. Regenerate CLI reference docs if command registry changes generated docs.
+    6. Verify with targeted tests, docs CLI freshness check, check-routing, and agentplane doctor.
+  Verify Steps: |-
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-13T17:12:25.652Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: implemented local-only insights report CLI with privacy-bounded payload, generated CLI docs, and targeted command coverage. Checks passed: bun test packages/agentplane/src/cli/run-cli/command-catalog.test.ts packages/agentplane/src/cli/run-cli.core.insights-report.test.ts (8 pass); bun run typecheck; bun run lint:core; bun run format:check; node .agentplane/policy/check-routing.mjs; ap doctor; node packages/agentplane/bin/agentplane.js insights report --json --recent-limit 1. Full bun run lint still fails in unrelated website TypeScript/Docusaurus typing files outside this task scope; core lint passes.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-13T16:38:35.223Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605131637-33VQFN-insights-report/.agentplane/tasks/202605131637-33VQFN/blueprint/resolved-snapshot.json
+    - old_digest: 7ffbb3963f8d2ce2f32fdf09503d7ece0df46db896d5e24e2cda3bb979e7213d
+    - current_digest: 7ffbb3963f8d2ce2f32fdf09503d7ece0df46db896d5e24e2cda3bb979e7213d
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605131637-33VQFN
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Command evidence: targeted tests 8 pass; JSON smoke returned schema=agentplane.insights.report.v1, version=0.6.0, network=not_used, upload=not_supported; routing OK; doctor OK.
+      Impact: The command gives users a pasteable local diagnostic state report without telemetry upload or raw task prose/traces.
+      Resolution: Keep broad website lint failure as unrelated residual; this task verifies CLI/core scope with lint:core, typecheck, format, routing, doctor, generated docs, and smoke.
+id_source: "generated"
+---
+## Summary
+
+Add local insights report command
+
+Implement a local-only agentplane insights report command that summarizes privacy-safe repository and AgentPlane diagnostic state for user-shared support analysis without uploading telemetry.
+
+## Scope
+
+- In scope: Implement a local-only agentplane insights report command that summarizes privacy-safe repository and AgentPlane diagnostic state for user-shared support analysis without uploading telemetry.
+- Out of scope: unrelated refactors not required for "Add local insights report command".
+
+## Plan
+
+1. Inspect existing CLI command registry/spec patterns and task/config store APIs.
+2. Add agentplane insights report as a local-only command with JSON default output and optional pretty output if existing CLI conventions support it.
+3. Include bounded diagnostics: AgentPlane version/config summary, workflow mode/backend id, git branch/dirty counts, task status counts, recent error/status evidence from local task metadata, and explicit privacy metadata stating no network/upload and excluded content classes.
+4. Add focused CLI tests covering command output, no sensitive raw task text exposure, and usage/help wiring.
+5. Regenerate CLI reference docs if command registry changes generated docs.
+6. Verify with targeted tests, docs CLI freshness check, check-routing, and agentplane doctor.
+
+## Verify Steps
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-13T17:12:25.652Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: implemented local-only insights report CLI with privacy-bounded payload, generated CLI docs, and targeted command coverage. Checks passed: bun test packages/agentplane/src/cli/run-cli/command-catalog.test.ts packages/agentplane/src/cli/run-cli.core.insights-report.test.ts (8 pass); bun run typecheck; bun run lint:core; bun run format:check; node .agentplane/policy/check-routing.mjs; ap doctor; node packages/agentplane/bin/agentplane.js insights report --json --recent-limit 1. Full bun run lint still fails in unrelated website TypeScript/Docusaurus typing files outside this task scope; core lint passes.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-13T16:38:35.223Z, excerpt_hash=sha256:0c911ba57bbda86e6b1d4b2c31f39ff10ccc1febf923fdb7f66dbb574080a0d7
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605131637-33VQFN-insights-report/.agentplane/tasks/202605131637-33VQFN/blueprint/resolved-snapshot.json
+- old_digest: 7ffbb3963f8d2ce2f32fdf09503d7ece0df46db896d5e24e2cda3bb979e7213d
+- current_digest: 7ffbb3963f8d2ce2f32fdf09503d7ece0df46db896d5e24e2cda3bb979e7213d
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605131637-33VQFN
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Command evidence: targeted tests 8 pass; JSON smoke returned schema=agentplane.insights.report.v1, version=0.6.0, network=not_used, upload=not_supported; routing OK; doctor OK.
+  Impact: The command gives users a pasteable local diagnostic state report without telemetry upload or raw task prose/traces.
+  Resolution: Keep broad website lint failure as unrelated residual; this task verifies CLI/core scope with lint:core, typecheck, format, routing, doctor, generated docs, and smoke.

--- a/.agentplane/tasks/202605131637-33VQFN/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605131637-33VQFN/blueprint/resolved-snapshot.json
@@ -1,0 +1,514 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605131637-33VQFN",
+    "title": "Add local insights report command",
+    "description": "Implement a local-only agentplane insights report command that summarizes privacy-safe repository and AgentPlane diagnostic state for user-shared support analysis without uploading telemetry.",
+    "tags": [
+      "cli",
+      "code",
+      "diagnostics"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605131637-33VQFN",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "7ffbb3963f8d2ce2f32fdf09503d7ece0df46db896d5e24e2cda3bb979e7213d"
+  }
+}

--- a/.agentplane/tasks/202605131637-33VQFN/pr/diffstat.txt
+++ b/.agentplane/tasks/202605131637-33VQFN/pr/diffstat.txt
@@ -1,0 +1,8 @@
+ .../blueprint/resolved-snapshot.json               | 514 +++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |  49 ++
+ .../src/cli/run-cli.core.insights-report.test.ts   | 170 +++++++
+ .../src/cli/run-cli/command-catalog/core.ts        |   8 +
+ .../src/cli/run-cli/command-loaders/core.ts        |   7 +
+ .../src/commands/insights/insights.command.ts      | 395 ++++++++++++++++
+ .../src/commands/insights/insights.spec.ts         |  62 +++
+ 7 files changed, 1205 insertions(+)

--- a/.agentplane/tasks/202605131637-33VQFN/pr/github-body.md
+++ b/.agentplane/tasks/202605131637-33VQFN/pr/github-body.md
@@ -22,12 +22,19 @@ Implement a local-only agentplane insights report command that summarizes privac
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-13T16:38:35.527Z
+- Updated: 2026-05-13T17:14:02.513Z
 - Branch: task/202605131637-33VQFN/insights-report
-- Head: c5f2d3ca04b9
+- Head: 36bfc0aa25ed
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 514 +++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |  49 ++
+ .../src/cli/run-cli.core.insights-report.test.ts   | 170 +++++++
+ .../src/cli/run-cli/command-catalog/core.ts        |   8 +
+ .../src/cli/run-cli/command-loaders/core.ts        |   7 +
+ .../src/commands/insights/insights.command.ts      | 395 ++++++++++++++++
+ .../src/commands/insights/insights.spec.ts         |  62 +++
+ 7 files changed, 1205 insertions(+)
 ```
 
 </details>

--- a/.agentplane/tasks/202605131637-33VQFN/pr/github-body.md
+++ b/.agentplane/tasks/202605131637-33VQFN/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605131637-33VQFN`
+Title: Add local insights report command
+Canonical task record: `.agentplane/tasks/202605131637-33VQFN/README.md`
+
+## Summary
+
+Add local insights report command
+
+Implement a local-only agentplane insights report command that summarizes privacy-safe repository and AgentPlane diagnostic state for user-shared support analysis without uploading telemetry.
+
+## Scope
+
+- In scope: Implement a local-only agentplane insights report command that summarizes privacy-safe repository and AgentPlane diagnostic state for user-shared support analysis without uploading telemetry.
+- Out of scope: unrelated refactors not required for "Add local insights report command".
+
+## Verification
+
+- State: ok
+- Note: Verified: implemented local-only insights report CLI with privacy-bounded payload, generated CLI docs, and targeted command coverage. Checks passed: bun test packages/agentplane/src/cli/run-cli/command-catalog.test.ts packages/agentplane/src/cli/run-cli.core.insights-report.test.ts (8 pass); bun run typecheck; bun run lint:core; bun run format:check; node .agentplane/policy/check-routing.mjs; ap doctor; node packages/agentplane/bin/agentplane.js insights report --json --recent-limit 1. Full bun run lint still fails in unrelated website TypeScript/Docusaurus typing files outside this task scope; core lint passes.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-13T16:38:35.527Z
+- Branch: task/202605131637-33VQFN/insights-report
+- Head: c5f2d3ca04b9
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605131637-33VQFN/pr/github-title.txt
+++ b/.agentplane/tasks/202605131637-33VQFN/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 33VQFN task: Add local insights report command [202605131637-33VQFN]

--- a/.agentplane/tasks/202605131637-33VQFN/pr/meta.json
+++ b/.agentplane/tasks/202605131637-33VQFN/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605131637-33VQFN/insights-report",
   "created_at": "2026-05-13T16:38:35.527Z",
-  "head_sha": "c5f2d3ca04b90e1e83e7e25fb92dd310a9d27d25",
+  "head_sha": "36bfc0aa25ed96b468fde947f5b027d9dc4b50ba",
   "last_verified_at": "2026-05-13T17:12:25.652Z",
   "last_verified_sha": "c5f2d3ca04b90e1e83e7e25fb92dd310a9d27d25",
   "schema_version": 1,
   "task_id": "202605131637-33VQFN",
-  "updated_at": "2026-05-13T16:38:35.527Z",
+  "updated_at": "2026-05-13T17:14:02.513Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605131637-33VQFN/pr/meta.json
+++ b/.agentplane/tasks/202605131637-33VQFN/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605131637-33VQFN/insights-report",
+  "created_at": "2026-05-13T16:38:35.527Z",
+  "head_sha": "c5f2d3ca04b90e1e83e7e25fb92dd310a9d27d25",
+  "last_verified_at": "2026-05-13T17:12:25.652Z",
+  "last_verified_sha": "c5f2d3ca04b90e1e83e7e25fb92dd310a9d27d25",
+  "schema_version": 1,
+  "task_id": "202605131637-33VQFN",
+  "updated_at": "2026-05-13T16:38:35.527Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605131637-33VQFN/pr/meta.json
+++ b/.agentplane/tasks/202605131637-33VQFN/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "36bfc0aa25ed96b468fde947f5b027d9dc4b50ba",
   "last_verified_at": "2026-05-13T17:12:25.652Z",
   "last_verified_sha": "c5f2d3ca04b90e1e83e7e25fb92dd310a9d27d25",
+  "pr_number": 3645,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3645",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605131637-33VQFN",
-  "updated_at": "2026-05-13T17:14:02.513Z",
+  "updated_at": "2026-05-13T17:14:15.847Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605131637-33VQFN/pr/review.md
+++ b/.agentplane/tasks/202605131637-33VQFN/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-13T16:38:35.527Z
+
+## Task
+
+- Task: `202605131637-33VQFN`
+- Title: Add local insights report command
+- Status: DOING
+- Branch: `task/202605131637-33VQFN/insights-report`
+- Canonical task record: `.agentplane/tasks/202605131637-33VQFN/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified: implemented local-only insights report CLI with privacy-bounded payload, generated CLI docs, and targeted command coverage. Checks passed: bun test packages/agentplane/src/cli/run-cli/command-catalog.test.ts packages/agentplane/src/cli/run-cli.core.insights-report.test.ts (8 pass); bun run typecheck; bun run lint:core; bun run format:check; node .agentplane/policy/check-routing.mjs; ap doctor; node packages/agentplane/bin/agentplane.js insights report --json --recent-limit 1. Full bun run lint still fails in unrelated website TypeScript/Docusaurus typing files outside this task scope; core lint passes.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-13T16:38:35.527Z
+- Branch: task/202605131637-33VQFN/insights-report
+- Head: c5f2d3ca04b9
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605131637-33VQFN/pr/review.md
+++ b/.agentplane/tasks/202605131637-33VQFN/pr/review.md
@@ -24,12 +24,19 @@ Created: 2026-05-13T16:38:35.527Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-13T16:38:35.527Z
+- Updated: 2026-05-13T17:14:02.513Z
 - Branch: task/202605131637-33VQFN/insights-report
-- Head: c5f2d3ca04b9
+- Head: 36bfc0aa25ed
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 514 +++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |  49 ++
+ .../src/cli/run-cli.core.insights-report.test.ts   | 170 +++++++
+ .../src/cli/run-cli/command-catalog/core.ts        |   8 +
+ .../src/cli/run-cli/command-loaders/core.ts        |   7 +
+ .../src/commands/insights/insights.command.ts      | 395 ++++++++++++++++
+ .../src/commands/insights/insights.spec.ts         |  62 +++
+ 7 files changed, 1205 insertions(+)
 ```
 
 </details>

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -85,6 +85,8 @@ This page is generated from the CLI command specs. Do not edit it by hand; edit 
   - [doctor](#doctor)
   - [doctor git-locks](#doctor-git-locks)
 - Diagnostics
+  - [insights](#insights)
+  - [insights report](#insights-report)
   - [runtime](#runtime)
   - [runtime explain](#runtime-explain)
 - Recipes
@@ -2354,6 +2356,53 @@ agentplane doctor git-locks --fix
 - Remove stale git index.lock after inspection.
 
 ## Diagnostics
+
+### insights
+
+Generate local-only diagnostic insights for support analysis.
+
+Usage:
+
+```text
+agentplane insights <report> [options]
+```
+
+Examples:
+
+```sh
+agentplane insights report
+```
+
+- Print a local diagnostic summary that can be shared manually.
+
+### insights report
+
+Print a local-only privacy-bounded AgentPlane diagnostic report.
+
+Usage:
+
+```text
+agentplane insights report [options]
+```
+
+Options:
+
+- `--json`: Emit the full report as machine-readable JSON. (default=false)
+- `--recent-limit <n>`: Number of recent task ids to include (default: 8, max: 25).
+
+Examples:
+
+```sh
+agentplane insights report
+```
+
+- Print a readable local diagnostic summary.
+
+```sh
+agentplane insights report --json
+```
+
+- Print the full local diagnostic report for support tooling.
 
 ### runtime
 

--- a/packages/agentplane/src/cli/run-cli.core.insights-report.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.insights-report.test.ts
@@ -1,0 +1,170 @@
+import { describe } from "vitest";
+
+import {
+  captureStdIO,
+  expect,
+  it,
+  mkGitRepoRoot,
+  runCli,
+  seedTaskQueryFixture,
+  splitOutputLines,
+  useRunCliIntegrationHarness,
+  writeFile,
+  path,
+} from "@agentplane/testkit/cli-core-tasks-query";
+
+useRunCliIntegrationHarness();
+
+describe("runCli insights report", () => {
+  it("prints a local-only readable diagnostic report without task prose", async () => {
+    const root = await mkGitRepoRoot();
+    await seedTaskQueryFixture(root, [
+      {
+        id: "202605010101-AAAAAA",
+        title: "Sensitive task title should not appear",
+        description: "Sensitive task description should not appear",
+        status: "TODO",
+        priority: "high",
+        owner: "CODER",
+        depends_on: [],
+        tags: ["code", "secret-tag"],
+        verify: ["bun test"],
+        plan_approval: { state: "approved", updated_at: null, updated_by: null, note: null },
+        verification: {
+          state: "pending",
+          attempts: 0,
+          updated_at: null,
+          updated_by: null,
+          note: null,
+        },
+        events: [
+          {
+            type: "comment",
+            at: "2026-05-01T01:01:01.000Z",
+            author: "CODER",
+            body: "Sensitive comment should not appear",
+          },
+        ],
+      },
+      {
+        id: "202605010102-BBBBBB",
+        title: "Done task title should not appear",
+        description: "Done task description should not appear",
+        status: "DONE",
+        priority: "med",
+        owner: "DOCS",
+        depends_on: [],
+        tags: ["docs"],
+        verify: [],
+      },
+    ]);
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["insights", "report", "--root", root]);
+      expect(code).toBe(0);
+      expect(io.stderr).toBe("");
+      expect(io.stdout).toContain("insights report: local diagnostic summary");
+      expect(io.stdout).toContain("local_only:");
+      expect(io.stdout).toContain("network:");
+      expect(io.stdout).toContain("not_used");
+      expect(io.stdout).toContain("tasks_total:");
+      expect(io.stdout).toContain("TODO=1");
+      expect(io.stdout).toContain("DONE=1");
+      expect(io.stdout).toContain("202605010101-AAAAAA");
+      expect(io.stdout).not.toContain("Sensitive task title");
+      expect(io.stdout).not.toContain("Sensitive task description");
+      expect(io.stdout).not.toContain("Sensitive comment");
+    } finally {
+      io.restore();
+    }
+  });
+
+  it("emits machine-readable JSON with bounded local diagnostics", async () => {
+    const root = await mkGitRepoRoot();
+    await seedTaskQueryFixture(root, [
+      {
+        id: "202605010101-AAAAAA",
+        title: "JSON sensitive task title should not appear",
+        description: "JSON sensitive task description should not appear",
+        status: "TODO",
+        priority: "high",
+        owner: "CODER",
+        depends_on: [],
+        tags: ["code"],
+        verify: ["bun test"],
+      },
+    ]);
+    await writeFile(path.join(root, "scratch.txt"), "untracked\n", "utf8");
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli([
+        "insights",
+        "report",
+        "--json",
+        "--recent-limit",
+        "1",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(0);
+      const payload = JSON.parse(io.stdout) as {
+        schema?: string;
+        privacy?: { local_only?: boolean; network?: string; upload?: string };
+        project?: { workflow_mode?: string; backend?: { id?: string } };
+        git?: { status_counts?: { untracked?: number }; dirty?: boolean };
+        tasks?: {
+          total?: number;
+          active_task_ids?: string[];
+          recent_task_ids?: string[];
+          by_status?: Record<string, number>;
+        };
+      };
+      expect(payload.schema).toBe("agentplane.insights.report.v1");
+      expect(payload.privacy).toMatchObject({
+        local_only: true,
+        network: "not_used",
+        upload: "not_supported",
+      });
+      expect(payload.project?.workflow_mode).toBe("direct");
+      expect(payload.project?.backend?.id).toBe("local");
+      expect(payload.git?.dirty).toBe(true);
+      expect(payload.git?.status_counts?.untracked).toBeGreaterThanOrEqual(1);
+      expect(payload.tasks?.total).toBe(1);
+      expect(payload.tasks?.by_status?.TODO).toBe(1);
+      expect(payload.tasks?.active_task_ids).toEqual(["202605010101-AAAAAA"]);
+      expect(payload.tasks?.recent_task_ids).toEqual(["202605010101-AAAAAA"]);
+      expect(io.stdout).not.toContain("JSON sensitive task title");
+      expect(io.stdout).not.toContain("JSON sensitive task description");
+    } finally {
+      io.restore();
+    }
+  });
+
+  it("exposes insights in help and rejects unknown subgroup usage", async () => {
+    const root = await mkGitRepoRoot();
+    {
+      const io = captureStdIO();
+      try {
+        const code = await runCli(["help", "insights", "--root", root]);
+        expect(code).toBe(0);
+        expect(io.stdout).toContain("agentplane insights <report> [options]");
+        expect(io.stdout).toContain("insights report");
+      } finally {
+        io.restore();
+      }
+    }
+
+    {
+      const io = captureStdIO();
+      try {
+        const code = await runCli(["insights", "unknown", "--root", root]);
+        expect(code).toBe(2);
+        expect(splitOutputLines(io.stderr).join("\n")).toContain("Unknown subcommand: unknown.");
+      } finally {
+        io.restore();
+      }
+    }
+  });
+});

--- a/packages/agentplane/src/cli/run-cli/command-catalog/core.ts
+++ b/packages/agentplane/src/cli/run-cli/command-catalog/core.ts
@@ -1,6 +1,7 @@
 import { doctorSpec } from "../../../commands/doctor.spec.js";
 import { doctorGitLocksSpec } from "../../../commands/doctor-git-locks.spec.js";
 import { runtimeExplainSpec, runtimeSpec } from "../../../commands/runtime.spec.js";
+import { insightsReportSpec, insightsSpec } from "../../../commands/insights/insights.spec.js";
 import { upgradeSpec } from "../../../commands/upgrade.spec.js";
 import { workflowBuildSpec } from "../../../commands/workflow-build.command.js";
 import { workflowSpec } from "../../../commands/workflow.command.js";
@@ -43,6 +44,7 @@ import {
   fromCommandsCorePreflight,
   fromCommandsCodex,
   fromCommandsRuntimeCommand,
+  fromCommandsInsightsCommand,
   fromCommandsIncidentsIncidentsCommand,
   fromCommandsCoreRole,
   fromCommandsDoctorRun,
@@ -61,6 +63,7 @@ import {
   loadModeSetSpec,
   loadProfileSetSpec,
   loadIdeSyncSpec,
+  loadInsightsReportSpec,
 } from "../command-loaders/core.js";
 
 export const CORE_COMMANDS = [
@@ -115,6 +118,11 @@ export const CORE_COMMANDS = [
   }),
   fromCommandsRuntimeCommand(runtimeSpec, "runRuntime", { needs: "none" }),
   fromCommandsRuntimeCommand(runtimeExplainSpec, "runRuntimeExplain", { needs: "none" }),
+  fromCommandsInsightsCommand(insightsSpec, "runInsights", { needs: "none" }),
+  declareCommand(insightsReportSpec, {
+    load: loadInsightsReportSpec,
+    needs: "project+config",
+  }),
   fromCommandsDoctorGitLocksCommand(doctorGitLocksSpec, "runDoctorGitLocks", {
     needs: "project",
   }),

--- a/packages/agentplane/src/cli/run-cli/command-loaders/core.ts
+++ b/packages/agentplane/src/cli/run-cli/command-loaders/core.ts
@@ -23,6 +23,9 @@ export const fromCommandsCodex = commandModule(() => import("../commands/codex.j
 export const fromCommandsRuntimeCommand = commandModule(
   () => import("../../../commands/runtime.command.js"),
 );
+export const fromCommandsInsightsCommand = commandModule(
+  () => import("../../../commands/insights/insights.command.js"),
+);
 export const fromCommandsIncidentsIncidentsCommand = commandModule(
   () => import("../../../commands/incidents/incidents.command.js"),
 );
@@ -67,3 +70,7 @@ export const loadProfileSetSpec = (deps: RunDeps) =>
   import("../commands/config.js").then((m) => m.makeRunProfileSetHandler(deps));
 export const loadIdeSyncSpec = (deps: RunDeps) =>
   import("../commands/ide.js").then((m) => m.makeRunIdeSyncHandler(deps));
+export const loadInsightsReportSpec = (deps: RunDeps) =>
+  import("../../../commands/insights/insights.command.js").then((m) =>
+    m.makeRunInsightsReportHandler(deps),
+  );

--- a/packages/agentplane/src/commands/insights/insights.command.ts
+++ b/packages/agentplane/src/commands/insights/insights.command.ts
@@ -1,0 +1,395 @@
+import { readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { execFile as execFileCb } from "node:child_process";
+
+import { listTasks, type TaskRecord } from "@agentplaneorg/core/tasks";
+
+import {
+  loadDirectSubcommandNames,
+  throwGroupCommandUsage,
+  type GroupCommandParsed,
+} from "../../cli/group-command.js";
+import { createCliEmitter, infoMessage, type CliReportEntry } from "../../cli/output.js";
+import type { CommandHandler } from "../../cli/spec/spec.js";
+import type { RunDeps } from "../../cli/run-cli/command-catalog/kernel.js";
+import { getVersion } from "../../meta/version.js";
+import { isRecord } from "../../shared/guards.js";
+import { wrapCommand } from "../../cli/run-cli/commands/wrap-command.js";
+
+import { insightsSpec, type InsightsReportParsed } from "./insights.spec.js";
+
+export { insightsReportSpec, insightsSpec } from "./insights.spec.js";
+
+const execFile = promisify(execFileCb);
+const output = createCliEmitter();
+
+type CountMap = Record<string, number>;
+
+type InsightsReport = {
+  schema: "agentplane.insights.report.v1";
+  generated_at: string;
+  privacy: {
+    local_only: true;
+    network: "not_used";
+    upload: "not_supported";
+    excludes: string[];
+  };
+  environment: {
+    agentplane_version: string | null;
+    node_major: number | null;
+    platform: NodeJS.Platform;
+    arch: string;
+  };
+  project: {
+    workflow_mode: string;
+    backend: {
+      id: string;
+      config_path: string;
+      cache_configured: boolean;
+    };
+    paths: {
+      workflow_dir: string;
+      worktrees_dir: string;
+    };
+  };
+  git: {
+    branch: string | null;
+    status_counts: CountMap;
+    dirty: boolean;
+  };
+  tasks: {
+    total: number;
+    by_status: CountMap;
+    by_owner: CountMap;
+    by_primary_tag: CountMap;
+    plan_approval: CountMap;
+    verification: CountMap;
+    doc_version: CountMap;
+    verify_steps: CountMap;
+    event_types: CountMap;
+    active_task_ids: string[];
+    recent_task_ids: string[];
+  };
+  runner: {
+    tasks_with_runner: number;
+    by_status: CountMap;
+    by_adapter: CountMap;
+    mode: CountMap;
+    duration_ms_buckets: CountMap;
+    stdout_bytes_buckets: CountMap;
+    stderr_bytes_buckets: CountMap;
+  };
+};
+
+function bump(counts: CountMap, raw: unknown, fallback = "unknown"): void {
+  const value = typeof raw === "string" && raw.trim() !== "" ? raw.trim() : fallback;
+  counts[value] = (counts[value] ?? 0) + 1;
+}
+
+function bucketBytes(value: unknown): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "unknown";
+  if (value === 0) return "0";
+  if (value < 1024) return "<1kb";
+  if (value < 10 * 1024) return "1kb-10kb";
+  if (value < 100 * 1024) return "10kb-100kb";
+  return ">=100kb";
+}
+
+function bucketDurationMs(value: unknown): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "unknown";
+  if (value < 100) return "<100ms";
+  if (value < 500) return "100ms-500ms";
+  if (value < 2000) return "500ms-2s";
+  if (value < 10_000) return "2s-10s";
+  return ">=10s";
+}
+
+async function readBackendSummary(
+  root: string,
+  configPath: string,
+): Promise<{
+  id: string;
+  config_path: string;
+  cache_configured: boolean;
+}> {
+  try {
+    const raw = JSON.parse(await readFile(path.join(root, configPath), "utf8")) as unknown;
+    const settings = isRecord(raw) && isRecord(raw.settings) ? raw.settings : {};
+    return {
+      id: isRecord(raw) && typeof raw.id === "string" && raw.id.trim() ? raw.id.trim() : "local",
+      config_path: configPath,
+      cache_configured: typeof settings.cache_dir === "string" && settings.cache_dir.trim() !== "",
+    };
+  } catch {
+    return { id: "local", config_path: configPath, cache_configured: false };
+  }
+}
+
+async function readGitStatus(root: string): Promise<InsightsReport["git"]> {
+  const [branchResult, statusResult] = await Promise.allSettled([
+    execFile("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: root }),
+    execFile("git", ["status", "--short", "--untracked-files=all"], { cwd: root }),
+  ]);
+  const branch =
+    branchResult.status === "fulfilled" ? branchResult.value.stdout.trim() || null : null;
+  const statusText = statusResult.status === "fulfilled" ? statusResult.value.stdout : "";
+  const statusCounts: CountMap = {
+    modified: 0,
+    added: 0,
+    deleted: 0,
+    renamed: 0,
+    copied: 0,
+    untracked: 0,
+    conflicted: 0,
+    other: 0,
+  };
+  for (const line of statusText.split("\n")) {
+    if (!line) continue;
+    const code = line.slice(0, 2);
+    if (code === "??") {
+      statusCounts.untracked += 1;
+    } else if (code.includes("U") || code === "AA" || code === "DD") {
+      statusCounts.conflicted += 1;
+    } else if (code.includes("R")) {
+      statusCounts.renamed += 1;
+    } else if (code.includes("C")) {
+      statusCounts.copied += 1;
+    } else if (code.includes("A")) {
+      statusCounts.added += 1;
+    } else if (code.includes("D")) {
+      statusCounts.deleted += 1;
+    } else if (code.includes("M")) {
+      statusCounts.modified += 1;
+    } else {
+      statusCounts.other += 1;
+    }
+  }
+  return {
+    branch,
+    status_counts: statusCounts,
+    dirty: Object.values(statusCounts).some((count) => count > 0),
+  };
+}
+
+function taskUpdatedAt(task: TaskRecord): string {
+  const value = task.frontmatter.doc_updated_at;
+  return typeof value === "string" ? value : "";
+}
+
+function summarizeTasks(tasks: TaskRecord[], recentLimit: number): InsightsReport["tasks"] {
+  const byStatus: CountMap = {};
+  const byOwner: CountMap = {};
+  const byPrimaryTag: CountMap = {};
+  const planApproval: CountMap = {};
+  const verification: CountMap = {};
+  const docVersion: CountMap = {};
+  const verifySteps: CountMap = {};
+  const eventTypes: CountMap = {};
+  const activeTaskIds: string[] = [];
+
+  for (const task of tasks) {
+    const fm = task.frontmatter;
+    bump(byStatus, fm.status);
+    bump(byOwner, fm.owner);
+    bump(byPrimaryTag, fm.tags[0] ?? "none");
+    bump(planApproval, fm.plan_approval?.state);
+    bump(verification, fm.verification?.state);
+    bump(docVersion, String(fm.doc_version ?? "unknown"));
+    bump(verifySteps, fm.verify.length > 0 ? "present" : "missing");
+    if (fm.status !== "DONE") activeTaskIds.push(task.id);
+    for (const event of fm.events ?? []) {
+      bump(eventTypes, event.type);
+    }
+  }
+
+  const recentTaskIds = [...tasks]
+    .toSorted((a, b) => taskUpdatedAt(b).localeCompare(taskUpdatedAt(a)))
+    .slice(0, recentLimit)
+    .map((task) => task.id);
+
+  return {
+    total: tasks.length,
+    by_status: byStatus,
+    by_owner: byOwner,
+    by_primary_tag: byPrimaryTag,
+    plan_approval: planApproval,
+    verification,
+    doc_version: docVersion,
+    verify_steps: verifySteps,
+    event_types: eventTypes,
+    active_task_ids: activeTaskIds.toSorted(),
+    recent_task_ids: recentTaskIds,
+  };
+}
+
+function summarizeRunner(tasks: TaskRecord[]): InsightsReport["runner"] {
+  const byStatus: CountMap = {};
+  const byAdapter: CountMap = {};
+  const mode: CountMap = {};
+  const durationBuckets: CountMap = {};
+  const stdoutBuckets: CountMap = {};
+  const stderrBuckets: CountMap = {};
+  let tasksWithRunner = 0;
+
+  for (const task of tasks) {
+    const runner = task.frontmatter.runner;
+    if (!runner) continue;
+    tasksWithRunner += 1;
+    const entries = [runner, ...(runner.history ?? [])];
+    for (const entry of entries) {
+      bump(byStatus, entry.status);
+      bump(byAdapter, entry.adapter_id);
+      bump(mode, entry.mode);
+      bump(durationBuckets, bucketDurationMs(entry.metrics?.duration_ms));
+      bump(stdoutBuckets, bucketBytes(entry.metrics?.stdout_bytes));
+      bump(stderrBuckets, bucketBytes(entry.metrics?.stderr_bytes));
+    }
+  }
+
+  return {
+    tasks_with_runner: tasksWithRunner,
+    by_status: byStatus,
+    by_adapter: byAdapter,
+    mode,
+    duration_ms_buckets: durationBuckets,
+    stdout_bytes_buckets: stdoutBuckets,
+    stderr_bytes_buckets: stderrBuckets,
+  };
+}
+
+async function buildInsightsReport(opts: {
+  deps: RunDeps;
+  recentLimit: number;
+}): Promise<InsightsReport> {
+  const [resolved, loaded] = await Promise.all([
+    opts.deps.getResolvedProject("insights report"),
+    opts.deps.getLoadedConfig("insights report"),
+  ]);
+  const root = resolved.gitRoot;
+  const [agentplaneVersion, backend, git, tasks] = await Promise.all([
+    Promise.resolve(getVersion()),
+    readBackendSummary(root, loaded.config.tasks_backend.config_path),
+    readGitStatus(root),
+    listTasks({ cwd: root, rootOverride: root }),
+  ]);
+  const nodeMajor = Number.parseInt(process.versions.node.split(".")[0] ?? "", 10);
+
+  return {
+    schema: "agentplane.insights.report.v1",
+    generated_at: new Date().toISOString(),
+    privacy: {
+      local_only: true,
+      network: "not_used",
+      upload: "not_supported",
+      excludes: [
+        "task titles",
+        "task descriptions",
+        "task document bodies",
+        "comments and event bodies",
+        "raw runner traces",
+        "stdout/stderr content",
+        "commit messages",
+        "git remotes",
+        "file paths outside AgentPlane-managed relative config paths",
+        "environment variables",
+      ],
+    },
+    environment: {
+      agentplane_version: agentplaneVersion,
+      node_major: Number.isFinite(nodeMajor) ? nodeMajor : null,
+      platform: os.platform(),
+      arch: os.arch(),
+    },
+    project: {
+      workflow_mode: loaded.config.workflow_mode,
+      backend,
+      paths: {
+        workflow_dir: loaded.config.paths.workflow_dir,
+        worktrees_dir: loaded.config.paths.worktrees_dir,
+      },
+    },
+    git,
+    tasks: summarizeTasks(tasks, opts.recentLimit),
+    runner: summarizeRunner(tasks),
+  };
+}
+
+function renderCountMap(map: CountMap, limit?: number): string {
+  let entries = Object.entries(map).filter(([, value]) => value > 0);
+  if (entries.length === 0) return "none";
+  entries = entries.toSorted(([keyA, valueA], [keyB, valueB]) => {
+    if (valueA !== valueB) return valueB - valueA;
+    return keyA.localeCompare(keyB);
+  });
+  if (limit !== undefined && entries.length > limit) {
+    const visible = entries.slice(0, limit);
+    const other = entries.slice(limit).reduce((sum, [, value]) => sum + value, 0);
+    entries = [...visible, ["other", other]];
+  }
+  return entries.map(([key, value]) => `${key}=${value}`).join(", ");
+}
+
+function renderInsightsReport(report: InsightsReport): CliReportEntry[] {
+  return [
+    { label: "schema", value: report.schema },
+    { label: "generated_at", value: report.generated_at },
+    { label: "local_only", value: report.privacy.local_only },
+    { label: "network", value: report.privacy.network },
+    { label: "upload", value: report.privacy.upload },
+    { label: "agentplane", value: report.environment.agentplane_version ?? "unknown" },
+    { label: "node_major", value: report.environment.node_major ?? "unknown" },
+    { label: "platform", value: `${report.environment.platform}/${report.environment.arch}` },
+    { label: "workflow_mode", value: report.project.workflow_mode },
+    { label: "backend", value: report.project.backend.id },
+    { label: "backend_cache_configured", value: report.project.backend.cache_configured },
+    { label: "git_branch", value: report.git.branch ?? "unknown" },
+    { label: "git_dirty", value: report.git.dirty },
+    { label: "git_status", value: renderCountMap(report.git.status_counts) },
+    { label: "tasks_total", value: report.tasks.total },
+    { label: "tasks_by_status", value: renderCountMap(report.tasks.by_status) },
+    { label: "tasks_by_owner", value: renderCountMap(report.tasks.by_owner) },
+    { label: "tasks_by_primary_tag", value: renderCountMap(report.tasks.by_primary_tag, 20) },
+    { label: "plan_approval", value: renderCountMap(report.tasks.plan_approval) },
+    { label: "verification", value: renderCountMap(report.tasks.verification) },
+    { label: "verify_steps", value: renderCountMap(report.tasks.verify_steps) },
+    { label: "task_event_types", value: renderCountMap(report.tasks.event_types) },
+    { label: "active_task_ids", value: report.tasks.active_task_ids.join(", ") || "none" },
+    { label: "recent_task_ids", value: report.tasks.recent_task_ids.join(", ") || "none" },
+    { label: "runner_tasks", value: report.runner.tasks_with_runner },
+    { label: "runner_status", value: renderCountMap(report.runner.by_status) },
+    { label: "runner_adapters", value: renderCountMap(report.runner.by_adapter) },
+    { label: "runner_modes", value: renderCountMap(report.runner.mode) },
+    { label: "runner_duration", value: renderCountMap(report.runner.duration_ms_buckets) },
+    {
+      label: "excluded_content",
+      value: report.privacy.excludes.join("; "),
+    },
+  ];
+}
+
+export const runInsights: CommandHandler<GroupCommandParsed> = async (_ctx, p) => {
+  throwGroupCommandUsage({
+    spec: insightsSpec,
+    cmd: p.cmd,
+    subcommands: await loadDirectSubcommandNames(["insights"]),
+    command: "insights",
+    contextCommand: "insights",
+  });
+};
+
+export function makeRunInsightsReportHandler(deps: RunDeps): CommandHandler<InsightsReportParsed> {
+  return async (ctx, parsed) =>
+    wrapCommand({ command: "insights report", rootOverride: ctx.rootOverride }, async () => {
+      const report = await buildInsightsReport({ deps, recentLimit: parsed.recentLimit });
+      if (parsed.json) {
+        output.json(report);
+      } else {
+        output.report(renderInsightsReport(report), {
+          header: infoMessage("insights report: local diagnostic summary"),
+        });
+      }
+      return 0;
+    });
+}

--- a/packages/agentplane/src/commands/insights/insights.spec.ts
+++ b/packages/agentplane/src/commands/insights/insights.spec.ts
@@ -1,0 +1,62 @@
+import { parseGroupCommand, type GroupCommandParsed } from "../../cli/group-command.js";
+import type { CommandSpec } from "../../cli/spec/spec.js";
+
+export type InsightsReportParsed = {
+  json: boolean;
+  recentLimit: number;
+};
+
+export const insightsSpec: CommandSpec<GroupCommandParsed> = {
+  id: ["insights"],
+  group: "Diagnostics",
+  summary: "Generate local-only diagnostic insights for support analysis.",
+  synopsis: ["agentplane insights <report> [options]"],
+  args: [{ name: "cmd", required: false, variadic: true, valueHint: "<cmd>" }],
+  examples: [
+    {
+      cmd: "agentplane insights report",
+      why: "Print a local diagnostic summary that can be shared manually.",
+    },
+  ],
+  parse: (raw) => parseGroupCommand(raw),
+};
+
+export const insightsReportSpec: CommandSpec<InsightsReportParsed> = {
+  id: ["insights", "report"],
+  group: "Diagnostics",
+  summary: "Print a local-only privacy-bounded AgentPlane diagnostic report.",
+  options: [
+    {
+      kind: "boolean",
+      name: "json",
+      default: false,
+      description: "Emit the full report as machine-readable JSON.",
+    },
+    {
+      kind: "string",
+      name: "recent-limit",
+      valueHint: "<n>",
+      description: "Number of recent task ids to include (default: 8, max: 25).",
+    },
+  ],
+  examples: [
+    {
+      cmd: "agentplane insights report",
+      why: "Print a readable local diagnostic summary.",
+    },
+    {
+      cmd: "agentplane insights report --json",
+      why: "Print the full local diagnostic report for support tooling.",
+    },
+  ],
+  parse: (raw) => {
+    const rawLimit = raw.opts["recent-limit"];
+    const parsedLimit =
+      typeof rawLimit === "string" && rawLimit.trim() !== "" ? Number.parseInt(rawLimit, 10) : 8;
+    const recentLimit = Number.isFinite(parsedLimit) ? Math.max(0, Math.min(25, parsedLimit)) : 8;
+    return {
+      json: raw.opts.json === true,
+      recentLimit,
+    };
+  },
+};


### PR DESCRIPTION
Task: `202605131637-33VQFN`
Title: Add local insights report command
Canonical task record: `.agentplane/tasks/202605131637-33VQFN/README.md`

## Summary

Add local insights report command

Implement a local-only agentplane insights report command that summarizes privacy-safe repository and AgentPlane diagnostic state for user-shared support analysis without uploading telemetry.

## Scope

- In scope: Implement a local-only agentplane insights report command that summarizes privacy-safe repository and AgentPlane diagnostic state for user-shared support analysis without uploading telemetry.
- Out of scope: unrelated refactors not required for "Add local insights report command".

## Verification

- State: ok
- Note: Verified: implemented local-only insights report CLI with privacy-bounded payload, generated CLI docs, and targeted command coverage. Checks passed: bun test packages/agentplane/src/cli/run-cli/command-catalog.test.ts packages/agentplane/src/cli/run-cli.core.insights-report.test.ts (8 pass); bun run typecheck; bun run lint:core; bun run format:check; node .agentplane/policy/check-routing.mjs; ap doctor; node packages/agentplane/bin/agentplane.js insights report --json --recent-limit 1. Full bun run lint still fails in unrelated website TypeScript/Docusaurus typing files outside this task scope; core lint passes.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-13T17:14:02.513Z
- Branch: task/202605131637-33VQFN/insights-report
- Head: 36bfc0aa25ed

```text
 .../blueprint/resolved-snapshot.json               | 514 +++++++++++++++++++++
 docs/user/cli-reference.generated.mdx              |  49 ++
 .../src/cli/run-cli.core.insights-report.test.ts   | 170 +++++++
 .../src/cli/run-cli/command-catalog/core.ts        |   8 +
 .../src/cli/run-cli/command-loaders/core.ts        |   7 +
 .../src/commands/insights/insights.command.ts      | 395 ++++++++++++++++
 .../src/commands/insights/insights.spec.ts         |  62 +++
 7 files changed, 1205 insertions(+)
```

</details>
