### PR TITLE
🚧 ESJ0SW task: Add portable context assimilation prompts [202605170721-ESJ0SW]

### DIFF
--- a/.agentplane/tasks/202605170721-BTF484/README.md
+++ b/.agentplane/tasks/202605170721-BTF484/README.md
@@ -1,0 +1,146 @@
+---
+id: "202605170721-BTF484"
+title: "Add llm-wiki page metadata and helper commands"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "cli"
+  - "code"
+  - "context"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-17T07:23:17.799Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-17T07:37:07.934Z"
+  updated_by: "CODER"
+  note: "Implemented context wiki helper commands for new/lint/explain/link with frontmatter manifest; verified directory lint regression and temp-dir CLI smoke."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Implement wiki page metadata and helper command behavior within the approved adaptive context curation batch worktree."
+events:
+  -
+    type: "status"
+    at: "2026-05-17T07:26:08.448Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Implement wiki page metadata and helper command behavior within the approved adaptive context curation batch worktree."
+  -
+    type: "verify"
+    at: "2026-05-17T07:37:07.934Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented context wiki helper commands for new/lint/explain/link with frontmatter manifest; verified directory lint regression and temp-dir CLI smoke."
+doc_version: 3
+doc_updated_at: "2026-05-17T07:37:07.950Z"
+doc_updated_by: "CODER"
+description: "Introduce a stable wiki page frontmatter contract plus CLI helpers for creating, linting, linking, explaining, and querying context wiki pages and claims."
+sections:
+  Summary: |-
+    Add llm-wiki page metadata and helper commands
+    
+    Introduce a stable wiki page frontmatter contract plus CLI helpers for creating, linting, linking, explaining, and querying context wiki pages and claims.
+  Scope: |-
+    - In scope: Introduce a stable wiki page frontmatter contract plus CLI helpers for creating, linting, linking, explaining, and querying context wiki pages and claims.
+    - Out of scope: unrelated refactors not required for "Add llm-wiki page metadata and helper commands".
+  Plan: "Add a stable wiki page metadata/frontmatter contract and helper CLI surfaces that let agents create, inspect, lint, and link wiki pages without inventing page manifests. Keep storage cloud-ready by treating markdown pages as context artifacts that reference atomic claims/entities/sources instead of replacing the claim layer."
+  Verify Steps: |-
+    1. bun test packages/agentplane/src/commands/context/context.spec.ts packages/agentplane/src/commands/context/context.learn.spec.ts
+    2. Run focused manual smoke for context wiki helper commands with --help or dry-run style paths where implemented.
+    3. node .agentplane/policy/check-routing.mjs
+    4. git diff --check
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-17T07:37:07.934Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Implemented context wiki helper commands for new/lint/explain/link with frontmatter manifest; verified directory lint regression and temp-dir CLI smoke.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T07:26:08.448Z, excerpt_hash=sha256:3710ab82c39103151926d6955c397cae1b50dcf70532226228015930e95aa232
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605170721-ESJ0SW-adaptive-context-curation/.agentplane/tasks/202605170721-BTF484/blueprint/resolved-snapshot.json
+    - old_digest: ad49f7dc04eebcd10f9a7571a1154bd5203f7f868825c8502742367e879d5f7c
+    - current_digest: ad49f7dc04eebcd10f9a7571a1154bd5203f7f868825c8502742367e879d5f7c
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605170721-BTF484
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add llm-wiki page metadata and helper commands
+
+Introduce a stable wiki page frontmatter contract plus CLI helpers for creating, linting, linking, explaining, and querying context wiki pages and claims.
+
+## Scope
+
+- In scope: Introduce a stable wiki page frontmatter contract plus CLI helpers for creating, linting, linking, explaining, and querying context wiki pages and claims.
+- Out of scope: unrelated refactors not required for "Add llm-wiki page metadata and helper commands".
+
+## Plan
+
+Add a stable wiki page metadata/frontmatter contract and helper CLI surfaces that let agents create, inspect, lint, and link wiki pages without inventing page manifests. Keep storage cloud-ready by treating markdown pages as context artifacts that reference atomic claims/entities/sources instead of replacing the claim layer.
+
+## Verify Steps
+
+1. bun test packages/agentplane/src/commands/context/context.spec.ts packages/agentplane/src/commands/context/context.learn.spec.ts
+2. Run focused manual smoke for context wiki helper commands with --help or dry-run style paths where implemented.
+3. node .agentplane/policy/check-routing.mjs
+4. git diff --check
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-17T07:37:07.934Z — VERIFY — ok
+
+By: CODER
+
+Note: Implemented context wiki helper commands for new/lint/explain/link with frontmatter manifest; verified directory lint regression and temp-dir CLI smoke.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T07:26:08.448Z, excerpt_hash=sha256:3710ab82c39103151926d6955c397cae1b50dcf70532226228015930e95aa232
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605170721-ESJ0SW-adaptive-context-curation/.agentplane/tasks/202605170721-BTF484/blueprint/resolved-snapshot.json
+- old_digest: ad49f7dc04eebcd10f9a7571a1154bd5203f7f868825c8502742367e879d5f7c
+- current_digest: ad49f7dc04eebcd10f9a7571a1154bd5203f7f868825c8502742367e879d5f7c
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605170721-BTF484
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605170721-BTF484/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605170721-BTF484/blueprint/resolved-snapshot.json
@@ -1,0 +1,535 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605170721-BTF484",
+    "title": "Add llm-wiki page metadata and helper commands",
+    "description": "Introduce a stable wiki page frontmatter contract plus CLI helpers for creating, linting, linking, explaining, and querying context wiki pages and claims.",
+    "tags": [
+      "cli",
+      "code",
+      "context"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605170721-BTF484",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "ad49f7dc04eebcd10f9a7571a1154bd5203f7f868825c8502742367e879d5f7c"
+  }
+}

--- a/.agentplane/tasks/202605170721-BY03BX/README.md
+++ b/.agentplane/tasks/202605170721-BY03BX/README.md
@@ -1,0 +1,146 @@
+---
+id: "202605170721-BY03BX"
+title: "Make context init guide adaptive wiki setup"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "context"
+  - "init"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-17T07:23:24.728Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-17T07:37:08.987Z"
+  updated_by: "CODER"
+  note: "Updated context init adaptive profile and generated manifest/readme/AGENTS guidance for llm-wiki setup; verified generated CLI reference and focused tests."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Align context init starter artifacts with a single adaptive llm-wiki contract while preserving noninteractive defaults."
+events:
+  -
+    type: "status"
+    at: "2026-05-17T07:26:20.557Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Align context init starter artifacts with a single adaptive llm-wiki contract while preserving noninteractive defaults."
+  -
+    type: "verify"
+    at: "2026-05-17T07:37:08.987Z"
+    author: "CODER"
+    state: "ok"
+    note: "Updated context init adaptive profile and generated manifest/readme/AGENTS guidance for llm-wiki setup; verified generated CLI reference and focused tests."
+doc_version: 3
+doc_updated_at: "2026-05-17T07:37:09.002Z"
+doc_updated_by: "CODER"
+description: "Align context init with the single adaptive llm-wiki contract, preserving noninteractive defaults while documenting and preparing an interactive setup path for durable cloud-ready metadata."
+sections:
+  Summary: |-
+    Make context init guide adaptive wiki setup
+    
+    Align context init with the single adaptive llm-wiki contract, preserving noninteractive defaults while documenting and preparing an interactive setup path for durable cloud-ready metadata.
+  Scope: |-
+    - In scope: Align context init with the single adaptive llm-wiki contract, preserving noninteractive defaults while documenting and preparing an interactive setup path for durable cloud-ready metadata.
+    - Out of scope: unrelated refactors not required for "Make context init guide adaptive wiki setup".
+  Plan: "Update context init behavior and docs toward a single adaptive llm-wiki contract. Preserve safe noninteractive defaults, avoid incompatible profile schemas, and make starter artifacts explain markdown frontmatter, claims, provenance, cross-links, private raw data, and future publication metadata."
+  Verify Steps: |-
+    1. bun test packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/commands/context/context.spec.ts
+    2. Verify context init docs/help still describe safe noninteractive defaults and adaptive llm-wiki setup.
+    3. node .agentplane/policy/check-routing.mjs
+    4. git diff --check
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-17T07:37:08.987Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Updated context init adaptive profile and generated manifest/readme/AGENTS guidance for llm-wiki setup; verified generated CLI reference and focused tests.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T07:26:20.557Z, excerpt_hash=sha256:498dc54efe5cd21a0171c9831fb43f688070a069a6976e536c5e3694dd899436
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605170721-ESJ0SW-adaptive-context-curation/.agentplane/tasks/202605170721-BY03BX/blueprint/resolved-snapshot.json
+    - old_digest: 66aaaa9e2205dd99b2c6e50ec6159b62dfe10ba60c41ba901eb2b75e884d9c52
+    - current_digest: 66aaaa9e2205dd99b2c6e50ec6159b62dfe10ba60c41ba901eb2b75e884d9c52
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605170721-BY03BX
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Make context init guide adaptive wiki setup
+
+Align context init with the single adaptive llm-wiki contract, preserving noninteractive defaults while documenting and preparing an interactive setup path for durable cloud-ready metadata.
+
+## Scope
+
+- In scope: Align context init with the single adaptive llm-wiki contract, preserving noninteractive defaults while documenting and preparing an interactive setup path for durable cloud-ready metadata.
+- Out of scope: unrelated refactors not required for "Make context init guide adaptive wiki setup".
+
+## Plan
+
+Update context init behavior and docs toward a single adaptive llm-wiki contract. Preserve safe noninteractive defaults, avoid incompatible profile schemas, and make starter artifacts explain markdown frontmatter, claims, provenance, cross-links, private raw data, and future publication metadata.
+
+## Verify Steps
+
+1. bun test packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/commands/context/context.spec.ts
+2. Verify context init docs/help still describe safe noninteractive defaults and adaptive llm-wiki setup.
+3. node .agentplane/policy/check-routing.mjs
+4. git diff --check
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-17T07:37:08.987Z — VERIFY — ok
+
+By: CODER
+
+Note: Updated context init adaptive profile and generated manifest/readme/AGENTS guidance for llm-wiki setup; verified generated CLI reference and focused tests.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T07:26:20.557Z, excerpt_hash=sha256:498dc54efe5cd21a0171c9831fb43f688070a069a6976e536c5e3694dd899436
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605170721-ESJ0SW-adaptive-context-curation/.agentplane/tasks/202605170721-BY03BX/blueprint/resolved-snapshot.json
+- old_digest: 66aaaa9e2205dd99b2c6e50ec6159b62dfe10ba60c41ba901eb2b75e884d9c52
+- current_digest: 66aaaa9e2205dd99b2c6e50ec6159b62dfe10ba60c41ba901eb2b75e884d9c52
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605170721-BY03BX
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605170721-BY03BX/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605170721-BY03BX/blueprint/resolved-snapshot.json
@@ -1,0 +1,535 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605170721-BY03BX",
+    "title": "Make context init guide adaptive wiki setup",
+    "description": "Align context init with the single adaptive llm-wiki contract, preserving noninteractive defaults while documenting and preparing an interactive setup path for durable cloud-ready metadata.",
+    "tags": [
+      "code",
+      "context",
+      "init"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605170721-BY03BX",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "66aaaa9e2205dd99b2c6e50ec6159b62dfe10ba60c41ba901eb2b75e884d9c52"
+  }
+}

--- a/.agentplane/tasks/202605170721-ESJ0SW/README.md
+++ b/.agentplane/tasks/202605170721-ESJ0SW/README.md
@@ -1,0 +1,146 @@
+---
+id: "202605170721-ESJ0SW"
+title: "Add portable context assimilation prompts"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "cli"
+  - "code"
+  - "context"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-17T07:23:07.710Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-17T07:37:06.075Z"
+  updated_by: "CODER"
+  note: "Implemented portable context assimilation prompt module and adaptive wiki task contract; verified with focused context tests, typecheck, CLI docs check, policy routing, diff check, and temp-dir wiki CLI smoke."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Implement adaptive context curation batch in the primary task worktree, covering portable context prompts, wiki metadata helpers, adaptive init, docs, and focused tests for related task IDs."
+events:
+  -
+    type: "status"
+    at: "2026-05-17T07:25:58.955Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Implement adaptive context curation batch in the primary task worktree, covering portable context prompts, wiki metadata helpers, adaptive init, docs, and focused tests for related task IDs."
+  -
+    type: "verify"
+    at: "2026-05-17T07:37:06.075Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented portable context assimilation prompt module and adaptive wiki task contract; verified with focused context tests, typecheck, CLI docs check, policy routing, diff check, and temp-dir wiki CLI smoke."
+doc_version: 3
+doc_updated_at: "2026-05-17T07:37:06.084Z"
+doc_updated_by: "CODER"
+description: "Make context learn files/changes create self-contained CURATOR tasks with an embedded context_assimilation prompt module and task-readable wiki/claim/cross-link contract for non-runner agents."
+sections:
+  Summary: |-
+    Add portable context assimilation prompts
+    
+    Make context learn files/changes create self-contained CURATOR tasks with an embedded context_assimilation prompt module and task-readable wiki/claim/cross-link contract for non-runner agents.
+  Scope: |-
+    - In scope: Make context learn files/changes create self-contained CURATOR tasks with an embedded context_assimilation prompt module and task-readable wiki/claim/cross-link contract for non-runner agents.
+    - Out of scope: unrelated refactors not required for "Add portable context assimilation prompts".
+  Plan: "Primary batch task for adaptive llm-wiki curation. Implement a reusable context_assimilation prompt module for learn files/changes, embed it into generated task extensions, and make generated task README content sufficient for non-runner agents. Included related tasks in this batch: 202605170721-BTF484, 202605170721-BY03BX, 202605170722-YP81RG. Verify with focused context command tests, type/lint checks if available, docs generation checks when touched, and policy routing."
+  Verify Steps: |-
+    1. bun test packages/agentplane/src/commands/context/ingest.spec.ts packages/agentplane/src/commands/context/context.learn.spec.ts
+    2. bun test packages/agentplane/src/commands/context/context.spec.ts
+    3. node .agentplane/policy/check-routing.mjs
+    4. git diff --check
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-17T07:37:06.075Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Implemented portable context assimilation prompt module and adaptive wiki task contract; verified with focused context tests, typecheck, CLI docs check, policy routing, diff check, and temp-dir wiki CLI smoke.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T07:25:58.955Z, excerpt_hash=sha256:51dab77a4ea9a67d91a1743ce333226a5b697607d7bd609f177d1a43dd66ab8e
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605170721-ESJ0SW-adaptive-context-curation/.agentplane/tasks/202605170721-ESJ0SW/blueprint/resolved-snapshot.json
+    - old_digest: 7058bc199fca37d553bc375308a245011cb42cc940277d531ceb485363543c95
+    - current_digest: 7058bc199fca37d553bc375308a245011cb42cc940277d531ceb485363543c95
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605170721-ESJ0SW
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add portable context assimilation prompts
+
+Make context learn files/changes create self-contained CURATOR tasks with an embedded context_assimilation prompt module and task-readable wiki/claim/cross-link contract for non-runner agents.
+
+## Scope
+
+- In scope: Make context learn files/changes create self-contained CURATOR tasks with an embedded context_assimilation prompt module and task-readable wiki/claim/cross-link contract for non-runner agents.
+- Out of scope: unrelated refactors not required for "Add portable context assimilation prompts".
+
+## Plan
+
+Primary batch task for adaptive llm-wiki curation. Implement a reusable context_assimilation prompt module for learn files/changes, embed it into generated task extensions, and make generated task README content sufficient for non-runner agents. Included related tasks in this batch: 202605170721-BTF484, 202605170721-BY03BX, 202605170722-YP81RG. Verify with focused context command tests, type/lint checks if available, docs generation checks when touched, and policy routing.
+
+## Verify Steps
+
+1. bun test packages/agentplane/src/commands/context/ingest.spec.ts packages/agentplane/src/commands/context/context.learn.spec.ts
+2. bun test packages/agentplane/src/commands/context/context.spec.ts
+3. node .agentplane/policy/check-routing.mjs
+4. git diff --check
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-17T07:37:06.075Z — VERIFY — ok
+
+By: CODER
+
+Note: Implemented portable context assimilation prompt module and adaptive wiki task contract; verified with focused context tests, typecheck, CLI docs check, policy routing, diff check, and temp-dir wiki CLI smoke.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T07:25:58.955Z, excerpt_hash=sha256:51dab77a4ea9a67d91a1743ce333226a5b697607d7bd609f177d1a43dd66ab8e
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605170721-ESJ0SW-adaptive-context-curation/.agentplane/tasks/202605170721-ESJ0SW/blueprint/resolved-snapshot.json
+- old_digest: 7058bc199fca37d553bc375308a245011cb42cc940277d531ceb485363543c95
+- current_digest: 7058bc199fca37d553bc375308a245011cb42cc940277d531ceb485363543c95
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605170721-ESJ0SW
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605170721-ESJ0SW/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605170721-ESJ0SW/blueprint/resolved-snapshot.json
@@ -1,0 +1,535 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605170721-ESJ0SW",
+    "title": "Add portable context assimilation prompts",
+    "description": "Make context learn files/changes create self-contained CURATOR tasks with an embedded context_assimilation prompt module and task-readable wiki/claim/cross-link contract for non-runner agents.",
+    "tags": [
+      "cli",
+      "code",
+      "context"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605170721-ESJ0SW",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "7058bc199fca37d553bc375308a245011cb42cc940277d531ceb485363543c95"
+  }
+}

--- a/.agentplane/tasks/202605170721-ESJ0SW/pr/diffstat.txt
+++ b/.agentplane/tasks/202605170721-ESJ0SW/pr/diffstat.txt
@@ -1,0 +1,18 @@
+ .agentplane/tasks/202605170721-BTF484/README.md    | 146 ++++++
+ .../blueprint/resolved-snapshot.json               | 535 +++++++++++++++++++++
+ .agentplane/tasks/202605170721-BY03BX/README.md    | 146 ++++++
+ .../blueprint/resolved-snapshot.json               | 535 +++++++++++++++++++++
+ .../blueprint/resolved-snapshot.json               | 535 +++++++++++++++++++++
+ .agentplane/tasks/202605170722-YP81RG/README.md    | 145 ++++++
+ .../blueprint/resolved-snapshot.json               | 534 ++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |  55 ++-
+ docs/user/commands.mdx                             |  10 +
+ docs/user/local-context.mdx                        |  29 ++
+ .../src/cli/run-cli/command-catalog/project.ts     |  10 +
+ .../src/commands/context/context.command.ts        |  61 +++
+ .../src/commands/context/context.spec.ts           | 117 ++++-
+ packages/agentplane/src/commands/context/init.ts   |  57 ++-
+ .../src/commands/context/release-readiness.test.ts |  56 +++
+ packages/agentplane/src/commands/context/wiki.ts   | 342 +++++++++++++
+ packages/agentplane/src/context/ingest-task.ts     | 103 ++++
+ 17 files changed, 3406 insertions(+), 10 deletions(-)

--- a/.agentplane/tasks/202605170721-ESJ0SW/pr/github-body.md
+++ b/.agentplane/tasks/202605170721-ESJ0SW/pr/github-body.md
@@ -1,0 +1,39 @@
+Task: `202605170721-ESJ0SW`
+Title: Add portable context assimilation prompts
+Canonical task record: `.agentplane/tasks/202605170721-ESJ0SW/README.md`
+
+## Summary
+
+Add portable context assimilation prompts
+
+Make context learn files/changes create self-contained CURATOR tasks with an embedded context_assimilation prompt module and task-readable wiki/claim/cross-link contract for non-runner agents.
+
+## Scope
+
+- In scope: Make context learn files/changes create self-contained CURATOR tasks with an embedded context_assimilation prompt module and task-readable wiki/claim/cross-link contract for non-runner agents.
+- Out of scope: unrelated refactors not required for "Add portable context assimilation prompts".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Implemented portable context assimilation prompt module and adaptive wiki task contract; verified
+with focused context tests, typecheck, CLI docs check, policy routing, diff check, and temp-dir wiki
+CLI smoke.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-17T07:25:59.347Z
+- Branch: task/202605170721-ESJ0SW/adaptive-context-curation
+- Head: a0d52cc0c3c7
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605170721-ESJ0SW/pr/github-body.md
+++ b/.agentplane/tasks/202605170721-ESJ0SW/pr/github-body.md
@@ -28,12 +28,29 @@ CLI smoke.
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-17T07:25:59.347Z
+- Updated: 2026-05-17T07:38:27.778Z
 - Branch: task/202605170721-ESJ0SW/adaptive-context-curation
-- Head: a0d52cc0c3c7
+- Head: 52891c9f5915
 
 ```text
-No changes detected.
+ .agentplane/tasks/202605170721-BTF484/README.md    | 146 ++++++
+ .../blueprint/resolved-snapshot.json               | 535 +++++++++++++++++++++
+ .agentplane/tasks/202605170721-BY03BX/README.md    | 146 ++++++
+ .../blueprint/resolved-snapshot.json               | 535 +++++++++++++++++++++
+ .../blueprint/resolved-snapshot.json               | 535 +++++++++++++++++++++
+ .agentplane/tasks/202605170722-YP81RG/README.md    | 145 ++++++
+ .../blueprint/resolved-snapshot.json               | 534 ++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |  55 ++-
+ docs/user/commands.mdx                             |  10 +
+ docs/user/local-context.mdx                        |  29 ++
+ .../src/cli/run-cli/command-catalog/project.ts     |  10 +
+ .../src/commands/context/context.command.ts        |  61 +++
+ .../src/commands/context/context.spec.ts           | 117 ++++-
+ packages/agentplane/src/commands/context/init.ts   |  57 ++-
+ .../src/commands/context/release-readiness.test.ts |  56 +++
+ packages/agentplane/src/commands/context/wiki.ts   | 342 +++++++++++++
+ packages/agentplane/src/context/ingest-task.ts     | 103 ++++
+ 17 files changed, 3406 insertions(+), 10 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605170721-ESJ0SW/pr/github-title.txt
+++ b/.agentplane/tasks/202605170721-ESJ0SW/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 ESJ0SW task: Add portable context assimilation prompts [202605170721-ESJ0SW]

--- a/.agentplane/tasks/202605170721-ESJ0SW/pr/meta.json
+++ b/.agentplane/tasks/202605170721-ESJ0SW/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605170721-ESJ0SW/adaptive-context-curation",
   "created_at": "2026-05-17T07:25:59.347Z",
-  "head_sha": "a0d52cc0c3c779b297238870ecc9e15488d9cf1a",
+  "head_sha": "52891c9f5915ce22aa72c93aee303029a15d50d9",
   "last_verified_at": "2026-05-17T07:37:06.075Z",
   "last_verified_sha": "a0d52cc0c3c779b297238870ecc9e15488d9cf1a",
   "schema_version": 1,
   "task_id": "202605170721-ESJ0SW",
-  "updated_at": "2026-05-17T07:25:59.347Z",
+  "updated_at": "2026-05-17T07:38:27.778Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605170721-ESJ0SW/pr/meta.json
+++ b/.agentplane/tasks/202605170721-ESJ0SW/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605170721-ESJ0SW/adaptive-context-curation",
+  "created_at": "2026-05-17T07:25:59.347Z",
+  "head_sha": "a0d52cc0c3c779b297238870ecc9e15488d9cf1a",
+  "last_verified_at": "2026-05-17T07:37:06.075Z",
+  "last_verified_sha": "a0d52cc0c3c779b297238870ecc9e15488d9cf1a",
+  "schema_version": 1,
+  "task_id": "202605170721-ESJ0SW",
+  "updated_at": "2026-05-17T07:25:59.347Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605170721-ESJ0SW/pr/review.md
+++ b/.agentplane/tasks/202605170721-ESJ0SW/pr/review.md
@@ -24,12 +24,29 @@ Created: 2026-05-17T07:25:59.347Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-17T07:25:59.347Z
+- Updated: 2026-05-17T07:38:27.778Z
 - Branch: task/202605170721-ESJ0SW/adaptive-context-curation
-- Head: a0d52cc0c3c7
+- Head: 52891c9f5915
 
 ```text
-No changes detected.
+ .agentplane/tasks/202605170721-BTF484/README.md    | 146 ++++++
+ .../blueprint/resolved-snapshot.json               | 535 +++++++++++++++++++++
+ .agentplane/tasks/202605170721-BY03BX/README.md    | 146 ++++++
+ .../blueprint/resolved-snapshot.json               | 535 +++++++++++++++++++++
+ .../blueprint/resolved-snapshot.json               | 535 +++++++++++++++++++++
+ .agentplane/tasks/202605170722-YP81RG/README.md    | 145 ++++++
+ .../blueprint/resolved-snapshot.json               | 534 ++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |  55 ++-
+ docs/user/commands.mdx                             |  10 +
+ docs/user/local-context.mdx                        |  29 ++
+ .../src/cli/run-cli/command-catalog/project.ts     |  10 +
+ .../src/commands/context/context.command.ts        |  61 +++
+ .../src/commands/context/context.spec.ts           | 117 ++++-
+ packages/agentplane/src/commands/context/init.ts   |  57 ++-
+ .../src/commands/context/release-readiness.test.ts |  56 +++
+ packages/agentplane/src/commands/context/wiki.ts   | 342 +++++++++++++
+ packages/agentplane/src/context/ingest-task.ts     | 103 ++++
+ 17 files changed, 3406 insertions(+), 10 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605170721-ESJ0SW/pr/review.md
+++ b/.agentplane/tasks/202605170721-ESJ0SW/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-17T07:25:59.347Z
+
+## Task
+
+- Task: `202605170721-ESJ0SW`
+- Title: Add portable context assimilation prompts
+- Status: DOING
+- Branch: `task/202605170721-ESJ0SW/adaptive-context-curation`
+- Canonical task record: `.agentplane/tasks/202605170721-ESJ0SW/README.md`
+
+## Verification
+
+- State: ok
+- Note: Implemented portable context assimilation prompt module and adaptive wiki task contract; verified with focused context tests, typecheck, CLI docs check, policy routing, diff check, and temp-dir wiki CLI smoke.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-17T07:25:59.347Z
+- Branch: task/202605170721-ESJ0SW/adaptive-context-curation
+- Head: a0d52cc0c3c7
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605170722-YP81RG/README.md
+++ b/.agentplane/tasks/202605170722-YP81RG/README.md
@@ -1,0 +1,145 @@
+---
+id: "202605170722-YP81RG"
+title: "Document and test adaptive context curation flow"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "context"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-17T07:23:29.588Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-17T07:37:09.984Z"
+  updated_by: "CODER"
+  note: "Updated user docs and generated CLI reference for adaptive context curation flow; docs:cli:check, policy routing, diff check, typecheck, and focused tests pass."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Update docs and regression coverage for the unified adaptive context curation workflow in the batch worktree."
+events:
+  -
+    type: "status"
+    at: "2026-05-17T07:26:28.821Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Update docs and regression coverage for the unified adaptive context curation workflow in the batch worktree."
+  -
+    type: "verify"
+    at: "2026-05-17T07:37:09.984Z"
+    author: "CODER"
+    state: "ok"
+    note: "Updated user docs and generated CLI reference for adaptive context curation flow; docs:cli:check, policy routing, diff check, typecheck, and focused tests pass."
+doc_version: 3
+doc_updated_at: "2026-05-17T07:37:10.000Z"
+doc_updated_by: "CODER"
+description: "Update docs and focused regression tests so context learn, wiki metadata helpers, and adaptive context init are documented as one cloud-ready llm-wiki curation workflow."
+sections:
+  Summary: |-
+    Document and test adaptive context curation flow
+    
+    Update docs and focused regression tests so context learn, wiki metadata helpers, and adaptive context init are documented as one cloud-ready llm-wiki curation workflow.
+  Scope: |-
+    - In scope: Update docs and focused regression tests so context learn, wiki metadata helpers, and adaptive context init are documented as one cloud-ready llm-wiki curation workflow.
+    - Out of scope: unrelated refactors not required for "Document and test adaptive context curation flow".
+  Plan: "Update focused docs and regression coverage so the adaptive context curation workflow is visible: learn files/changes creates portable CURATOR tasks, learn tasks uses the same mental model for task-history ADR/evolution extraction, wiki pages carry frontmatter, helper commands exist for agent ergonomics, and verification covers task generation plus wiki lint behavior."
+  Verify Steps: |-
+    1. bun test packages/agentplane/src/commands/context/ingest.spec.ts packages/agentplane/src/commands/context/context.learn.spec.ts packages/agentplane/src/commands/context/release-readiness.test.ts
+    2. Verify docs/user/local-context.mdx and docs/user/commands.mdx align with generated CLI behavior.
+    3. node .agentplane/policy/check-routing.mjs
+    4. git diff --check
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-17T07:37:09.984Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Updated user docs and generated CLI reference for adaptive context curation flow; docs:cli:check, policy routing, diff check, typecheck, and focused tests pass.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T07:26:28.821Z, excerpt_hash=sha256:b63910211981e9de98be7d3aa5be2f7ffe93f38a2f73c9357082a701c68bff53
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605170721-ESJ0SW-adaptive-context-curation/.agentplane/tasks/202605170722-YP81RG/blueprint/resolved-snapshot.json
+    - old_digest: 2354d4af8c002e90fa8731235f93a61f55b5229f4064d3f567c9ede8bf704f92
+    - current_digest: 2354d4af8c002e90fa8731235f93a61f55b5229f4064d3f567c9ede8bf704f92
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605170722-YP81RG
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Document and test adaptive context curation flow
+
+Update docs and focused regression tests so context learn, wiki metadata helpers, and adaptive context init are documented as one cloud-ready llm-wiki curation workflow.
+
+## Scope
+
+- In scope: Update docs and focused regression tests so context learn, wiki metadata helpers, and adaptive context init are documented as one cloud-ready llm-wiki curation workflow.
+- Out of scope: unrelated refactors not required for "Document and test adaptive context curation flow".
+
+## Plan
+
+Update focused docs and regression coverage so the adaptive context curation workflow is visible: learn files/changes creates portable CURATOR tasks, learn tasks uses the same mental model for task-history ADR/evolution extraction, wiki pages carry frontmatter, helper commands exist for agent ergonomics, and verification covers task generation plus wiki lint behavior.
+
+## Verify Steps
+
+1. bun test packages/agentplane/src/commands/context/ingest.spec.ts packages/agentplane/src/commands/context/context.learn.spec.ts packages/agentplane/src/commands/context/release-readiness.test.ts
+2. Verify docs/user/local-context.mdx and docs/user/commands.mdx align with generated CLI behavior.
+3. node .agentplane/policy/check-routing.mjs
+4. git diff --check
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-17T07:37:09.984Z — VERIFY — ok
+
+By: CODER
+
+Note: Updated user docs and generated CLI reference for adaptive context curation flow; docs:cli:check, policy routing, diff check, typecheck, and focused tests pass.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T07:26:28.821Z, excerpt_hash=sha256:b63910211981e9de98be7d3aa5be2f7ffe93f38a2f73c9357082a701c68bff53
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605170721-ESJ0SW-adaptive-context-curation/.agentplane/tasks/202605170722-YP81RG/blueprint/resolved-snapshot.json
+- old_digest: 2354d4af8c002e90fa8731235f93a61f55b5229f4064d3f567c9ede8bf704f92
+- current_digest: 2354d4af8c002e90fa8731235f93a61f55b5229f4064d3f567c9ede8bf704f92
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605170722-YP81RG
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605170722-YP81RG/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605170722-YP81RG/blueprint/resolved-snapshot.json
@@ -1,0 +1,534 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605170722-YP81RG",
+    "title": "Document and test adaptive context curation flow",
+    "description": "Update docs and focused regression tests so context learn, wiki metadata helpers, and adaptive context init are documented as one cloud-ready llm-wiki curation workflow.",
+    "tags": [
+      "code",
+      "context"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605170722-YP81RG",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "2354d4af8c002e90fa8731235f93a61f55b5229f4064d3f567c9ede8bf704f92"
+  }
+}

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -135,6 +135,10 @@ This page is generated from the CLI command specs. Do not edit it by hand; edit 
   - [context learn tasks](#context-learn-tasks)
   - [context search](#context-search)
   - [context show](#context-show)
+  - [context wiki explain](#context-wiki-explain)
+  - [context wiki link](#context-wiki-link)
+  - [context wiki lint](#context-wiki-lint)
+  - [context wiki new](#context-wiki-new)
 - Evaluators
   - [evaluator list](#evaluator-list)
   - [evaluator show](#evaluator-show)
@@ -3235,7 +3239,7 @@ agentplane context init [options]
 
 Options:
 
-- `--profile <minimal|wiki|codebase|research>`: Select an initial context profile. (choices=minimal|wiki|codebase|research, default=wiki)
+- `--profile <adaptive|minimal|wiki|codebase|research>`: Select initial context setup. adaptive is the default cloud-ready llm-wiki contract; legacy scaffold aliases remain available. (choices=adaptive|minimal|wiki|codebase|research, default=adaptive)
 - `--raw-gitignore <none|all>`: Ignore raw sources by default when set to all. (choices=none|all, default=none)
 - `--derived-gitignore <none|all>`: Ignore machine-derived context files under .agentplane/context/derived when set to all. (choices=none|all, default=none)
 - `--repair`: Create missing files only. (default=false)
@@ -3359,6 +3363,55 @@ Usage:
 ```text
 agentplane context show <source-ref>
 ```
+
+### context wiki explain
+
+Print a wiki page's AgentPlane context frontmatter.
+
+Usage:
+
+```text
+agentplane context wiki explain <path-or-slug>
+```
+
+### context wiki link
+
+Suggest existing wiki pages that may deserve cross-links.
+
+Usage:
+
+```text
+agentplane context wiki link <path-or-slug>
+```
+
+### context wiki lint
+
+Validate wiki page frontmatter and source-link hygiene.
+
+Usage:
+
+```text
+agentplane context wiki lint [<path>]
+```
+
+### context wiki new
+
+Create a wiki page with AgentPlane context frontmatter.
+
+Usage:
+
+```text
+agentplane context wiki new <path-or-slug> [options]
+```
+
+Options:
+
+- `--title <title>`: Page title. Defaults to a title derived from the path.
+- `--modality <modality>`: Primary page modality: factual_claim, observation, assumption, hypothesis, decision, policy, preference, requirement, risk, capability, definition, or deprecation. (default=factual_claim)
+- `--status <epistemic-status>`: Initial epistemic status such as extracted_candidate, sourced_claim, reviewed_claim, disputed, deprecated, or canonical_org_knowledge. (default=sourced_claim)
+- `--visibility <scope>`: Intended visibility scope for future publication metadata. (default=project)
+- `--source <source-ref>`: Repeatable markdown/source reference backing the page. (repeatable)
+- `--force`: Overwrite an existing page. (default=false)
 
 ## Evaluators
 

--- a/docs/user/commands.mdx
+++ b/docs/user/commands.mdx
@@ -208,6 +208,10 @@ agentplane context doctor
 agentplane context reindex
 agentplane context search "query"
 agentplane context show context/wiki/page.md#section=section-slug
+agentplane context wiki new decisions/context-storage --modality decision --source .agentplane/tasks/<task-id>/README.md
+agentplane context wiki lint context/wiki/decisions/context-storage.md
+agentplane context wiki explain context/wiki/decisions/context-storage.md
+agentplane context wiki link context/wiki/decisions/context-storage.md
 agentplane context ingest --changed
 agentplane context ingest ./notes.md --run
 agentplane context harvest tasks --tag release --limit 20 --dry-run
@@ -229,6 +233,12 @@ READMEs with `extensions.context_harvest` for raw ingestion and
 unchanged ingested or queued tasks by source digest instead of guessing from wiki files. Write modes
 require `agentplane context init` first. Use `context verify-task` before closing work that creates
 or relies on context artifacts. See [Local context](local-context).
+
+`context wiki` helpers keep markdown pages usable by both humans and agents. `wiki new` creates a
+page with AgentPlane frontmatter, `wiki lint` checks the page manifest and source-link hygiene,
+`wiki explain` prints the technical metadata, and `wiki link` suggests existing pages that may
+deserve meaningful cross-links. The helpers do not replace CURATOR judgment; they make page creation
+and review less error-prone.
 
 There is no public `context list` command by design. Search is the primary discovery surface; use
 `context graph summary`, `context graph show`, and `context graph neighbors` when you need structured

--- a/docs/user/local-context.mdx
+++ b/docs/user/local-context.mdx
@@ -64,8 +64,33 @@ project first and then creates the context workspace. In a non-empty directory t
 AgentPlane project, run `agentplane init` explicitly before `agentplane context init` so the project
 gateway, workflow, backend, and conflict handling stay visible.
 
+The default init profile is `adaptive`: one stable llm-wiki contract with project-specific page
+structure. Agents should generate the wiki hierarchy from evidence, but keep page frontmatter,
+source refs, modalities, claims, graph refs, conflicts, and visibility metadata stable enough for
+future publication proposals and context-pack synchronization.
+
 `context show` resolves whole files, markdown sections, and line ranges. Markdown section refs use
 stable slugs such as `#section=publish-gate`; line refs use `#lines=12-24` or `#line=12`.
+
+## Wiki pages and metadata
+
+```bash
+agentplane context wiki new decisions/context-storage --modality decision --source .agentplane/tasks/<task-id>/README.md
+agentplane context wiki lint context/wiki/decisions/context-storage.md
+agentplane context wiki explain context/wiki/decisions/context-storage.md
+agentplane context wiki link context/wiki/decisions/context-storage.md
+```
+
+Wiki pages are markdown context artifacts with YAML frontmatter. The frontmatter is a page manifest:
+it names the page's modality, epistemic status, source refs, related claims, graph refs, conflicts,
+and intended visibility. It is not a replacement for atomic claim/fact/graph rows; it links the
+human-readable page to those machine-readable artifacts.
+
+Use separate pages when a concept, entity, decision, requirement, policy, risk, definition, workflow,
+or module is likely to be reused. Keep related claims on one topic page when that is more readable,
+but keep each important claim's modality and source visible. Decisions extracted from task history
+should become ADR/evolution records with provenance and supersession metadata rather than
+probabilistic facts.
 
 ## Learn from files and changes
 
@@ -78,6 +103,10 @@ agentplane context learn files ./notes.md --run
 context assimilation task from changed local context sources. `learn files` creates one from explicit
 files or directories. `--run` hands the generated task to the configured runner adapter instead of
 only preparing the request.
+
+Generated file/change tasks carry a portable `context_assimilation` prompt module and repeat the
+CURATOR contract in the task description so runner, Codex, IDE agents, and humans get the same
+wiki/claims/cross-link/provenance instructions.
 
 `ap context ingest` remains the lower-level pipeline command for agents and automation, including
 `--all` and `--index-only`.

--- a/packages/agentplane/src/cli/run-cli/command-catalog/project.ts
+++ b/packages/agentplane/src/cli/run-cli/command-catalog/project.ts
@@ -99,6 +99,11 @@ import {
   contextShowSpec,
   contextSpec,
   contextVerifyTaskSpec,
+  contextWikiExplainSpec,
+  contextWikiLinkSpec,
+  contextWikiLintSpec,
+  contextWikiNewSpec,
+  contextWikiSpec,
 } from "../../../commands/context/context.spec.js";
 import {
   contextCheckSpec,
@@ -238,6 +243,11 @@ export const PROJECT_COMMANDS = [
   fromCommandsContextCommand(contextReindexSpec, "runContextReindex", { surface: "advanced" }),
   fromCommandsContextCommand(contextSearchSpec, "runContextSearch"),
   fromCommandsContextCommand(contextShowSpec, "runContextShow"),
+  fromCommandsContextCommand(contextWikiSpec, "runContextWikiGroup"),
+  fromCommandsContextCommand(contextWikiNewSpec, "runContextWikiNew"),
+  fromCommandsContextCommand(contextWikiLintSpec, "runContextWikiLint"),
+  fromCommandsContextCommand(contextWikiExplainSpec, "runContextWikiExplain"),
+  fromCommandsContextCommand(contextWikiLinkSpec, "runContextWikiLink"),
   fromCommandsContextCommand(contextDoctorSpec, "runContextDoctor", { surface: "advanced" }),
   fromCommandsContextCommand(contextVerifyTaskSpec, "runContextVerifyTask", {
     surface: "advanced",

--- a/packages/agentplane/src/commands/context/context.command.ts
+++ b/packages/agentplane/src/commands/context/context.command.ts
@@ -13,6 +13,12 @@ import { cmdContextSearch } from "./search.js";
 import { cmdContextShow } from "./show.js";
 import { cmdContextDoctor } from "./doctor.js";
 import { cmdContextVerifyTask } from "./verify-task.js";
+import {
+  cmdContextWikiExplain,
+  cmdContextWikiLink,
+  cmdContextWikiLint,
+  cmdContextWikiNew,
+} from "./wiki.js";
 import { cmdContextHarvestTasks, type ContextHarvestTasksParsed } from "./harvest-tasks.js";
 import {
   cmdContextGraphSummary,
@@ -44,6 +50,11 @@ import {
   contextShowSpec,
   contextSpec,
   contextGraphSpec,
+  contextWikiExplainSpec,
+  contextWikiLinkSpec,
+  contextWikiLintSpec,
+  contextWikiNewSpec,
+  contextWikiSpec,
 } from "./context.spec.js";
 import {
   contextCheckSpec,
@@ -75,6 +86,19 @@ export async function runContextGraphGroup(
     subcommands: await loadDirectSubcommandNames(["context", "graph"]),
     command: "context graph",
     contextCommand: "context graph",
+  });
+}
+
+export async function runContextWikiGroup(
+  _ctx: CommandCtx,
+  p: GroupCommandParsed,
+): Promise<number> {
+  return throwGroupCommandUsage({
+    spec: contextWikiSpec,
+    cmd: p.cmd,
+    subcommands: await loadDirectSubcommandNames(["context", "wiki"]),
+    command: "context wiki",
+    contextCommand: "context wiki",
   });
 }
 
@@ -262,6 +286,38 @@ export async function runContextVerifyTask(
   });
 }
 
+export async function runContextWikiNew(
+  _ctx: CommandCtx,
+  p: Parameters<typeof cmdContextWikiNew>[0]["parsed"],
+): Promise<number> {
+  return await cmdContextWikiNew({ cwd: _ctx.cwd, rootOverride: _ctx.rootOverride, parsed: p });
+}
+
+export async function runContextWikiLint(
+  _ctx: CommandCtx,
+  p: Parameters<typeof cmdContextWikiLint>[0]["parsed"],
+): Promise<number> {
+  return await cmdContextWikiLint({ cwd: _ctx.cwd, rootOverride: _ctx.rootOverride, parsed: p });
+}
+
+export async function runContextWikiExplain(
+  _ctx: CommandCtx,
+  p: Parameters<typeof cmdContextWikiExplain>[0]["parsed"],
+): Promise<number> {
+  return await cmdContextWikiExplain({
+    cwd: _ctx.cwd,
+    rootOverride: _ctx.rootOverride,
+    parsed: p,
+  });
+}
+
+export async function runContextWikiLink(
+  _ctx: CommandCtx,
+  p: Parameters<typeof cmdContextWikiLink>[0]["parsed"],
+): Promise<number> {
+  return await cmdContextWikiLink({ cwd: _ctx.cwd, rootOverride: _ctx.rootOverride, parsed: p });
+}
+
 export async function runContextHarvestTasks(
   _ctx: CommandCtx,
   p: ContextHarvestTasksParsed,
@@ -365,6 +421,11 @@ export {
   contextReindexSpec,
   contextSearchSpec,
   contextShowSpec,
+  contextWikiExplainSpec,
+  contextWikiLinkSpec,
+  contextWikiLintSpec,
+  contextWikiNewSpec,
+  contextWikiSpec,
 } from "./context.spec.js";
 export {
   contextCheckSpec,

--- a/packages/agentplane/src/commands/context/context.spec.ts
+++ b/packages/agentplane/src/commands/context/context.spec.ts
@@ -67,8 +67,7 @@ export const contextInitSpec: CommandSpec<{
   ],
   parse: (raw) => ({
     profile:
-      (raw.opts.profile as "adaptive" | "minimal" | "wiki" | "codebase" | "research") ??
-      "adaptive",
+      (raw.opts.profile as "adaptive" | "minimal" | "wiki" | "codebase" | "research") ?? "adaptive",
     rawGitignore: (raw.opts["raw-gitignore"] as "none" | "all") ?? "none",
     derivedGitignore: (raw.opts["derived-gitignore"] as "none" | "all") ?? "none",
     repair: raw.opts.repair === true,

--- a/packages/agentplane/src/commands/context/context.spec.ts
+++ b/packages/agentplane/src/commands/context/context.spec.ts
@@ -14,7 +14,7 @@ export const contextSpec: CommandSpec<GroupCommandParsed> = {
 };
 
 export const contextInitSpec: CommandSpec<{
-  profile: "minimal" | "wiki" | "codebase" | "research";
+  profile: "adaptive" | "minimal" | "wiki" | "codebase" | "research";
   rawGitignore: "none" | "all";
   derivedGitignore: "none" | "all";
   repair: boolean;
@@ -29,10 +29,11 @@ export const contextInitSpec: CommandSpec<{
     {
       kind: "string",
       name: "profile",
-      valueHint: "<minimal|wiki|codebase|research>",
-      choices: ["minimal", "wiki", "codebase", "research"],
-      default: "wiki",
-      description: "Select an initial context profile.",
+      valueHint: "<adaptive|minimal|wiki|codebase|research>",
+      choices: ["adaptive", "minimal", "wiki", "codebase", "research"],
+      default: "adaptive",
+      description:
+        "Select initial context setup. adaptive is the default cloud-ready llm-wiki contract; legacy scaffold aliases remain available.",
     },
     {
       kind: "string",
@@ -65,7 +66,9 @@ export const contextInitSpec: CommandSpec<{
     },
   ],
   parse: (raw) => ({
-    profile: (raw.opts.profile as "minimal" | "wiki" | "codebase" | "research") ?? "wiki",
+    profile:
+      (raw.opts.profile as "adaptive" | "minimal" | "wiki" | "codebase" | "research") ??
+      "adaptive",
     rawGitignore: (raw.opts["raw-gitignore"] as "none" | "all") ?? "none",
     derivedGitignore: (raw.opts["derived-gitignore"] as "none" | "all") ?? "none",
     repair: raw.opts.repair === true,
@@ -74,7 +77,7 @@ export const contextInitSpec: CommandSpec<{
 };
 
 export type ContextInitParsed = {
-  profile: "minimal" | "wiki" | "codebase" | "research";
+  profile: "adaptive" | "minimal" | "wiki" | "codebase" | "research";
   rawGitignore: "none" | "all";
   derivedGitignore: "none" | "all";
   repair: boolean;
@@ -172,6 +175,106 @@ export const contextGraphSpec: CommandSpec<GroupCommandParsed> = {
   summary: "Validate and inspect derived context graph.",
   args: [{ name: "cmd", required: false, variadic: true, valueHint: "<cmd>" }],
   parse: (raw) => parseGroupCommand(raw),
+};
+
+export const contextWikiSpec: CommandSpec<GroupCommandParsed> = {
+  id: ["context", "wiki"],
+  group: "Context",
+  summary: "Create, lint, explain, and link local context wiki pages.",
+  args: [{ name: "cmd", required: false, variadic: true, valueHint: "<cmd>" }],
+  parse: (raw) => parseGroupCommand(raw),
+};
+
+export const contextWikiNewSpec: CommandSpec<{
+  page: string;
+  title: string;
+  modality: string;
+  status: string;
+  visibility: string;
+  source: string[];
+  force: boolean;
+}> = {
+  id: ["context", "wiki", "new"],
+  group: "Context",
+  summary: "Create a wiki page with AgentPlane context frontmatter.",
+  args: [{ name: "page", required: true, valueHint: "<path-or-slug>" }],
+  options: [
+    {
+      kind: "string",
+      name: "title",
+      valueHint: "<title>",
+      description: "Page title. Defaults to a title derived from the path.",
+    },
+    {
+      kind: "string",
+      name: "modality",
+      default: "factual_claim",
+      valueHint: "<modality>",
+      description:
+        "Primary page modality: factual_claim, observation, assumption, hypothesis, decision, policy, preference, requirement, risk, capability, definition, or deprecation.",
+    },
+    {
+      kind: "string",
+      name: "status",
+      default: "sourced_claim",
+      valueHint: "<epistemic-status>",
+      description:
+        "Initial epistemic status such as extracted_candidate, sourced_claim, reviewed_claim, disputed, deprecated, or canonical_org_knowledge.",
+    },
+    {
+      kind: "string",
+      name: "visibility",
+      default: "project",
+      valueHint: "<scope>",
+      description: "Intended visibility scope for future publication metadata.",
+    },
+    {
+      kind: "string",
+      name: "source",
+      repeatable: true,
+      valueHint: "<source-ref>",
+      description: "Repeatable markdown/source reference backing the page.",
+    },
+    {
+      kind: "boolean",
+      name: "force",
+      default: false,
+      description: "Overwrite an existing page.",
+    },
+  ],
+  parse: (raw) => ({
+    page: String(raw.args.page),
+    title: typeof raw.opts.title === "string" ? raw.opts.title : "",
+    modality: typeof raw.opts.modality === "string" ? raw.opts.modality : "factual_claim",
+    status: typeof raw.opts.status === "string" ? raw.opts.status : "sourced_claim",
+    visibility: typeof raw.opts.visibility === "string" ? raw.opts.visibility : "project",
+    source: toStringList(raw.opts.source),
+    force: raw.opts.force === true,
+  }),
+};
+
+export const contextWikiLintSpec: CommandSpec<{ path: string }> = {
+  id: ["context", "wiki", "lint"],
+  group: "Context",
+  summary: "Validate wiki page frontmatter and source-link hygiene.",
+  args: [{ name: "path", required: false, valueHint: "<path>" }],
+  parse: (raw) => ({ path: typeof raw.args.path === "string" ? raw.args.path : "" }),
+};
+
+export const contextWikiExplainSpec: CommandSpec<{ page: string }> = {
+  id: ["context", "wiki", "explain"],
+  group: "Context",
+  summary: "Print a wiki page's AgentPlane context frontmatter.",
+  args: [{ name: "page", required: true, valueHint: "<path-or-slug>" }],
+  parse: (raw) => ({ page: String(raw.args.page) }),
+};
+
+export const contextWikiLinkSpec: CommandSpec<{ page: string }> = {
+  id: ["context", "wiki", "link"],
+  group: "Context",
+  summary: "Suggest existing wiki pages that may deserve cross-links.",
+  args: [{ name: "page", required: true, valueHint: "<path-or-slug>" }],
+  parse: (raw) => ({ page: String(raw.args.page) }),
 };
 
 export const contextHarvestSpec: CommandSpec<GroupCommandParsed> = {

--- a/packages/agentplane/src/commands/context/init.ts
+++ b/packages/agentplane/src/commands/context/init.ts
@@ -300,7 +300,12 @@ async function createContextWorkspace(
     { relative: ".agentplane/context/service/.gitkeep", content: "" },
   ];
 
-  if (parsed.profile === "wiki" || parsed.profile === "codebase" || parsed.profile === "research") {
+  if (
+    parsed.profile === "adaptive" ||
+    parsed.profile === "wiki" ||
+    parsed.profile === "codebase" ||
+    parsed.profile === "research"
+  ) {
     files.push(
       { relative: "context/raw/specs/.gitkeep", content: "" },
       { relative: "context/raw/research/.gitkeep", content: "" },
@@ -375,7 +380,22 @@ async function ensureContextGitignore(root: string, parsed: ContextInitParsed): 
 }
 
 function buildContextReadme(profile: ContextInitParsed["profile"]): string {
-  return `# Context workspace\n\nProfile: ${profile}\n\nUse this directory as the human-readable context surface.\n`;
+  return `# Context workspace
+
+Profile: ${profile}
+
+Use this directory as the human-readable context surface.
+
+AgentPlane local context uses one adaptive llm-wiki contract:
+
+- \`context/raw/**\` keeps source material.
+- \`context/wiki/**\` keeps readable synthesis pages with AgentPlane frontmatter.
+- \`.agentplane/context/derived/**\` keeps reproducible claims, graph rows, provenance, and reports.
+- \`.agentplane/context/service/**\` keeps local caches only.
+
+Agents should create wiki pages when a topic is reusable for future tasks, but keep atomic claims in
+derived machine artifacts. Source references should be markdown links where possible.
+`;
 }
 
 function buildWikiAgentsMarkdown(profile: ContextInitParsed["profile"]): string {
@@ -384,11 +404,24 @@ function buildWikiAgentsMarkdown(profile: ContextInitParsed["profile"]): string 
 Profile: ${profile}
 
 - Treat \`context/wiki/**\` as durable, source-backed project knowledge.
+- Treat this wiki as adaptive: generate the page hierarchy from project evidence, while preserving
+  stable frontmatter fields for future publication/synchronization.
+- Wiki pages are context artifacts; atomic claims and graph edges remain machine-readable derived
+  artifacts.
+- Use page frontmatter with \`agentplane_context.schema_version\`, \`artifact_type\`,
+  \`canonical_id\`, \`modality\`, \`epistemic_status\`, \`visibility\`, \`source_refs\`,
+  \`claims\`, \`graph_refs\`, and \`conflicts\`.
 - Analyze the base project, existing docs, task history, and raw sources before choosing a wiki structure.
 - Choose the smallest wiki hierarchy that fits this project; do not force a universal concepts/entities/decisions/modules layout.
 - Preserve and refine the chosen hierarchy after the first analysis; avoid reshaping it unless new evidence makes the old structure misleading.
+- Keep different modalities explicit: factual_claim, observation, assumption, hypothesis, decision,
+  policy, preference, requirement, risk, capability, definition, and deprecation.
+- Decisions from task history should be written as ADR/evolution records with provenance and
+  supersession metadata, not as probabilistic factual claims.
 - If a glossary is useful, keep it as a thin index over existing wiki pages and graph entities, not as a competing source of truth.
 - Prefer useful Markdown cross-links between related wiki pages and glossary entries, especially on first meaningful mentions of known concepts, entities, decisions, risks, or modules.
+- When claims conflict, keep both claims, create a conflict candidate, and ask for review before
+  promotion or overwrite.
 - Keep raw inputs in \`context/raw/**\`; do not copy private raw sources into public wiki pages.
 - Add source references for factual claims that come from raw files, task READMEs, ACRs, or code.
 - Use \`agentplane context verify-task <task-id>\` before closing context assimilation work.
@@ -411,6 +444,9 @@ project:
 workspace:
   namespace: local.project
   mode: ${profile}
+  layout_strategy: adaptive
+  page_granularity: topic_artifact
+  claim_granularity: atomic
   root: context
   raw: context/raw
   wiki: context/wiki
@@ -437,6 +473,23 @@ derived:
     edges: .agentplane/context/derived/capabilities/capability_edges.jsonl
   reports:
     events: .agentplane/context/derived/reports/assimilation-events.jsonl
+wiki:
+  frontmatter_required: true
+  source_refs_as_markdown_links: true
+  cross_links_required: true
+  modalities:
+    - factual_claim
+    - observation
+    - assumption
+    - hypothesis
+    - decision
+    - policy
+    - preference
+    - requirement
+    - risk
+    - capability
+    - definition
+    - deprecation
 agentplane:
   tasks_root: .agentplane/tasks
 service:

--- a/packages/agentplane/src/commands/context/release-readiness.test.ts
+++ b/packages/agentplane/src/commands/context/release-readiness.test.ts
@@ -364,4 +364,47 @@ describe("context release readiness guards", () => {
     expect(output).toContain("canonical_id:");
     expect(output).toContain("modality: decision");
   });
+
+  it("lints CRLF wiki frontmatter and rejects missing lint targets", async () => {
+    const root = await tempRoot();
+    await write(
+      root,
+      "context/wiki/decisions/crlf-page.md",
+      [
+        "---",
+        "agentplane_context:",
+        "  schema_version: 1",
+        "  artifact_type: wiki_page",
+        '  canonical_id: "wiki.decisions-crlf-page"',
+        '  title: "CRLF Page"',
+        "  modality: decision",
+        "  epistemic_status: sourced_claim",
+        "  source_refs: []",
+        "---",
+        "",
+        "# CRLF Page",
+        "",
+        "## Source References",
+        "",
+        "- no-source: local test fixture",
+        "",
+      ].join("\r\n"),
+    );
+    const out = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await cmdContextWikiLint({
+      cwd: root,
+      parsed: { path: "context/wiki/decisions/crlf-page.md" },
+    });
+    await expect(
+      cmdContextWikiLint({
+        cwd: root,
+        parsed: { path: "context/wiki/decisions/missing-page.md" },
+      }),
+    ).rejects.toThrow(/wiki lint target does not exist/u);
+
+    expect(out.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      "context wiki lint: ok (1 page(s))",
+    );
+  });
 });

--- a/packages/agentplane/src/commands/context/release-readiness.test.ts
+++ b/packages/agentplane/src/commands/context/release-readiness.test.ts
@@ -10,6 +10,7 @@ import { cmdContextReindex, readContextProjection } from "./reindex.js";
 import { cmdContextSearch } from "./search.js";
 import { cmdContextShow } from "./show.js";
 import { cmdContextVerifyTask } from "./verify-task.js";
+import { cmdContextWikiExplain, cmdContextWikiLint, cmdContextWikiNew } from "./wiki.js";
 
 let tempRoots: string[] = [];
 
@@ -284,6 +285,29 @@ describe("context release readiness guards", () => {
     });
 
     expect(createTask).toHaveBeenCalledOnce();
+    const createdArgs = createTask.mock.calls[0]?.[0] as {
+      parsed?: {
+        description?: string;
+        extensions?: {
+          "agentplane.context"?: {
+            prompt_module_ref?: string;
+            prompt_modules?: { content?: string }[];
+            wiki?: { layout_strategy?: string; frontmatter_required?: boolean };
+          };
+        };
+      };
+    };
+    expect(createdArgs.parsed?.description).toContain("CURATOR contract:");
+    expect(createdArgs.parsed?.extensions?.["agentplane.context"]?.prompt_module_ref).toBe(
+      "framework/template/generated.artifact/context_assimilation/v1",
+    );
+    expect(
+      createdArgs.parsed?.extensions?.["agentplane.context"]?.prompt_modules?.[0]?.content,
+    ).toContain("frontmatter");
+    expect(createdArgs.parsed?.extensions?.["agentplane.context"]?.wiki).toMatchObject({
+      layout_strategy: "adaptive",
+      frontmatter_required: true,
+    });
     expect(approveTaskPlan).toHaveBeenCalledWith(
       expect.objectContaining({
         cwd: root,
@@ -307,5 +331,37 @@ describe("context release readiness guards", () => {
     expect(out.mock.calls.map((call) => String(call[0])).join("")).toContain(
       "context ingestion task created: 202605130501-CTXRUN",
     );
+  });
+
+  it("creates and explains wiki pages with AgentPlane context frontmatter", async () => {
+    const root = await tempRoot();
+    const out = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await cmdContextWikiNew({
+      cwd: root,
+      parsed: {
+        page: "decisions/context-claims",
+        title: "Context Claims",
+        modality: "decision",
+        status: "reviewed_claim",
+        visibility: "project",
+        source: [".agentplane/tasks/202605130501-CTX001/README.md"],
+        force: false,
+      },
+    });
+    await cmdContextWikiLint({
+      cwd: root,
+      parsed: { path: "context/wiki" },
+    });
+    await cmdContextWikiExplain({
+      cwd: root,
+      parsed: { page: "decisions/context-claims" },
+    });
+
+    const output = out.mock.calls.map((call) => String(call[0])).join("");
+    expect(output).toContain("context wiki new: context/wiki/decisions/context-claims.md");
+    expect(output).toContain("context wiki lint: ok (1 page(s))");
+    expect(output).toContain("canonical_id:");
+    expect(output).toContain("modality: decision");
   });
 });

--- a/packages/agentplane/src/commands/context/wiki.ts
+++ b/packages/agentplane/src/commands/context/wiki.ts
@@ -180,7 +180,8 @@ async function collectWikiFiles(root: string, rel: string): Promise<string[]> {
   if (!(await fileExists(abs))) return [];
   const st = await stat(abs);
   if (st.isFile()) return [rel];
-  return (await collectMatchingFiles(root, rel)).filter((item) => item.endsWith(".md"));
+  const files = await collectMatchingFiles(root, rel);
+  return files.filter((item) => item.endsWith(".md"));
 }
 
 async function normalizeWikiLintTarget(root: string, input: string): Promise<string> {
@@ -318,7 +319,8 @@ export async function cmdContextWikiLink(opts: {
   const root = path.resolve(opts.rootOverride ?? opts.cwd);
   const rel = normalizeWikiPath(root, opts.parsed.page);
   const text = await readFile(path.join(root, rel), "utf8");
-  const files = (await collectWikiFiles(root, "context/wiki")).filter((file) => file !== rel);
+  const wikiFiles = await collectWikiFiles(root, "context/wiki");
+  const files = wikiFiles.filter((file) => file !== rel);
   const titleWords = new Set(
     text
       .toLowerCase()

--- a/packages/agentplane/src/commands/context/wiki.ts
+++ b/packages/agentplane/src/commands/context/wiki.ts
@@ -198,14 +198,21 @@ async function normalizeWikiLintTarget(root: string, input: string): Promise<str
     });
   }
   if (await fileExists(abs)) return toPosix(path.relative(root, abs));
-  return normalizeWikiPath(root, trimmed);
+  const pageRel = normalizeWikiPath(root, trimmed);
+  if (await fileExists(path.join(root, pageRel))) return pageRel;
+  throw new CliError({
+    exitCode: 3,
+    code: "E_VALIDATION",
+    message: `wiki lint target does not exist: ${input}`,
+  });
 }
 
 function extractFrontmatter(text: string): string | null {
-  if (!text.startsWith("---\n")) return null;
-  const end = text.indexOf("\n---", 4);
+  const normalized = text.replaceAll("\r\n", "\n");
+  if (!normalized.startsWith("---\n")) return null;
+  const end = normalized.indexOf("\n---", 4);
   if (end === -1) return null;
-  return text.slice(4, end).trim();
+  return normalized.slice(4, end).trim();
 }
 
 function lintWikiText(rel: string, text: string): string[] {

--- a/packages/agentplane/src/commands/context/wiki.ts
+++ b/packages/agentplane/src/commands/context/wiki.ts
@@ -1,0 +1,342 @@
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { CliError } from "../../shared/errors.js";
+import { collectMatchingFiles, fileExists, toPosix } from "./context-utils.js";
+
+type WikiModality =
+  | "factual_claim"
+  | "observation"
+  | "assumption"
+  | "hypothesis"
+  | "decision"
+  | "policy"
+  | "preference"
+  | "requirement"
+  | "risk"
+  | "capability"
+  | "definition"
+  | "deprecation";
+
+type WikiStatus =
+  | "mention"
+  | "extracted_candidate"
+  | "sourced_claim"
+  | "corroborated_claim"
+  | "reviewed_claim"
+  | "accepted_team_knowledge"
+  | "canonical_org_knowledge"
+  | "assumption"
+  | "hypothesis"
+  | "disputed"
+  | "deprecated"
+  | "superseded"
+  | "forbidden_for_use";
+
+const MODALITIES = new Set<WikiModality>([
+  "factual_claim",
+  "observation",
+  "assumption",
+  "hypothesis",
+  "decision",
+  "policy",
+  "preference",
+  "requirement",
+  "risk",
+  "capability",
+  "definition",
+  "deprecation",
+]);
+
+const STATUSES = new Set<WikiStatus>([
+  "mention",
+  "extracted_candidate",
+  "sourced_claim",
+  "corroborated_claim",
+  "reviewed_claim",
+  "accepted_team_knowledge",
+  "canonical_org_knowledge",
+  "assumption",
+  "hypothesis",
+  "disputed",
+  "deprecated",
+  "superseded",
+  "forbidden_for_use",
+]);
+
+function slug(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/gu, "-")
+    .replaceAll(/^-+|-+$/gu, "");
+}
+
+function normalizeWikiPath(root: string, input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new CliError({
+      exitCode: 3,
+      code: "E_VALIDATION",
+      message: "wiki page path must be non-empty",
+    });
+  }
+  const rel = toPosix(trimmed.endsWith(".md") ? trimmed : `${trimmed}.md`);
+  const scoped = rel.startsWith("context/wiki/") ? rel : `context/wiki/${rel}`;
+  const abs = path.resolve(root, scoped);
+  const wikiRoot = path.resolve(root, "context/wiki");
+  if (!abs.startsWith(`${wikiRoot}${path.sep}`) && abs !== wikiRoot) {
+    throw new CliError({
+      exitCode: 3,
+      code: "E_VALIDATION",
+      message: `wiki page path must stay under context/wiki: ${input}`,
+    });
+  }
+  return toPosix(path.relative(root, abs));
+}
+
+function titleFromPath(rel: string): string {
+  const base = path.basename(rel, path.extname(rel));
+  return base
+    .split(/[-_]+/u)
+    .filter(Boolean)
+    .map((word) => `${word.slice(0, 1).toUpperCase()}${word.slice(1)}`)
+    .join(" ");
+}
+
+function assertChoice<T extends string>(value: string, choices: Set<T>, label: string): T {
+  if (choices.has(value as T)) return value as T;
+  throw new CliError({
+    exitCode: 3,
+    code: "E_VALIDATION",
+    message: `${label} must be one of: ${[...choices].join(", ")}`,
+  });
+}
+
+function yamlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function renderSourceRefs(sourceRefs: string[]): string {
+  if (sourceRefs.length === 0) return "  []";
+  return sourceRefs
+    .map((source) => {
+      const label = source.includes("#") ? source.split("#")[0] : source;
+      return [
+        "  - path: " + yamlString(source),
+        "    ref: " + yamlString(source),
+        "    label: " + yamlString(label),
+      ].join("\n");
+    })
+    .join("\n");
+}
+
+function renderWikiPage(opts: {
+  rel: string;
+  title: string;
+  modality: WikiModality;
+  status: WikiStatus;
+  visibility: string;
+  sourceRefs: string[];
+}): string {
+  const canonicalId = `wiki.${slug(opts.rel.replace(/^context\/wiki\//u, "").replace(/\.md$/u, ""))}`;
+  return `---
+agentplane_context:
+  schema_version: 1
+  artifact_type: wiki_page
+  canonical_id: ${yamlString(canonicalId)}
+  title: ${yamlString(opts.title)}
+  modality: ${opts.modality}
+  epistemic_status: ${opts.status}
+  visibility: ${opts.visibility}
+  source_refs:
+${renderSourceRefs(opts.sourceRefs)}
+  claims: []
+  graph_refs:
+    entities: []
+    edges: []
+  conflicts: []
+  updated_by: CURATOR
+---
+
+# ${opts.title}
+
+## Summary
+
+<!-- Write source-backed synthesis here. Keep claims small, scoped, and linked. -->
+
+## Source References
+
+${opts.sourceRefs.length > 0 ? opts.sourceRefs.map((source) => `- [${source}](${source})`).join("\n") : "- no-source: add a source reference before promotion"}
+
+## Claims
+
+<!-- Link atomic claim ids or derived rows here. -->
+`;
+}
+
+async function collectWikiFiles(root: string, rel: string): Promise<string[]> {
+  const abs = path.join(root, rel);
+  if (!(await fileExists(abs))) return [];
+  const st = await stat(abs);
+  if (st.isFile()) return [rel];
+  return (await collectMatchingFiles(root, rel)).filter((item) => item.endsWith(".md"));
+}
+
+async function normalizeWikiLintTarget(root: string, input: string): Promise<string> {
+  const trimmed = input.trim();
+  if (!trimmed) return "context/wiki";
+  const scoped = toPosix(trimmed.startsWith("context/wiki") ? trimmed : `context/wiki/${trimmed}`);
+  const abs = path.resolve(root, scoped);
+  const wikiRoot = path.resolve(root, "context/wiki");
+  if (!abs.startsWith(`${wikiRoot}${path.sep}`) && abs !== wikiRoot) {
+    throw new CliError({
+      exitCode: 3,
+      code: "E_VALIDATION",
+      message: `wiki lint path must stay under context/wiki: ${input}`,
+    });
+  }
+  if (await fileExists(abs)) return toPosix(path.relative(root, abs));
+  return normalizeWikiPath(root, trimmed);
+}
+
+function extractFrontmatter(text: string): string | null {
+  if (!text.startsWith("---\n")) return null;
+  const end = text.indexOf("\n---", 4);
+  if (end === -1) return null;
+  return text.slice(4, end).trim();
+}
+
+function lintWikiText(rel: string, text: string): string[] {
+  const errors: string[] = [];
+  const frontmatter = extractFrontmatter(text);
+  if (!frontmatter) {
+    errors.push(`${rel}: missing YAML frontmatter`);
+    return errors;
+  }
+  for (const required of [
+    "agentplane_context:",
+    "schema_version:",
+    "artifact_type:",
+    "canonical_id:",
+    "modality:",
+    "epistemic_status:",
+    "source_refs:",
+  ]) {
+    if (!frontmatter.includes(required)) errors.push(`${rel}: missing ${required}`);
+  }
+  if (!/\[[^\]]+\]\([^)]+\)/u.test(text) && !text.includes("no-source:")) {
+    errors.push(`${rel}: missing markdown source/cross-link or explicit no-source marker`);
+  }
+  return errors;
+}
+
+export async function cmdContextWikiNew(opts: {
+  cwd: string;
+  rootOverride?: string;
+  parsed: {
+    page: string;
+    title: string;
+    modality: string;
+    status: string;
+    visibility: string;
+    source: string[];
+    force: boolean;
+  };
+}): Promise<number> {
+  const root = path.resolve(opts.rootOverride ?? opts.cwd);
+  const rel = normalizeWikiPath(root, opts.parsed.page);
+  const abs = path.join(root, rel);
+  if ((await fileExists(abs)) && !opts.parsed.force) {
+    throw new CliError({
+      exitCode: 3,
+      code: "E_VALIDATION",
+      message: `wiki page already exists: ${rel}`,
+    });
+  }
+  const modality = assertChoice(opts.parsed.modality, MODALITIES, "modality");
+  const status = assertChoice(opts.parsed.status, STATUSES, "status");
+  await mkdir(path.dirname(abs), { recursive: true });
+  await writeFile(
+    abs,
+    renderWikiPage({
+      rel,
+      title: opts.parsed.title.trim() || titleFromPath(rel),
+      modality,
+      status,
+      visibility: opts.parsed.visibility.trim() || "project",
+      sourceRefs: opts.parsed.source,
+    }),
+    "utf8",
+  );
+  process.stdout.write(`context wiki new: ${rel}\n`);
+  return 0;
+}
+
+export async function cmdContextWikiLint(opts: {
+  cwd: string;
+  rootOverride?: string;
+  parsed: { path: string };
+}): Promise<number> {
+  const root = path.resolve(opts.rootOverride ?? opts.cwd);
+  const rel = await normalizeWikiLintTarget(root, opts.parsed.path);
+  const files = await collectWikiFiles(root, rel);
+  const errors: string[] = [];
+  for (const file of files) {
+    errors.push(...lintWikiText(file, await readFile(path.join(root, file), "utf8")));
+  }
+  if (errors.length > 0) {
+    throw new CliError({
+      exitCode: 3,
+      code: "E_VALIDATION",
+      message: `context wiki lint failed: ${errors.length} issue(s)\n- ${errors.join("\n- ")}`,
+    });
+  }
+  process.stdout.write(`context wiki lint: ok (${files.length} page(s))\n`);
+  return 0;
+}
+
+export async function cmdContextWikiExplain(opts: {
+  cwd: string;
+  rootOverride?: string;
+  parsed: { page: string };
+}): Promise<number> {
+  const root = path.resolve(opts.rootOverride ?? opts.cwd);
+  const rel = normalizeWikiPath(root, opts.parsed.page);
+  const text = await readFile(path.join(root, rel), "utf8");
+  const frontmatter = extractFrontmatter(text);
+  process.stdout.write(`context wiki explain: ${rel}\n`);
+  process.stdout.write(frontmatter ? `${frontmatter}\n` : "frontmatter: missing\n");
+  return 0;
+}
+
+export async function cmdContextWikiLink(opts: {
+  cwd: string;
+  rootOverride?: string;
+  parsed: { page: string };
+}): Promise<number> {
+  const root = path.resolve(opts.rootOverride ?? opts.cwd);
+  const rel = normalizeWikiPath(root, opts.parsed.page);
+  const text = await readFile(path.join(root, rel), "utf8");
+  const files = (await collectWikiFiles(root, "context/wiki")).filter((file) => file !== rel);
+  const titleWords = new Set(
+    text
+      .toLowerCase()
+      .split(/[^a-z0-9]+/u)
+      .filter((word) => word.length >= 4),
+  );
+  const matches = files.filter((file) =>
+    file
+      .replace(/^context\/wiki\//u, "")
+      .replace(/\.md$/u, "")
+      .split(/[-_/]+/u)
+      .some((word) => titleWords.has(word.toLowerCase())),
+  );
+  process.stdout.write(`context wiki link: ${rel}\n`);
+  if (matches.length === 0) {
+    process.stdout.write("- no obvious wiki link candidates found\n");
+    return 0;
+  }
+  for (const match of matches.slice(0, 20)) process.stdout.write(`- ${match}\n`);
+  return 0;
+}

--- a/packages/agentplane/src/context/ingest-task.ts
+++ b/packages/agentplane/src/context/ingest-task.ts
@@ -3,7 +3,7 @@ import type { PromptModule } from "../runtime/prompt-modules/index.js";
 import { PROMPT_MODULE_CONTRACT_SCHEMA_VERSION } from "../runtime/prompt-modules/index.js";
 import type { ContextIngestParsed, ManifestEntry } from "./ingest.js";
 
-export const CONTEXT_ASSIMILATION_PROMPT_ADDRESS =
+const CONTEXT_ASSIMILATION_PROMPT_ADDRESS =
   "framework/template/generated.artifact/context_assimilation/v1";
 
 export function selectedSourceRows(

--- a/packages/agentplane/src/context/ingest-task.ts
+++ b/packages/agentplane/src/context/ingest-task.ts
@@ -1,5 +1,10 @@
 import type { TaskNewParsed } from "../commands/task/new.js";
+import type { PromptModule } from "../runtime/prompt-modules/index.js";
+import { PROMPT_MODULE_CONTRACT_SCHEMA_VERSION } from "../runtime/prompt-modules/index.js";
 import type { ContextIngestParsed, ManifestEntry } from "./ingest.js";
+
+export const CONTEXT_ASSIMILATION_PROMPT_ADDRESS =
+  "framework/template/generated.artifact/context_assimilation/v1";
 
 export function selectedSourceRows(
   opts: Pick<ContextIngestParsed, "mode" | "includePrivate">,
@@ -34,6 +39,7 @@ function buildIngestMetadata(
   }[opts.mode];
   const modeSource = selectedSourceRows(opts, sourceRows);
   const title = `context assimilation (${modeLabel})`;
+  const promptRef = CONTEXT_ASSIMILATION_PROMPT_ADDRESS;
   const description = [
     `Source context assimilation for ${modeLabel}.`,
     "This task is created by `context ingest`.",
@@ -43,6 +49,17 @@ function buildIngestMetadata(
     `Changed/new candidates: ${modeSource.length}`,
     `private-only filtering: enabled`,
     `Run policy: task-owner CURATOR`,
+    `Prompt module: ${promptRef}`,
+    "",
+    "CURATOR contract:",
+    "- Maintain `context/wiki/**` as a human-readable, source-backed llm-wiki.",
+    "- Use markdown frontmatter as the page manifest for modality, status, source_refs, claims, and graph refs.",
+    "- Keep atomic claims and graph rows in derived artifacts; do not turn every claim into a wiki page.",
+    "- Create or update wiki pages only when the topic is reusable for future tasks or useful to a human reader.",
+    "- Add meaningful markdown cross-links between related wiki pages on first useful mention.",
+    "- Represent facts, decisions, policies, requirements, risks, preferences, and definitions as distinct modalities.",
+    "- If claims conflict, create a conflict candidate and ask for review before promotion; never overwrite silently.",
+    "- Treat completed-task architecture changes as ADR/evolution records with provenance, not as probabilistic facts.",
   ].join("\n");
   return {
     title,
@@ -55,6 +72,81 @@ function buildIngestMetadata(
       "agentplane acr generate <created-task-id> --write",
       "agentplane acr check <created-task-id>",
     ],
+  };
+}
+
+function buildContextAssimilationPromptModule(): PromptModule {
+  return {
+    schema_version: PROMPT_MODULE_CONTRACT_SCHEMA_VERSION,
+    address: {
+      value: CONTEXT_ASSIMILATION_PROMPT_ADDRESS,
+      namespace: "framework",
+      surface: "template",
+      target: "generated.artifact",
+      slot: "body",
+      name: "context_assimilation_v1",
+    },
+    owner: {
+      kind: "framework",
+      package_name: "agentplane",
+    },
+    title: "Context assimilation prompt",
+    summary:
+      "Default CURATOR prompt module for turning raw or changed sources into a linked llm-wiki plus atomic claims, graph rows, and provenance.",
+    content_kind: "markdown",
+    content: [
+      "# Context Assimilation",
+      "",
+      "You are CURATOR maintaining an AgentPlane llm-wiki. The task may be executed by a runner, Codex, an IDE agent, or a human-assisted agent. Treat this task README and extension as the portable source of instructions.",
+      "",
+      "Goal: transform the selected sources into durable, human-readable wiki artifacts and machine-readable context artifacts without laundering weak claims into truth.",
+      "",
+      "Core rules:",
+      "- Raw sources remain source-of-truth. Do not mutate `context/raw/**`.",
+      "- Wiki pages are synthesis artifacts for humans and agents. They should be readable markdown with YAML frontmatter.",
+      "- Atomic claims belong in derived claim/fact rows and graph rows. Do not create one markdown page per minor claim.",
+      "- Create a new wiki page when a concept, entity, decision, requirement, policy, risk, definition, workflow, or module is likely to be reused by future tasks.",
+      "- Keep related claims on a topic page when that is more readable, but mark every important claim with modality, status, scope, and source_refs.",
+      "- Use markdown cross-links for source_refs and meaningful page-to-page references. Do not add decorative links to every repeated word.",
+      "- Represent every extracted assertion as a claim candidate until its source and status justify stronger use.",
+      "- Preserve modality: factual_claim, observation, assumption, hypothesis, decision, policy, preference, requirement, risk, capability, definition, deprecation.",
+      "- Use confidence vectors for factual/requirement/risk claims; do not use one scalar confidence score.",
+      "- For decisions from completed task evidence, write ADR/evolution records with source_refs, decision_status, scope, supersedes/superseded_by, and provenance integrity rather than probabilistic confidence.",
+      "- If a new claim contradicts existing context, write a conflict candidate, keep both claims, lower conflict_status, and ask the user before promotion or overwrite.",
+      "- Keep private or sensitive data out of public wiki artifacts. Preserve visibility/sensitivity metadata when relevant.",
+      "",
+      "Expected outputs:",
+      "- `context/wiki/**` pages with frontmatter manifests.",
+      "- `.agentplane/context/derived/facts/**` or claim/fact rows with source_refs and status.",
+      "- `.agentplane/context/derived/graph/**` entities, edges, and provenance edges.",
+      "- `.agentplane/context/derived/reports/**` when useful for conflict, stale, or open-question summaries.",
+      "",
+      "Before writing:",
+      "- Search existing wiki/facts/graph rows for matching entities and claims.",
+      "- Prefer updating canonical pages over creating duplicates.",
+      "- Use `possibly_same_as` style notes when entity identity is uncertain.",
+      "",
+      "Verification:",
+      "- Run `agentplane context verify-task <task-id>`.",
+      "- Run `agentplane context graph validate`.",
+      "- Run a smoke `agentplane context search` query using exact source terminology.",
+    ].join("\n"),
+    mutability: "replaceable",
+    merge: {
+      mode: "pick_one",
+      conflict: "error",
+      precedence: 100,
+    },
+    load: {
+      roles: ["CURATOR"],
+      commands: ["context ingest", "context learn files", "context learn changes"],
+      task_tags_any: ["context", "assimilation"],
+    },
+    provenance: {
+      source_kind: "framework_builtin",
+      source_ref: "context.ingest#create-context-assimilation-task",
+      generated_by: "context.ingest",
+    },
   };
 }
 
@@ -77,6 +169,7 @@ export function createTaskNewParsed(
   if (allowCapabilities) {
     allowedOutputs.push("context/capabilities/**", ".agentplane/context/derived/capabilities/**");
   }
+  const promptModule = buildContextAssimilationPromptModule();
   return {
     title: metadata.title,
     description: metadata.description,
@@ -105,7 +198,17 @@ export function createTaskNewParsed(
             size_bytes: row.size_bytes,
           })),
         },
+        prompt_modules: [promptModule],
+        prompt_module_ref: promptModule.address.value,
         allowed_outputs: allowedOutputs,
+        wiki: {
+          layout_strategy: "adaptive",
+          page_granularity: "topic_artifact",
+          claim_granularity: "atomic",
+          frontmatter_required: true,
+          cross_links_required: true,
+          source_refs_as_markdown_links: true,
+        },
         assimilation: {
           update_wiki: true,
           extract_entities: true,


### PR DESCRIPTION
Task: 202605170721-ESJ0SW

Summary:
- Adds a portable context_assimilation prompt module to generated context ingest tasks so non-runner agents can execute wiki curation with enough local context.
- Adds adaptive llm-wiki defaults for context init, including frontmatter/cross-link/source-ref contracts.
- Adds context wiki helper commands: new, lint, explain, link.
- Updates user docs and generated CLI reference.

Local verification:
- bun test packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/commands/context/ingest.spec.ts packages/agentplane/src/commands/context/context.learn.spec.ts
- bun run typecheck
- bun run docs:cli:check
- bun run knip:check
- node .agentplane/policy/check-routing.mjs
- git diff --check
- temp-dir CLI smoke for context wiki new/explain/lint/link

Hosted verification:
- Core CI: changes/test/test-windows/Release-ready manifest passed
- Docs CI: changes/docs passed
- CodeQL: Analyze actions/javascript-typescript and CodeQL passed

Integration note:
- ap pr open attempted to push HEAD -> main and GitHub rejected protected main; branch was published explicitly.
- ap integrate must run from the base checkout, but the registered base checkout is currently behind origin/main and contains pre-existing dirty/staged changes unrelated to this PR, so canonical local integration was not run from this thread.