### PR TITLE
🚧 GNXMCA task: Fix v0.6.1 publish payload drift [202605150000-GNXMCA]

### DIFF
--- a/.agentplane/tasks/202605150000-GNXMCA/README.md
+++ b/.agentplane/tasks/202605150000-GNXMCA/README.md
@@ -1,0 +1,152 @@
+---
+id: "202605150000-GNXMCA"
+title: "Fix v0.6.1 publish payload drift"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "release"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-15T00:00:23.444Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-15T00:02:00.386Z"
+  updated_by: "CODER"
+  note: "Release checks passed after updating ACR example payload to 0.6.1."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Fixing the v0.6.1 publish validation drift in the release payload fixture, then rerunning exact release checks before opening the branch PR."
+events:
+  -
+    type: "status"
+    at: "2026-05-15T00:00:33.722Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Fixing the v0.6.1 publish validation drift in the release payload fixture, then rerunning exact release checks before opening the branch PR."
+  -
+    type: "verify"
+    at: "2026-05-15T00:02:00.386Z"
+    author: "CODER"
+    state: "ok"
+    note: "Release checks passed after updating ACR example payload to 0.6.1."
+doc_version: 3
+doc_updated_at: "2026-05-15T00:02:00.392Z"
+doc_updated_by: "CODER"
+description: "Update the release payload fixtures so the v0.6.1 publish workflow passes exact-ref validation, then resume publication verification."
+sections:
+  Summary: |-
+    Fix v0.6.1 publish payload drift
+    
+    Update the release payload fixtures so the v0.6.1 publish workflow passes exact-ref validation, then resume publication verification.
+  Scope: |-
+    - In scope: Update the release payload fixtures so the v0.6.1 publish workflow passes exact-ref validation, then resume publication verification.
+    - Out of scope: unrelated refactors not required for "Fix v0.6.1 publish payload drift".
+  Plan: "Plan: fix v0.6.1 exact-ref publish validation by updating only stale release payload fixture versions first; run node scripts/checks/check-acr-example-version.mjs, bun run release:check, and targeted release metadata checks; open a small branch_pr PR; after merge, dispatch Publish release with the canonical release SHA and verify external distribution surfaces."
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+    
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-15T00:02:00.386Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Release checks passed after updating ACR example payload to 0.6.1.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-15T00:00:33.722Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+    
+    Details:
+    
+    Command: node scripts/checks/check-acr-example-version.mjs | Result: pass | Evidence: ACR example version OK (0.6.1) | Scope: packages/spec/examples/acr.json release payload.
+    Command: bun run release:check | Result: pass | Evidence: incidents gate, ACR gate, package builds, tarball policy, and blueprint release gate passed | Scope: v0.6.1 publish exact-ref validation.
+    Command: node scripts/check-release-version.mjs --tag v0.6.1 and node scripts/check-release-notes.mjs --tag v0.6.1 | Result: pass | Evidence: both exited 0 | Scope: version and release notes parity.
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605150000-GNXMCA-fix-v061-publish-payload/.agentplane/tasks/202605150000-GNXMCA/blueprint/resolved-snapshot.json
+    - old_digest: 78fcea3addd639bcd39aaa1b9d201552f50ebab498cadfffeabbe872288610b2
+    - current_digest: 78fcea3addd639bcd39aaa1b9d201552f50ebab498cadfffeabbe872288610b2
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605150000-GNXMCA
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Fix v0.6.1 publish payload drift
+
+Update the release payload fixtures so the v0.6.1 publish workflow passes exact-ref validation, then resume publication verification.
+
+## Scope
+
+- In scope: Update the release payload fixtures so the v0.6.1 publish workflow passes exact-ref validation, then resume publication verification.
+- Out of scope: unrelated refactors not required for "Fix v0.6.1 publish payload drift".
+
+## Plan
+
+Plan: fix v0.6.1 exact-ref publish validation by updating only stale release payload fixture versions first; run node scripts/checks/check-acr-example-version.mjs, bun run release:check, and targeted release metadata checks; open a small branch_pr PR; after merge, dispatch Publish release with the canonical release SHA and verify external distribution surfaces.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-15T00:02:00.386Z — VERIFY — ok
+
+By: CODER
+
+Note: Release checks passed after updating ACR example payload to 0.6.1.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-15T00:00:33.722Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+Command: node scripts/checks/check-acr-example-version.mjs | Result: pass | Evidence: ACR example version OK (0.6.1) | Scope: packages/spec/examples/acr.json release payload.
+Command: bun run release:check | Result: pass | Evidence: incidents gate, ACR gate, package builds, tarball policy, and blueprint release gate passed | Scope: v0.6.1 publish exact-ref validation.
+Command: node scripts/check-release-version.mjs --tag v0.6.1 and node scripts/check-release-notes.mjs --tag v0.6.1 | Result: pass | Evidence: both exited 0 | Scope: version and release notes parity.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605150000-GNXMCA-fix-v061-publish-payload/.agentplane/tasks/202605150000-GNXMCA/blueprint/resolved-snapshot.json
+- old_digest: 78fcea3addd639bcd39aaa1b9d201552f50ebab498cadfffeabbe872288610b2
+- current_digest: 78fcea3addd639bcd39aaa1b9d201552f50ebab498cadfffeabbe872288610b2
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605150000-GNXMCA
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605150000-GNXMCA/pr/diffstat.txt
+++ b/.agentplane/tasks/202605150000-GNXMCA/pr/diffstat.txt
@@ -1,0 +1,2 @@
+ packages/spec/examples/acr.json | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)

--- a/.agentplane/tasks/202605150000-GNXMCA/pr/github-body.md
+++ b/.agentplane/tasks/202605150000-GNXMCA/pr/github-body.md
@@ -1,0 +1,34 @@
+Task: `202605150000-GNXMCA`
+Title: Fix v0.6.1 publish payload drift
+Canonical task record: `.agentplane/tasks/202605150000-GNXMCA/README.md`
+
+## Summary
+
+Fix v0.6.1 publish payload drift
+
+Update the release payload fixtures so the v0.6.1 publish workflow passes exact-ref validation, then resume publication verification.
+
+## Scope
+
+- In scope: Update the release payload fixtures so the v0.6.1 publish workflow passes exact-ref validation, then resume publication verification.
+- Out of scope: unrelated refactors not required for "Fix v0.6.1 publish payload drift".
+
+## Verification
+
+- State: ok
+- Note: Release checks passed after updating ACR example payload to 0.6.1.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-15T00:02:00.415Z
+- Branch: task/202605150000-GNXMCA/fix-v061-publish-payload
+- Head: 3507111dfd82
+
+```text
+ packages/spec/examples/acr.json | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605150000-GNXMCA/pr/github-title.txt
+++ b/.agentplane/tasks/202605150000-GNXMCA/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 GNXMCA task: Fix v0.6.1 publish payload drift [202605150000-GNXMCA]

--- a/.agentplane/tasks/202605150000-GNXMCA/pr/meta.json
+++ b/.agentplane/tasks/202605150000-GNXMCA/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605150000-GNXMCA/fix-v061-publish-payload",
+  "created_at": "2026-05-15T00:00:33.761Z",
+  "head_sha": "3507111dfd82eb271e54e99b7208b227f5c784ce",
+  "last_verified_at": "2026-05-15T00:02:00.386Z",
+  "last_verified_sha": "3507111dfd82eb271e54e99b7208b227f5c784ce",
+  "schema_version": 1,
+  "task_id": "202605150000-GNXMCA",
+  "updated_at": "2026-05-15T00:02:00.415Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605150000-GNXMCA/pr/review.md
+++ b/.agentplane/tasks/202605150000-GNXMCA/pr/review.md
@@ -1,0 +1,37 @@
+# PR Review
+
+Created: 2026-05-15T00:00:33.761Z
+
+## Task
+
+- Task: `202605150000-GNXMCA`
+- Title: Fix v0.6.1 publish payload drift
+- Status: DOING
+- Branch: `task/202605150000-GNXMCA/fix-v061-publish-payload`
+- Canonical task record: `.agentplane/tasks/202605150000-GNXMCA/README.md`
+
+## Verification
+
+- State: ok
+- Note: Release checks passed after updating ACR example payload to 0.6.1.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-15T00:02:00.415Z
+- Branch: task/202605150000-GNXMCA/fix-v061-publish-payload
+- Head: 3507111dfd82
+
+```text
+ packages/spec/examples/acr.json | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/spec/examples/acr.json
+++ b/packages/spec/examples/acr.json
@@ -5,7 +5,7 @@
   "created_at": "2026-05-03T12:00:00.000Z",
   "producer": {
     "name": "agentplane",
-    "version": "0.6.0"
+    "version": "0.6.1"
   },
   "repository": {
     "vcs": "git",
@@ -31,7 +31,7 @@
     "toolchain": [
       {
         "name": "agentplane",
-        "version": "0.6.0"
+        "version": "0.6.1"
       }
     ]
   },


### PR DESCRIPTION
Task: `202605150000-GNXMCA`
Title: Fix v0.6.1 publish payload drift
Canonical task record: `.agentplane/tasks/202605150000-GNXMCA/README.md`

## Summary

Fix v0.6.1 publish payload drift

Update the release payload fixtures so the v0.6.1 publish workflow passes exact-ref validation, then resume publication verification.

## Scope

- In scope: Update the release payload fixtures so the v0.6.1 publish workflow passes exact-ref validation, then resume publication verification.
- Out of scope: unrelated refactors not required for "Fix v0.6.1 publish payload drift".

## Verification

- State: ok
- Note: Release checks passed after updating ACR example payload to 0.6.1.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-15T00:02:00.415Z
- Branch: task/202605150000-GNXMCA/fix-v061-publish-payload
- Head: 3507111dfd82

```text
 packages/spec/examples/acr.json | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

</details>
