### PR TITLE
🚧 0C84Z2 task: Fix doc section readback for issue #3747 [202605141849-0C84Z2]

### DIFF
--- a/.agentplane/tasks/202605141849-0C84Z2/README.md
+++ b/.agentplane/tasks/202605141849-0C84Z2/README.md
@@ -4,7 +4,7 @@ title: "Fix doc section readback for issue #3747"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 12
+revision: 13
 origin:
   system: "manual"
 depends_on: []
@@ -20,9 +20,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-14T19:03:38.416Z"
+  updated_at: "2026-05-14T19:21:14.035Z"
   updated_by: "CODER"
-  note: "Re-verified after lint fix: focused Vitest suites passed, core task-readme suite passed, exact ESLint check passed, and policy routing passed."
+  note: "Re-verified after addressing Codex review: exact ESLint passed, focused agentplane suites passed with 45 tests, and core task-readme suite passed."
   attempts: 0
 commit: null
 comments:
@@ -49,8 +49,14 @@ events:
     author: "CODER"
     state: "ok"
     note: "Re-verified after lint fix: focused Vitest suites passed, core task-readme suite passed, exact ESLint check passed, and policy routing passed."
+  -
+    type: "verify"
+    at: "2026-05-14T19:21:14.035Z"
+    author: "CODER"
+    state: "ok"
+    note: "Re-verified after addressing Codex review: exact ESLint passed, focused agentplane suites passed with 45 tests, and core task-readme suite passed."
 doc_version: 3
-doc_updated_at: "2026-05-14T19:03:38.424Z"
+doc_updated_at: "2026-05-14T19:21:14.045Z"
 doc_updated_by: "CODER"
 description: "Fix GitHub issue #3747: task doc set can accept a section that is later filtered from canonical task doc readback, causing task doc show and task plan approve to disagree."
 sections:
@@ -105,6 +111,25 @@ sections:
     - route_changed: no
     - safe_command: agentplane blueprint snapshot 202605141849-0C84Z2
     
+    ### 2026-05-14T19:21:14.035Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Re-verified after addressing Codex review: exact ESLint passed, focused agentplane suites passed with 45 tests, and core task-readme suite passed.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T19:03:38.424Z, excerpt_hash=sha256:cb8a842695eaeff155000681e024e8f218c0c2d71b83647f2f844b3b4b24db91
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141849-0C84Z2-fix-doc-section-readback-3747/.agentplane/tasks/202605141849-0C84Z2/blueprint/resolved-snapshot.json
+    - old_digest: 243283c66dce2f3f7b7898c6a9a67430ca1dc6185131829eb5b82f59ad33e12b
+    - current_digest: 243283c66dce2f3f7b7898c6a9a67430ca1dc6185131829eb5b82f59ad33e12b
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141849-0C84Z2
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: "Revert the task branch commit if the section contract fix regresses supported task README sections or plan approval behavior."
   Findings: |-
@@ -133,6 +158,10 @@ sections:
     - Observation: GitHub Core CI initially failed only on lint for the section merge expression; the expression was rewritten without an empty object spread fallback.
       Impact: Keeps issue #3747 behavior fix while satisfying repository lint rules.
       Resolution: Committed lint-safe merge logic and reran targeted verification.
+    
+    - Observation: Adjusted the fix to merge README body sections only when frontmatter sections exist, preserving raw legacy task doc order when frontmatter sections are absent.
+      Impact: Maintains issue #3747 fix without breaking optimistic-concurrency assumptions for legacy/custom-ordered README docs.
+      Resolution: Added regression coverage for raw legacy doc order and reran targeted lint/tests.
 id_source: "generated"
 ---
 ## Summary
@@ -197,6 +226,25 @@ BlueprintSnapshotRef:
 - route_changed: no
 - safe_command: agentplane blueprint snapshot 202605141849-0C84Z2
 
+### 2026-05-14T19:21:14.035Z — VERIFY — ok
+
+By: CODER
+
+Note: Re-verified after addressing Codex review: exact ESLint passed, focused agentplane suites passed with 45 tests, and core task-readme suite passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T19:03:38.424Z, excerpt_hash=sha256:cb8a842695eaeff155000681e024e8f218c0c2d71b83647f2f844b3b4b24db91
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141849-0C84Z2-fix-doc-section-readback-3747/.agentplane/tasks/202605141849-0C84Z2/blueprint/resolved-snapshot.json
+- old_digest: 243283c66dce2f3f7b7898c6a9a67430ca1dc6185131829eb5b82f59ad33e12b
+- current_digest: 243283c66dce2f3f7b7898c6a9a67430ca1dc6185131829eb5b82f59ad33e12b
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141849-0C84Z2
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -230,3 +278,7 @@ Verification evidence:
 - Observation: GitHub Core CI initially failed only on lint for the section merge expression; the expression was rewritten without an empty object spread fallback.
   Impact: Keeps issue #3747 behavior fix while satisfying repository lint rules.
   Resolution: Committed lint-safe merge logic and reran targeted verification.
+
+- Observation: Adjusted the fix to merge README body sections only when frontmatter sections exist, preserving raw legacy task doc order when frontmatter sections are absent.
+  Impact: Maintains issue #3747 fix without breaking optimistic-concurrency assumptions for legacy/custom-ordered README docs.
+  Resolution: Added regression coverage for raw legacy doc order and reran targeted lint/tests.

--- a/.agentplane/tasks/202605141849-0C84Z2/README.md
+++ b/.agentplane/tasks/202605141849-0C84Z2/README.md
@@ -1,0 +1,128 @@
+---
+id: "202605141849-0C84Z2"
+title: "Fix doc section readback for issue #3747"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 10
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "bug"
+  - "code"
+  - "tasks"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-14T18:50:04.286Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Implement issue #3747 fix in task doc section persistence/readback, add focused regression coverage, and verify with targeted tests from the dedicated task worktree."
+events:
+  -
+    type: "status"
+    at: "2026-05-14T18:50:36.323Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Implement issue #3747 fix in task doc section persistence/readback, add focused regression coverage, and verify with targeted tests from the dedicated task worktree."
+doc_version: 3
+doc_updated_at: "2026-05-14T18:54:29.235Z"
+doc_updated_by: "CODER"
+description: "Fix GitHub issue #3747: task doc set can accept a section that is later filtered from canonical task doc readback, causing task doc show and task plan approve to disagree."
+sections:
+  Summary: "Fix GitHub issue #3747 where task doc set can report success for a section that later disappears from canonical task doc readback, making task doc show and task plan approve disagree."
+  Scope: "In scope: local task README/doc section handling for doc_version=3, command behavior for task doc set/show, plan approval validation, and regression coverage for issue #3747. Out of scope: release publication, unrelated task backend sync, and unrelated existing task artifact drift."
+  Plan: |-
+    1. Add a regression test for issue #3747 that reproduces a configured doc section accepted by task doc set but filtered from v3 canonical readback.
+    2. Fix the section contract so task doc set/show and task plan approve use a consistent persisted/readback model for configured task doc sections. Prefer preserving explicitly configured sections over reporting a successful write that cannot be read back.
+    3. Run focused task doc/plan tests plus policy routing validation.
+    4. Link GitHub issue #3747 to this task and close/delete/project-sync after the PR lands.
+  Verify Steps: |-
+    1. Run focused task doc/plan unit tests covering issue #3747. Expected: a v3 task cannot report a successful write for a non-canonical section that is dropped from readback, or the section remains readable and approvable consistently.
+    2. Run targeted task document core tests. Expected: canonical section parsing/rendering behavior is stable.
+    3. Run policy routing check. Expected: gateway and loaded policy route remain valid.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: "Revert the task branch commit if the section contract fix regresses supported task README sections or plan approval behavior."
+  Findings: |-
+    Issue link: https://github.com/basilisk-labs/agentplane/issues/3747. Linked comment: https://github.com/basilisk-labs/agentplane/issues/3747#issuecomment-4453752174.
+    
+    Verification evidence:
+    - Command: ./node_modules/.bin/vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/backends/task-backend.test.ts packages/agentplane/src/commands/task/doc.unit.test.ts packages/agentplane/src/commands/task/plan.unit.test.ts
+    - Result: pass
+    - Evidence: 3 files passed, 44 tests passed.
+    - Scope: backend task record read-model plus task doc and plan command behavior.
+    
+    - Command: ./node_modules/.bin/vitest --config vitest.workspace.ts run --project core packages/core/src/tasks/task-readme.test.ts
+    - Result: pass
+    - Evidence: 1 file passed, 18 tests passed.
+    - Scope: core task README parse/render behavior.
+    
+    - Command: node .agentplane/policy/check-routing.mjs
+    - Result: pass
+    - Evidence: policy routing OK.
+    - Scope: gateway/policy route validity.
+id_source: "generated"
+---
+## Summary
+
+Fix GitHub issue #3747 where task doc set can report success for a section that later disappears from canonical task doc readback, making task doc show and task plan approve disagree.
+
+## Scope
+
+In scope: local task README/doc section handling for doc_version=3, command behavior for task doc set/show, plan approval validation, and regression coverage for issue #3747. Out of scope: release publication, unrelated task backend sync, and unrelated existing task artifact drift.
+
+## Plan
+
+1. Add a regression test for issue #3747 that reproduces a configured doc section accepted by task doc set but filtered from v3 canonical readback.
+2. Fix the section contract so task doc set/show and task plan approve use a consistent persisted/readback model for configured task doc sections. Prefer preserving explicitly configured sections over reporting a successful write that cannot be read back.
+3. Run focused task doc/plan tests plus policy routing validation.
+4. Link GitHub issue #3747 to this task and close/delete/project-sync after the PR lands.
+
+## Verify Steps
+
+1. Run focused task doc/plan unit tests covering issue #3747. Expected: a v3 task cannot report a successful write for a non-canonical section that is dropped from readback, or the section remains readable and approvable consistently.
+2. Run targeted task document core tests. Expected: canonical section parsing/rendering behavior is stable.
+3. Run policy routing check. Expected: gateway and loaded policy route remain valid.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+Revert the task branch commit if the section contract fix regresses supported task README sections or plan approval behavior.
+
+## Findings
+
+Issue link: https://github.com/basilisk-labs/agentplane/issues/3747. Linked comment: https://github.com/basilisk-labs/agentplane/issues/3747#issuecomment-4453752174.
+
+Verification evidence:
+- Command: ./node_modules/.bin/vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/backends/task-backend.test.ts packages/agentplane/src/commands/task/doc.unit.test.ts packages/agentplane/src/commands/task/plan.unit.test.ts
+- Result: pass
+- Evidence: 3 files passed, 44 tests passed.
+- Scope: backend task record read-model plus task doc and plan command behavior.
+
+- Command: ./node_modules/.bin/vitest --config vitest.workspace.ts run --project core packages/core/src/tasks/task-readme.test.ts
+- Result: pass
+- Evidence: 1 file passed, 18 tests passed.
+- Scope: core task README parse/render behavior.
+
+- Command: node .agentplane/policy/check-routing.mjs
+- Result: pass
+- Evidence: policy routing OK.
+- Scope: gateway/policy route validity.

--- a/.agentplane/tasks/202605141849-0C84Z2/README.md
+++ b/.agentplane/tasks/202605141849-0C84Z2/README.md
@@ -4,7 +4,7 @@ title: "Fix doc section readback for issue #3747"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 10
+revision: 11
 origin:
   system: "manual"
 depends_on: []
@@ -19,10 +19,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-14T18:55:27.359Z"
+  updated_by: "CODER"
+  note: "Focused verification passed for issue #3747 fix: agentplane backend/doc/plan Vitest suites passed, core task-readme suite passed, and policy routing passed."
   attempts: 0
 commit: null
 comments:
@@ -37,8 +37,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: Implement issue #3747 fix in task doc section persistence/readback, add focused regression coverage, and verify with targeted tests from the dedicated task worktree."
+  -
+    type: "verify"
+    at: "2026-05-14T18:55:27.359Z"
+    author: "CODER"
+    state: "ok"
+    note: "Focused verification passed for issue #3747 fix: agentplane backend/doc/plan Vitest suites passed, core task-readme suite passed, and policy routing passed."
 doc_version: 3
-doc_updated_at: "2026-05-14T18:54:29.235Z"
+doc_updated_at: "2026-05-14T18:55:27.364Z"
 doc_updated_by: "CODER"
 description: "Fix GitHub issue #3747: task doc set can accept a section that is later filtered from canonical task doc readback, causing task doc show and task plan approve to disagree."
 sections:
@@ -55,6 +61,25 @@ sections:
     3. Run policy routing check. Expected: gateway and loaded policy route remain valid.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-14T18:55:27.359Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Focused verification passed for issue #3747 fix: agentplane backend/doc/plan Vitest suites passed, core task-readme suite passed, and policy routing passed.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T18:54:29.235Z, excerpt_hash=sha256:cb8a842695eaeff155000681e024e8f218c0c2d71b83647f2f844b3b4b24db91
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141849-0C84Z2-fix-doc-section-readback-3747/.agentplane/tasks/202605141849-0C84Z2/blueprint/resolved-snapshot.json
+    - old_digest: 243283c66dce2f3f7b7898c6a9a67430ca1dc6185131829eb5b82f59ad33e12b
+    - current_digest: 243283c66dce2f3f7b7898c6a9a67430ca1dc6185131829eb5b82f59ad33e12b
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141849-0C84Z2
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: "Revert the task branch commit if the section contract fix regresses supported task README sections or plan approval behavior."
   Findings: |-
@@ -75,6 +100,10 @@ sections:
     - Result: pass
     - Evidence: policy routing OK.
     - Scope: gateway/policy route validity.
+    
+    - Observation: taskRecordToData now merges README body task-doc sections with frontmatter sections, preserving configured body-only sections such as Risks while keeping frontmatter sections authoritative for stale canonical body content.
+      Impact: Fixes task doc set/show and plan approve disagreement for configured sections that are rendered in README body but absent from v3 canonical frontmatter sections.
+      Resolution: Added regression coverage for body-only Risks alongside existing task doc/plan/core tests.
 id_source: "generated"
 ---
 ## Summary
@@ -101,6 +130,25 @@ In scope: local task README/doc section handling for doc_version=3, command beha
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-14T18:55:27.359Z — VERIFY — ok
+
+By: CODER
+
+Note: Focused verification passed for issue #3747 fix: agentplane backend/doc/plan Vitest suites passed, core task-readme suite passed, and policy routing passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T18:54:29.235Z, excerpt_hash=sha256:cb8a842695eaeff155000681e024e8f218c0c2d71b83647f2f844b3b4b24db91
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141849-0C84Z2-fix-doc-section-readback-3747/.agentplane/tasks/202605141849-0C84Z2/blueprint/resolved-snapshot.json
+- old_digest: 243283c66dce2f3f7b7898c6a9a67430ca1dc6185131829eb5b82f59ad33e12b
+- current_digest: 243283c66dce2f3f7b7898c6a9a67430ca1dc6185131829eb5b82f59ad33e12b
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141849-0C84Z2
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -126,3 +174,7 @@ Verification evidence:
 - Result: pass
 - Evidence: policy routing OK.
 - Scope: gateway/policy route validity.
+
+- Observation: taskRecordToData now merges README body task-doc sections with frontmatter sections, preserving configured body-only sections such as Risks while keeping frontmatter sections authoritative for stale canonical body content.
+  Impact: Fixes task doc set/show and plan approve disagreement for configured sections that are rendered in README body but absent from v3 canonical frontmatter sections.
+  Resolution: Added regression coverage for body-only Risks alongside existing task doc/plan/core tests.

--- a/.agentplane/tasks/202605141849-0C84Z2/README.md
+++ b/.agentplane/tasks/202605141849-0C84Z2/README.md
@@ -4,7 +4,7 @@ title: "Fix doc section readback for issue #3747"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 11
+revision: 12
 origin:
   system: "manual"
 depends_on: []
@@ -20,9 +20,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-14T18:55:27.359Z"
+  updated_at: "2026-05-14T19:03:38.416Z"
   updated_by: "CODER"
-  note: "Focused verification passed for issue #3747 fix: agentplane backend/doc/plan Vitest suites passed, core task-readme suite passed, and policy routing passed."
+  note: "Re-verified after lint fix: focused Vitest suites passed, core task-readme suite passed, exact ESLint check passed, and policy routing passed."
   attempts: 0
 commit: null
 comments:
@@ -43,8 +43,14 @@ events:
     author: "CODER"
     state: "ok"
     note: "Focused verification passed for issue #3747 fix: agentplane backend/doc/plan Vitest suites passed, core task-readme suite passed, and policy routing passed."
+  -
+    type: "verify"
+    at: "2026-05-14T19:03:38.416Z"
+    author: "CODER"
+    state: "ok"
+    note: "Re-verified after lint fix: focused Vitest suites passed, core task-readme suite passed, exact ESLint check passed, and policy routing passed."
 doc_version: 3
-doc_updated_at: "2026-05-14T18:55:27.364Z"
+doc_updated_at: "2026-05-14T19:03:38.424Z"
 doc_updated_by: "CODER"
 description: "Fix GitHub issue #3747: task doc set can accept a section that is later filtered from canonical task doc readback, causing task doc show and task plan approve to disagree."
 sections:
@@ -80,6 +86,25 @@ sections:
     - route_changed: no
     - safe_command: agentplane blueprint snapshot 202605141849-0C84Z2
     
+    ### 2026-05-14T19:03:38.416Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Re-verified after lint fix: focused Vitest suites passed, core task-readme suite passed, exact ESLint check passed, and policy routing passed.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T18:55:27.364Z, excerpt_hash=sha256:cb8a842695eaeff155000681e024e8f218c0c2d71b83647f2f844b3b4b24db91
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141849-0C84Z2-fix-doc-section-readback-3747/.agentplane/tasks/202605141849-0C84Z2/blueprint/resolved-snapshot.json
+    - old_digest: 243283c66dce2f3f7b7898c6a9a67430ca1dc6185131829eb5b82f59ad33e12b
+    - current_digest: 243283c66dce2f3f7b7898c6a9a67430ca1dc6185131829eb5b82f59ad33e12b
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141849-0C84Z2
+    
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: "Revert the task branch commit if the section contract fix regresses supported task README sections or plan approval behavior."
   Findings: |-
@@ -104,6 +129,10 @@ sections:
     - Observation: taskRecordToData now merges README body task-doc sections with frontmatter sections, preserving configured body-only sections such as Risks while keeping frontmatter sections authoritative for stale canonical body content.
       Impact: Fixes task doc set/show and plan approve disagreement for configured sections that are rendered in README body but absent from v3 canonical frontmatter sections.
       Resolution: Added regression coverage for body-only Risks alongside existing task doc/plan/core tests.
+    
+    - Observation: GitHub Core CI initially failed only on lint for the section merge expression; the expression was rewritten without an empty object spread fallback.
+      Impact: Keeps issue #3747 behavior fix while satisfying repository lint rules.
+      Resolution: Committed lint-safe merge logic and reran targeted verification.
 id_source: "generated"
 ---
 ## Summary
@@ -149,6 +178,25 @@ BlueprintSnapshotRef:
 - route_changed: no
 - safe_command: agentplane blueprint snapshot 202605141849-0C84Z2
 
+### 2026-05-14T19:03:38.416Z — VERIFY — ok
+
+By: CODER
+
+Note: Re-verified after lint fix: focused Vitest suites passed, core task-readme suite passed, exact ESLint check passed, and policy routing passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T18:55:27.364Z, excerpt_hash=sha256:cb8a842695eaeff155000681e024e8f218c0c2d71b83647f2f844b3b4b24db91
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141849-0C84Z2-fix-doc-section-readback-3747/.agentplane/tasks/202605141849-0C84Z2/blueprint/resolved-snapshot.json
+- old_digest: 243283c66dce2f3f7b7898c6a9a67430ca1dc6185131829eb5b82f59ad33e12b
+- current_digest: 243283c66dce2f3f7b7898c6a9a67430ca1dc6185131829eb5b82f59ad33e12b
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141849-0C84Z2
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -178,3 +226,7 @@ Verification evidence:
 - Observation: taskRecordToData now merges README body task-doc sections with frontmatter sections, preserving configured body-only sections such as Risks while keeping frontmatter sections authoritative for stale canonical body content.
   Impact: Fixes task doc set/show and plan approve disagreement for configured sections that are rendered in README body but absent from v3 canonical frontmatter sections.
   Resolution: Added regression coverage for body-only Risks alongside existing task doc/plan/core tests.
+
+- Observation: GitHub Core CI initially failed only on lint for the section merge expression; the expression was rewritten without an empty object spread fallback.
+  Impact: Keeps issue #3747 behavior fix while satisfying repository lint rules.
+  Resolution: Committed lint-safe merge logic and reran targeted verification.

--- a/.agentplane/tasks/202605141849-0C84Z2/pr/diffstat.txt
+++ b/.agentplane/tasks/202605141849-0C84Z2/pr/diffstat.txt
@@ -1,3 +1,3 @@
- .../agentplane/src/backends/task-backend.test.ts   | 37 ++++++++++++++++++++++
- .../src/backends/task-backend/shared/record.ts     | 19 ++++++++++-
- 2 files changed, 55 insertions(+), 1 deletion(-)
+ .../agentplane/src/backends/task-backend.test.ts   | 72 ++++++++++++++++++++++
+ .../src/backends/task-backend/shared/record.ts     | 18 +++++-
+ 2 files changed, 89 insertions(+), 1 deletion(-)

--- a/.agentplane/tasks/202605141849-0C84Z2/pr/diffstat.txt
+++ b/.agentplane/tasks/202605141849-0C84Z2/pr/diffstat.txt
@@ -1,3 +1,3 @@
  .../agentplane/src/backends/task-backend.test.ts   | 37 ++++++++++++++++++++++
- .../src/backends/task-backend/shared/record.ts     | 18 ++++++++++-
- 2 files changed, 54 insertions(+), 1 deletion(-)
+ .../src/backends/task-backend/shared/record.ts     | 19 ++++++++++-
+ 2 files changed, 55 insertions(+), 1 deletion(-)

--- a/.agentplane/tasks/202605141849-0C84Z2/pr/diffstat.txt
+++ b/.agentplane/tasks/202605141849-0C84Z2/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../agentplane/src/backends/task-backend.test.ts   | 37 ++++++++++++++++++++++
+ .../src/backends/task-backend/shared/record.ts     | 18 ++++++++++-
+ 2 files changed, 54 insertions(+), 1 deletion(-)

--- a/.agentplane/tasks/202605141849-0C84Z2/pr/github-body.md
+++ b/.agentplane/tasks/202605141849-0C84Z2/pr/github-body.md
@@ -16,22 +16,22 @@ In scope: local task README/doc section handling for doc_version=3, command beha
 - Note:
 
 ```text
-Re-verified after lint fix: focused Vitest suites passed, core task-readme suite passed, exact
-ESLint check passed, and policy routing passed.
+Re-verified after addressing Codex review: exact ESLint passed, focused agentplane suites passed
+with 45 tests, and core task-readme suite passed.
 ```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T19:03:38.449Z
+- Updated: 2026-05-14T19:21:14.069Z
 - Branch: task/202605141849-0C84Z2/fix-doc-section-readback-3747
-- Head: e450a2654939
+- Head: 984c07dd9c55
 
 ```text
- .../agentplane/src/backends/task-backend.test.ts   | 37 ++++++++++++++++++++++
- .../src/backends/task-backend/shared/record.ts     | 19 ++++++++++-
- 2 files changed, 55 insertions(+), 1 deletion(-)
+ .../agentplane/src/backends/task-backend.test.ts   | 72 ++++++++++++++++++++++
+ .../src/backends/task-backend/shared/record.ts     | 18 +++++-
+ 2 files changed, 89 insertions(+), 1 deletion(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605141849-0C84Z2/pr/github-body.md
+++ b/.agentplane/tasks/202605141849-0C84Z2/pr/github-body.md
@@ -2,6 +2,8 @@ Task: `202605141849-0C84Z2`
 Title: Fix doc section readback for issue #3747
 Canonical task record: `.agentplane/tasks/202605141849-0C84Z2/README.md`
 
+Closes #3747
+
 ## Summary
 
 Fix GitHub issue #3747 where task doc set can report success for a section that later disappears from canonical task doc readback, making task doc show and task plan approve disagree.
@@ -12,14 +14,19 @@ In scope: local task README/doc section handling for doc_version=3, command beha
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Focused verification passed for issue #3747 fix: agentplane backend/doc/plan Vitest suites passed,
+core task-readme suite passed, and policy routing passed.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T18:55:07.563Z
+- Updated: 2026-05-14T18:55:15.523Z
 - Branch: task/202605141849-0C84Z2/fix-doc-section-readback-3747
 - Head: 2917c1d0eb28
 

--- a/.agentplane/tasks/202605141849-0C84Z2/pr/github-body.md
+++ b/.agentplane/tasks/202605141849-0C84Z2/pr/github-body.md
@@ -2,8 +2,6 @@ Task: `202605141849-0C84Z2`
 Title: Fix doc section readback for issue #3747
 Canonical task record: `.agentplane/tasks/202605141849-0C84Z2/README.md`
 
-Closes #3747
-
 ## Summary
 
 Fix GitHub issue #3747 where task doc set can report success for a section that later disappears from canonical task doc readback, making task doc show and task plan approve disagree.
@@ -18,22 +16,22 @@ In scope: local task README/doc section handling for doc_version=3, command beha
 - Note:
 
 ```text
-Focused verification passed for issue #3747 fix: agentplane backend/doc/plan Vitest suites passed,
-core task-readme suite passed, and policy routing passed.
+Re-verified after lint fix: focused Vitest suites passed, core task-readme suite passed, exact
+ESLint check passed, and policy routing passed.
 ```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T18:55:15.523Z
+- Updated: 2026-05-14T19:03:38.449Z
 - Branch: task/202605141849-0C84Z2/fix-doc-section-readback-3747
-- Head: 2917c1d0eb28
+- Head: e450a2654939
 
 ```text
  .../agentplane/src/backends/task-backend.test.ts   | 37 ++++++++++++++++++++++
- .../src/backends/task-backend/shared/record.ts     | 18 ++++++++++-
- 2 files changed, 54 insertions(+), 1 deletion(-)
+ .../src/backends/task-backend/shared/record.ts     | 19 ++++++++++-
+ 2 files changed, 55 insertions(+), 1 deletion(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605141849-0C84Z2/pr/github-body.md
+++ b/.agentplane/tasks/202605141849-0C84Z2/pr/github-body.md
@@ -1,0 +1,32 @@
+Task: `202605141849-0C84Z2`
+Title: Fix doc section readback for issue #3747
+Canonical task record: `.agentplane/tasks/202605141849-0C84Z2/README.md`
+
+## Summary
+
+Fix GitHub issue #3747 where task doc set can report success for a section that later disappears from canonical task doc readback, making task doc show and task plan approve disagree.
+
+## Scope
+
+In scope: local task README/doc section handling for doc_version=3, command behavior for task doc set/show, plan approval validation, and regression coverage for issue #3747. Out of scope: release publication, unrelated task backend sync, and unrelated existing task artifact drift.
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T18:55:07.563Z
+- Branch: task/202605141849-0C84Z2/fix-doc-section-readback-3747
+- Head: 2917c1d0eb28
+
+```text
+ .../agentplane/src/backends/task-backend.test.ts   | 37 ++++++++++++++++++++++
+ .../src/backends/task-backend/shared/record.ts     | 18 ++++++++++-
+ 2 files changed, 54 insertions(+), 1 deletion(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605141849-0C84Z2/pr/github-title.txt
+++ b/.agentplane/tasks/202605141849-0C84Z2/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 0C84Z2 task: Fix doc section readback for issue #3747 [202605141849-0C84Z2]

--- a/.agentplane/tasks/202605141849-0C84Z2/pr/meta.json
+++ b/.agentplane/tasks/202605141849-0C84Z2/pr/meta.json
@@ -2,15 +2,15 @@
   "base": "main",
   "branch": "task/202605141849-0C84Z2/fix-doc-section-readback-3747",
   "created_at": "2026-05-14T18:50:37.324Z",
-  "head_sha": "2917c1d0eb281ea01deecbc5ea76ce51ab95c810",
-  "last_verified_at": "2026-05-14T18:55:27.359Z",
-  "last_verified_sha": "2917c1d0eb281ea01deecbc5ea76ce51ab95c810",
+  "head_sha": "e450a2654939addcf8c3a5fa896c626d3048e2fd",
+  "last_verified_at": "2026-05-14T19:03:38.416Z",
+  "last_verified_sha": "e450a2654939addcf8c3a5fa896c626d3048e2fd",
   "pr_number": 3750,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3750",
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202605141849-0C84Z2",
-  "updated_at": "2026-05-14T18:55:15.523Z",
+  "updated_at": "2026-05-14T19:03:38.449Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141849-0C84Z2/pr/meta.json
+++ b/.agentplane/tasks/202605141849-0C84Z2/pr/meta.json
@@ -2,15 +2,15 @@
   "base": "main",
   "branch": "task/202605141849-0C84Z2/fix-doc-section-readback-3747",
   "created_at": "2026-05-14T18:50:37.324Z",
-  "head_sha": "e450a2654939addcf8c3a5fa896c626d3048e2fd",
-  "last_verified_at": "2026-05-14T19:03:38.416Z",
-  "last_verified_sha": "e450a2654939addcf8c3a5fa896c626d3048e2fd",
+  "head_sha": "984c07dd9c555666d43ea300c14570dcbc82f4d4",
+  "last_verified_at": "2026-05-14T19:21:14.035Z",
+  "last_verified_sha": "984c07dd9c555666d43ea300c14570dcbc82f4d4",
   "pr_number": 3750,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3750",
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202605141849-0C84Z2",
-  "updated_at": "2026-05-14T19:03:38.449Z",
+  "updated_at": "2026-05-14T19:21:14.069Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141849-0C84Z2/pr/meta.json
+++ b/.agentplane/tasks/202605141849-0C84Z2/pr/meta.json
@@ -3,12 +3,15 @@
   "branch": "task/202605141849-0C84Z2/fix-doc-section-readback-3747",
   "created_at": "2026-05-14T18:50:37.324Z",
   "head_sha": "2917c1d0eb281ea01deecbc5ea76ce51ab95c810",
-  "last_verified_at": null,
-  "last_verified_sha": null,
+  "last_verified_at": "2026-05-14T18:55:27.359Z",
+  "last_verified_sha": "2917c1d0eb281ea01deecbc5ea76ce51ab95c810",
+  "pr_number": 3750,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3750",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605141849-0C84Z2",
-  "updated_at": "2026-05-14T18:55:07.563Z",
+  "updated_at": "2026-05-14T18:55:15.523Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605141849-0C84Z2/pr/meta.json
+++ b/.agentplane/tasks/202605141849-0C84Z2/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605141849-0C84Z2/fix-doc-section-readback-3747",
+  "created_at": "2026-05-14T18:50:37.324Z",
+  "head_sha": "2917c1d0eb281ea01deecbc5ea76ce51ab95c810",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202605141849-0C84Z2",
+  "updated_at": "2026-05-14T18:55:07.563Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605141849-0C84Z2/pr/review.md
+++ b/.agentplane/tasks/202605141849-0C84Z2/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-05-14T18:50:37.324Z
 ## Verification
 
 - State: ok
-- Note: Re-verified after lint fix: focused Vitest suites passed, core task-readme suite passed, exact ESLint check passed, and policy routing passed.
+- Note: Re-verified after addressing Codex review: exact ESLint passed, focused agentplane suites passed with 45 tests, and core task-readme suite passed.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,14 +24,14 @@ Created: 2026-05-14T18:50:37.324Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T19:03:38.449Z
+- Updated: 2026-05-14T19:21:14.069Z
 - Branch: task/202605141849-0C84Z2/fix-doc-section-readback-3747
-- Head: e450a2654939
+- Head: 984c07dd9c55
 
 ```text
- .../agentplane/src/backends/task-backend.test.ts   | 37 ++++++++++++++++++++++
- .../src/backends/task-backend/shared/record.ts     | 19 ++++++++++-
- 2 files changed, 55 insertions(+), 1 deletion(-)
+ .../agentplane/src/backends/task-backend.test.ts   | 72 ++++++++++++++++++++++
+ .../src/backends/task-backend/shared/record.ts     | 18 +++++-
+ 2 files changed, 89 insertions(+), 1 deletion(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605141849-0C84Z2/pr/review.md
+++ b/.agentplane/tasks/202605141849-0C84Z2/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-05-14T18:50:37.324Z
 ## Verification
 
 - State: ok
-- Note: Focused verification passed for issue #3747 fix: agentplane backend/doc/plan Vitest suites passed, core task-readme suite passed, and policy routing passed.
+- Note: Re-verified after lint fix: focused Vitest suites passed, core task-readme suite passed, exact ESLint check passed, and policy routing passed.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,14 +24,14 @@ Created: 2026-05-14T18:50:37.324Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T18:55:15.523Z
+- Updated: 2026-05-14T19:03:38.449Z
 - Branch: task/202605141849-0C84Z2/fix-doc-section-readback-3747
-- Head: 2917c1d0eb28
+- Head: e450a2654939
 
 ```text
  .../agentplane/src/backends/task-backend.test.ts   | 37 ++++++++++++++++++++++
- .../src/backends/task-backend/shared/record.ts     | 18 ++++++++++-
- 2 files changed, 54 insertions(+), 1 deletion(-)
+ .../src/backends/task-backend/shared/record.ts     | 19 ++++++++++-
+ 2 files changed, 55 insertions(+), 1 deletion(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605141849-0C84Z2/pr/review.md
+++ b/.agentplane/tasks/202605141849-0C84Z2/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-05-14T18:50:37.324Z
+
+## Task
+
+- Task: `202605141849-0C84Z2`
+- Title: Fix doc section readback for issue #3747
+- Status: DOING
+- Branch: `task/202605141849-0C84Z2/fix-doc-section-readback-3747`
+- Canonical task record: `.agentplane/tasks/202605141849-0C84Z2/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T18:55:07.563Z
+- Branch: task/202605141849-0C84Z2/fix-doc-section-readback-3747
+- Head: 2917c1d0eb28
+
+```text
+ .../agentplane/src/backends/task-backend.test.ts   | 37 ++++++++++++++++++++++
+ .../src/backends/task-backend/shared/record.ts     | 18 ++++++++++-
+ 2 files changed, 54 insertions(+), 1 deletion(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605141849-0C84Z2/pr/review.md
+++ b/.agentplane/tasks/202605141849-0C84Z2/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-05-14T18:50:37.324Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Focused verification passed for issue #3747 fix: agentplane backend/doc/plan Vitest suites passed, core task-readme suite passed, and policy routing passed.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,7 +24,7 @@ Created: 2026-05-14T18:50:37.324Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T18:55:07.563Z
+- Updated: 2026-05-14T18:55:15.523Z
 - Branch: task/202605141849-0C84Z2/fix-doc-section-readback-3747
 - Head: 2917c1d0eb28
 

--- a/packages/agentplane/src/backends/task-backend.test.ts
+++ b/packages/agentplane/src/backends/task-backend.test.ts
@@ -362,6 +362,41 @@ describe("task-backend helpers", () => {
     });
   });
 
+  it("taskRecordToData preserves raw legacy doc order when frontmatter sections are absent", () => {
+    const record = {
+      id: "202601300000-LEGACYORDER",
+      frontmatter: {
+        id: "202601300000-LEGACYORDER",
+        title: "Task",
+        description: "Desc",
+        status: "TODO",
+        priority: "med",
+        owner: "tester",
+      },
+      body: [
+        "## Summary",
+        "",
+        "First",
+        "",
+        "## Findings",
+        "",
+        "Second",
+        "",
+        "## Plan",
+        "",
+        "Third",
+      ].join("\n"),
+    } as unknown as TaskRecord;
+
+    const data = taskRecordToData(record);
+    expect(data.doc).toBe("## Summary\n\nFirst\n\n## Findings\n\nSecond\n\n## Plan\n\nThird");
+    expect(data.sections).toEqual({
+      Summary: "First",
+      Findings: "Second",
+      Plan: "Third",
+    });
+  });
+
   it("taskRecordToData defaults missing or invalid fields", () => {
     const record = {
       id: 123,

--- a/packages/agentplane/src/backends/task-backend.test.ts
+++ b/packages/agentplane/src/backends/task-backend.test.ts
@@ -301,6 +301,43 @@ describe("task-backend helpers", () => {
     });
   });
 
+  it("taskRecordToData preserves configured body-only sections when frontmatter sections exist", () => {
+    const record = {
+      id: "202605140000-ISS3747",
+      frontmatter: {
+        id: "202605140000-ISS3747",
+        title: "Task",
+        description: "Desc",
+        status: "TODO",
+        priority: "med",
+        owner: "tester",
+        revision: 1,
+        doc_version: 3,
+        sections: {
+          Summary: "Canonical summary",
+          Plan: "Canonical plan",
+        },
+      },
+      body: [
+        "## Summary",
+        "",
+        "Stale body summary",
+        "",
+        "## Risks",
+        "",
+        "Custom required risk section.",
+      ].join("\n"),
+    } as unknown as TaskRecord;
+
+    const data = taskRecordToData(record);
+    expect(data.doc).toContain("## Risks\n\nCustom required risk section.");
+    expect(data.sections).toEqual({
+      Summary: "Canonical summary",
+      Plan: "Canonical plan",
+      Risks: "Custom required risk section.",
+    });
+  });
+
   it("taskRecordToData derives canonical sections from legacy README body", () => {
     const record = {
       id: "202601300000-LEGACY",

--- a/packages/agentplane/src/backends/task-backend/shared/record.ts
+++ b/packages/agentplane/src/backends/task-backend/shared/record.ts
@@ -77,6 +77,19 @@ function normalizeCanonicalSections(value: unknown): Record<string, string> | un
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
+function mergeTaskDocSections(opts: {
+  frontmatterSections?: Record<string, string>;
+  body: string;
+}): Record<string, string> | undefined {
+  const bodyDoc = extractTaskDoc(opts.body);
+  const bodySections = bodyDoc ? taskDocToSectionMap(bodyDoc) : {};
+  const merged = {
+    ...bodySections,
+    ...(opts.frontmatterSections ?? {}),
+  };
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
 function stringEnumValue<T extends string>(value: unknown, allowed: Set<string>): T | undefined {
   return typeof value === "string" && allowed.has(value) ? (value as T) : undefined;
 }
@@ -113,7 +126,10 @@ export function taskRecordToData(record: TaskRecord): TaskData {
   const verification = normalizeVerificationResult(fm.verification);
   const origin = normalizeTaskOrigin(fm.origin);
   const runner = normalizeTaskRunnerOutcome(fm.runner);
-  const sections = normalizeCanonicalSections(fm.sections);
+  const sections = mergeTaskDocSections({
+    frontmatterSections: normalizeCanonicalSections(fm.sections),
+    body: record.body,
+  });
   const doc = sections ? renderTaskDocFromSections(sections) : extractTaskDoc(record.body);
 
   const baseId = typeof fm.id === "string" ? fm.id : typeof record.id === "string" ? record.id : "";

--- a/packages/agentplane/src/backends/task-backend/shared/record.ts
+++ b/packages/agentplane/src/backends/task-backend/shared/record.ts
@@ -81,13 +81,12 @@ function mergeTaskDocSections(opts: {
   frontmatterSections?: Record<string, string>;
   body: string;
 }): Record<string, string> | undefined {
+  if (!opts.frontmatterSections) return undefined;
   const bodyDoc = extractTaskDoc(opts.body);
   const bodySections = bodyDoc ? taskDocToSectionMap(bodyDoc) : undefined;
-  const merged = opts.frontmatterSections
-    ? bodySections
-      ? { ...bodySections, ...opts.frontmatterSections }
-      : { ...opts.frontmatterSections }
-    : bodySections;
+  const merged = bodySections
+    ? { ...bodySections, ...opts.frontmatterSections }
+    : { ...opts.frontmatterSections };
   return merged && Object.keys(merged).length > 0 ? merged : undefined;
 }
 

--- a/packages/agentplane/src/backends/task-backend/shared/record.ts
+++ b/packages/agentplane/src/backends/task-backend/shared/record.ts
@@ -82,12 +82,13 @@ function mergeTaskDocSections(opts: {
   body: string;
 }): Record<string, string> | undefined {
   const bodyDoc = extractTaskDoc(opts.body);
-  const bodySections = bodyDoc ? taskDocToSectionMap(bodyDoc) : {};
-  const merged = {
-    ...bodySections,
-    ...(opts.frontmatterSections ?? {}),
-  };
-  return Object.keys(merged).length > 0 ? merged : undefined;
+  const bodySections = bodyDoc ? taskDocToSectionMap(bodyDoc) : undefined;
+  const merged = opts.frontmatterSections
+    ? bodySections
+      ? { ...bodySections, ...opts.frontmatterSections }
+      : { ...opts.frontmatterSections }
+    : bodySections;
+  return merged && Object.keys(merged).length > 0 ? merged : undefined;
 }
 
 function stringEnumValue<T extends string>(value: unknown, allowed: Set<string>): T | undefined {


### PR DESCRIPTION
Task: `202605141849-0C84Z2`
Title: Fix doc section readback for issue #3747
Canonical task record: `.agentplane/tasks/202605141849-0C84Z2/README.md`

Closes #3747

## Summary

Fix GitHub issue #3747 where task doc set can report success for a section that later disappears from canonical task doc readback, making task doc show and task plan approve disagree.

## Scope

In scope: local task README/doc section handling for doc_version=3, command behavior for task doc set/show, plan approval validation, and regression coverage for issue #3747. Out of scope: release publication, unrelated task backend sync, and unrelated existing task artifact drift.

## Verification

- State: ok
- Note:

```text
Focused verification passed for issue #3747 fix: agentplane backend/doc/plan Vitest suites passed,
core task-readme suite passed, and policy routing passed.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-14T18:55:15.523Z
- Branch: task/202605141849-0C84Z2/fix-doc-section-readback-3747
- Head: 2917c1d0eb28

```text
 .../agentplane/src/backends/task-backend.test.ts   | 37 ++++++++++++++++++++++
 .../src/backends/task-backend/shared/record.ts     | 18 ++++++++++-
 2 files changed, 54 insertions(+), 1 deletion(-)
```

</details>
