### PR TITLE
🚧 GX777N task: Enrich feedback issue diagnostics [202605141737-GX777N]

### DIFF
--- a/.agentplane/tasks/202605141737-GX777N/README.md
+++ b/.agentplane/tasks/202605141737-GX777N/README.md
@@ -1,0 +1,145 @@
+---
+id: "202605141737-GX777N"
+title: "Enrich feedback issue diagnostics"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "diagnostics"
+  - "github"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-14T17:37:14.638Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-14T18:03:11.859Z"
+  updated_by: "CODER"
+  note: "Command: bun test packages/agentplane/src/cli/run-cli.core.insights-report.test.ts; Result: pass, 6 tests. Command: bun run typecheck; Result: pass. Command: bun run lint:core; Result: pass. Command: bun run format:check; Result: pass. Command: bun run docs:cli:check; Result: pass. Command: node .agentplane/policy/check-routing.mjs; Result: pass. Command: ap doctor; Result: OK with two unrelated existing branch_pr reconciliation warnings. External: created test feedback issue #3744 with Agent context and failure metadata, raw branch name absent."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement privacy-bounded feedback issue diagnostics in the dedicated task worktree, including tests and a sanitized test issue creation attempt."
+events:
+  -
+    type: "status"
+    at: "2026-05-14T17:37:26.111Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement privacy-bounded feedback issue diagnostics in the dedicated task worktree, including tests and a sanitized test issue creation attempt."
+  -
+    type: "verify"
+    at: "2026-05-14T18:03:11.859Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: bun test packages/agentplane/src/cli/run-cli.core.insights-report.test.ts; Result: pass, 6 tests. Command: bun run typecheck; Result: pass. Command: bun run lint:core; Result: pass. Command: bun run format:check; Result: pass. Command: bun run docs:cli:check; Result: pass. Command: node .agentplane/policy/check-routing.mjs; Result: pass. Command: ap doctor; Result: OK with two unrelated existing branch_pr reconciliation warnings. External: created test feedback issue #3744 with Agent context and failure metadata, raw branch name absent."
+doc_version: 3
+doc_updated_at: "2026-05-14T18:03:11.887Z"
+doc_updated_by: "CODER"
+description: "Add privacy-bounded failure context and required agent context support to AgentPlane insights issue reports, then create a test feedback issue."
+sections:
+  Summary: |-
+    Enrich feedback issue diagnostics
+    
+    Add privacy-bounded failure context and required agent context support to AgentPlane insights issue reports, then create a test feedback issue.
+  Scope: |-
+    - In scope: Add privacy-bounded failure context and required agent context support to AgentPlane insights issue reports, then create a test feedback issue.
+    - Out of scope: unrelated refactors not required for "Enrich feedback issue diagnostics".
+  Plan: "Implement privacy-bounded failure context for insights reports; add command options for agent context file and explicit missing-context override; require context for E_INTERNAL issue creation unless override is supplied; update focused tests and run dry-run plus test issue creation with sanitized context."
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+    
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-14T18:03:11.859Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Command: bun test packages/agentplane/src/cli/run-cli.core.insights-report.test.ts; Result: pass, 6 tests. Command: bun run typecheck; Result: pass. Command: bun run lint:core; Result: pass. Command: bun run format:check; Result: pass. Command: bun run docs:cli:check; Result: pass. Command: node .agentplane/policy/check-routing.mjs; Result: pass. Command: ap doctor; Result: OK with two unrelated existing branch_pr reconciliation warnings. External: created test feedback issue #3744 with Agent context and failure metadata, raw branch name absent.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T17:37:26.111Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141737-GX777N-feedback-issue-diagnostics/.agentplane/tasks/202605141737-GX777N/blueprint/resolved-snapshot.json
+    - old_digest: a92c708eda3bd2255ed9754e1ab81fdbd70f98fcdd66123088b775187fa7e608
+    - current_digest: a92c708eda3bd2255ed9754e1ab81fdbd70f98fcdd66123088b775187fa7e608
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141737-GX777N
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Enrich feedback issue diagnostics
+
+Add privacy-bounded failure context and required agent context support to AgentPlane insights issue reports, then create a test feedback issue.
+
+## Scope
+
+- In scope: Add privacy-bounded failure context and required agent context support to AgentPlane insights issue reports, then create a test feedback issue.
+- Out of scope: unrelated refactors not required for "Enrich feedback issue diagnostics".
+
+## Plan
+
+Implement privacy-bounded failure context for insights reports; add command options for agent context file and explicit missing-context override; require context for E_INTERNAL issue creation unless override is supplied; update focused tests and run dry-run plus test issue creation with sanitized context.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-14T18:03:11.859Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: bun test packages/agentplane/src/cli/run-cli.core.insights-report.test.ts; Result: pass, 6 tests. Command: bun run typecheck; Result: pass. Command: bun run lint:core; Result: pass. Command: bun run format:check; Result: pass. Command: bun run docs:cli:check; Result: pass. Command: node .agentplane/policy/check-routing.mjs; Result: pass. Command: ap doctor; Result: OK with two unrelated existing branch_pr reconciliation warnings. External: created test feedback issue #3744 with Agent context and failure metadata, raw branch name absent.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T17:37:26.111Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141737-GX777N-feedback-issue-diagnostics/.agentplane/tasks/202605141737-GX777N/blueprint/resolved-snapshot.json
+- old_digest: a92c708eda3bd2255ed9754e1ab81fdbd70f98fcdd66123088b775187fa7e608
+- current_digest: a92c708eda3bd2255ed9754e1ab81fdbd70f98fcdd66123088b775187fa7e608
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141737-GX777N
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605141737-GX777N/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605141737-GX777N/blueprint/resolved-snapshot.json
@@ -1,0 +1,528 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605141737-GX777N",
+    "title": "Enrich feedback issue diagnostics",
+    "description": "Add privacy-bounded failure context and required agent context support to AgentPlane insights issue reports, then create a test feedback issue.",
+    "tags": [
+      "code",
+      "diagnostics",
+      "github"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605141737-GX777N",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "a92c708eda3bd2255ed9754e1ab81fdbd70f98fcdd66123088b775187fa7e608"
+  }
+}

--- a/.agentplane/tasks/202605141737-GX777N/pr/diffstat.txt
+++ b/.agentplane/tasks/202605141737-GX777N/pr/diffstat.txt
@@ -1,0 +1,6 @@
+ docs/user/cli-reference.generated.mdx              |   8 ++
+ packages/agentplane/src/cli/reason-codes.ts        |   6 +
+ .../src/cli/run-cli.core.insights-report.test.ts   |  54 +++++++++
+ .../src/commands/insights/insights.command.ts      | 135 ++++++++++++++++++++-
+ .../src/commands/insights/insights.spec.ts         |  71 +++++++++++
+ 5 files changed, 272 insertions(+), 2 deletions(-)

--- a/.agentplane/tasks/202605141737-GX777N/pr/github-body.md
+++ b/.agentplane/tasks/202605141737-GX777N/pr/github-body.md
@@ -1,0 +1,47 @@
+Task: `202605141737-GX777N`
+Title: Enrich feedback issue diagnostics
+Canonical task record: `.agentplane/tasks/202605141737-GX777N/README.md`
+
+## Summary
+
+Enrich feedback issue diagnostics
+
+Add privacy-bounded failure context and required agent context support to AgentPlane insights issue reports, then create a test feedback issue.
+
+## Scope
+
+- In scope: Add privacy-bounded failure context and required agent context support to AgentPlane insights issue reports, then create a test feedback issue.
+- Out of scope: unrelated refactors not required for "Enrich feedback issue diagnostics".
+
+## Verification
+
+- State: ok
+- Note:
+
+```bash
+bun test packages/agentplane/src/cli/run-cli.core.insights-report.test.ts; Result: pass, 6 tests. \
+  Command: bun run typecheck; Result: pass. Command: bun run lint:core; Result: pass. Command: bun \
+  run format:check; Result: pass. Command: bun run docs:cli:check; Result: pass. Command: node \
+  .agentplane/policy/check-routing.mjs; Result: pass. Command: ap doctor; Result: OK with two \
+  unrelated existing branch_pr reconciliation warnings. External: created test feedback issue #3744 \
+  with Agent context and failure metadata, raw branch name absent.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T18:03:11.950Z
+- Branch: task/202605141737-GX777N/feedback-issue-diagnostics
+- Head: c8586bf5511d
+
+```text
+ docs/user/cli-reference.generated.mdx              |   8 ++
+ packages/agentplane/src/cli/reason-codes.ts        |   6 +
+ .../src/cli/run-cli.core.insights-report.test.ts   |  54 +++++++++
+ .../src/commands/insights/insights.command.ts      | 135 ++++++++++++++++++++-
+ .../src/commands/insights/insights.spec.ts         |  71 +++++++++++
+ 5 files changed, 272 insertions(+), 2 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605141737-GX777N/pr/github-title.txt
+++ b/.agentplane/tasks/202605141737-GX777N/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 GX777N task: Enrich feedback issue diagnostics [202605141737-GX777N]

--- a/.agentplane/tasks/202605141737-GX777N/pr/meta.json
+++ b/.agentplane/tasks/202605141737-GX777N/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605141737-GX777N/feedback-issue-diagnostics",
+  "created_at": "2026-05-14T17:37:26.165Z",
+  "head_sha": "c8586bf5511dfc034b82b15ef1f470e4f7ec4f76",
+  "last_verified_at": "2026-05-14T18:03:11.859Z",
+  "last_verified_sha": "c8586bf5511dfc034b82b15ef1f470e4f7ec4f76",
+  "schema_version": 1,
+  "task_id": "202605141737-GX777N",
+  "updated_at": "2026-05-14T18:03:11.950Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605141737-GX777N/pr/meta.json
+++ b/.agentplane/tasks/202605141737-GX777N/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "c8586bf5511dfc034b82b15ef1f470e4f7ec4f76",
   "last_verified_at": "2026-05-14T18:03:11.859Z",
   "last_verified_sha": "c8586bf5511dfc034b82b15ef1f470e4f7ec4f76",
+  "pr_number": 3745,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3745",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605141737-GX777N",
-  "updated_at": "2026-05-14T18:03:11.950Z",
+  "updated_at": "2026-05-14T18:03:56.814Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141737-GX777N/pr/review.md
+++ b/.agentplane/tasks/202605141737-GX777N/pr/review.md
@@ -1,0 +1,41 @@
+# PR Review
+
+Created: 2026-05-14T17:37:26.165Z
+
+## Task
+
+- Task: `202605141737-GX777N`
+- Title: Enrich feedback issue diagnostics
+- Status: DOING
+- Branch: `task/202605141737-GX777N/feedback-issue-diagnostics`
+- Canonical task record: `.agentplane/tasks/202605141737-GX777N/README.md`
+
+## Verification
+
+- State: ok
+- Note: Command: bun test packages/agentplane/src/cli/run-cli.core.insights-report.test.ts; Result: pass, 6 tests. Command: bun run typecheck; Result: pass. Command: bun run lint:core; Result: pass. Command: bun run format:check; Result: pass. Command: bun run docs:cli:check; Result: pass. Command: node .agentplane/policy/check-routing.mjs; Result: pass. Command: ap doctor; Result: OK with two unrelated existing branch_pr reconciliation warnings. External: created test feedback issue #3744 with Agent context and failure metadata, raw branch name absent.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T18:03:11.950Z
+- Branch: task/202605141737-GX777N/feedback-issue-diagnostics
+- Head: c8586bf5511d
+
+```text
+ docs/user/cli-reference.generated.mdx              |   8 ++
+ packages/agentplane/src/cli/reason-codes.ts        |   6 +
+ .../src/cli/run-cli.core.insights-report.test.ts   |  54 +++++++++
+ .../src/commands/insights/insights.command.ts      | 135 ++++++++++++++++++++-
+ .../src/commands/insights/insights.spec.ts         |  71 +++++++++++
+ 5 files changed, 272 insertions(+), 2 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -2031,7 +2031,15 @@ Options:
 
 - `--title <title>`: Issue title. Defaults to an internal AgentPlane error report title.
 - `--body <text>`: Optional short user-visible context to include before diagnostics.
+- `--agent-context <text>`: Sanitized agent-written diagnostic context to include in the public issue body.
+- `--agent-context-file <path>`: Read sanitized agent-written diagnostic context from a file before creating the issue.
+- `--allow-missing-agent-context`: Allow creating an E_INTERNAL issue without the recommended agent-written context. (default=false)
 - `--error-code <code>`: AgentPlane error code that triggered the report.
+- `--failure-command <command>`: Privacy-safe command id associated with the failure, for example task start-ready.
+- `--failure-phase <phase>`: Privacy-safe lifecycle phase associated with the failure.
+- `--failure-reason-code <code>`: Privacy-safe reason code associated with the failure.
+- `--failure-message-class <class>`: Privacy-safe error message class, not the raw error message.
+- `--failure-argv-shape <token>`: Repeatable sanitized argv shape token; values must not include raw secrets. (repeatable)
 - `--dry-run`: Print the GitHub issue payload without creating an issue. (default=false)
 
 Examples:

--- a/packages/agentplane/src/cli/reason-codes.ts
+++ b/packages/agentplane/src/cli/reason-codes.ts
@@ -144,6 +144,12 @@ const REASON_CODE_MAP: Readonly<Record<string, ReasonCodeMeta>> = {
     summary: "GitHub issue feedback is disabled for this project",
     action: "enable feedback.github_issues.enabled before creating feedback issues",
   },
+  feedback_agent_context_required: {
+    code: "feedback_agent_context_required",
+    category: "feedback",
+    summary: "E_INTERNAL feedback issues need sanitized agent context for actionable triage",
+    action: "pass --agent-context, --agent-context-file, or --allow-missing-agent-context",
+  },
 };
 
 export function getReasonCodeMeta(code: string | undefined): ReasonCodeMeta | undefined {

--- a/packages/agentplane/src/cli/run-cli.core.insights-report.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.insights-report.test.ts
@@ -114,6 +114,11 @@ describe("runCli insights report", () => {
       const payload = JSON.parse(io.stdout) as {
         schema?: string;
         privacy?: { local_only?: boolean; network?: string; upload?: string };
+        failure?: {
+          error_code?: string | null;
+          command_id?: string | null;
+          dedupe_signature?: string;
+        };
         project?: { workflow_mode?: string; backend?: { id?: string } };
         git?: { status_counts?: { untracked?: number }; dirty?: boolean };
         tasks?: {
@@ -129,6 +134,9 @@ describe("runCli insights report", () => {
         network: "not_used",
         upload: "not_supported",
       });
+      expect(payload.failure?.error_code).toBeNull();
+      expect(payload.failure?.command_id).toBeNull();
+      expect(payload.failure?.dedupe_signature).toMatch(/^sha256:/);
       expect(payload.project?.workflow_mode).toBe("direct");
       expect(payload.project?.backend?.id).toBe("local");
       expect(payload.git?.dirty).toBe(true);
@@ -184,6 +192,22 @@ describe("runCli insights report", () => {
         "--dry-run",
         "--error-code",
         "E_INTERNAL",
+        "--agent-context",
+        "Intent: test the public feedback issue payload. Observed failure: simulated E_INTERNAL during command dispatch. Sensitive data omitted: task prose, env, remotes, and raw output.",
+        "--failure-command",
+        "task start-ready",
+        "--failure-phase",
+        "resolve_context",
+        "--failure-reason-code",
+        "task_context_unexpected",
+        "--failure-message-class",
+        "internal_invariant",
+        "--failure-argv-shape",
+        "task",
+        "--failure-argv-shape",
+        "start-ready",
+        "--failure-argv-shape",
+        "<task-id>",
         "--body",
         "Internal error happened while testing.",
         "--root",
@@ -202,8 +226,38 @@ describe("runCli insights report", () => {
       expect(payload.title).toContain("E_INTERNAL");
       expect(payload.labels).toEqual(["agentplane-feedback", "bug"]);
       expect(payload.body).toContain("privacy-bounded");
+      expect(payload.body).toContain("## Agent context");
+      expect(payload.body).toContain("simulated E_INTERNAL during command dispatch");
       expect(payload.body).toContain('"schema": "agentplane.insights.report.v1"');
+      expect(payload.body).toContain('"failure"');
+      expect(payload.body).toContain('"command_id": "task start-ready"');
+      expect(payload.body).toContain('"phase": "resolve_context"');
+      expect(payload.body).toContain('"dedupe_signature": "sha256:');
       expect(payload.body).toContain("Internal error happened while testing.");
+    } finally {
+      io.restore();
+    }
+  });
+
+  it("requires agent context for real E_INTERNAL issue creation", async () => {
+    const root = await mkGitRepoRoot();
+    const config = defaultConfig();
+    config.feedback.github_issues.enabled = true;
+    await writeConfig(root, config);
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli([
+        "insights",
+        "issue",
+        "--error-code",
+        "E_INTERNAL",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(2);
+      expect(io.stderr).toContain("E_INTERNAL feedback issues require sanitized agent context");
+      expect(io.stderr).toContain("feedback_agent_context_required");
     } finally {
       io.restore();
     }

--- a/packages/agentplane/src/commands/insights/insights-issue-context.ts
+++ b/packages/agentplane/src/commands/insights/insights-issue-context.ts
@@ -1,0 +1,88 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+export type InsightsFailure = {
+  error_code: string | null;
+  command_id: string | null;
+  command_group: string | null;
+  phase: string | null;
+  reason_code: string | null;
+  message_class: string | null;
+  argv_shape: string[];
+  dedupe_signature: string;
+};
+
+export type FailureContextInput = {
+  errorCode?: string;
+  commandId?: string;
+  phase?: string;
+  reasonCode?: string;
+  messageClass?: string;
+  argvShape?: string[];
+};
+
+function cleanToken(value: string | undefined, maxLength = 80): string | null {
+  const trimmed = value?.trim() ?? "";
+  if (!trimmed) return null;
+  return trimmed
+    .replaceAll(/\/Users\/[^\s"'`]+/g, "<absolute-path>")
+    .replaceAll(/[A-Za-z]:\\[^\s"'`]+/g, "<absolute-path>")
+    .replaceAll(/\s+/g, " ")
+    .slice(0, maxLength);
+}
+
+function cleanArgvShape(tokens: readonly string[] | undefined): string[] {
+  return (tokens ?? [])
+    .flatMap((token) => {
+      const cleaned = cleanToken(token, 80);
+      return cleaned ? [cleaned] : [];
+    })
+    .slice(0, 24);
+}
+
+export function buildFailureContext(input: FailureContextInput | undefined): InsightsFailure {
+  const commandId = cleanToken(input?.commandId);
+  const failure = {
+    error_code: cleanToken(input?.errorCode, 40),
+    command_id: commandId,
+    command_group: commandId ? commandId.split(" ")[0] : null,
+    phase: cleanToken(input?.phase, 60),
+    reason_code: cleanToken(input?.reasonCode, 80),
+    message_class: cleanToken(input?.messageClass, 80),
+    argv_shape: cleanArgvShape(input?.argvShape),
+  };
+  const signatureInput = JSON.stringify(failure);
+  return {
+    ...failure,
+    dedupe_signature: `sha256:${createHash("sha256").update(signatureInput).digest("hex")}`,
+  };
+}
+
+function trimOptional(value: string | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed || null;
+}
+
+export async function resolveAgentContext(opts: {
+  inline: string | undefined;
+  file: string | undefined;
+  root: string;
+}): Promise<string | null> {
+  const inline = trimOptional(opts.inline);
+  if (inline) return inline;
+  const file = trimOptional(opts.file);
+  if (!file) return null;
+  const absolutePath = path.isAbsolute(file) ? file : path.join(opts.root, file);
+  return trimOptional(await readFile(absolutePath, "utf8"));
+}
+
+export function renderAgentContext(context: string | null): string[] {
+  if (!context) {
+    return [
+      "## Agent context",
+      "Not provided. Re-run with `--agent-context` or `--agent-context-file` for actionable triage.",
+    ];
+  }
+  return ["## Agent context", context];
+}

--- a/packages/agentplane/src/commands/insights/insights.command.ts
+++ b/packages/agentplane/src/commands/insights/insights.command.ts
@@ -1,5 +1,4 @@
 import { readFile } from "node:fs/promises";
-import { createHash } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -27,6 +26,13 @@ import {
   type InsightsIssueParsed,
   type InsightsReportParsed,
 } from "./insights.spec.js";
+import {
+  buildFailureContext,
+  renderAgentContext,
+  resolveAgentContext,
+  type FailureContextInput,
+  type InsightsFailure,
+} from "./insights-issue-context.js";
 
 export { insightsIssueSpec, insightsReportSpec, insightsSpec } from "./insights.spec.js";
 
@@ -44,16 +50,7 @@ type InsightsReport = {
     upload: "not_supported";
     excludes: string[];
   };
-  failure: {
-    error_code: string | null;
-    command_id: string | null;
-    command_group: string | null;
-    phase: string | null;
-    reason_code: string | null;
-    message_class: string | null;
-    argv_shape: string[];
-    dedupe_signature: string;
-  };
+  failure: InsightsFailure;
   environment: {
     agentplane_version: string | null;
     node_major: number | null;
@@ -99,15 +96,6 @@ type InsightsReport = {
     stdout_bytes_buckets: CountMap;
     stderr_bytes_buckets: CountMap;
   };
-};
-
-type FailureContextInput = {
-  errorCode?: string;
-  commandId?: string;
-  phase?: string;
-  reasonCode?: string;
-  messageClass?: string;
-  argvShape?: string[];
 };
 
 function bump(counts: CountMap, raw: unknown, fallback = "unknown"): void {
@@ -372,66 +360,6 @@ function sanitizeIssueTitle(title: string | undefined, errorCode: string | undef
   if (explicit) return explicit.slice(0, 120);
   const suffix = trimOptional(errorCode) ? ` (${trimOptional(errorCode)})` : "";
   return `AgentPlane internal error report${suffix}`;
-}
-
-function cleanToken(value: string | undefined, maxLength = 80): string | null {
-  const trimmed = value?.trim() ?? "";
-  if (!trimmed) return null;
-  return trimmed
-    .replaceAll(/\/Users\/[^\s"'`]+/g, "<absolute-path>")
-    .replaceAll(/[A-Za-z]:\\[^\s"'`]+/g, "<absolute-path>")
-    .replaceAll(/\s+/g, " ")
-    .slice(0, maxLength);
-}
-
-function cleanArgvShape(tokens: readonly string[] | undefined): string[] {
-  return (tokens ?? [])
-    .flatMap((token) => {
-      const cleaned = cleanToken(token, 80);
-      return cleaned ? [cleaned] : [];
-    })
-    .slice(0, 24);
-}
-
-function buildFailureContext(input: FailureContextInput | undefined): InsightsReport["failure"] {
-  const commandId = cleanToken(input?.commandId);
-  const failure = {
-    error_code: cleanToken(input?.errorCode, 40),
-    command_id: commandId,
-    command_group: commandId ? commandId.split(" ")[0] : null,
-    phase: cleanToken(input?.phase, 60),
-    reason_code: cleanToken(input?.reasonCode, 80),
-    message_class: cleanToken(input?.messageClass, 80),
-    argv_shape: cleanArgvShape(input?.argvShape),
-  };
-  const signatureInput = JSON.stringify(failure);
-  return {
-    ...failure,
-    dedupe_signature: `sha256:${createHash("sha256").update(signatureInput).digest("hex")}`,
-  };
-}
-
-async function resolveAgentContext(opts: {
-  inline: string | undefined;
-  file: string | undefined;
-  root: string;
-}): Promise<string | null> {
-  const inline = trimOptional(opts.inline);
-  if (inline) return inline;
-  const file = trimOptional(opts.file);
-  if (!file) return null;
-  const absolutePath = path.isAbsolute(file) ? file : path.join(opts.root, file);
-  return trimOptional(await readFile(absolutePath, "utf8"));
-}
-
-function renderAgentContext(context: string | null): string[] {
-  if (!context) {
-    return [
-      "## Agent context",
-      "Not provided. Re-run with `--agent-context` or `--agent-context-file` for actionable triage.",
-    ];
-  }
-  return ["## Agent context", context];
 }
 
 function renderIssueBody(opts: {

--- a/packages/agentplane/src/commands/insights/insights.command.ts
+++ b/packages/agentplane/src/commands/insights/insights.command.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -42,6 +43,16 @@ type InsightsReport = {
     network: "not_used";
     upload: "not_supported";
     excludes: string[];
+  };
+  failure: {
+    error_code: string | null;
+    command_id: string | null;
+    command_group: string | null;
+    phase: string | null;
+    reason_code: string | null;
+    message_class: string | null;
+    argv_shape: string[];
+    dedupe_signature: string;
   };
   environment: {
     agentplane_version: string | null;
@@ -88,6 +99,15 @@ type InsightsReport = {
     stdout_bytes_buckets: CountMap;
     stderr_bytes_buckets: CountMap;
   };
+};
+
+type FailureContextInput = {
+  errorCode?: string;
+  commandId?: string;
+  phase?: string;
+  reasonCode?: string;
+  messageClass?: string;
+  argvShape?: string[];
 };
 
 function bump(counts: CountMap, raw: unknown, fallback = "unknown"): void {
@@ -139,8 +159,9 @@ async function readGitStatus(root: string): Promise<InsightsReport["git"]> {
     execFile("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: root }),
     execFile("git", ["status", "--short", "--untracked-files=all"], { cwd: root }),
   ]);
-  const branch =
+  const rawBranch =
     branchResult.status === "fulfilled" ? branchResult.value.stdout.trim() || null : null;
+  const branch = rawBranch === null ? null : rawBranch === "HEAD" ? "detached" : "attached";
   const statusText = statusResult.status === "fulfilled" ? statusResult.value.stdout : "";
   const statusCounts: CountMap = {
     modified: 0,
@@ -269,6 +290,7 @@ function summarizeRunner(tasks: TaskRecord[]): InsightsReport["runner"] {
 export async function buildInsightsReport(opts: {
   deps: RunDeps;
   recentLimit: number;
+  failure?: FailureContextInput;
 }): Promise<InsightsReport> {
   const [resolved, loaded] = await Promise.all([
     opts.deps.getResolvedProject("insights report"),
@@ -301,8 +323,13 @@ export async function buildInsightsReport(opts: {
         "git remotes",
         "file paths outside AgentPlane-managed relative config paths",
         "environment variables",
+        "raw branch names",
+        "raw command arguments",
+        "raw error messages",
+        "raw stack traces",
       ],
     },
+    failure: buildFailureContext(opts.failure),
     environment: {
       agentplane_version: agentplaneVersion,
       node_major: Number.isFinite(nodeMajor) ? nodeMajor : null,
@@ -347,11 +374,72 @@ function sanitizeIssueTitle(title: string | undefined, errorCode: string | undef
   return `AgentPlane internal error report${suffix}`;
 }
 
+function cleanToken(value: string | undefined, maxLength = 80): string | null {
+  const trimmed = value?.trim() ?? "";
+  if (!trimmed) return null;
+  return trimmed
+    .replaceAll(/\/Users\/[^\s"'`]+/g, "<absolute-path>")
+    .replaceAll(/[A-Za-z]:\\[^\s"'`]+/g, "<absolute-path>")
+    .replaceAll(/\s+/g, " ")
+    .slice(0, maxLength);
+}
+
+function cleanArgvShape(tokens: readonly string[] | undefined): string[] {
+  return (tokens ?? [])
+    .flatMap((token) => {
+      const cleaned = cleanToken(token, 80);
+      return cleaned ? [cleaned] : [];
+    })
+    .slice(0, 24);
+}
+
+function buildFailureContext(input: FailureContextInput | undefined): InsightsReport["failure"] {
+  const commandId = cleanToken(input?.commandId);
+  const failure = {
+    error_code: cleanToken(input?.errorCode, 40),
+    command_id: commandId,
+    command_group: commandId ? commandId.split(" ")[0] : null,
+    phase: cleanToken(input?.phase, 60),
+    reason_code: cleanToken(input?.reasonCode, 80),
+    message_class: cleanToken(input?.messageClass, 80),
+    argv_shape: cleanArgvShape(input?.argvShape),
+  };
+  const signatureInput = JSON.stringify(failure);
+  return {
+    ...failure,
+    dedupe_signature: `sha256:${createHash("sha256").update(signatureInput).digest("hex")}`,
+  };
+}
+
+async function resolveAgentContext(opts: {
+  inline: string | undefined;
+  file: string | undefined;
+  root: string;
+}): Promise<string | null> {
+  const inline = trimOptional(opts.inline);
+  if (inline) return inline;
+  const file = trimOptional(opts.file);
+  if (!file) return null;
+  const absolutePath = path.isAbsolute(file) ? file : path.join(opts.root, file);
+  return trimOptional(await readFile(absolutePath, "utf8"));
+}
+
+function renderAgentContext(context: string | null): string[] {
+  if (!context) {
+    return [
+      "## Agent context",
+      "Not provided. Re-run with `--agent-context` or `--agent-context-file` for actionable triage.",
+    ];
+  }
+  return ["## Agent context", context];
+}
+
 function renderIssueBody(opts: {
   body: string | undefined;
   errorCode: string | undefined;
   report: InsightsReport;
   includeInsightsReport: boolean;
+  agentContext: string | null;
 }): string {
   const sections = [
     "## Summary",
@@ -367,6 +455,8 @@ function renderIssueBody(opts: {
     "- This issue was created only after project opt-in.",
     "- The attached diagnostic report is privacy-bounded.",
     `- Excluded content: ${opts.report.privacy.excludes.join("; ")}`,
+    "",
+    ...renderAgentContext(opts.agentContext),
   ];
   if (opts.includeInsightsReport) {
     sections.push("", "## Insights report", "```json", JSON.stringify(opts.report, null, 2), "```");
@@ -396,6 +486,11 @@ function renderInsightsReport(report: InsightsReport): CliReportEntry[] {
     { label: "local_only", value: report.privacy.local_only },
     { label: "network", value: report.privacy.network },
     { label: "upload", value: report.privacy.upload },
+    { label: "failure_error_code", value: report.failure.error_code ?? "unknown" },
+    { label: "failure_command", value: report.failure.command_id ?? "unknown" },
+    { label: "failure_phase", value: report.failure.phase ?? "unknown" },
+    { label: "failure_reason_code", value: report.failure.reason_code ?? "unknown" },
+    { label: "failure_dedupe", value: report.failure.dedupe_signature },
     { label: "agentplane", value: report.environment.agentplane_version ?? "unknown" },
     { label: "node_major", value: report.environment.node_major ?? "unknown" },
     { label: "platform", value: `${report.environment.platform}/${report.environment.arch}` },
@@ -474,13 +569,49 @@ export function makeRunInsightsIssueHandler(deps: RunDeps): CommandHandler<Insig
         });
       }
 
-      const report = await buildInsightsReport({ deps, recentLimit: 8 });
+      const agentContext = await resolveAgentContext({
+        inline: parsed.agentContext,
+        file: parsed.agentContextFile,
+        root: resolved.gitRoot,
+      });
+      const errorCode = trimOptional(parsed.errorCode);
+      if (
+        errorCode === "E_INTERNAL" &&
+        !agentContext &&
+        !parsed.dryRun &&
+        !parsed.allowMissingAgentContext
+      ) {
+        throw new CliError({
+          exitCode: exitCodeForError("E_USAGE"),
+          code: "E_USAGE",
+          message:
+            "E_INTERNAL feedback issues require sanitized agent context. Pass --agent-context, --agent-context-file, or --allow-missing-agent-context.",
+          context: {
+            command: "insights issue",
+            reason_code: "feedback_agent_context_required",
+          },
+        });
+      }
+
+      const report = await buildInsightsReport({
+        deps,
+        recentLimit: 8,
+        failure: {
+          errorCode: parsed.errorCode,
+          commandId: parsed.failureCommand,
+          phase: parsed.failurePhase,
+          reasonCode: parsed.failureReasonCode,
+          messageClass: parsed.failureMessageClass,
+          argvShape: parsed.failureArgvShape,
+        },
+      });
       const title = sanitizeIssueTitle(parsed.title, parsed.errorCode);
       const body = renderIssueBody({
         body: parsed.body,
         errorCode: parsed.errorCode,
         report,
         includeInsightsReport: settings.include_insights_report,
+        agentContext,
       });
       const payload = {
         repository: settings.repository,

--- a/packages/agentplane/src/commands/insights/insights.spec.ts
+++ b/packages/agentplane/src/commands/insights/insights.spec.ts
@@ -10,6 +10,14 @@ export type InsightsIssueParsed = {
   title?: string;
   body?: string;
   errorCode?: string;
+  agentContext?: string;
+  agentContextFile?: string;
+  allowMissingAgentContext: boolean;
+  failureCommand?: string;
+  failurePhase?: string;
+  failureReasonCode?: string;
+  failureMessageClass?: string;
+  failureArgvShape: string[];
   dryRun: boolean;
 };
 
@@ -91,9 +99,62 @@ export const insightsIssueSpec: CommandSpec<InsightsIssueParsed> = {
     },
     {
       kind: "string",
+      name: "agent-context",
+      valueHint: "<text>",
+      description:
+        "Sanitized agent-written diagnostic context to include in the public issue body.",
+    },
+    {
+      kind: "string",
+      name: "agent-context-file",
+      valueHint: "<path>",
+      description:
+        "Read sanitized agent-written diagnostic context from a file before creating the issue.",
+    },
+    {
+      kind: "boolean",
+      name: "allow-missing-agent-context",
+      default: false,
+      description:
+        "Allow creating an E_INTERNAL issue without the recommended agent-written context.",
+    },
+    {
+      kind: "string",
       name: "error-code",
       valueHint: "<code>",
       description: "AgentPlane error code that triggered the report.",
+    },
+    {
+      kind: "string",
+      name: "failure-command",
+      valueHint: "<command>",
+      description:
+        "Privacy-safe command id associated with the failure, for example task start-ready.",
+    },
+    {
+      kind: "string",
+      name: "failure-phase",
+      valueHint: "<phase>",
+      description: "Privacy-safe lifecycle phase associated with the failure.",
+    },
+    {
+      kind: "string",
+      name: "failure-reason-code",
+      valueHint: "<code>",
+      description: "Privacy-safe reason code associated with the failure.",
+    },
+    {
+      kind: "string",
+      name: "failure-message-class",
+      valueHint: "<class>",
+      description: "Privacy-safe error message class, not the raw error message.",
+    },
+    {
+      kind: "string",
+      name: "failure-argv-shape",
+      valueHint: "<token>",
+      repeatable: true,
+      description: "Repeatable sanitized argv shape token; values must not include raw secrets.",
     },
     {
       kind: "boolean",
@@ -115,7 +176,17 @@ export const insightsIssueSpec: CommandSpec<InsightsIssueParsed> = {
   parse: (raw) => ({
     title: raw.opts.title as string | undefined,
     body: raw.opts.body as string | undefined,
+    agentContext: raw.opts["agent-context"] as string | undefined,
+    agentContextFile: raw.opts["agent-context-file"] as string | undefined,
+    allowMissingAgentContext: raw.opts["allow-missing-agent-context"] === true,
     errorCode: raw.opts["error-code"] as string | undefined,
+    failureCommand: raw.opts["failure-command"] as string | undefined,
+    failurePhase: raw.opts["failure-phase"] as string | undefined,
+    failureReasonCode: raw.opts["failure-reason-code"] as string | undefined,
+    failureMessageClass: raw.opts["failure-message-class"] as string | undefined,
+    failureArgvShape: Array.isArray(raw.opts["failure-argv-shape"])
+      ? (raw.opts["failure-argv-shape"] as string[])
+      : [],
     dryRun: raw.opts["dry-run"] === true,
   }),
 };


### PR DESCRIPTION
Task: `202605141737-GX777N`
Title: Enrich feedback issue diagnostics
Canonical task record: `.agentplane/tasks/202605141737-GX777N/README.md`

## Summary

Enrich feedback issue diagnostics

Add privacy-bounded failure context and required agent context support to AgentPlane insights issue reports, then create a test feedback issue.

## Scope

- In scope: Add privacy-bounded failure context and required agent context support to AgentPlane insights issue reports, then create a test feedback issue.
- Out of scope: unrelated refactors not required for "Enrich feedback issue diagnostics".

## Verification

- State: ok
- Note:

```bash
bun test packages/agentplane/src/cli/run-cli.core.insights-report.test.ts; Result: pass, 6 tests. \
  Command: bun run typecheck; Result: pass. Command: bun run lint:core; Result: pass. Command: bun \
  run format:check; Result: pass. Command: bun run docs:cli:check; Result: pass. Command: node \
  .agentplane/policy/check-routing.mjs; Result: pass. Command: ap doctor; Result: OK with two \
  unrelated existing branch_pr reconciliation warnings. External: created test feedback issue #3744 \
  with Agent context and failure metadata, raw branch name absent.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-14T18:03:11.950Z
- Branch: task/202605141737-GX777N/feedback-issue-diagnostics
- Head: c8586bf5511d

```text
 docs/user/cli-reference.generated.mdx              |   8 ++
 packages/agentplane/src/cli/reason-codes.ts        |   6 +
 .../src/cli/run-cli.core.insights-report.test.ts   |  54 +++++++++
 .../src/commands/insights/insights.command.ts      | 135 ++++++++++++++++++++-
 .../src/commands/insights/insights.spec.ts         |  71 +++++++++++
 5 files changed, 272 insertions(+), 2 deletions(-)
```

</details>
