### PR TITLE
🚧 363FBC task: Ignore SQLite cache on read-heavy commands [202605141516-363FBC]

### DIFF
--- a/.agentplane/tasks/202605141516-363FBC/README.md
+++ b/.agentplane/tasks/202605141516-363FBC/README.md
@@ -4,7 +4,7 @@ title: "Ignore SQLite cache on read-heavy commands"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 4
+revision: 5
 origin:
   system: "manual"
 depends_on: []
@@ -19,10 +19,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-14T15:37:51.644Z"
+  updated_by: "CODER"
+  note: "Verified: SQLite cache writers repair stale .gitignore entries for .agentplane/cache.sqlite, .agentplane/cache.sqlite-wal, and .agentplane/cache.sqlite-shm before writing the shared cache. Evidence: focused LocalBackend/context tests pass, exact-file ESLint passes, typecheck passes, policy routing passes, git diff whitespace check passes, and doctor is OK with unrelated pre-existing branch_pr normalization warnings."
   attempts: 0
 commit: null
 comments:
@@ -37,8 +37,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: Implementing the approved SQLite cache ignore repair in the dedicated task worktree, scoped to runtime gitignore/cache handling plus a regression test for stale initialized repositories."
+  -
+    type: "verify"
+    at: "2026-05-14T15:37:51.644Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: SQLite cache writers repair stale .gitignore entries for .agentplane/cache.sqlite, .agentplane/cache.sqlite-wal, and .agentplane/cache.sqlite-shm before writing the shared cache. Evidence: focused LocalBackend/context tests pass, exact-file ESLint passes, typecheck passes, policy routing passes, git diff whitespace check passes, and doctor is OK with unrelated pre-existing branch_pr normalization warnings."
 doc_version: 3
-doc_updated_at: "2026-05-14T15:17:28.752Z"
+doc_updated_at: "2026-05-14T15:37:51.747Z"
 doc_updated_by: "CODER"
 description: "Ensure read-heavy commands that create the shared SQLite cache also prevent .agentplane/cache.sqlite and WAL/SHM files from appearing as untracked files in older AgentPlane repositories whose .gitignore predates the v0.6 cache ignore entries."
 sections:
@@ -58,11 +64,33 @@ sections:
     3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-14T15:37:51.644Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: SQLite cache writers repair stale .gitignore entries for .agentplane/cache.sqlite, .agentplane/cache.sqlite-wal, and .agentplane/cache.sqlite-shm before writing the shared cache. Evidence: focused LocalBackend/context tests pass, exact-file ESLint passes, typecheck passes, policy routing passes, git diff whitespace check passes, and doctor is OK with unrelated pre-existing branch_pr normalization warnings.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T15:17:28.752Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141516-363FBC-sqlite-cache-ignore/.agentplane/tasks/202605141516-363FBC/blueprint/resolved-snapshot.json
+    - old_digest: ea88cb250271e954e79b8e87a91f7589117e4171f0f823318a307167976477a2
+    - current_digest: ea88cb250271e954e79b8e87a91f7589117e4171f0f823318a307167976477a2
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141516-363FBC
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
     - Re-run required checks to confirm rollback safety.
-  Findings: ""
+  Findings: |-
+    - Observation: Old initialized repositories can lack the v0.6 SQLite ignore entries while read-heavy task projection still writes .agentplane/cache.sqlite.
+      Impact: Without the repair, task list/search/next can leave .agentplane/cache.sqlite as an untracked file even though the cache is disposable and must not be committed.
+      Resolution: Moved runtime gitignore append logic into a shared helper, kept init on the full runtime ignore contract, and made task projection/context reindex call a narrowed SQLite-only repair before shared cache writes.
 id_source: "generated"
 ---
 ## Summary
@@ -91,6 +119,25 @@ PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLA
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-14T15:37:51.644Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: SQLite cache writers repair stale .gitignore entries for .agentplane/cache.sqlite, .agentplane/cache.sqlite-wal, and .agentplane/cache.sqlite-shm before writing the shared cache. Evidence: focused LocalBackend/context tests pass, exact-file ESLint passes, typecheck passes, policy routing passes, git diff whitespace check passes, and doctor is OK with unrelated pre-existing branch_pr normalization warnings.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T15:17:28.752Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141516-363FBC-sqlite-cache-ignore/.agentplane/tasks/202605141516-363FBC/blueprint/resolved-snapshot.json
+- old_digest: ea88cb250271e954e79b8e87a91f7589117e4171f0f823318a307167976477a2
+- current_digest: ea88cb250271e954e79b8e87a91f7589117e4171f0f823318a307167976477a2
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141516-363FBC
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -99,3 +146,7 @@ PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLA
 - Re-run required checks to confirm rollback safety.
 
 ## Findings
+
+- Observation: Old initialized repositories can lack the v0.6 SQLite ignore entries while read-heavy task projection still writes .agentplane/cache.sqlite.
+  Impact: Without the repair, task list/search/next can leave .agentplane/cache.sqlite as an untracked file even though the cache is disposable and must not be committed.
+  Resolution: Moved runtime gitignore append logic into a shared helper, kept init on the full runtime ignore contract, and made task projection/context reindex call a narrowed SQLite-only repair before shared cache writes.

--- a/.agentplane/tasks/202605141516-363FBC/README.md
+++ b/.agentplane/tasks/202605141516-363FBC/README.md
@@ -1,0 +1,101 @@
+---
+id: "202605141516-363FBC"
+title: "Ignore SQLite cache on read-heavy commands"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "bug"
+  - "cli"
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-14T15:17:04.537Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Implementing the approved SQLite cache ignore repair in the dedicated task worktree, scoped to runtime gitignore/cache handling plus a regression test for stale initialized repositories."
+events:
+  -
+    type: "status"
+    at: "2026-05-14T15:17:28.752Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Implementing the approved SQLite cache ignore repair in the dedicated task worktree, scoped to runtime gitignore/cache handling plus a regression test for stale initialized repositories."
+doc_version: 3
+doc_updated_at: "2026-05-14T15:17:28.752Z"
+doc_updated_by: "CODER"
+description: "Ensure read-heavy commands that create the shared SQLite cache also prevent .agentplane/cache.sqlite and WAL/SHM files from appearing as untracked files in older AgentPlane repositories whose .gitignore predates the v0.6 cache ignore entries."
+sections:
+  Summary: |-
+    Ignore SQLite cache on read-heavy commands
+    
+    Ensure read-heavy commands that create the shared SQLite cache also prevent .agentplane/cache.sqlite and WAL/SHM files from appearing as untracked files in older AgentPlane repositories whose .gitignore predates the v0.6 cache ignore entries.
+  Scope: |-
+    - In scope: Ensure read-heavy commands that create the shared SQLite cache also prevent .agentplane/cache.sqlite and WAL/SHM files from appearing as untracked files in older AgentPlane repositories whose .gitignore predates the v0.6 cache ignore entries.
+    - Out of scope: unrelated refactors not required for "Ignore SQLite cache on read-heavy commands".
+  Plan: "Implement a defensive cache-ignore repair for the shared SQLite projection path so read-heavy commands cannot leave .agentplane/cache.sqlite, .agentplane/cache.sqlite-wal, or .agentplane/cache.sqlite-shm as untracked files in older initialized repos. Prefer reusing the existing runtime gitignore contract. Add a regression test that simulates an initialized repo with stale .gitignore, runs a cache-producing read path, and asserts git status does not report sqlite cache files. Verify with the focused test file and routing check."
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+    
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Ignore SQLite cache on read-heavy commands
+
+Ensure read-heavy commands that create the shared SQLite cache also prevent .agentplane/cache.sqlite and WAL/SHM files from appearing as untracked files in older AgentPlane repositories whose .gitignore predates the v0.6 cache ignore entries.
+
+## Scope
+
+- In scope: Ensure read-heavy commands that create the shared SQLite cache also prevent .agentplane/cache.sqlite and WAL/SHM files from appearing as untracked files in older AgentPlane repositories whose .gitignore predates the v0.6 cache ignore entries.
+- Out of scope: unrelated refactors not required for "Ignore SQLite cache on read-heavy commands".
+
+## Plan
+
+Implement a defensive cache-ignore repair for the shared SQLite projection path so read-heavy commands cannot leave .agentplane/cache.sqlite, .agentplane/cache.sqlite-wal, or .agentplane/cache.sqlite-shm as untracked files in older initialized repos. Prefer reusing the existing runtime gitignore contract. Add a regression test that simulates an initialized repo with stale .gitignore, runs a cache-producing read path, and asserts git status does not report sqlite cache files. Verify with the focused test file and routing check.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605141516-363FBC/README.md
+++ b/.agentplane/tasks/202605141516-363FBC/README.md
@@ -4,7 +4,7 @@ title: "Ignore SQLite cache on read-heavy commands"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -20,9 +20,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-14T15:37:51.644Z"
+  updated_at: "2026-05-14T16:18:28.201Z"
   updated_by: "CODER"
-  note: "Verified: SQLite cache writers repair stale .gitignore entries for .agentplane/cache.sqlite, .agentplane/cache.sqlite-wal, and .agentplane/cache.sqlite-shm before writing the shared cache. Evidence: focused LocalBackend/context tests pass, exact-file ESLint passes, typecheck passes, policy routing passes, git diff whitespace check passes, and doctor is OK with unrelated pre-existing branch_pr normalization warnings."
+  note: "Verified after Codex review fix: SQLite gitignore repair is best-effort, so projection cache writes continue even if .gitignore cannot be read or updated. Evidence: focused LocalBackend SQLite gitignore regression tests pass, LocalBackend/context release readiness tests pass, exact-file ESLint passes, typecheck passes, and hotspots baseline passes."
   attempts: 0
 commit: null
 comments:
@@ -43,8 +43,14 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified: SQLite cache writers repair stale .gitignore entries for .agentplane/cache.sqlite, .agentplane/cache.sqlite-wal, and .agentplane/cache.sqlite-shm before writing the shared cache. Evidence: focused LocalBackend/context tests pass, exact-file ESLint passes, typecheck passes, policy routing passes, git diff whitespace check passes, and doctor is OK with unrelated pre-existing branch_pr normalization warnings."
+  -
+    type: "verify"
+    at: "2026-05-14T16:18:28.201Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified after Codex review fix: SQLite gitignore repair is best-effort, so projection cache writes continue even if .gitignore cannot be read or updated. Evidence: focused LocalBackend SQLite gitignore regression tests pass, LocalBackend/context release readiness tests pass, exact-file ESLint passes, typecheck passes, and hotspots baseline passes."
 doc_version: 3
-doc_updated_at: "2026-05-14T15:37:51.747Z"
+doc_updated_at: "2026-05-14T16:18:28.209Z"
 doc_updated_by: "CODER"
 description: "Ensure read-heavy commands that create the shared SQLite cache also prevent .agentplane/cache.sqlite and WAL/SHM files from appearing as untracked files in older AgentPlane repositories whose .gitignore predates the v0.6 cache ignore entries."
 sections:
@@ -83,6 +89,25 @@ sections:
     - route_changed: no
     - safe_command: agentplane blueprint snapshot 202605141516-363FBC
     
+    ### 2026-05-14T16:18:28.201Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified after Codex review fix: SQLite gitignore repair is best-effort, so projection cache writes continue even if .gitignore cannot be read or updated. Evidence: focused LocalBackend SQLite gitignore regression tests pass, LocalBackend/context release readiness tests pass, exact-file ESLint passes, typecheck passes, and hotspots baseline passes.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T15:37:51.747Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141516-363FBC-sqlite-cache-ignore/.agentplane/tasks/202605141516-363FBC/blueprint/resolved-snapshot.json
+    - old_digest: ea88cb250271e954e79b8e87a91f7589117e4171f0f823318a307167976477a2
+    - current_digest: ea88cb250271e954e79b8e87a91f7589117e4171f0f823318a307167976477a2
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141516-363FBC
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -91,6 +116,10 @@ sections:
     - Observation: Old initialized repositories can lack the v0.6 SQLite ignore entries while read-heavy task projection still writes .agentplane/cache.sqlite.
       Impact: Without the repair, task list/search/next can leave .agentplane/cache.sqlite as an untracked file even though the cache is disposable and must not be committed.
       Resolution: Moved runtime gitignore append logic into a shared helper, kept init on the full runtime ignore contract, and made task projection/context reindex call a narrowed SQLite-only repair before shared cache writes.
+    
+    - Observation: Review found that awaiting gitignore repair directly could make read-heavy projection paths fail on normal filesystem errors.
+      Impact: The cache writer could regress from best-effort behavior to command failure when .gitignore is read-only, malformed as a directory, or otherwise unavailable.
+      Resolution: Wrapped SQLite ignore repair in non-fatal catch paths for task projection and context reindex, and added a regression that keeps projection reads working when .gitignore repair fails.
 id_source: "generated"
 ---
 ## Summary
@@ -138,6 +167,25 @@ BlueprintSnapshotRef:
 - route_changed: no
 - safe_command: agentplane blueprint snapshot 202605141516-363FBC
 
+### 2026-05-14T16:18:28.201Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified after Codex review fix: SQLite gitignore repair is best-effort, so projection cache writes continue even if .gitignore cannot be read or updated. Evidence: focused LocalBackend SQLite gitignore regression tests pass, LocalBackend/context release readiness tests pass, exact-file ESLint passes, typecheck passes, and hotspots baseline passes.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T15:37:51.747Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141516-363FBC-sqlite-cache-ignore/.agentplane/tasks/202605141516-363FBC/blueprint/resolved-snapshot.json
+- old_digest: ea88cb250271e954e79b8e87a91f7589117e4171f0f823318a307167976477a2
+- current_digest: ea88cb250271e954e79b8e87a91f7589117e4171f0f823318a307167976477a2
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141516-363FBC
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -150,3 +198,7 @@ BlueprintSnapshotRef:
 - Observation: Old initialized repositories can lack the v0.6 SQLite ignore entries while read-heavy task projection still writes .agentplane/cache.sqlite.
   Impact: Without the repair, task list/search/next can leave .agentplane/cache.sqlite as an untracked file even though the cache is disposable and must not be committed.
   Resolution: Moved runtime gitignore append logic into a shared helper, kept init on the full runtime ignore contract, and made task projection/context reindex call a narrowed SQLite-only repair before shared cache writes.
+
+- Observation: Review found that awaiting gitignore repair directly could make read-heavy projection paths fail on normal filesystem errors.
+  Impact: The cache writer could regress from best-effort behavior to command failure when .gitignore is read-only, malformed as a directory, or otherwise unavailable.
+  Resolution: Wrapped SQLite ignore repair in non-fatal catch paths for task projection and context reindex, and added a regression that keeps projection reads working when .gitignore repair fails.

--- a/.agentplane/tasks/202605141516-363FBC/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605141516-363FBC/blueprint/resolved-snapshot.json
@@ -1,0 +1,528 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605141516-363FBC",
+    "title": "Ignore SQLite cache on read-heavy commands",
+    "description": "Ensure read-heavy commands that create the shared SQLite cache also prevent .agentplane/cache.sqlite and WAL/SHM files from appearing as untracked files in older AgentPlane repositories whose .gitignore predates the v0.6 cache ignore entries.",
+    "tags": [
+      "bug",
+      "cli",
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605141516-363FBC",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "ea88cb250271e954e79b8e87a91f7589117e4171f0f823318a307167976477a2"
+  }
+}

--- a/.agentplane/tasks/202605141516-363FBC/pr/diffstat.txt
+++ b/.agentplane/tasks/202605141516-363FBC/pr/diffstat.txt
@@ -1,7 +1,7 @@
  .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
- .../src/backends/task-backend.local.test.ts        |  43 ++
+ .../task-backend.local-sqlite-gitignore.test.ts    | 101 ++++
  .../task-backend/local-task-sqlite-cache.ts        |   4 +
  .../cli/run-cli/commands/init/write-gitignore.ts   |  42 +-
  packages/agentplane/src/context/reindex.ts         |   2 +
- .../src/runtime/shared/runtime-gitignore.ts        |  61 +++
- 6 files changed, 643 insertions(+), 37 deletions(-)
+ .../src/runtime/shared/runtime-gitignore.ts        |  58 +++
+ 6 files changed, 698 insertions(+), 37 deletions(-)

--- a/.agentplane/tasks/202605141516-363FBC/pr/diffstat.txt
+++ b/.agentplane/tasks/202605141516-363FBC/pr/diffstat.txt
@@ -1,0 +1,7 @@
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ .../src/backends/task-backend.local.test.ts        |  43 ++
+ .../task-backend/local-task-sqlite-cache.ts        |   4 +
+ .../cli/run-cli/commands/init/write-gitignore.ts   |  42 +-
+ packages/agentplane/src/context/reindex.ts         |   2 +
+ .../src/runtime/shared/runtime-gitignore.ts        |  61 +++
+ 6 files changed, 643 insertions(+), 37 deletions(-)

--- a/.agentplane/tasks/202605141516-363FBC/pr/github-body.md
+++ b/.agentplane/tasks/202605141516-363FBC/pr/github-body.md
@@ -15,19 +15,33 @@ Ensure read-heavy commands that create the shared SQLite cache also prevent .age
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Verified: SQLite cache writers repair stale .gitignore entries for .agentplane/cache.sqlite,
+.agentplane/cache.sqlite-wal, and .agentplane/cache.sqlite-shm before writing the shared cache.
+Evidence: focused LocalBackend/context tests pass, exact-file ESLint passes, typecheck passes,
+policy routing passes, git diff whitespace check passes, and doctor is OK with unrelated
+pre-existing branch_pr normalization warnings.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T15:17:28.899Z
+- Updated: 2026-05-14T15:37:51.952Z
 - Branch: task/202605141516-363FBC/sqlite-cache-ignore
-- Head: d2760c7e11ce
+- Head: 5670c639f092
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ .../src/backends/task-backend.local.test.ts        |  43 ++
+ .../task-backend/local-task-sqlite-cache.ts        |   4 +
+ .../cli/run-cli/commands/init/write-gitignore.ts   |  42 +-
+ packages/agentplane/src/context/reindex.ts         |   2 +
+ .../src/runtime/shared/runtime-gitignore.ts        |  61 +++
+ 6 files changed, 643 insertions(+), 37 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605141516-363FBC/pr/github-body.md
+++ b/.agentplane/tasks/202605141516-363FBC/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605141516-363FBC`
+Title: Ignore SQLite cache on read-heavy commands
+Canonical task record: `.agentplane/tasks/202605141516-363FBC/README.md`
+
+## Summary
+
+Ignore SQLite cache on read-heavy commands
+
+Ensure read-heavy commands that create the shared SQLite cache also prevent .agentplane/cache.sqlite and WAL/SHM files from appearing as untracked files in older AgentPlane repositories whose .gitignore predates the v0.6 cache ignore entries.
+
+## Scope
+
+- In scope: Ensure read-heavy commands that create the shared SQLite cache also prevent .agentplane/cache.sqlite and WAL/SHM files from appearing as untracked files in older AgentPlane repositories whose .gitignore predates the v0.6 cache ignore entries.
+- Out of scope: unrelated refactors not required for "Ignore SQLite cache on read-heavy commands".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T15:17:28.899Z
+- Branch: task/202605141516-363FBC/sqlite-cache-ignore
+- Head: d2760c7e11ce
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605141516-363FBC/pr/github-body.md
+++ b/.agentplane/tasks/202605141516-363FBC/pr/github-body.md
@@ -30,7 +30,7 @@ pre-existing branch_pr normalization warnings.
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T15:37:51.952Z
+- Updated: 2026-05-14T15:38:47.046Z
 - Branch: task/202605141516-363FBC/sqlite-cache-ignore
 - Head: 5670c639f092
 

--- a/.agentplane/tasks/202605141516-363FBC/pr/github-body.md
+++ b/.agentplane/tasks/202605141516-363FBC/pr/github-body.md
@@ -19,29 +19,28 @@ Ensure read-heavy commands that create the shared SQLite cache also prevent .age
 - Note:
 
 ```text
-Verified: SQLite cache writers repair stale .gitignore entries for .agentplane/cache.sqlite,
-.agentplane/cache.sqlite-wal, and .agentplane/cache.sqlite-shm before writing the shared cache.
-Evidence: focused LocalBackend/context tests pass, exact-file ESLint passes, typecheck passes,
-policy routing passes, git diff whitespace check passes, and doctor is OK with unrelated
-pre-existing branch_pr normalization warnings.
+Verified after Codex review fix: SQLite gitignore repair is best-effort, so projection cache writes
+continue even if .gitignore cannot be read or updated. Evidence: focused LocalBackend SQLite
+gitignore regression tests pass, LocalBackend/context release readiness tests pass, exact-file
+ESLint passes, typecheck passes, and hotspots baseline passes.
 ```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T15:38:47.046Z
+- Updated: 2026-05-14T16:18:28.250Z
 - Branch: task/202605141516-363FBC/sqlite-cache-ignore
-- Head: 5670c639f092
+- Head: eeccc8e14af6
 
 ```text
  .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
- .../src/backends/task-backend.local.test.ts        |  43 ++
+ .../task-backend.local-sqlite-gitignore.test.ts    | 101 ++++
  .../task-backend/local-task-sqlite-cache.ts        |   4 +
  .../cli/run-cli/commands/init/write-gitignore.ts   |  42 +-
  packages/agentplane/src/context/reindex.ts         |   2 +
- .../src/runtime/shared/runtime-gitignore.ts        |  61 +++
- 6 files changed, 643 insertions(+), 37 deletions(-)
+ .../src/runtime/shared/runtime-gitignore.ts        |  58 +++
+ 6 files changed, 698 insertions(+), 37 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605141516-363FBC/pr/github-title.txt
+++ b/.agentplane/tasks/202605141516-363FBC/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 363FBC task: Ignore SQLite cache on read-heavy commands [202605141516-363FBC]

--- a/.agentplane/tasks/202605141516-363FBC/pr/meta.json
+++ b/.agentplane/tasks/202605141516-363FBC/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "5670c639f0928c5816a3b15365f5968491b18f56",
   "last_verified_at": "2026-05-14T15:37:51.644Z",
   "last_verified_sha": "5670c639f0928c5816a3b15365f5968491b18f56",
+  "pr_number": 3726,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3726",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605141516-363FBC",
-  "updated_at": "2026-05-14T15:37:51.952Z",
+  "updated_at": "2026-05-14T15:38:47.046Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141516-363FBC/pr/meta.json
+++ b/.agentplane/tasks/202605141516-363FBC/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605141516-363FBC/sqlite-cache-ignore",
+  "created_at": "2026-05-14T15:17:28.899Z",
+  "head_sha": "d2760c7e11cef17dd1279659f83cfebe242ad327",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202605141516-363FBC",
+  "updated_at": "2026-05-14T15:17:28.899Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605141516-363FBC/pr/meta.json
+++ b/.agentplane/tasks/202605141516-363FBC/pr/meta.json
@@ -2,13 +2,13 @@
   "base": "main",
   "branch": "task/202605141516-363FBC/sqlite-cache-ignore",
   "created_at": "2026-05-14T15:17:28.899Z",
-  "head_sha": "d2760c7e11cef17dd1279659f83cfebe242ad327",
-  "last_verified_at": null,
-  "last_verified_sha": null,
+  "head_sha": "5670c639f0928c5816a3b15365f5968491b18f56",
+  "last_verified_at": "2026-05-14T15:37:51.644Z",
+  "last_verified_sha": "5670c639f0928c5816a3b15365f5968491b18f56",
   "schema_version": 1,
   "task_id": "202605141516-363FBC",
-  "updated_at": "2026-05-14T15:17:28.899Z",
+  "updated_at": "2026-05-14T15:37:51.952Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605141516-363FBC/pr/meta.json
+++ b/.agentplane/tasks/202605141516-363FBC/pr/meta.json
@@ -2,15 +2,15 @@
   "base": "main",
   "branch": "task/202605141516-363FBC/sqlite-cache-ignore",
   "created_at": "2026-05-14T15:17:28.899Z",
-  "head_sha": "5670c639f0928c5816a3b15365f5968491b18f56",
-  "last_verified_at": "2026-05-14T15:37:51.644Z",
-  "last_verified_sha": "5670c639f0928c5816a3b15365f5968491b18f56",
+  "head_sha": "eeccc8e14af62a2cafb9af099f00d05a7da2df2b",
+  "last_verified_at": "2026-05-14T16:18:28.201Z",
+  "last_verified_sha": "eeccc8e14af62a2cafb9af099f00d05a7da2df2b",
   "pr_number": 3726,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3726",
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202605141516-363FBC",
-  "updated_at": "2026-05-14T15:38:47.046Z",
+  "updated_at": "2026-05-14T16:18:28.250Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141516-363FBC/pr/review.md
+++ b/.agentplane/tasks/202605141516-363FBC/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-05-14T15:17:28.899Z
 ## Verification
 
 - State: ok
-- Note: Verified: SQLite cache writers repair stale .gitignore entries for .agentplane/cache.sqlite, .agentplane/cache.sqlite-wal, and .agentplane/cache.sqlite-shm before writing the shared cache. Evidence: focused LocalBackend/context tests pass, exact-file ESLint passes, typecheck passes, policy routing passes, git diff whitespace check passes, and doctor is OK with unrelated pre-existing branch_pr normalization warnings.
+- Note: Verified after Codex review fix: SQLite gitignore repair is best-effort, so projection cache writes continue even if .gitignore cannot be read or updated. Evidence: focused LocalBackend SQLite gitignore regression tests pass, LocalBackend/context release readiness tests pass, exact-file ESLint passes, typecheck passes, and hotspots baseline passes.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,18 +24,18 @@ Created: 2026-05-14T15:17:28.899Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T15:38:47.046Z
+- Updated: 2026-05-14T16:18:28.250Z
 - Branch: task/202605141516-363FBC/sqlite-cache-ignore
-- Head: 5670c639f092
+- Head: eeccc8e14af6
 
 ```text
  .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
- .../src/backends/task-backend.local.test.ts        |  43 ++
+ .../task-backend.local-sqlite-gitignore.test.ts    | 101 ++++
  .../task-backend/local-task-sqlite-cache.ts        |   4 +
  .../cli/run-cli/commands/init/write-gitignore.ts   |  42 +-
  packages/agentplane/src/context/reindex.ts         |   2 +
- .../src/runtime/shared/runtime-gitignore.ts        |  61 +++
- 6 files changed, 643 insertions(+), 37 deletions(-)
+ .../src/runtime/shared/runtime-gitignore.ts        |  58 +++
+ 6 files changed, 698 insertions(+), 37 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605141516-363FBC/pr/review.md
+++ b/.agentplane/tasks/202605141516-363FBC/pr/review.md
@@ -24,7 +24,7 @@ Created: 2026-05-14T15:17:28.899Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T15:37:51.952Z
+- Updated: 2026-05-14T15:38:47.046Z
 - Branch: task/202605141516-363FBC/sqlite-cache-ignore
 - Head: 5670c639f092
 

--- a/.agentplane/tasks/202605141516-363FBC/pr/review.md
+++ b/.agentplane/tasks/202605141516-363FBC/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-14T15:17:28.899Z
+
+## Task
+
+- Task: `202605141516-363FBC`
+- Title: Ignore SQLite cache on read-heavy commands
+- Status: DOING
+- Branch: `task/202605141516-363FBC/sqlite-cache-ignore`
+- Canonical task record: `.agentplane/tasks/202605141516-363FBC/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T15:17:28.899Z
+- Branch: task/202605141516-363FBC/sqlite-cache-ignore
+- Head: d2760c7e11ce
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605141516-363FBC/pr/review.md
+++ b/.agentplane/tasks/202605141516-363FBC/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-05-14T15:17:28.899Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified: SQLite cache writers repair stale .gitignore entries for .agentplane/cache.sqlite, .agentplane/cache.sqlite-wal, and .agentplane/cache.sqlite-shm before writing the shared cache. Evidence: focused LocalBackend/context tests pass, exact-file ESLint passes, typecheck passes, policy routing passes, git diff whitespace check passes, and doctor is OK with unrelated pre-existing branch_pr normalization warnings.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,12 +24,18 @@ Created: 2026-05-14T15:17:28.899Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T15:17:28.899Z
+- Updated: 2026-05-14T15:37:51.952Z
 - Branch: task/202605141516-363FBC/sqlite-cache-ignore
-- Head: d2760c7e11ce
+- Head: 5670c639f092
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ .../src/backends/task-backend.local.test.ts        |  43 ++
+ .../task-backend/local-task-sqlite-cache.ts        |   4 +
+ .../cli/run-cli/commands/init/write-gitignore.ts   |  42 +-
+ packages/agentplane/src/context/reindex.ts         |   2 +
+ .../src/runtime/shared/runtime-gitignore.ts        |  61 +++
+ 6 files changed, 643 insertions(+), 37 deletions(-)
 ```
 
 </details>

--- a/packages/agentplane/src/backends/task-backend.local-sqlite-gitignore.test.ts
+++ b/packages/agentplane/src/backends/task-backend.local-sqlite-gitignore.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -63,5 +63,39 @@ describe("LocalBackend SQLite gitignore repair", () => {
       cwd: tempDir,
     });
     expect(stdout).not.toContain(".agentplane/cache.sqlite");
+  });
+
+  it("keeps projection reads working when gitignore repair fails", async () => {
+    await execFileAsync("git", ["init", "-q"], { cwd: tempDir });
+    await execFileAsync("git", ["config", "user.email", "test@example.com"], { cwd: tempDir });
+    await execFileAsync("git", ["config", "user.name", "Test User"], { cwd: tempDir });
+    await mkdir(path.join(tempDir, ".gitignore"));
+    await writeFile(path.join(tempDir, "seed.txt"), "seed\n", "utf8");
+    await execFileAsync("git", ["add", "seed.txt"], { cwd: tempDir });
+    await execFileAsync("git", ["commit", "-m", "seed"], { cwd: tempDir });
+
+    const task: TaskData = {
+      id: "202601300016-ABCD",
+      title: "Repair failure fallback",
+      description: "Desc",
+      status: "TODO",
+      priority: "med",
+      owner: "tester",
+      depends_on: [],
+      tags: ["projection"],
+      verify: [],
+      doc: "## Summary\n\nSQLite body",
+    };
+    const backend = new LocalBackend({
+      dir: path.join(tempDir, ".agentplane", "tasks"),
+      updatedBy: "tester",
+    });
+
+    await backend.writeTask(task);
+    const projection = await backend.listProjectionTasks();
+
+    expect(projection.map((entry) => entry.id)).toEqual([task.id]);
+    const sqliteStat = await stat(path.join(tempDir, ".agentplane", "cache.sqlite"));
+    expect(sqliteStat.size).toBeGreaterThan(0);
   });
 });

--- a/packages/agentplane/src/backends/task-backend.local-sqlite-gitignore.test.ts
+++ b/packages/agentplane/src/backends/task-backend.local-sqlite-gitignore.test.ts
@@ -1,0 +1,67 @@
+import { execFile } from "node:child_process";
+import { readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { mkTempDir, silenceStdIO } from "@agentplane/testkit";
+
+import { LocalBackend, type TaskData } from "./task-backend.js";
+
+const execFileAsync = promisify(execFile);
+
+describe("LocalBackend SQLite gitignore repair", () => {
+  let tempDir = "";
+  let restoreStdIO: (() => void) | null = null;
+
+  beforeEach(async () => {
+    restoreStdIO = silenceStdIO();
+    tempDir = await mkTempDir();
+  });
+
+  afterEach(async () => {
+    restoreStdIO?.();
+    restoreStdIO = null;
+    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("repairs stale runtime gitignore entries before writing repository SQLite cache", async () => {
+    await execFileAsync("git", ["init", "-q"], { cwd: tempDir });
+    await execFileAsync("git", ["config", "user.email", "test@example.com"], { cwd: tempDir });
+    await execFileAsync("git", ["config", "user.name", "Test User"], { cwd: tempDir });
+    await writeFile(path.join(tempDir, ".gitignore"), ".agentplane/worktrees\n", "utf8");
+    await writeFile(path.join(tempDir, "seed.txt"), "seed\n", "utf8");
+    await execFileAsync("git", ["add", ".gitignore", "seed.txt"], { cwd: tempDir });
+    await execFileAsync("git", ["commit", "-m", "seed"], { cwd: tempDir });
+
+    const task: TaskData = {
+      id: "202601300015-ABCD",
+      title: "Old ignore cache",
+      description: "Desc",
+      status: "TODO",
+      priority: "med",
+      owner: "tester",
+      depends_on: [],
+      tags: ["projection"],
+      verify: [],
+      doc: "## Summary\n\nSQLite body",
+    };
+    const backend = new LocalBackend({
+      dir: path.join(tempDir, ".agentplane", "tasks"),
+      updatedBy: "tester",
+    });
+
+    await backend.writeTask(task);
+    await backend.listProjectionTasks();
+
+    const gitignore = await readFile(path.join(tempDir, ".gitignore"), "utf8");
+    expect(gitignore).toContain(".agentplane/cache.sqlite");
+    expect(gitignore).toContain(".agentplane/cache.sqlite-wal");
+    expect(gitignore).toContain(".agentplane/cache.sqlite-shm");
+
+    const { stdout } = await execFileAsync("git", ["status", "--short", "--untracked-files=all"], {
+      cwd: tempDir,
+    });
+    expect(stdout).not.toContain(".agentplane/cache.sqlite");
+  });
+});

--- a/packages/agentplane/src/backends/task-backend.local.test.ts
+++ b/packages/agentplane/src/backends/task-backend.local.test.ts
@@ -1,5 +1,7 @@
+import { execFile } from "node:child_process";
 import { mkdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { promisify } from "node:util";
 import { renderTaskReadme } from "@agentplaneorg/core/tasks";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -9,6 +11,8 @@ import {
   resolveTaskProjectionSqlitePath,
 } from "./task-backend/local-task-sqlite-cache.js";
 import { mkTempDir, silenceStdIO } from "@agentplane/testkit";
+
+const execFileAsync = promisify(execFile);
 
 type QuerySummaryView = Pick<
   TaskSummary,
@@ -255,6 +259,45 @@ describe("LocalBackend", () => {
     expect(resolveTaskProjectionSqlitePath(tasksDir)).toBe(
       path.join(tempDir, ".agentplane", "cache.sqlite"),
     );
+  });
+
+  it("repairs stale runtime gitignore entries before writing repository SQLite cache", async () => {
+    await execFileAsync("git", ["init", "-q"], { cwd: tempDir });
+    await execFileAsync("git", ["config", "user.email", "test@example.com"], { cwd: tempDir });
+    await execFileAsync("git", ["config", "user.name", "Test User"], { cwd: tempDir });
+    await writeFile(path.join(tempDir, ".gitignore"), ".agentplane/worktrees\n", "utf8");
+    await writeFile(path.join(tempDir, "seed.txt"), "seed\n", "utf8");
+    await execFileAsync("git", ["add", ".gitignore", "seed.txt"], { cwd: tempDir });
+    await execFileAsync("git", ["commit", "-m", "seed"], { cwd: tempDir });
+
+    const tasksDir = path.join(tempDir, ".agentplane", "tasks");
+    const backend = new LocalBackend({ dir: tasksDir, updatedBy: "tester" });
+    await backend.writeTask({
+      id: "202601300015-ABCD",
+      title: "Old ignore cache",
+      description: "Desc",
+      status: "TODO",
+      priority: "med",
+      owner: "tester",
+      depends_on: [],
+      tags: ["projection"],
+      verify: [],
+      doc: "## Summary\n\nSQLite body",
+    });
+
+    await backend.listProjectionTasks();
+
+    const gitignore = await readFile(path.join(tempDir, ".gitignore"), "utf8");
+    expect(gitignore).toContain(".agentplane/cache.sqlite");
+    expect(gitignore).toContain(".agentplane/cache.sqlite-wal");
+    expect(gitignore).toContain(".agentplane/cache.sqlite-shm");
+
+    const { stdout } = await execFileAsync(
+      "git",
+      ["status", "--short", "--untracked-files=all"],
+      { cwd: tempDir },
+    );
+    expect(stdout).not.toContain(".agentplane/cache.sqlite");
   });
 
   it("reparses projection entries after README invalidation", async () => {

--- a/packages/agentplane/src/backends/task-backend.local.test.ts
+++ b/packages/agentplane/src/backends/task-backend.local.test.ts
@@ -1,7 +1,5 @@
-import { execFile } from "node:child_process";
 import { mkdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { promisify } from "node:util";
 import { renderTaskReadme } from "@agentplaneorg/core/tasks";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -11,8 +9,6 @@ import {
   resolveTaskProjectionSqlitePath,
 } from "./task-backend/local-task-sqlite-cache.js";
 import { mkTempDir, silenceStdIO } from "@agentplane/testkit";
-
-const execFileAsync = promisify(execFile);
 
 type QuerySummaryView = Pick<
   TaskSummary,
@@ -259,43 +255,6 @@ describe("LocalBackend", () => {
     expect(resolveTaskProjectionSqlitePath(tasksDir)).toBe(
       path.join(tempDir, ".agentplane", "cache.sqlite"),
     );
-  });
-
-  it("repairs stale runtime gitignore entries before writing repository SQLite cache", async () => {
-    await execFileAsync("git", ["init", "-q"], { cwd: tempDir });
-    await execFileAsync("git", ["config", "user.email", "test@example.com"], { cwd: tempDir });
-    await execFileAsync("git", ["config", "user.name", "Test User"], { cwd: tempDir });
-    await writeFile(path.join(tempDir, ".gitignore"), ".agentplane/worktrees\n", "utf8");
-    await writeFile(path.join(tempDir, "seed.txt"), "seed\n", "utf8");
-    await execFileAsync("git", ["add", ".gitignore", "seed.txt"], { cwd: tempDir });
-    await execFileAsync("git", ["commit", "-m", "seed"], { cwd: tempDir });
-
-    const tasksDir = path.join(tempDir, ".agentplane", "tasks");
-    const backend = new LocalBackend({ dir: tasksDir, updatedBy: "tester" });
-    await backend.writeTask({
-      id: "202601300015-ABCD",
-      title: "Old ignore cache",
-      description: "Desc",
-      status: "TODO",
-      priority: "med",
-      owner: "tester",
-      depends_on: [],
-      tags: ["projection"],
-      verify: [],
-      doc: "## Summary\n\nSQLite body",
-    });
-
-    await backend.listProjectionTasks();
-
-    const gitignore = await readFile(path.join(tempDir, ".gitignore"), "utf8");
-    expect(gitignore).toContain(".agentplane/cache.sqlite");
-    expect(gitignore).toContain(".agentplane/cache.sqlite-wal");
-    expect(gitignore).toContain(".agentplane/cache.sqlite-shm");
-
-    const { stdout } = await execFileAsync("git", ["status", "--short", "--untracked-files=all"], {
-      cwd: tempDir,
-    });
-    expect(stdout).not.toContain(".agentplane/cache.sqlite");
   });
 
   it("reparses projection entries after README invalidation", async () => {

--- a/packages/agentplane/src/backends/task-backend.local.test.ts
+++ b/packages/agentplane/src/backends/task-backend.local.test.ts
@@ -292,11 +292,9 @@ describe("LocalBackend", () => {
     expect(gitignore).toContain(".agentplane/cache.sqlite-wal");
     expect(gitignore).toContain(".agentplane/cache.sqlite-shm");
 
-    const { stdout } = await execFileAsync(
-      "git",
-      ["status", "--short", "--untracked-files=all"],
-      { cwd: tempDir },
-    );
+    const { stdout } = await execFileAsync("git", ["status", "--short", "--untracked-files=all"], {
+      cwd: tempDir,
+    });
     expect(stdout).not.toContain(".agentplane/cache.sqlite");
   });
 

--- a/packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.ts
+++ b/packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.ts
@@ -327,7 +327,7 @@ export async function writeSqliteTaskProjection(opts: {
   fingerprintEntries?: readonly { path: string; mtimeMs: number; size: number }[];
 }): Promise<void> {
   const gitRoot = maybeRepoRootFromTasksDir(opts.tasksDir);
-  if (gitRoot) await ensureRuntimeSqliteGitignore({ gitRoot });
+  if (gitRoot) await ensureRuntimeSqliteGitignore({ gitRoot }).catch(() => null);
 
   const dbPath = resolveTaskProjectionSqlitePath(opts.tasksDir);
   const gitCacheKey = buildGitCacheKey(opts.tasksDir);

--- a/packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.ts
+++ b/packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, statSync } from "node
 import path from "node:path";
 
 import { resolveAgentplaneCacheSqlitePath } from "../../shared/cache-paths.js";
+import { ensureRuntimeSqliteGitignore } from "../../runtime/shared/runtime-gitignore.js";
 import { openSqliteDatabase, type SqliteDatabase } from "../../shared/sqlite-driver.js";
 import type { TaskSummary } from "./shared.js";
 
@@ -325,6 +326,9 @@ export async function writeSqliteTaskProjection(opts: {
   tasks: readonly TaskSummary[];
   fingerprintEntries?: readonly { path: string; mtimeMs: number; size: number }[];
 }): Promise<void> {
+  const gitRoot = maybeRepoRootFromTasksDir(opts.tasksDir);
+  if (gitRoot) await ensureRuntimeSqliteGitignore({ gitRoot });
+
   const dbPath = resolveTaskProjectionSqlitePath(opts.tasksDir);
   const gitCacheKey = buildGitCacheKey(opts.tasksDir);
   const cacheKey =

--- a/packages/agentplane/src/cli/run-cli/commands/init/write-gitignore.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/write-gitignore.ts
@@ -1,43 +1,11 @@
-import path from "node:path";
-import { readFile } from "node:fs/promises";
-
-import {
-  AGENT_PROMPT_GITIGNORE_LINES,
-  RUNTIME_GITIGNORE_LINES,
-} from "../../../../runtime/shared/runtime-artifacts.js";
-import { writeTextIfChanged } from "../../../../shared/write-if-changed.js";
-
-async function readTextIfExists(filePath: string): Promise<string | null> {
-  try {
-    return await readFile(filePath, "utf8");
-  } catch (err) {
-    const code = (err as { code?: string } | null)?.code;
-    if (code === "ENOENT") return null;
-    throw err;
-  }
-}
+import { ensureRuntimeGitignore } from "../../../../runtime/shared/runtime-gitignore.js";
 
 export async function ensureInitGitignore(opts: {
   gitRoot: string;
   includeAgentPromptFiles: boolean;
 }): Promise<void> {
-  const gitignorePath = path.join(opts.gitRoot, ".gitignore");
-  const existing = (await readTextIfExists(gitignorePath)) ?? "";
-  const ensuredLines = opts.includeAgentPromptFiles
-    ? [...RUNTIME_GITIGNORE_LINES, ...AGENT_PROMPT_GITIGNORE_LINES]
-    : [...RUNTIME_GITIGNORE_LINES];
-
-  const existingLines = existing.split(/\r?\n/);
-  const existingSet = new Set(existingLines.map((line) => line.trimEnd()));
-
-  const missing = ensuredLines.filter((line) => !existingSet.has(line));
-  if (missing.length === 0) return;
-
-  const nextLines = [...existingLines];
-  // Keep content stable and append a trailing newline.
-  if (nextLines.length > 0 && nextLines.at(-1) !== "") nextLines.push("");
-  nextLines.push(...missing, "");
-
-  const nextText = `${nextLines.join("\n")}`.replaceAll(/\n{2,}$/g, "\n");
-  await writeTextIfChanged(gitignorePath, nextText);
+  await ensureRuntimeGitignore({
+    gitRoot: opts.gitRoot,
+    includeAgentPromptFiles: opts.includeAgentPromptFiles,
+  });
 }

--- a/packages/agentplane/src/context/reindex.ts
+++ b/packages/agentplane/src/context/reindex.ts
@@ -4,6 +4,7 @@ import { access, stat, mkdir, rm, readFile } from "node:fs/promises";
 import path from "node:path";
 
 import { infoMessage, warnMessage } from "../cli/output.js";
+import { ensureRuntimeSqliteGitignore } from "../runtime/shared/runtime-gitignore.js";
 import { resolveAgentplaneCacheSqlitePath } from "../shared/cache-paths.js";
 import {
   collectMatchingFiles,
@@ -391,6 +392,7 @@ export async function cmdContextReindex(opts: {
       size_bytes: row.size_bytes,
     })),
   };
+  await ensureRuntimeSqliteGitignore({ gitRoot: root });
   await writeSqliteProjection(sqlitePath, payload);
 
   process.stdout.write(infoMessage(`reindex prepared at ${sqlitePath}`) + "\n");

--- a/packages/agentplane/src/context/reindex.ts
+++ b/packages/agentplane/src/context/reindex.ts
@@ -392,7 +392,7 @@ export async function cmdContextReindex(opts: {
       size_bytes: row.size_bytes,
     })),
   };
-  await ensureRuntimeSqliteGitignore({ gitRoot: root });
+  await ensureRuntimeSqliteGitignore({ gitRoot: root }).catch(() => null);
   await writeSqliteProjection(sqlitePath, payload);
 
   process.stdout.write(infoMessage(`reindex prepared at ${sqlitePath}`) + "\n");

--- a/packages/agentplane/src/runtime/shared/runtime-gitignore.ts
+++ b/packages/agentplane/src/runtime/shared/runtime-gitignore.ts
@@ -2,10 +2,7 @@ import path from "node:path";
 import { readFile } from "node:fs/promises";
 
 import { writeTextIfChanged } from "../../shared/write-if-changed.js";
-import {
-  AGENT_PROMPT_GITIGNORE_LINES,
-  RUNTIME_GITIGNORE_LINES,
-} from "./runtime-artifacts.js";
+import { AGENT_PROMPT_GITIGNORE_LINES, RUNTIME_GITIGNORE_LINES } from "./runtime-artifacts.js";
 
 async function readTextIfExists(filePath: string): Promise<string | null> {
   try {

--- a/packages/agentplane/src/runtime/shared/runtime-gitignore.ts
+++ b/packages/agentplane/src/runtime/shared/runtime-gitignore.ts
@@ -1,0 +1,61 @@
+import path from "node:path";
+import { readFile } from "node:fs/promises";
+
+import { writeTextIfChanged } from "../../shared/write-if-changed.js";
+import {
+  AGENT_PROMPT_GITIGNORE_LINES,
+  RUNTIME_GITIGNORE_LINES,
+} from "./runtime-artifacts.js";
+
+async function readTextIfExists(filePath: string): Promise<string | null> {
+  try {
+    return await readFile(filePath, "utf8");
+  } catch (err) {
+    const code = (err as { code?: string } | null)?.code;
+    if (code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+export async function ensureRuntimeGitignore(opts: {
+  gitRoot: string;
+  includeAgentPromptFiles?: boolean;
+}): Promise<void> {
+  await ensureGitignoreLines({
+    gitRoot: opts.gitRoot,
+    lines:
+      opts.includeAgentPromptFiles === true
+        ? [...RUNTIME_GITIGNORE_LINES, ...AGENT_PROMPT_GITIGNORE_LINES]
+        : [...RUNTIME_GITIGNORE_LINES],
+  });
+}
+
+export async function ensureRuntimeSqliteGitignore(opts: { gitRoot: string }): Promise<void> {
+  await ensureGitignoreLines({
+    gitRoot: opts.gitRoot,
+    lines: [
+      ".agentplane/cache.sqlite",
+      ".agentplane/cache.sqlite-wal",
+      ".agentplane/cache.sqlite-shm",
+    ],
+  });
+}
+
+async function ensureGitignoreLines(opts: { gitRoot: string; lines: string[] }): Promise<void> {
+  const gitignorePath = path.join(opts.gitRoot, ".gitignore");
+  const existing = (await readTextIfExists(gitignorePath)) ?? "";
+
+  const existingLines = existing.split(/\r?\n/);
+  const existingSet = new Set(existingLines.map((line) => line.trimEnd()));
+
+  const missing = opts.lines.filter((line) => !existingSet.has(line));
+  if (missing.length === 0) return;
+
+  const nextLines = [...existingLines];
+  // Keep content stable and append a trailing newline.
+  if (nextLines.length > 0 && nextLines.at(-1) !== "") nextLines.push("");
+  nextLines.push(...missing, "");
+
+  const nextText = `${nextLines.join("\n")}`.replaceAll(/\n{2,}$/g, "\n");
+  await writeTextIfChanged(gitignorePath, nextText);
+}


### PR DESCRIPTION
Task: `202605141516-363FBC`
Title: Ignore SQLite cache on read-heavy commands
Canonical task record: `.agentplane/tasks/202605141516-363FBC/README.md`

## Summary

Ignore SQLite cache on read-heavy commands

Ensure read-heavy commands that create the shared SQLite cache also prevent .agentplane/cache.sqlite and WAL/SHM files from appearing as untracked files in older AgentPlane repositories whose .gitignore predates the v0.6 cache ignore entries.

## Scope

- In scope: Ensure read-heavy commands that create the shared SQLite cache also prevent .agentplane/cache.sqlite and WAL/SHM files from appearing as untracked files in older AgentPlane repositories whose .gitignore predates the v0.6 cache ignore entries.
- Out of scope: unrelated refactors not required for "Ignore SQLite cache on read-heavy commands".

## Verification

- State: ok
- Note:

```text
Verified: SQLite cache writers repair stale .gitignore entries for .agentplane/cache.sqlite,
.agentplane/cache.sqlite-wal, and .agentplane/cache.sqlite-shm before writing the shared cache.
Evidence: focused LocalBackend/context tests pass, exact-file ESLint passes, typecheck passes,
policy routing passes, git diff whitespace check passes, and doctor is OK with unrelated
pre-existing branch_pr normalization warnings.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-14T15:37:51.952Z
- Branch: task/202605141516-363FBC/sqlite-cache-ignore
- Head: 5670c639f092

```text
 .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
 .../src/backends/task-backend.local.test.ts        |  43 ++
 .../task-backend/local-task-sqlite-cache.ts        |   4 +
 .../cli/run-cli/commands/init/write-gitignore.ts   |  42 +-
 packages/agentplane/src/context/reindex.ts         |   2 +
 .../src/runtime/shared/runtime-gitignore.ts        |  61 +++
 6 files changed, 643 insertions(+), 37 deletions(-)
```

</details>
