### PR TITLE
🚧 K64QQ7 task: Allow context init bootstrap through pre-push [202605141547-K64QQ7]

### DIFF
--- a/.agentplane/tasks/202605141547-K64QQ7/README.md
+++ b/.agentplane/tasks/202605141547-K64QQ7/README.md
@@ -1,0 +1,150 @@
+---
+id: "202605141547-K64QQ7"
+title: "Allow context init bootstrap through pre-push"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-14T15:47:35.204Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-14T15:51:27.771Z"
+  updated_by: "CODER"
+  note: "Implemented managed context bootstrap pre-push evidence for the exact CTX1NT context-init commit shape, constrained to .agentplane/context/**, context/**, and .gitignore. Regression coverage passed for accepted context bootstrap commits and rejected non-context paths. Checks passed: pre-push task-binding Vitest 9/9, Prettier touched files, ESLint touched files, typecheck, and policy routing."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement the approved context init bootstrap pre-push fix by adding a narrow managed CTX1NT context bootstrap exception, regression tests for accepted context files and rejected non-context files, then verify with focused hook tests and code checks."
+events:
+  -
+    type: "status"
+    at: "2026-05-14T15:48:01.250Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement the approved context init bootstrap pre-push fix by adding a narrow managed CTX1NT context bootstrap exception, regression tests for accepted context files and rejected non-context files, then verify with focused hook tests and code checks."
+  -
+    type: "verify"
+    at: "2026-05-14T15:51:27.771Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented managed context bootstrap pre-push evidence for the exact CTX1NT context-init commit shape, constrained to .agentplane/context/**, context/**, and .gitignore. Regression coverage passed for accepted context bootstrap commits and rejected non-context paths. Checks passed: pre-push task-binding Vitest 9/9, Prettier touched files, ESLint touched files, typecheck, and policy routing."
+doc_version: 3
+doc_updated_at: "2026-05-14T15:51:27.788Z"
+doc_updated_by: "CODER"
+description: "Fix task-bound pre-push auditing so the managed context init bootstrap commit can be pushed when it contains only AgentPlane context bootstrap files, and add regression coverage that non-context paths with the same subject remain blocked."
+sections:
+  Summary: |-
+    Allow context init bootstrap through pre-push
+    
+    Fix task-bound pre-push auditing so the managed context init bootstrap commit can be pushed when it contains only AgentPlane context bootstrap files, and add regression coverage that non-context paths with the same subject remain blocked.
+  Scope: |-
+    - In scope: Fix task-bound pre-push auditing so the managed context init bootstrap commit can be pushed when it contains only AgentPlane context bootstrap files, and add regression coverage that non-context paths with the same subject remain blocked.
+    - Out of scope: unrelated refactors not required for "Allow context init bootstrap through pre-push".
+  Plan: "Plan: (1) Add a narrow managed context bootstrap exception to both pre-push implementations for the exact CTX1NT context-init subject. (2) Restrict the exception to AgentPlane context bootstrap paths plus .gitignore so ordinary implementation changes with the same subject remain blocked. (3) Add regression coverage for allowed context bootstrap and denied non-context paths. (4) Run focused pre-push task-binding tests, formatting/lint/typecheck, and routing checks. (5) Re-run a source audit of managed commit shapes and record any remaining concrete gaps."
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+    
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-14T15:51:27.771Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Implemented managed context bootstrap pre-push evidence for the exact CTX1NT context-init commit shape, constrained to .agentplane/context/**, context/**, and .gitignore. Regression coverage passed for accepted context bootstrap commits and rejected non-context paths. Checks passed: pre-push task-binding Vitest 9/9, Prettier touched files, ESLint touched files, typecheck, and policy routing.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T15:48:01.250Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141547-K64QQ7-context-bootstrap-prepush/.agentplane/tasks/202605141547-K64QQ7/blueprint/resolved-snapshot.json
+    - old_digest: b9460241002574247f3e97064bee29e77f2a6e74d7972eb85fed05ebae58f74e
+    - current_digest: b9460241002574247f3e97064bee29e77f2a6e74d7972eb85fed05ebae58f74e
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141547-K64QQ7
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: A context init bootstrap commit containing .agentplane/context yaml/jsonl files can be blocked by pre-push task-bound mutation audit because CTX1NT is synthetic and has no task directory.
+      Impact: First push after context bootstrap can fail in the same class as the Windows install-commit report when the managed context bootstrap commit exists.
+      Resolution: Added a narrow managed context bootstrap exception with path constraints and negative regression coverage.
+id_source: "generated"
+---
+## Summary
+
+Allow context init bootstrap through pre-push
+
+Fix task-bound pre-push auditing so the managed context init bootstrap commit can be pushed when it contains only AgentPlane context bootstrap files, and add regression coverage that non-context paths with the same subject remain blocked.
+
+## Scope
+
+- In scope: Fix task-bound pre-push auditing so the managed context init bootstrap commit can be pushed when it contains only AgentPlane context bootstrap files, and add regression coverage that non-context paths with the same subject remain blocked.
+- Out of scope: unrelated refactors not required for "Allow context init bootstrap through pre-push".
+
+## Plan
+
+Plan: (1) Add a narrow managed context bootstrap exception to both pre-push implementations for the exact CTX1NT context-init subject. (2) Restrict the exception to AgentPlane context bootstrap paths plus .gitignore so ordinary implementation changes with the same subject remain blocked. (3) Add regression coverage for allowed context bootstrap and denied non-context paths. (4) Run focused pre-push task-binding tests, formatting/lint/typecheck, and routing checks. (5) Re-run a source audit of managed commit shapes and record any remaining concrete gaps.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-14T15:51:27.771Z — VERIFY — ok
+
+By: CODER
+
+Note: Implemented managed context bootstrap pre-push evidence for the exact CTX1NT context-init commit shape, constrained to .agentplane/context/**, context/**, and .gitignore. Regression coverage passed for accepted context bootstrap commits and rejected non-context paths. Checks passed: pre-push task-binding Vitest 9/9, Prettier touched files, ESLint touched files, typecheck, and policy routing.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T15:48:01.250Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141547-K64QQ7-context-bootstrap-prepush/.agentplane/tasks/202605141547-K64QQ7/blueprint/resolved-snapshot.json
+- old_digest: b9460241002574247f3e97064bee29e77f2a6e74d7972eb85fed05ebae58f74e
+- current_digest: b9460241002574247f3e97064bee29e77f2a6e74d7972eb85fed05ebae58f74e
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141547-K64QQ7
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: A context init bootstrap commit containing .agentplane/context yaml/jsonl files can be blocked by pre-push task-bound mutation audit because CTX1NT is synthetic and has no task directory.
+  Impact: First push after context bootstrap can fail in the same class as the Windows install-commit report when the managed context bootstrap commit exists.
+  Resolution: Added a narrow managed context bootstrap exception with path constraints and negative regression coverage.

--- a/.agentplane/tasks/202605141547-K64QQ7/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605141547-K64QQ7/blueprint/resolved-snapshot.json
@@ -1,0 +1,552 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605141547-K64QQ7",
+    "title": "Allow context init bootstrap through pre-push",
+    "description": "Fix task-bound pre-push auditing so the managed context init bootstrap commit can be pushed when it contains only AgentPlane context bootstrap files, and add regression coverage that non-context paths with the same subject remain blocked.",
+    "tags": [
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "quality.regression",
+    "version": 1,
+    "title": "Quality regression",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "quality.regression",
+    "blueprintVersion": 1,
+    "title": "Quality regression",
+    "taskId": "202605141547-K64QQ7",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to quality.regression",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest",
+          "artifact"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "check_result"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "weak_links"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "regression.original_failure",
+        "kind": "artifact",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Original failure log or check output."
+      },
+      {
+        "id": "regression.reproduction",
+        "kind": "check_result",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Local reproduction or explicit non-reproduction result."
+      },
+      {
+        "id": "regression.focused_check",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Focused regression check."
+      },
+      {
+        "id": "regression.matrix_or_scope",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Affected test/check matrix or bounded scope."
+      },
+      {
+        "id": "regression.full_gate",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Full relevant gate or hosted check evidence."
+      },
+      {
+        "id": "regression.flake_classification",
+        "kind": "weak_links",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Flake classification or residual risk."
+      },
+      {
+        "id": "regression.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "affected matrix or full relevant gate",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "failure reproduction command",
+      "focused regression check",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest",
+        "artifact"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "check_result"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "weak_links"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "regression.original_failure",
+      "kind": "artifact",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Original failure log or check output."
+    },
+    {
+      "id": "regression.reproduction",
+      "kind": "check_result",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Local reproduction or explicit non-reproduction result."
+    },
+    {
+      "id": "regression.focused_check",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Focused regression check."
+    },
+    {
+      "id": "regression.matrix_or_scope",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Affected test/check matrix or bounded scope."
+    },
+    {
+      "id": "regression.full_gate",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Full relevant gate or hosted check evidence."
+    },
+    {
+      "id": "regression.flake_classification",
+      "kind": "weak_links",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Flake classification or residual risk."
+    },
+    {
+      "id": "regression.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "affected matrix or full relevant gate",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "failure reproduction command",
+    "focused regression check",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to quality.regression",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "b9460241002574247f3e97064bee29e77f2a6e74d7972eb85fed05ebae58f74e"
+  }
+}

--- a/.agentplane/tasks/202605141547-K64QQ7/pr/diffstat.txt
+++ b/.agentplane/tasks/202605141547-K64QQ7/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ ...un-cli.core.hooks.pre-push-task-binding.test.ts | 55 ++++++++++++++++++++++
+ .../agentplane/src/commands/hooks/run.pre-push.ts  | 25 ++++++++++
+ scripts/checks/run-pre-push-hook.mjs               | 22 +++++++++
+ 3 files changed, 102 insertions(+)

--- a/.agentplane/tasks/202605141547-K64QQ7/pr/github-body.md
+++ b/.agentplane/tasks/202605141547-K64QQ7/pr/github-body.md
@@ -1,0 +1,44 @@
+Task: `202605141547-K64QQ7`
+Title: Allow context init bootstrap through pre-push
+Canonical task record: `.agentplane/tasks/202605141547-K64QQ7/README.md`
+
+## Summary
+
+Allow context init bootstrap through pre-push
+
+Fix task-bound pre-push auditing so the managed context init bootstrap commit can be pushed when it contains only AgentPlane context bootstrap files, and add regression coverage that non-context paths with the same subject remain blocked.
+
+## Scope
+
+- In scope: Fix task-bound pre-push auditing so the managed context init bootstrap commit can be pushed when it contains only AgentPlane context bootstrap files, and add regression coverage that non-context paths with the same subject remain blocked.
+- Out of scope: unrelated refactors not required for "Allow context init bootstrap through pre-push".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Implemented managed context bootstrap pre-push evidence for the exact CTX1NT context-init commit
+shape, constrained to .agentplane/context/**, context/**, and .gitignore. Regression coverage passed
+for accepted context bootstrap commits and rejected non-context paths. Checks passed: pre-push
+task-binding Vitest 9/9, Prettier touched files, ESLint touched files, typecheck, and policy
+routing.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T15:51:45.574Z
+- Branch: task/202605141547-K64QQ7/context-bootstrap-prepush
+- Head: 226d4a0f7921
+
+```text
+ ...un-cli.core.hooks.pre-push-task-binding.test.ts | 55 ++++++++++++++++++++++
+ .../agentplane/src/commands/hooks/run.pre-push.ts  | 25 ++++++++++
+ scripts/checks/run-pre-push-hook.mjs               | 22 +++++++++
+ 3 files changed, 102 insertions(+)
+```
+
+</details>

--- a/.agentplane/tasks/202605141547-K64QQ7/pr/github-title.txt
+++ b/.agentplane/tasks/202605141547-K64QQ7/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 K64QQ7 task: Allow context init bootstrap through pre-push [202605141547-K64QQ7]

--- a/.agentplane/tasks/202605141547-K64QQ7/pr/meta.json
+++ b/.agentplane/tasks/202605141547-K64QQ7/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605141547-K64QQ7/context-bootstrap-prepush",
+  "created_at": "2026-05-14T15:48:01.410Z",
+  "head_sha": "226d4a0f792173007f73c44c03bdf13b633a1773",
+  "last_verified_at": "2026-05-14T15:51:27.771Z",
+  "last_verified_sha": "8fbbdfff39bb2c59e727bca3c47066a772f1a7cd",
+  "schema_version": 1,
+  "task_id": "202605141547-K64QQ7",
+  "updated_at": "2026-05-14T15:51:45.574Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605141547-K64QQ7/pr/meta.json
+++ b/.agentplane/tasks/202605141547-K64QQ7/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "226d4a0f792173007f73c44c03bdf13b633a1773",
   "last_verified_at": "2026-05-14T15:51:27.771Z",
   "last_verified_sha": "8fbbdfff39bb2c59e727bca3c47066a772f1a7cd",
+  "pr_number": 3728,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3728",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605141547-K64QQ7",
-  "updated_at": "2026-05-14T15:51:45.574Z",
+  "updated_at": "2026-05-14T15:51:57.465Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141547-K64QQ7/pr/review.md
+++ b/.agentplane/tasks/202605141547-K64QQ7/pr/review.md
@@ -1,0 +1,39 @@
+# PR Review
+
+Created: 2026-05-14T15:48:01.410Z
+
+## Task
+
+- Task: `202605141547-K64QQ7`
+- Title: Allow context init bootstrap through pre-push
+- Status: DOING
+- Branch: `task/202605141547-K64QQ7/context-bootstrap-prepush`
+- Canonical task record: `.agentplane/tasks/202605141547-K64QQ7/README.md`
+
+## Verification
+
+- State: ok
+- Note: Implemented managed context bootstrap pre-push evidence for the exact CTX1NT context-init commit shape, constrained to .agentplane/context/**, context/**, and .gitignore. Regression coverage passed for accepted context bootstrap commits and rejected non-context paths. Checks passed: pre-push task-binding Vitest 9/9, Prettier touched files, ESLint touched files, typecheck, and policy routing.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T15:51:45.574Z
+- Branch: task/202605141547-K64QQ7/context-bootstrap-prepush
+- Head: 226d4a0f7921
+
+```text
+ ...un-cli.core.hooks.pre-push-task-binding.test.ts | 55 ++++++++++++++++++++++
+ .../agentplane/src/commands/hooks/run.pre-push.ts  | 25 ++++++++++
+ scripts/checks/run-pre-push-hook.mjs               | 22 +++++++++
+ 3 files changed, 102 insertions(+)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/cli/run-cli.core.hooks.pre-push-task-binding.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.hooks.pre-push-task-binding.test.ts
@@ -207,6 +207,61 @@ describe("pre-push task binding audit", () => {
     expect(String(result.failure?.stderr ?? "")).toContain("src/app.ts");
   });
 
+  it("accepts managed context init bootstrap commits", async () => {
+    const root = await mkGitRepoRootWithBranch("main");
+    await configureGitUser(root);
+    await writeFastHookPackage(root);
+    await commitAll(root, "chore: base");
+    const baseSha = head(root);
+
+    await mkdir(path.join(root, ".agentplane", "context", "derived", "facts"), {
+      recursive: true,
+    });
+    await mkdir(path.join(root, ".agentplane", "context", "policies"), { recursive: true });
+    await mkdir(path.join(root, "context", "wiki"), { recursive: true });
+    await writeFile(path.join(root, ".gitignore"), ".agentplane/cache.sqlite\n", "utf8");
+    await writeFile(
+      path.join(root, ".agentplane", "context", "agentplane.context.yaml"),
+      "version: 1\n",
+      "utf8",
+    );
+    await writeFile(
+      path.join(root, ".agentplane", "context", "derived", "facts", "facts.jsonl"),
+      "{}\n",
+      "utf8",
+    );
+    await writeFile(
+      path.join(root, ".agentplane", "context", "policies", "sync.rules.yaml"),
+      "version: 1\n",
+      "utf8",
+    );
+    await writeFile(path.join(root, "context", "wiki", "index.md"), "# Wiki\n", "utf8");
+    await commitAll(root, "✅ CTX1NT task: initialize AgentPlane context");
+    const result = runPrePush(root, baseSha, head(root));
+
+    expect(result.failure).toBeNull();
+    expect(result.stdout).toContain("Running pre-push checks in standard mode.");
+  });
+
+  it("does not let context-bootstrap subjects bypass task binding for non-context paths", async () => {
+    const root = await mkGitRepoRootWithBranch("main");
+    await configureGitUser(root);
+    await writeFastHookPackage(root);
+    await commitAll(root, "chore: base");
+    const baseSha = head(root);
+
+    await mkdir(path.join(root, "src"), { recursive: true });
+    await writeFile(path.join(root, "src", "app.ts"), "export const value = 1;\n", "utf8");
+    await commitAll(root, "✅ CTX1NT task: initialize AgentPlane context");
+    const result = runPrePush(root, baseSha, head(root));
+
+    expect(result.failure).not.toBeNull();
+    expect(String(result.failure?.stderr ?? "")).toContain(
+      "pre-push blocked: mutating commits require a valid task id",
+    );
+    expect(String(result.failure?.stderr ?? "")).toContain("src/app.ts");
+  });
+
   it("includes merge commits in mutating commit audits", async () => {
     const root = await mkGitRepoRootWithBranch("main");
     await configureGitUser(root);

--- a/packages/agentplane/src/cli/run-cli.core.hooks.pre-push-task-binding.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.hooks.pre-push-task-binding.test.ts
@@ -235,12 +235,51 @@ describe("pre-push task binding audit", () => {
       "version: 1\n",
       "utf8",
     );
+    await writeFile(
+      path.join(root, ".agentplane", "context", "manifest.lock.json"),
+      "{}\n",
+      "utf8",
+    );
     await writeFile(path.join(root, "context", "wiki", "index.md"), "# Wiki\n", "utf8");
-    await commitAll(root, "✅ CTX1NT task: initialize AgentPlane context");
+    const execFileAsync = promisify(execFile);
+    await execFileAsync("git", ["add", ".gitignore", ".agentplane", "context"], { cwd: root });
+    await execFileAsync(
+      "git",
+      [
+        "commit",
+        "-m",
+        "✅ CTX1NT task: initialize AgentPlane context",
+        "-m",
+        ["Context-Bootstrap: true", "Context-Bootstrap-Task: 202601010101-CTX1NT"].join("\n"),
+      ],
+      { cwd: root },
+    );
     const result = runPrePush(root, baseSha, head(root));
 
     expect(result.failure).toBeNull();
     expect(result.stdout).toContain("Running pre-push checks in standard mode.");
+  });
+
+  it("requires context-bootstrap trailers for the managed context init bypass", async () => {
+    const root = await mkGitRepoRootWithBranch("main");
+    await configureGitUser(root);
+    await writeFastHookPackage(root);
+    await commitAll(root, "chore: base");
+    const baseSha = head(root);
+
+    await mkdir(path.join(root, ".agentplane", "context"), { recursive: true });
+    await writeFile(
+      path.join(root, ".agentplane", "context", "manifest.lock.json"),
+      "{}\n",
+      "utf8",
+    );
+    await commitAll(root, "✅ CTX1NT task: initialize AgentPlane context");
+    const result = runPrePush(root, baseSha, head(root));
+
+    expect(result.failure).not.toBeNull();
+    expect(String(result.failure?.stderr ?? "")).toContain(
+      "pre-push blocked: mutating commits require a valid task id",
+    );
   });
 
   it("does not let context-bootstrap subjects bypass task binding for non-context paths", async () => {

--- a/packages/agentplane/src/commands/context/init.ts
+++ b/packages/agentplane/src/commands/context/init.ts
@@ -153,10 +153,19 @@ async function commitContextBootstrapIfChanged(root: string): Promise<boolean> {
     AGENTPLANE_TASK_ID: CONTEXT_BOOTSTRAP_TASK_ID,
   };
   await execFileAsync("git", ["add", "."], { cwd: root, env: baseGitEnv });
-  await execFileAsync("git", ["commit", "-m", "✅ CTX1NT task: initialize AgentPlane context"], {
-    cwd: root,
-    env,
-  });
+  await execFileAsync(
+    "git",
+    [
+      "commit",
+      "-m",
+      "✅ CTX1NT task: initialize AgentPlane context",
+      "-m",
+      ["Context-Bootstrap: true", `Context-Bootstrap-Task: ${CONTEXT_BOOTSTRAP_TASK_ID}`].join(
+        "\n",
+      ),
+    ],
+    { cwd: root, env },
+  );
   return true;
 }
 

--- a/packages/agentplane/src/commands/hooks/run.pre-push.ts
+++ b/packages/agentplane/src/commands/hooks/run.pre-push.ts
@@ -283,22 +283,23 @@ function hasManagedInstallEvidence(body: string, mutatingPaths: readonly string[
   );
 }
 
-function isManagedContextBootstrapPath(filePath: string): boolean {
-  return (
-    filePath === ".gitignore" ||
-    gitPathIsUnder(filePath, ".agentplane/context") ||
-    gitPathIsUnder(filePath, "context")
-  );
-}
-
 function hasManagedContextBootstrapEvidence(
   body: string,
   mutatingPaths: readonly string[],
 ): boolean {
-  if (commitSubject(body) !== "✅ CTX1NT task: initialize AgentPlane context") return false;
+  const hasBootstrapEvidence =
+    commitSubject(body) === "✅ CTX1NT task: initialize AgentPlane context" &&
+    /^Context-Bootstrap:\s*true\s*$/im.test(body) &&
+    /^Context-Bootstrap-Task:\s*202601010101-CTX1NT\s*$/im.test(body) &&
+    mutatingPaths.includes(".agentplane/context/manifest.lock.json");
   return (
-    mutatingPaths.length > 0 &&
-    mutatingPaths.every((filePath) => isManagedContextBootstrapPath(filePath))
+    hasBootstrapEvidence &&
+    mutatingPaths.every(
+      (filePath) =>
+        filePath === ".gitignore" ||
+        gitPathIsUnder(filePath, ".agentplane/context") ||
+        gitPathIsUnder(filePath, "context"),
+    )
   );
 }
 

--- a/packages/agentplane/src/commands/hooks/run.pre-push.ts
+++ b/packages/agentplane/src/commands/hooks/run.pre-push.ts
@@ -282,6 +282,30 @@ function hasManagedInstallEvidence(body: string, mutatingPaths: readonly string[
   );
 }
 
+function isManagedContextBootstrapPath(filePath: string): boolean {
+  return (
+    filePath === ".gitignore" ||
+    gitPathIsUnder(filePath, ".agentplane/context") ||
+    gitPathIsUnder(filePath, "context")
+  );
+}
+
+function hasManagedContextBootstrapEvidence(
+  body: string,
+  mutatingPaths: readonly string[],
+): boolean {
+  const subject =
+    body
+      .split("\n")
+      .find((line) => line.trim())
+      ?.trim() ?? "";
+  if (subject !== "✅ CTX1NT task: initialize AgentPlane context") return false;
+  return (
+    mutatingPaths.length > 0 &&
+    mutatingPaths.every((filePath) => isManagedContextBootstrapPath(filePath))
+  );
+}
+
 function readCommitList(gitRoot: string, range: { from: string; to: string } | null): string[] {
   if (!range) return [];
   return readGitText(gitRoot, ["log", "--format=%H", `${range.from}..${range.to}`])
@@ -321,6 +345,7 @@ function enforceTaskBoundOutgoingCommits(
     if (taskIdFromSubject(gitRoot, subject)) continue;
     if (hasManagedUpgradeEvidence(body)) continue;
     if (hasManagedInstallEvidence(body, mutating)) continue;
+    if (hasManagedContextBootstrapEvidence(body, mutating)) continue;
     if (hasEmergencyBackfillEvidence(body)) continue;
 
     failures.push(

--- a/packages/agentplane/src/commands/hooks/run.pre-push.ts
+++ b/packages/agentplane/src/commands/hooks/run.pre-push.ts
@@ -243,13 +243,19 @@ function hasEmergencyBackfillEvidence(body: string): boolean {
   return evidence.length >= 12;
 }
 
-function hasManagedUpgradeEvidence(body: string): boolean {
-  const subject =
+function commitSubject(body: string): string {
+  return (
     body
       .split("\n")
       .find((line) => line.trim())
-      ?.trim() ?? "";
-  return /^⬆️\s+upgrade:\s+/u.test(subject) && /^Upgrade-Version:\s*\S+\s*$/im.test(body);
+      ?.trim() ?? ""
+  );
+}
+
+function hasManagedUpgradeEvidence(body: string): boolean {
+  return (
+    /^⬆️\s+upgrade:\s+/u.test(commitSubject(body)) && /^Upgrade-Version:\s*\S+\s*$/im.test(body)
+  );
 }
 
 function isManagedInstallPath(filePath: string): boolean {
@@ -265,14 +271,9 @@ function isManagedInstallPath(filePath: string): boolean {
 }
 
 function hasManagedInstallEvidence(body: string, mutatingPaths: readonly string[]): boolean {
-  const subject =
-    body
-      .split("\n")
-      .find((line) => line.trim())
-      ?.trim() ?? "";
   if (
     !/^chore:\s+install agentplane \d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(
-      subject,
+      commitSubject(body),
     )
   ) {
     return false;
@@ -294,12 +295,7 @@ function hasManagedContextBootstrapEvidence(
   body: string,
   mutatingPaths: readonly string[],
 ): boolean {
-  const subject =
-    body
-      .split("\n")
-      .find((line) => line.trim())
-      ?.trim() ?? "";
-  if (subject !== "✅ CTX1NT task: initialize AgentPlane context") return false;
+  if (commitSubject(body) !== "✅ CTX1NT task: initialize AgentPlane context") return false;
   return (
     mutatingPaths.length > 0 &&
     mutatingPaths.every((filePath) => isManagedContextBootstrapPath(filePath))

--- a/scripts/checks/run-pre-push-hook.mjs
+++ b/scripts/checks/run-pre-push-hook.mjs
@@ -220,19 +220,20 @@ function hasManagedInstallEvidence(body, mutatingPaths) {
   );
 }
 
-function isManagedContextBootstrapPath(filePath) {
-  return (
-    filePath === ".gitignore" ||
-    isUnder(filePath, ".agentplane/context") ||
-    isUnder(filePath, "context")
-  );
-}
-
 function hasManagedContextBootstrapEvidence(body, mutatingPaths) {
-  if (commitSubject(body) !== "✅ CTX1NT task: initialize AgentPlane context") return false;
+  const hasBootstrapEvidence =
+    commitSubject(body) === "✅ CTX1NT task: initialize AgentPlane context" &&
+    /^Context-Bootstrap:\s*true\s*$/im.test(body) &&
+    /^Context-Bootstrap-Task:\s*202601010101-CTX1NT\s*$/im.test(body) &&
+    mutatingPaths.includes(".agentplane/context/manifest.lock.json");
   return (
-    mutatingPaths.length > 0 &&
-    mutatingPaths.every((filePath) => isManagedContextBootstrapPath(filePath))
+    hasBootstrapEvidence &&
+    mutatingPaths.every(
+      (filePath) =>
+        filePath === ".gitignore" ||
+        isUnder(filePath, ".agentplane/context") ||
+        isUnder(filePath, "context"),
+    )
   );
 }
 

--- a/scripts/checks/run-pre-push-hook.mjs
+++ b/scripts/checks/run-pre-push-hook.mjs
@@ -219,6 +219,27 @@ function hasManagedInstallEvidence(body, mutatingPaths) {
   );
 }
 
+function isManagedContextBootstrapPath(filePath) {
+  return (
+    filePath === ".gitignore" ||
+    isUnder(filePath, ".agentplane/context") ||
+    isUnder(filePath, "context")
+  );
+}
+
+function hasManagedContextBootstrapEvidence(body, mutatingPaths) {
+  const subject =
+    body
+      .split("\n")
+      .find((line) => line.trim())
+      ?.trim() ?? "";
+  if (subject !== "✅ CTX1NT task: initialize AgentPlane context") return false;
+  return (
+    mutatingPaths.length > 0 &&
+    mutatingPaths.every((filePath) => isManagedContextBootstrapPath(filePath))
+  );
+}
+
 function readCommitList(range) {
   if (!range) return [];
   return readQuiet("git", ["log", "--format=%H", `${range.from}..${range.to}`])
@@ -255,6 +276,7 @@ function enforceTaskBoundOutgoingCommits(range) {
     if (taskIdFromSubject(subject)) continue;
     if (hasManagedUpgradeEvidence(body)) continue;
     if (hasManagedInstallEvidence(body, mutating)) continue;
+    if (hasManagedContextBootstrapEvidence(body, mutating)) continue;
     if (hasEmergencyBackfillEvidence(body)) continue;
 
     failures.push(

--- a/scripts/checks/run-pre-push-hook.mjs
+++ b/scripts/checks/run-pre-push-hook.mjs
@@ -180,13 +180,19 @@ function hasEmergencyBackfillEvidence(body) {
   return evidence.length >= 12;
 }
 
-function hasManagedUpgradeEvidence(body) {
-  const subject =
+function commitSubject(body) {
+  return (
     body
       .split("\n")
       .find((line) => line.trim())
-      ?.trim() ?? "";
-  return /^⬆️\s+upgrade:\s+/u.test(subject) && /^Upgrade-Version:\s*\S+\s*$/im.test(body);
+      ?.trim() ?? ""
+  );
+}
+
+function hasManagedUpgradeEvidence(body) {
+  return (
+    /^⬆️\s+upgrade:\s+/u.test(commitSubject(body)) && /^Upgrade-Version:\s*\S+\s*$/im.test(body)
+  );
 }
 
 function isManagedInstallPath(filePath) {
@@ -202,14 +208,9 @@ function isManagedInstallPath(filePath) {
 }
 
 function hasManagedInstallEvidence(body, mutatingPaths) {
-  const subject =
-    body
-      .split("\n")
-      .find((line) => line.trim())
-      ?.trim() ?? "";
   if (
     !/^chore:\s+install agentplane \d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(
-      subject,
+      commitSubject(body),
     )
   ) {
     return false;
@@ -228,12 +229,7 @@ function isManagedContextBootstrapPath(filePath) {
 }
 
 function hasManagedContextBootstrapEvidence(body, mutatingPaths) {
-  const subject =
-    body
-      .split("\n")
-      .find((line) => line.trim())
-      ?.trim() ?? "";
-  if (subject !== "✅ CTX1NT task: initialize AgentPlane context") return false;
+  if (commitSubject(body) !== "✅ CTX1NT task: initialize AgentPlane context") return false;
   return (
     mutatingPaths.length > 0 &&
     mutatingPaths.every((filePath) => isManagedContextBootstrapPath(filePath))


### PR DESCRIPTION
Task: `202605141547-K64QQ7`
Title: Allow context init bootstrap through pre-push
Canonical task record: `.agentplane/tasks/202605141547-K64QQ7/README.md`

## Summary

Allow context init bootstrap through pre-push

Fix task-bound pre-push auditing so the managed context init bootstrap commit can be pushed when it contains only AgentPlane context bootstrap files, and add regression coverage that non-context paths with the same subject remain blocked.

## Scope

- In scope: Fix task-bound pre-push auditing so the managed context init bootstrap commit can be pushed when it contains only AgentPlane context bootstrap files, and add regression coverage that non-context paths with the same subject remain blocked.
- Out of scope: unrelated refactors not required for "Allow context init bootstrap through pre-push".

## Verification

- State: ok
- Note:

```text
Implemented managed context bootstrap pre-push evidence for the exact CTX1NT context-init commit
shape, constrained to .agentplane/context/**, context/**, and .gitignore. Regression coverage passed
for accepted context bootstrap commits and rejected non-context paths. Checks passed: pre-push
task-binding Vitest 9/9, Prettier touched files, ESLint touched files, typecheck, and policy
routing.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-14T15:51:45.574Z
- Branch: task/202605141547-K64QQ7/context-bootstrap-prepush
- Head: 226d4a0f7921

```text
 ...un-cli.core.hooks.pre-push-task-binding.test.ts | 55 ++++++++++++++++++++++
 .../agentplane/src/commands/hooks/run.pre-push.ts  | 25 ++++++++++
 scripts/checks/run-pre-push-hook.mjs               | 22 +++++++++
 3 files changed, 102 insertions(+)
```

</details>
