### PR TITLE
🚧 DQV6A3 task: Use full-width README header on GitHub and npm [202605141242-DQV6A3]

### DIFF
--- a/.agentplane/tasks/202605141242-DQV6A3/README.md
+++ b/.agentplane/tasks/202605141242-DQV6A3/README.md
@@ -1,0 +1,161 @@
+---
+id: "202605141242-DQV6A3"
+title: "Use full-width README header on GitHub and npm"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "docs"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-14T12:42:44.430Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-14T12:44:57.353Z"
+  updated_by: "CODER"
+  note: "Verified full-width root README header, npm README raw GitHub header, formatting, policy routing, doctor, npm package dry run, and whitespace checks. Doctor passed with pre-existing branch_pr normalization warnings unrelated to this diff."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement full-width root README header and add the same generated header to the npm package README surface."
+events:
+  -
+    type: "status"
+    at: "2026-05-14T12:43:22.733Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement full-width root README header and add the same generated header to the npm package README surface."
+  -
+    type: "verify"
+    at: "2026-05-14T12:44:57.353Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified full-width root README header, npm README raw GitHub header, formatting, policy routing, doctor, npm package dry run, and whitespace checks. Doctor passed with pre-existing branch_pr normalization warnings unrelated to this diff."
+doc_version: 3
+doc_updated_at: "2026-05-14T12:44:57.363Z"
+doc_updated_by: "CODER"
+description: "Make the generated header image use full available width in the root README and add the same generated header to the npm package README surface."
+sections:
+  Summary: |-
+    Use full-width README header on GitHub and npm
+    
+    Make the generated header image use full available width in the root README and add the same generated header to the npm package README surface.
+  Scope: |-
+    - In scope: Make the generated header image use full available width in the root README and add the same generated header to the npm package README surface.
+    - Out of scope: unrelated refactors not required for "Use full-width README header on GitHub and npm".
+  Plan: |-
+    1. Inspect the root README, npm package README, and package metadata to confirm the rendered surfaces.
+    2. Update the root README header image to render at full available width on GitHub.
+    3. Add the same generated header asset to packages/agentplane/README.md using a GitHub raw URL suitable for npmjs rendering, also at full available width.
+    4. Verify formatting, routing policy, package tarball contents, and docs diff before opening/integrating the branch.
+  Verify Steps: |-
+    1. Inspect `README.md`. Expected: the generated header image uses `width="100%"`.
+    2. Inspect `packages/agentplane/README.md`. Expected: it includes the same generated header asset via a GitHub raw URL suitable for npmjs rendering, also with `width="100%"`.
+    3. Run `bunx prettier --check README.md packages/agentplane/README.md .agentplane/tasks/202605141242-DQV6A3/README.md`. Expected: formatting passes.
+    4. Run `node .agentplane/policy/check-routing.mjs`. Expected: policy routing passes.
+    5. Run `agentplane doctor`. Expected: repository health checks pass.
+    6. Run `npm pack --json --dry-run --ignore-scripts` from `packages/agentplane`. Expected: the package dry run succeeds and includes `package/README.md`.
+    7. Run `git diff --check`. Expected: no whitespace errors.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-14T12:44:57.353Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified full-width root README header, npm README raw GitHub header, formatting, policy routing, doctor, npm package dry run, and whitespace checks. Doctor passed with pre-existing branch_pr normalization warnings unrelated to this diff.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T12:43:22.733Z, excerpt_hash=sha256:90fd1b2c116a68892d86a8e33ee41f0150ad36d780c9cc95a7aa33e34b07b17a
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141242-DQV6A3-npm-readme-header/.agentplane/tasks/202605141242-DQV6A3/blueprint/resolved-snapshot.json
+    - old_digest: 7eff10a80745b59188c6807ff2ba53cad11207aaa99d0085f928c18dc92ed163
+    - current_digest: 7eff10a80745b59188c6807ff2ba53cad11207aaa99d0085f928c18dc92ed163
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141242-DQV6A3
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: README.md uses docs/assets/header.svg with width=100%; packages/agentplane/README.md uses the same generated SVG via raw.githubusercontent.com with width=100%; npm pack dry run includes package/README.md.
+      Impact: GitHub README renders the header at full available content width; npmjs package README will render the same generated header after the next package publication.
+      Resolution: No code changes required; package publication remains a separate release step.
+id_source: "generated"
+---
+## Summary
+
+Use full-width README header on GitHub and npm
+
+Make the generated header image use full available width in the root README and add the same generated header to the npm package README surface.
+
+## Scope
+
+- In scope: Make the generated header image use full available width in the root README and add the same generated header to the npm package README surface.
+- Out of scope: unrelated refactors not required for "Use full-width README header on GitHub and npm".
+
+## Plan
+
+1. Inspect the root README, npm package README, and package metadata to confirm the rendered surfaces.
+2. Update the root README header image to render at full available width on GitHub.
+3. Add the same generated header asset to packages/agentplane/README.md using a GitHub raw URL suitable for npmjs rendering, also at full available width.
+4. Verify formatting, routing policy, package tarball contents, and docs diff before opening/integrating the branch.
+
+## Verify Steps
+
+1. Inspect `README.md`. Expected: the generated header image uses `width="100%"`.
+2. Inspect `packages/agentplane/README.md`. Expected: it includes the same generated header asset via a GitHub raw URL suitable for npmjs rendering, also with `width="100%"`.
+3. Run `bunx prettier --check README.md packages/agentplane/README.md .agentplane/tasks/202605141242-DQV6A3/README.md`. Expected: formatting passes.
+4. Run `node .agentplane/policy/check-routing.mjs`. Expected: policy routing passes.
+5. Run `agentplane doctor`. Expected: repository health checks pass.
+6. Run `npm pack --json --dry-run --ignore-scripts` from `packages/agentplane`. Expected: the package dry run succeeds and includes `package/README.md`.
+7. Run `git diff --check`. Expected: no whitespace errors.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-14T12:44:57.353Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified full-width root README header, npm README raw GitHub header, formatting, policy routing, doctor, npm package dry run, and whitespace checks. Doctor passed with pre-existing branch_pr normalization warnings unrelated to this diff.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T12:43:22.733Z, excerpt_hash=sha256:90fd1b2c116a68892d86a8e33ee41f0150ad36d780c9cc95a7aa33e34b07b17a
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141242-DQV6A3-npm-readme-header/.agentplane/tasks/202605141242-DQV6A3/blueprint/resolved-snapshot.json
+- old_digest: 7eff10a80745b59188c6807ff2ba53cad11207aaa99d0085f928c18dc92ed163
+- current_digest: 7eff10a80745b59188c6807ff2ba53cad11207aaa99d0085f928c18dc92ed163
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141242-DQV6A3
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: README.md uses docs/assets/header.svg with width=100%; packages/agentplane/README.md uses the same generated SVG via raw.githubusercontent.com with width=100%; npm pack dry run includes package/README.md.
+  Impact: GitHub README renders the header at full available content width; npmjs package README will render the same generated header after the next package publication.
+  Resolution: No code changes required; package publication remains a separate release step.

--- a/.agentplane/tasks/202605141242-DQV6A3/README.md
+++ b/.agentplane/tasks/202605141242-DQV6A3/README.md
@@ -4,7 +4,7 @@ title: "Use full-width README header on GitHub and npm"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -18,9 +18,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-14T12:44:57.353Z"
+  updated_at: "2026-05-14T13:02:26.080Z"
   updated_by: "CODER"
-  note: "Verified full-width root README header, npm README raw GitHub header, formatting, policy routing, doctor, npm package dry run, and whitespace checks. Doctor passed with pre-existing branch_pr normalization warnings unrelated to this diff."
+  note: "Re-verified after addressing Codex review: README headers now use CSS style width/max-width instead of invalid percentage width attributes; formatting, policy routing, doctor, npm pack dry run, and whitespace checks passed."
   attempts: 0
 commit: null
 comments:
@@ -41,8 +41,14 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified full-width root README header, npm README raw GitHub header, formatting, policy routing, doctor, npm package dry run, and whitespace checks. Doctor passed with pre-existing branch_pr normalization warnings unrelated to this diff."
+  -
+    type: "verify"
+    at: "2026-05-14T13:02:26.080Z"
+    author: "CODER"
+    state: "ok"
+    note: "Re-verified after addressing Codex review: README headers now use CSS style width/max-width instead of invalid percentage width attributes; formatting, policy routing, doctor, npm pack dry run, and whitespace checks passed."
 doc_version: 3
-doc_updated_at: "2026-05-14T12:44:57.363Z"
+doc_updated_at: "2026-05-14T13:02:26.089Z"
 doc_updated_by: "CODER"
 description: "Make the generated header image use full available width in the root README and add the same generated header to the npm package README surface."
 sections:
@@ -59,8 +65,8 @@ sections:
     3. Add the same generated header asset to packages/agentplane/README.md using a GitHub raw URL suitable for npmjs rendering, also at full available width.
     4. Verify formatting, routing policy, package tarball contents, and docs diff before opening/integrating the branch.
   Verify Steps: |-
-    1. Inspect `README.md`. Expected: the generated header image uses `width="100%"`.
-    2. Inspect `packages/agentplane/README.md`. Expected: it includes the same generated header asset via a GitHub raw URL suitable for npmjs rendering, also with `width="100%"`.
+    1. Inspect `README.md`. Expected: the generated header image uses `style="width:100%;max-width:100%;"`.
+    2. Inspect `packages/agentplane/README.md`. Expected: it includes the same generated header asset via a GitHub raw URL suitable for npmjs rendering, also with `style="width:100%;max-width:100%;"`.
     3. Run `bunx prettier --check README.md packages/agentplane/README.md .agentplane/tasks/202605141242-DQV6A3/README.md`. Expected: formatting passes.
     4. Run `node .agentplane/policy/check-routing.mjs`. Expected: policy routing passes.
     5. Run `agentplane doctor`. Expected: repository health checks pass.
@@ -87,6 +93,25 @@ sections:
     - route_changed: no
     - safe_command: agentplane blueprint snapshot 202605141242-DQV6A3
     
+    ### 2026-05-14T13:02:26.080Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Re-verified after addressing Codex review: README headers now use CSS style width/max-width instead of invalid percentage width attributes; formatting, policy routing, doctor, npm pack dry run, and whitespace checks passed.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T12:44:57.363Z, excerpt_hash=sha256:69e062ff4e9a560db36db0342c672ee3c3f0e39c705867793e8286f21afc5a9a
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141242-DQV6A3-npm-readme-header/.agentplane/tasks/202605141242-DQV6A3/blueprint/resolved-snapshot.json
+    - old_digest: 7eff10a80745b59188c6807ff2ba53cad11207aaa99d0085f928c18dc92ed163
+    - current_digest: 7eff10a80745b59188c6807ff2ba53cad11207aaa99d0085f928c18dc92ed163
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141242-DQV6A3
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -95,6 +120,10 @@ sections:
     - Observation: README.md uses docs/assets/header.svg with width=100%; packages/agentplane/README.md uses the same generated SVG via raw.githubusercontent.com with width=100%; npm pack dry run includes package/README.md.
       Impact: GitHub README renders the header at full available content width; npmjs package README will render the same generated header after the next package publication.
       Resolution: No code changes required; package publication remains a separate release step.
+    
+    - Observation: README.md and packages/agentplane/README.md both use style="width:100%;max-width:100%;"; package README uses the raw GitHub URL for the generated header and npm pack dry run includes package/README.md.
+      Impact: GitHub and npm README rendering can fill the available content width with valid HTML/CSS.
+      Resolution: Addressed review comment 3241418628 by replacing width attributes with inline style sizing.
 id_source: "generated"
 ---
 ## Summary
@@ -117,8 +146,8 @@ Make the generated header image use full available width in the root README and 
 
 ## Verify Steps
 
-1. Inspect `README.md`. Expected: the generated header image uses `width="100%"`.
-2. Inspect `packages/agentplane/README.md`. Expected: it includes the same generated header asset via a GitHub raw URL suitable for npmjs rendering, also with `width="100%"`.
+1. Inspect `README.md`. Expected: the generated header image uses `style="width:100%;max-width:100%;"`.
+2. Inspect `packages/agentplane/README.md`. Expected: it includes the same generated header asset via a GitHub raw URL suitable for npmjs rendering, also with `style="width:100%;max-width:100%;"`.
 3. Run `bunx prettier --check README.md packages/agentplane/README.md .agentplane/tasks/202605141242-DQV6A3/README.md`. Expected: formatting passes.
 4. Run `node .agentplane/policy/check-routing.mjs`. Expected: policy routing passes.
 5. Run `agentplane doctor`. Expected: repository health checks pass.
@@ -147,6 +176,25 @@ BlueprintSnapshotRef:
 - route_changed: no
 - safe_command: agentplane blueprint snapshot 202605141242-DQV6A3
 
+### 2026-05-14T13:02:26.080Z — VERIFY — ok
+
+By: CODER
+
+Note: Re-verified after addressing Codex review: README headers now use CSS style width/max-width instead of invalid percentage width attributes; formatting, policy routing, doctor, npm pack dry run, and whitespace checks passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T12:44:57.363Z, excerpt_hash=sha256:69e062ff4e9a560db36db0342c672ee3c3f0e39c705867793e8286f21afc5a9a
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141242-DQV6A3-npm-readme-header/.agentplane/tasks/202605141242-DQV6A3/blueprint/resolved-snapshot.json
+- old_digest: 7eff10a80745b59188c6807ff2ba53cad11207aaa99d0085f928c18dc92ed163
+- current_digest: 7eff10a80745b59188c6807ff2ba53cad11207aaa99d0085f928c18dc92ed163
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141242-DQV6A3
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -159,3 +207,7 @@ BlueprintSnapshotRef:
 - Observation: README.md uses docs/assets/header.svg with width=100%; packages/agentplane/README.md uses the same generated SVG via raw.githubusercontent.com with width=100%; npm pack dry run includes package/README.md.
   Impact: GitHub README renders the header at full available content width; npmjs package README will render the same generated header after the next package publication.
   Resolution: No code changes required; package publication remains a separate release step.
+
+- Observation: README.md and packages/agentplane/README.md both use style="width:100%;max-width:100%;"; package README uses the raw GitHub URL for the generated header and npm pack dry run includes package/README.md.
+  Impact: GitHub and npm README rendering can fill the available content width with valid HTML/CSS.
+  Resolution: Addressed review comment 3241418628 by replacing width attributes with inline style sizing.

--- a/.agentplane/tasks/202605141242-DQV6A3/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605141242-DQV6A3/blueprint/resolved-snapshot.json
@@ -1,0 +1,357 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605141242-DQV6A3",
+    "title": "Use full-width README header on GitHub and npm",
+    "description": "Make the generated header image use full available width in the root README and add the same generated header to the npm package README surface.",
+    "tags": [
+      "docs"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "docs",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "docs.change",
+    "version": 1,
+    "title": "Documentation change",
+    "taskKinds": [
+      "docs"
+    ],
+    "workflowModes": [
+      "direct",
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "docs.change",
+    "blueprintVersion": 1,
+    "title": "Documentation change",
+    "taskId": "202605141242-DQV6A3",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "docs"
+    },
+    "whySelected": [
+      "task kind resolved to docs",
+      "workflow mode: branch_pr",
+      "mutation scope: docs"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.docs.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "artifact"
+        ]
+      },
+      {
+        "id": "deterministic_check",
+        "kind": "deterministic_check",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "docs.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed documentation paths."
+      },
+      {
+        "id": "docs.check",
+        "kind": "check_result",
+        "producedBy": "deterministic_check",
+        "required": true,
+        "description": "Documentation checks."
+      },
+      {
+        "id": "docs.artifact",
+        "kind": "artifact",
+        "producedBy": "artifact_write",
+        "required": true,
+        "description": "Updated documentation artifact."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/dod.docs.md",
+      ".agentplane/policy/security.must.md"
+    ],
+    "allowedCommands": [
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "documentation checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 3,
+      "maxPromptBlocks": 10,
+      "rationale": "Documentation changes need docs DoD and minimal workflow/security policy."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.docs.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "artifact"
+      ]
+    },
+    {
+      "id": "deterministic_check",
+      "kind": "deterministic_check",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "docs.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed documentation paths."
+    },
+    {
+      "id": "docs.check",
+      "kind": "check_result",
+      "producedBy": "deterministic_check",
+      "required": true,
+      "description": "Documentation checks."
+    },
+    {
+      "id": "docs.artifact",
+      "kind": "artifact",
+      "producedBy": "artifact_write",
+      "required": true,
+      "description": "Updated documentation artifact."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/dod.docs.md",
+    ".agentplane/policy/security.must.md"
+  ],
+  "allowedCommands": [
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "documentation checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 3,
+    "maxPromptBlocks": 10,
+    "rationale": "Documentation changes need docs DoD and minimal workflow/security policy."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to docs",
+    "workflow mode: branch_pr",
+    "mutation scope: docs"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "7eff10a80745b59188c6807ff2ba53cad11207aaa99d0085f928c18dc92ed163"
+  }
+}

--- a/.agentplane/tasks/202605141242-DQV6A3/pr/diffstat.txt
+++ b/.agentplane/tasks/202605141242-DQV6A3/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ .../blueprint/resolved-snapshot.json               | 357 +++++++++++++++++++++
+ README.md                                          |   2 +-
+ packages/agentplane/README.md                      |   4 +
+ 3 files changed, 362 insertions(+), 1 deletion(-)

--- a/.agentplane/tasks/202605141242-DQV6A3/pr/github-body.md
+++ b/.agentplane/tasks/202605141242-DQV6A3/pr/github-body.md
@@ -19,18 +19,18 @@ Make the generated header image use full available width in the root README and 
 - Note:
 
 ```text
-Verified full-width root README header, npm README raw GitHub header, formatting, policy routing,
-doctor, npm package dry run, and whitespace checks. Doctor passed with pre-existing branch_pr
-normalization warnings unrelated to this diff.
+Re-verified after addressing Codex review: README headers now use CSS style width/max-width instead
+of invalid percentage width attributes; formatting, policy routing, doctor, npm pack dry run, and
+whitespace checks passed.
 ```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T12:45:50.914Z
+- Updated: 2026-05-14T13:02:26.120Z
 - Branch: task/202605141242-DQV6A3/npm-readme-header
-- Head: 5e86050cfa1a
+- Head: e6c6e16a941e
 
 ```text
  .../blueprint/resolved-snapshot.json               | 357 +++++++++++++++++++++

--- a/.agentplane/tasks/202605141242-DQV6A3/pr/github-body.md
+++ b/.agentplane/tasks/202605141242-DQV6A3/pr/github-body.md
@@ -1,0 +1,39 @@
+Task: `202605141242-DQV6A3`
+Title: Use full-width README header on GitHub and npm
+Canonical task record: `.agentplane/tasks/202605141242-DQV6A3/README.md`
+
+## Summary
+
+Use full-width README header on GitHub and npm
+
+Make the generated header image use full available width in the root README and add the same generated header to the npm package README surface.
+
+## Scope
+
+- In scope: Make the generated header image use full available width in the root README and add the same generated header to the npm package README surface.
+- Out of scope: unrelated refactors not required for "Use full-width README header on GitHub and npm".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Verified full-width root README header, npm README raw GitHub header, formatting, policy routing,
+doctor, npm package dry run, and whitespace checks. Doctor passed with pre-existing branch_pr
+normalization warnings unrelated to this diff.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T12:43:23.167Z
+- Branch: task/202605141242-DQV6A3/npm-readme-header
+- Head: 5a48fda04451
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605141242-DQV6A3/pr/github-body.md
+++ b/.agentplane/tasks/202605141242-DQV6A3/pr/github-body.md
@@ -28,12 +28,15 @@ normalization warnings unrelated to this diff.
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T12:43:23.167Z
+- Updated: 2026-05-14T12:45:50.914Z
 - Branch: task/202605141242-DQV6A3/npm-readme-header
-- Head: 5a48fda04451
+- Head: 5e86050cfa1a
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 357 +++++++++++++++++++++
+ README.md                                          |   2 +-
+ packages/agentplane/README.md                      |   4 +
+ 3 files changed, 362 insertions(+), 1 deletion(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605141242-DQV6A3/pr/github-title.txt
+++ b/.agentplane/tasks/202605141242-DQV6A3/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 DQV6A3 task: Use full-width README header on GitHub and npm [202605141242-DQV6A3]

--- a/.agentplane/tasks/202605141242-DQV6A3/pr/meta.json
+++ b/.agentplane/tasks/202605141242-DQV6A3/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605141242-DQV6A3/npm-readme-header",
+  "created_at": "2026-05-14T12:43:23.167Z",
+  "head_sha": "5a48fda0445136000c7792dbc9907dddd143e41d",
+  "last_verified_at": "2026-05-14T12:44:57.353Z",
+  "last_verified_sha": "5a48fda0445136000c7792dbc9907dddd143e41d",
+  "schema_version": 1,
+  "task_id": "202605141242-DQV6A3",
+  "updated_at": "2026-05-14T12:43:23.167Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605141242-DQV6A3/pr/meta.json
+++ b/.agentplane/tasks/202605141242-DQV6A3/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "5e86050cfa1a77ac0a90e5b3efe4ce8e77094c9b",
   "last_verified_at": "2026-05-14T12:44:57.353Z",
   "last_verified_sha": "5a48fda0445136000c7792dbc9907dddd143e41d",
+  "pr_number": 3711,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3711",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605141242-DQV6A3",
-  "updated_at": "2026-05-14T12:45:50.914Z",
+  "updated_at": "2026-05-14T12:45:56.541Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141242-DQV6A3/pr/meta.json
+++ b/.agentplane/tasks/202605141242-DQV6A3/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605141242-DQV6A3/npm-readme-header",
   "created_at": "2026-05-14T12:43:23.167Z",
-  "head_sha": "5a48fda0445136000c7792dbc9907dddd143e41d",
+  "head_sha": "5e86050cfa1a77ac0a90e5b3efe4ce8e77094c9b",
   "last_verified_at": "2026-05-14T12:44:57.353Z",
   "last_verified_sha": "5a48fda0445136000c7792dbc9907dddd143e41d",
   "schema_version": 1,
   "task_id": "202605141242-DQV6A3",
-  "updated_at": "2026-05-14T12:43:23.167Z",
+  "updated_at": "2026-05-14T12:45:50.914Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141242-DQV6A3/pr/meta.json
+++ b/.agentplane/tasks/202605141242-DQV6A3/pr/meta.json
@@ -2,15 +2,15 @@
   "base": "main",
   "branch": "task/202605141242-DQV6A3/npm-readme-header",
   "created_at": "2026-05-14T12:43:23.167Z",
-  "head_sha": "5e86050cfa1a77ac0a90e5b3efe4ce8e77094c9b",
-  "last_verified_at": "2026-05-14T12:44:57.353Z",
-  "last_verified_sha": "5a48fda0445136000c7792dbc9907dddd143e41d",
+  "head_sha": "e6c6e16a941e6ff8807e4bb85ad26b0426be9069",
+  "last_verified_at": "2026-05-14T13:02:26.080Z",
+  "last_verified_sha": "e6c6e16a941e6ff8807e4bb85ad26b0426be9069",
   "pr_number": 3711,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3711",
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202605141242-DQV6A3",
-  "updated_at": "2026-05-14T12:45:56.541Z",
+  "updated_at": "2026-05-14T13:02:26.120Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141242-DQV6A3/pr/review.md
+++ b/.agentplane/tasks/202605141242-DQV6A3/pr/review.md
@@ -24,12 +24,15 @@ Created: 2026-05-14T12:43:23.167Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T12:43:23.167Z
+- Updated: 2026-05-14T12:45:50.914Z
 - Branch: task/202605141242-DQV6A3/npm-readme-header
-- Head: 5a48fda04451
+- Head: 5e86050cfa1a
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 357 +++++++++++++++++++++
+ README.md                                          |   2 +-
+ packages/agentplane/README.md                      |   4 +
+ 3 files changed, 362 insertions(+), 1 deletion(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605141242-DQV6A3/pr/review.md
+++ b/.agentplane/tasks/202605141242-DQV6A3/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-14T12:43:23.167Z
+
+## Task
+
+- Task: `202605141242-DQV6A3`
+- Title: Use full-width README header on GitHub and npm
+- Status: DOING
+- Branch: `task/202605141242-DQV6A3/npm-readme-header`
+- Canonical task record: `.agentplane/tasks/202605141242-DQV6A3/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified full-width root README header, npm README raw GitHub header, formatting, policy routing, doctor, npm package dry run, and whitespace checks. Doctor passed with pre-existing branch_pr normalization warnings unrelated to this diff.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T12:43:23.167Z
+- Branch: task/202605141242-DQV6A3/npm-readme-header
+- Head: 5a48fda04451
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605141242-DQV6A3/pr/review.md
+++ b/.agentplane/tasks/202605141242-DQV6A3/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-05-14T12:43:23.167Z
 ## Verification
 
 - State: ok
-- Note: Verified full-width root README header, npm README raw GitHub header, formatting, policy routing, doctor, npm package dry run, and whitespace checks. Doctor passed with pre-existing branch_pr normalization warnings unrelated to this diff.
+- Note: Re-verified after addressing Codex review: README headers now use CSS style width/max-width instead of invalid percentage width attributes; formatting, policy routing, doctor, npm pack dry run, and whitespace checks passed.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,9 +24,9 @@ Created: 2026-05-14T12:43:23.167Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T12:45:50.914Z
+- Updated: 2026-05-14T13:02:26.120Z
 - Branch: task/202605141242-DQV6A3/npm-readme-header
-- Head: 5e86050cfa1a
+- Head: e6c6e16a941e
 
 ```text
  .../blueprint/resolved-snapshot.json               | 357 +++++++++++++++++++++

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/assets/header.svg" alt="AgentPlane latest release header" width="100%"/>
+  <img src="docs/assets/header.svg" alt="AgentPlane latest release header" style="width:100%;max-width:100%;"/>
 </p>
 
 # AgentPlane

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/assets/header.svg" alt="AgentPlane latest release header" width="720"/>
+  <img src="docs/assets/header.svg" alt="AgentPlane latest release header" width="100%"/>
 </p>
 
 # AgentPlane

--- a/packages/agentplane/README.md
+++ b/packages/agentplane/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/basilisk-labs/agentplane/main/docs/assets/header.svg" alt="AgentPlane latest release header" width="100%"/>
+  <img src="https://raw.githubusercontent.com/basilisk-labs/agentplane/main/docs/assets/header.svg" alt="AgentPlane latest release header" style="width:100%;max-width:100%;"/>
 </p>
 
 # AgentPlane CLI

--- a/packages/agentplane/README.md
+++ b/packages/agentplane/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/basilisk-labs/agentplane/main/docs/assets/header.svg" alt="AgentPlane latest release header" width="100%"/>
+</p>
+
 # AgentPlane CLI
 
 **Git-native infrastructure for traceable AI work.**


### PR DESCRIPTION
Task: `202605141242-DQV6A3`
Title: Use full-width README header on GitHub and npm
Canonical task record: `.agentplane/tasks/202605141242-DQV6A3/README.md`

## Summary

Use full-width README header on GitHub and npm

Make the generated header image use full available width in the root README and add the same generated header to the npm package README surface.

## Scope

- In scope: Make the generated header image use full available width in the root README and add the same generated header to the npm package README surface.
- Out of scope: unrelated refactors not required for "Use full-width README header on GitHub and npm".

## Verification

- State: ok
- Note:

```text
Verified full-width root README header, npm README raw GitHub header, formatting, policy routing,
doctor, npm package dry run, and whitespace checks. Doctor passed with pre-existing branch_pr
normalization warnings unrelated to this diff.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-14T12:45:50.914Z
- Branch: task/202605141242-DQV6A3/npm-readme-header
- Head: 5e86050cfa1a

```text
 .../blueprint/resolved-snapshot.json               | 357 +++++++++++++++++++++
 README.md                                          |   2 +-
 packages/agentplane/README.md                      |   4 +
 3 files changed, 362 insertions(+), 1 deletion(-)
```

</details>
