### PR TITLE
🚧 SAV86C task: Allow initial install commit through pre-push [202605141500-SAV86C]

### DIFF
--- a/.agentplane/tasks/202605141500-SAV86C/README.md
+++ b/.agentplane/tasks/202605141500-SAV86C/README.md
@@ -1,0 +1,150 @@
+---
+id: "202605141500-SAV86C"
+title: "Allow initial install commit through pre-push"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-14T15:00:54.644Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-14T15:20:53.373Z"
+  updated_by: "CODER"
+  note: "Implemented a narrow managed initial install commit exception in both pre-push implementations and added regression coverage proving fresh install commits pass while install-like subjects touching src remain blocked. Checks passed: pre-push task-binding Vitest 7/7, runtime-shim Vitest 5/5, Prettier check, ESLint on touched files, typecheck after bootstrap, and policy routing. Audit finding: context init uses synthetic CTX1NT bootstrap commit and may have a similar first-push edge; it needs a separate focused reproduction because the temp hook simulation was dominated by package-script resolution noise."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement the approved init/pre-push bootstrap fix by adding a narrow managed initial install commit exception, regression coverage for the first push after init with hooks, and an audit of adjacent managed commit flows for similar hook exception gaps."
+events:
+  -
+    type: "status"
+    at: "2026-05-14T15:01:27.245Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement the approved init/pre-push bootstrap fix by adding a narrow managed initial install commit exception, regression coverage for the first push after init with hooks, and an audit of adjacent managed commit flows for similar hook exception gaps."
+  -
+    type: "verify"
+    at: "2026-05-14T15:20:53.373Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented a narrow managed initial install commit exception in both pre-push implementations and added regression coverage proving fresh install commits pass while install-like subjects touching src remain blocked. Checks passed: pre-push task-binding Vitest 7/7, runtime-shim Vitest 5/5, Prettier check, ESLint on touched files, typecheck after bootstrap, and policy routing. Audit finding: context init uses synthetic CTX1NT bootstrap commit and may have a similar first-push edge; it needs a separate focused reproduction because the temp hook simulation was dominated by package-script resolution noise."
+doc_version: 3
+doc_updated_at: "2026-05-14T15:20:53.451Z"
+doc_updated_by: "CODER"
+description: "Fix the task-bound pre-push audit so the AgentPlane-managed initial install commit created by agentplane init can be pushed, then audit adjacent bootstrap/hook exceptions for similar contract gaps."
+sections:
+  Summary: |-
+    Allow initial install commit through pre-push
+    
+    Fix the task-bound pre-push audit so the AgentPlane-managed initial install commit created by agentplane init can be pushed, then audit adjacent bootstrap/hook exceptions for similar contract gaps.
+  Scope: |-
+    - In scope: Fix the task-bound pre-push audit so the AgentPlane-managed initial install commit created by agentplane init can be pushed, then audit adjacent bootstrap/hook exceptions for similar contract gaps.
+    - Out of scope: unrelated refactors not required for "Allow initial install commit through pre-push".
+  Plan: "Plan: (1) Reproduce the gap in existing hook/init tests and identify both pre-push implementations that audit outgoing commits. (2) Add a narrow managed initial install commit exception for subjects created by agentplane init, without weakening task-bound mutation checks for ordinary chore commits. (3) Add regression coverage that fresh init install commits with hooks pass the simulated pre-push audit. (4) Run focused hook/init tests plus routing checks. (5) Audit adjacent managed commit flows (upgrade, lifecycle/status/finish, release/apply) for similar hook exception mismatches and record findings."
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+    
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-14T15:20:53.373Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Implemented a narrow managed initial install commit exception in both pre-push implementations and added regression coverage proving fresh install commits pass while install-like subjects touching src remain blocked. Checks passed: pre-push task-binding Vitest 7/7, runtime-shim Vitest 5/5, Prettier check, ESLint on touched files, typecheck after bootstrap, and policy routing. Audit finding: context init uses synthetic CTX1NT bootstrap commit and may have a similar first-push edge; it needs a separate focused reproduction because the temp hook simulation was dominated by package-script resolution noise.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T15:01:27.245Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141500-SAV86C-init-install-prepush/.agentplane/tasks/202605141500-SAV86C/blueprint/resolved-snapshot.json
+    - old_digest: 92e173a05253ed5c96af65642f6b9edde2b34f9696faa45067b8798ecaf71355
+    - current_digest: 92e173a05253ed5c96af65642f6b9edde2b34f9696faa45067b8798ecaf71355
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141500-SAV86C
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Initial install commits created by agentplane init were not recognized as managed commits by outgoing pre-push task-bound mutation audit.
+      Impact: Fresh users could initialize successfully but fail their first git push, as seen in the Windows report.
+      Resolution: Added managed install evidence checks constrained by exact install subject shape and bootstrap-managed paths; ordinary mutating paths with the same subject still fail.
+id_source: "generated"
+---
+## Summary
+
+Allow initial install commit through pre-push
+
+Fix the task-bound pre-push audit so the AgentPlane-managed initial install commit created by agentplane init can be pushed, then audit adjacent bootstrap/hook exceptions for similar contract gaps.
+
+## Scope
+
+- In scope: Fix the task-bound pre-push audit so the AgentPlane-managed initial install commit created by agentplane init can be pushed, then audit adjacent bootstrap/hook exceptions for similar contract gaps.
+- Out of scope: unrelated refactors not required for "Allow initial install commit through pre-push".
+
+## Plan
+
+Plan: (1) Reproduce the gap in existing hook/init tests and identify both pre-push implementations that audit outgoing commits. (2) Add a narrow managed initial install commit exception for subjects created by agentplane init, without weakening task-bound mutation checks for ordinary chore commits. (3) Add regression coverage that fresh init install commits with hooks pass the simulated pre-push audit. (4) Run focused hook/init tests plus routing checks. (5) Audit adjacent managed commit flows (upgrade, lifecycle/status/finish, release/apply) for similar hook exception mismatches and record findings.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-14T15:20:53.373Z — VERIFY — ok
+
+By: CODER
+
+Note: Implemented a narrow managed initial install commit exception in both pre-push implementations and added regression coverage proving fresh install commits pass while install-like subjects touching src remain blocked. Checks passed: pre-push task-binding Vitest 7/7, runtime-shim Vitest 5/5, Prettier check, ESLint on touched files, typecheck after bootstrap, and policy routing. Audit finding: context init uses synthetic CTX1NT bootstrap commit and may have a similar first-push edge; it needs a separate focused reproduction because the temp hook simulation was dominated by package-script resolution noise.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T15:01:27.245Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141500-SAV86C-init-install-prepush/.agentplane/tasks/202605141500-SAV86C/blueprint/resolved-snapshot.json
+- old_digest: 92e173a05253ed5c96af65642f6b9edde2b34f9696faa45067b8798ecaf71355
+- current_digest: 92e173a05253ed5c96af65642f6b9edde2b34f9696faa45067b8798ecaf71355
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141500-SAV86C
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Initial install commits created by agentplane init were not recognized as managed commits by outgoing pre-push task-bound mutation audit.
+  Impact: Fresh users could initialize successfully but fail their first git push, as seen in the Windows report.
+  Resolution: Added managed install evidence checks constrained by exact install subject shape and bootstrap-managed paths; ordinary mutating paths with the same subject still fail.

--- a/.agentplane/tasks/202605141500-SAV86C/pr/diffstat.txt
+++ b/.agentplane/tasks/202605141500-SAV86C/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ ...un-cli.core.hooks.pre-push-task-binding.test.ts | 45 ++++++++++++++++++++++
+ .../agentplane/src/commands/hooks/run.pre-push.ts  | 31 +++++++++++++++
+ scripts/checks/run-pre-push-hook.mjs               | 31 +++++++++++++++
+ 3 files changed, 107 insertions(+)

--- a/.agentplane/tasks/202605141500-SAV86C/pr/github-body.md
+++ b/.agentplane/tasks/202605141500-SAV86C/pr/github-body.md
@@ -1,0 +1,46 @@
+Task: `202605141500-SAV86C`
+Title: Allow initial install commit through pre-push
+Canonical task record: `.agentplane/tasks/202605141500-SAV86C/README.md`
+
+## Summary
+
+Allow initial install commit through pre-push
+
+Fix the task-bound pre-push audit so the AgentPlane-managed initial install commit created by agentplane init can be pushed, then audit adjacent bootstrap/hook exceptions for similar contract gaps.
+
+## Scope
+
+- In scope: Fix the task-bound pre-push audit so the AgentPlane-managed initial install commit created by agentplane init can be pushed, then audit adjacent bootstrap/hook exceptions for similar contract gaps.
+- Out of scope: unrelated refactors not required for "Allow initial install commit through pre-push".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Implemented a narrow managed initial install commit exception in both pre-push implementations and
+added regression coverage proving fresh install commits pass while install-like subjects touching
+src remain blocked. Checks passed: pre-push task-binding Vitest 7/7, runtime-shim Vitest 5/5,
+Prettier check, ESLint on touched files, typecheck after bootstrap, and policy routing. Audit
+finding: context init uses synthetic CTX1NT bootstrap commit and may have a similar first-push edge;
+it needs a separate focused reproduction because the temp hook simulation was dominated by
+package-script resolution noise.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T15:24:28.289Z
+- Branch: task/202605141500-SAV86C/init-install-prepush
+- Head: f8e9d536b1b5
+
+```text
+ ...un-cli.core.hooks.pre-push-task-binding.test.ts | 45 ++++++++++++++++++++++
+ .../agentplane/src/commands/hooks/run.pre-push.ts  | 31 +++++++++++++++
+ scripts/checks/run-pre-push-hook.mjs               | 31 +++++++++++++++
+ 3 files changed, 107 insertions(+)
+```
+
+</details>

--- a/.agentplane/tasks/202605141500-SAV86C/pr/github-title.txt
+++ b/.agentplane/tasks/202605141500-SAV86C/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 SAV86C task: Allow initial install commit through pre-push [202605141500-SAV86C]

--- a/.agentplane/tasks/202605141500-SAV86C/pr/meta.json
+++ b/.agentplane/tasks/202605141500-SAV86C/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "f8e9d536b1b5e93c7b9f13659f2746074e5c74f2",
   "last_verified_at": "2026-05-14T15:20:53.373Z",
   "last_verified_sha": "31bb4314cf339cc4e2fe113ba191c2acc2f730bb",
+  "pr_number": 3724,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3724",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605141500-SAV86C",
-  "updated_at": "2026-05-14T15:24:28.289Z",
+  "updated_at": "2026-05-14T15:26:25.307Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141500-SAV86C/pr/meta.json
+++ b/.agentplane/tasks/202605141500-SAV86C/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605141500-SAV86C/init-install-prepush",
+  "created_at": "2026-05-14T15:01:27.456Z",
+  "head_sha": "f8e9d536b1b5e93c7b9f13659f2746074e5c74f2",
+  "last_verified_at": "2026-05-14T15:20:53.373Z",
+  "last_verified_sha": "31bb4314cf339cc4e2fe113ba191c2acc2f730bb",
+  "schema_version": 1,
+  "task_id": "202605141500-SAV86C",
+  "updated_at": "2026-05-14T15:24:28.289Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605141500-SAV86C/pr/review.md
+++ b/.agentplane/tasks/202605141500-SAV86C/pr/review.md
@@ -1,0 +1,39 @@
+# PR Review
+
+Created: 2026-05-14T15:01:27.456Z
+
+## Task
+
+- Task: `202605141500-SAV86C`
+- Title: Allow initial install commit through pre-push
+- Status: DOING
+- Branch: `task/202605141500-SAV86C/init-install-prepush`
+- Canonical task record: `.agentplane/tasks/202605141500-SAV86C/README.md`
+
+## Verification
+
+- State: ok
+- Note: Implemented a narrow managed initial install commit exception in both pre-push implementations and added regression coverage proving fresh install commits pass while install-like subjects touching src remain blocked. Checks passed: pre-push task-binding Vitest 7/7, runtime-shim Vitest 5/5, Prettier check, ESLint on touched files, typecheck after bootstrap, and policy routing. Audit finding: context init uses synthetic CTX1NT bootstrap commit and may have a similar first-push edge; it needs a separate focused reproduction because the temp hook simulation was dominated by package-script resolution noise.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T15:24:28.289Z
+- Branch: task/202605141500-SAV86C/init-install-prepush
+- Head: f8e9d536b1b5
+
+```text
+ ...un-cli.core.hooks.pre-push-task-binding.test.ts | 45 ++++++++++++++++++++++
+ .../agentplane/src/commands/hooks/run.pre-push.ts  | 31 +++++++++++++++
+ scripts/checks/run-pre-push-hook.mjs               | 31 +++++++++++++++
+ 3 files changed, 107 insertions(+)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/cli/run-cli.core.hooks.pre-push-task-binding.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.hooks.pre-push-task-binding.test.ts
@@ -162,6 +162,51 @@ describe("pre-push task binding audit", () => {
     expect(String(result.failure?.stderr ?? "")).toContain("src/app.ts");
   });
 
+  it("accepts managed initial install commits", async () => {
+    const root = await mkGitRepoRootWithBranch("main");
+    await configureGitUser(root);
+    await writeFastHookPackage(root);
+    await commitAll(root, "chore: base");
+    const baseSha = head(root);
+
+    await mkdir(path.join(root, ".agentplane", "agents"), { recursive: true });
+    await mkdir(path.join(root, ".agentplane", "policy"), { recursive: true });
+    await mkdir(path.join(root, ".cursor", "rules"), { recursive: true });
+    await writeFile(path.join(root, "AGENTS.md"), "# Policy gateway\n", "utf8");
+    await writeFile(path.join(root, ".gitignore"), ".agentplane/tasks.json\n", "utf8");
+    await writeFile(path.join(root, ".agentplane", "agents", "CODER.json"), "{}\n", "utf8");
+    await writeFile(path.join(root, ".agentplane", "policy", "dod.core.md"), "# DoD\n", "utf8");
+    await writeFile(
+      path.join(root, ".cursor", "rules", "agentplane.mdc"),
+      "Use AGENTS.md.\n",
+      "utf8",
+    );
+    await commitAll(root, "chore: install agentplane 0.6.0");
+    const result = runPrePush(root, baseSha, head(root));
+
+    expect(result.failure).toBeNull();
+    expect(result.stdout).toContain("Running pre-push checks in standard mode.");
+  });
+
+  it("does not let install-like subjects bypass task binding for non-install paths", async () => {
+    const root = await mkGitRepoRootWithBranch("main");
+    await configureGitUser(root);
+    await writeFastHookPackage(root);
+    await commitAll(root, "chore: base");
+    const baseSha = head(root);
+
+    await mkdir(path.join(root, "src"), { recursive: true });
+    await writeFile(path.join(root, "src", "app.ts"), "export const value = 1;\n", "utf8");
+    await commitAll(root, "chore: install agentplane 0.6.0");
+    const result = runPrePush(root, baseSha, head(root));
+
+    expect(result.failure).not.toBeNull();
+    expect(String(result.failure?.stderr ?? "")).toContain(
+      "pre-push blocked: mutating commits require a valid task id",
+    );
+    expect(String(result.failure?.stderr ?? "")).toContain("src/app.ts");
+  });
+
   it("includes merge commits in mutating commit audits", async () => {
     const root = await mkGitRepoRootWithBranch("main");
     await configureGitUser(root);

--- a/packages/agentplane/src/commands/hooks/run.pre-push.ts
+++ b/packages/agentplane/src/commands/hooks/run.pre-push.ts
@@ -252,6 +252,36 @@ function hasManagedUpgradeEvidence(body: string): boolean {
   return /^⬆️\s+upgrade:\s+/u.test(subject) && /^Upgrade-Version:\s*\S+\s*$/im.test(body);
 }
 
+function isManagedInstallPath(filePath: string): boolean {
+  return (
+    filePath === "AGENTS.md" ||
+    filePath === "CLAUDE.md" ||
+    filePath === ".gitignore" ||
+    filePath === ".env.example" ||
+    gitPathIsUnder(filePath, ".agentplane") ||
+    gitPathIsUnder(filePath, ".cursor") ||
+    gitPathIsUnder(filePath, ".windsurf")
+  );
+}
+
+function hasManagedInstallEvidence(body: string, mutatingPaths: readonly string[]): boolean {
+  const subject =
+    body
+      .split("\n")
+      .find((line) => line.trim())
+      ?.trim() ?? "";
+  if (
+    !/^chore:\s+install agentplane \d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(
+      subject,
+    )
+  ) {
+    return false;
+  }
+  return (
+    mutatingPaths.length > 0 && mutatingPaths.every((filePath) => isManagedInstallPath(filePath))
+  );
+}
+
 function readCommitList(gitRoot: string, range: { from: string; to: string } | null): string[] {
   if (!range) return [];
   return readGitText(gitRoot, ["log", "--format=%H", `${range.from}..${range.to}`])
@@ -290,6 +320,7 @@ function enforceTaskBoundOutgoingCommits(
         ?.trim() ?? "";
     if (taskIdFromSubject(gitRoot, subject)) continue;
     if (hasManagedUpgradeEvidence(body)) continue;
+    if (hasManagedInstallEvidence(body, mutating)) continue;
     if (hasEmergencyBackfillEvidence(body)) continue;
 
     failures.push(

--- a/scripts/checks/run-pre-push-hook.mjs
+++ b/scripts/checks/run-pre-push-hook.mjs
@@ -189,6 +189,36 @@ function hasManagedUpgradeEvidence(body) {
   return /^⬆️\s+upgrade:\s+/u.test(subject) && /^Upgrade-Version:\s*\S+\s*$/im.test(body);
 }
 
+function isManagedInstallPath(filePath) {
+  return (
+    filePath === "AGENTS.md" ||
+    filePath === "CLAUDE.md" ||
+    filePath === ".gitignore" ||
+    filePath === ".env.example" ||
+    isUnder(filePath, ".agentplane") ||
+    isUnder(filePath, ".cursor") ||
+    isUnder(filePath, ".windsurf")
+  );
+}
+
+function hasManagedInstallEvidence(body, mutatingPaths) {
+  const subject =
+    body
+      .split("\n")
+      .find((line) => line.trim())
+      ?.trim() ?? "";
+  if (
+    !/^chore:\s+install agentplane \d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(
+      subject,
+    )
+  ) {
+    return false;
+  }
+  return (
+    mutatingPaths.length > 0 && mutatingPaths.every((filePath) => isManagedInstallPath(filePath))
+  );
+}
+
 function readCommitList(range) {
   if (!range) return [];
   return readQuiet("git", ["log", "--format=%H", `${range.from}..${range.to}`])
@@ -224,6 +254,7 @@ function enforceTaskBoundOutgoingCommits(range) {
         ?.trim() ?? "";
     if (taskIdFromSubject(subject)) continue;
     if (hasManagedUpgradeEvidence(body)) continue;
+    if (hasManagedInstallEvidence(body, mutating)) continue;
     if (hasEmergencyBackfillEvidence(body)) continue;
 
     failures.push(


### PR DESCRIPTION
Task: `202605141500-SAV86C`
Title: Allow initial install commit through pre-push
Canonical task record: `.agentplane/tasks/202605141500-SAV86C/README.md`

## Summary

Allow initial install commit through pre-push

Fix the task-bound pre-push audit so the AgentPlane-managed initial install commit created by agentplane init can be pushed, then audit adjacent bootstrap/hook exceptions for similar contract gaps.

## Scope

- In scope: Fix the task-bound pre-push audit so the AgentPlane-managed initial install commit created by agentplane init can be pushed, then audit adjacent bootstrap/hook exceptions for similar contract gaps.
- Out of scope: unrelated refactors not required for "Allow initial install commit through pre-push".

## Verification

- State: ok
- Note:

```text
Implemented a narrow managed initial install commit exception in both pre-push implementations and
added regression coverage proving fresh install commits pass while install-like subjects touching
src remain blocked. Checks passed: pre-push task-binding Vitest 7/7, runtime-shim Vitest 5/5,
Prettier check, ESLint on touched files, typecheck after bootstrap, and policy routing. Audit
finding: context init uses synthetic CTX1NT bootstrap commit and may have a similar first-push edge;
it needs a separate focused reproduction because the temp hook simulation was dominated by
package-script resolution noise.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-14T15:24:28.289Z
- Branch: task/202605141500-SAV86C/init-install-prepush
- Head: f8e9d536b1b5

```text
 ...un-cli.core.hooks.pre-push-task-binding.test.ts | 45 ++++++++++++++++++++++
 .../agentplane/src/commands/hooks/run.pre-push.ts  | 31 +++++++++++++++
 scripts/checks/run-pre-push-hook.mjs               | 31 +++++++++++++++
 3 files changed, 107 insertions(+)
```

</details>
