### PR TITLE
✅ J5YVSS close: finalize merged v0.6 task [202605132103-J5YVSS]

### DIFF
--- a/.agentplane/tasks/202605132103-J5YVSS/README.md
+++ b/.agentplane/tasks/202605132103-J5YVSS/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202605132103-J5YVSS"
 title: "Remove legacy tasks.json export surface"
-status: "DOING"
+result_summary: "Merged to main in PR #3694; v0.6 readiness and assimilation checks passed."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -24,11 +25,16 @@ verification:
   updated_by: "CODER"
   note: "Verified in 202605140709-5H7BAA readiness sweep: focused tests, release/docs gates, package install smoke, and empty-folder context assimilation smoke passed."
   attempts: 0
-commit: null
+commit:
+  hash: "ec628cd9a2aa899cca01611be9519181845ba555"
+  message: "Merge pull request #3694 from basilisk-labs/task/202605140709-5H7BAA/v06-readiness-blockers"
 comments:
   -
     author: "CODER"
     body: "Start: Implement removal of obsolete tasks.json export surface and complete the four approved TODO tasks in one related batch worktree."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: merged via PR #3694 after full v0.6 readiness checks and GitHub CI passed."
 events:
   -
     type: "status"
@@ -49,9 +55,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified in 202605140709-5H7BAA readiness sweep: focused tests, release/docs gates, package install smoke, and empty-folder context assimilation smoke passed."
+  -
+    type: "status"
+    at: "2026-05-14T09:07:05.559Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: merged via PR #3694 after full v0.6 readiness checks and GitHub CI passed."
 doc_version: 3
-doc_updated_at: "2026-05-14T07:59:43.316Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-14T09:07:05.561Z"
+doc_updated_by: "INTEGRATOR"
 description: "Remove the obsolete .agentplane/tasks.json export snapshot surface now that task reads use task docs and sqlite cache."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605132103-J5YVSS/acr.json
+++ b/.agentplane/tasks/202605132103-J5YVSS/acr.json
@@ -1,0 +1,225 @@
+{
+  "acr_version": "0.1.0",
+  "record_type": "agent_change_record",
+  "record_id": "acr_202605132103-J5YVSS",
+  "created_at": "2026-05-14T09:07:06.193Z",
+  "producer": {
+    "name": "agentplane",
+    "version": "0.4.2"
+  },
+  "repository": {
+    "vcs": "git",
+    "remote": "https://github.com/basilisk-labs/agentplane.git",
+    "base_ref": "main",
+    "base_commit": "ec628cd9a2aa899cca01611be9519181845ba555",
+    "work_ref": "main",
+    "work_commit": "ec628cd9a2aa899cca01611be9519181845ba555"
+  },
+  "task": {
+    "task_id": "202605132103-J5YVSS",
+    "title": "Remove legacy tasks.json export surface",
+    "intent": "Remove the obsolete .agentplane/tasks.json export snapshot surface now that task reads use task docs and sqlite cache.",
+    "requested_by": {
+      "type": "agentplane_role",
+      "id": "ORCHESTRATOR"
+    }
+  },
+  "agent": {
+    "id": "INTEGRATOR",
+    "name": "INTEGRATOR",
+    "agent_type": "coding_agent",
+    "model": {
+      "provider": "unknown",
+      "name": "unknown",
+      "version": "unknown"
+    },
+    "toolchain": [
+      {
+        "name": "agentplane",
+        "version": "0.4.2"
+      }
+    ]
+  },
+  "plan": {
+    "status": "approved",
+    "artifact": {
+      "path": ".agentplane/tasks/202605132103-J5YVSS/README.md",
+      "sha256": "sha256:a6aa42eb0cf883d6401313364f48a696b236a1644132ef0fa25bbaf6383a5cc5"
+    },
+    "approved_at": "2026-05-13T21:06:11.760Z",
+    "approved_by": {
+      "type": "agentplane_role",
+      "id": "ORCHESTRATOR"
+    }
+  },
+  "permissions": {
+    "network": {
+      "mode": "unknown"
+    },
+    "secrets": {
+      "access": "none"
+    },
+    "tools": [
+      {
+        "name": "shell",
+        "allowed": true
+      }
+    ]
+  },
+  "policy": {
+    "policy_version": "0.1.0",
+    "decisions": [
+      {
+        "rule_id": "plan.required",
+        "decision": "pass",
+        "reason": "Approved plan exists."
+      },
+      {
+        "rule_id": "verification.required",
+        "decision": "pass",
+        "reason": "Verification is recorded as ok."
+      }
+    ]
+  },
+  "changes": {
+    "summary": "Merged to main in PR #3694; v0.6 readiness and assimilation checks passed.",
+    "diff_stats": {
+      "files_changed": 0,
+      "insertions": 0,
+      "deletions": 0
+    },
+    "files": [],
+    "risk": {
+      "level": "medium",
+      "categories": [],
+      "protected_paths_touched": false
+    }
+  },
+  "verification": {
+    "status": "passed",
+    "checks": []
+  },
+  "approvals": [
+    {
+      "approval_id": "approval_202605132103-J5YVSS_plan",
+      "type": "plan_approval",
+      "decision": "approved",
+      "approved_by": {
+        "type": "agentplane_role",
+        "id": "ORCHESTRATOR"
+      },
+      "approved_at": "2026-05-13T21:06:11.760Z",
+      "scope": "task"
+    }
+  ],
+  "evidence": [
+    {
+      "type": "task",
+      "path": ".agentplane/tasks/202605132103-J5YVSS/README.md",
+      "sha256": "sha256:a6aa42eb0cf883d6401313364f48a696b236a1644132ef0fa25bbaf6383a5cc5"
+    },
+    {
+      "type": "plan",
+      "path": ".agentplane/tasks/202605132103-J5YVSS/README.md",
+      "sha256": "sha256:a6aa42eb0cf883d6401313364f48a696b236a1644132ef0fa25bbaf6383a5cc5"
+    },
+    {
+      "type": "verification_log",
+      "path": ".agentplane/tasks/202605132103-J5YVSS/README.md",
+      "sha256": "sha256:a6aa42eb0cf883d6401313364f48a696b236a1644132ef0fa25bbaf6383a5cc5"
+    },
+    {
+      "type": "other",
+      "path": ".agentplane/tasks/202605132103-J5YVSS/blueprint/resolved-snapshot.json",
+      "sha256": "sha256:e7c52f7afe9a673e83d5a9b0300a6a38732f1923652e20d8a8be6cd9f52f23fa"
+    }
+  ],
+  "result": {
+    "status": "finished",
+    "merge_ready": false,
+    "residual_risks": [
+      "Passed verification has no checks."
+    ],
+    "rollback": {
+      "available": true,
+      "notes": "Revert work_commit ec628cd9a2aa899cca01611be9519181845ba555 if downstream validation fails."
+    }
+  },
+  "integrity": {
+    "digest_algorithm": "sha256",
+    "record_digest": "sha256:20bc3b5a7ec6a00b4894a0062851b15df6453cc39445137d8857f51252352fa0",
+    "canonicalization": "rfc8785-jcs",
+    "signatures": []
+  },
+  "extensions": {
+    "agentplane.blueprint": {
+      "blueprint_id": "code.branch_pr",
+      "blueprint_version": 1,
+      "workflow_mode": "branch_pr",
+      "route": [
+        "intake",
+        "scope",
+        "approval_gate",
+        "context_resolve",
+        "worktree_start",
+        "work_unit",
+        "fast_local_checks",
+        "pr_artifact",
+        "verify_record",
+        "hosted_checks",
+        "publish_or_integrate",
+        "finish"
+      ],
+      "required_evidence": [
+        {
+          "id": "code_pr.paths",
+          "kind": "changed_paths",
+          "produced_by": "work_unit",
+          "required": true
+        },
+        {
+          "id": "code_pr.fast_checks",
+          "kind": "check_result",
+          "produced_by": "fast_local_checks",
+          "required": true
+        },
+        {
+          "id": "code_pr.pr",
+          "kind": "external_link",
+          "produced_by": "pr_artifact",
+          "required": true
+        },
+        {
+          "id": "code_pr.verify",
+          "kind": "check_result",
+          "produced_by": "verify_record",
+          "required": true
+        },
+        {
+          "id": "code_pr.hosted",
+          "kind": "check_result",
+          "produced_by": "hosted_checks",
+          "required": true
+        },
+        {
+          "id": "code_pr.commit",
+          "kind": "commit",
+          "produced_by": "publish_or_integrate",
+          "required": true
+        }
+      ],
+      "accepted_recipe_extensions": [],
+      "rejected_recipe_extensions": [],
+      "stop_reasons": [],
+      "snapshot": {
+        "state": "current",
+        "path": ".agentplane/tasks/202605132103-J5YVSS/blueprint/resolved-snapshot.json",
+        "digest": "23cb3278a45e66fe2b45e36675d23909dd920ae303d6a6844bd518917f98c26f",
+        "current_digest": "23cb3278a45e66fe2b45e36675d23909dd920ae303d6a6844bd518917f98c26f",
+        "route_changed": false,
+        "artifact_sha256": "sha256:e7c52f7afe9a673e83d5a9b0300a6a38732f1923652e20d8a8be6cd9f52f23fa",
+        "safe_command": "agentplane blueprint snapshot 202605132103-J5YVSS"
+      }
+    }
+  }
+}

--- a/.agentplane/tasks/202605132103-J5YVSS/pr/github-title.txt
+++ b/.agentplane/tasks/202605132103-J5YVSS/pr/github-title.txt
@@ -1,1 +1,1 @@
-🚧 J5YVSS task: Remove legacy tasks.json export surface [202605132103-J5YVSS]
+✅ J5YVSS task: Remove legacy tasks.json export surface [202605132103-J5YVSS]

--- a/.agentplane/tasks/202605132103-J5YVSS/pr/review.md
+++ b/.agentplane/tasks/202605132103-J5YVSS/pr/review.md
@@ -6,7 +6,7 @@ Created: 2026-05-13T21:29:59.252Z
 
 - Task: `202605132103-J5YVSS`
 - Title: Remove legacy tasks.json export surface
-- Status: DOING
+- Status: DONE
 - Branch: `task/202605132103-J5YVSS/remove-tasks-json`
 - Canonical task record: `.agentplane/tasks/202605132103-J5YVSS/README.md`
 


### PR DESCRIPTION
Closes AgentPlane task 202605132103-J5YVSS after the implementation was merged to main in #3694 and the primary hosted-close follow-up landed in #3695.

This PR contains only the task closure artifact for 202605132103-J5YVSS; no runtime implementation changes are included.