### PR TITLE
🚧 1YX6ZA task: Remove duplicate Recipes navbar link [202605142028-1YX6ZA]

### DIFF
--- a/.agentplane/tasks/202605142028-1YX6ZA/README.md
+++ b/.agentplane/tasks/202605142028-1YX6ZA/README.md
@@ -1,0 +1,148 @@
+---
+id: "202605142028-1YX6ZA"
+title: "Remove duplicate Recipes navbar link"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "docs"
+  - "frontend"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-14T20:28:44.336Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-14T20:30:11.950Z"
+  updated_by: "CODER"
+  note: "Verified duplicate Recipes navbar regression is fixed."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: remove duplicate Recipes navbar link found during live production verification and keep the docs onboarding navbar check green."
+events:
+  -
+    type: "status"
+    at: "2026-05-14T20:28:54.639Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: remove duplicate Recipes navbar link found during live production verification and keep the docs onboarding navbar check green."
+  -
+    type: "verify"
+    at: "2026-05-14T20:30:11.950Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified duplicate Recipes navbar regression is fixed."
+doc_version: 3
+doc_updated_at: "2026-05-14T20:30:11.955Z"
+doc_updated_by: "CODER"
+description: "Fix the website navbar regression introduced by the OSS polish so Recipes appears only once while preserving docs onboarding expectations."
+sections:
+  Summary: |-
+    Remove duplicate Recipes navbar link
+    
+    Fix the website navbar regression introduced by the OSS polish so Recipes appears only once while preserving docs onboarding expectations.
+  Scope: |-
+    - In scope: Fix the website navbar regression introduced by the OSS polish so Recipes appears only once while preserving docs onboarding expectations.
+    - Out of scope: unrelated refactors not required for "Remove duplicate Recipes navbar link".
+  Plan: "Remove the duplicate Recipes navbar entry from the Docusaurus config, verify the onboarding/nav check still passes, rebuild the website, and confirm live output after merge."
+  Verify Steps: |-
+    PLANNER fallback scaffold for "Remove duplicate Recipes navbar link". Replace with task-specific acceptance checks when PLANNER context is available.
+    
+    1. Review the requested outcome for "Remove duplicate Recipes navbar link". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-14T20:30:11.950Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Verified duplicate Recipes navbar regression is fixed.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T20:28:54.639Z, excerpt_hash=sha256:07f88178a180212d3784c2a3a979e9c2d9d3596c9e6a7ef7cf3041227ddcf7ed
+    
+    Details:
+    
+    Checks: bun run --cwd website check-content; bun run docs:onboarding:check; node .agentplane/policy/check-routing.mjs; bun run docs:site:build; built homepage grep confirms one Recipes navbar link.
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605142028-1YX6ZA-fix-duplicate-recipes-nav/.agentplane/tasks/202605142028-1YX6ZA/blueprint/resolved-snapshot.json
+    - old_digest: b256277467bfc3d8cc9434a288eedc416a8900481e6550acaf9af6a2da8efec4
+    - current_digest: b256277467bfc3d8cc9434a288eedc416a8900481e6550acaf9af6a2da8efec4
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605142028-1YX6ZA
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Remove duplicate Recipes navbar link
+
+Fix the website navbar regression introduced by the OSS polish so Recipes appears only once while preserving docs onboarding expectations.
+
+## Scope
+
+- In scope: Fix the website navbar regression introduced by the OSS polish so Recipes appears only once while preserving docs onboarding expectations.
+- Out of scope: unrelated refactors not required for "Remove duplicate Recipes navbar link".
+
+## Plan
+
+Remove the duplicate Recipes navbar entry from the Docusaurus config, verify the onboarding/nav check still passes, rebuild the website, and confirm live output after merge.
+
+## Verify Steps
+
+PLANNER fallback scaffold for "Remove duplicate Recipes navbar link". Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the requested outcome for "Remove duplicate Recipes navbar link". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-14T20:30:11.950Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified duplicate Recipes navbar regression is fixed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-14T20:28:54.639Z, excerpt_hash=sha256:07f88178a180212d3784c2a3a979e9c2d9d3596c9e6a7ef7cf3041227ddcf7ed
+
+Details:
+
+Checks: bun run --cwd website check-content; bun run docs:onboarding:check; node .agentplane/policy/check-routing.mjs; bun run docs:site:build; built homepage grep confirms one Recipes navbar link.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605142028-1YX6ZA-fix-duplicate-recipes-nav/.agentplane/tasks/202605142028-1YX6ZA/blueprint/resolved-snapshot.json
+- old_digest: b256277467bfc3d8cc9434a288eedc416a8900481e6550acaf9af6a2da8efec4
+- current_digest: b256277467bfc3d8cc9434a288eedc416a8900481e6550acaf9af6a2da8efec4
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605142028-1YX6ZA
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605142028-1YX6ZA/pr/diffstat.txt
+++ b/.agentplane/tasks/202605142028-1YX6ZA/pr/diffstat.txt
@@ -1,0 +1,2 @@
+ website/docusaurus.config.ts | 6 ------
+ 1 file changed, 6 deletions(-)

--- a/.agentplane/tasks/202605142028-1YX6ZA/pr/github-body.md
+++ b/.agentplane/tasks/202605142028-1YX6ZA/pr/github-body.md
@@ -1,0 +1,34 @@
+Task: `202605142028-1YX6ZA`
+Title: Remove duplicate Recipes navbar link
+Canonical task record: `.agentplane/tasks/202605142028-1YX6ZA/README.md`
+
+## Summary
+
+Remove duplicate Recipes navbar link
+
+Fix the website navbar regression introduced by the OSS polish so Recipes appears only once while preserving docs onboarding expectations.
+
+## Scope
+
+- In scope: Fix the website navbar regression introduced by the OSS polish so Recipes appears only once while preserving docs onboarding expectations.
+- Out of scope: unrelated refactors not required for "Remove duplicate Recipes navbar link".
+
+## Verification
+
+- State: ok
+- Note: Verified duplicate Recipes navbar regression is fixed.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T20:30:29.559Z
+- Branch: task/202605142028-1YX6ZA/fix-duplicate-recipes-nav
+- Head: e791add752ab
+
+```text
+ website/docusaurus.config.ts | 6 ------
+ 1 file changed, 6 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605142028-1YX6ZA/pr/github-title.txt
+++ b/.agentplane/tasks/202605142028-1YX6ZA/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 1YX6ZA task: Remove duplicate Recipes navbar link [202605142028-1YX6ZA]

--- a/.agentplane/tasks/202605142028-1YX6ZA/pr/meta.json
+++ b/.agentplane/tasks/202605142028-1YX6ZA/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "e791add752ab6a1ffec42a5c1cd2d327d9f85419",
   "last_verified_at": "2026-05-14T20:30:11.950Z",
   "last_verified_sha": "c43d665480b4407ff52909bb8f9f02556f913a53",
+  "pr_number": 3768,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3768",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605142028-1YX6ZA",
-  "updated_at": "2026-05-14T20:30:29.559Z",
+  "updated_at": "2026-05-14T20:30:35.025Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605142028-1YX6ZA/pr/meta.json
+++ b/.agentplane/tasks/202605142028-1YX6ZA/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605142028-1YX6ZA/fix-duplicate-recipes-nav",
+  "created_at": "2026-05-14T20:28:54.679Z",
+  "head_sha": "e791add752ab6a1ffec42a5c1cd2d327d9f85419",
+  "last_verified_at": "2026-05-14T20:30:11.950Z",
+  "last_verified_sha": "c43d665480b4407ff52909bb8f9f02556f913a53",
+  "schema_version": 1,
+  "task_id": "202605142028-1YX6ZA",
+  "updated_at": "2026-05-14T20:30:29.559Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605142028-1YX6ZA/pr/review.md
+++ b/.agentplane/tasks/202605142028-1YX6ZA/pr/review.md
@@ -1,0 +1,37 @@
+# PR Review
+
+Created: 2026-05-14T20:28:54.679Z
+
+## Task
+
+- Task: `202605142028-1YX6ZA`
+- Title: Remove duplicate Recipes navbar link
+- Status: DOING
+- Branch: `task/202605142028-1YX6ZA/fix-duplicate-recipes-nav`
+- Canonical task record: `.agentplane/tasks/202605142028-1YX6ZA/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified duplicate Recipes navbar regression is fixed.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-14T20:30:29.559Z
+- Branch: task/202605142028-1YX6ZA/fix-duplicate-recipes-nav
+- Head: e791add752ab
+
+```text
+ website/docusaurus.config.ts | 6 ------
+ 1 file changed, 6 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -147,12 +147,6 @@ const config = {
           activeBaseRegex: "^/docs/compare",
         },
         {
-          to: "/docs/recipes",
-          label: "Recipes",
-          position: "right",
-          activeBaseRegex: "^/docs/recipes",
-        },
-        {
           to: "/docs/user/setup",
           label: "Quickstart",
           position: "right",


### PR DESCRIPTION
Task: `202605142028-1YX6ZA`
Title: Remove duplicate Recipes navbar link
Canonical task record: `.agentplane/tasks/202605142028-1YX6ZA/README.md`

## Summary

Remove duplicate Recipes navbar link

Fix the website navbar regression introduced by the OSS polish so Recipes appears only once while preserving docs onboarding expectations.

## Scope

- In scope: Fix the website navbar regression introduced by the OSS polish so Recipes appears only once while preserving docs onboarding expectations.
- Out of scope: unrelated refactors not required for "Remove duplicate Recipes navbar link".

## Verification

- State: ok
- Note: Verified duplicate Recipes navbar regression is fixed.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-14T20:30:29.559Z
- Branch: task/202605142028-1YX6ZA/fix-duplicate-recipes-nav
- Head: e791add752ab

```text
 website/docusaurus.config.ts | 6 ------
 1 file changed, 6 deletions(-)
```

</details>
