### PR TITLE
🚧 ER7JEJ task: Hotfix v0.6 audit correctness regressions [202605141638-ER7JEJ]

### DIFF
--- a/.agentplane/tasks/202605141638-3VAJ2V/README.md
+++ b/.agentplane/tasks/202605141638-3VAJ2V/README.md
@@ -1,0 +1,81 @@
+---
+id: "202605141638-3VAJ2V"
+title: "Finish shared guard and sleep deduplication"
+status: "TODO"
+priority: "med"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-14T16:41:03.645Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-14T16:39:53.027Z"
+doc_updated_by: "PLANNER"
+description: "Migrate remaining local isRecord and sleep copies to canonical shared helpers where appropriate, then add a lint or check guard that prevents new local isRecord definitions in packages/agentplane/src except approved canonical guard modules."
+sections:
+  Summary: |-
+    Finish shared guard and sleep deduplication
+    
+    Migrate remaining local isRecord and sleep copies to canonical shared helpers where appropriate, then add a lint or check guard that prevents new local isRecord definitions in packages/agentplane/src except approved canonical guard modules.
+  Scope: |-
+    - In scope: Migrate remaining local isRecord and sleep copies to canonical shared helpers where appropriate, then add a lint or check guard that prevents new local isRecord definitions in packages/agentplane/src except approved canonical guard modules.
+    - Out of scope: unrelated refactors not required for "Finish shared guard and sleep deduplication".
+  Plan: "Finish utility dedup governance. Scope: migrate remaining local isRecord definitions in packages/agentplane/src where canonical imports are straightforward, replace integrate queue local sleep with shared concurrency helper, and add a lint/check guard against new local isRecord copies except approved canonical modules. Out of scope: packages/core and packages/recipes canonical guard design changes."
+  Verify Steps: "1. Run a guard command that counts local isRecord definitions in packages/agentplane/src and fails on newly introduced non-canonical copies. 2. Run targeted tests or typecheck covering migrated modules. 3. Run bun run lint:core -- changed guard/refactor files. 4. Run node .agentplane/policy/check-routing.mjs. 5. Document any intentionally retained local guard wrappers in task Findings."
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Finish shared guard and sleep deduplication
+
+Migrate remaining local isRecord and sleep copies to canonical shared helpers where appropriate, then add a lint or check guard that prevents new local isRecord definitions in packages/agentplane/src except approved canonical guard modules.
+
+## Scope
+
+- In scope: Migrate remaining local isRecord and sleep copies to canonical shared helpers where appropriate, then add a lint or check guard that prevents new local isRecord definitions in packages/agentplane/src except approved canonical guard modules.
+- Out of scope: unrelated refactors not required for "Finish shared guard and sleep deduplication".
+
+## Plan
+
+Finish utility dedup governance. Scope: migrate remaining local isRecord definitions in packages/agentplane/src where canonical imports are straightforward, replace integrate queue local sleep with shared concurrency helper, and add a lint/check guard against new local isRecord copies except approved canonical modules. Out of scope: packages/core and packages/recipes canonical guard design changes.
+
+## Verify Steps
+
+1. Run a guard command that counts local isRecord definitions in packages/agentplane/src and fails on newly introduced non-canonical copies. 2. Run targeted tests or typecheck covering migrated modules. 3. Run bun run lint:core -- changed guard/refactor files. 4. Run node .agentplane/policy/check-routing.mjs. 5. Document any intentionally retained local guard wrappers in task Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605141638-78JKTQ/README.md
+++ b/.agentplane/tasks/202605141638-78JKTQ/README.md
@@ -1,0 +1,81 @@
+---
+id: "202605141638-78JKTQ"
+title: "Harden cloud auto-push failure semantics"
+status: "TODO"
+priority: "high"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "backend"
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-14T16:40:44.731Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-14T16:39:21.665Z"
+doc_updated_by: "PLANNER"
+description: "Design and implement protection for cloud-backend local mutations when maybeAutoPush fails, so pending local writes cannot be silently overwritten by a later prefer-remote pull. Add tests that cover network/retriable push failure followed by pull conflict resolution."
+sections:
+  Summary: |-
+    Harden cloud auto-push failure semantics
+    
+    Design and implement protection for cloud-backend local mutations when maybeAutoPush fails, so pending local writes cannot be silently overwritten by a later prefer-remote pull. Add tests that cover network/retriable push failure followed by pull conflict resolution.
+  Scope: |-
+    - In scope: Design and implement protection for cloud-backend local mutations when maybeAutoPush fails, so pending local writes cannot be silently overwritten by a later prefer-remote pull. Add tests that cover network/retriable push failure followed by pull conflict resolution.
+    - Out of scope: unrelated refactors not required for "Harden cloud auto-push failure semantics".
+  Plan: "Design and implement cloud auto-push failure protection. Scope: writeTask/writeTasks/delete paths around maybeAutoPush, durable pending-push or rollback semantics, conflict behavior under prefer-remote pull, and regression tests for failed push followed by pull. Out of scope: remote-only/deletion pull application, release tooling, and unrelated backend refactors."
+  Verify Steps: "1. Add or update regression tests proving a failed cloud auto-push cannot be silently overwritten by a later prefer-remote pull. 2. Verify the chosen rollback or pending-push marker behavior is visible in task/backend diagnostics. 3. Run targeted cloud backend tests. 4. Run bun run lint:core -- changed cloud backend files. 5. Run node .agentplane/policy/check-routing.mjs."
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Harden cloud auto-push failure semantics
+
+Design and implement protection for cloud-backend local mutations when maybeAutoPush fails, so pending local writes cannot be silently overwritten by a later prefer-remote pull. Add tests that cover network/retriable push failure followed by pull conflict resolution.
+
+## Scope
+
+- In scope: Design and implement protection for cloud-backend local mutations when maybeAutoPush fails, so pending local writes cannot be silently overwritten by a later prefer-remote pull. Add tests that cover network/retriable push failure followed by pull conflict resolution.
+- Out of scope: unrelated refactors not required for "Harden cloud auto-push failure semantics".
+
+## Plan
+
+Design and implement cloud auto-push failure protection. Scope: writeTask/writeTasks/delete paths around maybeAutoPush, durable pending-push or rollback semantics, conflict behavior under prefer-remote pull, and regression tests for failed push followed by pull. Out of scope: remote-only/deletion pull application, release tooling, and unrelated backend refactors.
+
+## Verify Steps
+
+1. Add or update regression tests proving a failed cloud auto-push cannot be silently overwritten by a later prefer-remote pull. 2. Verify the chosen rollback or pending-push marker behavior is visible in task/backend diagnostics. 3. Run targeted cloud backend tests. 4. Run bun run lint:core -- changed cloud backend files. 5. Run node .agentplane/policy/check-routing.mjs.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605141638-DYD163/README.md
+++ b/.agentplane/tasks/202605141638-DYD163/README.md
@@ -1,0 +1,81 @@
+---
+id: "202605141638-DYD163"
+title: "Unify release note validation rules"
+status: "TODO"
+priority: "med"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "release"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-14T16:41:00.774Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-14T16:39:42.123Z"
+doc_updated_by: "PLANNER"
+description: "Move duplicated release-note validation invariants out of the TS preflight and MJS release script into one canonical rules surface, keep both callers aligned, and add fixture tests that prove section, placeholder, duplicate heading, and bullet-count behavior share the same contract."
+sections:
+  Summary: |-
+    Unify release note validation rules
+    
+    Move duplicated release-note validation invariants out of the TS preflight and MJS release script into one canonical rules surface, keep both callers aligned, and add fixture tests that prove section, placeholder, duplicate heading, and bullet-count behavior share the same contract.
+  Scope: |-
+    - In scope: Move duplicated release-note validation invariants out of the TS preflight and MJS release script into one canonical rules surface, keep both callers aligned, and add fixture tests that prove section, placeholder, duplicate heading, and bullet-count behavior share the same contract.
+    - Out of scope: unrelated refactors not required for "Unify release note validation rules".
+  Plan: "Unify release-note validation rule ownership. Scope: shared rule module usable by release apply TS preflight and MJS release script, fixture tests for headings/placeholders/duplicates/bullets/fences, and removal of duplicated constants/functions. Out of scope: changing release-note public template content unless required by tests."
+  Verify Steps: "1. Prove TS release apply preflight and scripts/release/check-release-notes.mjs consume one canonical rule set or generated mirror. 2. Add/adjust fixtures for required sections, duplicate headings, template placeholders, fenced bullet lines, and tag validation. 3. Run targeted release-note tests and the release-note script against docs/releases/v0.6.0.md. 4. Run bun run lint:core -- changed release validation files. 5. Run node .agentplane/policy/check-routing.mjs."
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Unify release note validation rules
+
+Move duplicated release-note validation invariants out of the TS preflight and MJS release script into one canonical rules surface, keep both callers aligned, and add fixture tests that prove section, placeholder, duplicate heading, and bullet-count behavior share the same contract.
+
+## Scope
+
+- In scope: Move duplicated release-note validation invariants out of the TS preflight and MJS release script into one canonical rules surface, keep both callers aligned, and add fixture tests that prove section, placeholder, duplicate heading, and bullet-count behavior share the same contract.
+- Out of scope: unrelated refactors not required for "Unify release note validation rules".
+
+## Plan
+
+Unify release-note validation rule ownership. Scope: shared rule module usable by release apply TS preflight and MJS release script, fixture tests for headings/placeholders/duplicates/bullets/fences, and removal of duplicated constants/functions. Out of scope: changing release-note public template content unless required by tests.
+
+## Verify Steps
+
+1. Prove TS release apply preflight and scripts/release/check-release-notes.mjs consume one canonical rule set or generated mirror. 2. Add/adjust fixtures for required sections, duplicate headings, template placeholders, fenced bullet lines, and tag validation. 3. Run targeted release-note tests and the release-note script against docs/releases/v0.6.0.md. 4. Run bun run lint:core -- changed release validation files. 5. Run node .agentplane/policy/check-routing.mjs.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605141638-ER7JEJ/README.md
+++ b/.agentplane/tasks/202605141638-ER7JEJ/README.md
@@ -1,0 +1,136 @@
+---
+id: "202605141638-ER7JEJ"
+title: "Hotfix v0.6 audit correctness regressions"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "backend"
+  - "code"
+  - "release"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-14T16:40:31.843Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-14T16:48:40.957Z"
+  updated_by: "CODER"
+  note: "Command: rg -n '\"0\\.4\\.2\"|version: \"0\\.4\\.2\"|Math\\.random\\(\\)\\.toString\\(36\\).*slice\\(2, 8\\)|pull\\.lastCheckedAt \\?\\? new Date' packages/agentplane/src/commands/acr packages/agentplane/src/backends/task-backend packages/agentplane/src/cli.ts packages/agentplane/src/cli/fs-utils.ts packages/agentplane/src/commands/branch/internal/archive-pr.ts; Result: pass; Evidence: no scoped stale ACR version, Math.random backup suffix, or client-now pull freshness matches remain. Scope: audit hotfix regressions. Command: bun run test:project -- agentplane packages/agentplane/src/backends/task-backend/cloud-backend-state.test.ts packages/agentplane/src/commands/release/apply.preflight.test.ts packages/agentplane/src/commands/acr/acr.command.test.ts; Result: pass; Evidence: 3 files, 28 tests passed. Scope: cloud state, release-note preflight, ACR semantics. Command: bun run lint:core -- changed files; Result: pass; Evidence: eslint completed with exit 0. Scope: changed source/test/script files. Command: bun run --filter=agentplane typecheck; Result: pass; Evidence: agentplane typecheck exited 0. Scope: agentplane package types. Command: node scripts/release/check-release-notes.mjs --tag v0.6.0 and fenced-bullet smoke; Result: pass; Evidence: v0.6.0 accepted and fenced bullets fail min-bullet smoke as expected. Scope: MJS release-note checker. Command: node .agentplane/policy/check-routing.mjs; Result: pass; Evidence: policy routing OK. Scope: policy routing gate."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implementing the approved v0.6 audit hotfix scope in the task worktree, covering ACR version truthfulness, cloud state durability, release-note checker accuracy, CLI rejection output, crypto-safe backup suffixes, and pull freshness fallback without widening into larger cloud semantics refactors."
+events:
+  -
+    type: "status"
+    at: "2026-05-14T16:41:27.016Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implementing the approved v0.6 audit hotfix scope in the task worktree, covering ACR version truthfulness, cloud state durability, release-note checker accuracy, CLI rejection output, crypto-safe backup suffixes, and pull freshness fallback without widening into larger cloud semantics refactors."
+  -
+    type: "verify"
+    at: "2026-05-14T16:48:40.957Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: rg -n '\"0\\.4\\.2\"|version: \"0\\.4\\.2\"|Math\\.random\\(\\)\\.toString\\(36\\).*slice\\(2, 8\\)|pull\\.lastCheckedAt \\?\\? new Date' packages/agentplane/src/commands/acr packages/agentplane/src/backends/task-backend packages/agentplane/src/cli.ts packages/agentplane/src/cli/fs-utils.ts packages/agentplane/src/commands/branch/internal/archive-pr.ts; Result: pass; Evidence: no scoped stale ACR version, Math.random backup suffix, or client-now pull freshness matches remain. Scope: audit hotfix regressions. Command: bun run test:project -- agentplane packages/agentplane/src/backends/task-backend/cloud-backend-state.test.ts packages/agentplane/src/commands/release/apply.preflight.test.ts packages/agentplane/src/commands/acr/acr.command.test.ts; Result: pass; Evidence: 3 files, 28 tests passed. Scope: cloud state, release-note preflight, ACR semantics. Command: bun run lint:core -- changed files; Result: pass; Evidence: eslint completed with exit 0. Scope: changed source/test/script files. Command: bun run --filter=agentplane typecheck; Result: pass; Evidence: agentplane typecheck exited 0. Scope: agentplane package types. Command: node scripts/release/check-release-notes.mjs --tag v0.6.0 and fenced-bullet smoke; Result: pass; Evidence: v0.6.0 accepted and fenced bullets fail min-bullet smoke as expected. Scope: MJS release-note checker. Command: node .agentplane/policy/check-routing.mjs; Result: pass; Evidence: policy routing OK. Scope: policy routing gate."
+doc_version: 3
+doc_updated_at: "2026-05-14T16:48:40.965Z"
+doc_updated_by: "CODER"
+description: "Fix the low-risk v0.6 audit regressions that have narrow verification boundaries: ACR producer/toolchain version must match the package version, cloud backend state writes must be atomic and recover from malformed state JSON, release-note bullet counting must ignore fenced code blocks and use a strict release tag regex, CLI entrypoint must report unexpected rejections, random backup suffixes must use crypto randomness, and pull freshness must avoid client-now fallback."
+sections:
+  Summary: |-
+    Hotfix v0.6 audit correctness regressions
+    
+    Fix the low-risk v0.6 audit regressions that have narrow verification boundaries: ACR producer/toolchain version must match the package version, cloud backend state writes must be atomic and recover from malformed state JSON, release-note bullet counting must ignore fenced code blocks and use a strict release tag regex, CLI entrypoint must report unexpected rejections, random backup suffixes must use crypto randomness, and pull freshness must avoid client-now fallback.
+  Scope: |-
+    - In scope: Fix the low-risk v0.6 audit regressions that have narrow verification boundaries: ACR producer/toolchain version must match the package version, cloud backend state writes must be atomic and recover from malformed state JSON, release-note bullet counting must ignore fenced code blocks and use a strict release tag regex, CLI entrypoint must report unexpected rejections, random backup suffixes must use crypto randomness, and pull freshness must avoid client-now fallback.
+    - Out of scope: unrelated refactors not required for "Hotfix v0.6 audit correctness regressions".
+  Plan: "Fix narrow v0.6 audit regressions in one branch_pr worktree. Scope: ACR generator and tests, cloud backend state persistence, release-note checker, CLI entrypoint rejection handling, crypto-safe backup suffixes, and pull freshness fallback. Out of scope: cloud pending-push semantics, remote-only/deletion pull behavior, full release-note SSOT refactor, broad isRecord migration, and schema canonicalization."
+  Verify Steps: "1. Run rg -n '\"0\\.4\\.2\"' packages scripts and confirm no stale ACR/toolchain version literals remain except unrelated historical text if any. 2. Run targeted tests covering ACR generation/schema fixtures, cloud backend state read/write corruption handling, release-note validation, CLI entrypoint behavior, and backup suffix generation where tests exist or are added. 3. Run bun run lint:core -- changed source/test files. 4. Run node .agentplane/policy/check-routing.mjs. 5. Run agentplane task verify-show 202605141638-ER7JEJ before final verification."
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-14T16:48:40.957Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Command: rg -n '"0\.4\.2"|version: "0\.4\.2"|Math\.random\(\)\.toString\(36\).*slice\(2, 8\)|pull\.lastCheckedAt \?\? new Date' packages/agentplane/src/commands/acr packages/agentplane/src/backends/task-backend packages/agentplane/src/cli.ts packages/agentplane/src/cli/fs-utils.ts packages/agentplane/src/commands/branch/internal/archive-pr.ts; Result: pass; Evidence: no scoped stale ACR version, Math.random backup suffix, or client-now pull freshness matches remain. Scope: audit hotfix regressions. Command: bun run test:project -- agentplane packages/agentplane/src/backends/task-backend/cloud-backend-state.test.ts packages/agentplane/src/commands/release/apply.preflight.test.ts packages/agentplane/src/commands/acr/acr.command.test.ts; Result: pass; Evidence: 3 files, 28 tests passed. Scope: cloud state, release-note preflight, ACR semantics. Command: bun run lint:core -- changed files; Result: pass; Evidence: eslint completed with exit 0. Scope: changed source/test/script files. Command: bun run --filter=agentplane typecheck; Result: pass; Evidence: agentplane typecheck exited 0. Scope: agentplane package types. Command: node scripts/release/check-release-notes.mjs --tag v0.6.0 and fenced-bullet smoke; Result: pass; Evidence: v0.6.0 accepted and fenced bullets fail min-bullet smoke as expected. Scope: MJS release-note checker. Command: node .agentplane/policy/check-routing.mjs; Result: pass; Evidence: policy routing OK. Scope: policy routing gate.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T16:41:27.016Z, excerpt_hash=sha256:79328cc5b9c45a557d35719ffe010e9d767b6ad309b1865d5e49b37d9b3e3321
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141638-ER7JEJ-v06-audit-hotfix/.agentplane/tasks/202605141638-ER7JEJ/blueprint/resolved-snapshot.json
+    - old_digest: 321095422c48a87783674539511cd79e3e920d29c3bda7c9f06657f869d6adb1
+    - current_digest: 321095422c48a87783674539511cd79e3e920d29c3bda7c9f06657f869d6adb1
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141638-ER7JEJ
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Hotfix v0.6 audit correctness regressions
+
+Fix the low-risk v0.6 audit regressions that have narrow verification boundaries: ACR producer/toolchain version must match the package version, cloud backend state writes must be atomic and recover from malformed state JSON, release-note bullet counting must ignore fenced code blocks and use a strict release tag regex, CLI entrypoint must report unexpected rejections, random backup suffixes must use crypto randomness, and pull freshness must avoid client-now fallback.
+
+## Scope
+
+- In scope: Fix the low-risk v0.6 audit regressions that have narrow verification boundaries: ACR producer/toolchain version must match the package version, cloud backend state writes must be atomic and recover from malformed state JSON, release-note bullet counting must ignore fenced code blocks and use a strict release tag regex, CLI entrypoint must report unexpected rejections, random backup suffixes must use crypto randomness, and pull freshness must avoid client-now fallback.
+- Out of scope: unrelated refactors not required for "Hotfix v0.6 audit correctness regressions".
+
+## Plan
+
+Fix narrow v0.6 audit regressions in one branch_pr worktree. Scope: ACR generator and tests, cloud backend state persistence, release-note checker, CLI entrypoint rejection handling, crypto-safe backup suffixes, and pull freshness fallback. Out of scope: cloud pending-push semantics, remote-only/deletion pull behavior, full release-note SSOT refactor, broad isRecord migration, and schema canonicalization.
+
+## Verify Steps
+
+1. Run rg -n '"0\.4\.2"' packages scripts and confirm no stale ACR/toolchain version literals remain except unrelated historical text if any. 2. Run targeted tests covering ACR generation/schema fixtures, cloud backend state read/write corruption handling, release-note validation, CLI entrypoint behavior, and backup suffix generation where tests exist or are added. 3. Run bun run lint:core -- changed source/test files. 4. Run node .agentplane/policy/check-routing.mjs. 5. Run agentplane task verify-show 202605141638-ER7JEJ before final verification.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-14T16:48:40.957Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: rg -n '"0\.4\.2"|version: "0\.4\.2"|Math\.random\(\)\.toString\(36\).*slice\(2, 8\)|pull\.lastCheckedAt \?\? new Date' packages/agentplane/src/commands/acr packages/agentplane/src/backends/task-backend packages/agentplane/src/cli.ts packages/agentplane/src/cli/fs-utils.ts packages/agentplane/src/commands/branch/internal/archive-pr.ts; Result: pass; Evidence: no scoped stale ACR version, Math.random backup suffix, or client-now pull freshness matches remain. Scope: audit hotfix regressions. Command: bun run test:project -- agentplane packages/agentplane/src/backends/task-backend/cloud-backend-state.test.ts packages/agentplane/src/commands/release/apply.preflight.test.ts packages/agentplane/src/commands/acr/acr.command.test.ts; Result: pass; Evidence: 3 files, 28 tests passed. Scope: cloud state, release-note preflight, ACR semantics. Command: bun run lint:core -- changed files; Result: pass; Evidence: eslint completed with exit 0. Scope: changed source/test/script files. Command: bun run --filter=agentplane typecheck; Result: pass; Evidence: agentplane typecheck exited 0. Scope: agentplane package types. Command: node scripts/release/check-release-notes.mjs --tag v0.6.0 and fenced-bullet smoke; Result: pass; Evidence: v0.6.0 accepted and fenced bullets fail min-bullet smoke as expected. Scope: MJS release-note checker. Command: node .agentplane/policy/check-routing.mjs; Result: pass; Evidence: policy routing OK. Scope: policy routing gate.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T16:41:27.016Z, excerpt_hash=sha256:79328cc5b9c45a557d35719ffe010e9d767b6ad309b1865d5e49b37d9b3e3321
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141638-ER7JEJ-v06-audit-hotfix/.agentplane/tasks/202605141638-ER7JEJ/blueprint/resolved-snapshot.json
+- old_digest: 321095422c48a87783674539511cd79e3e920d29c3bda7c9f06657f869d6adb1
+- current_digest: 321095422c48a87783674539511cd79e3e920d29c3bda7c9f06657f869d6adb1
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141638-ER7JEJ
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605141638-ER7JEJ/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605141638-ER7JEJ/blueprint/resolved-snapshot.json
@@ -1,0 +1,417 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605141638-ER7JEJ",
+    "title": "Hotfix v0.6 audit correctness regressions",
+    "description": "Fix the low-risk v0.6 audit regressions that have narrow verification boundaries: ACR producer/toolchain version must match the package version, cloud backend state writes must be atomic and recover from malformed state JSON, release-note bullet counting must ignore fenced code blocks and use a strict release tag regex, CLI entrypoint must report unexpected rejections, random backup suffixes must use crypto randomness, and pull freshness must avoid client-now fallback.",
+    "tags": [
+      "backend",
+      "code",
+      "release"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "release",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "release.strict",
+    "version": 1,
+    "title": "Strict release",
+    "taskKinds": [
+      "release"
+    ],
+    "workflowModes": [
+      "direct",
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "release.strict",
+    "blueprintVersion": 1,
+    "title": "Strict release",
+    "taskId": "202605141638-ER7JEJ",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "release"
+    },
+    "whySelected": [
+      "task kind resolved to release",
+      "workflow mode: branch_pr",
+      "mutation scope: release"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.release.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "deterministic_check",
+        "kind": "deterministic_check",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "release.approval",
+        "kind": "approval",
+        "producedBy": "approval_gate",
+        "required": true,
+        "description": "Release approval."
+      },
+      {
+        "id": "release.plan",
+        "kind": "artifact",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Release plan or candidate artifact."
+      },
+      {
+        "id": "release.check",
+        "kind": "check_result",
+        "producedBy": "deterministic_check",
+        "required": true,
+        "description": "Release gates."
+      },
+      {
+        "id": "release.publish",
+        "kind": "external_link",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Publish evidence."
+      },
+      {
+        "id": "release.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Release commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.release.md"
+    ],
+    "allowedCommands": [
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "publish commands after approval",
+      "release gates"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Release work needs strict release policy, approval evidence, and rollback context."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.release.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "deterministic_check",
+      "kind": "deterministic_check",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "release.approval",
+      "kind": "approval",
+      "producedBy": "approval_gate",
+      "required": true,
+      "description": "Release approval."
+    },
+    {
+      "id": "release.plan",
+      "kind": "artifact",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Release plan or candidate artifact."
+    },
+    {
+      "id": "release.check",
+      "kind": "check_result",
+      "producedBy": "deterministic_check",
+      "required": true,
+      "description": "Release gates."
+    },
+    {
+      "id": "release.publish",
+      "kind": "external_link",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Publish evidence."
+    },
+    {
+      "id": "release.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Release commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.release.md"
+  ],
+  "allowedCommands": [
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "publish commands after approval",
+    "release gates"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Release work needs strict release policy, approval evidence, and rollback context."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to release",
+    "workflow mode: branch_pr",
+    "mutation scope: release"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "321095422c48a87783674539511cd79e3e920d29c3bda7c9f06657f869d6adb1"
+  }
+}

--- a/.agentplane/tasks/202605141638-ER7JEJ/pr/diffstat.txt
+++ b/.agentplane/tasks/202605141638-ER7JEJ/pr/diffstat.txt
@@ -4,15 +4,17 @@
  .../blueprint/resolved-snapshot.json               | 417 +++++++++++++++++++++
  .agentplane/tasks/202605141638-HGNT7H/README.md    |  81 ++++
  .agentplane/tasks/202605141638-TTVFMD/README.md    |  81 ++++
+ .../src/backends/task-backend.cloud.test.ts        |  11 +-
  .../task-backend/cloud-backend-state.test.ts       |  30 ++
  .../backends/task-backend/cloud-backend-state.ts   |   9 +-
  .../src/backends/task-backend/cloud-backend.ts     |   8 +-
  packages/agentplane/src/cli.ts                     |  13 +-
+ packages/agentplane/src/cli/fs-utils.test.ts       |   6 +-
  packages/agentplane/src/cli/fs-utils.ts            |   3 +-
  .../src/commands/acr/acr.command.test.ts           |  13 +-
  packages/agentplane/src/commands/acr/generate.ts   |   6 +-
  .../src/commands/branch/internal/archive-pr.ts     |   3 +-
  .../commands/release/apply.preflight.package.ts    |   4 +-
- .../src/commands/release/apply.preflight.test.ts   |  37 ++
+ .../src/commands/release/apply.preflight.test.ts   |  35 ++
  scripts/release/check-release-notes.mjs            |  11 +-
- 17 files changed, 936 insertions(+), 23 deletions(-)
+ 19 files changed, 940 insertions(+), 34 deletions(-)

--- a/.agentplane/tasks/202605141638-ER7JEJ/pr/diffstat.txt
+++ b/.agentplane/tasks/202605141638-ER7JEJ/pr/diffstat.txt
@@ -1,0 +1,18 @@
+ .agentplane/tasks/202605141638-3VAJ2V/README.md    |  81 ++++
+ .agentplane/tasks/202605141638-78JKTQ/README.md    |  81 ++++
+ .agentplane/tasks/202605141638-DYD163/README.md    |  81 ++++
+ .../blueprint/resolved-snapshot.json               | 417 +++++++++++++++++++++
+ .agentplane/tasks/202605141638-HGNT7H/README.md    |  81 ++++
+ .agentplane/tasks/202605141638-TTVFMD/README.md    |  81 ++++
+ .../task-backend/cloud-backend-state.test.ts       |  30 ++
+ .../backends/task-backend/cloud-backend-state.ts   |   9 +-
+ .../src/backends/task-backend/cloud-backend.ts     |   8 +-
+ packages/agentplane/src/cli.ts                     |  13 +-
+ packages/agentplane/src/cli/fs-utils.ts            |   3 +-
+ .../src/commands/acr/acr.command.test.ts           |  13 +-
+ packages/agentplane/src/commands/acr/generate.ts   |   6 +-
+ .../src/commands/branch/internal/archive-pr.ts     |   3 +-
+ .../commands/release/apply.preflight.package.ts    |   4 +-
+ .../src/commands/release/apply.preflight.test.ts   |  37 ++
+ scripts/release/check-release-notes.mjs            |  11 +-
+ 17 files changed, 936 insertions(+), 23 deletions(-)

--- a/.agentplane/tasks/202605141638-ER7JEJ/pr/github-body.md
+++ b/.agentplane/tasks/202605141638-ER7JEJ/pr/github-body.md
@@ -43,12 +43,29 @@ policy routing OK. Scope: policy routing gate.
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T16:41:27.081Z
+- Updated: 2026-05-14T16:49:52.706Z
 - Branch: task/202605141638-ER7JEJ/v06-audit-hotfix
-- Head: 3e44c426f846
+- Head: 2f4705071cd5
 
 ```text
-No changes detected.
+ .agentplane/tasks/202605141638-3VAJ2V/README.md    |  81 ++++
+ .agentplane/tasks/202605141638-78JKTQ/README.md    |  81 ++++
+ .agentplane/tasks/202605141638-DYD163/README.md    |  81 ++++
+ .../blueprint/resolved-snapshot.json               | 417 +++++++++++++++++++++
+ .agentplane/tasks/202605141638-HGNT7H/README.md    |  81 ++++
+ .agentplane/tasks/202605141638-TTVFMD/README.md    |  81 ++++
+ .../task-backend/cloud-backend-state.test.ts       |  30 ++
+ .../backends/task-backend/cloud-backend-state.ts   |   9 +-
+ .../src/backends/task-backend/cloud-backend.ts     |   8 +-
+ packages/agentplane/src/cli.ts                     |  13 +-
+ packages/agentplane/src/cli/fs-utils.ts            |   3 +-
+ .../src/commands/acr/acr.command.test.ts           |  13 +-
+ packages/agentplane/src/commands/acr/generate.ts   |   6 +-
+ .../src/commands/branch/internal/archive-pr.ts     |   3 +-
+ .../commands/release/apply.preflight.package.ts    |   4 +-
+ .../src/commands/release/apply.preflight.test.ts   |  37 ++
+ scripts/release/check-release-notes.mjs            |  11 +-
+ 17 files changed, 936 insertions(+), 23 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605141638-ER7JEJ/pr/github-body.md
+++ b/.agentplane/tasks/202605141638-ER7JEJ/pr/github-body.md
@@ -43,9 +43,9 @@ policy routing OK. Scope: policy routing gate.
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T16:49:52.706Z
+- Updated: 2026-05-14T17:17:41.313Z
 - Branch: task/202605141638-ER7JEJ/v06-audit-hotfix
-- Head: 2f4705071cd5
+- Head: bdb86e4ec818
 
 ```text
  .agentplane/tasks/202605141638-3VAJ2V/README.md    |  81 ++++
@@ -54,18 +54,20 @@ policy routing OK. Scope: policy routing gate.
  .../blueprint/resolved-snapshot.json               | 417 +++++++++++++++++++++
  .agentplane/tasks/202605141638-HGNT7H/README.md    |  81 ++++
  .agentplane/tasks/202605141638-TTVFMD/README.md    |  81 ++++
+ .../src/backends/task-backend.cloud.test.ts        |  11 +-
  .../task-backend/cloud-backend-state.test.ts       |  30 ++
  .../backends/task-backend/cloud-backend-state.ts   |   9 +-
  .../src/backends/task-backend/cloud-backend.ts     |   8 +-
  packages/agentplane/src/cli.ts                     |  13 +-
+ packages/agentplane/src/cli/fs-utils.test.ts       |   6 +-
  packages/agentplane/src/cli/fs-utils.ts            |   3 +-
  .../src/commands/acr/acr.command.test.ts           |  13 +-
  packages/agentplane/src/commands/acr/generate.ts   |   6 +-
  .../src/commands/branch/internal/archive-pr.ts     |   3 +-
  .../commands/release/apply.preflight.package.ts    |   4 +-
- .../src/commands/release/apply.preflight.test.ts   |  37 ++
+ .../src/commands/release/apply.preflight.test.ts   |  35 ++
  scripts/release/check-release-notes.mjs            |  11 +-
- 17 files changed, 936 insertions(+), 23 deletions(-)
+ 19 files changed, 940 insertions(+), 34 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605141638-ER7JEJ/pr/github-body.md
+++ b/.agentplane/tasks/202605141638-ER7JEJ/pr/github-body.md
@@ -1,0 +1,54 @@
+Task: `202605141638-ER7JEJ`
+Title: Hotfix v0.6 audit correctness regressions
+Canonical task record: `.agentplane/tasks/202605141638-ER7JEJ/README.md`
+
+## Summary
+
+Hotfix v0.6 audit correctness regressions
+
+Fix the low-risk v0.6 audit regressions that have narrow verification boundaries: ACR producer/toolchain version must match the package version, cloud backend state writes must be atomic and recover from malformed state JSON, release-note bullet counting must ignore fenced code blocks and use a strict release tag regex, CLI entrypoint must report unexpected rejections, random backup suffixes must use crypto randomness, and pull freshness must avoid client-now fallback.
+
+## Scope
+
+- In scope: Fix the low-risk v0.6 audit regressions that have narrow verification boundaries: ACR producer/toolchain version must match the package version, cloud backend state writes must be atomic and recover from malformed state JSON, release-note bullet counting must ignore fenced code blocks and use a strict release tag regex, CLI entrypoint must report unexpected rejections, random backup suffixes must use crypto randomness, and pull freshness must avoid client-now fallback.
+- Out of scope: unrelated refactors not required for "Hotfix v0.6 audit correctness regressions".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Command: rg -n '"0\.4\.2"|version: "0\.4\.2"|Math\.random\(\)\.toString\(36\).*slice\(2,
+8\)|pull\.lastCheckedAt \?\? new Date' packages/agentplane/src/commands/acr
+packages/agentplane/src/backends/task-backend packages/agentplane/src/cli.ts
+packages/agentplane/src/cli/fs-utils.ts
+packages/agentplane/src/commands/branch/internal/archive-pr.ts; Result: pass; Evidence: no scoped
+stale ACR version, Math.random backup suffix, or client-now pull freshness matches remain. Scope:
+audit hotfix regressions. Command: bun run test:project -- agentplane
+packages/agentplane/src/backends/task-backend/cloud-backend-state.test.ts
+packages/agentplane/src/commands/release/apply.preflight.test.ts
+packages/agentplane/src/commands/acr/acr.command.test.ts; Result: pass; Evidence: 3 files, 28 tests
+passed. Scope: cloud state, release-note preflight, ACR semantics. Command: bun run lint:core --
+changed files; Result: pass; Evidence: eslint completed with exit 0. Scope: changed
+source/test/script files. Command: bun run --filter=agentplane typecheck; Result: pass; Evidence:
+agentplane typecheck exited 0. Scope: agentplane package types. Command: node
+scripts/release/check-release-notes.mjs --tag v0.6.0 and fenced-bullet smoke; Result: pass;
+Evidence: v0.6.0 accepted and fenced bullets fail min-bullet smoke as expected. Scope: MJS
+release-note checker. Command: node .agentplane/policy/check-routing.mjs; Result: pass; Evidence:
+policy routing OK. Scope: policy routing gate.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T16:41:27.081Z
+- Branch: task/202605141638-ER7JEJ/v06-audit-hotfix
+- Head: 3e44c426f846
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605141638-ER7JEJ/pr/github-title.txt
+++ b/.agentplane/tasks/202605141638-ER7JEJ/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 ER7JEJ task: Hotfix v0.6 audit correctness regressions [202605141638-ER7JEJ]

--- a/.agentplane/tasks/202605141638-ER7JEJ/pr/meta.json
+++ b/.agentplane/tasks/202605141638-ER7JEJ/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605141638-ER7JEJ/v06-audit-hotfix",
   "created_at": "2026-05-14T16:41:27.081Z",
-  "head_sha": "3e44c426f8460f35fe0b3a3a45e259eb1ea023f4",
+  "head_sha": "2f4705071cd57c4105fcb95e838717705cb80b13",
   "last_verified_at": "2026-05-14T16:48:40.957Z",
   "last_verified_sha": "3e44c426f8460f35fe0b3a3a45e259eb1ea023f4",
   "schema_version": 1,
   "task_id": "202605141638-ER7JEJ",
-  "updated_at": "2026-05-14T16:41:27.081Z",
+  "updated_at": "2026-05-14T16:49:52.706Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141638-ER7JEJ/pr/meta.json
+++ b/.agentplane/tasks/202605141638-ER7JEJ/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605141638-ER7JEJ/v06-audit-hotfix",
   "created_at": "2026-05-14T16:41:27.081Z",
-  "head_sha": "2f4705071cd57c4105fcb95e838717705cb80b13",
+  "head_sha": "bdb86e4ec818121133070cb84a4f5e74ed72ca8c",
   "last_verified_at": "2026-05-14T16:48:40.957Z",
   "last_verified_sha": "3e44c426f8460f35fe0b3a3a45e259eb1ea023f4",
   "pr_number": 3739,
@@ -10,7 +10,7 @@
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202605141638-ER7JEJ",
-  "updated_at": "2026-05-14T16:50:04.888Z",
+  "updated_at": "2026-05-14T17:17:41.313Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141638-ER7JEJ/pr/meta.json
+++ b/.agentplane/tasks/202605141638-ER7JEJ/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "2f4705071cd57c4105fcb95e838717705cb80b13",
   "last_verified_at": "2026-05-14T16:48:40.957Z",
   "last_verified_sha": "3e44c426f8460f35fe0b3a3a45e259eb1ea023f4",
+  "pr_number": 3739,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3739",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605141638-ER7JEJ",
-  "updated_at": "2026-05-14T16:49:52.706Z",
+  "updated_at": "2026-05-14T16:50:04.888Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141638-ER7JEJ/pr/meta.json
+++ b/.agentplane/tasks/202605141638-ER7JEJ/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605141638-ER7JEJ/v06-audit-hotfix",
+  "created_at": "2026-05-14T16:41:27.081Z",
+  "head_sha": "3e44c426f8460f35fe0b3a3a45e259eb1ea023f4",
+  "last_verified_at": "2026-05-14T16:48:40.957Z",
+  "last_verified_sha": "3e44c426f8460f35fe0b3a3a45e259eb1ea023f4",
+  "schema_version": 1,
+  "task_id": "202605141638-ER7JEJ",
+  "updated_at": "2026-05-14T16:41:27.081Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605141638-ER7JEJ/pr/review.md
+++ b/.agentplane/tasks/202605141638-ER7JEJ/pr/review.md
@@ -24,9 +24,9 @@ Created: 2026-05-14T16:41:27.081Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T16:49:52.706Z
+- Updated: 2026-05-14T17:17:41.313Z
 - Branch: task/202605141638-ER7JEJ/v06-audit-hotfix
-- Head: 2f4705071cd5
+- Head: bdb86e4ec818
 
 ```text
  .agentplane/tasks/202605141638-3VAJ2V/README.md    |  81 ++++
@@ -35,18 +35,20 @@ Created: 2026-05-14T16:41:27.081Z
  .../blueprint/resolved-snapshot.json               | 417 +++++++++++++++++++++
  .agentplane/tasks/202605141638-HGNT7H/README.md    |  81 ++++
  .agentplane/tasks/202605141638-TTVFMD/README.md    |  81 ++++
+ .../src/backends/task-backend.cloud.test.ts        |  11 +-
  .../task-backend/cloud-backend-state.test.ts       |  30 ++
  .../backends/task-backend/cloud-backend-state.ts   |   9 +-
  .../src/backends/task-backend/cloud-backend.ts     |   8 +-
  packages/agentplane/src/cli.ts                     |  13 +-
+ packages/agentplane/src/cli/fs-utils.test.ts       |   6 +-
  packages/agentplane/src/cli/fs-utils.ts            |   3 +-
  .../src/commands/acr/acr.command.test.ts           |  13 +-
  packages/agentplane/src/commands/acr/generate.ts   |   6 +-
  .../src/commands/branch/internal/archive-pr.ts     |   3 +-
  .../commands/release/apply.preflight.package.ts    |   4 +-
- .../src/commands/release/apply.preflight.test.ts   |  37 ++
+ .../src/commands/release/apply.preflight.test.ts   |  35 ++
  scripts/release/check-release-notes.mjs            |  11 +-
- 17 files changed, 936 insertions(+), 23 deletions(-)
+ 19 files changed, 940 insertions(+), 34 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605141638-ER7JEJ/pr/review.md
+++ b/.agentplane/tasks/202605141638-ER7JEJ/pr/review.md
@@ -24,12 +24,29 @@ Created: 2026-05-14T16:41:27.081Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T16:41:27.081Z
+- Updated: 2026-05-14T16:49:52.706Z
 - Branch: task/202605141638-ER7JEJ/v06-audit-hotfix
-- Head: 3e44c426f846
+- Head: 2f4705071cd5
 
 ```text
-No changes detected.
+ .agentplane/tasks/202605141638-3VAJ2V/README.md    |  81 ++++
+ .agentplane/tasks/202605141638-78JKTQ/README.md    |  81 ++++
+ .agentplane/tasks/202605141638-DYD163/README.md    |  81 ++++
+ .../blueprint/resolved-snapshot.json               | 417 +++++++++++++++++++++
+ .agentplane/tasks/202605141638-HGNT7H/README.md    |  81 ++++
+ .agentplane/tasks/202605141638-TTVFMD/README.md    |  81 ++++
+ .../task-backend/cloud-backend-state.test.ts       |  30 ++
+ .../backends/task-backend/cloud-backend-state.ts   |   9 +-
+ .../src/backends/task-backend/cloud-backend.ts     |   8 +-
+ packages/agentplane/src/cli.ts                     |  13 +-
+ packages/agentplane/src/cli/fs-utils.ts            |   3 +-
+ .../src/commands/acr/acr.command.test.ts           |  13 +-
+ packages/agentplane/src/commands/acr/generate.ts   |   6 +-
+ .../src/commands/branch/internal/archive-pr.ts     |   3 +-
+ .../commands/release/apply.preflight.package.ts    |   4 +-
+ .../src/commands/release/apply.preflight.test.ts   |  37 ++
+ scripts/release/check-release-notes.mjs            |  11 +-
+ 17 files changed, 936 insertions(+), 23 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605141638-ER7JEJ/pr/review.md
+++ b/.agentplane/tasks/202605141638-ER7JEJ/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-14T16:41:27.081Z
+
+## Task
+
+- Task: `202605141638-ER7JEJ`
+- Title: Hotfix v0.6 audit correctness regressions
+- Status: DOING
+- Branch: `task/202605141638-ER7JEJ/v06-audit-hotfix`
+- Canonical task record: `.agentplane/tasks/202605141638-ER7JEJ/README.md`
+
+## Verification
+
+- State: ok
+- Note: Command: rg -n '"0\.4\.2"|version: "0\.4\.2"|Math\.random\(\)\.toString\(36\).*slice\(2, 8\)|pull\.lastCheckedAt \?\? new Date' packages/agentplane/src/commands/acr packages/agentplane/src/backends/task-backend packages/agentplane/src/cli.ts packages/agentplane/src/cli/fs-utils.ts packages/agentplane/src/commands/branch/internal/archive-pr.ts; Result: pass; Evidence: no scoped stale ACR version, Math.random backup suffix, or client-now pull freshness matches remain. Scope: audit hotfix regressions. Command: bun run test:project -- agentplane packages/agentplane/src/backends/task-backend/cloud-backend-state.test.ts packages/agentplane/src/commands/release/apply.preflight.test.ts packages/agentplane/src/commands/acr/acr.command.test.ts; Result: pass; Evidence: 3 files, 28 tests passed. Scope: cloud state, release-note preflight, ACR semantics. Command: bun run lint:core -- changed files; Result: pass; Evidence: eslint completed with exit 0. Scope: changed source/test/script files. Command: bun run --filter=agentplane typecheck; Result: pass; Evidence: agentplane typecheck exited 0. Scope: agentplane package types. Command: node scripts/release/check-release-notes.mjs --tag v0.6.0 and fenced-bullet smoke; Result: pass; Evidence: v0.6.0 accepted and fenced bullets fail min-bullet smoke as expected. Scope: MJS release-note checker. Command: node .agentplane/policy/check-routing.mjs; Result: pass; Evidence: policy routing OK. Scope: policy routing gate.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T16:41:27.081Z
+- Branch: task/202605141638-ER7JEJ/v06-audit-hotfix
+- Head: 3e44c426f846
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605141638-HGNT7H/README.md
+++ b/.agentplane/tasks/202605141638-HGNT7H/README.md
@@ -1,0 +1,81 @@
+---
+id: "202605141638-HGNT7H"
+title: "Define schema canonical source contract"
+status: "TODO"
+priority: "low"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "schemas"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-14T16:41:06.597Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-14T16:40:12.908Z"
+doc_updated_by: "PLANNER"
+description: "Resolve the three schema directory source-of-truth ambiguity across root schemas, packages/spec/schemas, and packages/core/schemas by documenting or enforcing a single generated/canonical flow, including recipe/workflow and context schema coverage."
+sections:
+  Summary: |-
+    Define schema canonical source contract
+    
+    Resolve the three schema directory source-of-truth ambiguity across root schemas, packages/spec/schemas, and packages/core/schemas by documenting or enforcing a single generated/canonical flow, including recipe/workflow and context schema coverage.
+  Scope: |-
+    - In scope: Resolve the three schema directory source-of-truth ambiguity across root schemas, packages/spec/schemas, and packages/core/schemas by documenting or enforcing a single generated/canonical flow, including recipe/workflow and context schema coverage.
+    - Out of scope: unrelated refactors not required for "Define schema canonical source contract".
+  Plan: "Define and enforce schema source-of-truth. Scope: current schema directory inventory, decision for canonical/generated directories, sync/check updates if required, and tests or checks proving root/spec/core schema drift is intentional or impossible. Out of scope: unrelated schema shape changes."
+  Verify Steps: "1. Inventory schemas in root, packages/spec/schemas, and packages/core/schemas and record the intended canonical/generated relationship. 2. Update sync/check logic or documentation so recipe/workflow/context schema coverage is explicit. 3. Run schema sync/check tests or scripts. 4. Run bun run lint:core -- changed schema tooling/docs files if applicable. 5. Run node .agentplane/policy/check-routing.mjs."
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Define schema canonical source contract
+
+Resolve the three schema directory source-of-truth ambiguity across root schemas, packages/spec/schemas, and packages/core/schemas by documenting or enforcing a single generated/canonical flow, including recipe/workflow and context schema coverage.
+
+## Scope
+
+- In scope: Resolve the three schema directory source-of-truth ambiguity across root schemas, packages/spec/schemas, and packages/core/schemas by documenting or enforcing a single generated/canonical flow, including recipe/workflow and context schema coverage.
+- Out of scope: unrelated refactors not required for "Define schema canonical source contract".
+
+## Plan
+
+Define and enforce schema source-of-truth. Scope: current schema directory inventory, decision for canonical/generated directories, sync/check updates if required, and tests or checks proving root/spec/core schema drift is intentional or impossible. Out of scope: unrelated schema shape changes.
+
+## Verify Steps
+
+1. Inventory schemas in root, packages/spec/schemas, and packages/core/schemas and record the intended canonical/generated relationship. 2. Update sync/check logic or documentation so recipe/workflow/context schema coverage is explicit. 3. Run schema sync/check tests or scripts. 4. Run bun run lint:core -- changed schema tooling/docs files if applicable. 5. Run node .agentplane/policy/check-routing.mjs.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605141638-TTVFMD/README.md
+++ b/.agentplane/tasks/202605141638-TTVFMD/README.md
@@ -1,0 +1,81 @@
+---
+id: "202605141638-TTVFMD"
+title: "Handle remote-only and removed cloud tasks"
+status: "TODO"
+priority: "high"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "backend"
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-14T16:40:57.852Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-14T16:39:33.005Z"
+doc_updated_by: "PLANNER"
+description: "Extend CloudPullPlan and applyCloudPullPlan so remote-only tasks and remote deletions are explicit contract cases instead of ignored diagnostics under canonical_source=remote. Define user-confirmation or prefer-remote behavior and cover added/removed plans in tests."
+sections:
+  Summary: |-
+    Handle remote-only and removed cloud tasks
+    
+    Extend CloudPullPlan and applyCloudPullPlan so remote-only tasks and remote deletions are explicit contract cases instead of ignored diagnostics under canonical_source=remote. Define user-confirmation or prefer-remote behavior and cover added/removed plans in tests.
+  Scope: |-
+    - In scope: Extend CloudPullPlan and applyCloudPullPlan so remote-only tasks and remote deletions are explicit contract cases instead of ignored diagnostics under canonical_source=remote. Define user-confirmation or prefer-remote behavior and cover added/removed plans in tests.
+    - Out of scope: unrelated refactors not required for "Handle remote-only and removed cloud tasks".
+  Plan: "Make cloud pull projection semantics explicit for remote-only and removed tasks. Scope: CloudPullPlan model, applyCloudPullPlan behavior, prefer-remote/user-confirm contract, diff summary wording, and tests for added and removed task IDs. Out of scope: auto-push failure pending marker and broader cloud revision-token protocol."
+  Verify Steps: "1. Add tests for buildCloudPullPlan covering remote-only tasks, local-only tasks missing remotely, and unchanged/updated tasks. 2. Add tests for applyCloudPullPlan proving added/removed behavior matches the selected conflict mode. 3. Run targeted cloud pull tests. 4. Run bun run lint:core -- changed cloud pull files. 5. Run node .agentplane/policy/check-routing.mjs."
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Handle remote-only and removed cloud tasks
+
+Extend CloudPullPlan and applyCloudPullPlan so remote-only tasks and remote deletions are explicit contract cases instead of ignored diagnostics under canonical_source=remote. Define user-confirmation or prefer-remote behavior and cover added/removed plans in tests.
+
+## Scope
+
+- In scope: Extend CloudPullPlan and applyCloudPullPlan so remote-only tasks and remote deletions are explicit contract cases instead of ignored diagnostics under canonical_source=remote. Define user-confirmation or prefer-remote behavior and cover added/removed plans in tests.
+- Out of scope: unrelated refactors not required for "Handle remote-only and removed cloud tasks".
+
+## Plan
+
+Make cloud pull projection semantics explicit for remote-only and removed tasks. Scope: CloudPullPlan model, applyCloudPullPlan behavior, prefer-remote/user-confirm contract, diff summary wording, and tests for added and removed task IDs. Out of scope: auto-push failure pending marker and broader cloud revision-token protocol.
+
+## Verify Steps
+
+1. Add tests for buildCloudPullPlan covering remote-only tasks, local-only tasks missing remotely, and unchanged/updated tasks. 2. Add tests for applyCloudPullPlan proving added/removed behavior matches the selected conflict mode. 3. Run targeted cloud pull tests. 4. Run bun run lint:core -- changed cloud pull files. 5. Run node .agentplane/policy/check-routing.mjs.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/packages/agentplane/src/backends/task-backend.cloud.test.ts
+++ b/packages/agentplane/src/backends/task-backend.cloud.test.ts
@@ -752,10 +752,7 @@ describe("CloudBackend", () => {
     await backend.sync({ direction: "pull", conflict: "diff", quiet: true, confirm: true });
 
     await expect(
-      readFile(
-        path.join(tempDir, ".agentplane", "backends", "cloud", "state.json"),
-        "utf8",
-      ),
+      readFile(path.join(tempDir, ".agentplane", "backends", "cloud", "state.json"), "utf8"),
     ).rejects.toMatchObject({ code: "ENOENT" });
   });
 

--- a/packages/agentplane/src/backends/task-backend.cloud.test.ts
+++ b/packages/agentplane/src/backends/task-backend.cloud.test.ts
@@ -723,7 +723,7 @@ describe("CloudBackend", () => {
     expect(state.last_checked_at).toBe("2000-01-01T00:00:00.000Z");
   });
 
-  it("uses a local freshness fallback after a no-op pull only when the service omits a timestamp", async () => {
+  it("does not advance freshness after a no-op pull when the service omits a timestamp", async () => {
     const cache = new LocalBackend({ dir: path.join(tempDir, ".agentplane", "tasks") });
     const task: TaskData = makeTask({
       id: "202605051806-C1D2",
@@ -751,12 +751,12 @@ describe("CloudBackend", () => {
 
     await backend.sync({ direction: "pull", conflict: "diff", quiet: true, confirm: true });
 
-    const stateText = await readFile(
-      path.join(tempDir, ".agentplane", "backends", "cloud", "state.json"),
-      "utf8",
-    );
-    const state = JSON.parse(stateText) as { last_checked_at: string };
-    expect(Number.isFinite(Date.parse(state.last_checked_at))).toBe(true);
+    await expect(
+      readFile(
+        path.join(tempDir, ".agentplane", "backends", "cloud", "state.json"),
+        "utf8",
+      ),
+    ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("conflict=fail refuses to write open service conflicts", async () => {

--- a/packages/agentplane/src/backends/task-backend.cloud.test.ts
+++ b/packages/agentplane/src/backends/task-backend.cloud.test.ts
@@ -85,7 +85,32 @@ describe("CloudBackend", () => {
       ],
     });
     expect(result.freshness?.lastCheckedAt).toBeNull();
-    expect(result.freshness?.stale).toBe(false);
+    expect(result.freshness?.stale).toBe(true);
+  });
+
+  it("treats a malformed cloud state file as stale for mutation guards", async () => {
+    const stateDir = path.join(tempDir, ".agentplane", "backends", "cloud");
+    await mkdir(stateDir, { recursive: true });
+    await writeFile(path.join(stateDir, "state.json"), "{", "utf8");
+    const fetchImpl = vi.fn<typeof fetch>(() => Promise.resolve(Response.json({})));
+    const backend = new CloudBackend(
+      {
+        endpoint: "https://cloud.example/",
+        token: "token",
+        project_id: "project-1",
+        stale_after_seconds: 300,
+      },
+      {
+        root: tempDir,
+        cache: new LocalBackend({ dir: path.join(tempDir, ".agentplane", "tasks") }),
+        fetchImpl,
+      },
+    );
+
+    await expect(backend.assertLocalMutationReady()).rejects.toThrow(
+      "Safe command: agentplane backend sync cloud --direction pull --yes",
+    );
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 
   it("rejects local mutations before cache writes when the cloud projection is stale", async () => {

--- a/packages/agentplane/src/backends/task-backend/cloud-backend-state.test.ts
+++ b/packages/agentplane/src/backends/task-backend/cloud-backend-state.test.ts
@@ -1,0 +1,30 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { readCloudBackendState, writeCloudBackendState } from "./cloud-backend-state.js";
+
+describe("cloud backend state", () => {
+  it("falls back to stale state when state JSON is malformed", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "agentplane-cloud-state-"));
+    const statePath = path.join(dir, "state.json");
+    await writeFile(statePath, "{", "utf8");
+
+    await expect(readCloudBackendState(statePath)).resolves.toEqual({ last_checked_at: null });
+  });
+
+  it("writes state JSON through the shared atomic write helper", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "agentplane-cloud-state-"));
+    const statePath = path.join(dir, "nested", "state.json");
+
+    await writeCloudBackendState(statePath, { last_checked_at: "2026-05-14T09:00:00.000Z" });
+
+    await expect(readCloudBackendState(statePath)).resolves.toEqual({
+      last_checked_at: "2026-05-14T09:00:00.000Z",
+    });
+    await expect(readFile(statePath, "utf8")).resolves.toContain(
+      '"last_checked_at": "2026-05-14T09:00:00.000Z"',
+    );
+  });
+});

--- a/packages/agentplane/src/backends/task-backend/cloud-backend-state.ts
+++ b/packages/agentplane/src/backends/task-backend/cloud-backend-state.ts
@@ -1,5 +1,5 @@
-import path from "node:path";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
+import { atomicWriteFile } from "@agentplaneorg/core/fs";
 
 type CloudBackendState = { last_checked_at: string | null };
 
@@ -15,7 +15,7 @@ export async function readCloudBackendState(statePath: string): Promise<CloudBac
     }
   } catch (err) {
     const code = (err as { code?: string } | null)?.code;
-    if (code !== "ENOENT") throw err;
+    if (code !== "ENOENT" && !(err instanceof SyntaxError)) throw err;
   }
   return { last_checked_at: null };
 }
@@ -24,6 +24,5 @@ export async function writeCloudBackendState(
   statePath: string,
   state: { last_checked_at: string },
 ): Promise<void> {
-  await mkdir(path.dirname(statePath), { recursive: true });
-  await writeFile(statePath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await atomicWriteFile(statePath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
 }

--- a/packages/agentplane/src/backends/task-backend/cloud-backend-utils.ts
+++ b/packages/agentplane/src/backends/task-backend/cloud-backend-utils.ts
@@ -195,7 +195,8 @@ export function splitTasksByPayloadBytes(tasks: TaskData[], maxBytes: number): T
 }
 
 export function isStale(lastCheckedAt: string | null, staleAfterSeconds: number | null): boolean {
-  if (!lastCheckedAt || !staleAfterSeconds) return false;
+  if (!staleAfterSeconds) return false;
+  if (!lastCheckedAt) return true;
   const checkedAt = Date.parse(lastCheckedAt);
   if (!Number.isFinite(checkedAt)) return true;
   return Date.now() - checkedAt > staleAfterSeconds * 1000;

--- a/packages/agentplane/src/backends/task-backend/cloud-backend.ts
+++ b/packages/agentplane/src/backends/task-backend/cloud-backend.ts
@@ -335,9 +335,11 @@ export class CloudBackend implements TaskBackend {
       }
     }
     if (opts.direction === "pull") {
-      await writeCloudBackendState(this.statePath, {
-        last_checked_at: pull.lastCheckedAt ?? new Date().toISOString(),
-      });
+      if (pull.lastCheckedAt) {
+        await writeCloudBackendState(this.statePath, {
+          last_checked_at: pull.lastCheckedAt,
+        });
+      }
       return;
     }
     if (!pull.lastCheckedAt) return;

--- a/packages/agentplane/src/cli.ts
+++ b/packages/agentplane/src/cli.ts
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 import { runCli } from "./cli/run-cli.js";
 
-void runCli(process.argv.slice(2)).then((code) => {
-  process.exit(code);
-});
+void runCli(process.argv.slice(2)).then(
+  (code) => {
+    return (process.exitCode = code);
+  },
+  (err: unknown) => {
+    const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+    process.stderr.write(`${message}\n`);
+    return (process.exitCode = 1);
+  },
+);

--- a/packages/agentplane/src/cli/fs-utils.test.ts
+++ b/packages/agentplane/src/cli/fs-utils.test.ts
@@ -25,7 +25,7 @@ describe("cli/fs-utils", () => {
     expect(await fileExists(filePath)).toBe(false);
   });
 
-  it("backupPath appends a random suffix when backup already exists", async () => {
+  it("backupPath appends a crypto-random suffix when backup already exists", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "agentplane-fs-utils-"));
     const filePath = path.join(root, "data.txt");
     await writeFile(filePath, "hello", "utf8");
@@ -37,15 +37,13 @@ describe("cli/fs-utils", () => {
     expect(await fileExists(original)).toBe(true);
     await writeFile(filePath, "second", "utf8");
 
-    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.123_456);
     try {
       const dest = await backupPath(filePath);
-      expect(dest).toMatch(new RegExp(String.raw`^${escapeRegExp(original)}-[a-z0-9]{6}$`));
+      expect(dest).toMatch(new RegExp(String.raw`^${escapeRegExp(original)}-[0-9a-f]{8}$`));
       expect(dest).not.toBe(original);
       expect(await fileExists(dest)).toBe(true);
       expect(await fileExists(filePath)).toBe(false);
     } finally {
-      randomSpy.mockRestore();
       originalDateToISOString.mockRestore();
     }
   });

--- a/packages/agentplane/src/cli/fs-utils.ts
+++ b/packages/agentplane/src/cli/fs-utils.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { access, lstat, rename } from "node:fs/promises";
 
 export async function fileExists(filePath: string): Promise<boolean> {
@@ -22,7 +23,7 @@ export async function backupPath(filePath: string): Promise<string> {
   const stamp = new Date().toISOString().replaceAll(/[:.]/g, "");
   let dest = `${filePath}.bak-${stamp}`;
   if (await fileExists(dest)) {
-    dest = `${filePath}.bak-${stamp}-${Math.random().toString(36).slice(2, 8)}`;
+    dest = `${filePath}.bak-${stamp}-${randomUUID().slice(0, 8)}`;
   }
   await rename(filePath, dest);
   return dest;

--- a/packages/agentplane/src/commands/acr/acr.command.test.ts
+++ b/packages/agentplane/src/commands/acr/acr.command.test.ts
@@ -13,6 +13,7 @@ import {
   makeRunAcrSchemaHandler,
 } from "./acr.command.js";
 import { CliError } from "../../shared/errors.js";
+import { getVersion } from "../../meta/version.js";
 import { readDiagnosticContext } from "../shared/diagnostics.js";
 
 const ciOptions = {
@@ -24,12 +25,13 @@ const ciOptions = {
 };
 
 function mergeReadyRecord(): AgentChangeRecord {
+  const producerVersion = getVersion();
   const record: AgentChangeRecord = {
     acr_version: "0.1.0",
     record_type: "agent_change_record",
     record_id: "acr_202605031856_H059JF",
     created_at: "2026-05-03T18:56:00.000Z",
-    producer: { name: "agentplane", version: "0.4.2" },
+    producer: { name: "agentplane", version: producerVersion },
     repository: {
       vcs: "git",
       base_ref: "main",
@@ -47,7 +49,7 @@ function mergeReadyRecord(): AgentChangeRecord {
       name: "Codex",
       agent_type: "coding_agent",
       model: { provider: "openai", name: "unknown", version: "unknown" },
-      toolchain: [{ name: "agentplane", version: "0.4.2" }],
+      toolchain: [{ name: "agentplane", version: producerVersion }],
     },
     plan: {
       status: "approved",
@@ -225,6 +227,13 @@ describe("acr command specs", () => {
       agent: "CODER",
       modelProvider: "openai",
     });
+  });
+
+  it("keeps ACR producer and toolchain versions tied to the package version", () => {
+    const record = mergeReadyRecord();
+
+    expect(record.producer.version).toBe(getVersion());
+    expect(record.agent.toolchain).toContainEqual({ name: "agentplane", version: getVersion() });
   });
 
   it("parses acr validate against an example path", () => {

--- a/packages/agentplane/src/commands/acr/generate.ts
+++ b/packages/agentplane/src/commands/acr/generate.ts
@@ -15,6 +15,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 
 import { explainResolvedBlueprint, resolveBlueprint } from "../../blueprints/index.js";
+import { getVersion } from "../../meta/version.js";
 import { blueprintResolveInputFromTask } from "../blueprint/task-input.js";
 import { checkTaskBlueprintSnapshotDrift } from "../blueprint/snapshot-artifact.js";
 import { loadTaskFromContext, type CommandContext } from "../shared/task-backend.js";
@@ -61,6 +62,7 @@ export async function generateAcr(opts: {
   const planState = task.plan_approval?.state ?? "pending";
   const verificationState = task.verification?.state ?? "pending";
   const now = new Date().toISOString();
+  const producerVersion = getVersion();
   const approvals =
     planState === "approved"
       ? [
@@ -145,7 +147,7 @@ export async function generateAcr(opts: {
     created_at: now,
     producer: {
       name: "agentplane",
-      version: "0.4.2",
+      version: producerVersion,
     },
     repository: {
       vcs: "git",
@@ -170,7 +172,7 @@ export async function generateAcr(opts: {
         name: opts.modelName ?? "unknown",
         version: "unknown",
       },
-      toolchain: [{ name: "agentplane", version: "0.4.2" }],
+      toolchain: [{ name: "agentplane", version: producerVersion }],
     },
     plan: {
       status:

--- a/packages/agentplane/src/commands/branch/internal/archive-pr.ts
+++ b/packages/agentplane/src/commands/branch/internal/archive-pr.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { mkdir, rename } from "node:fs/promises";
 import path from "node:path";
 
@@ -11,7 +12,7 @@ export async function archivePrArtifacts(taskDir: string): Promise<string | null
   const stamp = new Date().toISOString().replaceAll(/[:.]/g, "");
   let dest = path.join(archiveRoot, stamp);
   if (await fileExists(dest)) {
-    dest = path.join(archiveRoot, `${stamp}-${Math.random().toString(36).slice(2, 8)}`);
+    dest = path.join(archiveRoot, `${stamp}-${randomUUID().slice(0, 8)}`);
   }
   await rename(prDir, dest);
   return dest;

--- a/packages/agentplane/src/commands/release/apply.preflight.package.ts
+++ b/packages/agentplane/src/commands/release/apply.preflight.package.ts
@@ -177,7 +177,9 @@ export async function validateReleaseNotes(notesPath: string, minBullets: number
       message: `Release notes must not include duplicate section headings in ${notesPath}: ${duplicateHeadings.join(", ")}`,
     });
   }
-  const bulletCount = content.split(/\r?\n/u).filter((line) => /^\s*[-*]\s+\S+/u.test(line)).length;
+  const bulletCount = releaseNoteLinesOutsideCodeFences(content).filter((line) =>
+    /^\s*[-*]\s+\S+/u.test(line),
+  ).length;
   if (bulletCount < minBullets) {
     throw new CliError({
       exitCode: exitCodeForError("E_VALIDATION"),

--- a/packages/agentplane/src/commands/release/apply.preflight.test.ts
+++ b/packages/agentplane/src/commands/release/apply.preflight.test.ts
@@ -207,9 +207,7 @@ describeWhenNotHook(
         "utf8",
       );
 
-      await expect(validateReleaseNotes(notesPath, 2)).rejects.toThrow(
-        /at least 2 bullet points/u,
-      );
+      await expect(validateReleaseNotes(notesPath, 2)).rejects.toThrow(/at least 2 bullet points/u);
     });
 
     it("rejects release notes with duplicate section headings", async () => {

--- a/packages/agentplane/src/commands/release/apply.preflight.test.ts
+++ b/packages/agentplane/src/commands/release/apply.preflight.test.ts
@@ -175,6 +175,43 @@ describeWhenNotHook(
       await expect(validateReleaseNotes(notesPath, 1)).resolves.toBeUndefined();
     });
 
+    it("does not count fenced example bullets toward release note content minimums", async () => {
+      const root = await mkGitRepoRoot();
+      const notesPath = path.join(root, "docs", "releases", "v0.2.7.md");
+      await mkdir(path.dirname(notesPath), { recursive: true });
+      await writeFile(
+        notesPath,
+        [
+          "# Release Notes - v0.2.7",
+          "",
+          "## Summary",
+          "",
+          "- Actual summary bullet.",
+          "",
+          "## Added",
+          "",
+          "## Improved",
+          "",
+          "## Fixed",
+          "",
+          "## Upgrade Notes",
+          "",
+          "## Verification",
+          "",
+          "```md",
+          "- Fenced example bullet.",
+          "- Another fenced example bullet.",
+          "```",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      await expect(validateReleaseNotes(notesPath, 2)).rejects.toThrow(
+        /at least 2 bullet points/u,
+      );
+    });
+
     it("rejects release notes with duplicate section headings", async () => {
       const root = await mkGitRepoRoot();
       const notesPath = path.join(root, "docs", "releases", "v0.2.7.md");

--- a/scripts/release/check-release-notes.mjs
+++ b/scripts/release/check-release-notes.mjs
@@ -36,6 +36,7 @@ const REQUIRED_RELEASE_NOTE_SECTIONS = [
   "Upgrade Notes",
   "Verification",
 ];
+const MIN_RELEASE_NOTE_BULLETS = 6;
 
 function releaseNotesHeadingPresent(content, tag) {
   const headingPattern = new RegExp(
@@ -119,7 +120,7 @@ const main = defineCheck({
       }
     }
 
-    const releaseTags = [...tags].filter((tag) => /^v\d+\.\d+\.\d+/.test(tag));
+    const releaseTags = [...tags].filter((tag) => /^v\d+\.\d+\.\d+$/.test(tag));
     if (releaseTags.length === 0) {
       return;
     }
@@ -160,10 +161,10 @@ const main = defineCheck({
           `Release notes must not include duplicate section headings in ${relPath}: ${duplicateHeadings.join(", ")}`,
         );
       }
-      const minBullets = minBulletsOverride ?? REQUIRED_RELEASE_NOTE_SECTIONS.length;
-      const bulletCount = content
-        .split(/\r?\n/)
-        .filter((line) => /^\s*[-*]\s+\S+/.test(line)).length;
+      const minBullets = minBulletsOverride ?? MIN_RELEASE_NOTE_BULLETS;
+      const bulletCount = releaseNoteLinesOutsideCodeFences(content).filter((line) =>
+        /^\s*[-*]\s+\S+/.test(line),
+      ).length;
       if (bulletCount < minBullets) {
         errors.push(
           `Release notes must include at least ${minBullets} bullet points in ${relPath}.`,


### PR DESCRIPTION
Task: `202605141638-ER7JEJ`
Title: Hotfix v0.6 audit correctness regressions
Canonical task record: `.agentplane/tasks/202605141638-ER7JEJ/README.md`

## Summary

Hotfix v0.6 audit correctness regressions

Fix the low-risk v0.6 audit regressions that have narrow verification boundaries: ACR producer/toolchain version must match the package version, cloud backend state writes must be atomic and recover from malformed state JSON, release-note bullet counting must ignore fenced code blocks and use a strict release tag regex, CLI entrypoint must report unexpected rejections, random backup suffixes must use crypto randomness, and pull freshness must avoid client-now fallback.

## Scope

- In scope: Fix the low-risk v0.6 audit regressions that have narrow verification boundaries: ACR producer/toolchain version must match the package version, cloud backend state writes must be atomic and recover from malformed state JSON, release-note bullet counting must ignore fenced code blocks and use a strict release tag regex, CLI entrypoint must report unexpected rejections, random backup suffixes must use crypto randomness, and pull freshness must avoid client-now fallback.
- Out of scope: unrelated refactors not required for "Hotfix v0.6 audit correctness regressions".

## Verification

- State: ok
- Note:

```text
Command: rg -n '"0\.4\.2"|version: "0\.4\.2"|Math\.random\(\)\.toString\(36\).*slice\(2,
8\)|pull\.lastCheckedAt \?\? new Date' packages/agentplane/src/commands/acr
packages/agentplane/src/backends/task-backend packages/agentplane/src/cli.ts
packages/agentplane/src/cli/fs-utils.ts
packages/agentplane/src/commands/branch/internal/archive-pr.ts; Result: pass; Evidence: no scoped
stale ACR version, Math.random backup suffix, or client-now pull freshness matches remain. Scope:
audit hotfix regressions. Command: bun run test:project -- agentplane
packages/agentplane/src/backends/task-backend/cloud-backend-state.test.ts
packages/agentplane/src/commands/release/apply.preflight.test.ts
packages/agentplane/src/commands/acr/acr.command.test.ts; Result: pass; Evidence: 3 files, 28 tests
passed. Scope: cloud state, release-note preflight, ACR semantics. Command: bun run lint:core --
changed files; Result: pass; Evidence: eslint completed with exit 0. Scope: changed
source/test/script files. Command: bun run --filter=agentplane typecheck; Result: pass; Evidence:
agentplane typecheck exited 0. Scope: agentplane package types. Command: node
scripts/release/check-release-notes.mjs --tag v0.6.0 and fenced-bullet smoke; Result: pass;
Evidence: v0.6.0 accepted and fenced bullets fail min-bullet smoke as expected. Scope: MJS
release-note checker. Command: node .agentplane/policy/check-routing.mjs; Result: pass; Evidence:
policy routing OK. Scope: policy routing gate.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-14T16:49:52.706Z
- Branch: task/202605141638-ER7JEJ/v06-audit-hotfix
- Head: 2f4705071cd5

```text
 .agentplane/tasks/202605141638-3VAJ2V/README.md    |  81 ++++
 .agentplane/tasks/202605141638-78JKTQ/README.md    |  81 ++++
 .agentplane/tasks/202605141638-DYD163/README.md    |  81 ++++
 .../blueprint/resolved-snapshot.json               | 417 +++++++++++++++++++++
 .agentplane/tasks/202605141638-HGNT7H/README.md    |  81 ++++
 .agentplane/tasks/202605141638-TTVFMD/README.md    |  81 ++++
 .../task-backend/cloud-backend-state.test.ts       |  30 ++
 .../backends/task-backend/cloud-backend-state.ts   |   9 +-
 .../src/backends/task-backend/cloud-backend.ts     |   8 +-
 packages/agentplane/src/cli.ts                     |  13 +-
 packages/agentplane/src/cli/fs-utils.ts            |   3 +-
 .../src/commands/acr/acr.command.test.ts           |  13 +-
 packages/agentplane/src/commands/acr/generate.ts   |   6 +-
 .../src/commands/branch/internal/archive-pr.ts     |   3 +-
 .../commands/release/apply.preflight.package.ts    |   4 +-
 .../src/commands/release/apply.preflight.test.ts   |  37 ++
 scripts/release/check-release-notes.mjs            |  11 +-
 17 files changed, 936 insertions(+), 23 deletions(-)
```

</details>
