### PR TITLE
🚧 84A77P task: Announce v0.6 context management [202605141717-84A77P]

### DIFF
--- a/.agentplane/tasks/202605141717-84A77P/README.md
+++ b/.agentplane/tasks/202605141717-84A77P/README.md
@@ -1,0 +1,142 @@
+---
+id: "202605141717-84A77P"
+title: "Announce v0.6 context management"
+status: "DOING"
+priority: "med"
+owner: "DOCS"
+revision: 7
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "context"
+  - "docs"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-14T17:17:50.282Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-14T17:23:22.088Z"
+  updated_by: "DOCS"
+  note: "Docs/site verification passed for v0.6 context-management announcement. node .agentplane/policy/check-routing.mjs: policy routing OK. agentplane doctor: OK with pre-existing branch_pr drift warnings unrelated to this task. bun run docs:site:typecheck: pass after restoring ignored website dependencies with bun install --ignore-scripts. bun run docs:site:build: pass; remaining warnings are pre-existing blueprints tag/truncation warnings. git diff --check: pass."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "DOCS"
+    body: "Start: documenting the v0.6 context-management story across README, user docs, website navigation, homepage copy, and a blog announcement grounded in the shipped local-context behavior and Karpathy LLM Wiki source."
+events:
+  -
+    type: "status"
+    at: "2026-05-14T17:18:06.890Z"
+    author: "DOCS"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: documenting the v0.6 context-management story across README, user docs, website navigation, homepage copy, and a blog announcement grounded in the shipped local-context behavior and Karpathy LLM Wiki source."
+  -
+    type: "verify"
+    at: "2026-05-14T17:23:22.088Z"
+    author: "DOCS"
+    state: "ok"
+    note: "Docs/site verification passed for v0.6 context-management announcement. node .agentplane/policy/check-routing.mjs: policy routing OK. agentplane doctor: OK with pre-existing branch_pr drift warnings unrelated to this task. bun run docs:site:typecheck: pass after restoring ignored website dependencies with bun install --ignore-scripts. bun run docs:site:build: pass; remaining warnings are pre-existing blueprints tag/truncation warnings. git diff --check: pass."
+doc_version: 3
+doc_updated_at: "2026-05-14T17:23:22.098Z"
+doc_updated_by: "DOCS"
+description: "Add public announcement, README and docs coverage, website navigation, homepage context block, and a v0.6 blog article connecting AgentPlane context management to Andrej Karpathy's LLM Wiki pattern."
+sections:
+  Summary: |-
+    Announce v0.6 context management
+    
+    Add public announcement, README and docs coverage, website navigation, homepage context block, and a v0.6 blog article connecting AgentPlane context management to Andrej Karpathy's LLM Wiki pattern.
+  Scope: |-
+    - In scope: Add public announcement, README and docs coverage, website navigation, homepage context block, and a v0.6 blog article connecting AgentPlane context management to Andrej Karpathy's LLM Wiki pattern.
+    - Out of scope: unrelated refactors not required for "Announce v0.6 context management".
+  Plan: "1. Add README and documentation entry points for AgentPlane context management, using the current local-context contract as the source of truth. 2. Expose context management in website navigation and homepage content without changing runtime behavior. 3. Add a v0.6 announcement blog article that cites Andrej Karpathy's LLM Wiki pattern and explains how AgentPlane adapts it for repo-owned agent work: raw sources, wiki/facts/graph, provenance, proposal-before-promotion, and verification. 4. Run docs/policy verification gates and record evidence."
+  Verify Steps: |-
+    - Run node .agentplane/policy/check-routing.mjs and confirm routing budgets pass.
+    - Run agentplane doctor and confirm repo health gates pass or record concrete residual risk.
+    - Run the fastest available docs/site validation for Docusaurus content/navigation after inspecting package scripts.
+    - Confirm README, docs navigation, website navbar/homepage copy, and blog article point to the context-management story without claiming unimplemented vector/label retrieval as shipped.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-14T17:23:22.088Z — VERIFY — ok
+    
+    By: DOCS
+    
+    Note: Docs/site verification passed for v0.6 context-management announcement. node .agentplane/policy/check-routing.mjs: policy routing OK. agentplane doctor: OK with pre-existing branch_pr drift warnings unrelated to this task. bun run docs:site:typecheck: pass after restoring ignored website dependencies with bun install --ignore-scripts. bun run docs:site:build: pass; remaining warnings are pre-existing blueprints tag/truncation warnings. git diff --check: pass.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T17:20:13.438Z, excerpt_hash=sha256:87987643047b6f79d6a019fc6fb39c7a7a749c02b9523e8581e6c41064eb51ee
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141717-84A77P-context-management-announcement/.agentplane/tasks/202605141717-84A77P/blueprint/resolved-snapshot.json
+    - old_digest: 8e068a9a29cd42d899e24282f784cf3654f32c47dc5b1f9f6beb6f0c4d1a3ceb
+    - current_digest: 8e068a9a29cd42d899e24282f784cf3654f32c47dc5b1f9f6beb6f0c4d1a3ceb
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141717-84A77P
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Announce v0.6 context management
+
+Add public announcement, README and docs coverage, website navigation, homepage context block, and a v0.6 blog article connecting AgentPlane context management to Andrej Karpathy's LLM Wiki pattern.
+
+## Scope
+
+- In scope: Add public announcement, README and docs coverage, website navigation, homepage context block, and a v0.6 blog article connecting AgentPlane context management to Andrej Karpathy's LLM Wiki pattern.
+- Out of scope: unrelated refactors not required for "Announce v0.6 context management".
+
+## Plan
+
+1. Add README and documentation entry points for AgentPlane context management, using the current local-context contract as the source of truth. 2. Expose context management in website navigation and homepage content without changing runtime behavior. 3. Add a v0.6 announcement blog article that cites Andrej Karpathy's LLM Wiki pattern and explains how AgentPlane adapts it for repo-owned agent work: raw sources, wiki/facts/graph, provenance, proposal-before-promotion, and verification. 4. Run docs/policy verification gates and record evidence.
+
+## Verify Steps
+
+- Run node .agentplane/policy/check-routing.mjs and confirm routing budgets pass.
+- Run agentplane doctor and confirm repo health gates pass or record concrete residual risk.
+- Run the fastest available docs/site validation for Docusaurus content/navigation after inspecting package scripts.
+- Confirm README, docs navigation, website navbar/homepage copy, and blog article point to the context-management story without claiming unimplemented vector/label retrieval as shipped.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-14T17:23:22.088Z — VERIFY — ok
+
+By: DOCS
+
+Note: Docs/site verification passed for v0.6 context-management announcement. node .agentplane/policy/check-routing.mjs: policy routing OK. agentplane doctor: OK with pre-existing branch_pr drift warnings unrelated to this task. bun run docs:site:typecheck: pass after restoring ignored website dependencies with bun install --ignore-scripts. bun run docs:site:build: pass; remaining warnings are pre-existing blueprints tag/truncation warnings. git diff --check: pass.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T17:20:13.438Z, excerpt_hash=sha256:87987643047b6f79d6a019fc6fb39c7a7a749c02b9523e8581e6c41064eb51ee
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141717-84A77P-context-management-announcement/.agentplane/tasks/202605141717-84A77P/blueprint/resolved-snapshot.json
+- old_digest: 8e068a9a29cd42d899e24282f784cf3654f32c47dc5b1f9f6beb6f0c4d1a3ceb
+- current_digest: 8e068a9a29cd42d899e24282f784cf3654f32c47dc5b1f9f6beb6f0c4d1a3ceb
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141717-84A77P
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605141717-84A77P/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605141717-84A77P/blueprint/resolved-snapshot.json
@@ -1,0 +1,358 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605141717-84A77P",
+    "title": "Announce v0.6 context management",
+    "description": "Add public announcement, README and docs coverage, website navigation, homepage context block, and a v0.6 blog article connecting AgentPlane context management to Andrej Karpathy's LLM Wiki pattern.",
+    "tags": [
+      "context",
+      "docs"
+    ],
+    "owner": "DOCS",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "docs",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "docs.change",
+    "version": 1,
+    "title": "Documentation change",
+    "taskKinds": [
+      "docs"
+    ],
+    "workflowModes": [
+      "direct",
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "docs.change",
+    "blueprintVersion": 1,
+    "title": "Documentation change",
+    "taskId": "202605141717-84A77P",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "docs"
+    },
+    "whySelected": [
+      "task kind resolved to docs",
+      "workflow mode: branch_pr",
+      "mutation scope: docs"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.docs.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "artifact"
+        ]
+      },
+      {
+        "id": "deterministic_check",
+        "kind": "deterministic_check",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "docs.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed documentation paths."
+      },
+      {
+        "id": "docs.check",
+        "kind": "check_result",
+        "producedBy": "deterministic_check",
+        "required": true,
+        "description": "Documentation checks."
+      },
+      {
+        "id": "docs.artifact",
+        "kind": "artifact",
+        "producedBy": "artifact_write",
+        "required": true,
+        "description": "Updated documentation artifact."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/dod.docs.md",
+      ".agentplane/policy/security.must.md"
+    ],
+    "allowedCommands": [
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "documentation checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 3,
+      "maxPromptBlocks": 10,
+      "rationale": "Documentation changes need docs DoD and minimal workflow/security policy."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.docs.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "artifact"
+      ]
+    },
+    {
+      "id": "deterministic_check",
+      "kind": "deterministic_check",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "docs.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed documentation paths."
+    },
+    {
+      "id": "docs.check",
+      "kind": "check_result",
+      "producedBy": "deterministic_check",
+      "required": true,
+      "description": "Documentation checks."
+    },
+    {
+      "id": "docs.artifact",
+      "kind": "artifact",
+      "producedBy": "artifact_write",
+      "required": true,
+      "description": "Updated documentation artifact."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/dod.docs.md",
+    ".agentplane/policy/security.must.md"
+  ],
+  "allowedCommands": [
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "documentation checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 3,
+    "maxPromptBlocks": 10,
+    "rationale": "Documentation changes need docs DoD and minimal workflow/security policy."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to docs",
+    "workflow mode: branch_pr",
+    "mutation scope: docs"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "8e068a9a29cd42d899e24282f784cf3654f32c47dc5b1f9f6beb6f0c4d1a3ceb"
+  }
+}

--- a/.agentplane/tasks/202605141717-84A77P/pr/diffstat.txt
+++ b/.agentplane/tasks/202605141717-84A77P/pr/diffstat.txt
@@ -1,10 +1,11 @@
- README.md                                          |  30 +++++
+ .../blueprint/resolved-snapshot.json               | 358 +++++++++++++++++++++
+ README.md                                          |  30 ++
  docs/index.mdx                                     |   3 +
- docs/user/local-context.mdx                        |  26 +++++
+ docs/user/local-context.mdx                        |  26 ++
  docs/user/overview.mdx                             |   6 +-
- ...-agentplane-0-6-context-management-llm-wiki.mdx | 130 +++++++++++++++++++++
+ ...-agentplane-0-6-context-management-llm-wiki.mdx | 130 ++++++++
  website/blog/tags.yml                              |   5 +
  website/docusaurus.config.ts                       |   6 +
- website/src/data/homepage-content.ts               |  27 +++++
- website/src/pages/index.tsx                        |  23 ++++
- 9 files changed, 255 insertions(+), 1 deletion(-)
+ website/src/data/homepage-content.ts               |  27 ++
+ website/src/pages/index.tsx                        |  23 ++
+ 10 files changed, 613 insertions(+), 1 deletion(-)

--- a/.agentplane/tasks/202605141717-84A77P/pr/diffstat.txt
+++ b/.agentplane/tasks/202605141717-84A77P/pr/diffstat.txt
@@ -1,0 +1,10 @@
+ README.md                                          |  30 +++++
+ docs/index.mdx                                     |   3 +
+ docs/user/local-context.mdx                        |  26 +++++
+ docs/user/overview.mdx                             |   6 +-
+ ...-agentplane-0-6-context-management-llm-wiki.mdx | 130 +++++++++++++++++++++
+ website/blog/tags.yml                              |   5 +
+ website/docusaurus.config.ts                       |   6 +
+ website/src/data/homepage-content.ts               |  27 +++++
+ website/src/pages/index.tsx                        |  23 ++++
+ 9 files changed, 255 insertions(+), 1 deletion(-)

--- a/.agentplane/tasks/202605141717-84A77P/pr/github-body.md
+++ b/.agentplane/tasks/202605141717-84A77P/pr/github-body.md
@@ -1,0 +1,50 @@
+Task: `202605141717-84A77P`
+Title: Announce v0.6 context management
+Canonical task record: `.agentplane/tasks/202605141717-84A77P/README.md`
+
+## Summary
+
+Announce v0.6 context management
+
+Add public announcement, README and docs coverage, website navigation, homepage context block, and a v0.6 blog article connecting AgentPlane context management to Andrej Karpathy's LLM Wiki pattern.
+
+## Scope
+
+- In scope: Add public announcement, README and docs coverage, website navigation, homepage context block, and a v0.6 blog article connecting AgentPlane context management to Andrej Karpathy's LLM Wiki pattern.
+- Out of scope: unrelated refactors not required for "Announce v0.6 context management".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Docs/site verification passed for v0.6 context-management announcement. node
+.agentplane/policy/check-routing.mjs: policy routing OK. agentplane doctor: OK with pre-existing
+branch_pr drift warnings unrelated to this task. bun run docs:site:typecheck: pass after restoring
+ignored website dependencies with bun install --ignore-scripts. bun run docs:site:build: pass;
+remaining warnings are pre-existing blueprints tag/truncation warnings. git diff --check: pass.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T17:24:22.196Z
+- Branch: task/202605141717-84A77P/context-management-announcement
+- Head: 25e785c43fe6
+
+```text
+ README.md                                          |  30 +++++
+ docs/index.mdx                                     |   3 +
+ docs/user/local-context.mdx                        |  26 +++++
+ docs/user/overview.mdx                             |   6 +-
+ ...-agentplane-0-6-context-management-llm-wiki.mdx | 130 +++++++++++++++++++++
+ website/blog/tags.yml                              |   5 +
+ website/docusaurus.config.ts                       |   6 +
+ website/src/data/homepage-content.ts               |  27 +++++
+ website/src/pages/index.tsx                        |  23 ++++
+ 9 files changed, 255 insertions(+), 1 deletion(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605141717-84A77P/pr/github-body.md
+++ b/.agentplane/tasks/202605141717-84A77P/pr/github-body.md
@@ -30,21 +30,22 @@ remaining warnings are pre-existing blueprints tag/truncation warnings. git diff
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T17:24:22.196Z
+- Updated: 2026-05-14T17:24:29.117Z
 - Branch: task/202605141717-84A77P/context-management-announcement
 - Head: 25e785c43fe6
 
 ```text
- README.md                                          |  30 +++++
+ .../blueprint/resolved-snapshot.json               | 358 +++++++++++++++++++++
+ README.md                                          |  30 ++
  docs/index.mdx                                     |   3 +
- docs/user/local-context.mdx                        |  26 +++++
+ docs/user/local-context.mdx                        |  26 ++
  docs/user/overview.mdx                             |   6 +-
- ...-agentplane-0-6-context-management-llm-wiki.mdx | 130 +++++++++++++++++++++
+ ...-agentplane-0-6-context-management-llm-wiki.mdx | 130 ++++++++
  website/blog/tags.yml                              |   5 +
  website/docusaurus.config.ts                       |   6 +
- website/src/data/homepage-content.ts               |  27 +++++
- website/src/pages/index.tsx                        |  23 ++++
- 9 files changed, 255 insertions(+), 1 deletion(-)
+ website/src/data/homepage-content.ts               |  27 ++
+ website/src/pages/index.tsx                        |  23 ++
+ 10 files changed, 613 insertions(+), 1 deletion(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605141717-84A77P/pr/github-title.txt
+++ b/.agentplane/tasks/202605141717-84A77P/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 84A77P task: Announce v0.6 context management [202605141717-84A77P]

--- a/.agentplane/tasks/202605141717-84A77P/pr/meta.json
+++ b/.agentplane/tasks/202605141717-84A77P/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605141717-84A77P/context-management-announcement",
+  "created_at": "2026-05-14T17:18:06.934Z",
+  "head_sha": "25e785c43fe6984bb0b8d9044d975a7584bae286",
+  "last_verified_at": "2026-05-14T17:23:22.088Z",
+  "last_verified_sha": "bc694ec383f274e2961b315d2ae677b5f084ad12",
+  "schema_version": 1,
+  "task_id": "202605141717-84A77P",
+  "updated_at": "2026-05-14T17:24:22.196Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605141717-84A77P/pr/meta.json
+++ b/.agentplane/tasks/202605141717-84A77P/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "25e785c43fe6984bb0b8d9044d975a7584bae286",
   "last_verified_at": "2026-05-14T17:23:22.088Z",
   "last_verified_sha": "bc694ec383f274e2961b315d2ae677b5f084ad12",
+  "pr_number": 3742,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3742",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605141717-84A77P",
-  "updated_at": "2026-05-14T17:24:22.196Z",
+  "updated_at": "2026-05-14T17:24:29.117Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141717-84A77P/pr/review.md
+++ b/.agentplane/tasks/202605141717-84A77P/pr/review.md
@@ -1,0 +1,45 @@
+# PR Review
+
+Created: 2026-05-14T17:18:06.934Z
+
+## Task
+
+- Task: `202605141717-84A77P`
+- Title: Announce v0.6 context management
+- Status: DOING
+- Branch: `task/202605141717-84A77P/context-management-announcement`
+- Canonical task record: `.agentplane/tasks/202605141717-84A77P/README.md`
+
+## Verification
+
+- State: ok
+- Note: Docs/site verification passed for v0.6 context-management announcement. node .agentplane/policy/check-routing.mjs: policy routing OK. agentplane doctor: OK with pre-existing branch_pr drift warnings unrelated to this task. bun run docs:site:typecheck: pass after restoring ignored website dependencies with bun install --ignore-scripts. bun run docs:site:build: pass; remaining warnings are pre-existing blueprints tag/truncation warnings. git diff --check: pass.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T17:24:22.196Z
+- Branch: task/202605141717-84A77P/context-management-announcement
+- Head: 25e785c43fe6
+
+```text
+ README.md                                          |  30 +++++
+ docs/index.mdx                                     |   3 +
+ docs/user/local-context.mdx                        |  26 +++++
+ docs/user/overview.mdx                             |   6 +-
+ ...-agentplane-0-6-context-management-llm-wiki.mdx | 130 +++++++++++++++++++++
+ website/blog/tags.yml                              |   5 +
+ website/docusaurus.config.ts                       |   6 +
+ website/src/data/homepage-content.ts               |  27 +++++
+ website/src/pages/index.tsx                        |  23 ++++
+ 9 files changed, 255 insertions(+), 1 deletion(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605141717-84A77P/pr/review.md
+++ b/.agentplane/tasks/202605141717-84A77P/pr/review.md
@@ -24,21 +24,22 @@ Created: 2026-05-14T17:18:06.934Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T17:24:22.196Z
+- Updated: 2026-05-14T17:24:29.117Z
 - Branch: task/202605141717-84A77P/context-management-announcement
 - Head: 25e785c43fe6
 
 ```text
- README.md                                          |  30 +++++
+ .../blueprint/resolved-snapshot.json               | 358 +++++++++++++++++++++
+ README.md                                          |  30 ++
  docs/index.mdx                                     |   3 +
- docs/user/local-context.mdx                        |  26 +++++
+ docs/user/local-context.mdx                        |  26 ++
  docs/user/overview.mdx                             |   6 +-
- ...-agentplane-0-6-context-management-llm-wiki.mdx | 130 +++++++++++++++++++++
+ ...-agentplane-0-6-context-management-llm-wiki.mdx | 130 ++++++++
  website/blog/tags.yml                              |   5 +
  website/docusaurus.config.ts                       |   6 +
- website/src/data/homepage-content.ts               |  27 +++++
- website/src/pages/index.tsx                        |  23 ++++
- 9 files changed, 255 insertions(+), 1 deletion(-)
+ website/src/data/homepage-content.ts               |  27 ++
+ website/src/pages/index.tsx                        |  23 ++
+ 10 files changed, 613 insertions(+), 1 deletion(-)
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -95,6 +95,36 @@ agentplane acr explain <task-id>
 
 Schema: [`schemas/acr-v0.1.schema.json`](schemas/acr-v0.1.schema.json).
 
+## Context management
+
+AgentPlane also gives agents a repository-owned memory layer. Instead of asking an agent to
+rediscover project knowledge from raw files on every prompt, keep reusable context in Git and let
+AgentPlane project it into searchable local state.
+
+```text
+context/raw/**              source material
+context/wiki/**             maintained markdown wiki
+context/facts/**/*.jsonl    sourced facts
+context/graph/**/*.jsonl    entities and relationships
+.agentplane/context/derived disposable generated projection
+```
+
+Initialize it with:
+
+```bash
+agentplane context init
+agentplane context learn changes
+agentplane context learn tasks --tag release --limit 20 --dry-run
+agentplane context search "release checklist"
+agentplane context check
+```
+
+The model matches the LLM Wiki pattern: raw sources stay immutable, the wiki accumulates synthesis,
+and schema/policy files tell agents how to maintain it. AgentPlane adds task lifecycle, provenance,
+proposal-before-promotion, and verification gates so context updates remain reviewable.
+
+Read [Local context](docs/user/local-context.mdx).
+
 ## First task flow
 
 Create a task:

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -45,6 +45,9 @@ context, Agent Change Record, and closure.
 - [Agent discovery](user/agent-discovery)
 - [Indexing and webmaster operations](user/indexing-and-webmaster-operations)
 
+Local context is the v0.6 context-management surface: raw sources, maintained wiki pages, sourced
+facts, graph edges, disposable projections, and verification gates for agent-maintained knowledge.
+
 ### Workflow guides
 
 - [Workflow guides overview](workflow-guides)

--- a/docs/user/local-context.mdx
+++ b/docs/user/local-context.mdx
@@ -11,6 +11,23 @@ versioned files, then builds a SQLite projection for fast search and retrieval.
 Use it when an agent needs facts, wiki pages, graph edges, capability notes, or task-specific
 source sets that should survive outside one chat session.
 
+## Context management in v0.6
+
+AgentPlane v0.6 turns local context from a search helper into a context-management workflow:
+
+- raw sources remain in the repository and are treated as evidence
+- wiki pages accumulate synthesis instead of forcing agents to re-derive it from scratch
+- fact and graph rows preserve structured claims and relationships
+- generated projections stay disposable and can be rebuilt
+- task history can become new context through explicit extraction tasks
+- verification checks keep sourced context from drifting into unsourced memory
+
+This follows the LLM Wiki pattern described by Andrej Karpathy: keep raw sources separate, let an
+LLM maintain a persistent markdown wiki, and use a schema file such as `AGENTS.md` to make the agent
+a disciplined maintainer rather than a generic chatbot. AgentPlane adapts that pattern for software
+repositories by adding task lifecycle, source refs, proposal-before-promotion, and verification
+gates.
+
 ## Source of truth
 
 Editable source artifacts live under `context/**`:
@@ -124,6 +141,15 @@ The verifier checks that task-facing context claims are source-backed:
 - completed context tasks have an ACR context extension
 
 Run it before closing tasks that write or rely on context artifacts.
+
+## How this differs from RAG
+
+RAG retrieves source chunks at answer time. Local context still supports search, but the durable
+artifact is the maintained knowledge layer: markdown pages, facts, graph edges, capability notes,
+and task evidence that can be reviewed in Git.
+
+Use raw search when you need to inspect source material. Use context management when a finding
+should compound into future agent work.
 
 ## Privacy boundary
 

--- a/docs/user/overview.mdx
+++ b/docs/user/overview.mdx
@@ -31,7 +31,8 @@ task -> plan -> approve -> implement -> verify -> finish
 - Policy gateway through `AGENTS.md` or `CLAUDE.md`.
 - Explicit task lifecycle.
 - Verification evidence.
-- Local context ingestion, projection, search, and task-context verification.
+- Local context management: raw sources, wiki pages, facts, graph edges, projection, search, and
+  task-context verification.
 - ACR generation and validation.
 - `direct` and `branch_pr` workflows.
 
@@ -62,6 +63,9 @@ context/wiki/**/*
 context/facts/**/*.jsonl
 context/graph/**/*.jsonl
 ```
+
+This is AgentPlane's implementation of the LLM Wiki pattern for repositories: agents maintain a
+source-backed knowledge layer in Git instead of re-reading every raw source on every question.
 
 ## Source of truth model
 

--- a/website/blog/2026-05-15-agentplane-0-6-context-management-llm-wiki.mdx
+++ b/website/blog/2026-05-15-agentplane-0-6-context-management-llm-wiki.mdx
@@ -1,0 +1,130 @@
+---
+slug: agentplane-0-6-context-management-llm-wiki
+title: "AgentPlane 0.6: context management for the LLM Wiki pattern"
+description: "AgentPlane 0.6 adapts Andrej Karpathy's LLM Wiki idea for software repositories: raw sources, maintained wiki pages, sourced facts, graph edges, task history, and verification in Git."
+authors: [team]
+tags: [release, context, workflow]
+---
+
+Andrej Karpathy's [LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)
+pattern names a failure mode most teams already feel: plain RAG keeps rediscovering knowledge from
+scratch.
+
+You upload files. The model retrieves chunks. It answers. Then the synthesis disappears back into
+the session.
+
+The LLM Wiki pattern changes the unit of work. Raw sources remain source material, but the durable
+artifact is a maintained markdown wiki. The model updates entity pages, concept pages, indexes,
+cross-references, contradictions, and logs. Knowledge compounds.
+
+AgentPlane 0.6 brings that idea into repository work.
+
+<!-- truncate -->
+
+## From personal wiki to repo-owned context
+
+Karpathy's architecture has three layers:
+
+1. raw sources
+2. a maintained wiki
+3. a schema file that tells the LLM how to operate
+
+AgentPlane maps those layers onto a Git repository:
+
+```text
+context/raw/**              raw source material
+context/wiki/**             maintained markdown wiki
+context/facts/**/*.jsonl    sourced facts
+context/graph/**/*.jsonl    entities and relationships
+AGENTS.md                   policy and operating schema
+.agentplane/tasks/**        task intent, plan, verification, ACR
+```
+
+The important shift is not "better search". Search matters, but it is not the source of truth.
+AgentPlane treats the wiki, facts, graph rows, and task evidence as reviewable repository artifacts.
+Generated projections under `.agentplane/context/derived/**` and `.agentplane/cache.sqlite` are
+disposable. They can be rebuilt.
+
+## Why this matters for coding agents
+
+Coding agents do not only need snippets of code. They need working context:
+
+- why the release process has a specific gate
+- which policy file owns a workflow rule
+- which previous task discovered a failure mode
+- what source backed a claim
+- whether an old conclusion was superseded
+
+Without a maintained context layer, each agent session pays the same cost again. It searches, reads,
+guesses the hierarchy, and reconstructs history from scattered files.
+
+With AgentPlane local context, the repository can carry that knowledge forward.
+
+## What is new in the 0.6 context story
+
+AgentPlane 0.6 makes context management a first-class workflow surface:
+
+```bash
+agentplane context init
+agentplane context learn changes
+agentplane context learn files ./notes.md --run
+agentplane context learn tasks --tag release --limit 20 --dry-run
+agentplane context search "release checklist"
+agentplane context check
+```
+
+`context learn` is the human-facing layer. It creates bounded context-assimilation work instead of
+turning every prompt into an uncontrolled wiki edit.
+
+For completed tasks, AgentPlane can use task READMEs and Agent Change Records as source material.
+That matters because task history already contains the most valuable project memory: what changed,
+what was approved, what failed, what verified, and what should not be repeated.
+
+## Provenance before promotion
+
+A weak memory system accumulates claims. A useful one preserves evidence.
+
+AgentPlane's context workflow is deliberately conservative:
+
+- raw sources are separate from synthesized pages
+- facts and graph edges carry source refs
+- task extraction can write proposals before canonical promotion
+- stale and conflicting claims can be marked instead of silently merged
+- `context verify-task <task-id>` checks that context-bearing work is source-backed
+
+That is the repo version of the LLM Wiki health check. The goal is not to let an agent write more
+markdown. The goal is to let useful context become durable without losing the audit trail.
+
+## Not just RAG, not just notes
+
+RAG is useful when the model needs source chunks at answer time. The LLM Wiki pattern is different:
+the synthesis itself becomes an artifact.
+
+AgentPlane keeps that distinction:
+
+- `context/raw/**` is evidence
+- `context/wiki/**` is maintained synthesis
+- `context/facts/**/*.jsonl` is structured claim storage
+- `context/graph/**/*.jsonl` is the relationship layer
+- `.agentplane/context/derived/**` is rebuildable projection
+- `.agentplane/tasks/**` is the workflow trail that explains how context changed
+
+The cache can help retrieval. It does not own truth.
+
+## The practical outcome
+
+For a repository, the payoff is direct:
+
+- a new agent can search context before touching files
+- a reviewer can inspect which source backed a wiki update
+- a repeated failure mode can become a sourced project fact
+- a release lesson can be harvested from a completed task
+- context changes can pass through the same task, plan, verification, and ACR loop as code
+
+Karpathy's formulation is personal and exploratory: Obsidian as the IDE, the LLM as the maintainer,
+the wiki as the codebase.
+
+AgentPlane's version is operational: Git as the durability layer, `AGENTS.md` as the operating
+schema, task history as evidence, and verification as the promotion gate.
+
+That is the context-management story in AgentPlane 0.6.

--- a/website/blog/tags.yml
+++ b/website/blog/tags.yml
@@ -22,3 +22,8 @@ backend:
   label: Backend
   permalink: /backend
   description: Backend projection, sync behavior, and external task-source integration.
+
+context:
+  label: Context
+  permalink: /context
+  description: Local context, repo-owned memory, and source-backed agent knowledge.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -127,6 +127,12 @@ const config = {
           activeBaseRegex: "^/docs/user/agent-change-record",
         },
         {
+          to: "/docs/user/local-context",
+          label: "Context",
+          position: "right",
+          activeBaseRegex: "^/docs/user/local-context",
+        },
+        {
           to: "/docs/workflow-guides",
           label: "Workflows",
           position: "right",

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -157,6 +157,12 @@ const config = {
           activeBaseRegex: "^/docs/compare",
         },
         {
+          to: "/blog",
+          label: "Blog",
+          position: "right",
+          activeBaseRegex: "^/blog",
+        },
+        {
           href: "https://github.com/basilisk-labs/agentplane",
           label: "GitHub",
           position: "right",

--- a/website/src/data/homepage-content.ts
+++ b/website/src/data/homepage-content.ts
@@ -1,6 +1,7 @@
 export const githubUrl = "https://github.com/basilisk-labs/agentplane";
 export const docsUrl = "/docs/user/overview";
 export const acrUrl = "/docs/user/agent-change-record";
+export const contextUrl = "/docs/user/local-context";
 export const workflowGuidesUrl = "/docs/workflow-guides";
 export const recipesUrl = "/docs/recipes";
 export const comparisonUrl = "/docs/compare";
@@ -144,6 +145,26 @@ export const homepageContent = {
     },
     action: { label: "Read the ACR spec", to: acrUrl },
   },
+  context: {
+    title: "Context management for agent work.",
+    text: "AgentPlane applies the LLM Wiki pattern to software repositories: raw sources stay in Git, agents maintain a structured wiki, facts and graph edges preserve sourced claims, and disposable projections make the knowledge searchable without becoming the source of truth.",
+    terminal: {
+      title: "Context path",
+      lines: [
+        "agentplane context init",
+        "agentplane context learn changes",
+        "agentplane context learn tasks --tag release --limit 20 --dry-run",
+        'agentplane context search "release checklist"',
+      ],
+    },
+    bullets: [
+      "`context/raw/**` keeps source material.",
+      "`context/wiki/**` accumulates maintained markdown synthesis.",
+      "`context/facts/**/*.jsonl` and `context/graph/**/*.jsonl` keep structured claims.",
+      "`context verify-task` checks provenance before context-bearing tasks close.",
+    ],
+    action: { label: "Read local context docs", to: contextUrl },
+  },
   recipesCatalog: {
     title: "Extensions, not the core story.",
     text: "Recipes are optional signed packages for teams that want reusable agent profiles, prompt modules, skills, or repository mapping assets.",
@@ -175,6 +196,12 @@ export const homepageContent = {
         text: "Add task evidence and ACR validation before merge.",
         action: "Read ACR",
         to: acrUrl,
+      },
+      {
+        title: "Managing context?",
+        text: "Use local context to turn raw sources, completed tasks, and recurring findings into reviewable repository knowledge.",
+        action: "Open context docs",
+        to: contextUrl,
       },
       {
         title: "Comparing alternatives?",

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -401,6 +401,7 @@ export default function Home(): ReactNode {
     workflow,
     artifacts,
     acr,
+    context,
     whyNow,
     nextSteps,
     closing,
@@ -530,6 +531,28 @@ export default function Home(): ReactNode {
               </p>
               <Link className={`${styles.action} ${styles.actionPrimary}`} to={acr.action.to}>
                 {acr.action.label}
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.shell}`}>
+          <SectionLead label="Context management" title={context.title} text={context.text} />
+          <div className={styles.demoGrid}>
+            <TerminalPreview
+              title={context.terminal.title}
+              lines={context.terminal.lines}
+              compact
+            />
+            <div className={styles.demoAside}>
+              <span className={styles.sectionLabel}>Repo-owned memory</span>
+              <ul className={styles.artifactBullets}>
+                {context.bullets.map((bullet) => (
+                  <li key={bullet}>{bullet}</li>
+                ))}
+              </ul>
+              <Link className={`${styles.action} ${styles.actionPrimary}`} to={context.action.to}>
+                {context.action.label}
               </Link>
             </div>
           </div>


### PR DESCRIPTION
Task: `202605141717-84A77P`
Title: Announce v0.6 context management
Canonical task record: `.agentplane/tasks/202605141717-84A77P/README.md`

## Summary

Announce v0.6 context management

Add public announcement, README and docs coverage, website navigation, homepage context block, and a v0.6 blog article connecting AgentPlane context management to Andrej Karpathy's LLM Wiki pattern.

## Scope

- In scope: Add public announcement, README and docs coverage, website navigation, homepage context block, and a v0.6 blog article connecting AgentPlane context management to Andrej Karpathy's LLM Wiki pattern.
- Out of scope: unrelated refactors not required for "Announce v0.6 context management".

## Verification

- State: ok
- Note:

```text
Docs/site verification passed for v0.6 context-management announcement. node
.agentplane/policy/check-routing.mjs: policy routing OK. agentplane doctor: OK with pre-existing
branch_pr drift warnings unrelated to this task. bun run docs:site:typecheck: pass after restoring
ignored website dependencies with bun install --ignore-scripts. bun run docs:site:build: pass;
remaining warnings are pre-existing blueprints tag/truncation warnings. git diff --check: pass.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-14T17:24:22.196Z
- Branch: task/202605141717-84A77P/context-management-announcement
- Head: 25e785c43fe6

```text
 README.md                                          |  30 +++++
 docs/index.mdx                                     |   3 +
 docs/user/local-context.mdx                        |  26 +++++
 docs/user/overview.mdx                             |   6 +-
 ...-agentplane-0-6-context-management-llm-wiki.mdx | 130 +++++++++++++++++++++
 website/blog/tags.yml                              |   5 +
 website/docusaurus.config.ts                       |   6 +
 website/src/data/homepage-content.ts               |  27 +++++
 website/src/pages/index.tsx                        |  23 ++++
 9 files changed, 255 insertions(+), 1 deletion(-)
```

</details>
