### PR TITLE
🚧 RT8HXD task: Harden release publish evidence and external metadata [202605141400-RT8HXD]

### DIFF
--- a/.agentplane/tasks/202605141400-RT8HXD/README.md
+++ b/.agentplane/tasks/202605141400-RT8HXD/README.md
@@ -1,0 +1,139 @@
+---
+id: "202605141400-RT8HXD"
+title: "Harden release publish evidence and external metadata"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-14T14:01:04.617Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-14T14:08:24.956Z"
+  updated_by: "CODER"
+  note: "Focused release hardening checks passed: release-task-evidence merge-commit regression suite 5/5, publish-external-distribution topics payload suite 4/4, policy routing OK, git diff whitespace check clean."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: fix release publish evidence resolution for branch_pr merge commits and correct external distribution topics API payloads, then verify with focused release script tests."
+events:
+  -
+    type: "status"
+    at: "2026-05-14T14:02:11.942Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: fix release publish evidence resolution for branch_pr merge commits and correct external distribution topics API payloads, then verify with focused release script tests."
+  -
+    type: "verify"
+    at: "2026-05-14T14:08:24.956Z"
+    author: "CODER"
+    state: "ok"
+    note: "Focused release hardening checks passed: release-task-evidence merge-commit regression suite 5/5, publish-external-distribution topics payload suite 4/4, policy routing OK, git diff whitespace check clean."
+doc_version: 3
+doc_updated_at: "2026-05-14T14:08:24.991Z"
+doc_updated_by: "CODER"
+description: "Fix release publish evidence resolution for branch_pr merge commits and correct external repository topics API payloads so hosted publish logs produce durable task evidence without GitHub 422 warnings."
+sections:
+  Summary: |-
+    Harden release publish evidence and external metadata
+    
+    Fix release publish evidence resolution for branch_pr merge commits and correct external repository topics API payloads so hosted publish logs produce durable task evidence without GitHub 422 warnings.
+  Scope: |-
+    - In scope: Fix release publish evidence resolution for branch_pr merge commits and correct external repository topics API payloads so hosted publish logs produce durable task evidence without GitHub 422 warnings.
+    - Out of scope: unrelated refactors not required for "Harden release publish evidence and external metadata".
+  Plan: "Plan: fix release publish evidence resolution for branch_pr merge commits by detecting task README changes against merge parents or PR metadata, fix external distribution topics updates to send a proper GitHub JSON array payload, add regression tests for both logged failures, and verify focused release script tests plus policy routing."
+  Verify Steps: |-
+    1. Run `bunx vitest run packages/agentplane/src/commands/release/release-task-evidence-script.test.ts`. Expected: release task evidence resolves normal commits and branch_pr merge commits, and apply/audit behavior still passes.
+    2. Run `bunx vitest run packages/agentplane/src/commands/release/publish-external-distribution-script.test.ts`. Expected: external distribution PR flow still tolerates permission warnings and topics updates use a GitHub JSON array payload.
+    3. Run `node .agentplane/policy/check-routing.mjs`. Expected: policy routing remains valid.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-14T14:08:24.956Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Focused release hardening checks passed: release-task-evidence merge-commit regression suite 5/5, publish-external-distribution topics payload suite 4/4, policy routing OK, git diff whitespace check clean.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T14:05:42.306Z, excerpt_hash=sha256:e50a4d0bc61077643a9004197311fb2bb6ac467bd265c32aeffa84da6d46b62a
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141400-RT8HXD-release-evidence-hardening/.agentplane/tasks/202605141400-RT8HXD/blueprint/resolved-snapshot.json
+    - old_digest: 242e48847c9973d113802dd254df3114ef61bea751907f0d23c4e2d11cb45ea5
+    - current_digest: 242e48847c9973d113802dd254df3114ef61bea751907f0d23c4e2d11cb45ea5
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141400-RT8HXD
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Harden release publish evidence and external metadata
+
+Fix release publish evidence resolution for branch_pr merge commits and correct external repository topics API payloads so hosted publish logs produce durable task evidence without GitHub 422 warnings.
+
+## Scope
+
+- In scope: Fix release publish evidence resolution for branch_pr merge commits and correct external repository topics API payloads so hosted publish logs produce durable task evidence without GitHub 422 warnings.
+- Out of scope: unrelated refactors not required for "Harden release publish evidence and external metadata".
+
+## Plan
+
+Plan: fix release publish evidence resolution for branch_pr merge commits by detecting task README changes against merge parents or PR metadata, fix external distribution topics updates to send a proper GitHub JSON array payload, add regression tests for both logged failures, and verify focused release script tests plus policy routing.
+
+## Verify Steps
+
+1. Run `bunx vitest run packages/agentplane/src/commands/release/release-task-evidence-script.test.ts`. Expected: release task evidence resolves normal commits and branch_pr merge commits, and apply/audit behavior still passes.
+2. Run `bunx vitest run packages/agentplane/src/commands/release/publish-external-distribution-script.test.ts`. Expected: external distribution PR flow still tolerates permission warnings and topics updates use a GitHub JSON array payload.
+3. Run `node .agentplane/policy/check-routing.mjs`. Expected: policy routing remains valid.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-14T14:08:24.956Z — VERIFY — ok
+
+By: CODER
+
+Note: Focused release hardening checks passed: release-task-evidence merge-commit regression suite 5/5, publish-external-distribution topics payload suite 4/4, policy routing OK, git diff whitespace check clean.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T14:05:42.306Z, excerpt_hash=sha256:e50a4d0bc61077643a9004197311fb2bb6ac467bd265c32aeffa84da6d46b62a
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141400-RT8HXD-release-evidence-hardening/.agentplane/tasks/202605141400-RT8HXD/blueprint/resolved-snapshot.json
+- old_digest: 242e48847c9973d113802dd254df3114ef61bea751907f0d23c4e2d11cb45ea5
+- current_digest: 242e48847c9973d113802dd254df3114ef61bea751907f0d23c4e2d11cb45ea5
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141400-RT8HXD
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605141400-RT8HXD/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605141400-RT8HXD/blueprint/resolved-snapshot.json
@@ -1,0 +1,526 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605141400-RT8HXD",
+    "title": "Harden release publish evidence and external metadata",
+    "description": "Fix release publish evidence resolution for branch_pr merge commits and correct external repository topics API payloads so hosted publish logs produce durable task evidence without GitHub 422 warnings.",
+    "tags": [
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605141400-RT8HXD",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "242e48847c9973d113802dd254df3114ef61bea751907f0d23c4e2d11cb45ea5"
+  }
+}

--- a/.agentplane/tasks/202605141400-RT8HXD/pr/diffstat.txt
+++ b/.agentplane/tasks/202605141400-RT8HXD/pr/diffstat.txt
@@ -1,0 +1,6 @@
+ .../blueprint/resolved-snapshot.json               | 526 +++++++++++++++++++++
+ .../publish-external-distribution-script.test.ts   |  89 ++++
+ .../release/release-task-evidence-script.test.ts   |  47 ++
+ scripts/release/publish-external-distribution.mjs  |   7 +-
+ scripts/release/release-task-evidence.mjs          |   1 +
+ 5 files changed, 667 insertions(+), 3 deletions(-)

--- a/.agentplane/tasks/202605141400-RT8HXD/pr/github-body.md
+++ b/.agentplane/tasks/202605141400-RT8HXD/pr/github-body.md
@@ -28,12 +28,17 @@ clean.
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T14:02:12.360Z
+- Updated: 2026-05-14T14:09:49.252Z
 - Branch: task/202605141400-RT8HXD/release-evidence-hardening
-- Head: 3d5c3b4706ea
+- Head: 6e8a0f7a57f7
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 526 +++++++++++++++++++++
+ .../publish-external-distribution-script.test.ts   |  89 ++++
+ .../release/release-task-evidence-script.test.ts   |  47 ++
+ scripts/release/publish-external-distribution.mjs  |   7 +-
+ scripts/release/release-task-evidence.mjs          |   1 +
+ 5 files changed, 667 insertions(+), 3 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605141400-RT8HXD/pr/github-body.md
+++ b/.agentplane/tasks/202605141400-RT8HXD/pr/github-body.md
@@ -1,0 +1,39 @@
+Task: `202605141400-RT8HXD`
+Title: Harden release publish evidence and external metadata
+Canonical task record: `.agentplane/tasks/202605141400-RT8HXD/README.md`
+
+## Summary
+
+Harden release publish evidence and external metadata
+
+Fix release publish evidence resolution for branch_pr merge commits and correct external repository topics API payloads so hosted publish logs produce durable task evidence without GitHub 422 warnings.
+
+## Scope
+
+- In scope: Fix release publish evidence resolution for branch_pr merge commits and correct external repository topics API payloads so hosted publish logs produce durable task evidence without GitHub 422 warnings.
+- Out of scope: unrelated refactors not required for "Harden release publish evidence and external metadata".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Focused release hardening checks passed: release-task-evidence merge-commit regression suite 5/5,
+publish-external-distribution topics payload suite 4/4, policy routing OK, git diff whitespace check
+clean.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T14:02:12.360Z
+- Branch: task/202605141400-RT8HXD/release-evidence-hardening
+- Head: 3d5c3b4706ea
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605141400-RT8HXD/pr/github-title.txt
+++ b/.agentplane/tasks/202605141400-RT8HXD/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 RT8HXD task: Harden release publish evidence and external metadata [202605141400-RT8HXD]

--- a/.agentplane/tasks/202605141400-RT8HXD/pr/meta.json
+++ b/.agentplane/tasks/202605141400-RT8HXD/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605141400-RT8HXD/release-evidence-hardening",
+  "created_at": "2026-05-14T14:02:12.360Z",
+  "head_sha": "3d5c3b4706eae9b3f7de27132be995c01a7b742a",
+  "last_verified_at": "2026-05-14T14:08:24.956Z",
+  "last_verified_sha": "3d5c3b4706eae9b3f7de27132be995c01a7b742a",
+  "schema_version": 1,
+  "task_id": "202605141400-RT8HXD",
+  "updated_at": "2026-05-14T14:02:12.360Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605141400-RT8HXD/pr/meta.json
+++ b/.agentplane/tasks/202605141400-RT8HXD/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605141400-RT8HXD/release-evidence-hardening",
   "created_at": "2026-05-14T14:02:12.360Z",
-  "head_sha": "3d5c3b4706eae9b3f7de27132be995c01a7b742a",
+  "head_sha": "6e8a0f7a57f72b1c920797df5a7d5f39d11c1f85",
   "last_verified_at": "2026-05-14T14:08:24.956Z",
   "last_verified_sha": "3d5c3b4706eae9b3f7de27132be995c01a7b742a",
   "schema_version": 1,
   "task_id": "202605141400-RT8HXD",
-  "updated_at": "2026-05-14T14:02:12.360Z",
+  "updated_at": "2026-05-14T14:09:49.252Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141400-RT8HXD/pr/meta.json
+++ b/.agentplane/tasks/202605141400-RT8HXD/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "6e8a0f7a57f72b1c920797df5a7d5f39d11c1f85",
   "last_verified_at": "2026-05-14T14:08:24.956Z",
   "last_verified_sha": "3d5c3b4706eae9b3f7de27132be995c01a7b742a",
+  "pr_number": 3717,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3717",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605141400-RT8HXD",
-  "updated_at": "2026-05-14T14:09:49.252Z",
+  "updated_at": "2026-05-14T14:09:56.540Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141400-RT8HXD/pr/review.md
+++ b/.agentplane/tasks/202605141400-RT8HXD/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-14T14:02:12.360Z
+
+## Task
+
+- Task: `202605141400-RT8HXD`
+- Title: Harden release publish evidence and external metadata
+- Status: DOING
+- Branch: `task/202605141400-RT8HXD/release-evidence-hardening`
+- Canonical task record: `.agentplane/tasks/202605141400-RT8HXD/README.md`
+
+## Verification
+
+- State: ok
+- Note: Focused release hardening checks passed: release-task-evidence merge-commit regression suite 5/5, publish-external-distribution topics payload suite 4/4, policy routing OK, git diff whitespace check clean.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T14:02:12.360Z
+- Branch: task/202605141400-RT8HXD/release-evidence-hardening
+- Head: 3d5c3b4706ea
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605141400-RT8HXD/pr/review.md
+++ b/.agentplane/tasks/202605141400-RT8HXD/pr/review.md
@@ -24,12 +24,17 @@ Created: 2026-05-14T14:02:12.360Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T14:02:12.360Z
+- Updated: 2026-05-14T14:09:49.252Z
 - Branch: task/202605141400-RT8HXD/release-evidence-hardening
-- Head: 3d5c3b4706ea
+- Head: 6e8a0f7a57f7
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 526 +++++++++++++++++++++
+ .../publish-external-distribution-script.test.ts   |  89 ++++
+ .../release/release-task-evidence-script.test.ts   |  47 ++
+ scripts/release/publish-external-distribution.mjs  |   7 +-
+ scripts/release/release-task-evidence.mjs          |   1 +
+ 5 files changed, 667 insertions(+), 3 deletions(-)
 ```
 
 </details>

--- a/packages/agentplane/src/commands/release/publish-external-distribution-script.test.ts
+++ b/packages/agentplane/src/commands/release/publish-external-distribution-script.test.ts
@@ -219,4 +219,93 @@ describe("publish-external-distribution script", () => {
       }),
     );
   });
+
+  it("updates repository topics with a GitHub API JSON array payload", async () => {
+    const root = await makeTempRoot();
+    const binDir = path.join(root, "bin");
+    const topicsPayloadLog = path.join(root, "topics-payload.json");
+    await mkdir(path.join(root, "source", "bucket"), { recursive: true });
+    await mkdir(binDir, { recursive: true });
+    await writeFile(path.join(root, "source", "bucket", "agentplane.json"), "{}\n");
+    await writeFile(
+      path.join(binDir, "gh"),
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "if (args[0] === 'repo' && args[1] === 'clone') { fs.mkdirSync(args[3], { recursive: true }); process.exit(0); }",
+        "if (args[0] === 'auth') process.exit(0);",
+        "if (args[0] === 'api' && args.includes('/repos/basilisk-labs/scoop-bucket/topics')) {",
+        "  const inputIndex = args.indexOf('--input');",
+        "  if (inputIndex < 0) { console.error('missing --input'); process.exit(2); }",
+        `  fs.copyFileSync(args[inputIndex + 1], ${JSON.stringify(topicsPayloadLog)});`,
+        "  const payload = JSON.parse(fs.readFileSync(args[inputIndex + 1], 'utf8'));",
+        "  if (!Array.isArray(payload.names)) { console.error('names is not an array'); process.exit(3); }",
+        "  process.exit(0);",
+        "}",
+        "if (args[0] === 'api') process.exit(0);",
+        "if (args[0] === 'pr' && args[1] === 'list') { process.stdout.write(''); process.exit(0); }",
+        "if (args[0] === 'pr' && args[1] === 'create') { process.stdout.write('https://github.com/basilisk-labs/scoop-bucket/pull/7' + String.fromCharCode(10)); process.exit(0); }",
+        "console.error('unexpected gh ' + args.join(' '));",
+        "process.exit(2);",
+      ].join("\n"),
+    );
+    await writeFile(
+      path.join(binDir, "git"),
+      [
+        "#!/usr/bin/env node",
+        "const args = process.argv.slice(2);",
+        "if (args[0] === 'status') { process.stdout.write(' M bucket/agentplane.json' + String.fromCharCode(10)); process.exit(0); }",
+        "process.exit(0);",
+      ].join("\n"),
+    );
+    await chmod(path.join(binDir, "gh"), 0o755);
+    await chmod(path.join(binDir, "git"), 0o755);
+    const outPath = path.join(root, "result.json");
+
+    await execFileAsync(
+      "node",
+      [
+        SCRIPT_PATH,
+        "--module",
+        "scoop",
+        "--repo",
+        "basilisk-labs/scoop-bucket",
+        "--source",
+        path.join(root, "source"),
+        "--copy",
+        "bucket/agentplane.json:bucket/agentplane.json",
+        "--repo-topics",
+        "agentplane,scoop,windows,cli",
+        "--version",
+        "0.4.2",
+        "--tag",
+        "v0.4.2",
+        "--sha",
+        "abc123",
+        "--token-env",
+        "AGENTPLANE_TEST_TOKEN",
+        "--out",
+        outPath,
+      ],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          AGENTPLANE_TEST_TOKEN: "token",
+        },
+      },
+    );
+
+    const payload = JSON.parse(await readFile(outPath, "utf8")) as {
+      metadata: { ok: boolean; updated: string[] };
+    };
+    const topicsPayload = JSON.parse(await readFile(topicsPayloadLog, "utf8")) as {
+      names: string[];
+    };
+    expect(payload.metadata.ok).toBe(true);
+    expect(payload.metadata.updated).toContain("topics");
+    expect(topicsPayload.names).toEqual(["agentplane", "scoop", "windows", "cli"]);
+  });
 });

--- a/packages/agentplane/src/commands/release/release-task-evidence-script.test.ts
+++ b/packages/agentplane/src/commands/release/release-task-evidence-script.test.ts
@@ -228,6 +228,53 @@ describe("release-task-evidence script", () => {
     expect(payload.pr_body).toContain("## Scope");
   });
 
+  it("prepares evidence for a branch_pr merge commit that carries the release task README", async () => {
+    const root = await initRepo();
+    await writeFile(path.join(root, "README.md"), "# fixture\n");
+    await commitAll(root, "seed main");
+    await git(root, ["switch", "-c", "task/202604191130-JWBEB7/release"]);
+    const taskId = "202604191130-JWBEB7";
+    await writeTaskReadme(root, taskId);
+    await commitAll(root, "release task artifacts");
+    await git(root, ["switch", "main"]);
+    await git(root, [
+      "merge",
+      "--no-ff",
+      "task/202604191130-JWBEB7/release",
+      "-m",
+      "Merge pull request #123 from basilisk-labs/task/202604191130-JWBEB7/release",
+    ]);
+    const { stdout: shaStdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      env: process.env,
+    });
+    const releaseSha = shaStdout.trim();
+    const publishResultPath = await writePublishResult(root, buildPublishResult(true));
+
+    const result = await execFileAsync(
+      "bun",
+      [
+        SCRIPT_PATH,
+        "prepare",
+        "--release-sha",
+        releaseSha,
+        "--publish-result",
+        publishResultPath,
+        "--repo",
+        "basilisk-labs/agentplane",
+      ],
+      { cwd: root, env: process.env },
+    );
+
+    const payload = JSON.parse(String(result.stdout ?? "")) as {
+      actionable: boolean;
+      task_id: string;
+    };
+
+    expect(payload.actionable).toBe(true);
+    expect(payload.task_id).toBe(taskId);
+  });
+
   it("marks prepare as non-actionable when publish-result is incomplete", async () => {
     const root = await initRepo();
     const taskId = "202604191130-JWBEB7";

--- a/packages/agentplane/src/commands/release/release-task-evidence-script.test.ts
+++ b/packages/agentplane/src/commands/release/release-task-evidence-script.test.ts
@@ -237,6 +237,8 @@ describe("release-task-evidence script", () => {
     await writeTaskReadme(root, taskId);
     await commitAll(root, "release task artifacts");
     await git(root, ["switch", "main"]);
+    await writeTaskReadme(root, "202604191131-OTHER1");
+    await commitAll(root, "other task landed before merge");
     await git(root, [
       "merge",
       "--no-ff",
@@ -273,7 +275,7 @@ describe("release-task-evidence script", () => {
 
     expect(payload.actionable).toBe(true);
     expect(payload.task_id).toBe(taskId);
-  });
+  }, 60_000);
 
   it("marks prepare as non-actionable when publish-result is incomplete", async () => {
     const root = await initRepo();

--- a/scripts/release/publish-external-distribution.mjs
+++ b/scripts/release/publish-external-distribution.mjs
@@ -190,9 +190,9 @@ async function publishExternal(args) {
   async function syncRepositoryMetadata(cloneDir) {
     const updates = [];
     const warnings = [];
-    const repoFlags = [];
     if (args.topics.length > 0) {
-      repoFlags.push("-f", `names=${JSON.stringify(args.topics)}`);
+      const topicsPayloadPath = path.join(tempRoot, "repository-topics.json");
+      await writeFile(topicsPayloadPath, `${JSON.stringify({ names: args.topics })}\n`, "utf8");
       try {
         await run(
           "gh",
@@ -203,7 +203,8 @@ async function publishExternal(args) {
             `/repos/${args.repo}/topics`,
             "-H",
             "Accept: application/vnd.github+json",
-            ...repoFlags,
+            "--input",
+            topicsPayloadPath,
           ],
           { cwd: cloneDir, env },
         );

--- a/scripts/release/release-task-evidence.mjs
+++ b/scripts/release/release-task-evidence.mjs
@@ -91,15 +91,12 @@ async function readPublishResult(filePath) {
 }
 
 async function resolveReleaseTaskIdsFromCommit(releaseSha) {
-  const stdout = await git([
-    "diff-tree",
-    "-m",
-    "--root",
-    "--no-commit-id",
-    "--name-only",
-    "-r",
-    releaseSha,
-  ]);
+  const parentLine = await git(["rev-list", "--parents", "-n", "1", releaseSha]);
+  const parents = parentLine.split(/\s+/u).filter(Boolean).slice(1);
+  const stdout =
+    parents.length > 0
+      ? await git(["diff", "--name-only", `${releaseSha}^1`, releaseSha])
+      : await git(["diff-tree", "--root", "--no-commit-id", "--name-only", "-r", releaseSha]);
   const taskIds = stdout
     .split("\n")
     .map((line) => line.trim())

--- a/scripts/release/release-task-evidence.mjs
+++ b/scripts/release/release-task-evidence.mjs
@@ -93,6 +93,7 @@ async function readPublishResult(filePath) {
 async function resolveReleaseTaskIdsFromCommit(releaseSha) {
   const stdout = await git([
     "diff-tree",
+    "-m",
     "--root",
     "--no-commit-id",
     "--name-only",


### PR DESCRIPTION
Task: `202605141400-RT8HXD`
Title: Harden release publish evidence and external metadata
Canonical task record: `.agentplane/tasks/202605141400-RT8HXD/README.md`

## Summary

Harden release publish evidence and external metadata

Fix release publish evidence resolution for branch_pr merge commits and correct external repository topics API payloads so hosted publish logs produce durable task evidence without GitHub 422 warnings.

## Scope

- In scope: Fix release publish evidence resolution for branch_pr merge commits and correct external repository topics API payloads so hosted publish logs produce durable task evidence without GitHub 422 warnings.
- Out of scope: unrelated refactors not required for "Harden release publish evidence and external metadata".

## Verification

- State: ok
- Note:

```text
Focused release hardening checks passed: release-task-evidence merge-commit regression suite 5/5,
publish-external-distribution topics payload suite 4/4, policy routing OK, git diff whitespace check
clean.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-14T14:09:49.252Z
- Branch: task/202605141400-RT8HXD/release-evidence-hardening
- Head: 6e8a0f7a57f7

```text
 .../blueprint/resolved-snapshot.json               | 526 +++++++++++++++++++++
 .../publish-external-distribution-script.test.ts   |  89 ++++
 .../release/release-task-evidence-script.test.ts   |  47 ++
 scripts/release/publish-external-distribution.mjs  |   7 +-
 scripts/release/release-task-evidence.mjs          |   1 +
 5 files changed, 667 insertions(+), 3 deletions(-)
```

</details>
