### PR TITLE
🚧 HNXBJ4 task: Fix context search JSONL row freshness [202605141005-HNXBJ4]

### DIFF
--- a/.agentplane/tasks/202605141005-HNXBJ4/README.md
+++ b/.agentplane/tasks/202605141005-HNXBJ4/README.md
@@ -1,0 +1,150 @@
+---
+id: "202605141005-HNXBJ4"
+title: "Fix context search JSONL row freshness"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "context"
+  - "release"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-14T10:05:28.914Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-14T10:10:18.421Z"
+  updated_by: "CODER"
+  note: "Fixed context search JSONL row freshness by recomputing current row hashes for row-level projection refs. Verified focused context tests, eslint/prettier, release/docs gates, platform-critical, and empty-folder semantic assimilation smoke with no stale search rows."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Fix context search JSONL row freshness regression found during v0.6 empty-folder assimilation smoke."
+events:
+  -
+    type: "status"
+    at: "2026-05-14T10:05:38.854Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Fix context search JSONL row freshness regression found during v0.6 empty-folder assimilation smoke."
+  -
+    type: "verify"
+    at: "2026-05-14T10:10:18.421Z"
+    author: "CODER"
+    state: "ok"
+    note: "Fixed context search JSONL row freshness by recomputing current row hashes for row-level projection refs. Verified focused context tests, eslint/prettier, release/docs gates, platform-critical, and empty-folder semantic assimilation smoke with no stale search rows."
+doc_version: 3
+doc_updated_at: "2026-05-14T10:10:18.432Z"
+doc_updated_by: "CODER"
+description: "Context search marks fresh JSONL facts and graph projection rows as stale because row-level projection hashes are compared to whole-file hashes. Fix row-level freshness and cover it with regression tests so empty-folder semantic assimilation search reports fresh derived rows."
+sections:
+  Summary: |-
+    Fix context search JSONL row freshness
+    
+    Context search marks fresh JSONL facts and graph projection rows as stale because row-level projection hashes are compared to whole-file hashes. Fix row-level freshness and cover it with regression tests so empty-folder semantic assimilation search reports fresh derived rows.
+  Scope: |-
+    - In scope: Context search marks fresh JSONL facts and graph projection rows as stale because row-level projection hashes are compared to whole-file hashes. Fix row-level freshness and cover it with regression tests so empty-folder semantic assimilation search reports fresh derived rows.
+    - Out of scope: unrelated refactors not required for "Fix context search JSONL row freshness".
+  Plan: |-
+    1. Update context search freshness handling so JSONL row refs recompute the current row hash for matching row-level refs and compare file hashes only for file-level refs.
+    2. Add focused regression coverage for facts/graph JSONL row projection freshness after reindex.
+    3. Run focused context tests, platform-critical, release/docs gates, and repeat the empty-folder semantic assimilation smoke.
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+    
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-14T10:10:18.421Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Fixed context search JSONL row freshness by recomputing current row hashes for row-level projection refs. Verified focused context tests, eslint/prettier, release/docs gates, platform-critical, and empty-folder semantic assimilation smoke with no stale search rows.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T10:05:38.854Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141005-HNXBJ4-context-jsonl-freshness/.agentplane/tasks/202605141005-HNXBJ4/blueprint/resolved-snapshot.json
+    - old_digest: f3c5df08acba8e7ddf0a4372e13f47ef625e2224065742986e2ecd5d7cc8749c
+    - current_digest: f3c5df08acba8e7ddf0a4372e13f47ef625e2224065742986e2ecd5d7cc8749c
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141005-HNXBJ4
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Fix context search JSONL row freshness
+
+Context search marks fresh JSONL facts and graph projection rows as stale because row-level projection hashes are compared to whole-file hashes. Fix row-level freshness and cover it with regression tests so empty-folder semantic assimilation search reports fresh derived rows.
+
+## Scope
+
+- In scope: Context search marks fresh JSONL facts and graph projection rows as stale because row-level projection hashes are compared to whole-file hashes. Fix row-level freshness and cover it with regression tests so empty-folder semantic assimilation search reports fresh derived rows.
+- Out of scope: unrelated refactors not required for "Fix context search JSONL row freshness".
+
+## Plan
+
+1. Update context search freshness handling so JSONL row refs recompute the current row hash for matching row-level refs and compare file hashes only for file-level refs.
+2. Add focused regression coverage for facts/graph JSONL row projection freshness after reindex.
+3. Run focused context tests, platform-critical, release/docs gates, and repeat the empty-folder semantic assimilation smoke.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-14T10:10:18.421Z — VERIFY — ok
+
+By: CODER
+
+Note: Fixed context search JSONL row freshness by recomputing current row hashes for row-level projection refs. Verified focused context tests, eslint/prettier, release/docs gates, platform-critical, and empty-folder semantic assimilation smoke with no stale search rows.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T10:05:38.854Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141005-HNXBJ4-context-jsonl-freshness/.agentplane/tasks/202605141005-HNXBJ4/blueprint/resolved-snapshot.json
+- old_digest: f3c5df08acba8e7ddf0a4372e13f47ef625e2224065742986e2ecd5d7cc8749c
+- current_digest: f3c5df08acba8e7ddf0a4372e13f47ef625e2224065742986e2ecd5d7cc8749c
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141005-HNXBJ4
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605141005-HNXBJ4/README.md
+++ b/.agentplane/tasks/202605141005-HNXBJ4/README.md
@@ -4,7 +4,7 @@ title: "Fix context search JSONL row freshness"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -20,9 +20,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-14T10:10:18.421Z"
+  updated_at: "2026-05-14T10:26:23.138Z"
   updated_by: "CODER"
-  note: "Fixed context search JSONL row freshness by recomputing current row hashes for row-level projection refs. Verified focused context tests, eslint/prettier, release/docs gates, platform-critical, and empty-folder semantic assimilation smoke with no stale search rows."
+  note: "Fixed context search JSONL row freshness, including non-string row ids found in review. Verified focused context tests, eslint/prettier, release/docs gates, platform-critical, and empty-folder semantic assimilation smoke with no stale search rows."
   attempts: 0
 commit: null
 comments:
@@ -43,8 +43,14 @@ events:
     author: "CODER"
     state: "ok"
     note: "Fixed context search JSONL row freshness by recomputing current row hashes for row-level projection refs. Verified focused context tests, eslint/prettier, release/docs gates, platform-critical, and empty-folder semantic assimilation smoke with no stale search rows."
+  -
+    type: "verify"
+    at: "2026-05-14T10:26:23.138Z"
+    author: "CODER"
+    state: "ok"
+    note: "Fixed context search JSONL row freshness, including non-string row ids found in review. Verified focused context tests, eslint/prettier, release/docs gates, platform-critical, and empty-folder semantic assimilation smoke with no stale search rows."
 doc_version: 3
-doc_updated_at: "2026-05-14T10:10:18.432Z"
+doc_updated_at: "2026-05-14T10:26:23.166Z"
 doc_updated_by: "CODER"
 description: "Context search marks fresh JSONL facts and graph projection rows as stale because row-level projection hashes are compared to whole-file hashes. Fix row-level freshness and cover it with regression tests so empty-folder semantic assimilation search reports fresh derived rows."
 sections:
@@ -75,6 +81,25 @@ sections:
     Attempts: 0
     
     VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T10:05:38.854Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141005-HNXBJ4-context-jsonl-freshness/.agentplane/tasks/202605141005-HNXBJ4/blueprint/resolved-snapshot.json
+    - old_digest: f3c5df08acba8e7ddf0a4372e13f47ef625e2224065742986e2ecd5d7cc8749c
+    - current_digest: f3c5df08acba8e7ddf0a4372e13f47ef625e2224065742986e2ecd5d7cc8749c
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141005-HNXBJ4
+    
+    ### 2026-05-14T10:26:23.138Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Fixed context search JSONL row freshness, including non-string row ids found in review. Verified focused context tests, eslint/prettier, release/docs gates, platform-critical, and empty-folder semantic assimilation smoke with no stale search rows.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T10:10:18.432Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
     
     Details:
     
@@ -129,6 +154,25 @@ Note: Fixed context search JSONL row freshness by recomputing current row hashes
 Attempts: 0
 
 VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T10:05:38.854Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141005-HNXBJ4-context-jsonl-freshness/.agentplane/tasks/202605141005-HNXBJ4/blueprint/resolved-snapshot.json
+- old_digest: f3c5df08acba8e7ddf0a4372e13f47ef625e2224065742986e2ecd5d7cc8749c
+- current_digest: f3c5df08acba8e7ddf0a4372e13f47ef625e2224065742986e2ecd5d7cc8749c
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141005-HNXBJ4
+
+### 2026-05-14T10:26:23.138Z — VERIFY — ok
+
+By: CODER
+
+Note: Fixed context search JSONL row freshness, including non-string row ids found in review. Verified focused context tests, eslint/prettier, release/docs gates, platform-critical, and empty-folder semantic assimilation smoke with no stale search rows.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T10:10:18.432Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
 
 Details:
 

--- a/.agentplane/tasks/202605141005-HNXBJ4/pr/diffstat.txt
+++ b/.agentplane/tasks/202605141005-HNXBJ4/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../src/commands/context/release-readiness.test.ts | 55 ++++++++++++++++++++++
+ packages/agentplane/src/commands/context/search.ts | 33 +++++++++++++
+ 2 files changed, 88 insertions(+)

--- a/.agentplane/tasks/202605141005-HNXBJ4/pr/github-body.md
+++ b/.agentplane/tasks/202605141005-HNXBJ4/pr/github-body.md
@@ -1,0 +1,41 @@
+Task: `202605141005-HNXBJ4`
+Title: Fix context search JSONL row freshness
+Canonical task record: `.agentplane/tasks/202605141005-HNXBJ4/README.md`
+
+## Summary
+
+Fix context search JSONL row freshness
+
+Context search marks fresh JSONL facts and graph projection rows as stale because row-level projection hashes are compared to whole-file hashes. Fix row-level freshness and cover it with regression tests so empty-folder semantic assimilation search reports fresh derived rows.
+
+## Scope
+
+- In scope: Context search marks fresh JSONL facts and graph projection rows as stale because row-level projection hashes are compared to whole-file hashes. Fix row-level freshness and cover it with regression tests so empty-folder semantic assimilation search reports fresh derived rows.
+- Out of scope: unrelated refactors not required for "Fix context search JSONL row freshness".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Fixed context search JSONL row freshness, including non-string row ids found in review. Verified
+focused context tests, eslint/prettier, release/docs gates, platform-critical, and empty-folder
+semantic assimilation smoke with no stale search rows.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T10:10:43.519Z
+- Branch: task/202605141005-HNXBJ4/context-jsonl-freshness
+- Head: b9a6042a9ccc
+
+```text
+ .../src/commands/context/release-readiness.test.ts | 55 ++++++++++++++++++++++
+ packages/agentplane/src/commands/context/search.ts | 33 +++++++++++++
+ 2 files changed, 88 insertions(+)
+```
+
+</details>

--- a/.agentplane/tasks/202605141005-HNXBJ4/pr/github-title.txt
+++ b/.agentplane/tasks/202605141005-HNXBJ4/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 HNXBJ4 task: Fix context search JSONL row freshness [202605141005-HNXBJ4]

--- a/.agentplane/tasks/202605141005-HNXBJ4/pr/meta.json
+++ b/.agentplane/tasks/202605141005-HNXBJ4/pr/meta.json
@@ -1,0 +1,17 @@
+{
+  "base": "main",
+  "branch": "task/202605141005-HNXBJ4/context-jsonl-freshness",
+  "created_at": "2026-05-14T10:05:38.905Z",
+  "head_sha": "b9a6042a9cccd3ad8576d16f9b7fdcce1aac13af",
+  "last_verified_at": "2026-05-14T10:26:23.138Z",
+  "last_verified_sha": "b9a6042a9cccd3ad8576d16f9b7fdcce1aac13af",
+  "pr_number": 3707,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3707",
+  "schema_version": 1,
+  "status": "OPEN",
+  "task_id": "202605141005-HNXBJ4",
+  "updated_at": "2026-05-14T10:10:43.519Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605141005-HNXBJ4/pr/review.md
+++ b/.agentplane/tasks/202605141005-HNXBJ4/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-05-14T10:05:38.905Z
+
+## Task
+
+- Task: `202605141005-HNXBJ4`
+- Title: Fix context search JSONL row freshness
+- Status: DOING
+- Branch: `task/202605141005-HNXBJ4/context-jsonl-freshness`
+- Canonical task record: `.agentplane/tasks/202605141005-HNXBJ4/README.md`
+
+## Verification
+
+- State: ok
+- Note: Fixed context search JSONL row freshness, including non-string row ids found in review. Verified focused context tests, eslint/prettier, release/docs gates, platform-critical, and empty-folder semantic assimilation smoke with no stale search rows.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T10:10:43.519Z
+- Branch: task/202605141005-HNXBJ4/context-jsonl-freshness
+- Head: b9a6042a9ccc
+
+```text
+ .../src/commands/context/release-readiness.test.ts | 55 ++++++++++++++++++++++
+ packages/agentplane/src/commands/context/search.ts | 33 +++++++++++++
+ 2 files changed, 88 insertions(+)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/context/release-readiness.test.ts
+++ b/packages/agentplane/src/commands/context/release-readiness.test.ts
@@ -103,6 +103,61 @@ describe("context release readiness guards", () => {
     expect(sectionResult?.freshness.stale).toBe(false);
   });
 
+  it("does not mark fresh JSONL fact and graph projection rows as stale", async () => {
+    const root = await tempRoot();
+    await write(
+      root,
+      ".agentplane/context/derived/facts/facts.jsonl",
+      `${JSON.stringify({
+        id: "fact:meridian-relay:stages",
+        subject: "Meridian Relay",
+        predicate: "has_stages",
+        object: "capture, normalize, curator review",
+        confidence: 0.94,
+        status: "active",
+        source_refs: ["context/raw/research/meridian-relay.md"],
+      })}\n`,
+    );
+    await write(
+      root,
+      ".agentplane/context/derived/graph/entities.jsonl",
+      `${JSON.stringify({
+        id: "concept:meridian-relay",
+        kind: "concept",
+        label: "Meridian Relay",
+        status: "active",
+        source_refs: ["context/raw/research/meridian-relay.md"],
+      })}\n`,
+    );
+    await cmdContextReindex({
+      cwd: root,
+      parsed: { includeTasks: false, includeRaw: true, reset: false },
+    });
+    const out = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await cmdContextSearch({
+      cwd: root,
+      parsed: {
+        query: "meridian relay",
+        scope: "context",
+        format: "json",
+        explain: false,
+      },
+    });
+
+    const payload = JSON.parse(out.mock.calls.map((call) => String(call[0])).join("")) as {
+      results: { ref: string; freshness: { stale: boolean } }[];
+    };
+    const factResult = payload.results.find((result) =>
+      result.ref.endsWith("facts.jsonl#fact=fact:meridian-relay:stages"),
+    );
+    const entityResult = payload.results.find((result) =>
+      result.ref.endsWith("entities.jsonl#entity=concept:meridian-relay"),
+    );
+    expect(factResult?.freshness.stale).toBe(false);
+    expect(entityResult?.freshness.stale).toBe(false);
+  });
+
   it("resolves markdown sections by slug", async () => {
     const root = await tempRoot();
     await write(

--- a/packages/agentplane/src/commands/context/release-readiness.test.ts
+++ b/packages/agentplane/src/commands/context/release-readiness.test.ts
@@ -108,15 +108,28 @@ describe("context release readiness guards", () => {
     await write(
       root,
       ".agentplane/context/derived/facts/facts.jsonl",
-      `${JSON.stringify({
-        id: "fact:meridian-relay:stages",
-        subject: "Meridian Relay",
-        predicate: "has_stages",
-        object: "capture, normalize, curator review",
-        confidence: 0.94,
-        status: "active",
-        source_refs: ["context/raw/research/meridian-relay.md"],
-      })}\n`,
+      [
+        {
+          id: "fact:meridian-relay:stages",
+          subject: "Meridian Relay",
+          predicate: "has_stages",
+          object: "capture, normalize, curator review",
+          confidence: 0.94,
+          status: "active",
+          source_refs: ["context/raw/research/meridian-relay.md"],
+        },
+        {
+          id: 42,
+          subject: "Numeric Meridian Relay",
+          predicate: "has_numeric_id",
+          object: "true",
+          confidence: 0.9,
+          status: "active",
+          source_refs: ["context/raw/research/meridian-relay.md"],
+        },
+      ]
+        .map((row) => JSON.stringify(row))
+        .join("\n") + "\n",
     );
     await write(
       root,
@@ -154,8 +167,12 @@ describe("context release readiness guards", () => {
     const entityResult = payload.results.find((result) =>
       result.ref.endsWith("entities.jsonl#entity=concept:meridian-relay"),
     );
+    const numericIdResult = payload.results.find((result) =>
+      result.ref.endsWith("facts.jsonl#fact=42"),
+    );
     expect(factResult?.freshness.stale).toBe(false);
     expect(entityResult?.freshness.stale).toBe(false);
+    expect(numericIdResult?.freshness.stale).toBe(false);
   });
 
   it("resolves markdown sections by slug", async () => {

--- a/packages/agentplane/src/commands/context/search.ts
+++ b/packages/agentplane/src/commands/context/search.ts
@@ -180,12 +180,45 @@ async function buildFreshness(
   } catch {
     return { projection_sha256: projectionSha256, file_sha256: null, stale: true };
   }
+  if (base.endsWith(".jsonl") && rowPath.includes("#")) {
+    return buildJsonlRowFreshness(absolute, rowPath, projectionSha256);
+  }
   const fileSha256 = await calculateSha256(absolute);
   return {
     projection_sha256: projectionSha256,
     file_sha256: fileSha256,
     stale: fileSha256 !== projectionSha256,
   };
+}
+
+async function buildJsonlRowFreshness(
+  filePath: string,
+  rowPath: string,
+  projectionSha256: string,
+): Promise<{ projection_sha256: string; file_sha256: string | null; stale: boolean }> {
+  const marker = rowPath.slice(rowPath.indexOf("#") + 1);
+  const separator = marker.indexOf("=");
+  if (separator === -1) {
+    const fileSha256 = await calculateSha256(filePath);
+    return {
+      projection_sha256: projectionSha256,
+      file_sha256: fileSha256,
+      stale: fileSha256 !== projectionSha256,
+    };
+  }
+  const expectedId = marker.slice(separator + 1);
+  const rows = parseJsonlLines(await readText(filePath));
+  for (const [index, row] of rows.entries()) {
+    const id = typeof row.id === "string" ? row.id : String(index + 1);
+    if (id !== expectedId) continue;
+    const rowSha256 = `sha256:${createHash("sha256").update(JSON.stringify(row)).digest("hex")}`;
+    return {
+      projection_sha256: projectionSha256,
+      file_sha256: rowSha256,
+      stale: rowSha256 !== projectionSha256,
+    };
+  }
+  return { projection_sha256: projectionSha256, file_sha256: null, stale: true };
 }
 
 async function calculateSha256(filePath: string): Promise<string> {

--- a/packages/agentplane/src/commands/context/search.ts
+++ b/packages/agentplane/src/commands/context/search.ts
@@ -82,7 +82,7 @@ export async function cmdContextSearch(opts: {
       for (const [index, row] of rows.entries()) {
         const haystack = JSON.stringify(row).toLowerCase();
         if (!haystack.includes(query)) continue;
-        const id = typeof row.id === "string" ? row.id : `row-${index + 1}`;
+        const id = String(row.id ?? index + 1);
         results.push({
           path: `${relative}#entity=${id}`,
           score: scoreMatch(haystack, query),
@@ -209,7 +209,7 @@ async function buildJsonlRowFreshness(
   const expectedId = marker.slice(separator + 1);
   const rows = parseJsonlLines(await readText(filePath));
   for (const [index, row] of rows.entries()) {
-    const id = typeof row.id === "string" ? row.id : String(index + 1);
+    const id = String(row.id ?? index + 1);
     if (id !== expectedId) continue;
     const rowSha256 = `sha256:${createHash("sha256").update(JSON.stringify(row)).digest("hex")}`;
     return {


### PR DESCRIPTION
Task: `202605141005-HNXBJ4`
Title: Fix context search JSONL row freshness
Canonical task record: `.agentplane/tasks/202605141005-HNXBJ4/README.md`

## Summary

Fix context search JSONL row freshness

Context search marks fresh JSONL facts and graph projection rows as stale because row-level projection hashes are compared to whole-file hashes. Fix row-level freshness and cover it with regression tests so empty-folder semantic assimilation search reports fresh derived rows.

## Scope

- In scope: Context search marks fresh JSONL facts and graph projection rows as stale because row-level projection hashes are compared to whole-file hashes. Fix row-level freshness and cover it with regression tests so empty-folder semantic assimilation search reports fresh derived rows.
- Out of scope: unrelated refactors not required for "Fix context search JSONL row freshness".

## Verification

- State: ok
- Note:

```text
Fixed context search JSONL row freshness by recomputing current row hashes for row-level projection
refs. Verified focused context tests, eslint/prettier, release/docs gates, platform-critical, and
empty-folder semantic assimilation smoke with no stale search rows.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-14T10:10:38.032Z
- Branch: task/202605141005-HNXBJ4/context-jsonl-freshness
- Head: b9a6042a9ccc

```text
 .../src/commands/context/release-readiness.test.ts | 55 ++++++++++++++++++++++
 packages/agentplane/src/commands/context/search.ts | 33 +++++++++++++
 2 files changed, 88 insertions(+)
```

</details>
