### PR TITLE
🚧 FB780T task: Fix remote-check wait helper timeout contract (issue #3760) [202605141957-FB780T]

### DIFF
--- a/.agentplane/tasks/202605141957-FB780T/README.md
+++ b/.agentplane/tasks/202605141957-FB780T/README.md
@@ -1,0 +1,387 @@
+---
+id: "202605141957-FB780T"
+title: "Fix remote-check wait helper timeout contract (issue #3760)"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 7
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "bug"
+  - "code"
+  - "workflow"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-14T19:57:20.323Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-14T20:01:46.438Z"
+  updated_by: "CODER"
+  note: "Re-verified after replacing fallback Verify Steps with task-specific checks; all previously run focused code/docs/workflow checks remain passing."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implementing issue #3760 by aligning workflow:wait-remote-checks timeout/timing CLI contract with docs and focused verification in the dedicated task worktree."
+events:
+  -
+    type: "status"
+    at: "2026-05-14T19:57:37.037Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implementing issue #3760 by aligning workflow:wait-remote-checks timeout/timing CLI contract with docs and focused verification in the dedicated task worktree."
+  -
+    type: "verify"
+    at: "2026-05-14T20:00:43.102Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented issue #3760: workflow:wait-remote-checks now accepts --timeout-ms, help documents timing controls, docs no longer describe the helper as raw gh delegation, and focused checks passed."
+  -
+    type: "verify"
+    at: "2026-05-14T20:01:46.438Z"
+    author: "CODER"
+    state: "ok"
+    note: "Re-verified after replacing fallback Verify Steps with task-specific checks; all previously run focused code/docs/workflow checks remain passing."
+doc_version: 3
+doc_updated_at: "2026-05-14T20:01:46.465Z"
+doc_updated_by: "CODER"
+description: "Align workflow:wait-remote-checks CLI contract with branch_pr policy/docs so timeout guidance is explicit and tested. GitHub issue: https://github.com/basilisk-labs/agentplane/issues/3760"
+sections:
+  Summary: |-
+    Fix remote-check wait helper timeout contract (issue #3760)
+
+    Align workflow:wait-remote-checks CLI contract with branch_pr policy/docs so timeout guidance is explicit and tested. GitHub issue: https://github.com/basilisk-labs/agentplane/issues/3760
+  Scope: |-
+    - In scope: Align workflow:wait-remote-checks CLI contract with branch_pr policy/docs so timeout guidance is explicit and tested. GitHub issue: https://github.com/basilisk-labs/agentplane/issues/3760.
+    - Out of scope: unrelated refactors not required for "Fix remote-check wait helper timeout contract (issue #3760)".
+  Plan: |-
+    Scope:
+    1. Link GitHub issue #3760 and the AgentPlane task as the traceability pair.
+    2. Update workflow:wait-remote-checks so its supported timeout/timing contract is explicit and machine-covered.
+    3. Align user docs/policy-adjacent guidance so --timeout-ms is not misapplied from integrate queue waiting to remote-check waiting.
+    4. Verify with focused tests/help output checks plus required routing/doctor checks.
+    5. Publish through branch_pr PR, wait for hosted checks, merge, and finish/close through the protected-base route.
+
+    Implementation approach:
+    - Prefer adding a supported --timeout-ms alias to the helper if it maps cleanly to existing interval/max-attempt polling; otherwise document env controls and reject --timeout-ms intentionally.
+    - Keep changes scoped to scripts/workflow/wait-remote-pr-checks.mjs, focused tests/docs, and task/PR artifacts.
+
+    Verification:
+    - agentplane task verify-show 202605141957-FB780T
+    - focused test for wait-remote-pr-checks argument parsing/help behavior
+    - bun run workflow:wait-remote-checks -- --help
+    - node .agentplane/policy/check-routing.mjs
+    - agentplane doctor
+  Verify Steps: |-
+    1. Run `bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts`. Expected: focused wait-remote-pr-checks tests pass, including --timeout-ms coverage.
+    2. Run `bun run workflow:wait-remote-checks -- --help`. Expected: help lists --timeout-ms and AGENTPLANE_REMOTE_CHECK_* timing controls.
+    3. Run formatting, docs, workflow, lint, policy routing, and doctor checks for changed scope. Expected: all pass, with only unrelated pre-existing doctor warnings if present.
+    4. Publish the branch_pr PR, wait for hosted required checks, merge through GitHub, then finish/close the task with the implementation commit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-14T20:00:43.102Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Implemented issue #3760: workflow:wait-remote-checks now accepts --timeout-ms, help documents timing controls, docs no longer describe the helper as raw gh delegation, and focused checks passed.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T19:57:37.037Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141957-FB780T-remote-check-timeout-contract/.agentplane/tasks/202605141957-FB780T/blueprint/resolved-snapshot.json
+    - old_digest: c866fede321f158d320f481427dd68025bfac8a660a617bd78d7660be107c6aa
+    - current_digest: c866fede321f158d320f481427dd68025bfac8a660a617bd78d7660be107c6aa
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141957-FB780T
+
+    ### 2026-05-14T20:01:46.438Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Re-verified after replacing fallback Verify Steps with task-specific checks; all previously run focused code/docs/workflow checks remain passing.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T20:01:32.440Z, excerpt_hash=sha256:1a3cc6df4a1da3d0c7311c05090340b5d9caf607483a6fa32d129409d59ec919
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141957-FB780T-remote-check-timeout-contract/.agentplane/tasks/202605141957-FB780T/blueprint/resolved-snapshot.json
+    - old_digest: c866fede321f158d320f481427dd68025bfac8a660a617bd78d7660be107c6aa
+    - current_digest: c866fede321f158d320f481427dd68025bfac8a660a617bd78d7660be107c6aa
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605141957-FB780T
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Command: bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts
+    Result: pass
+    Evidence: 1 file passed, 17 tests passed, including accepts --timeout-ms as an idle poll budget derived from the poll interval.
+    Scope: wait-remote-pr-checks parser/help/polling behavior.
+
+    Command: bun run workflow:wait-remote-checks -- --help
+    Result: pass
+    Evidence: help lists --timeout-ms and AGENTPLANE_REMOTE_CHECK_* timing environment.
+    Scope: CLI helper user-facing contract.
+
+    Command: ./node_modules/.bin/prettier --check scripts/workflow/wait-remote-pr-checks.mjs packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts docs/user/commands.mdx docs/user/branching-and-pr-artifacts.mdx
+    Result: pass
+    Evidence: All matched files use Prettier code style.
+    Scope: changed files.
+
+    Command: bun run docs:ia:check
+    Result: pass
+    Evidence: docs IA, sidebar coverage, and current path references are aligned.
+    Scope: docs changes.
+
+    Command: bun run workflows:command-check
+    Result: pass
+    Evidence: workflow and command guidance contract OK; workflow lifecycle parity OK; critical Vitest route OK.
+    Scope: workflow command guidance.
+
+    Command: ./node_modules/.bin/eslint scripts/workflow/wait-remote-pr-checks.mjs packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts
+    Result: pass
+    Evidence: no lint output.
+    Scope: changed script and test.
+
+    Command: node .agentplane/policy/check-routing.mjs
+    Result: pass
+    Evidence: policy routing OK.
+    Scope: policy routing contract.
+
+    Command: agentplane doctor
+    Result: pass
+    Evidence: doctor (OK); unrelated pre-existing branch_pr task artifact warnings remain.
+    Scope: repository workflow/runtime health.
+      Impact: Remote-check waiting now supports the timeout-style operator contract that agents may carry over from branch_pr queue guidance.
+      Resolution: Added --timeout-ms parsing and help text; converted timeout to idle poll attempts using the configured poll interval; updated docs and focused tests.
+
+    - Observation: Command: bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts
+    Result: pass
+    Evidence: 1 file passed, 17 tests passed.
+    Scope: wait-remote-pr-checks parser/help/polling behavior.
+
+    Command: bun run workflow:wait-remote-checks -- --help
+    Result: pass
+    Evidence: help lists --timeout-ms and AGENTPLANE_REMOTE_CHECK_* timing environment.
+    Scope: CLI helper contract.
+
+    Command: ./node_modules/.bin/prettier --check scripts/workflow/wait-remote-pr-checks.mjs packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts docs/user/commands.mdx docs/user/branching-and-pr-artifacts.mdx
+    Result: pass
+    Evidence: All matched files use Prettier code style.
+    Scope: changed files.
+
+    Command: bun run docs:ia:check
+    Result: pass
+    Evidence: docs IA, sidebar coverage, and current path references are aligned.
+    Scope: docs changes.
+
+    Command: bun run workflows:command-check
+    Result: pass
+    Evidence: workflow and command guidance contract OK; workflow lifecycle parity OK; critical Vitest route OK.
+    Scope: workflow command guidance.
+
+    Command: ./node_modules/.bin/eslint scripts/workflow/wait-remote-pr-checks.mjs packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts
+    Result: pass
+    Evidence: no lint output.
+    Scope: changed script/test.
+
+    Command: node .agentplane/policy/check-routing.mjs
+    Result: pass
+    Evidence: policy routing OK.
+    Scope: policy routing.
+
+    Command: agentplane doctor
+    Result: pass
+    Evidence: doctor (OK); unrelated pre-existing branch_pr artifact warnings remain.
+    Scope: workflow/runtime health.
+      Impact: Task-specific Verify Steps now match the executed checks and issue #3760 acceptance criteria.
+      Resolution: Replaced fallback Verify Steps and recorded verification against the updated task document.
+id_source: "generated"
+---
+## Summary
+
+Fix remote-check wait helper timeout contract (issue #3760)
+
+Align workflow:wait-remote-checks CLI contract with branch_pr policy/docs so timeout guidance is explicit and tested. GitHub issue: https://github.com/basilisk-labs/agentplane/issues/3760
+
+## Scope
+
+- In scope: Align workflow:wait-remote-checks CLI contract with branch_pr policy/docs so timeout guidance is explicit and tested. GitHub issue: https://github.com/basilisk-labs/agentplane/issues/3760.
+- Out of scope: unrelated refactors not required for "Fix remote-check wait helper timeout contract (issue #3760)".
+
+## Plan
+
+Scope:
+1. Link GitHub issue #3760 and the AgentPlane task as the traceability pair.
+2. Update workflow:wait-remote-checks so its supported timeout/timing contract is explicit and machine-covered.
+3. Align user docs/policy-adjacent guidance so --timeout-ms is not misapplied from integrate queue waiting to remote-check waiting.
+4. Verify with focused tests/help output checks plus required routing/doctor checks.
+5. Publish through branch_pr PR, wait for hosted checks, merge, and finish/close through the protected-base route.
+
+Implementation approach:
+- Prefer adding a supported --timeout-ms alias to the helper if it maps cleanly to existing interval/max-attempt polling; otherwise document env controls and reject --timeout-ms intentionally.
+- Keep changes scoped to scripts/workflow/wait-remote-pr-checks.mjs, focused tests/docs, and task/PR artifacts.
+
+Verification:
+- agentplane task verify-show 202605141957-FB780T
+- focused test for wait-remote-pr-checks argument parsing/help behavior
+- bun run workflow:wait-remote-checks -- --help
+- node .agentplane/policy/check-routing.mjs
+- agentplane doctor
+
+## Verify Steps
+
+1. Run `bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts`. Expected: focused wait-remote-pr-checks tests pass, including --timeout-ms coverage.
+2. Run `bun run workflow:wait-remote-checks -- --help`. Expected: help lists --timeout-ms and AGENTPLANE_REMOTE_CHECK_* timing controls.
+3. Run formatting, docs, workflow, lint, policy routing, and doctor checks for changed scope. Expected: all pass, with only unrelated pre-existing doctor warnings if present.
+4. Publish the branch_pr PR, wait for hosted required checks, merge through GitHub, then finish/close the task with the implementation commit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-14T20:00:43.102Z — VERIFY — ok
+
+By: CODER
+
+Note: Implemented issue #3760: workflow:wait-remote-checks now accepts --timeout-ms, help documents timing controls, docs no longer describe the helper as raw gh delegation, and focused checks passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T19:57:37.037Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141957-FB780T-remote-check-timeout-contract/.agentplane/tasks/202605141957-FB780T/blueprint/resolved-snapshot.json
+- old_digest: c866fede321f158d320f481427dd68025bfac8a660a617bd78d7660be107c6aa
+- current_digest: c866fede321f158d320f481427dd68025bfac8a660a617bd78d7660be107c6aa
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141957-FB780T
+
+### 2026-05-14T20:01:46.438Z — VERIFY — ok
+
+By: CODER
+
+Note: Re-verified after replacing fallback Verify Steps with task-specific checks; all previously run focused code/docs/workflow checks remain passing.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T20:01:32.440Z, excerpt_hash=sha256:1a3cc6df4a1da3d0c7311c05090340b5d9caf607483a6fa32d129409d59ec919
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605141957-FB780T-remote-check-timeout-contract/.agentplane/tasks/202605141957-FB780T/blueprint/resolved-snapshot.json
+- old_digest: c866fede321f158d320f481427dd68025bfac8a660a617bd78d7660be107c6aa
+- current_digest: c866fede321f158d320f481427dd68025bfac8a660a617bd78d7660be107c6aa
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605141957-FB780T
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Command: bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts
+Result: pass
+Evidence: 1 file passed, 17 tests passed, including accepts --timeout-ms as an idle poll budget derived from the poll interval.
+Scope: wait-remote-pr-checks parser/help/polling behavior.
+
+Command: bun run workflow:wait-remote-checks -- --help
+Result: pass
+Evidence: help lists --timeout-ms and AGENTPLANE_REMOTE_CHECK_* timing environment.
+Scope: CLI helper user-facing contract.
+
+Command: ./node_modules/.bin/prettier --check scripts/workflow/wait-remote-pr-checks.mjs packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts docs/user/commands.mdx docs/user/branching-and-pr-artifacts.mdx
+Result: pass
+Evidence: All matched files use Prettier code style.
+Scope: changed files.
+
+Command: bun run docs:ia:check
+Result: pass
+Evidence: docs IA, sidebar coverage, and current path references are aligned.
+Scope: docs changes.
+
+Command: bun run workflows:command-check
+Result: pass
+Evidence: workflow and command guidance contract OK; workflow lifecycle parity OK; critical Vitest route OK.
+Scope: workflow command guidance.
+
+Command: ./node_modules/.bin/eslint scripts/workflow/wait-remote-pr-checks.mjs packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts
+Result: pass
+Evidence: no lint output.
+Scope: changed script and test.
+
+Command: node .agentplane/policy/check-routing.mjs
+Result: pass
+Evidence: policy routing OK.
+Scope: policy routing contract.
+
+Command: agentplane doctor
+Result: pass
+Evidence: doctor (OK); unrelated pre-existing branch_pr task artifact warnings remain.
+Scope: repository workflow/runtime health.
+  Impact: Remote-check waiting now supports the timeout-style operator contract that agents may carry over from branch_pr queue guidance.
+  Resolution: Added --timeout-ms parsing and help text; converted timeout to idle poll attempts using the configured poll interval; updated docs and focused tests.
+
+- Observation: Command: bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts
+Result: pass
+Evidence: 1 file passed, 17 tests passed.
+Scope: wait-remote-pr-checks parser/help/polling behavior.
+
+Command: bun run workflow:wait-remote-checks -- --help
+Result: pass
+Evidence: help lists --timeout-ms and AGENTPLANE_REMOTE_CHECK_* timing environment.
+Scope: CLI helper contract.
+
+Command: ./node_modules/.bin/prettier --check scripts/workflow/wait-remote-pr-checks.mjs packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts docs/user/commands.mdx docs/user/branching-and-pr-artifacts.mdx
+Result: pass
+Evidence: All matched files use Prettier code style.
+Scope: changed files.
+
+Command: bun run docs:ia:check
+Result: pass
+Evidence: docs IA, sidebar coverage, and current path references are aligned.
+Scope: docs changes.
+
+Command: bun run workflows:command-check
+Result: pass
+Evidence: workflow and command guidance contract OK; workflow lifecycle parity OK; critical Vitest route OK.
+Scope: workflow command guidance.
+
+Command: ./node_modules/.bin/eslint scripts/workflow/wait-remote-pr-checks.mjs packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts
+Result: pass
+Evidence: no lint output.
+Scope: changed script/test.
+
+Command: node .agentplane/policy/check-routing.mjs
+Result: pass
+Evidence: policy routing OK.
+Scope: policy routing.
+
+Command: agentplane doctor
+Result: pass
+Evidence: doctor (OK); unrelated pre-existing branch_pr artifact warnings remain.
+Scope: workflow/runtime health.
+  Impact: Task-specific Verify Steps now match the executed checks and issue #3760 acceptance criteria.
+  Resolution: Replaced fallback Verify Steps and recorded verification against the updated task document.

--- a/.agentplane/tasks/202605141957-FB780T/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605141957-FB780T/blueprint/resolved-snapshot.json
@@ -1,0 +1,528 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605141957-FB780T",
+    "title": "Fix remote-check wait helper timeout contract (issue #3760)",
+    "description": "Align workflow:wait-remote-checks CLI contract with branch_pr policy/docs so timeout guidance is explicit and tested. GitHub issue: https://github.com/basilisk-labs/agentplane/issues/3760",
+    "tags": [
+      "bug",
+      "code",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605141957-FB780T",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "c866fede321f158d320f481427dd68025bfac8a660a617bd78d7660be107c6aa"
+  }
+}

--- a/.agentplane/tasks/202605141957-FB780T/pr/diffstat.txt
+++ b/.agentplane/tasks/202605141957-FB780T/pr/diffstat.txt
@@ -1,0 +1,6 @@
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ docs/user/branching-and-pr-artifacts.mdx           |   4 +-
+ docs/user/commands.mdx                             |   4 +-
+ .../src/cli/wait-remote-pr-checks-script.test.ts   |  24 +
+ scripts/workflow/wait-remote-pr-checks.mjs         |  38 ++
+ 5 files changed, 594 insertions(+), 4 deletions(-)

--- a/.agentplane/tasks/202605141957-FB780T/pr/github-body.md
+++ b/.agentplane/tasks/202605141957-FB780T/pr/github-body.md
@@ -1,0 +1,38 @@
+Task: `202605141957-FB780T`
+Title: Fix remote-check wait helper timeout contract (issue #3760)
+Canonical task record: `.agentplane/tasks/202605141957-FB780T/README.md`
+
+## Summary
+
+Fix remote-check wait helper timeout contract (issue #3760)
+
+Align workflow:wait-remote-checks CLI contract with branch_pr policy/docs so timeout guidance is explicit and tested. GitHub issue: https://github.com/basilisk-labs/agentplane/issues/3760
+
+## Scope
+
+- In scope: Align workflow:wait-remote-checks CLI contract with branch_pr policy/docs so timeout guidance is explicit and tested. GitHub issue: https://github.com/basilisk-labs/agentplane/issues/3760.
+- Out of scope: unrelated refactors not required for "Fix remote-check wait helper timeout contract (issue #3760)".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Re-verified after replacing fallback Verify Steps with task-specific checks; all previously run
+focused code/docs/workflow checks remain passing.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T19:57:37.081Z
+- Branch: task/202605141957-FB780T/remote-check-timeout-contract
+- Head: b9ebb6e0eb9c
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605141957-FB780T/pr/github-body.md
+++ b/.agentplane/tasks/202605141957-FB780T/pr/github-body.md
@@ -27,12 +27,17 @@ focused code/docs/workflow checks remain passing.
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T19:57:37.081Z
+- Updated: 2026-05-14T20:03:50.727Z
 - Branch: task/202605141957-FB780T/remote-check-timeout-contract
-- Head: b9ebb6e0eb9c
+- Head: 01c4f7b330f4
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ docs/user/branching-and-pr-artifacts.mdx           |   4 +-
+ docs/user/commands.mdx                             |   4 +-
+ .../src/cli/wait-remote-pr-checks-script.test.ts   |  24 +
+ scripts/workflow/wait-remote-pr-checks.mjs         |  38 ++
+ 5 files changed, 594 insertions(+), 4 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605141957-FB780T/pr/github-title.txt
+++ b/.agentplane/tasks/202605141957-FB780T/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 FB780T task: Fix remote-check wait helper timeout contract (issue #3760) [202605141957-FB780T]

--- a/.agentplane/tasks/202605141957-FB780T/pr/meta.json
+++ b/.agentplane/tasks/202605141957-FB780T/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605141957-FB780T/remote-check-timeout-contract",
   "created_at": "2026-05-14T19:57:37.081Z",
-  "head_sha": "b9ebb6e0eb9c2f74dccaabbd7d9559bea497422b",
+  "head_sha": "01c4f7b330f4b043ea299412bdab9634a50fbe9e",
   "last_verified_at": "2026-05-14T20:01:46.438Z",
   "last_verified_sha": "b9ebb6e0eb9c2f74dccaabbd7d9559bea497422b",
   "schema_version": 1,
   "task_id": "202605141957-FB780T",
-  "updated_at": "2026-05-14T19:57:37.081Z",
+  "updated_at": "2026-05-14T20:03:50.727Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141957-FB780T/pr/meta.json
+++ b/.agentplane/tasks/202605141957-FB780T/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "01c4f7b330f4b043ea299412bdab9634a50fbe9e",
   "last_verified_at": "2026-05-14T20:01:46.438Z",
   "last_verified_sha": "b9ebb6e0eb9c2f74dccaabbd7d9559bea497422b",
+  "pr_number": 3761,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3761",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605141957-FB780T",
-  "updated_at": "2026-05-14T20:03:50.727Z",
+  "updated_at": "2026-05-14T20:04:40.888Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605141957-FB780T/pr/meta.json
+++ b/.agentplane/tasks/202605141957-FB780T/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605141957-FB780T/remote-check-timeout-contract",
+  "created_at": "2026-05-14T19:57:37.081Z",
+  "head_sha": "b9ebb6e0eb9c2f74dccaabbd7d9559bea497422b",
+  "last_verified_at": "2026-05-14T20:01:46.438Z",
+  "last_verified_sha": "b9ebb6e0eb9c2f74dccaabbd7d9559bea497422b",
+  "schema_version": 1,
+  "task_id": "202605141957-FB780T",
+  "updated_at": "2026-05-14T19:57:37.081Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605141957-FB780T/pr/review.md
+++ b/.agentplane/tasks/202605141957-FB780T/pr/review.md
@@ -24,12 +24,17 @@ Created: 2026-05-14T19:57:37.081Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-14T19:57:37.081Z
+- Updated: 2026-05-14T20:03:50.727Z
 - Branch: task/202605141957-FB780T/remote-check-timeout-contract
-- Head: b9ebb6e0eb9c
+- Head: 01c4f7b330f4
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ docs/user/branching-and-pr-artifacts.mdx           |   4 +-
+ docs/user/commands.mdx                             |   4 +-
+ .../src/cli/wait-remote-pr-checks-script.test.ts   |  24 +
+ scripts/workflow/wait-remote-pr-checks.mjs         |  38 ++
+ 5 files changed, 594 insertions(+), 4 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605141957-FB780T/pr/review.md
+++ b/.agentplane/tasks/202605141957-FB780T/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-14T19:57:37.081Z
+
+## Task
+
+- Task: `202605141957-FB780T`
+- Title: Fix remote-check wait helper timeout contract (issue #3760)
+- Status: DOING
+- Branch: `task/202605141957-FB780T/remote-check-timeout-contract`
+- Canonical task record: `.agentplane/tasks/202605141957-FB780T/README.md`
+
+## Verification
+
+- State: ok
+- Note: Re-verified after replacing fallback Verify Steps with task-specific checks; all previously run focused code/docs/workflow checks remain passing.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T19:57:37.081Z
+- Branch: task/202605141957-FB780T/remote-check-timeout-contract
+- Head: b9ebb6e0eb9c
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/docs/user/branching-and-pr-artifacts.mdx
+++ b/docs/user/branching-and-pr-artifacts.mdx
@@ -119,10 +119,10 @@ checkout, so it records the explicit implementation commit hash that already exi
 branch. Use comment-driven status commits only where the specific lifecycle command supports them
 from the task worktree.
 
-Underlying hosted-check command:
+Repository helper for hosted checks:
 
 ```bash
-gh pr checks --watch --required --fail-fast
+bun run workflow:wait-remote-checks -- --timeout-ms 600000
 ```
 
 Hosted checks are the gate. Do not integrate or finish on base branch until `bun run workflow:wait-remote-checks` returns green.

--- a/docs/user/commands.mdx
+++ b/docs/user/commands.mdx
@@ -270,7 +270,7 @@ agentplane integrate <task-id> --branch task/<task-id>/<slug> --run-verify
 agentplane finish <task-id> --author INTEGRATOR --body "Verified: ..." --result "One-line outcome" --commit <git-rev> --close-commit
 ```
 
-`agentplane pr ...` manages local PR artifacts under `.agentplane/tasks/<task-id>/pr/`, including `review.md`, `github-title.txt`, and `github-body.md`. A normal `agentplane pr open` run also publishes the task branch and creates or links the hosted GitHub PR; use `--sync-only` only when you intentionally want local artifacts without remote side effects. The canonical required-check wait step is `bun run workflow:wait-remote-checks`, which delegates to `gh pr checks --watch --required --fail-fast`. `agentplane integrate` defaults to `merge` so task branch commits stay in base history; pass `--merge-strategy squash` only when compacting history is intentional.
+`agentplane pr ...` manages local PR artifacts under `.agentplane/tasks/<task-id>/pr/`, including `review.md`, `github-title.txt`, and `github-body.md`. A normal `agentplane pr open` run also publishes the task branch and creates or links the hosted GitHub PR; use `--sync-only` only when you intentionally want local artifacts without remote side effects. The canonical required-check wait step is `bun run workflow:wait-remote-checks`, which polls GitHub PR check state with bounded retries, stable ready polls, and optional `--timeout-ms` conversion to an idle poll budget. `agentplane integrate` defaults to `merge` so task branch commits stay in base history; pass `--merge-strategy squash` only when compacting history is intentional.
 
 GitHub protection audit for this repository:
 
@@ -345,7 +345,7 @@ agentplane task verify-show <task-id>
 agentplane pr open <task-id>
 agentplane pr update <task-id>
 agentplane verify <task-id> --ok --by CODER --note "Focused checks passed on the task branch."
-bun run workflow:wait-remote-checks
+bun run workflow:wait-remote-checks -- --timeout-ms 600000
 agentplane pr check <task-id>
 agentplane integrate <task-id> --branch task/<task-id>/<slug> --run-verify
 ```

--- a/packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts
+++ b/packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts
@@ -419,6 +419,28 @@ describe("wait-remote-pr-checks script", () => {
     expect(output).toContain("timed out waiting for required checks after 3 idle polls");
   });
 
+  it("honors --timeout-ms when the poll interval is zero", async () => {
+    const root = await makeTempRoot();
+    const { stateFile } = await writeGhMock(root);
+
+    const result = await runScript(["--timeout-ms=2"], {
+      env: {
+        PATH: `${path.join(root, "bin")}:${process.env.PATH ?? ""}`,
+        GH_STATE_FILE: stateFile,
+        GH_SCENARIO: "timeout",
+        ...DEFAULT_BRANCH_ENV,
+        AGENTPLANE_REMOTE_CHECK_INTERVAL_MS: "0",
+        AGENTPLANE_REMOTE_CHECK_MAX_ATTEMPTS: "99",
+        AGENTPLANE_REMOTE_CHECK_STABLE_POLLS: "1",
+      },
+    });
+
+    expect(result.exitCode).toBe(1);
+    const output = transcript(result);
+    expect(output).toContain("poll 2 (idle 2/2)");
+    expect(output).toContain("timed out waiting for required checks after 2 idle polls");
+  });
+
   it("fails explicitly for detached push checkouts without an explicit PR target", async () => {
     const root = await makeTempRoot();
     const detachedRoot = await makeDetachedGitRoot();

--- a/packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts
+++ b/packages/agentplane/src/cli/wait-remote-pr-checks-script.test.ts
@@ -270,6 +270,8 @@ describe("wait-remote-pr-checks script", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("workflow:wait-remote-checks");
     expect(result.stdout).toContain("polls PR check state");
+    expect(result.stdout).toContain("--timeout-ms <ms>");
+    expect(result.stdout).toContain("AGENTPLANE_REMOTE_CHECK_MAX_ATTEMPTS");
     expect(result.stdout).not.toContain("gh pr checks --watch");
   });
 
@@ -393,6 +395,28 @@ describe("wait-remote-pr-checks script", () => {
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("Unknown option: --mystery");
     expect(result.stderr).not.toContain("required checks passed");
+  });
+
+  it("accepts --timeout-ms as an idle poll budget derived from the poll interval", async () => {
+    const root = await makeTempRoot();
+    const { stateFile } = await writeGhMock(root);
+
+    const result = await runScript(["--timeout-ms=25"], {
+      env: {
+        PATH: `${path.join(root, "bin")}:${process.env.PATH ?? ""}`,
+        GH_STATE_FILE: stateFile,
+        GH_SCENARIO: "timeout",
+        ...DEFAULT_BRANCH_ENV,
+        AGENTPLANE_REMOTE_CHECK_INTERVAL_MS: "10",
+        AGENTPLANE_REMOTE_CHECK_MAX_ATTEMPTS: "99",
+        AGENTPLANE_REMOTE_CHECK_STABLE_POLLS: "1",
+      },
+    });
+
+    expect(result.exitCode).toBe(1);
+    const output = transcript(result);
+    expect(output).toContain("poll 3 (idle 3/3)");
+    expect(output).toContain("timed out waiting for required checks after 3 idle polls");
   });
 
   it("fails explicitly for detached push checkouts without an explicit PR target", async () => {

--- a/scripts/workflow/wait-remote-pr-checks.mjs
+++ b/scripts/workflow/wait-remote-pr-checks.mjs
@@ -25,6 +25,17 @@ function usage() {
       "This command polls PR check state with bounded retries and explicit status output.",
       "Pass one or more PR targets; they are resolved and waited in input order.",
       "",
+      "Options:",
+      "  --repo <owner/name>       GitHub repository slug. Defaults to gh repo view.",
+      "  --pr <target>             PR number, URL, or branch target. Can be repeated.",
+      "  --stable-polls <count>    Consecutive ready polls required before success.",
+      "  --timeout-ms <ms>         Convert a wall-clock timeout into the idle poll budget.",
+      "",
+      "Timing environment:",
+      "  AGENTPLANE_REMOTE_CHECK_INTERVAL_MS      Poll interval. Default: 5000.",
+      "  AGENTPLANE_REMOTE_CHECK_MAX_ATTEMPTS     Idle poll budget. Default: 60.",
+      "  AGENTPLANE_REMOTE_CHECK_STABLE_POLLS     Ready stability budget. Default: 2.",
+      "",
       "Examples:",
       "  bun run workflow:wait-remote-checks",
       "  bun run workflow:wait-remote-checks -- task/202603241919-QVGXZ5/remote-check-wait",
@@ -46,6 +57,12 @@ function parseNonNegativeInteger(value, fallback) {
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
 }
 
+function maxAttemptsFromTimeoutMs(timeoutMs, intervalMs) {
+  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) return null;
+  if (!Number.isInteger(intervalMs) || intervalMs <= 0) return null;
+  return Math.max(1, Math.ceil(timeoutMs / intervalMs));
+}
+
 function parseArgs(argv) {
   const options = {
     help: false,
@@ -63,6 +80,7 @@ function parseArgs(argv) {
       process.env.AGENTPLANE_REMOTE_CHECK_STABLE_POLLS,
       DEFAULT_STABLE_POLLS,
     ),
+    timeoutMs: null,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -94,6 +112,15 @@ function parseArgs(argv) {
       index += 1;
       continue;
     }
+    if (arg === "--timeout-ms") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("Missing value for --timeout-ms");
+      const parsed = parsePositiveInteger(value, Number.NaN);
+      if (!Number.isInteger(parsed)) throw new Error("Invalid value for --timeout-ms");
+      options.timeoutMs = parsed;
+      index += 1;
+      continue;
+    }
     if (arg.startsWith("--repo=")) {
       const value = arg.slice("--repo=".length);
       if (!value) throw new Error("Missing value for --repo");
@@ -114,6 +141,14 @@ function parseArgs(argv) {
       options.stablePolls = parsed;
       continue;
     }
+    if (arg.startsWith("--timeout-ms=")) {
+      const value = arg.slice("--timeout-ms=".length);
+      if (!value) throw new Error("Missing value for --timeout-ms");
+      const parsed = parsePositiveInteger(value, Number.NaN);
+      if (!Number.isInteger(parsed)) throw new Error("Invalid value for --timeout-ms");
+      options.timeoutMs = parsed;
+      continue;
+    }
     if (IGNORED_LEGACY_FLAGS.has(arg)) {
       continue;
     }
@@ -122,6 +157,9 @@ function parseArgs(argv) {
     }
     options.targetArgs.push(arg);
   }
+
+  const timeoutMaxAttempts = maxAttemptsFromTimeoutMs(options.timeoutMs, options.intervalMs);
+  if (timeoutMaxAttempts !== null) options.maxAttempts = timeoutMaxAttempts;
 
   return options;
 }

--- a/scripts/workflow/wait-remote-pr-checks.mjs
+++ b/scripts/workflow/wait-remote-pr-checks.mjs
@@ -59,8 +59,9 @@ function parseNonNegativeInteger(value, fallback) {
 
 function maxAttemptsFromTimeoutMs(timeoutMs, intervalMs) {
   if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) return null;
-  if (!Number.isInteger(intervalMs) || intervalMs <= 0) return null;
-  return Math.max(1, Math.ceil(timeoutMs / intervalMs));
+  if (!Number.isInteger(intervalMs) || intervalMs < 0) return null;
+  const effectiveIntervalMs = Math.max(1, intervalMs);
+  return Math.max(1, Math.ceil(timeoutMs / effectiveIntervalMs));
 }
 
 function parseArgs(argv) {


### PR DESCRIPTION
Task: `202605141957-FB780T`
Title: Fix remote-check wait helper timeout contract (issue #3760)
Canonical task record: `.agentplane/tasks/202605141957-FB780T/README.md`

## Summary

Fix remote-check wait helper timeout contract (issue #3760)

Align workflow:wait-remote-checks CLI contract with branch_pr policy/docs so timeout guidance is explicit and tested. GitHub issue: https://github.com/basilisk-labs/agentplane/issues/3760

## Scope

- In scope: Align workflow:wait-remote-checks CLI contract with branch_pr policy/docs so timeout guidance is explicit and tested. GitHub issue: https://github.com/basilisk-labs/agentplane/issues/3760.
- Out of scope: unrelated refactors not required for "Fix remote-check wait helper timeout contract (issue #3760)".

## Verification

- State: ok
- Note:

```text
Re-verified after replacing fallback Verify Steps with task-specific checks; all previously run
focused code/docs/workflow checks remain passing.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-14T20:03:50.727Z
- Branch: task/202605141957-FB780T/remote-check-timeout-contract
- Head: 01c4f7b330f4

```text
 .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
 docs/user/branching-and-pr-artifacts.mdx           |   4 +-
 docs/user/commands.mdx                             |   4 +-
 .../src/cli/wait-remote-pr-checks-script.test.ts   |  24 +
 scripts/workflow/wait-remote-pr-checks.mjs         |  38 ++
 5 files changed, 594 insertions(+), 4 deletions(-)
```

</details>

Closes #3760