### PR TITLE
🚧 FFRZBW task: Add runner playbook contracts [202605141556-FFRZBW]

### DIFF
--- a/.agentplane/tasks/202605141556-FFRZBW/README.md
+++ b/.agentplane/tasks/202605141556-FFRZBW/README.md
@@ -1,0 +1,213 @@
+---
+id: "202605141556-FFRZBW"
+title: "Add runner playbook contracts"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "blueprints"
+  - "code"
+  - "runner"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-14T15:57:20.586Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-14T16:09:58.900Z"
+  updated_by: "CODER"
+  note: "Re-verified after task-specific Verify Steps were recorded: runner playbook contract layer is implemented and covered by focused checks."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement the approved generic runner playbook contract layer in the task worktree, keeping the diff scoped to runtime contract code, focused tests, and task verification evidence."
+events:
+  -
+    type: "status"
+    at: "2026-05-14T15:57:47.446Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement the approved generic runner playbook contract layer in the task worktree, keeping the diff scoped to runtime contract code, focused tests, and task verification evidence."
+  -
+    type: "verify"
+    at: "2026-05-14T16:09:28.564Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: runner playbook contract layer implemented with generic blueprint/playbook/runtime capability/final verifier contracts, attached to runner bundle/bootstrap, and covered by focused tests."
+  -
+    type: "verify"
+    at: "2026-05-14T16:09:58.900Z"
+    author: "CODER"
+    state: "ok"
+    note: "Re-verified after task-specific Verify Steps were recorded: runner playbook contract layer is implemented and covered by focused checks."
+doc_version: 3
+doc_updated_at: "2026-05-14T16:09:58.914Z"
+doc_updated_by: "CODER"
+description: "Introduce generic execution blueprint, task playbook, runtime capability, and verifier contracts informed by BitGN failure classes without benchmark-specific task-id hacks."
+sections:
+  Summary: |-
+    Add runner playbook contracts
+    
+    Introduce generic execution blueprint, task playbook, runtime capability, and verifier contracts informed by BitGN failure classes without benchmark-specific task-id hacks.
+  Scope: |-
+    - In scope: Introduce generic execution blueprint, task playbook, runtime capability, and verifier contracts informed by BitGN failure classes without benchmark-specific task-id hacks.
+    - Out of scope: unrelated refactors not required for "Add runner playbook contracts".
+  Plan: "Implement a minimal generic runner contract layer: (1) inspect existing blueprint/evaluator/runtime surfaces and choose the local package boundary; (2) add typed ExecutionBlueprint, TaskPlaybook, RuntimeCapability, ExecutionState, and verification result contracts; (3) add a built-in knowledge-capture playbook as a generic example with deterministic success checks; (4) add focused unit tests and documentation comments only where needed; (5) run task verification, targeted tests, policy routing check, and agentplane doctor."
+  Verify Steps: |-
+    1. `bunx vitest run packages/agentplane/src/runner/playbooks.test.ts packages/agentplane/src/runner/usecases/task-run-blueprint.test.ts` - validates playbook selection, blueprint/playbook separation, final verifier blocking, and bootstrap rendering.
+    2. `bun run --filter=agentplane typecheck` - validates the runner bundle and exported type contracts.
+    3. `bun run format:check -- packages/agentplane/src/runner/playbooks.ts packages/agentplane/src/runner/playbooks.test.ts packages/agentplane/src/runner/types/playbooks.ts packages/agentplane/src/runner/usecases/task-run-blueprint.test.ts packages/agentplane/src/runner/usecases/task-run-bootstrap.ts packages/agentplane/src/runner/usecases/task-run.ts packages/agentplane/src/runner/types.ts packages/agentplane/src/runner/types/context.ts` - validates formatting in touched source files.
+    4. `node .agentplane/policy/check-routing.mjs` - validates policy routing after task metadata changes.
+    5. `ap doctor` - validates repository/runtime health for this task worktree.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-14T16:09:28.564Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified: runner playbook contract layer implemented with generic blueprint/playbook/runtime capability/final verifier contracts, attached to runner bundle/bootstrap, and covered by focused tests.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T15:57:47.446Z, excerpt_hash=sha256:dc97acf9e455281943c19e1613a5796b2fb4958b34201acf6657f1e1467eead5
+    
+    Details:
+    
+    Command: bunx vitest run packages/agentplane/src/runner/playbooks.test.ts packages/agentplane/src/runner/usecases/task-run-blueprint.test.ts | Result: pass | Evidence: 2 files and 6 tests passed | Scope: playbook selection, blueprint/playbook separation, final verifier blocking, bootstrap rendering.
+    Command: bun run --filter=agentplane typecheck | Result: pass | Evidence: agentplane typecheck exited 0 | Scope: runner bundle/types exports.
+    Command: bun run format:check -- touched runner files | Result: pass | Evidence: All matched files use Prettier code style | Scope: touched TS files.
+    Command: node .agentplane/policy/check-routing.mjs | Result: pass | Evidence: policy routing OK | Scope: policy routing after task metadata changes.
+    Command: ap doctor | Result: pass with pre-existing warnings | Evidence: doctor OK, errors=0, warnings=2 for old branch_pr reconciliation tasks | Scope: repo/runtime health.
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141556-FFRZBW-runner-playbook-contracts/.agentplane/tasks/202605141556-FFRZBW/blueprint/resolved-snapshot.json
+    - old_digest: 63b2132fc7671065de0df8ab156b973f5e532c9b33ca007b188c23c25b49e2e1
+    - current_digest: 63b2132fc7671065de0df8ab156b973f5e532c9b33ca007b188c23c25b49e2e1
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141556-FFRZBW
+    
+    ### 2026-05-14T16:09:58.900Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Re-verified after task-specific Verify Steps were recorded: runner playbook contract layer is implemented and covered by focused checks.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T16:09:28.572Z, excerpt_hash=sha256:dc97acf9e455281943c19e1613a5796b2fb4958b34201acf6657f1e1467eead5
+    
+    Details:
+    
+    Command: bunx vitest run packages/agentplane/src/runner/playbooks.test.ts packages/agentplane/src/runner/usecases/task-run-blueprint.test.ts | Result: pass | Evidence: 2 files and 6 tests passed | Scope: playbook selection, blueprint/playbook separation, final verifier blocking, bootstrap rendering.
+    Command: bun run --filter=agentplane typecheck | Result: pass | Evidence: agentplane typecheck exited 0 | Scope: runner bundle/types exports.
+    Command: bun run format:check -- touched runner files | Result: pass | Evidence: All matched files use Prettier code style | Scope: touched TS files.
+    Command: node .agentplane/policy/check-routing.mjs | Result: pass | Evidence: policy routing OK | Scope: policy routing after task metadata changes.
+    Command: ap doctor | Result: pass with pre-existing warnings | Evidence: doctor OK, errors=0, warnings=2 for old branch_pr reconciliation tasks | Scope: repo/runtime health.
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141556-FFRZBW-runner-playbook-contracts/.agentplane/tasks/202605141556-FFRZBW/blueprint/resolved-snapshot.json
+    - old_digest: 63b2132fc7671065de0df8ab156b973f5e532c9b33ca007b188c23c25b49e2e1
+    - current_digest: 63b2132fc7671065de0df8ab156b973f5e532c9b33ca007b188c23c25b49e2e1
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141556-FFRZBW
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add runner playbook contracts
+
+Introduce generic execution blueprint, task playbook, runtime capability, and verifier contracts informed by BitGN failure classes without benchmark-specific task-id hacks.
+
+## Scope
+
+- In scope: Introduce generic execution blueprint, task playbook, runtime capability, and verifier contracts informed by BitGN failure classes without benchmark-specific task-id hacks.
+- Out of scope: unrelated refactors not required for "Add runner playbook contracts".
+
+## Plan
+
+Implement a minimal generic runner contract layer: (1) inspect existing blueprint/evaluator/runtime surfaces and choose the local package boundary; (2) add typed ExecutionBlueprint, TaskPlaybook, RuntimeCapability, ExecutionState, and verification result contracts; (3) add a built-in knowledge-capture playbook as a generic example with deterministic success checks; (4) add focused unit tests and documentation comments only where needed; (5) run task verification, targeted tests, policy routing check, and agentplane doctor.
+
+## Verify Steps
+
+1. `bunx vitest run packages/agentplane/src/runner/playbooks.test.ts packages/agentplane/src/runner/usecases/task-run-blueprint.test.ts` - validates playbook selection, blueprint/playbook separation, final verifier blocking, and bootstrap rendering.
+2. `bun run --filter=agentplane typecheck` - validates the runner bundle and exported type contracts.
+3. `bun run format:check -- packages/agentplane/src/runner/playbooks.ts packages/agentplane/src/runner/playbooks.test.ts packages/agentplane/src/runner/types/playbooks.ts packages/agentplane/src/runner/usecases/task-run-blueprint.test.ts packages/agentplane/src/runner/usecases/task-run-bootstrap.ts packages/agentplane/src/runner/usecases/task-run.ts packages/agentplane/src/runner/types.ts packages/agentplane/src/runner/types/context.ts` - validates formatting in touched source files.
+4. `node .agentplane/policy/check-routing.mjs` - validates policy routing after task metadata changes.
+5. `ap doctor` - validates repository/runtime health for this task worktree.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-14T16:09:28.564Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: runner playbook contract layer implemented with generic blueprint/playbook/runtime capability/final verifier contracts, attached to runner bundle/bootstrap, and covered by focused tests.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T15:57:47.446Z, excerpt_hash=sha256:dc97acf9e455281943c19e1613a5796b2fb4958b34201acf6657f1e1467eead5
+
+Details:
+
+Command: bunx vitest run packages/agentplane/src/runner/playbooks.test.ts packages/agentplane/src/runner/usecases/task-run-blueprint.test.ts | Result: pass | Evidence: 2 files and 6 tests passed | Scope: playbook selection, blueprint/playbook separation, final verifier blocking, bootstrap rendering.
+Command: bun run --filter=agentplane typecheck | Result: pass | Evidence: agentplane typecheck exited 0 | Scope: runner bundle/types exports.
+Command: bun run format:check -- touched runner files | Result: pass | Evidence: All matched files use Prettier code style | Scope: touched TS files.
+Command: node .agentplane/policy/check-routing.mjs | Result: pass | Evidence: policy routing OK | Scope: policy routing after task metadata changes.
+Command: ap doctor | Result: pass with pre-existing warnings | Evidence: doctor OK, errors=0, warnings=2 for old branch_pr reconciliation tasks | Scope: repo/runtime health.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141556-FFRZBW-runner-playbook-contracts/.agentplane/tasks/202605141556-FFRZBW/blueprint/resolved-snapshot.json
+- old_digest: 63b2132fc7671065de0df8ab156b973f5e532c9b33ca007b188c23c25b49e2e1
+- current_digest: 63b2132fc7671065de0df8ab156b973f5e532c9b33ca007b188c23c25b49e2e1
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141556-FFRZBW
+
+### 2026-05-14T16:09:58.900Z — VERIFY — ok
+
+By: CODER
+
+Note: Re-verified after task-specific Verify Steps were recorded: runner playbook contract layer is implemented and covered by focused checks.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T16:09:28.572Z, excerpt_hash=sha256:dc97acf9e455281943c19e1613a5796b2fb4958b34201acf6657f1e1467eead5
+
+Details:
+
+Command: bunx vitest run packages/agentplane/src/runner/playbooks.test.ts packages/agentplane/src/runner/usecases/task-run-blueprint.test.ts | Result: pass | Evidence: 2 files and 6 tests passed | Scope: playbook selection, blueprint/playbook separation, final verifier blocking, bootstrap rendering.
+Command: bun run --filter=agentplane typecheck | Result: pass | Evidence: agentplane typecheck exited 0 | Scope: runner bundle/types exports.
+Command: bun run format:check -- touched runner files | Result: pass | Evidence: All matched files use Prettier code style | Scope: touched TS files.
+Command: node .agentplane/policy/check-routing.mjs | Result: pass | Evidence: policy routing OK | Scope: policy routing after task metadata changes.
+Command: ap doctor | Result: pass with pre-existing warnings | Evidence: doctor OK, errors=0, warnings=2 for old branch_pr reconciliation tasks | Scope: repo/runtime health.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141556-FFRZBW-runner-playbook-contracts/.agentplane/tasks/202605141556-FFRZBW/blueprint/resolved-snapshot.json
+- old_digest: 63b2132fc7671065de0df8ab156b973f5e532c9b33ca007b188c23c25b49e2e1
+- current_digest: 63b2132fc7671065de0df8ab156b973f5e532c9b33ca007b188c23c25b49e2e1
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141556-FFRZBW
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605141556-FFRZBW/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605141556-FFRZBW/blueprint/resolved-snapshot.json
@@ -1,0 +1,552 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605141556-FFRZBW",
+    "title": "Add runner playbook contracts",
+    "description": "Introduce generic execution blueprint, task playbook, runtime capability, and verifier contracts informed by BitGN failure classes without benchmark-specific task-id hacks.",
+    "tags": [
+      "blueprints",
+      "code",
+      "runner"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "runner.execution",
+    "version": 1,
+    "title": "Runner execution",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "runner.execution",
+    "blueprintVersion": 1,
+    "title": "Runner execution",
+    "taskId": "202605141556-FFRZBW",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to runner.execution",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest",
+          "artifact"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "artifact"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "artifact"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "runner.bundle",
+        "kind": "artifact",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Runner context bundle or bundle inspection."
+      },
+      {
+        "id": "runner.invocation",
+        "kind": "artifact",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Invocation inputs and command or adapter capability."
+      },
+      {
+        "id": "runner.result_manifest",
+        "kind": "artifact",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Result manifest or manifest validation."
+      },
+      {
+        "id": "runner.trace",
+        "kind": "artifact",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Execution trace or log path."
+      },
+      {
+        "id": "runner.execution_state",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Execution state transition evidence."
+      },
+      {
+        "id": "runner.replay_or_resume",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Replay or resume validation."
+      },
+      {
+        "id": "runner.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks",
+      "runner bundle inspection",
+      "runner execution/replay/resume check"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Runner execution work needs branch_pr policy plus runner bundle and execution-state artifacts."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest",
+        "artifact"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "artifact"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "artifact"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "runner.bundle",
+      "kind": "artifact",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Runner context bundle or bundle inspection."
+    },
+    {
+      "id": "runner.invocation",
+      "kind": "artifact",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Invocation inputs and command or adapter capability."
+    },
+    {
+      "id": "runner.result_manifest",
+      "kind": "artifact",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Result manifest or manifest validation."
+    },
+    {
+      "id": "runner.trace",
+      "kind": "artifact",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Execution trace or log path."
+    },
+    {
+      "id": "runner.execution_state",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Execution state transition evidence."
+    },
+    {
+      "id": "runner.replay_or_resume",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Replay or resume validation."
+    },
+    {
+      "id": "runner.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks",
+    "runner bundle inspection",
+    "runner execution/replay/resume check"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Runner execution work needs branch_pr policy plus runner bundle and execution-state artifacts."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to runner.execution",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "63b2132fc7671065de0df8ab156b973f5e532c9b33ca007b188c23c25b49e2e1"
+  }
+}

--- a/.agentplane/tasks/202605141556-FFRZBW/pr/diffstat.txt
+++ b/.agentplane/tasks/202605141556-FFRZBW/pr/diffstat.txt
@@ -1,0 +1,10 @@
+ .../blueprint/resolved-snapshot.json               | 552 +++++++++++++++++++++
+ packages/agentplane/src/runner/playbooks.test.ts   |  61 +++
+ packages/agentplane/src/runner/playbooks.ts        | 165 ++++++
+ packages/agentplane/src/runner/types.ts            |  15 +
+ packages/agentplane/src/runner/types/context.ts    |   2 +
+ packages/agentplane/src/runner/types/playbooks.ts  |  89 ++++
+ .../src/runner/usecases/task-run-blueprint.test.ts |  15 +
+ .../src/runner/usecases/task-run-bootstrap.ts      |  18 +
+ .../agentplane/src/runner/usecases/task-run.ts     |   2 +
+ 9 files changed, 919 insertions(+)

--- a/.agentplane/tasks/202605141556-FFRZBW/pr/github-body.md
+++ b/.agentplane/tasks/202605141556-FFRZBW/pr/github-body.md
@@ -27,12 +27,21 @@ implemented and covered by focused checks.
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T15:57:47.506Z
+- Updated: 2026-05-14T16:10:56.775Z
 - Branch: task/202605141556-FFRZBW/runner-playbook-contracts
-- Head: bc43cfb088e0
+- Head: ba7585811055
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 552 +++++++++++++++++++++
+ packages/agentplane/src/runner/playbooks.test.ts   |  61 +++
+ packages/agentplane/src/runner/playbooks.ts        | 165 ++++++
+ packages/agentplane/src/runner/types.ts            |  15 +
+ packages/agentplane/src/runner/types/context.ts    |   2 +
+ packages/agentplane/src/runner/types/playbooks.ts  |  89 ++++
+ .../src/runner/usecases/task-run-blueprint.test.ts |  15 +
+ .../src/runner/usecases/task-run-bootstrap.ts      |  18 +
+ .../agentplane/src/runner/usecases/task-run.ts     |   2 +
+ 9 files changed, 919 insertions(+)
 ```
 
 </details>

--- a/.agentplane/tasks/202605141556-FFRZBW/pr/github-body.md
+++ b/.agentplane/tasks/202605141556-FFRZBW/pr/github-body.md
@@ -1,0 +1,38 @@
+Task: `202605141556-FFRZBW`
+Title: Add runner playbook contracts
+Canonical task record: `.agentplane/tasks/202605141556-FFRZBW/README.md`
+
+## Summary
+
+Add runner playbook contracts
+
+Introduce generic execution blueprint, task playbook, runtime capability, and verifier contracts informed by BitGN failure classes without benchmark-specific task-id hacks.
+
+## Scope
+
+- In scope: Introduce generic execution blueprint, task playbook, runtime capability, and verifier contracts informed by BitGN failure classes without benchmark-specific task-id hacks.
+- Out of scope: unrelated refactors not required for "Add runner playbook contracts".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Re-verified after task-specific Verify Steps were recorded: runner playbook contract layer is
+implemented and covered by focused checks.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T15:57:47.506Z
+- Branch: task/202605141556-FFRZBW/runner-playbook-contracts
+- Head: bc43cfb088e0
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605141556-FFRZBW/pr/github-title.txt
+++ b/.agentplane/tasks/202605141556-FFRZBW/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 FFRZBW task: Add runner playbook contracts [202605141556-FFRZBW]

--- a/.agentplane/tasks/202605141556-FFRZBW/pr/meta.json
+++ b/.agentplane/tasks/202605141556-FFRZBW/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605141556-FFRZBW/runner-playbook-contracts",
   "created_at": "2026-05-14T15:57:47.506Z",
-  "head_sha": "bc43cfb088e056e6e7aa029cdda9ce7bac55429c",
+  "head_sha": "ba75858110554d893bbce2f1f72470c375d344df",
   "last_verified_at": "2026-05-14T16:09:58.900Z",
   "last_verified_sha": "bc43cfb088e056e6e7aa029cdda9ce7bac55429c",
   "schema_version": 1,
   "task_id": "202605141556-FFRZBW",
-  "updated_at": "2026-05-14T15:57:47.506Z",
+  "updated_at": "2026-05-14T16:10:56.775Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141556-FFRZBW/pr/meta.json
+++ b/.agentplane/tasks/202605141556-FFRZBW/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "ba75858110554d893bbce2f1f72470c375d344df",
   "last_verified_at": "2026-05-14T16:09:58.900Z",
   "last_verified_sha": "bc43cfb088e056e6e7aa029cdda9ce7bac55429c",
+  "pr_number": 3730,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3730",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605141556-FFRZBW",
-  "updated_at": "2026-05-14T16:10:56.775Z",
+  "updated_at": "2026-05-14T16:11:02.894Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141556-FFRZBW/pr/meta.json
+++ b/.agentplane/tasks/202605141556-FFRZBW/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605141556-FFRZBW/runner-playbook-contracts",
+  "created_at": "2026-05-14T15:57:47.506Z",
+  "head_sha": "bc43cfb088e056e6e7aa029cdda9ce7bac55429c",
+  "last_verified_at": "2026-05-14T16:09:58.900Z",
+  "last_verified_sha": "bc43cfb088e056e6e7aa029cdda9ce7bac55429c",
+  "schema_version": 1,
+  "task_id": "202605141556-FFRZBW",
+  "updated_at": "2026-05-14T15:57:47.506Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605141556-FFRZBW/pr/review.md
+++ b/.agentplane/tasks/202605141556-FFRZBW/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-14T15:57:47.506Z
+
+## Task
+
+- Task: `202605141556-FFRZBW`
+- Title: Add runner playbook contracts
+- Status: DOING
+- Branch: `task/202605141556-FFRZBW/runner-playbook-contracts`
+- Canonical task record: `.agentplane/tasks/202605141556-FFRZBW/README.md`
+
+## Verification
+
+- State: ok
+- Note: Re-verified after task-specific Verify Steps were recorded: runner playbook contract layer is implemented and covered by focused checks.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T15:57:47.506Z
+- Branch: task/202605141556-FFRZBW/runner-playbook-contracts
+- Head: bc43cfb088e0
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605141556-FFRZBW/pr/review.md
+++ b/.agentplane/tasks/202605141556-FFRZBW/pr/review.md
@@ -24,12 +24,21 @@ Created: 2026-05-14T15:57:47.506Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T15:57:47.506Z
+- Updated: 2026-05-14T16:10:56.775Z
 - Branch: task/202605141556-FFRZBW/runner-playbook-contracts
-- Head: bc43cfb088e0
+- Head: ba7585811055
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 552 +++++++++++++++++++++
+ packages/agentplane/src/runner/playbooks.test.ts   |  61 +++
+ packages/agentplane/src/runner/playbooks.ts        | 165 ++++++
+ packages/agentplane/src/runner/types.ts            |  15 +
+ packages/agentplane/src/runner/types/context.ts    |   2 +
+ packages/agentplane/src/runner/types/playbooks.ts  |  89 ++++
+ .../src/runner/usecases/task-run-blueprint.test.ts |  15 +
+ .../src/runner/usecases/task-run-bootstrap.ts      |  18 +
+ .../agentplane/src/runner/usecases/task-run.ts     |   2 +
+ 9 files changed, 919 insertions(+)
 ```
 
 </details>

--- a/packages/agentplane/src/runner/playbooks.test.ts
+++ b/packages/agentplane/src/runner/playbooks.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { makeRunnerContextBundle } from "@agentplane/testkit/runner";
+
+import {
+  buildRunnerExecutionPlaybookContract,
+  resolveRunnerTaskPlaybook,
+  verifyRunnerFinalState,
+} from "./playbooks.js";
+
+describe("runner execution playbooks", () => {
+  it("selects the knowledge capture playbook from task signals", () => {
+    const bundle = makeRunnerContextBundle({
+      title: "Process inbox item into capture and distill thread",
+      description: "Read the inbox source, create a knowledge card, and update the thread.",
+      tags: ["context"],
+    });
+
+    const resolved = resolveRunnerTaskPlaybook(bundle);
+
+    expect(resolved.playbook?.id).toBe("knowledge_capture_pipeline");
+    expect(resolved.match_reasons.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("keeps execution blueprint state separate from playbook steps", () => {
+    const bundle = makeRunnerContextBundle({
+      title: "Capture inbox source into knowledge base",
+      description: "Create capture, distill card, thread update, and retire the source.",
+    });
+
+    const contract = buildRunnerExecutionPlaybookContract(bundle);
+
+    expect(contract.execution_blueprint.id).toBe("knowledge_capture_result");
+    expect(contract.selected_playbook?.required_steps).toContain("write_card");
+    expect(contract.execution_blueprint.required_state).toEqual([
+      "capture_artifact_exists",
+      "distill_card_exists",
+      "retrieval_index_updated",
+      "source_retired",
+    ]);
+  });
+
+  it("blocks success when the final verifier state is incomplete", () => {
+    const bundle = makeRunnerContextBundle({
+      title: "Capture inbox source into knowledge base",
+      description: "Create capture, distill card, thread update, and retire the source.",
+    });
+    const contract = buildRunnerExecutionPlaybookContract(bundle);
+
+    const result = verifyRunnerFinalState({
+      contract,
+      state: {
+        capture_artifact_exists: true,
+        distill_card_exists: true,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.missing).toEqual(["retrieval_index_updated", "source_retired"]);
+  });
+});

--- a/packages/agentplane/src/runner/playbooks.ts
+++ b/packages/agentplane/src/runner/playbooks.ts
@@ -1,0 +1,165 @@
+import type { RunnerContextBundle } from "./types/context.js";
+import type {
+  RunnerExecutionBlueprintStateId,
+  RunnerExecutionPlaybookContract,
+  RunnerFinalVerifierCheck,
+  RunnerFinalVerifierResult,
+  RunnerFinalVerifierState,
+  RunnerRuntimeCapabilityContract,
+  RunnerRuntimeCapabilityId,
+  RunnerRuntimeCapabilityState,
+  RunnerTaskPlaybookContract,
+} from "./types/playbooks.js";
+
+const CAPABILITY_IDS: readonly RunnerRuntimeCapabilityId[] = [
+  "file.read",
+  "file.write",
+  "file.delete",
+  "file.move",
+  "file.search",
+  "process.exec",
+  "result.manifest.write",
+];
+
+export const KNOWLEDGE_CAPTURE_PLAYBOOK: RunnerTaskPlaybookContract = {
+  id: "knowledge_capture_pipeline",
+  version: 1,
+  title: "Knowledge capture pipeline",
+  applies_to_blueprint: "knowledge_capture_result",
+  match_signals: ["inbox", "capture", "distill", "thread", "knowledge"],
+  required_steps: [
+    "read_policy",
+    "read_source",
+    "write_capture",
+    "write_card",
+    "update_retrieval_index",
+    "retire_source",
+    "verify_blueprint",
+  ],
+  required_capabilities: ["file.read", "file.write", "file.delete", "file.search"],
+  allowed_outcomes: ["OUTCOME_OK", "OUTCOME_NONE_CLARIFICATION", "OUTCOME_NONE_UNSUPPORTED"],
+};
+
+export const BUILTIN_RUNNER_PLAYBOOKS: readonly RunnerTaskPlaybookContract[] = [
+  KNOWLEDGE_CAPTURE_PLAYBOOK,
+];
+
+function textFromBundle(bundle: RunnerContextBundle): string {
+  return [
+    bundle.task?.data.title,
+    bundle.task?.data.description,
+    ...(bundle.task?.data.tags ?? []),
+    bundle.task?.data.blueprint_request,
+    bundle.blueprint?.blueprintId,
+    bundle.recipe?.scenario_id,
+    bundle.recipe?.recipe_name,
+  ]
+    .filter((item): item is string => typeof item === "string" && item.length > 0)
+    .join("\n")
+    .toLowerCase();
+}
+
+function playbookMatchReasons(opts: {
+  bundle: RunnerContextBundle;
+  playbook: RunnerTaskPlaybookContract;
+}): string[] {
+  const haystack = textFromBundle(opts.bundle);
+  return opts.playbook.match_signals
+    .filter((signal) => haystack.includes(signal))
+    .map((signal) => `matched signal ${JSON.stringify(signal)}`);
+}
+
+export function resolveRunnerTaskPlaybook(bundle: RunnerContextBundle): {
+  playbook?: RunnerTaskPlaybookContract;
+  match_reasons: readonly string[];
+} {
+  const scored = BUILTIN_RUNNER_PLAYBOOKS.map((playbook) => ({
+    playbook,
+    reasons: playbookMatchReasons({ bundle, playbook }),
+  })).filter((item) => item.reasons.length > 0);
+  scored.sort((left, right) => right.reasons.length - left.reasons.length);
+  const winner = scored[0];
+  if (!winner) return { match_reasons: [] };
+  return { playbook: winner.playbook, match_reasons: winner.reasons };
+}
+
+function capabilityStateForAdapterField(opts: {
+  bundle: RunnerContextBundle;
+  id: RunnerRuntimeCapabilityId;
+}): RunnerRuntimeCapabilityState {
+  if (opts.id === "result.manifest.write") return "available";
+  const adapterId = opts.bundle.execution.adapter_id;
+  if (adapterId === "codex") return "unknown";
+  return "unknown";
+}
+
+export function resolveRunnerRuntimeCapabilityContract(
+  bundle: RunnerContextBundle,
+): RunnerRuntimeCapabilityContract {
+  const capabilities = Object.fromEntries(
+    CAPABILITY_IDS.map((id) => [id, capabilityStateForAdapterField({ bundle, id })]),
+  ) as Record<RunnerRuntimeCapabilityId, RunnerRuntimeCapabilityState>;
+  return {
+    runtime_id: bundle.execution.adapter_id,
+    capabilities,
+  };
+}
+
+function checksForRequiredState(
+  requiredState: readonly RunnerExecutionBlueprintStateId[],
+): RunnerFinalVerifierCheck[] {
+  return requiredState.map((id) => ({
+    id,
+    required: true,
+    description: `Required execution blueprint state ${id} must be observed before success.`,
+  }));
+}
+
+export function buildRunnerExecutionPlaybookContract(
+  bundle: RunnerContextBundle,
+): RunnerExecutionPlaybookContract {
+  const selected = resolveRunnerTaskPlaybook(bundle);
+  const requiredState: readonly RunnerExecutionBlueprintStateId[] = selected.playbook
+    ? [
+        "capture_artifact_exists",
+        "distill_card_exists",
+        "retrieval_index_updated",
+        "source_retired",
+      ]
+    : ["policy_decision_recorded"];
+  return {
+    schema_version: 1,
+    artifact_kind: "agentplane.runner.execution_playbook_contract",
+    ...(selected.playbook ? { selected_playbook: selected.playbook } : {}),
+    execution_blueprint: {
+      id: selected.playbook?.applies_to_blueprint ?? "generic_runner_execution_result",
+      ...(bundle.blueprint?.blueprintId
+        ? { source_blueprint_id: bundle.blueprint.blueprintId }
+        : {}),
+      required_state: requiredState,
+      success_outcome: "OUTCOME_OK",
+    },
+    runtime_capabilities: resolveRunnerRuntimeCapabilityContract(bundle),
+    final_verifier: {
+      mode: "pre_success_guard",
+      blocks_success_when_missing: true,
+      checks: checksForRequiredState(requiredState),
+    },
+    match_reasons: selected.match_reasons,
+  };
+}
+
+export function verifyRunnerFinalState(opts: {
+  contract: RunnerExecutionPlaybookContract;
+  state: RunnerFinalVerifierState;
+}): RunnerFinalVerifierResult {
+  const checked = opts.contract.final_verifier.checks
+    .filter((check) => check.required)
+    .map((check) => check.id);
+  const missing = checked.filter((id) => opts.state[id] !== true);
+  return {
+    ok: missing.length === 0,
+    missing,
+    checked,
+  };
+}

--- a/packages/agentplane/src/runner/types.ts
+++ b/packages/agentplane/src/runner/types.ts
@@ -6,6 +6,21 @@ export {
 export type { RunnerTarget } from "./types/target.js";
 export type { RunnerPromptBlock, RunnerPromptRole } from "./types/prompts.js";
 export type { RunnerAdapterCapabilities } from "./types/capabilities.js";
+export type {
+  RunnerExecutionBlueprintContract,
+  RunnerExecutionBlueprintStateId,
+  RunnerExecutionPlaybookContract,
+  RunnerFinalVerifierCheck,
+  RunnerFinalVerifierContract,
+  RunnerFinalVerifierResult,
+  RunnerFinalVerifierState,
+  RunnerOutcomeName,
+  RunnerPlaybookStepId,
+  RunnerRuntimeCapabilityContract,
+  RunnerRuntimeCapabilityId,
+  RunnerRuntimeCapabilityState,
+  RunnerTaskPlaybookContract,
+} from "./types/playbooks.js";
 export type { RunnerPolicyDecision, RunnerPolicyRefusal } from "./types/policy.js";
 export type {
   RunnerArtifactPaths,

--- a/packages/agentplane/src/runner/types/context.ts
+++ b/packages/agentplane/src/runner/types/context.ts
@@ -9,6 +9,7 @@ import type { FrameworkProtocolSurface } from "../../runtime/protocol/index.js";
 
 import type { RunnerAdapterCapabilities } from "./capabilities.js";
 import type { RUNNER_API_VERSION, RUNNER_BUNDLE_SCHEMA_VERSION } from "./constants.js";
+import type { RunnerExecutionPlaybookContract } from "./playbooks.js";
 import type { RunnerPolicyDecision } from "./policy.js";
 import type { RunnerPromptBlock } from "./prompts.js";
 import type { RunnerTarget } from "./target.js";
@@ -121,5 +122,6 @@ export type RunnerContextBundle = {
   task?: RunnerTaskContext;
   recipe?: RunnerRecipeContext;
   blueprint?: BlueprintPlanArtifact;
+  playbook?: RunnerExecutionPlaybookContract;
   execution: RunnerExecutionContract;
 };

--- a/packages/agentplane/src/runner/types/playbooks.ts
+++ b/packages/agentplane/src/runner/types/playbooks.ts
@@ -1,0 +1,89 @@
+import type { BlueprintId } from "../../blueprints/model.js";
+
+export type RunnerExecutionBlueprintStateId =
+  | "capture_artifact_exists"
+  | "distill_card_exists"
+  | "retrieval_index_updated"
+  | "source_retired"
+  | "policy_decision_recorded";
+
+export type RunnerPlaybookStepId =
+  | "read_policy"
+  | "read_source"
+  | "write_capture"
+  | "write_card"
+  | "update_retrieval_index"
+  | "retire_source"
+  | "verify_blueprint"
+  | "classify_blocker";
+
+export type RunnerRuntimeCapabilityId =
+  | "file.read"
+  | "file.write"
+  | "file.delete"
+  | "file.move"
+  | "file.search"
+  | "process.exec"
+  | "result.manifest.write";
+
+export type RunnerRuntimeCapabilityState = "available" | "unavailable" | "unknown";
+
+export type RunnerOutcomeName =
+  | "OUTCOME_OK"
+  | "OUTCOME_DENIED_SECURITY"
+  | "OUTCOME_NONE_CLARIFICATION"
+  | "OUTCOME_NONE_UNSUPPORTED"
+  | "OUTCOME_ERR_INTERNAL";
+
+export type RunnerExecutionBlueprintContract = {
+  id: string;
+  source_blueprint_id?: BlueprintId;
+  required_state: readonly RunnerExecutionBlueprintStateId[];
+  success_outcome: "OUTCOME_OK";
+};
+
+export type RunnerRuntimeCapabilityContract = {
+  runtime_id: string;
+  capabilities: Record<RunnerRuntimeCapabilityId, RunnerRuntimeCapabilityState>;
+};
+
+export type RunnerFinalVerifierCheck = {
+  id: RunnerExecutionBlueprintStateId;
+  required: boolean;
+  description: string;
+};
+
+export type RunnerFinalVerifierContract = {
+  mode: "pre_success_guard";
+  blocks_success_when_missing: boolean;
+  checks: readonly RunnerFinalVerifierCheck[];
+};
+
+export type RunnerTaskPlaybookContract = {
+  id: string;
+  version: 1;
+  title: string;
+  applies_to_blueprint: string;
+  match_signals: readonly string[];
+  required_steps: readonly RunnerPlaybookStepId[];
+  required_capabilities: readonly RunnerRuntimeCapabilityId[];
+  allowed_outcomes: readonly RunnerOutcomeName[];
+};
+
+export type RunnerExecutionPlaybookContract = {
+  schema_version: 1;
+  artifact_kind: "agentplane.runner.execution_playbook_contract";
+  selected_playbook?: RunnerTaskPlaybookContract;
+  execution_blueprint: RunnerExecutionBlueprintContract;
+  runtime_capabilities: RunnerRuntimeCapabilityContract;
+  final_verifier: RunnerFinalVerifierContract;
+  match_reasons: readonly string[];
+};
+
+export type RunnerFinalVerifierState = Partial<Record<RunnerExecutionBlueprintStateId, boolean>>;
+
+export type RunnerFinalVerifierResult = {
+  ok: boolean;
+  missing: readonly RunnerExecutionBlueprintStateId[];
+  checked: readonly RunnerExecutionBlueprintStateId[];
+};

--- a/packages/agentplane/src/runner/usecases/task-run-blueprint.test.ts
+++ b/packages/agentplane/src/runner/usecases/task-run-blueprint.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { makeRunnerContextBundle } from "@agentplane/testkit/runner";
 
+import { buildRunnerExecutionPlaybookContract } from "../playbooks.js";
 import { assertRunnerBlueprintPolicyModuleBudget, renderTaskRunnerBootstrap } from "./task-run.js";
 
 describe("runner blueprint guards", () => {
@@ -65,5 +66,19 @@ describe("runner blueprint guards", () => {
 
     expect(renderTaskRunnerBootstrap(bundle)).toContain("Blueprint stop rules:");
     expect(renderTaskRunnerBootstrap(bundle)).toContain("hard: Task scope changed. (scope_drift)");
+  });
+
+  it("renders execution playbook verifier checks into the runner bootstrap", () => {
+    const bundle = makeRunnerContextBundle({
+      title: "Capture inbox item",
+      description: "Create capture, distill card, thread update, and retire the source.",
+    });
+    bundle.playbook = buildRunnerExecutionPlaybookContract(bundle);
+
+    const bootstrap = renderTaskRunnerBootstrap(bundle);
+
+    expect(bootstrap).toContain("Execution playbook contract:");
+    expect(bootstrap).toContain("selected_playbook: knowledge_capture_pipeline");
+    expect(bootstrap).toContain("source_retired");
   });
 });

--- a/packages/agentplane/src/runner/usecases/task-run-bootstrap.ts
+++ b/packages/agentplane/src/runner/usecases/task-run-bootstrap.ts
@@ -9,6 +9,8 @@ export function renderTaskRunnerBootstrap(
       ? `task ${bundle.target.task_id}`
       : `recipe scenario ${bundle.target.recipe_id}:${bundle.target.scenario_id}`;
   const stopRules = bundle.blueprint?.stopReasons ?? [];
+  const playbook = bundle.playbook?.selected_playbook;
+  const verifierChecks = bundle.playbook?.final_verifier.checks ?? [];
   return [
     "# agentplane runner bootstrap",
     "",
@@ -32,6 +34,22 @@ export function renderTaskRunnerBootstrap(
           "",
           "Blueprint stop rules:",
           ...stopRules.map((rule) => `- ${rule.severity}: ${rule.reason} (${rule.id})`),
+        ]
+      : []),
+    ...(bundle.playbook
+      ? [
+          "",
+          "Execution playbook contract:",
+          `- blueprint_result: ${bundle.playbook.execution_blueprint.id}`,
+          `- selected_playbook: ${playbook?.id ?? "none"}`,
+          `- runtime: ${bundle.playbook.runtime_capabilities.runtime_id}`,
+          "- final verifier blocks success when required state is missing.",
+          ...(verifierChecks.length > 0
+            ? [
+                "Required final state:",
+                ...verifierChecks.map((check) => `- ${check.id}: ${check.description}`),
+              ]
+            : []),
         ]
       : []),
     "Execute-mode runs must write a valid JSON result manifest to result_path before exiting.",

--- a/packages/agentplane/src/runner/usecases/task-run.ts
+++ b/packages/agentplane/src/runner/usecases/task-run.ts
@@ -34,6 +34,7 @@ import { readRecipeRunProfile } from "../adapters/recipe-run-profile.js";
 import { collectRunnerBasePrompts } from "../context/base-prompts.js";
 import { assembleRunnerTaskContext } from "../context/task-context.js";
 import { applyRunnerPolicyRefusal, buildRunnerPolicyDecision } from "../policy-decision.js";
+import { buildRunnerExecutionPlaybookContract } from "../playbooks.js";
 import { persistRunnerOutcomeToTask } from "../task-state.js";
 import { RunnerRunRepository } from "../run-repository.js";
 import { createRunnerRunId, resolveTaskRunnerPaths } from "../task-run-paths.js";
@@ -449,6 +450,7 @@ export async function prepareTaskRunnerExecution(opts: {
       },
     },
   };
+  bundle.playbook = buildRunnerExecutionPlaybookContract(bundle);
   executionProfile = consumeExecutionProfileBudget({
     runtime: bundle.execution.profile_runtime ?? executionProfile,
     phase: "implementation",


### PR DESCRIPTION
Task: `202605141556-FFRZBW`
Title: Add runner playbook contracts
Canonical task record: `.agentplane/tasks/202605141556-FFRZBW/README.md`

## Summary

Add runner playbook contracts

Introduce generic execution blueprint, task playbook, runtime capability, and verifier contracts informed by BitGN failure classes without benchmark-specific task-id hacks.

## Scope

- In scope: Introduce generic execution blueprint, task playbook, runtime capability, and verifier contracts informed by BitGN failure classes without benchmark-specific task-id hacks.
- Out of scope: unrelated refactors not required for "Add runner playbook contracts".

## Verification

- State: ok
- Note:

```text
Re-verified after task-specific Verify Steps were recorded: runner playbook contract layer is
implemented and covered by focused checks.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-14T16:10:56.775Z
- Branch: task/202605141556-FFRZBW/runner-playbook-contracts
- Head: ba7585811055

```text
 .../blueprint/resolved-snapshot.json               | 552 +++++++++++++++++++++
 packages/agentplane/src/runner/playbooks.test.ts   |  61 +++
 packages/agentplane/src/runner/playbooks.ts        | 165 ++++++
 packages/agentplane/src/runner/types.ts            |  15 +
 packages/agentplane/src/runner/types/context.ts    |   2 +
 packages/agentplane/src/runner/types/playbooks.ts  |  89 ++++
 .../src/runner/usecases/task-run-blueprint.test.ts |  15 +
 .../src/runner/usecases/task-run-bootstrap.ts      |  18 +
 .../agentplane/src/runner/usecases/task-run.ts     |   2 +
 9 files changed, 919 insertions(+)
```

</details>
