### PR TITLE
Fix shared env root detection for separate git dirs

### DIFF
--- a/.agentplane/tasks/202605131918-0ASXKY/README.md
+++ b/.agentplane/tasks/202605131918-0ASXKY/README.md
@@ -1,0 +1,202 @@
+---
+id: "202605131918-0ASXKY"
+title: "Harden shared env root worktree detection"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "config"
+  - "sync"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-13T19:19:32.664Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-13T19:46:09.182Z"
+  updated_by: "CODER"
+  note: "Re-verified after fallback refinement: backend/CLI tests pass, changed-file ESLint passes, routing policy passes, doctor passed earlier after bootstrap."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Address PR #3662 review by making shared .env root detection independent of the repo-local .git/worktrees path layout."
+events:
+  -
+    type: "status"
+    at: "2026-05-13T19:20:22.689Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Address PR #3662 review by making shared .env root detection independent of the repo-local .git/worktrees path layout."
+  -
+    type: "verify"
+    at: "2026-05-13T19:43:22.202Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified env root hardening with targeted backend/CLI tests, changed-file ESLint, routing policy, and doctor."
+  -
+    type: "verify"
+    at: "2026-05-13T19:46:09.182Z"
+    author: "CODER"
+    state: "ok"
+    note: "Re-verified after fallback refinement: backend/CLI tests pass, changed-file ESLint passes, routing policy passes, doctor passed earlier after bootstrap."
+doc_version: 3
+doc_updated_at: "2026-05-13T19:46:09.196Z"
+doc_updated_by: "CODER"
+description: "Address PR #3662 review feedback by resolving the shared .env root without assuming the repo-local .git/worktrees layout, including separate git-dir worktree layouts."
+sections:
+  Summary: |-
+    Harden shared env root worktree detection
+    
+    Address PR #3662 review feedback by resolving the shared .env root without assuming the repo-local .git/worktrees layout, including separate git-dir worktree layouts.
+  Scope: |-
+    - In scope: Address PR #3662 review feedback by resolving the shared .env root without assuming the repo-local .git/worktrees layout, including separate git-dir worktree layouts.
+    - Out of scope: unrelated refactors not required for "Harden shared env root worktree detection".
+  Plan: "1. Replace the string-slice .git/worktrees heuristic in resolveDotEnvRoot with a layout-independent Git-backed worktree root resolver. 2. Preserve the existing current-root behavior for normal checkouts and non-worktree repositories. 3. Add regression coverage for worktrees whose gitdir lives under a separate common git dir such as /tmp/repo.git/worktrees/name. 4. Run targeted backend/env tests plus lint/policy checks. 5. Publish a follow-up PR referencing PR #3662 review comment."
+  Verify Steps: |-
+    1. Run bun test packages/agentplane/src/backends/task-backend.load.test.ts packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts. Expected: shared root .env tests pass for normal and separate git-dir worktree layouts.
+    2. Run bun run lint:core. Expected: ESLint passes for touched TypeScript.
+    3. Run node .agentplane/policy/check-routing.mjs. Expected: policy routing OK.
+    4. Run ap doctor. Expected: doctor OK or only pre-existing unrelated workspace drift is reported.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-13T19:43:22.202Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified env root hardening with targeted backend/CLI tests, changed-file ESLint, routing policy, and doctor.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-13T19:20:22.689Z, excerpt_hash=sha256:4d4c749d2edbfc3576c40eda3956f7280f50e4a5f6ccb3f102278893d142febd
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605131918-0ASXKY-harden-env-root/.agentplane/tasks/202605131918-0ASXKY/blueprint/resolved-snapshot.json
+    - old_digest: 76d60ef4e010bb3a5c8e9203e1aa3daeafc33fbb3d3a067826808bc10e53a6f1
+    - current_digest: 76d60ef4e010bb3a5c8e9203e1aa3daeafc33fbb3d3a067826808bc10e53a6f1
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605131918-0ASXKY
+    
+    ### 2026-05-13T19:46:09.182Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Re-verified after fallback refinement: backend/CLI tests pass, changed-file ESLint passes, routing policy passes, doctor passed earlier after bootstrap.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-13T19:43:22.218Z, excerpt_hash=sha256:4d4c749d2edbfc3576c40eda3956f7280f50e4a5f6ccb3f102278893d142febd
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605131918-0ASXKY-harden-env-root/.agentplane/tasks/202605131918-0ASXKY/blueprint/resolved-snapshot.json
+    - old_digest: 76d60ef4e010bb3a5c8e9203e1aa3daeafc33fbb3d3a067826808bc10e53a6f1
+    - current_digest: 76d60ef4e010bb3a5c8e9203e1aa3daeafc33fbb3d3a067826808bc10e53a6f1
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605131918-0ASXKY
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Full bun run lint:core was attempted twice but did not complete or emit diagnostics after a long wait; terminated to avoid leaving a stale eslint process.
+      Impact: Repo-wide lint remains unconfirmed for this task; changed files pass ESLint directly.
+      Resolution: Regression coverage passes for standard worktree and separate git-dir layouts.
+    
+    - Observation: Full bun run lint:core still did not complete during this session and was terminated without diagnostics.
+      Impact: Repo-wide lint remains unconfirmed; task-local changed files are lint-clean.
+      Resolution: Shared .env root resolution no longer depends only on repo-local .git/worktrees path slicing and covers separate git-dir worktree layouts.
+id_source: "generated"
+---
+## Summary
+
+Harden shared env root worktree detection
+
+Address PR #3662 review feedback by resolving the shared .env root without assuming the repo-local .git/worktrees layout, including separate git-dir worktree layouts.
+
+## Scope
+
+- In scope: Address PR #3662 review feedback by resolving the shared .env root without assuming the repo-local .git/worktrees layout, including separate git-dir worktree layouts.
+- Out of scope: unrelated refactors not required for "Harden shared env root worktree detection".
+
+## Plan
+
+1. Replace the string-slice .git/worktrees heuristic in resolveDotEnvRoot with a layout-independent Git-backed worktree root resolver. 2. Preserve the existing current-root behavior for normal checkouts and non-worktree repositories. 3. Add regression coverage for worktrees whose gitdir lives under a separate common git dir such as /tmp/repo.git/worktrees/name. 4. Run targeted backend/env tests plus lint/policy checks. 5. Publish a follow-up PR referencing PR #3662 review comment.
+
+## Verify Steps
+
+1. Run bun test packages/agentplane/src/backends/task-backend.load.test.ts packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts. Expected: shared root .env tests pass for normal and separate git-dir worktree layouts.
+2. Run bun run lint:core. Expected: ESLint passes for touched TypeScript.
+3. Run node .agentplane/policy/check-routing.mjs. Expected: policy routing OK.
+4. Run ap doctor. Expected: doctor OK or only pre-existing unrelated workspace drift is reported.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-13T19:43:22.202Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified env root hardening with targeted backend/CLI tests, changed-file ESLint, routing policy, and doctor.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-13T19:20:22.689Z, excerpt_hash=sha256:4d4c749d2edbfc3576c40eda3956f7280f50e4a5f6ccb3f102278893d142febd
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605131918-0ASXKY-harden-env-root/.agentplane/tasks/202605131918-0ASXKY/blueprint/resolved-snapshot.json
+- old_digest: 76d60ef4e010bb3a5c8e9203e1aa3daeafc33fbb3d3a067826808bc10e53a6f1
+- current_digest: 76d60ef4e010bb3a5c8e9203e1aa3daeafc33fbb3d3a067826808bc10e53a6f1
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605131918-0ASXKY
+
+### 2026-05-13T19:46:09.182Z — VERIFY — ok
+
+By: CODER
+
+Note: Re-verified after fallback refinement: backend/CLI tests pass, changed-file ESLint passes, routing policy passes, doctor passed earlier after bootstrap.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-13T19:43:22.218Z, excerpt_hash=sha256:4d4c749d2edbfc3576c40eda3956f7280f50e4a5f6ccb3f102278893d142febd
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605131918-0ASXKY-harden-env-root/.agentplane/tasks/202605131918-0ASXKY/blueprint/resolved-snapshot.json
+- old_digest: 76d60ef4e010bb3a5c8e9203e1aa3daeafc33fbb3d3a067826808bc10e53a6f1
+- current_digest: 76d60ef4e010bb3a5c8e9203e1aa3daeafc33fbb3d3a067826808bc10e53a6f1
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605131918-0ASXKY
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Full bun run lint:core was attempted twice but did not complete or emit diagnostics after a long wait; terminated to avoid leaving a stale eslint process.
+  Impact: Repo-wide lint remains unconfirmed for this task; changed files pass ESLint directly.
+  Resolution: Regression coverage passes for standard worktree and separate git-dir layouts.
+
+- Observation: Full bun run lint:core still did not complete during this session and was terminated without diagnostics.
+  Impact: Repo-wide lint remains unconfirmed; task-local changed files are lint-clean.
+  Resolution: Shared .env root resolution no longer depends only on repo-local .git/worktrees path slicing and covers separate git-dir worktree layouts.

--- a/.agentplane/tasks/202605131918-0ASXKY/pr/diffstat.txt
+++ b/.agentplane/tasks/202605131918-0ASXKY/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../src/backends/task-backend.load.test.ts         |  44 +++++++
+ packages/agentplane/src/shared/env.ts              | 136 +++++++++++++++++++--
+ 2 files changed, 168 insertions(+), 12 deletions(-)

--- a/.agentplane/tasks/202605131918-0ASXKY/pr/github-body.md
+++ b/.agentplane/tasks/202605131918-0ASXKY/pr/github-body.md
@@ -22,7 +22,7 @@ Address PR #3662 review feedback by resolving the shared .env root without assum
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-13T19:50:11.014Z
+- Updated: 2026-05-13T19:52:03.891Z
 - Branch: task/202605131918-0ASXKY/harden-env-root
 - Head: 10b643372150
 

--- a/.agentplane/tasks/202605131918-0ASXKY/pr/github-body.md
+++ b/.agentplane/tasks/202605131918-0ASXKY/pr/github-body.md
@@ -1,0 +1,35 @@
+Task: `202605131918-0ASXKY`
+Title: Harden shared env root worktree detection
+Canonical task record: `.agentplane/tasks/202605131918-0ASXKY/README.md`
+
+## Summary
+
+Harden shared env root worktree detection
+
+Address PR #3662 review feedback by resolving the shared .env root without assuming the repo-local .git/worktrees layout, including separate git-dir worktree layouts.
+
+## Scope
+
+- In scope: Address PR #3662 review feedback by resolving the shared .env root without assuming the repo-local .git/worktrees layout, including separate git-dir worktree layouts.
+- Out of scope: unrelated refactors not required for "Harden shared env root worktree detection".
+
+## Verification
+
+- State: ok
+- Note: Re-verified after fallback refinement: backend/CLI tests pass, changed-file ESLint passes, routing policy passes, doctor passed earlier after bootstrap.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-13T19:50:11.014Z
+- Branch: task/202605131918-0ASXKY/harden-env-root
+- Head: 10b643372150
+
+```text
+ .../src/backends/task-backend.load.test.ts         |  44 +++++++
+ packages/agentplane/src/shared/env.ts              | 136 +++++++++++++++++++--
+ 2 files changed, 168 insertions(+), 12 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605131918-0ASXKY/pr/github-title.txt
+++ b/.agentplane/tasks/202605131918-0ASXKY/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 0ASXKY task: Harden shared env root worktree detection [202605131918-0ASXKY]

--- a/.agentplane/tasks/202605131918-0ASXKY/pr/meta.json
+++ b/.agentplane/tasks/202605131918-0ASXKY/pr/meta.json
@@ -1,0 +1,17 @@
+{
+  "base": "main",
+  "branch": "task/202605131918-0ASXKY/harden-env-root",
+  "created_at": "2026-05-13T19:20:22.934Z",
+  "head_sha": "10b643372150e1e7c3a75e401c76fb8b7cd9b45e",
+  "last_verified_at": "2026-05-13T19:46:09.182Z",
+  "last_verified_sha": "e7ca0fa9b4112295b41dae7313ea175c3a58a2c8",
+  "pr_number": 3668,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3668",
+  "schema_version": 1,
+  "status": "OPEN",
+  "task_id": "202605131918-0ASXKY",
+  "updated_at": "2026-05-13T19:50:11.014Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605131918-0ASXKY/pr/meta.json
+++ b/.agentplane/tasks/202605131918-0ASXKY/pr/meta.json
@@ -10,7 +10,7 @@
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202605131918-0ASXKY",
-  "updated_at": "2026-05-13T19:50:11.014Z",
+  "updated_at": "2026-05-13T19:52:03.891Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605131918-0ASXKY/pr/review.md
+++ b/.agentplane/tasks/202605131918-0ASXKY/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-05-13T19:20:22.934Z
+
+## Task
+
+- Task: `202605131918-0ASXKY`
+- Title: Harden shared env root worktree detection
+- Status: DOING
+- Branch: `task/202605131918-0ASXKY/harden-env-root`
+- Canonical task record: `.agentplane/tasks/202605131918-0ASXKY/README.md`
+
+## Verification
+
+- State: ok
+- Note: Re-verified after fallback refinement: backend/CLI tests pass, changed-file ESLint passes, routing policy passes, doctor passed earlier after bootstrap.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-13T19:50:11.014Z
+- Branch: task/202605131918-0ASXKY/harden-env-root
+- Head: 10b643372150
+
+```text
+ .../src/backends/task-backend.load.test.ts         |  44 +++++++
+ packages/agentplane/src/shared/env.ts              | 136 +++++++++++++++++++--
+ 2 files changed, 168 insertions(+), 12 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605131918-0ASXKY/pr/review.md
+++ b/.agentplane/tasks/202605131918-0ASXKY/pr/review.md
@@ -24,7 +24,7 @@ Created: 2026-05-13T19:20:22.934Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-13T19:50:11.014Z
+- Updated: 2026-05-13T19:52:03.891Z
 - Branch: task/202605131918-0ASXKY/harden-env-root
 - Head: 10b643372150
 

--- a/packages/agentplane/src/backends/task-backend.load.test.ts
+++ b/packages/agentplane/src/backends/task-backend.load.test.ts
@@ -1,5 +1,7 @@
+import { execFile } from "node:child_process";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { promisify } from "node:util";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -12,6 +14,8 @@ import {
   type TaskData,
 } from "./task-backend.js";
 import { mkTempDir, silenceStdIO } from "@agentplane/testkit";
+
+const execFileAsync = promisify(execFile);
 
 describe("loadTaskBackend", () => {
   let tempDir = "";
@@ -257,6 +261,46 @@ describe("loadTaskBackend", () => {
     expect(cloud.endpoint).toBe("https://cloud.example");
     expect(cloud.token).toBe("shared-token");
     expect(cloud.projectId).toBe("shared-project");
+  });
+
+  it("loads cloud backend credentials from the shared root .env with a separate git dir", async () => {
+    const repoDir = path.join(tempDir, "repo");
+    const gitDir = path.join(tempDir, "repo.git");
+    const worktreeRoot = path.join(tempDir, "linked-worktree");
+    await execFileAsync("git", ["init", "--separate-git-dir", gitDir, repoDir]);
+    await execFileAsync("git", ["-C", repoDir, "config", "user.email", "test@example.com"]);
+    await execFileAsync("git", ["-C", repoDir, "config", "user.name", "Test User"]);
+    await writeFile(path.join(repoDir, "seed.txt"), "seed\n", "utf8");
+    await execFileAsync("git", ["-C", repoDir, "add", "seed.txt"]);
+    await execFileAsync("git", ["-C", repoDir, "commit", "-m", "seed"]);
+    await execFileAsync("git", ["-C", repoDir, "worktree", "add", worktreeRoot, "-b", "task"]);
+    await mkdir(path.join(worktreeRoot, ".agentplane", "backends", "local"), { recursive: true });
+    await writeFile(
+      path.join(worktreeRoot, ".agentplane", "backends", "local", "backend.json"),
+      JSON.stringify({
+        id: "cloud",
+        settings: {
+          cache_dir: ".agentplane/tasks",
+        },
+      }),
+      "utf8",
+    );
+    await writeFile(
+      path.join(repoDir, ".env"),
+      [
+        "AGENTPLANE_CLOUD_ENDPOINT=https://cloud.example/",
+        "AGENTPLANE_CLOUD_TOKEN=separate-gitdir-token",
+        "AGENTPLANE_CLOUD_PROJECT_ID=separate-gitdir-project",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = await loadTaskBackend({ cwd: worktreeRoot });
+    expect(result.backendId).toBe("cloud");
+    const cloud = result.backend as CloudBackend;
+    expect(cloud.endpoint).toBe("https://cloud.example");
+    expect(cloud.token).toBe("separate-gitdir-token");
+    expect(cloud.projectId).toBe("separate-gitdir-project");
   });
 
   it("parses quoted .env values and resolves backend directories", async () => {

--- a/packages/agentplane/src/backends/task-backend/cloud-backend.ts
+++ b/packages/agentplane/src/backends/task-backend/cloud-backend.ts
@@ -139,31 +139,24 @@ export class CloudBackend implements TaskBackend {
   async generateTaskId(opts: { length: number; attempts: number }): Promise<string> {
     return await this.cache.generateTaskId(opts);
   }
-
   async listTasks(): Promise<TaskData[]> {
     return await this.cache.listTasks();
   }
-
   async listProjectionTasks(): Promise<TaskSummary[]> {
     return await this.cache.listProjectionTasks();
   }
-
   getLastListWarnings(): string[] {
     return this.cache.getLastListWarnings();
   }
-
   async getTask(taskId: string): Promise<TaskData | null> {
     return await this.cache.getTask(taskId);
   }
-
   async getTasks(taskIds: string[]): Promise<(TaskData | null)[]> {
     return await this.cache.getTasks(taskIds);
   }
-
   async getTaskDoc(taskId: string): Promise<string> {
     return await this.cache.getTaskDoc(taskId);
   }
-
   async assertLocalMutationReady(): Promise<void> {
     await this.assertProjectionFreshForLocalMutation();
   }
@@ -177,7 +170,6 @@ export class CloudBackend implements TaskBackend {
     await this.assertProjectionFreshForLocalMutation();
     await this.cache.setTaskDoc(taskId, doc, updatedBy, opts);
   }
-
   async touchTaskDocMetadata(
     taskId: string,
     updatedBy?: string,
@@ -191,20 +183,16 @@ export class CloudBackend implements TaskBackend {
     await this.assertProjectionFreshForLocalMutation();
     await this.cache.writeTask(task, opts);
   }
-
   async writeTasks(tasks: TaskData[], opts?: TaskWriteOptions): Promise<void> {
     await this.assertProjectionFreshForLocalMutation();
     await this.cache.writeTasks(tasks, opts);
   }
-
   async normalizeTasks(): Promise<{ scanned: number; changed: number }> {
     return await this.cache.normalizeTasks();
   }
-
   async exportTasksJson(outputPath: string): Promise<void> {
     await this.cache.exportTasksJson(outputPath);
   }
-
   async exportProjectionSnapshot(outputPath: string): Promise<void> {
     await this.cache.exportProjectionSnapshot(outputPath);
   }

--- a/packages/agentplane/src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap
+++ b/packages/agentplane/src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap
@@ -86,6 +86,8 @@ Commands:
     doctor  Check workspace invariants for a normal agentplane installation (with optional dev source checks).
     doctor git-locks  Check Git index lock state for this repository and suggest cleanup.
   Diagnostics:
+    insights  Generate local-only diagnostic insights for support analysis.
+    insights report  Print a local-only privacy-bounded AgentPlane diagnostic report.
     runtime  Inspect which agentplane runtime/binary/package sources are active.
     runtime explain  Explain the active binary, runtime mode, and resolved package roots.
   Recipes:
@@ -147,25 +149,14 @@ Commands:
     ide sync  Generate IDE entrypoints from policy gateway file (AGENTS.md or CLAUDE.md).
   Context:
     context  Manage local project context, durable derivations, projections, and search surfaces.
-    context capability  Capability maintenance fallback under context namespace.
-    context capability discover  Discover capability candidates from context operations.
-    context capability search  Search capability registry and candidate surface.
-    context capability validate  Validate a unified capability artifact.
-    context doctor  Diagnose local context health and projection consistency.
-    context graph  Validate and inspect derived context graph.
-    context graph export  Export graph artifacts for offline consumption.
-    context graph neighbors  Show direct neighbors for one graph node.
-    context graph show  Show a node with neighborhood summary.
-    context graph summary  Print a context-graph summary.
-    context graph validate  Validate derived graph JSONL rows and references.
-    context harvest  Harvest existing project evidence into source-backed context proposals.
-    context harvest tasks  Harvest completed task evidence into raw scaffolds or CURATOR extraction tasks.
-    context ingest  Create and optionally run a context assimilation task.
+    context check  Check context workspace health.
     context init  Initialize local context workspace and system manifest.
-    context reindex  Rebuild local SQLite projection from source artifacts.
+    context learn  Create context processing tasks from files, changes, or completed tasks.
+    context learn changes  Create a context assimilation task from changed context sources.
+    context learn files  Create a context assimilation task from explicit files or paths.
+    context learn tasks  Create CURATOR extraction tasks from completed task history.
     context search  Search indexed local context, facts, graph, tasks, and capabilities.
     context show  Resolve a context source reference and print addressed content.
-    context verify-task  Validate mutations for a context_assimilation task.
   Framework Dev:
     codex  Codex integration commands.
     codex plugin  Install and inspect bundled Codex plugin integrations.

--- a/packages/agentplane/src/commands/blueprints/catalog-cache.ts
+++ b/packages/agentplane/src/commands/blueprints/catalog-cache.ts
@@ -57,8 +57,8 @@ function compareSemverish(left: string, right: string): number {
   const parsedLeft = parseSemver(left);
   const parsedRight = parseSemver(right);
   if (parsedLeft && parsedRight) {
-    for (let idx = 0; idx < parsedLeft.length; idx += 1) {
-      const delta = parsedLeft[idx] - parsedRight[idx];
+    for (const [idx, leftPart] of parsedLeft.entries()) {
+      const delta = leftPart - parsedRight[idx];
       if (delta !== 0) return delta;
     }
     return 0;

--- a/packages/agentplane/src/commands/task/shared/branch-pr-list-state.ts
+++ b/packages/agentplane/src/commands/task/shared/branch-pr-list-state.ts
@@ -5,7 +5,7 @@ import type { CommandContext } from "../../shared/task-backend.js";
 
 const BRANCH_PR_LIST_STATE_KEY = "agentplane.branch_pr_list_state";
 
-export const MERGED_PENDING_CLOSE_STATUS = "MERGED_PENDING_CLOSE";
+const MERGED_PENDING_CLOSE_STATUS = "MERGED_PENDING_CLOSE";
 const MERGED_PENDING_CLOSE_LABEL = "MERGED->DONE?";
 
 type BranchPrMergedPendingCloseState = {

--- a/packages/agentplane/src/shared/env.ts
+++ b/packages/agentplane/src/shared/env.ts
@@ -1,7 +1,10 @@
+import { execFile } from "node:child_process";
 import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
+import { promisify } from "node:util";
 
 const DOTENV_LOADED_KEYS_ENV = "AGENTPLANE_DOTENV_LOADED_KEYS";
+const execFileAsync = promisify(execFile);
 
 export function parseDotEnv(text: string): Record<string, string> {
   const out: Record<string, string> = {};
@@ -54,6 +57,119 @@ export function isDotEnvLoadedKey(key: string, env: NodeJS.ProcessEnv = process.
   return readDotEnvLoadedKeys(env).has(key);
 }
 
+async function gitStdout(rootDir: string, args: string[]): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", rootDir, ...args], {
+      timeout: 2000,
+      maxBuffer: 1024 * 1024,
+    });
+    return stdout;
+  } catch {
+    return null;
+  }
+}
+
+async function gitStdoutRaw(args: string[]): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", args, {
+      timeout: 2000,
+      maxBuffer: 1024 * 1024,
+    });
+    return stdout;
+  } catch {
+    return null;
+  }
+}
+
+function firstPorcelainWorktree(output: string | null, ignoredPaths: string[] = []): string | null {
+  if (!output) return null;
+  const ignored = new Set(ignoredPaths.map((entry) => path.resolve(entry)));
+  for (const line of output.split(/\r?\n/u)) {
+    if (!line.startsWith("worktree ")) continue;
+    const rawWorktree = line.slice("worktree ".length).trim();
+    if (!rawWorktree) continue;
+    const worktree = path.resolve(rawWorktree);
+    if (ignored.has(worktree)) continue;
+    return worktree;
+  }
+  return null;
+}
+
+async function resolveDotEnvRootFromGit(
+  rootDir: string,
+  ignoredPaths: string[] = [],
+): Promise<string | null> {
+  return firstPorcelainWorktree(
+    await gitStdout(rootDir, ["worktree", "list", "--porcelain"]),
+    ignoredPaths,
+  );
+}
+
+async function readGitFileDir(resolvedRoot: string, gitPath: string): Promise<string | null> {
+  let gitFile = "";
+  try {
+    gitFile = await readFile(gitPath, "utf8");
+  } catch {
+    return null;
+  }
+
+  const match = /^gitdir:\s*(.+)\s*$/imu.exec(gitFile);
+  if (!match) return null;
+  return path.resolve(resolvedRoot, match[1]);
+}
+
+async function resolveCommonGitDir(gitDir: string): Promise<string> {
+  try {
+    const commonDirText = await readFile(path.join(gitDir, "commondir"), "utf8");
+    const commonDir = commonDirText.trim();
+    if (commonDir) return path.resolve(gitDir, commonDir);
+  } catch {
+    // Non-linked or synthetic worktrees may not have commondir.
+  }
+  return gitDir;
+}
+
+async function resolveCoreWorktree(commonGitDir: string): Promise<string | null> {
+  const output = await gitStdoutRaw([
+    "config",
+    "--file",
+    path.join(commonGitDir, "config"),
+    "--get",
+    "core.worktree",
+  ]);
+  const raw = output?.trim();
+  if (!raw) return null;
+  return path.resolve(commonGitDir, raw);
+}
+
+async function resolveWorktreeFromCommonGitDir(commonGitDir: string): Promise<string | null> {
+  const basename = path.basename(commonGitDir);
+  const parent = path.dirname(commonGitDir);
+  const candidate =
+    basename === ".git"
+      ? parent
+      : basename.endsWith(".git")
+        ? path.join(parent, basename.slice(0, -".git".length))
+        : null;
+  if (!candidate) return null;
+
+  try {
+    const candidateStats = await stat(candidate);
+    if (candidateStats.isDirectory()) return path.resolve(candidate);
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function resolveDotEnvRootFromGitDirLayout(gitDir: string): string | null {
+  const worktreesMarker = `${path.sep}.git${path.sep}worktrees${path.sep}`;
+  const markerIndex = gitDir.indexOf(worktreesMarker);
+  if (markerIndex === -1) return null;
+
+  return gitDir.slice(0, markerIndex);
+}
+
 export async function resolveDotEnvRoot(rootDir: string): Promise<string> {
   const resolvedRoot = path.resolve(rootDir);
   const gitPath = path.join(resolvedRoot, ".git");
@@ -67,30 +183,17 @@ export async function resolveDotEnvRoot(rootDir: string): Promise<string> {
   if (gitPathStats.isDirectory()) return resolvedRoot;
   if (!gitPathStats.isFile()) return resolvedRoot;
 
-  let gitFile = "";
-  try {
-    gitFile = await readFile(gitPath, "utf8");
-  } catch {
-    return resolvedRoot;
-  }
+  const gitDir = await readGitFileDir(resolvedRoot, gitPath);
+  if (!gitDir) return resolvedRoot;
+  const commonGitDir = await resolveCommonGitDir(gitDir);
 
-  const match = /^gitdir:\s*(.+)\s*$/imu.exec(gitFile);
-  if (!match) return resolvedRoot;
-  const gitDir = path.resolve(resolvedRoot, match[1]);
-  try {
-    const rawCommonDir = (await readFile(path.join(gitDir, "commondir"), "utf8")).trim();
-    if (rawCommonDir) {
-      const commonDir = path.resolve(gitDir, rawCommonDir);
-      if (path.basename(commonDir) === ".git") return path.dirname(commonDir);
-    }
-  } catch {
-    // Older or synthetic worktree layouts may not expose commondir; use the legacy marker below.
-  }
-  const worktreesMarker = `${path.sep}.git${path.sep}worktrees${path.sep}`;
-  const markerIndex = gitDir.indexOf(worktreesMarker);
-  if (markerIndex === -1) return resolvedRoot;
-
-  return gitDir.slice(0, markerIndex);
+  return (
+    (await resolveCoreWorktree(commonGitDir)) ??
+    (await resolveWorktreeFromCommonGitDir(commonGitDir)) ??
+    (await resolveDotEnvRootFromGit(resolvedRoot, [commonGitDir])) ??
+    resolveDotEnvRootFromGitDirLayout(gitDir) ??
+    resolvedRoot
+  );
 }
 
 export async function loadDotEnv(rootDir: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Hardened shared `.env` root detection for linked worktrees without assuming a repo-local `.git/worktrees` layout.
- Added regression coverage for repositories initialized with `git init --separate-git-dir`.
- Kept required CI gates green after rebasing onto the moving `main` branch.

Addresses the unresolved review comment from #3662.

## Verification

```bash
bun test packages/agentplane/src/backends/task-backend.load.test.ts \
  packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts

bun test packages/agentplane/src/cli/run-cli.core.tasks.branch-pr-list-state.test.ts \
  packages/agentplane/src/commands/blueprints/catalog-cache.test.ts \
  packages/agentplane/src/backends/task-backend.load.test.ts \
  packages/agentplane/src/backends/task-backend.cloud.test.ts \
  packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts

./node_modules/.bin/eslint \
  packages/agentplane/src/commands/task/shared/branch-pr-list-state.ts \
  packages/agentplane/src/commands/blueprints/catalog-cache.ts \
  packages/agentplane/src/backends/task-backend/cloud-backend.ts \
  packages/agentplane/src/shared/env.ts \
  packages/agentplane/src/backends/task-backend.load.test.ts

bun run lint:core
bun run knip:check
bun run format:check
node .agentplane/policy/check-routing.mjs
ap doctor
```

```bash
node scripts/checks/hotspot-report.mjs --check \
  --warning-lines 400 \
  --oversized-lines 600 \
  --test-warning-lines 1000 \
  --oversized-test-lines 1300

node scripts/checks/check-oversized-test-baseline.mjs --threshold-lines 1000
```

GitHub checks passed before merge:

- `docs`
- `test`
- `test-windows`
- `Release-ready manifest`

## Notes

The extra gate-fix commits were follow-up cleanup for required CI drift encountered after rebasing onto the moving `main` branch. The resolver fix itself is in `packages/agentplane/src/shared/env.ts` with regression coverage in `task-backend.load.test.ts`.
