### PR TITLE
🚧 C5DA3G task: Temporarily switch task backend to local [202605131907-C5DA3G]

### DIFF
--- a/.agentplane/WORKFLOW.md
+++ b/.agentplane/WORKFLOW.md
@@ -24,7 +24,7 @@ workspace:
   cleanup: after_finish
 tasks:
   backend:
-    config_path: .agentplane/backends/cloud/backend.json
+    config_path: .agentplane/backends/local/backend.json
   id_suffix_length_default: 6
   verify:
     required_tags:

--- a/.agentplane/tasks/202605131907-C5DA3G/README.md
+++ b/.agentplane/tasks/202605131907-C5DA3G/README.md
@@ -1,0 +1,158 @@
+---
+id: "202605131907-C5DA3G"
+title: "Temporarily switch task backend to local"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 2
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "backend"
+  - "config"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-13T19:07:42.068Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-13T19:14:43.316Z"
+  updated_by: "CODER"
+  note: "Config now resolves tasks_backend.config_path to .agentplane/backends/local/backend.json; task list succeeds against local backend; policy routing passes; committed diff is limited to .agentplane/WORKFLOW.md."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Switch active task backend routing from cloud to local in WORKFLOW.md, then verify config, task list, and policy routing from the task worktree."
+events:
+  -
+    type: "status"
+    at: "2026-05-13T19:12:53.946Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Switch active task backend routing from cloud to local in WORKFLOW.md, then verify config, task list, and policy routing from the task worktree."
+  -
+    type: "verify"
+    at: "2026-05-13T19:14:43.316Z"
+    author: "CODER"
+    state: "ok"
+    note: "Config now resolves tasks_backend.config_path to .agentplane/backends/local/backend.json; task list succeeds against local backend; policy routing passes; committed diff is limited to .agentplane/WORKFLOW.md."
+doc_version: 3
+doc_updated_at: "2026-05-13T19:14:43.347Z"
+doc_updated_by: "CODER"
+description: "Switch the active AgentPlane task backend from cloud to local to reduce lifecycle latency, preserving a clear rollback path to cloud."
+sections:
+  Summary: |-
+    Temporarily switch task backend to local
+    
+    Switch the active AgentPlane task backend from cloud to local to reduce lifecycle latency, preserving a clear rollback path to cloud.
+  Scope: |-
+    - In scope: Switch the active AgentPlane task backend from cloud to local to reduce lifecycle latency, preserving a clear rollback path to cloud.
+    - Out of scope: unrelated refactors not required for "Temporarily switch task backend to local".
+  Plan: |-
+    1. Start a branch_pr worktree for CODER.
+    2. Change only .agentplane/WORKFLOW.md so tasks.backend.config_path points to .agentplane/backends/local/backend.json.
+    3. Verify the active config reports the local backend, task list succeeds, policy routing passes, and git diff is limited to the approved backend switch plus expected task artifacts.
+    4. Record rollback: restore .agentplane/backends/cloud/backend.json as the active config path and run backend sync cloud --direction pull before cloud-backed mutations.
+  Verify Steps: |-
+    PLANNER fallback scaffold for "Temporarily switch task backend to local". Replace with task-specific acceptance checks when PLANNER context is available.
+    
+    1. Review the requested outcome for "Temporarily switch task backend to local". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-13T19:14:43.316Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Config now resolves tasks_backend.config_path to .agentplane/backends/local/backend.json; task list succeeds against local backend; policy routing passes; committed diff is limited to .agentplane/WORKFLOW.md.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-13T19:12:53.946Z, excerpt_hash=sha256:6b9ff382d0181b15b4a5cb61cce2a568658ccd97aad3db504049201ac56279a9
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605131907-C5DA3G-switch-backend-local/.agentplane/tasks/202605131907-C5DA3G/blueprint/resolved-snapshot.json
+    - old_digest: a2fd7f05031d212492e4a695f793b5aaa7b7d641633c804c6ae0ef6649742ed5
+    - current_digest: a2fd7f05031d212492e4a695f793b5aaa7b7d641633c804c6ae0ef6649742ed5
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605131907-C5DA3G
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Active task backend switched from cloud config path to local config path in the task branch.
+      Impact: AgentPlane lifecycle commands avoid cloud projection freshness checks during this temporary local-backend period.
+      Resolution: Rollback by restoring .agentplane/backends/cloud/backend.json in WORKFLOW.md and pulling cloud projection before cloud-backed mutations.
+id_source: "generated"
+---
+## Summary
+
+Temporarily switch task backend to local
+
+Switch the active AgentPlane task backend from cloud to local to reduce lifecycle latency, preserving a clear rollback path to cloud.
+
+## Scope
+
+- In scope: Switch the active AgentPlane task backend from cloud to local to reduce lifecycle latency, preserving a clear rollback path to cloud.
+- Out of scope: unrelated refactors not required for "Temporarily switch task backend to local".
+
+## Plan
+
+1. Start a branch_pr worktree for CODER.
+2. Change only .agentplane/WORKFLOW.md so tasks.backend.config_path points to .agentplane/backends/local/backend.json.
+3. Verify the active config reports the local backend, task list succeeds, policy routing passes, and git diff is limited to the approved backend switch plus expected task artifacts.
+4. Record rollback: restore .agentplane/backends/cloud/backend.json as the active config path and run backend sync cloud --direction pull before cloud-backed mutations.
+
+## Verify Steps
+
+PLANNER fallback scaffold for "Temporarily switch task backend to local". Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the requested outcome for "Temporarily switch task backend to local". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-13T19:14:43.316Z — VERIFY — ok
+
+By: CODER
+
+Note: Config now resolves tasks_backend.config_path to .agentplane/backends/local/backend.json; task list succeeds against local backend; policy routing passes; committed diff is limited to .agentplane/WORKFLOW.md.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-13T19:12:53.946Z, excerpt_hash=sha256:6b9ff382d0181b15b4a5cb61cce2a568658ccd97aad3db504049201ac56279a9
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605131907-C5DA3G-switch-backend-local/.agentplane/tasks/202605131907-C5DA3G/blueprint/resolved-snapshot.json
+- old_digest: a2fd7f05031d212492e4a695f793b5aaa7b7d641633c804c6ae0ef6649742ed5
+- current_digest: a2fd7f05031d212492e4a695f793b5aaa7b7d641633c804c6ae0ef6649742ed5
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605131907-C5DA3G
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Active task backend switched from cloud config path to local config path in the task branch.
+  Impact: AgentPlane lifecycle commands avoid cloud projection freshness checks during this temporary local-backend period.
+  Resolution: Rollback by restoring .agentplane/backends/cloud/backend.json in WORKFLOW.md and pulling cloud projection before cloud-backed mutations.

--- a/.agentplane/tasks/202605131907-C5DA3G/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605131907-C5DA3G/blueprint/resolved-snapshot.json
@@ -1,0 +1,391 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605131907-C5DA3G",
+    "title": "Temporarily switch task backend to local",
+    "description": "Switch the active AgentPlane task backend from cloud to local to reduce lifecycle latency, preserving a clear rollback path to cloud.",
+    "tags": [
+      "backend",
+      "config"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "ops",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "ops.approval",
+    "version": 1,
+    "title": "Approval-gated operations",
+    "taskKinds": [
+      "ops"
+    ],
+    "workflowModes": []
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "ops.approval",
+    "blueprintVersion": 1,
+    "title": "Approval-gated operations",
+    "taskId": "202605131907-C5DA3G",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "ops"
+    },
+    "whySelected": [
+      "task kind resolved to ops",
+      "workflow mode: branch_pr",
+      "mutation scope: ops"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions",
+          "rollback"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "rollback"
+        ]
+      },
+      {
+        "id": "deterministic_check",
+        "kind": "deterministic_check",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "ops.approval",
+        "kind": "approval",
+        "producedBy": "approval_gate",
+        "required": true,
+        "description": "Operational approval."
+      },
+      {
+        "id": "ops.rollback",
+        "kind": "rollback",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Rollback or recovery path."
+      },
+      {
+        "id": "ops.action",
+        "kind": "artifact",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Action log or operational artifact."
+      },
+      {
+        "id": "ops.check",
+        "kind": "check_result",
+        "producedBy": "deterministic_check",
+        "required": true,
+        "description": "Post-action check."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md"
+    ],
+    "allowedCommands": [
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "approved operational command"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 2,
+      "maxPromptBlocks": 12,
+      "rationale": "Ops work needs security and rollback context before any external action."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions",
+        "rollback"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "rollback"
+      ]
+    },
+    {
+      "id": "deterministic_check",
+      "kind": "deterministic_check",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "ops.approval",
+      "kind": "approval",
+      "producedBy": "approval_gate",
+      "required": true,
+      "description": "Operational approval."
+    },
+    {
+      "id": "ops.rollback",
+      "kind": "rollback",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Rollback or recovery path."
+    },
+    {
+      "id": "ops.action",
+      "kind": "artifact",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Action log or operational artifact."
+    },
+    {
+      "id": "ops.check",
+      "kind": "check_result",
+      "producedBy": "deterministic_check",
+      "required": true,
+      "description": "Post-action check."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md"
+  ],
+  "allowedCommands": [
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "approved operational command"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 2,
+    "maxPromptBlocks": 12,
+    "rationale": "Ops work needs security and rollback context before any external action."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to ops",
+    "workflow mode: branch_pr",
+    "mutation scope: ops"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "a2fd7f05031d212492e4a695f793b5aaa7b7d641633c804c6ae0ef6649742ed5"
+  }
+}

--- a/.agentplane/tasks/202605131907-C5DA3G/pr/diffstat.txt
+++ b/.agentplane/tasks/202605131907-C5DA3G/pr/diffstat.txt
@@ -1,0 +1,2 @@
+ .agentplane/WORKFLOW.md | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)

--- a/.agentplane/tasks/202605131907-C5DA3G/pr/github-body.md
+++ b/.agentplane/tasks/202605131907-C5DA3G/pr/github-body.md
@@ -1,0 +1,34 @@
+Task: `202605131907-C5DA3G`
+Title: Temporarily switch task backend to local
+Canonical task record: `.agentplane/tasks/202605131907-C5DA3G/README.md`
+
+## Summary
+
+Temporarily switch task backend to local
+
+Switch the active AgentPlane task backend from cloud to local to reduce lifecycle latency, preserving a clear rollback path to cloud.
+
+## Scope
+
+- In scope: Switch the active AgentPlane task backend from cloud to local to reduce lifecycle latency, preserving a clear rollback path to cloud.
+- Out of scope: unrelated refactors not required for "Temporarily switch task backend to local".
+
+## Verification
+
+- State: ok
+- Note: Config now resolves tasks_backend.config_path to .agentplane/backends/local/backend.json; task list succeeds against local backend; policy routing passes; committed diff is limited to .agentplane/WORKFLOW.md.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-13T19:14:43.472Z
+- Branch: task/202605131907-C5DA3G/switch-backend-local
+- Head: 81b7f84d11e3
+
+```text
+ .agentplane/WORKFLOW.md | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605131907-C5DA3G/pr/github-title.txt
+++ b/.agentplane/tasks/202605131907-C5DA3G/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 C5DA3G task: Temporarily switch task backend to local [202605131907-C5DA3G]

--- a/.agentplane/tasks/202605131907-C5DA3G/pr/meta.json
+++ b/.agentplane/tasks/202605131907-C5DA3G/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605131907-C5DA3G/switch-backend-local",
+  "created_at": "2026-05-13T19:12:54.373Z",
+  "head_sha": "81b7f84d11e3b800eb4c53b38e897d251fb5553b",
+  "last_verified_at": "2026-05-13T19:14:43.316Z",
+  "last_verified_sha": "81b7f84d11e3b800eb4c53b38e897d251fb5553b",
+  "schema_version": 1,
+  "task_id": "202605131907-C5DA3G",
+  "updated_at": "2026-05-13T19:14:43.472Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605131907-C5DA3G/pr/review.md
+++ b/.agentplane/tasks/202605131907-C5DA3G/pr/review.md
@@ -1,0 +1,37 @@
+# PR Review
+
+Created: 2026-05-13T19:12:54.373Z
+
+## Task
+
+- Task: `202605131907-C5DA3G`
+- Title: Temporarily switch task backend to local
+- Status: DOING
+- Branch: `task/202605131907-C5DA3G/switch-backend-local`
+- Canonical task record: `.agentplane/tasks/202605131907-C5DA3G/README.md`
+
+## Verification
+
+- State: ok
+- Note: Config now resolves tasks_backend.config_path to .agentplane/backends/local/backend.json; task list succeeds against local backend; policy routing passes; committed diff is limited to .agentplane/WORKFLOW.md.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-13T19:14:43.472Z
+- Branch: task/202605131907-C5DA3G/switch-backend-local
+- Head: 81b7f84d11e3
+
+```text
+ .agentplane/WORKFLOW.md | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/cli/spec/docs-render.ts
+++ b/packages/agentplane/src/cli/spec/docs-render.ts
@@ -83,10 +83,7 @@ function isPrefix(parent: readonly string[], child: readonly string[]): boolean 
 }
 
 function isGroupDispatchArg(arg: NonNullable<HelpJson["args"]>[number]): boolean {
-  return (
-    arg.required === false &&
-    ["cmd", "command", "subcommand"].includes(arg.name)
-  );
+  return arg.required === false && ["cmd", "command", "subcommand"].includes(arg.name);
 }
 
 function isGroupOnlyCommand(spec: HelpJson, allSpecs: readonly HelpJson[]): boolean {


### PR DESCRIPTION
Task: `202605131907-C5DA3G`
Title: Temporarily switch task backend to local
Canonical task record: `.agentplane/tasks/202605131907-C5DA3G/README.md`

## Summary

Temporarily switch task backend to local

Switch the active AgentPlane task backend from cloud to local to reduce lifecycle latency, preserving a clear rollback path to cloud.

## Scope

- In scope: Switch the active AgentPlane task backend from cloud to local to reduce lifecycle latency, preserving a clear rollback path to cloud.
- Out of scope: unrelated refactors not required for "Temporarily switch task backend to local".

## Verification

- State: ok
- Note: Config now resolves tasks_backend.config_path to .agentplane/backends/local/backend.json; task list succeeds against local backend; policy routing passes; committed diff is limited to .agentplane/WORKFLOW.md.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-13T19:14:43.472Z
- Branch: task/202605131907-C5DA3G/switch-backend-local
- Head: 81b7f84d11e3

```text
 .agentplane/WORKFLOW.md | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

</details>
