### PR TITLE
🚧 8FZMYJ task: Fail closed on external release publication [202605141404-8FZMYJ]

### DIFF
--- a/.agentplane/tasks/202605141404-8FZMYJ/README.md
+++ b/.agentplane/tasks/202605141404-8FZMYJ/README.md
@@ -1,0 +1,151 @@
+---
+id: "202605141404-8FZMYJ"
+title: "Fail closed on external release publication"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "release"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-14T14:05:06.965Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-14T14:22:56.266Z"
+  updated_by: "CODER"
+  note: "Focused release publication checks passed: publish-result now treats pr_opened as incomplete, external publisher verifies merged default-branch state, setup-agentplane tag publication is covered, workflow contract fails incomplete publish-result, routing check passed."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implementing fail-closed external release publication proof with focused release workflow tests and documentation updates."
+events:
+  -
+    type: "status"
+    at: "2026-05-14T14:06:23.707Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implementing fail-closed external release publication proof with focused release workflow tests and documentation updates."
+  -
+    type: "verify"
+    at: "2026-05-14T14:22:56.266Z"
+    author: "CODER"
+    state: "ok"
+    note: "Focused release publication checks passed: publish-result now treats pr_opened as incomplete, external publisher verifies merged default-branch state, setup-agentplane tag publication is covered, workflow contract fails incomplete publish-result, routing check passed."
+doc_version: 3
+doc_updated_at: "2026-05-14T14:22:56.364Z"
+doc_updated_by: "CODER"
+description: "External distribution PR handoff must not be treated as completed publication; release evidence must require merged/default-branch verified channels or mark the release incomplete."
+sections:
+  Summary: |-
+    Fail closed on external release publication
+    
+    External distribution PR handoff must not be treated as completed publication; release evidence must require merged/default-branch verified channels or mark the release incomplete.
+  Scope: |-
+    - In scope: External distribution PR handoff must not be treated as completed publication; release evidence must require merged/default-branch verified channels or mark the release incomplete.
+    - Out of scope: unrelated refactors not required for "Fail closed on external release publication".
+  Plan: "Plan: 1. Audit current external distribution statuses and encode the failure mode in tests. 2. Update publish-result semantics so pr_opened is incomplete rather than success. 3. Extend external distribution publisher to merge clean PRs where possible, verify default-branch content, and tag setup-agentplane after merge. 4. Update release workflow/docs to reflect publication proof versus handoff. 5. Run focused release tests plus routing check."
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+    
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-14T14:22:56.266Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Focused release publication checks passed: publish-result now treats pr_opened as incomplete, external publisher verifies merged default-branch state, setup-agentplane tag publication is covered, workflow contract fails incomplete publish-result, routing check passed.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T14:06:23.707Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141404-8FZMYJ-external-release-publish-proof/.agentplane/tasks/202605141404-8FZMYJ/blueprint/resolved-snapshot.json
+    - old_digest: 699da31cdfae9e38295b19e27aa9d3c19a711b0c9cd5c4a9e6436a30d05be77a
+    - current_digest: 699da31cdfae9e38295b19e27aa9d3c19a711b0c9cd5c4a9e6436a30d05be77a
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141404-8FZMYJ
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Commands: bun test packages/agentplane/src/commands/release/write-publish-result-manifest-script.test.ts packages/agentplane/src/commands/release/publish-external-distribution-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts; bunx eslint scripts/release/manifest.mjs scripts/release/publish-external-distribution.mjs packages/agentplane/src/commands/release/write-publish-result-manifest-script.test.ts packages/agentplane/src/commands/release/publish-external-distribution-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts; node .agentplane/policy/check-routing.mjs; git diff --check.
+      Impact: Release workflow no longer records external package-manager handoff PRs as successful publication.
+      Resolution: Require published/unchanged external statuses in publish-result and make publish workflows fail on incomplete external distribution evidence.
+id_source: "generated"
+---
+## Summary
+
+Fail closed on external release publication
+
+External distribution PR handoff must not be treated as completed publication; release evidence must require merged/default-branch verified channels or mark the release incomplete.
+
+## Scope
+
+- In scope: External distribution PR handoff must not be treated as completed publication; release evidence must require merged/default-branch verified channels or mark the release incomplete.
+- Out of scope: unrelated refactors not required for "Fail closed on external release publication".
+
+## Plan
+
+Plan: 1. Audit current external distribution statuses and encode the failure mode in tests. 2. Update publish-result semantics so pr_opened is incomplete rather than success. 3. Extend external distribution publisher to merge clean PRs where possible, verify default-branch content, and tag setup-agentplane after merge. 4. Update release workflow/docs to reflect publication proof versus handoff. 5. Run focused release tests plus routing check.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-14T14:22:56.266Z — VERIFY — ok
+
+By: CODER
+
+Note: Focused release publication checks passed: publish-result now treats pr_opened as incomplete, external publisher verifies merged default-branch state, setup-agentplane tag publication is covered, workflow contract fails incomplete publish-result, routing check passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T14:06:23.707Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141404-8FZMYJ-external-release-publish-proof/.agentplane/tasks/202605141404-8FZMYJ/blueprint/resolved-snapshot.json
+- old_digest: 699da31cdfae9e38295b19e27aa9d3c19a711b0c9cd5c4a9e6436a30d05be77a
+- current_digest: 699da31cdfae9e38295b19e27aa9d3c19a711b0c9cd5c4a9e6436a30d05be77a
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141404-8FZMYJ
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Commands: bun test packages/agentplane/src/commands/release/write-publish-result-manifest-script.test.ts packages/agentplane/src/commands/release/publish-external-distribution-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts; bunx eslint scripts/release/manifest.mjs scripts/release/publish-external-distribution.mjs packages/agentplane/src/commands/release/write-publish-result-manifest-script.test.ts packages/agentplane/src/commands/release/publish-external-distribution-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts; node .agentplane/policy/check-routing.mjs; git diff --check.
+  Impact: Release workflow no longer records external package-manager handoff PRs as successful publication.
+  Resolution: Require published/unchanged external statuses in publish-result and make publish workflows fail on incomplete external distribution evidence.

--- a/.agentplane/tasks/202605141404-8FZMYJ/pr/diffstat.txt
+++ b/.agentplane/tasks/202605141404-8FZMYJ/pr/diffstat.txt
@@ -1,0 +1,9 @@
+ .github/workflows/publish-distribution-module.yml  |  26 ++++
+ .github/workflows/publish.yml                      |   6 +
+ docs/developer/release-and-publishing.mdx          |  11 +-
+ .../publish-external-distribution-script.test.ts   | 104 +++++++++++++-
+ .../release/publish-workflow-contract.test.ts      |   4 +
+ .../write-publish-result-manifest-script.test.ts   |  76 +++++++++-
+ scripts/release/manifest.mjs                       |   5 +-
+ scripts/release/publish-external-distribution.mjs  | 159 ++++++++++++++++++++-
+ 8 files changed, 377 insertions(+), 14 deletions(-)

--- a/.agentplane/tasks/202605141404-8FZMYJ/pr/github-body.md
+++ b/.agentplane/tasks/202605141404-8FZMYJ/pr/github-body.md
@@ -28,7 +28,7 @@ covered, workflow contract fails incomplete publish-result, routing check passed
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T14:24:30.441Z
+- Updated: 2026-05-14T14:24:44.507Z
 - Branch: task/202605141404-8FZMYJ/external-release-publish-proof
 - Head: 635a230e3ef1
 

--- a/.agentplane/tasks/202605141404-8FZMYJ/pr/github-body.md
+++ b/.agentplane/tasks/202605141404-8FZMYJ/pr/github-body.md
@@ -1,0 +1,47 @@
+Task: `202605141404-8FZMYJ`
+Title: Fail closed on external release publication
+Canonical task record: `.agentplane/tasks/202605141404-8FZMYJ/README.md`
+
+## Summary
+
+Fail closed on external release publication
+
+External distribution PR handoff must not be treated as completed publication; release evidence must require merged/default-branch verified channels or mark the release incomplete.
+
+## Scope
+
+- In scope: External distribution PR handoff must not be treated as completed publication; release evidence must require merged/default-branch verified channels or mark the release incomplete.
+- Out of scope: unrelated refactors not required for "Fail closed on external release publication".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Focused release publication checks passed: publish-result now treats pr_opened as incomplete,
+external publisher verifies merged default-branch state, setup-agentplane tag publication is
+covered, workflow contract fails incomplete publish-result, routing check passed.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T14:24:30.441Z
+- Branch: task/202605141404-8FZMYJ/external-release-publish-proof
+- Head: 635a230e3ef1
+
+```text
+ .github/workflows/publish-distribution-module.yml  |  26 ++++
+ .github/workflows/publish.yml                      |   6 +
+ docs/developer/release-and-publishing.mdx          |  11 +-
+ .../publish-external-distribution-script.test.ts   | 104 +++++++++++++-
+ .../release/publish-workflow-contract.test.ts      |   4 +
+ .../write-publish-result-manifest-script.test.ts   |  76 +++++++++-
+ scripts/release/manifest.mjs                       |   5 +-
+ scripts/release/publish-external-distribution.mjs  | 159 ++++++++++++++++++++-
+ 8 files changed, 377 insertions(+), 14 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605141404-8FZMYJ/pr/github-title.txt
+++ b/.agentplane/tasks/202605141404-8FZMYJ/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 8FZMYJ task: Fail closed on external release publication [202605141404-8FZMYJ]

--- a/.agentplane/tasks/202605141404-8FZMYJ/pr/meta.json
+++ b/.agentplane/tasks/202605141404-8FZMYJ/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "635a230e3ef14d84f754efb5518adfc2a9977bfc",
   "last_verified_at": "2026-05-14T14:22:56.266Z",
   "last_verified_sha": "3d5c3b4706eae9b3f7de27132be995c01a7b742a",
+  "pr_number": 3721,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3721",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605141404-8FZMYJ",
-  "updated_at": "2026-05-14T14:24:30.441Z",
+  "updated_at": "2026-05-14T14:24:44.507Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141404-8FZMYJ/pr/meta.json
+++ b/.agentplane/tasks/202605141404-8FZMYJ/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605141404-8FZMYJ/external-release-publish-proof",
+  "created_at": "2026-05-14T14:06:24.052Z",
+  "head_sha": "635a230e3ef14d84f754efb5518adfc2a9977bfc",
+  "last_verified_at": "2026-05-14T14:22:56.266Z",
+  "last_verified_sha": "3d5c3b4706eae9b3f7de27132be995c01a7b742a",
+  "schema_version": 1,
+  "task_id": "202605141404-8FZMYJ",
+  "updated_at": "2026-05-14T14:24:30.441Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605141404-8FZMYJ/pr/review.md
+++ b/.agentplane/tasks/202605141404-8FZMYJ/pr/review.md
@@ -24,7 +24,7 @@ Created: 2026-05-14T14:06:24.052Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T14:24:30.441Z
+- Updated: 2026-05-14T14:24:44.507Z
 - Branch: task/202605141404-8FZMYJ/external-release-publish-proof
 - Head: 635a230e3ef1
 

--- a/.agentplane/tasks/202605141404-8FZMYJ/pr/review.md
+++ b/.agentplane/tasks/202605141404-8FZMYJ/pr/review.md
@@ -1,0 +1,44 @@
+# PR Review
+
+Created: 2026-05-14T14:06:24.052Z
+
+## Task
+
+- Task: `202605141404-8FZMYJ`
+- Title: Fail closed on external release publication
+- Status: DOING
+- Branch: `task/202605141404-8FZMYJ/external-release-publish-proof`
+- Canonical task record: `.agentplane/tasks/202605141404-8FZMYJ/README.md`
+
+## Verification
+
+- State: ok
+- Note: Focused release publication checks passed: publish-result now treats pr_opened as incomplete, external publisher verifies merged default-branch state, setup-agentplane tag publication is covered, workflow contract fails incomplete publish-result, routing check passed.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T14:24:30.441Z
+- Branch: task/202605141404-8FZMYJ/external-release-publish-proof
+- Head: 635a230e3ef1
+
+```text
+ .github/workflows/publish-distribution-module.yml  |  26 ++++
+ .github/workflows/publish.yml                      |   6 +
+ docs/developer/release-and-publishing.mdx          |  11 +-
+ .../publish-external-distribution-script.test.ts   | 104 +++++++++++++-
+ .../release/publish-workflow-contract.test.ts      |   4 +
+ .../write-publish-result-manifest-script.test.ts   |  76 +++++++++-
+ scripts/release/manifest.mjs                       |   5 +-
+ scripts/release/publish-external-distribution.mjs  | 159 ++++++++++++++++++++-
+ 8 files changed, 377 insertions(+), 14 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.github/workflows/publish-distribution-module.yml
+++ b/.github/workflows/publish-distribution-module.yml
@@ -235,3 +235,29 @@ jobs:
           name: distribution-module-${{ github.event.inputs.module }}-${{ github.event.inputs.tag }}
           path: .agentplane/.release/publish/
           if-no-files-found: warn
+      - name: Fail incomplete external distribution module
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          node <<'EOF'
+          const fs = require("node:fs");
+          const path = require("node:path");
+          const root = ".agentplane/.release/publish";
+          const files = [
+            "homebrew/homebrew-publish-result.json",
+            "scoop/scoop-publish-result.json",
+            "setup-agentplane/setup-agentplane-publish-result.json",
+          ].map((file) => path.join(root, file)).filter((file) => fs.existsSync(file));
+          const failures = [];
+          for (const file of files) {
+            const payload = JSON.parse(fs.readFileSync(file, "utf8"));
+            if (!["published", "unchanged"].includes(payload.status)) {
+              failures.push(`${payload.module ?? file}: ${payload.status}`);
+            }
+          }
+          if (failures.length > 0) {
+            console.error(`external distribution incomplete: ${failures.join("; ")}`);
+            process.exit(1);
+          }
+          EOF

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -585,6 +585,12 @@ jobs:
           name: publish-result
           path: .agentplane/.release/publish/publish-result.json
           if-no-files-found: error
+      - name: Fail incomplete publish-result
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          node -e "const fs=require('node:fs'); const payload=JSON.parse(fs.readFileSync('.agentplane/.release/publish/publish-result.json','utf8')); if (!payload.success) { console.error(payload.message); process.exit(1); }"
       - name: Prepare release task evidence
         if: always()
         id: release_evidence

--- a/docs/developer/release-and-publishing.mdx
+++ b/docs/developer/release-and-publishing.mdx
@@ -321,6 +321,12 @@ gh workflow run publish-distribution-module.yml \
   -f module=homebrew
 ```
 
+The release result is fail-closed for AgentPlane-owned external channels. Opening a Homebrew,
+Scoop, or `setup-agentplane` PR is only a handoff state and must not be recorded as completed
+publication. The channel is publish-confirmed only after the PR is merged, the target repository's
+default branch contains the rendered files for the exact version, and `setup-agentplane` has the
+matching `vX.Y.Z` tag.
+
 External moderated registries such as `homebrew/core`, winget, Chocolatey, AUR, and nixpkgs are
 follow-up publication targets. They should be opened as PR jobs or manual recovery tasks after the
 release is already published, because their review queues are outside the AgentPlane release SLA.
@@ -466,6 +472,5 @@ versions, or release notes for you.
 - verify `SHA256SUMS` covers all install and upgrade assets
 - verify the GHCR tags recorded in `ghcr-result.json` resolve and `agentplane --version` works in
   the container
-- verify Homebrew tap, Scoop bucket, and setup-action module artifacts are either externally
-  published by a follow-up PR or explicitly recorded as `skipped_missing_credentials` with recovery
-  instructions
+- verify Homebrew tap, Scoop bucket, and setup-action module artifacts are published on their
+  target default branches, or explicitly recorded as incomplete with recovery instructions

--- a/packages/agentplane/src/commands/release/publish-external-distribution-script.test.ts
+++ b/packages/agentplane/src/commands/release/publish-external-distribution-script.test.ts
@@ -326,7 +326,7 @@ describe("publish-external-distribution script", () => {
     expect(payload.metadata.ok).toBe(true);
     expect(payload.metadata.updated).toContain("topics");
     expect(topicsPayload.names).toEqual(["agentplane", "scoop", "windows", "cli"]);
-  });
+  }, 180_000);
 
   it("creates the setup-agentplane version tag after publishing the action repository", async () => {
     const root = await makeTempRoot();
@@ -426,5 +426,93 @@ describe("publish-external-distribution script", () => {
       tag: "v0.4.2",
     });
     expect(payload.setupTag.sha).toMatch(/^[0-9a-f]{40}$/u);
+  }, 180_000);
+
+  it("verifies setup-agentplane tag proof when action files are unchanged", async () => {
+    const root = await makeTempRoot();
+    const binDir = path.join(root, "bin");
+    await mkdir(path.join(root, "source"), { recursive: true });
+    await mkdir(binDir, { recursive: true });
+    await writeFile(path.join(root, "source", "action.yml"), "name: setup-agentplane\n");
+    await writeFile(path.join(root, "source", "README.md"), "# setup-agentplane\n");
+    await writeFile(
+      path.join(binDir, "gh"),
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "const path = require('node:path');",
+        "const args = process.argv.slice(2);",
+        "if (args[0] === 'repo' && args[1] === 'clone') {",
+        "  fs.mkdirSync(args[3], { recursive: true });",
+        "  fs.writeFileSync(path.join(args[3], 'action.yml'), 'name: setup-agentplane' + String.fromCharCode(10));",
+        "  fs.writeFileSync(path.join(args[3], 'README.md'), '# setup-agentplane' + String.fromCharCode(10));",
+        "  process.exit(0);",
+        "}",
+        "if (args[0] === 'auth') process.exit(0);",
+        "if (args[0] === 'api') process.exit(0);",
+        "console.error('unexpected gh ' + args.join(' '));",
+        "process.exit(2);",
+      ].join("\n"),
+    );
+    await writeFile(
+      path.join(binDir, "git"),
+      [
+        "#!/usr/bin/env node",
+        "const args = process.argv.slice(2);",
+        "if (args[0] === 'status') process.exit(0);",
+        "if (args[0] === 'rev-parse') { process.stdout.write('c'.repeat(40) + String.fromCharCode(10)); process.exit(0); }",
+        "if (args[0] === 'ls-remote') { process.stdout.write('c'.repeat(40) + String.fromCharCode(9) + 'refs/tags/v0.4.2' + String.fromCharCode(10)); process.exit(0); }",
+        "process.exit(0);",
+      ].join("\n"),
+    );
+    await chmod(path.join(binDir, "gh"), 0o755);
+    await chmod(path.join(binDir, "git"), 0o755);
+    const outPath = path.join(root, "result.json");
+
+    await execFileAsync(
+      "node",
+      [
+        SCRIPT_PATH,
+        "--module",
+        "setup-agentplane",
+        "--repo",
+        "basilisk-labs/setup-agentplane",
+        "--source",
+        path.join(root, "source"),
+        "--copy",
+        "action.yml:action.yml",
+        "--copy",
+        "README.md:README.md",
+        "--version",
+        "0.4.2",
+        "--tag",
+        "v0.4.2",
+        "--sha",
+        "abc123",
+        "--token-env",
+        "AGENTPLANE_TEST_TOKEN",
+        "--out",
+        outPath,
+      ],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          AGENTPLANE_TEST_TOKEN: "token",
+        },
+      },
+    );
+
+    const payload = JSON.parse(await readFile(outPath, "utf8")) as {
+      status: string;
+      setupTag: { status: string; tag: string; sha: string };
+    };
+    expect(payload.status).toBe("unchanged");
+    expect(payload.setupTag).toMatchObject({
+      status: "published",
+      tag: "v0.4.2",
+      sha: "c".repeat(40),
+    });
   }, 180_000);
 });

--- a/packages/agentplane/src/commands/release/publish-external-distribution-script.test.ts
+++ b/packages/agentplane/src/commands/release/publish-external-distribution-script.test.ts
@@ -122,11 +122,11 @@ describe("publish-external-distribution script", () => {
     expect(filePayload).toEqual(stdoutPayload);
   });
 
-  it("opens the distribution PR even when optional repository metadata updates are denied", async () => {
+  it("merges and verifies the distribution PR even when optional repository metadata updates are denied", async () => {
     const root = await makeTempRoot();
     const binDir = path.join(root, "bin");
     const cloneLog = path.join(root, "clone.log");
-    const gitLog = path.join(root, "git.log");
+    const originDir = path.join(root, "origin.git");
     await mkdir(path.join(root, "source", "Formula"), { recursive: true });
     await mkdir(binDir, { recursive: true });
     await writeFile(
@@ -139,31 +139,45 @@ describe("publish-external-distribution script", () => {
         "#!/usr/bin/env node",
         "const fs = require('node:fs');",
         "const path = require('node:path');",
+        "const { execFileSync } = require('node:child_process');",
         "const args = process.argv.slice(2);",
         `fs.appendFileSync(${JSON.stringify(cloneLog)}, args.join(" ") + String.fromCharCode(10));`,
-        "if (args[0] === 'repo' && args[1] === 'clone') { fs.mkdirSync(args[3], { recursive: true }); process.exit(0); }",
+        `const originDir = ${JSON.stringify(originDir)};`,
+        "function git(gitArgs, cwd) { execFileSync('git', gitArgs, { cwd, stdio: 'ignore' }); }",
+        [
+          "if (args[0] === 'repo' && args[1] === 'clone') {",
+          "  fs.rmSync(originDir, { recursive: true, force: true });",
+          "  git(['init', '--bare', originDir]);",
+          "  git(['clone', originDir, args[3]]);",
+          "  git(['config', 'user.name', 'test'], args[3]);",
+          "  git(['config', 'user.email', 'test@example.com'], args[3]);",
+          "  git(['switch', '-c', 'main'], args[3]);",
+          "  fs.mkdirSync(path.join(args[3], 'Formula'), { recursive: true });",
+          "  fs.writeFileSync(path.join(args[3], 'Formula', 'agentplane.rb'), 'old formula' + String.fromCharCode(10));",
+          "  git(['add', '.'], args[3]);",
+          "  git(['commit', '-m', 'initial'], args[3]);",
+          "  git(['push', '--set-upstream', 'origin', 'main'], args[3]);",
+          "  process.exit(0);",
+          "}",
+        ].join("\n"),
         "if (args[0] === 'auth') process.exit(0);",
         "if (args[0] === 'api' && args.includes('/repos/basilisk-labs/homebrew-tap/topics')) { console.error('gh: Resource not accessible by personal access token (HTTP 403)'); process.exit(1); }",
         "if (args[0] === 'api') process.exit(0);",
         "if (args[0] === 'pr' && args[1] === 'list') { process.stdout.write(''); process.exit(0); }",
         "if (args[0] === 'pr' && args[1] === 'create') { process.stdout.write('https://github.com/basilisk-labs/homebrew-tap/pull/7' + String.fromCharCode(10)); process.exit(0); }",
+        [
+          "if (args[0] === 'pr' && args[1] === 'merge') {",
+          "  git(['switch', 'main'], process.cwd());",
+          "  git(['merge', '--ff-only', 'agentplane/v0.4.2'], process.cwd());",
+          "  git(['push', 'origin', 'main'], process.cwd());",
+          "  process.exit(0);",
+          "}",
+        ].join("\n"),
         "console.error('unexpected gh ' + args.join(' '));",
         "process.exit(2);",
       ].join("\n"),
     );
-    await writeFile(
-      path.join(binDir, "git"),
-      [
-        "#!/usr/bin/env node",
-        "const fs = require('node:fs');",
-        "const args = process.argv.slice(2);",
-        `fs.appendFileSync(${JSON.stringify(gitLog)}, args.join(" ") + String.fromCharCode(10));`,
-        "if (args[0] === 'status') { process.stdout.write(' M Formula/agentplane.rb' + String.fromCharCode(10)); process.exit(0); }",
-        "process.exit(0);",
-      ].join("\n"),
-    );
     await chmod(path.join(binDir, "gh"), 0o755);
-    await chmod(path.join(binDir, "git"), 0o755);
     const outPath = path.join(root, "result.json");
 
     const { stdout } = await execFileAsync(
@@ -206,11 +220,17 @@ describe("publish-external-distribution script", () => {
     const payload = JSON.parse(await readFile(outPath, "utf8")) as {
       status: string;
       prUrl: string;
+      verification: { ok: boolean; branch: string; sha: string };
       metadata: { ok: boolean; warnings: { target: string; reasonCode: string }[] };
     };
-    expect(stdout).toContain("homebrew external publish pr_opened");
-    expect(payload.status).toBe("pr_opened");
+    expect(stdout).toContain("homebrew external publish published");
+    expect(payload.status).toBe("published");
     expect(payload.prUrl).toBe("https://github.com/basilisk-labs/homebrew-tap/pull/7");
+    expect(payload.verification).toMatchObject({
+      ok: true,
+      branch: "main",
+    });
+    expect(payload.verification.sha).toMatch(/^[0-9a-f]{40}$/u);
     expect(payload.metadata.ok).toBe(false);
     expect(payload.metadata.warnings).toContainEqual(
       expect.objectContaining({
@@ -218,7 +238,7 @@ describe("publish-external-distribution script", () => {
         reasonCode: "external_metadata_permission_denied",
       }),
     );
-  });
+  }, 180_000);
 
   it("updates repository topics with a GitHub API JSON array payload", async () => {
     const root = await makeTempRoot();
@@ -255,7 +275,7 @@ describe("publish-external-distribution script", () => {
       [
         "#!/usr/bin/env node",
         "const args = process.argv.slice(2);",
-        "if (args[0] === 'status') { process.stdout.write(' M bucket/agentplane.json' + String.fromCharCode(10)); process.exit(0); }",
+        "if (args[0] === 'status') process.exit(0);",
         "process.exit(0);",
       ].join("\n"),
     );
@@ -308,4 +328,104 @@ describe("publish-external-distribution script", () => {
     expect(payload.metadata.updated).toContain("topics");
     expect(topicsPayload.names).toEqual(["agentplane", "scoop", "windows", "cli"]);
   });
+
+  it("creates the setup-agentplane version tag after publishing the action repository", async () => {
+    const root = await makeTempRoot();
+    const binDir = path.join(root, "bin");
+    const originDir = path.join(root, "origin.git");
+    await mkdir(path.join(root, "source"), { recursive: true });
+    await mkdir(binDir, { recursive: true });
+    await writeFile(path.join(root, "source", "action.yml"), "name: setup-agentplane\n");
+    await writeFile(path.join(root, "source", "README.md"), "# setup-agentplane\n");
+    await writeFile(
+      path.join(binDir, "gh"),
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "const path = require('node:path');",
+        "const { execFileSync } = require('node:child_process');",
+        "const args = process.argv.slice(2);",
+        `const originDir = ${JSON.stringify(originDir)};`,
+        "function git(gitArgs, cwd) { execFileSync('git', gitArgs, { cwd, stdio: 'ignore' }); }",
+        [
+          "if (args[0] === 'repo' && args[1] === 'clone') {",
+          "  fs.rmSync(originDir, { recursive: true, force: true });",
+          "  git(['init', '--bare', originDir]);",
+          "  git(['clone', originDir, args[3]]);",
+          "  git(['config', 'user.name', 'test'], args[3]);",
+          "  git(['config', 'user.email', 'test@example.com'], args[3]);",
+          "  git(['switch', '-c', 'main'], args[3]);",
+          "  fs.writeFileSync(path.join(args[3], 'action.yml'), 'name: old setup-agentplane' + String.fromCharCode(10));",
+          "  fs.writeFileSync(path.join(args[3], 'README.md'), '# old setup-agentplane' + String.fromCharCode(10));",
+          "  git(['add', '.'], args[3]);",
+          "  git(['commit', '-m', 'initial'], args[3]);",
+          "  git(['push', '--set-upstream', 'origin', 'main'], args[3]);",
+          "  process.exit(0);",
+          "}",
+        ].join("\n"),
+        "if (args[0] === 'auth') process.exit(0);",
+        "if (args[0] === 'api') process.exit(0);",
+        "if (args[0] === 'pr' && args[1] === 'list') { process.stdout.write(''); process.exit(0); }",
+        "if (args[0] === 'pr' && args[1] === 'create') { process.stdout.write('https://github.com/basilisk-labs/setup-agentplane/pull/7' + String.fromCharCode(10)); process.exit(0); }",
+        [
+          "if (args[0] === 'pr' && args[1] === 'merge') {",
+          "  git(['switch', 'main'], process.cwd());",
+          "  git(['merge', '--ff-only', 'agentplane/v0.4.2'], process.cwd());",
+          "  git(['push', 'origin', 'main'], process.cwd());",
+          "  process.exit(0);",
+          "}",
+        ].join("\n"),
+        "console.error('unexpected gh ' + args.join(' '));",
+        "process.exit(2);",
+      ].join("\n"),
+    );
+    await chmod(path.join(binDir, "gh"), 0o755);
+    const outPath = path.join(root, "result.json");
+
+    await execFileAsync(
+      "node",
+      [
+        SCRIPT_PATH,
+        "--module",
+        "setup-agentplane",
+        "--repo",
+        "basilisk-labs/setup-agentplane",
+        "--source",
+        path.join(root, "source"),
+        "--copy",
+        "action.yml:action.yml",
+        "--copy",
+        "README.md:README.md",
+        "--version",
+        "0.4.2",
+        "--tag",
+        "v0.4.2",
+        "--sha",
+        "abc123",
+        "--token-env",
+        "AGENTPLANE_TEST_TOKEN",
+        "--out",
+        outPath,
+      ],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          AGENTPLANE_TEST_TOKEN: "token",
+        },
+      },
+    );
+
+    const payload = JSON.parse(await readFile(outPath, "utf8")) as {
+      status: string;
+      setupTag: { status: string; tag: string; sha: string };
+    };
+    expect(payload.status).toBe("published");
+    expect(payload.setupTag).toMatchObject({
+      status: "published",
+      tag: "v0.4.2",
+    });
+    expect(payload.setupTag.sha).toMatch(/^[0-9a-f]{40}$/u);
+  }, 180_000);
 });

--- a/packages/agentplane/src/commands/release/publish-external-distribution-script.test.ts
+++ b/packages/agentplane/src/commands/release/publish-external-distribution-script.test.ts
@@ -239,7 +239,6 @@ describe("publish-external-distribution script", () => {
       }),
     );
   }, 180_000);
-
   it("updates repository topics with a GitHub API JSON array payload", async () => {
     const root = await makeTempRoot();
     const binDir = path.join(root, "bin");

--- a/packages/agentplane/src/commands/release/publish-workflow-contract.test.ts
+++ b/packages/agentplane/src/commands/release/publish-workflow-contract.test.ts
@@ -49,6 +49,8 @@ describe("publish workflow contract", () => {
     expect(workflow).toContain("node scripts/manifest.mjs publish-result");
     expect(workflow).toContain("name: publish-result");
     expect(workflow).toContain("path: .agentplane/.release/publish/publish-result.json");
+    expect(workflow).toContain("Fail incomplete publish-result");
+    expect(workflow).toContain("if (!payload.success)");
     expect(workflow).toContain("Generate release distribution assets");
     expect(workflow).toContain("node scripts/generate-release-distribution.mjs");
     expect(workflow).toContain("Smoke Bun release assets");
@@ -265,6 +267,8 @@ describe("publish workflow contract", () => {
     expect(workflow).toContain("Publish Scoop bucket PR");
     expect(workflow).toContain("Publish setup-agentplane PR");
     expect(workflow).toContain("distribution-module-${{ github.event.inputs.module }}");
+    expect(workflow).toContain("Fail incomplete external distribution module");
+    expect(workflow).toContain('["published", "unchanged"].includes(payload.status)');
     expect(workflow).not.toContain("npm publish");
     expect(workflow).not.toContain("Write npm auth config");
   });

--- a/packages/agentplane/src/commands/release/write-publish-result-manifest-script.test.ts
+++ b/packages/agentplane/src/commands/release/write-publish-result-manifest-script.test.ts
@@ -450,4 +450,74 @@ describe("manifest script publish-result command", () => {
       verification: { ok: true },
     });
   });
+
+  it("requires setup-agentplane tag proof when external files are unchanged", async () => {
+    const root = await makeRoot();
+    const setupResult = path.join(
+      root,
+      ".agentplane",
+      ".release",
+      "publish",
+      "setup-agentplane.json",
+    );
+    await mkdir(path.dirname(setupResult), { recursive: true });
+    await writeFile(
+      setupResult,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        module: "setup-agentplane",
+        repository: "basilisk-labs/setup-agentplane",
+        status: "unchanged",
+        verification: {
+          ok: true,
+          branch: "main",
+          sha: "a".repeat(40),
+        },
+      })}\n`,
+      "utf8",
+    );
+
+    const result = await runScript(root, [
+      "--json",
+      "--sha",
+      "abc123",
+      "--version",
+      "0.4.2",
+      "--tag",
+      "v0.4.2",
+      "--job-status",
+      "success",
+      "--core-prepublished",
+      "true",
+      "--recipes-prepublished",
+      "true",
+      "--cli-prepublished",
+      "true",
+      "--core-outcome",
+      "skipped",
+      "--recipes-outcome",
+      "skipped",
+      "--cli-outcome",
+      "skipped",
+      "--smoke-outcome",
+      "success",
+      "--tag-exists",
+      "true",
+      "--tag-outcome",
+      "skipped",
+      "--release-outcome",
+      "success",
+      "--external-result",
+      setupResult,
+    ]);
+
+    const payload = JSON.parse(String(result.stdout ?? "")) as {
+      success: boolean;
+      failures: string[];
+    };
+    expect(payload.success).toBe(false);
+    expect(payload.failures).toContain(
+      "external distribution setup-agentplane not confirmed (status=unchanged; setupTag=missing)",
+    );
+  });
 });

--- a/packages/agentplane/src/commands/release/write-publish-result-manifest-script.test.ts
+++ b/packages/agentplane/src/commands/release/write-publish-result-manifest-script.test.ts
@@ -286,7 +286,7 @@ describe("manifest script publish-result command", () => {
     );
   });
 
-  it("marks publish incomplete when required external distribution results are not confirmed", async () => {
+  it("marks publish incomplete when an external distribution PR is only opened", async () => {
     const root = await makeRoot();
     const homebrewResult = path.join(root, ".agentplane", ".release", "publish", "homebrew.json");
     const scoopResult = path.join(root, ".agentplane", ".release", "publish", "scoop.json");
@@ -373,7 +373,81 @@ describe("manifest script publish-result command", () => {
       metadata: { ok: false },
     });
     expect(payload.failures).toContain(
+      "external distribution homebrew not confirmed (status=pr_opened)",
+    );
+    expect(payload.failures).toContain(
       "external distribution scoop not confirmed (status=skipped_missing_credentials reason=missing_credentials)",
     );
+  });
+
+  it("accepts merged and verified external distribution results as publish proof", async () => {
+    const root = await makeRoot();
+    const homebrewResult = path.join(root, ".agentplane", ".release", "publish", "homebrew.json");
+    await mkdir(path.dirname(homebrewResult), { recursive: true });
+    await writeFile(
+      homebrewResult,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        module: "homebrew",
+        repository: "basilisk-labs/homebrew-tap",
+        status: "published",
+        prUrl: "https://github.com/basilisk-labs/homebrew-tap/pull/7",
+        verification: {
+          ok: true,
+          branch: "main",
+          sha: "a".repeat(40),
+        },
+      })}\n`,
+      "utf8",
+    );
+
+    const result = await runScript(root, [
+      "--json",
+      "--sha",
+      "abc123",
+      "--version",
+      "0.4.2",
+      "--tag",
+      "v0.4.2",
+      "--job-status",
+      "success",
+      "--core-prepublished",
+      "true",
+      "--recipes-prepublished",
+      "true",
+      "--cli-prepublished",
+      "true",
+      "--core-outcome",
+      "skipped",
+      "--recipes-outcome",
+      "skipped",
+      "--cli-outcome",
+      "skipped",
+      "--smoke-outcome",
+      "success",
+      "--tag-exists",
+      "true",
+      "--tag-outcome",
+      "skipped",
+      "--release-outcome",
+      "success",
+      "--external-result",
+      homebrewResult,
+    ]);
+
+    const payload = JSON.parse(String(result.stdout ?? "")) as {
+      success: boolean;
+      failures: string[];
+      external: {
+        modules: { name: string; status: string; verification?: { ok: boolean } }[];
+      };
+    };
+    expect(payload.success).toBe(true);
+    expect(payload.failures).toHaveLength(0);
+    expect(payload.external.modules[0]).toMatchObject({
+      name: "homebrew",
+      status: "published",
+      verification: { ok: true },
+    });
   });
 });

--- a/scripts/release/manifest.mjs
+++ b/scripts/release/manifest.mjs
@@ -353,11 +353,21 @@ function buildPublishResultManifest(args) {
   }
   const externalModules = args.external?.modules ?? [];
   for (const module of externalModules) {
-    if (module.loaded && ["published", "unchanged"].includes(module.status)) continue;
+    const setupTagConfirmed =
+      module.name !== "setup-agentplane" || module.setupTag?.status === "published";
+    if (module.loaded && ["published", "unchanged"].includes(module.status) && setupTagConfirmed) {
+      continue;
+    }
     const detail = module.loaded
       ? `status=${module.status}${module.reasonCode ? ` reason=${module.reasonCode}` : ""}`
       : `unavailable (${module.reason})`;
-    failures.push(`external distribution ${module.name} not confirmed (${detail})`);
+    const setupTagDetail =
+      module.loaded && module.name === "setup-agentplane" && !setupTagConfirmed
+        ? `; setupTag=${module.setupTag?.status ?? "missing"}`
+        : "";
+    failures.push(
+      `external distribution ${module.name} not confirmed (${detail}${setupTagDetail})`,
+    );
   }
 
   const success = failures.length === 0;

--- a/scripts/release/manifest.mjs
+++ b/scripts/release/manifest.mjs
@@ -353,7 +353,7 @@ function buildPublishResultManifest(args) {
   }
   const externalModules = args.external?.modules ?? [];
   for (const module of externalModules) {
-    if (module.loaded && ["pr_opened", "unchanged"].includes(module.status)) continue;
+    if (module.loaded && ["published", "unchanged"].includes(module.status)) continue;
     const detail = module.loaded
       ? `status=${module.status}${module.reasonCode ? ` reason=${module.reasonCode}` : ""}`
       : `unavailable (${module.reason})`;
@@ -480,6 +480,9 @@ async function loadExternalResult(filePath) {
       prUrl: payload.prUrl ?? null,
       branch: payload.branch ?? null,
       metadata: payload.metadata ?? null,
+      mergeAttempts: Array.isArray(payload.mergeAttempts) ? payload.mergeAttempts : [],
+      verification: payload.verification ?? null,
+      setupTag: payload.setupTag ?? null,
       nextAction: payload.nextAction ?? null,
     };
   } catch (error) {

--- a/scripts/release/publish-external-distribution.mjs
+++ b/scripts/release/publish-external-distribution.mjs
@@ -276,10 +276,14 @@ async function publishExternal(args) {
         env,
       });
       const headSha = headStdout.trim();
-      const { stdout: existingStdout } = await run("git", ["ls-remote", "--tags", "origin", tagRef], {
-        cwd: cloneDir,
-        env,
-      });
+      const { stdout: existingStdout } = await run(
+        "git",
+        ["ls-remote", "--tags", "origin", tagRef],
+        {
+          cwd: cloneDir,
+          env,
+        },
+      );
       const existingSha = existingStdout
         .trim()
         .split(/\s+/u)

--- a/scripts/release/publish-external-distribution.mjs
+++ b/scripts/release/publish-external-distribution.mjs
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
-import { mkdir, writeFile, copyFile } from "node:fs/promises";
+import { mkdir, writeFile, copyFile, readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -119,6 +119,7 @@ async function run(command, args, opts = {}) {
   return execFileAsync(command, args, {
     cwd: opts.cwd,
     env: opts.env ?? process.env,
+    input: opts.input,
     maxBuffer: 20 * 1024 * 1024,
   });
 }
@@ -241,6 +242,148 @@ async function publishExternal(args) {
     };
   }
 
+  async function verifyDefaultBranchPublished(cloneDir) {
+    await run("git", ["fetch", "origin", "main"], { cwd: cloneDir, env });
+    await run("git", ["switch", "main"], { cwd: cloneDir, env });
+    await run("git", ["pull", "--ff-only", "origin", "main"], { cwd: cloneDir, env });
+    const mismatches = [];
+    for (const copy of args.copies.map((entry) => parseCopySpec(entry))) {
+      const source = await readFile(path.join(args.sourceDir, copy.from), "utf8");
+      const target = await readFile(path.join(cloneDir, copy.to), "utf8").catch(() => null);
+      if (target !== source) mismatches.push(copy.to);
+    }
+    if (mismatches.length > 0) {
+      return {
+        ok: false,
+        mismatches,
+      };
+    }
+    const { stdout } = await run("git", ["rev-parse", "HEAD"], { cwd: cloneDir, env });
+    return {
+      ok: true,
+      branch: "main",
+      sha: stdout.trim(),
+      mismatches,
+    };
+  }
+
+  async function ensureSetupAgentplaneTag(cloneDir) {
+    if (args.module !== "setup-agentplane") return null;
+    const tagRef = `refs/tags/${args.tag}`;
+    try {
+      const { stdout: headStdout } = await run("git", ["rev-parse", "HEAD"], {
+        cwd: cloneDir,
+        env,
+      });
+      const headSha = headStdout.trim();
+      const { stdout: existingStdout } = await run("git", ["ls-remote", "--tags", "origin", tagRef], {
+        cwd: cloneDir,
+        env,
+      });
+      const existingSha = existingStdout
+        .trim()
+        .split(/\s+/u)
+        .find((entry) => /^[0-9a-f]{40}$/iu.test(entry));
+      if (existingSha) {
+        return {
+          status: existingSha === headSha ? "published" : "failed",
+          tag: args.tag,
+          sha: existingSha,
+          message:
+            existingSha === headSha
+              ? "setup-agentplane tag already points at the published commit."
+              : `setup-agentplane tag ${args.tag} points at ${existingSha}, expected ${headSha}.`,
+        };
+      }
+      await run("git", ["tag", args.tag], { cwd: cloneDir, env });
+      await run("git", ["push", "origin", `${tagRef}:${tagRef}`], {
+        cwd: cloneDir,
+        env,
+      });
+      const { stdout: pushedStdout } = await run("git", ["ls-remote", "--tags", "origin", tagRef], {
+        cwd: cloneDir,
+        env,
+      });
+      const pushedSha = pushedStdout
+        .trim()
+        .split(/\s+/u)
+        .find((entry) => /^[0-9a-f]{40}$/iu.test(entry));
+      return {
+        status: pushedSha === headSha ? "published" : "not_confirmed",
+        tag: args.tag,
+        sha: pushedSha ?? null,
+      };
+    } catch (error) {
+      return {
+        status: "failed",
+        tag: args.tag,
+        message: String(error?.stderr ?? error?.message ?? error).trim(),
+      };
+    }
+  }
+
+  async function mergeAndVerifyExternalPr(cloneDir, prUrl) {
+    const mergeAttempts = [];
+    try {
+      await run("gh", ["pr", "merge", "--repo", args.repo, "--merge", "--delete-branch", prUrl], {
+        cwd: cloneDir,
+        env,
+      });
+      mergeAttempts.push({ mode: "merge", status: "success" });
+    } catch (error) {
+      mergeAttempts.push({
+        mode: "merge",
+        status: "failed",
+        message: String(error?.stderr ?? error?.message ?? error).trim(),
+      });
+      try {
+        await run(
+          "gh",
+          ["pr", "merge", "--repo", args.repo, "--auto", "--merge", "--delete-branch", prUrl],
+          { cwd: cloneDir, env },
+        );
+        mergeAttempts.push({ mode: "auto_merge", status: "enabled" });
+      } catch (autoError) {
+        mergeAttempts.push({
+          mode: "auto_merge",
+          status: "failed",
+          message: String(autoError?.stderr ?? autoError?.message ?? autoError).trim(),
+        });
+      }
+      return {
+        status: "pr_opened",
+        mergeAttempts,
+        verification: null,
+        setupTag: null,
+      };
+    }
+
+    const verification = await verifyDefaultBranchPublished(cloneDir);
+    const setupTag = verification.ok ? await ensureSetupAgentplaneTag(cloneDir) : null;
+    if (!verification.ok) {
+      return {
+        status: "merge_unverified",
+        mergeAttempts,
+        verification,
+        setupTag,
+      };
+    }
+    if (setupTag && setupTag.status !== "published") {
+      return {
+        status: "tag_unverified",
+        mergeAttempts,
+        verification,
+        setupTag,
+      };
+    }
+    return {
+      status: "published",
+      mergeAttempts,
+      verification,
+      setupTag,
+    };
+  }
+
   const tempRoot = mkdtempSync(path.join(os.tmpdir(), "agentplane-external-dist-"));
   const cloneDir = path.join(tempRoot, "repo");
   const branch = `agentplane/${args.tag}`;
@@ -326,13 +469,20 @@ async function publishExternal(args) {
     }
     const prUrl = existingPrUrl || createdPrUrl;
     const metadata = await syncRepositoryMetadata(cloneDir);
+    const publication = await mergeAndVerifyExternalPr(cloneDir, prUrl);
     return {
       ...baseEvidence,
-      status: "pr_opened",
+      status: publication.status,
       branch,
       prUrl,
       metadata,
-      nextAction: `Review and merge ${prUrl}.`,
+      mergeAttempts: publication.mergeAttempts,
+      verification: publication.verification,
+      setupTag: publication.setupTag,
+      nextAction:
+        publication.status === "published"
+          ? `External distribution published through ${prUrl}.`
+          : `Review and merge ${prUrl}; this channel is not published until main contains ${args.version}.`,
     };
   } finally {
     rmSync(tempRoot, { recursive: true, force: true });

--- a/scripts/release/publish-external-distribution.mjs
+++ b/scripts/release/publish-external-distribution.mjs
@@ -407,11 +407,40 @@ async function publishExternal(args) {
     });
     if (!statusStdout.trim()) {
       const metadata = await syncRepositoryMetadata(cloneDir);
+      const verification = await verifyDefaultBranchPublished(cloneDir);
+      const setupTag = verification.ok ? await ensureSetupAgentplaneTag(cloneDir) : null;
+      if (!verification.ok) {
+        return {
+          ...baseEvidence,
+          status: "merge_unverified",
+          branch,
+          metadata,
+          mergeAttempts: [],
+          verification,
+          setupTag,
+          nextAction: `External distribution files did not match ${args.version} on main.`,
+        };
+      }
+      if (setupTag && setupTag.status !== "published") {
+        return {
+          ...baseEvidence,
+          status: "tag_unverified",
+          branch,
+          metadata,
+          mergeAttempts: [],
+          verification,
+          setupTag,
+          nextAction: `Fix setup-agentplane tag ${args.tag}; this channel is not published until the tag points at main.`,
+        };
+      }
       return {
         ...baseEvidence,
         status: "unchanged",
         branch,
         metadata,
+        mergeAttempts: [],
+        verification,
+        setupTag,
         nextAction: "No external distribution repository changes were needed.",
       };
     }


### PR DESCRIPTION
Task: `202605141404-8FZMYJ`
Title: Fail closed on external release publication
Canonical task record: `.agentplane/tasks/202605141404-8FZMYJ/README.md`

## Summary

Fail closed on external release publication

External distribution PR handoff must not be treated as completed publication; release evidence must require merged/default-branch verified channels or mark the release incomplete.

## Scope

- In scope: External distribution PR handoff must not be treated as completed publication; release evidence must require merged/default-branch verified channels or mark the release incomplete.
- Out of scope: unrelated refactors not required for "Fail closed on external release publication".

## Verification

- State: ok
- Note:

```text
Focused release publication checks passed: publish-result now treats pr_opened as incomplete,
external publisher verifies merged default-branch state, setup-agentplane tag publication is
covered, workflow contract fails incomplete publish-result, routing check passed.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-14T14:24:30.441Z
- Branch: task/202605141404-8FZMYJ/external-release-publish-proof
- Head: 635a230e3ef1

```text
 .github/workflows/publish-distribution-module.yml  |  26 ++++
 .github/workflows/publish.yml                      |   6 +
 docs/developer/release-and-publishing.mdx          |  11 +-
 .../publish-external-distribution-script.test.ts   | 104 +++++++++++++-
 .../release/publish-workflow-contract.test.ts      |   4 +
 .../write-publish-result-manifest-script.test.ts   |  76 +++++++++-
 scripts/release/manifest.mjs                       |   5 +-
 scripts/release/publish-external-distribution.mjs  | 159 ++++++++++++++++++++-
 8 files changed, 377 insertions(+), 14 deletions(-)
```

</details>
