### PR TITLE
🚧 YAM2DX task: Clarify context wiki structure guidance [202605141348-YAM2DX]

### DIFF
--- a/.agentplane/tasks/202605141348-YAM2DX/README.md
+++ b/.agentplane/tasks/202605141348-YAM2DX/README.md
@@ -1,0 +1,144 @@
+---
+id: "202605141348-YAM2DX"
+title: "Clarify context wiki structure guidance"
+status: "DOING"
+priority: "med"
+owner: "DOCS"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "context"
+  - "docs"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-14T13:48:30.454Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-14T13:54:33.959Z"
+  updated_by: "DOCS"
+  note: "Command: bun test packages/agentplane/src/cli/run-cli.core.init.test.ts --timeout 120000; Result: pass; Evidence: 27 tests passed, including context init bootstraps AgentPlane and verifies generated context/wiki/AGENTS.md guidance. Scope: context init scaffold and regression coverage. Command: node .agentplane/policy/check-routing.mjs; Result: pass; Evidence: policy routing OK. Scope: policy routing. Command: ap doctor; Result: pass with unrelated warnings; Evidence: doctor (OK), warnings only for pre-existing branch_pr reconciliation drift on older tasks. Scope: repository runtime health."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "DOCS"
+    body: "Start: update the context wiki agent-notes scaffold to require project-specific structure selection, then verify the generated context init behavior with focused tests."
+events:
+  -
+    type: "status"
+    at: "2026-05-14T13:49:11.005Z"
+    author: "DOCS"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: update the context wiki agent-notes scaffold to require project-specific structure selection, then verify the generated context init behavior with focused tests."
+  -
+    type: "verify"
+    at: "2026-05-14T13:54:33.959Z"
+    author: "DOCS"
+    state: "ok"
+    note: "Command: bun test packages/agentplane/src/cli/run-cli.core.init.test.ts --timeout 120000; Result: pass; Evidence: 27 tests passed, including context init bootstraps AgentPlane and verifies generated context/wiki/AGENTS.md guidance. Scope: context init scaffold and regression coverage. Command: node .agentplane/policy/check-routing.mjs; Result: pass; Evidence: policy routing OK. Scope: policy routing. Command: ap doctor; Result: pass with unrelated warnings; Evidence: doctor (OK), warnings only for pre-existing branch_pr reconciliation drift on older tasks. Scope: repository runtime health."
+doc_version: 3
+doc_updated_at: "2026-05-14T13:54:33.982Z"
+doc_updated_by: "DOCS"
+description: "Update the generated context/wiki/AGENTS.md template so agents analyze the base project and choose an appropriate wiki structure instead of assuming one fixed hierarchy."
+sections:
+  Summary: |-
+    Clarify context wiki structure guidance
+    
+    Update the generated context/wiki/AGENTS.md template so agents analyze the base project and choose an appropriate wiki structure instead of assuming one fixed hierarchy.
+  Scope: |-
+    - In scope: Update the generated context/wiki/AGENTS.md template so agents analyze the base project and choose an appropriate wiki structure instead of assuming one fixed hierarchy.
+    - Out of scope: unrelated refactors not required for "Clarify context wiki structure guidance".
+  Plan: "1. Inspect current context init scaffold and tests for context/wiki/AGENTS.md. 2. Update the generated wiki agent notes so agents first analyze the base project/context and choose the wiki hierarchy that fits, keeping only durable source-backed project knowledge in context/wiki. 3. Add or update focused regression coverage for the generated AGENTS.md content. 4. Run targeted context init tests plus routing/doctor checks, then record verification evidence."
+  Verify Steps: |-
+    PLANNER fallback scaffold for "Clarify context wiki structure guidance". Replace with task-specific acceptance checks when PLANNER context is available.
+    
+    1. Review the requested outcome for "Clarify context wiki structure guidance". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-14T13:54:33.959Z — VERIFY — ok
+    
+    By: DOCS
+    
+    Note: Command: bun test packages/agentplane/src/cli/run-cli.core.init.test.ts --timeout 120000; Result: pass; Evidence: 27 tests passed, including context init bootstraps AgentPlane and verifies generated context/wiki/AGENTS.md guidance. Scope: context init scaffold and regression coverage. Command: node .agentplane/policy/check-routing.mjs; Result: pass; Evidence: policy routing OK. Scope: policy routing. Command: ap doctor; Result: pass with unrelated warnings; Evidence: doctor (OK), warnings only for pre-existing branch_pr reconciliation drift on older tasks. Scope: repository runtime health.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T13:49:11.005Z, excerpt_hash=sha256:74352f58f024a4e85150c41605cbbf445541380b2994364b9cd746921817adee
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141348-YAM2DX-wiki-structure-guidance/.agentplane/tasks/202605141348-YAM2DX/blueprint/resolved-snapshot.json
+    - old_digest: 6eafd5f026f6ff7a55a02caa2639233a75555d2618d6c1b32b6e217679ec4229
+    - current_digest: 6eafd5f026f6ff7a55a02caa2639233a75555d2618d6c1b32b6e217679ec4229
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141348-YAM2DX
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Clarify context wiki structure guidance
+
+Update the generated context/wiki/AGENTS.md template so agents analyze the base project and choose an appropriate wiki structure instead of assuming one fixed hierarchy.
+
+## Scope
+
+- In scope: Update the generated context/wiki/AGENTS.md template so agents analyze the base project and choose an appropriate wiki structure instead of assuming one fixed hierarchy.
+- Out of scope: unrelated refactors not required for "Clarify context wiki structure guidance".
+
+## Plan
+
+1. Inspect current context init scaffold and tests for context/wiki/AGENTS.md. 2. Update the generated wiki agent notes so agents first analyze the base project/context and choose the wiki hierarchy that fits, keeping only durable source-backed project knowledge in context/wiki. 3. Add or update focused regression coverage for the generated AGENTS.md content. 4. Run targeted context init tests plus routing/doctor checks, then record verification evidence.
+
+## Verify Steps
+
+PLANNER fallback scaffold for "Clarify context wiki structure guidance". Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the requested outcome for "Clarify context wiki structure guidance". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-14T13:54:33.959Z — VERIFY — ok
+
+By: DOCS
+
+Note: Command: bun test packages/agentplane/src/cli/run-cli.core.init.test.ts --timeout 120000; Result: pass; Evidence: 27 tests passed, including context init bootstraps AgentPlane and verifies generated context/wiki/AGENTS.md guidance. Scope: context init scaffold and regression coverage. Command: node .agentplane/policy/check-routing.mjs; Result: pass; Evidence: policy routing OK. Scope: policy routing. Command: ap doctor; Result: pass with unrelated warnings; Evidence: doctor (OK), warnings only for pre-existing branch_pr reconciliation drift on older tasks. Scope: repository runtime health.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T13:49:11.005Z, excerpt_hash=sha256:74352f58f024a4e85150c41605cbbf445541380b2994364b9cd746921817adee
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141348-YAM2DX-wiki-structure-guidance/.agentplane/tasks/202605141348-YAM2DX/blueprint/resolved-snapshot.json
+- old_digest: 6eafd5f026f6ff7a55a02caa2639233a75555d2618d6c1b32b6e217679ec4229
+- current_digest: 6eafd5f026f6ff7a55a02caa2639233a75555d2618d6c1b32b6e217679ec4229
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141348-YAM2DX
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605141348-YAM2DX/pr/diffstat.txt
+++ b/.agentplane/tasks/202605141348-YAM2DX/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ packages/agentplane/src/cli/run-cli.core.init.test.ts | 7 +++++++
+ packages/agentplane/src/commands/context/init.ts      | 2 ++
+ 2 files changed, 9 insertions(+)

--- a/.agentplane/tasks/202605141348-YAM2DX/pr/github-body.md
+++ b/.agentplane/tasks/202605141348-YAM2DX/pr/github-body.md
@@ -1,0 +1,45 @@
+Task: `202605141348-YAM2DX`
+Title: Clarify context wiki structure guidance
+Canonical task record: `.agentplane/tasks/202605141348-YAM2DX/README.md`
+
+## Summary
+
+Clarify context wiki structure guidance
+
+Update the generated context/wiki/AGENTS.md template so agents analyze the base project and choose an appropriate wiki structure instead of assuming one fixed hierarchy.
+
+## Scope
+
+- In scope: Update the generated context/wiki/AGENTS.md template so agents analyze the base project and choose an appropriate wiki structure instead of assuming one fixed hierarchy.
+- Out of scope: unrelated refactors not required for "Clarify context wiki structure guidance".
+
+## Verification
+
+- State: ok
+- Note:
+
+```bash
+bun test packages/agentplane/src/cli/run-cli.core.init.test.ts --timeout 120000; Result: pass; \
+  Evidence: 27 tests passed, including context init bootstraps AgentPlane and verifies generated \
+  context/wiki/AGENTS.md guidance. Scope: context init scaffold and regression coverage. Command: \
+  node .agentplane/policy/check-routing.mjs; Result: pass; Evidence: policy routing OK. Scope: \
+  policy routing. Command: ap doctor; Result: pass with unrelated warnings; Evidence: doctor (OK), \
+  warnings only for pre-existing branch_pr reconciliation drift on older tasks. Scope: repository \
+  runtime health.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T13:56:54.473Z
+- Branch: task/202605141348-YAM2DX/wiki-structure-guidance
+- Head: 45a8ac8bfe06
+
+```text
+ packages/agentplane/src/cli/run-cli.core.init.test.ts | 7 +++++++
+ packages/agentplane/src/commands/context/init.ts      | 2 ++
+ 2 files changed, 9 insertions(+)
+```
+
+</details>

--- a/.agentplane/tasks/202605141348-YAM2DX/pr/github-title.txt
+++ b/.agentplane/tasks/202605141348-YAM2DX/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 YAM2DX task: Clarify context wiki structure guidance [202605141348-YAM2DX]

--- a/.agentplane/tasks/202605141348-YAM2DX/pr/meta.json
+++ b/.agentplane/tasks/202605141348-YAM2DX/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "45a8ac8bfe067b10290a6cdf4c8ebecce756ac64",
   "last_verified_at": "2026-05-14T13:54:33.959Z",
   "last_verified_sha": "3d5c3b4706eae9b3f7de27132be995c01a7b742a",
+  "pr_number": 3715,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3715",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605141348-YAM2DX",
-  "updated_at": "2026-05-14T13:56:54.473Z",
+  "updated_at": "2026-05-14T13:57:19.558Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141348-YAM2DX/pr/meta.json
+++ b/.agentplane/tasks/202605141348-YAM2DX/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605141348-YAM2DX/wiki-structure-guidance",
+  "created_at": "2026-05-14T13:49:11.168Z",
+  "head_sha": "45a8ac8bfe067b10290a6cdf4c8ebecce756ac64",
+  "last_verified_at": "2026-05-14T13:54:33.959Z",
+  "last_verified_sha": "3d5c3b4706eae9b3f7de27132be995c01a7b742a",
+  "schema_version": 1,
+  "task_id": "202605141348-YAM2DX",
+  "updated_at": "2026-05-14T13:56:54.473Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605141348-YAM2DX/pr/review.md
+++ b/.agentplane/tasks/202605141348-YAM2DX/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-05-14T13:49:11.168Z
+
+## Task
+
+- Task: `202605141348-YAM2DX`
+- Title: Clarify context wiki structure guidance
+- Status: DOING
+- Branch: `task/202605141348-YAM2DX/wiki-structure-guidance`
+- Canonical task record: `.agentplane/tasks/202605141348-YAM2DX/README.md`
+
+## Verification
+
+- State: ok
+- Note: Command: bun test packages/agentplane/src/cli/run-cli.core.init.test.ts --timeout 120000; Result: pass; Evidence: 27 tests passed, including context init bootstraps AgentPlane and verifies generated context/wiki/AGENTS.md guidance. Scope: context init scaffold and regression coverage. Command: node .agentplane/policy/check-routing.mjs; Result: pass; Evidence: policy routing OK. Scope: policy routing. Command: ap doctor; Result: pass with unrelated warnings; Evidence: doctor (OK), warnings only for pre-existing branch_pr reconciliation drift on older tasks. Scope: repository runtime health.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T13:56:54.473Z
+- Branch: task/202605141348-YAM2DX/wiki-structure-guidance
+- Head: 45a8ac8bfe06
+
+```text
+ packages/agentplane/src/cli/run-cli.core.init.test.ts | 7 +++++++
+ packages/agentplane/src/commands/context/init.ts      | 2 ++
+ 2 files changed, 9 insertions(+)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/cli/run-cli.core.init.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.init.test.ts
@@ -443,6 +443,13 @@ describe("runCli", () => {
     expect(await pathExists(path.join(root, "AGENTS.md"))).toBe(true);
     expect(await pathExists(path.join(root, "context", "README.md"))).toBe(true);
     expect(await pathExists(path.join(root, "context", "wiki", "AGENTS.md"))).toBe(true);
+    const wikiAgents = await readFile(path.join(root, "context", "wiki", "AGENTS.md"), "utf8");
+    expect(wikiAgents).toContain(
+      "Analyze the base project, existing docs, task history, and raw sources before choosing a wiki structure.",
+    );
+    expect(wikiAgents).toContain(
+      "Choose the smallest wiki hierarchy that fits this project; do not force a universal concepts/entities/decisions/modules layout.",
+    );
     expect(await pathExists(path.join(root, ".agentplane", "cache.sqlite"))).toBe(true);
     expect(
       await pathExists(path.join(root, ".agentplane", "context", "agentplane.context.yaml")),

--- a/packages/agentplane/src/commands/context/init.ts
+++ b/packages/agentplane/src/commands/context/init.ts
@@ -375,6 +375,8 @@ function buildWikiAgentsMarkdown(profile: ContextInitParsed["profile"]): string 
 Profile: ${profile}
 
 - Treat \`context/wiki/**\` as durable, source-backed project knowledge.
+- Analyze the base project, existing docs, task history, and raw sources before choosing a wiki structure.
+- Choose the smallest wiki hierarchy that fits this project; do not force a universal concepts/entities/decisions/modules layout.
 - Keep raw inputs in \`context/raw/**\`; do not copy private raw sources into public wiki pages.
 - Add source references for factual claims that come from raw files, task READMEs, ACRs, or code.
 - Use \`agentplane context verify-task <task-id>\` before closing context assimilation work.


### PR DESCRIPTION
Task: `202605141348-YAM2DX`
Title: Clarify context wiki structure guidance
Canonical task record: `.agentplane/tasks/202605141348-YAM2DX/README.md`

## Summary

Clarify context wiki structure guidance

Update the generated context/wiki/AGENTS.md template so agents analyze the base project and choose an appropriate wiki structure instead of assuming one fixed hierarchy.

## Scope

- In scope: Update the generated context/wiki/AGENTS.md template so agents analyze the base project and choose an appropriate wiki structure instead of assuming one fixed hierarchy.
- Out of scope: unrelated refactors not required for "Clarify context wiki structure guidance".

## Verification

- State: ok
- Note:

```bash
bun test packages/agentplane/src/cli/run-cli.core.init.test.ts --timeout 120000; Result: pass; \
  Evidence: 27 tests passed, including context init bootstraps AgentPlane and verifies generated \
  context/wiki/AGENTS.md guidance. Scope: context init scaffold and regression coverage. Command: \
  node .agentplane/policy/check-routing.mjs; Result: pass; Evidence: policy routing OK. Scope: \
  policy routing. Command: ap doctor; Result: pass with unrelated warnings; Evidence: doctor (OK), \
  warnings only for pre-existing branch_pr reconciliation drift on older tasks. Scope: repository \
  runtime health.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-14T13:56:54.473Z
- Branch: task/202605141348-YAM2DX/wiki-structure-guidance
- Head: 45a8ac8bfe06

```text
 packages/agentplane/src/cli/run-cli.core.init.test.ts | 7 +++++++
 packages/agentplane/src/commands/context/init.ts      | 2 ++
 2 files changed, 9 insertions(+)
```

</details>
