### PR TITLE
🚧 8DPCYD task: Fix CodeQL hosted close checkout alert [202605170811-8DPCYD]

### DIFF
--- a/.agentplane/tasks/202605170811-8DPCYD/README.md
+++ b/.agentplane/tasks/202605170811-8DPCYD/README.md
@@ -1,0 +1,150 @@
+---
+id: "202605170811-8DPCYD"
+title: "Fix CodeQL hosted close checkout alert"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "github"
+  - "security"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-17T08:14:21.839Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-17T08:47:52.404Z"
+  updated_by: "CODER"
+  note: "Local verification passed for hosted-close workflow remediation: removed the pull_request_target PR-head fetch, updated the workflow contract test, ran targeted tests (93 pass), exact-file ESLint, core and agentplane typecheck, workflow lint, and policy routing. GitHub Code scanning alert #1 remains open until this branch is published and CodeQL reruns."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implementing the primary CodeQL remediation batch in this isolated branch_pr worktree, covering hosted-close checkout plus included task IDs J4R55A, Q06434, X4C8DJ, and 9FFE6Y."
+events:
+  -
+    type: "status"
+    at: "2026-05-17T08:26:36.260Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implementing the primary CodeQL remediation batch in this isolated branch_pr worktree, covering hosted-close checkout plus included task IDs J4R55A, Q06434, X4C8DJ, and 9FFE6Y."
+  -
+    type: "verify"
+    at: "2026-05-17T08:47:52.404Z"
+    author: "CODER"
+    state: "ok"
+    note: "Local verification passed for hosted-close workflow remediation: removed the pull_request_target PR-head fetch, updated the workflow contract test, ran targeted tests (93 pass), exact-file ESLint, core and agentplane typecheck, workflow lint, and policy routing. GitHub Code scanning alert #1 remains open until this branch is published and CodeQL reruns."
+doc_version: 3
+doc_updated_at: "2026-05-17T08:47:52.454Z"
+doc_updated_by: "CODER"
+description: "Harden GitHub Actions hosted-close checkout/fetch handling for CodeQL alert #1."
+sections:
+  Summary: |-
+    Fix CodeQL hosted close checkout alert
+    
+    Harden GitHub Actions hosted-close checkout/fetch handling for CodeQL alert #1.
+  Scope: |-
+    - In scope: Harden GitHub Actions hosted-close checkout/fetch handling for CodeQL alert #1.
+    - Out of scope: unrelated refactors not required for "Fix CodeQL hosted close checkout alert".
+  Plan: "Primary batch task. Scope: fix CodeQL hosted-close checkout alert #1 and own the shared PR/worktree for related CodeQL remediation tasks 202605170812-J4R55A, 202605170812-Q06434, 202605170812-X4C8DJ, and 202605170812-9FFE6Y. Implement only security-focused changes needed to remove the unsafe checkout/fetch pattern and keep hosted-close behavior covered by tests or workflow validation."
+  Verify Steps: |-
+    - Inspect .github/workflows/task-hosted-close.yml and confirm PR code is not checked out/executed from an untrusted head ref before trust boundaries are enforced.
+    - Run the focused hosted-close/workflow test or static workflow validation available in this repository.
+    - Run node .agentplane/policy/check-routing.mjs.
+    - After PR publication or merge, re-query GitHub Code scanning alert #1 and record whether GitHub has closed it or the result is pending a CodeQL run.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-17T08:47:52.404Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Local verification passed for hosted-close workflow remediation: removed the pull_request_target PR-head fetch, updated the workflow contract test, ran targeted tests (93 pass), exact-file ESLint, core and agentplane typecheck, workflow lint, and policy routing. GitHub Code scanning alert #1 remains open until this branch is published and CodeQL reruns.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T08:26:36.260Z, excerpt_hash=sha256:5e57166058677aca57155a6387a42f80d8072ff2913c2766db42332ffe55cf66
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605170811-8DPCYD-codeql-security-fixes/.agentplane/tasks/202605170811-8DPCYD/blueprint/resolved-snapshot.json
+    - old_digest: 09e157dcfaf26fce51f63538493b2ba43d5d8e83d556ac5577f7c10d1811b659
+    - current_digest: 09e157dcfaf26fce51f63538493b2ba43d5d8e83d556ac5577f7c10d1811b659
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605170811-8DPCYD
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: GitHub Code scanning still reports alert #1 on main.
+      Impact: External alert closure is pending hosted CodeQL analysis, not a local test failure.
+      Resolution: Publish PR and re-query code scanning after GitHub CodeQL completes.
+id_source: "generated"
+---
+## Summary
+
+Fix CodeQL hosted close checkout alert
+
+Harden GitHub Actions hosted-close checkout/fetch handling for CodeQL alert #1.
+
+## Scope
+
+- In scope: Harden GitHub Actions hosted-close checkout/fetch handling for CodeQL alert #1.
+- Out of scope: unrelated refactors not required for "Fix CodeQL hosted close checkout alert".
+
+## Plan
+
+Primary batch task. Scope: fix CodeQL hosted-close checkout alert #1 and own the shared PR/worktree for related CodeQL remediation tasks 202605170812-J4R55A, 202605170812-Q06434, 202605170812-X4C8DJ, and 202605170812-9FFE6Y. Implement only security-focused changes needed to remove the unsafe checkout/fetch pattern and keep hosted-close behavior covered by tests or workflow validation.
+
+## Verify Steps
+
+- Inspect .github/workflows/task-hosted-close.yml and confirm PR code is not checked out/executed from an untrusted head ref before trust boundaries are enforced.
+- Run the focused hosted-close/workflow test or static workflow validation available in this repository.
+- Run node .agentplane/policy/check-routing.mjs.
+- After PR publication or merge, re-query GitHub Code scanning alert #1 and record whether GitHub has closed it or the result is pending a CodeQL run.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-17T08:47:52.404Z — VERIFY — ok
+
+By: CODER
+
+Note: Local verification passed for hosted-close workflow remediation: removed the pull_request_target PR-head fetch, updated the workflow contract test, ran targeted tests (93 pass), exact-file ESLint, core and agentplane typecheck, workflow lint, and policy routing. GitHub Code scanning alert #1 remains open until this branch is published and CodeQL reruns.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T08:26:36.260Z, excerpt_hash=sha256:5e57166058677aca57155a6387a42f80d8072ff2913c2766db42332ffe55cf66
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605170811-8DPCYD-codeql-security-fixes/.agentplane/tasks/202605170811-8DPCYD/blueprint/resolved-snapshot.json
+- old_digest: 09e157dcfaf26fce51f63538493b2ba43d5d8e83d556ac5577f7c10d1811b659
+- current_digest: 09e157dcfaf26fce51f63538493b2ba43d5d8e83d556ac5577f7c10d1811b659
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605170811-8DPCYD
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: GitHub Code scanning still reports alert #1 on main.
+  Impact: External alert closure is pending hosted CodeQL analysis, not a local test failure.
+  Resolution: Publish PR and re-query code scanning after GitHub CodeQL completes.

--- a/.agentplane/tasks/202605170811-8DPCYD/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605170811-8DPCYD/blueprint/resolved-snapshot.json
@@ -1,0 +1,528 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605170811-8DPCYD",
+    "title": "Fix CodeQL hosted close checkout alert",
+    "description": "Harden GitHub Actions hosted-close checkout/fetch handling for CodeQL alert #1.",
+    "tags": [
+      "code",
+      "github",
+      "security"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605170811-8DPCYD",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "09e157dcfaf26fce51f63538493b2ba43d5d8e83d556ac5577f7c10d1811b659"
+  }
+}

--- a/.agentplane/tasks/202605170811-8DPCYD/pr/diffstat.txt
+++ b/.agentplane/tasks/202605170811-8DPCYD/pr/diffstat.txt
@@ -1,0 +1,24 @@
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ .agentplane/tasks/202605170812-9FFE6Y/README.md    | 150 ++++++
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ .agentplane/tasks/202605170812-J4R55A/README.md    | 150 ++++++
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ .agentplane/tasks/202605170812-Q06434/README.md    | 150 ++++++
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ .agentplane/tasks/202605170812-X4C8DJ/README.md    | 150 ++++++
+ .../blueprint/resolved-snapshot.json               | 392 +++++++++++++++
+ .github/workflows/task-hosted-close.yml            |   9 -
+ .../task/hosted-close-workflow-contract.test.ts    |   5 +-
+ .../agentplane/src/commands/upgrade.unit.test.ts   |  13 +
+ packages/agentplane/src/commands/upgrade/source.ts |   6 +-
+ packages/core/src/commit/commit-policy.test.ts     |  11 +
+ packages/core/src/commit/commit-policy.ts          |  72 +--
+ packages/core/src/config/config.test.ts            |  10 +
+ packages/core/src/config/defaults.ts               |   7 +
+ packages/core/src/process/run-process.test.ts      |   9 +
+ packages/core/src/process/run-process.ts           |  11 +-
+ packages/core/src/tasks/task-doc.test.ts           |   5 +
+ packages/core/src/tasks/task-doc.ts                |  16 +-
+ packages/core/src/tasks/task-readme.test.ts        |  28 ++
+ packages/core/src/tasks/task-readme.ts             |  12 +-
+ 23 files changed, 3265 insertions(+), 53 deletions(-)

--- a/.agentplane/tasks/202605170811-8DPCYD/pr/github-body.md
+++ b/.agentplane/tasks/202605170811-8DPCYD/pr/github-body.md
@@ -29,12 +29,35 @@ remains open until this branch is published and CodeQL reruns.
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-17T08:26:36.463Z
+- Updated: 2026-05-17T08:51:27.708Z
 - Branch: task/202605170811-8DPCYD/codeql-security-fixes
-- Head: 545e13ed1618
+- Head: afede7721e4b
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ .agentplane/tasks/202605170812-9FFE6Y/README.md    | 150 ++++++
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ .agentplane/tasks/202605170812-J4R55A/README.md    | 150 ++++++
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ .agentplane/tasks/202605170812-Q06434/README.md    | 150 ++++++
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ .agentplane/tasks/202605170812-X4C8DJ/README.md    | 150 ++++++
+ .../blueprint/resolved-snapshot.json               | 392 +++++++++++++++
+ .github/workflows/task-hosted-close.yml            |   9 -
+ .../task/hosted-close-workflow-contract.test.ts    |   5 +-
+ .../agentplane/src/commands/upgrade.unit.test.ts   |  13 +
+ packages/agentplane/src/commands/upgrade/source.ts |   6 +-
+ packages/core/src/commit/commit-policy.test.ts     |  11 +
+ packages/core/src/commit/commit-policy.ts          |  72 +--
+ packages/core/src/config/config.test.ts            |  10 +
+ packages/core/src/config/defaults.ts               |   7 +
+ packages/core/src/process/run-process.test.ts      |   9 +
+ packages/core/src/process/run-process.ts           |  11 +-
+ packages/core/src/tasks/task-doc.test.ts           |   5 +
+ packages/core/src/tasks/task-doc.ts                |  16 +-
+ packages/core/src/tasks/task-readme.test.ts        |  28 ++
+ packages/core/src/tasks/task-readme.ts             |  12 +-
+ 23 files changed, 3265 insertions(+), 53 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605170811-8DPCYD/pr/github-body.md
+++ b/.agentplane/tasks/202605170811-8DPCYD/pr/github-body.md
@@ -1,0 +1,40 @@
+Task: `202605170811-8DPCYD`
+Title: Fix CodeQL hosted close checkout alert
+Canonical task record: `.agentplane/tasks/202605170811-8DPCYD/README.md`
+
+## Summary
+
+Fix CodeQL hosted close checkout alert
+
+Harden GitHub Actions hosted-close checkout/fetch handling for CodeQL alert #1.
+
+## Scope
+
+- In scope: Harden GitHub Actions hosted-close checkout/fetch handling for CodeQL alert #1.
+- Out of scope: unrelated refactors not required for "Fix CodeQL hosted close checkout alert".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Local verification passed for hosted-close workflow remediation: removed the pull_request_target
+PR-head fetch, updated the workflow contract test, ran targeted tests (93 pass), exact-file ESLint,
+core and agentplane typecheck, workflow lint, and policy routing. GitHub Code scanning alert #1
+remains open until this branch is published and CodeQL reruns.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-17T08:26:36.463Z
+- Branch: task/202605170811-8DPCYD/codeql-security-fixes
+- Head: 545e13ed1618
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605170811-8DPCYD/pr/github-title.txt
+++ b/.agentplane/tasks/202605170811-8DPCYD/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 8DPCYD task: Fix CodeQL hosted close checkout alert [202605170811-8DPCYD]

--- a/.agentplane/tasks/202605170811-8DPCYD/pr/meta.json
+++ b/.agentplane/tasks/202605170811-8DPCYD/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605170811-8DPCYD/codeql-security-fixes",
   "created_at": "2026-05-17T08:26:36.463Z",
-  "head_sha": "545e13ed1618aa3c3439e88517d4cf55e0b21b46",
+  "head_sha": "afede7721e4bdb17a43b08b98b2c452fb482cce3",
   "last_verified_at": "2026-05-17T08:47:52.404Z",
   "last_verified_sha": "545e13ed1618aa3c3439e88517d4cf55e0b21b46",
   "schema_version": 1,
   "task_id": "202605170811-8DPCYD",
-  "updated_at": "2026-05-17T08:26:36.463Z",
+  "updated_at": "2026-05-17T08:51:27.708Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605170811-8DPCYD/pr/meta.json
+++ b/.agentplane/tasks/202605170811-8DPCYD/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605170811-8DPCYD/codeql-security-fixes",
+  "created_at": "2026-05-17T08:26:36.463Z",
+  "head_sha": "545e13ed1618aa3c3439e88517d4cf55e0b21b46",
+  "last_verified_at": "2026-05-17T08:47:52.404Z",
+  "last_verified_sha": "545e13ed1618aa3c3439e88517d4cf55e0b21b46",
+  "schema_version": 1,
+  "task_id": "202605170811-8DPCYD",
+  "updated_at": "2026-05-17T08:26:36.463Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605170811-8DPCYD/pr/meta.json
+++ b/.agentplane/tasks/202605170811-8DPCYD/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "afede7721e4bdb17a43b08b98b2c452fb482cce3",
   "last_verified_at": "2026-05-17T08:47:52.404Z",
   "last_verified_sha": "545e13ed1618aa3c3439e88517d4cf55e0b21b46",
+  "pr_number": 3793,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3793",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605170811-8DPCYD",
-  "updated_at": "2026-05-17T08:51:27.708Z",
+  "updated_at": "2026-05-17T08:51:46.254Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605170811-8DPCYD/pr/review.md
+++ b/.agentplane/tasks/202605170811-8DPCYD/pr/review.md
@@ -24,12 +24,35 @@ Created: 2026-05-17T08:26:36.463Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-17T08:26:36.463Z
+- Updated: 2026-05-17T08:51:27.708Z
 - Branch: task/202605170811-8DPCYD/codeql-security-fixes
-- Head: 545e13ed1618
+- Head: afede7721e4b
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ .agentplane/tasks/202605170812-9FFE6Y/README.md    | 150 ++++++
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ .agentplane/tasks/202605170812-J4R55A/README.md    | 150 ++++++
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ .agentplane/tasks/202605170812-Q06434/README.md    | 150 ++++++
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ .agentplane/tasks/202605170812-X4C8DJ/README.md    | 150 ++++++
+ .../blueprint/resolved-snapshot.json               | 392 +++++++++++++++
+ .github/workflows/task-hosted-close.yml            |   9 -
+ .../task/hosted-close-workflow-contract.test.ts    |   5 +-
+ .../agentplane/src/commands/upgrade.unit.test.ts   |  13 +
+ packages/agentplane/src/commands/upgrade/source.ts |   6 +-
+ packages/core/src/commit/commit-policy.test.ts     |  11 +
+ packages/core/src/commit/commit-policy.ts          |  72 +--
+ packages/core/src/config/config.test.ts            |  10 +
+ packages/core/src/config/defaults.ts               |   7 +
+ packages/core/src/process/run-process.test.ts      |   9 +
+ packages/core/src/process/run-process.ts           |  11 +-
+ packages/core/src/tasks/task-doc.test.ts           |   5 +
+ packages/core/src/tasks/task-doc.ts                |  16 +-
+ packages/core/src/tasks/task-readme.test.ts        |  28 ++
+ packages/core/src/tasks/task-readme.ts             |  12 +-
+ 23 files changed, 3265 insertions(+), 53 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605170811-8DPCYD/pr/review.md
+++ b/.agentplane/tasks/202605170811-8DPCYD/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-17T08:26:36.463Z
+
+## Task
+
+- Task: `202605170811-8DPCYD`
+- Title: Fix CodeQL hosted close checkout alert
+- Status: DOING
+- Branch: `task/202605170811-8DPCYD/codeql-security-fixes`
+- Canonical task record: `.agentplane/tasks/202605170811-8DPCYD/README.md`
+
+## Verification
+
+- State: ok
+- Note: Local verification passed for hosted-close workflow remediation: removed the pull_request_target PR-head fetch, updated the workflow contract test, ran targeted tests (93 pass), exact-file ESLint, core and agentplane typecheck, workflow lint, and policy routing. GitHub Code scanning alert #1 remains open until this branch is published and CodeQL reruns.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-17T08:26:36.463Z
+- Branch: task/202605170811-8DPCYD/codeql-security-fixes
+- Head: 545e13ed1618
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605170812-9FFE6Y/README.md
+++ b/.agentplane/tasks/202605170812-9FFE6Y/README.md
@@ -1,0 +1,150 @@
+---
+id: "202605170812-9FFE6Y"
+title: "Fix CodeQL polynomial regex alerts"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "parser"
+  - "security"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-17T08:14:51.822Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-17T08:49:12.917Z"
+  updated_by: "CODER"
+  note: "Local verification passed for polynomial regex remediation: commit subject, task doc, and task README parsing now use bounded/manual parsing in the alerted paths, with adversarial long-input tests. Focused tests, exact-file ESLint, core typecheck, and policy routing passed. GitHub Code scanning alerts #2-#4 remain open until this branch is published and CodeQL reruns."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: replacing risky regex parsing hotspots with bounded or linear parsing and focused adversarial-input coverage for the approved CodeQL remediation batch."
+events:
+  -
+    type: "status"
+    at: "2026-05-17T08:27:35.137Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: replacing risky regex parsing hotspots with bounded or linear parsing and focused adversarial-input coverage for the approved CodeQL remediation batch."
+  -
+    type: "verify"
+    at: "2026-05-17T08:49:12.917Z"
+    author: "CODER"
+    state: "ok"
+    note: "Local verification passed for polynomial regex remediation: commit subject, task doc, and task README parsing now use bounded/manual parsing in the alerted paths, with adversarial long-input tests. Focused tests, exact-file ESLint, core typecheck, and policy routing passed. GitHub Code scanning alerts #2-#4 remain open until this branch is published and CodeQL reruns."
+doc_version: 3
+doc_updated_at: "2026-05-17T08:49:12.991Z"
+doc_updated_by: "CODER"
+description: "Replace regex parsing hotspots that trigger CodeQL polynomial ReDoS alerts #2-#4."
+sections:
+  Summary: |-
+    Fix CodeQL polynomial regex alerts
+    
+    Replace regex parsing hotspots that trigger CodeQL polynomial ReDoS alerts #2-#4.
+  Scope: |-
+    - In scope: Replace regex parsing hotspots that trigger CodeQL polynomial ReDoS alerts #2-#4.
+    - Out of scope: unrelated refactors not required for "Fix CodeQL polynomial regex alerts".
+  Plan: "Scope: fix CodeQL polynomial regex alerts #2-#4 by replacing risky regex usage in commit-policy and task doc/readme parsing with bounded or linear parsing. Coordinate implementation in the primary batch worktree owned by 202605170811-8DPCYD."
+  Verify Steps: |-
+    - Add or update focused tests for affected parsing helpers with normal and adversarial long inputs.
+    - Verify task doc/readme heading behavior and commit subject parsing remain compatible.
+    - Run the focused task doc/readme and commit policy tests.
+    - Re-query Code scanning alerts #2-#4 after GitHub CodeQL runs and record closed or pending status.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-17T08:49:12.917Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Local verification passed for polynomial regex remediation: commit subject, task doc, and task README parsing now use bounded/manual parsing in the alerted paths, with adversarial long-input tests. Focused tests, exact-file ESLint, core typecheck, and policy routing passed. GitHub Code scanning alerts #2-#4 remain open until this branch is published and CodeQL reruns.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T08:27:35.137Z, excerpt_hash=sha256:4fd6d59d12273981e4634e138c028875ed30aafdf4443fa7d228de304fe0fa33
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605170811-8DPCYD-codeql-security-fixes/.agentplane/tasks/202605170812-9FFE6Y/blueprint/resolved-snapshot.json
+    - old_digest: 56fe422511a9db028cb940428bb15bece4189c7128ad66812914f8d774ca4c58
+    - current_digest: 56fe422511a9db028cb940428bb15bece4189c7128ad66812914f8d774ca4c58
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605170812-9FFE6Y
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: GitHub Code scanning still reports alerts #2-#4 on main.
+      Impact: External alert closure is pending hosted CodeQL analysis, not a local test failure.
+      Resolution: Publish PR and re-query code scanning after GitHub CodeQL completes.
+id_source: "generated"
+---
+## Summary
+
+Fix CodeQL polynomial regex alerts
+
+Replace regex parsing hotspots that trigger CodeQL polynomial ReDoS alerts #2-#4.
+
+## Scope
+
+- In scope: Replace regex parsing hotspots that trigger CodeQL polynomial ReDoS alerts #2-#4.
+- Out of scope: unrelated refactors not required for "Fix CodeQL polynomial regex alerts".
+
+## Plan
+
+Scope: fix CodeQL polynomial regex alerts #2-#4 by replacing risky regex usage in commit-policy and task doc/readme parsing with bounded or linear parsing. Coordinate implementation in the primary batch worktree owned by 202605170811-8DPCYD.
+
+## Verify Steps
+
+- Add or update focused tests for affected parsing helpers with normal and adversarial long inputs.
+- Verify task doc/readme heading behavior and commit subject parsing remain compatible.
+- Run the focused task doc/readme and commit policy tests.
+- Re-query Code scanning alerts #2-#4 after GitHub CodeQL runs and record closed or pending status.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-17T08:49:12.917Z — VERIFY — ok
+
+By: CODER
+
+Note: Local verification passed for polynomial regex remediation: commit subject, task doc, and task README parsing now use bounded/manual parsing in the alerted paths, with adversarial long-input tests. Focused tests, exact-file ESLint, core typecheck, and policy routing passed. GitHub Code scanning alerts #2-#4 remain open until this branch is published and CodeQL reruns.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T08:27:35.137Z, excerpt_hash=sha256:4fd6d59d12273981e4634e138c028875ed30aafdf4443fa7d228de304fe0fa33
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605170811-8DPCYD-codeql-security-fixes/.agentplane/tasks/202605170812-9FFE6Y/blueprint/resolved-snapshot.json
+- old_digest: 56fe422511a9db028cb940428bb15bece4189c7128ad66812914f8d774ca4c58
+- current_digest: 56fe422511a9db028cb940428bb15bece4189c7128ad66812914f8d774ca4c58
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605170812-9FFE6Y
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: GitHub Code scanning still reports alerts #2-#4 on main.
+  Impact: External alert closure is pending hosted CodeQL analysis, not a local test failure.
+  Resolution: Publish PR and re-query code scanning after GitHub CodeQL completes.

--- a/.agentplane/tasks/202605170812-9FFE6Y/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605170812-9FFE6Y/blueprint/resolved-snapshot.json
@@ -1,0 +1,528 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605170812-9FFE6Y",
+    "title": "Fix CodeQL polynomial regex alerts",
+    "description": "Replace regex parsing hotspots that trigger CodeQL polynomial ReDoS alerts #2-#4.",
+    "tags": [
+      "code",
+      "parser",
+      "security"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605170812-9FFE6Y",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "56fe422511a9db028cb940428bb15bece4189c7128ad66812914f8d774ca4c58"
+  }
+}

--- a/.agentplane/tasks/202605170812-J4R55A/README.md
+++ b/.agentplane/tasks/202605170812-J4R55A/README.md
@@ -1,0 +1,150 @@
+---
+id: "202605170812-J4R55A"
+title: "Fix CodeQL process execution alerts"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "process"
+  - "security"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-17T08:14:32.328Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-17T08:48:11.320Z"
+  updated_by: "CODER"
+  note: "Local verification passed for process execution remediation: run-process now forces argv-only execution and rejects invalid executable names; focused tests, exact-file ESLint, core/agentplane typecheck, and policy routing passed. GitHub Code scanning alerts #7-#17 remain open until this branch is published and CodeQL reruns."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: hardening the shared process execution and git helper command contracts for CodeQL shell command findings in the approved CodeQL remediation batch."
+events:
+  -
+    type: "status"
+    at: "2026-05-17T08:26:55.984Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: hardening the shared process execution and git helper command contracts for CodeQL shell command findings in the approved CodeQL remediation batch."
+  -
+    type: "verify"
+    at: "2026-05-17T08:48:11.320Z"
+    author: "CODER"
+    state: "ok"
+    note: "Local verification passed for process execution remediation: run-process now forces argv-only execution and rejects invalid executable names; focused tests, exact-file ESLint, core/agentplane typecheck, and policy routing passed. GitHub Code scanning alerts #7-#17 remain open until this branch is published and CodeQL reruns."
+doc_version: 3
+doc_updated_at: "2026-05-17T08:48:11.420Z"
+doc_updated_by: "CODER"
+description: "Harden process and git command execution contracts for CodeQL shell command alerts #7-#17."
+sections:
+  Summary: |-
+    Fix CodeQL process execution alerts
+    
+    Harden process and git command execution contracts for CodeQL shell command alerts #7-#17.
+  Scope: |-
+    - In scope: Harden process and git command execution contracts for CodeQL shell command alerts #7-#17.
+    - Out of scope: unrelated refactors not required for "Fix CodeQL process execution alerts".
+  Plan: "Scope: fix CodeQL shell command findings #7-#17 by hardening process execution and git helper contracts. Prefer argv-only subprocess APIs, fail closed on shell usage where possible, and keep shell allowance explicit and narrow. Coordinate implementation in the primary batch worktree owned by 202605170811-8DPCYD."
+  Verify Steps: |-
+    - Add or update focused tests for process execution and git helper command construction.
+    - Run the focused process/git test files that cover run-process, git-client, git-diff, task-backend branch snapshot, and commit policy behavior as applicable.
+    - Run TypeScript/package checks required by the touched package.
+    - Re-query open Code scanning alerts #7-#17 after GitHub CodeQL runs and record closed or pending status.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-17T08:48:11.320Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Local verification passed for process execution remediation: run-process now forces argv-only execution and rejects invalid executable names; focused tests, exact-file ESLint, core/agentplane typecheck, and policy routing passed. GitHub Code scanning alerts #7-#17 remain open until this branch is published and CodeQL reruns.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T08:26:55.984Z, excerpt_hash=sha256:37f5dc2e72ba8ff0c1062b0db5bdb1cfa04ff260b0f295b10e870700c754c841
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605170811-8DPCYD-codeql-security-fixes/.agentplane/tasks/202605170812-J4R55A/blueprint/resolved-snapshot.json
+    - old_digest: 5f4d86c1ec0f7d9f79cfc5a9aecefe1e6f131bdc7335681912a7128dea6bf6a5
+    - current_digest: 5f4d86c1ec0f7d9f79cfc5a9aecefe1e6f131bdc7335681912a7128dea6bf6a5
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605170812-J4R55A
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: GitHub Code scanning still reports alerts #7-#17 on main.
+      Impact: External alert closure is pending hosted CodeQL analysis, not a local test failure.
+      Resolution: Publish PR and re-query code scanning after GitHub CodeQL completes.
+id_source: "generated"
+---
+## Summary
+
+Fix CodeQL process execution alerts
+
+Harden process and git command execution contracts for CodeQL shell command alerts #7-#17.
+
+## Scope
+
+- In scope: Harden process and git command execution contracts for CodeQL shell command alerts #7-#17.
+- Out of scope: unrelated refactors not required for "Fix CodeQL process execution alerts".
+
+## Plan
+
+Scope: fix CodeQL shell command findings #7-#17 by hardening process execution and git helper contracts. Prefer argv-only subprocess APIs, fail closed on shell usage where possible, and keep shell allowance explicit and narrow. Coordinate implementation in the primary batch worktree owned by 202605170811-8DPCYD.
+
+## Verify Steps
+
+- Add or update focused tests for process execution and git helper command construction.
+- Run the focused process/git test files that cover run-process, git-client, git-diff, task-backend branch snapshot, and commit policy behavior as applicable.
+- Run TypeScript/package checks required by the touched package.
+- Re-query open Code scanning alerts #7-#17 after GitHub CodeQL runs and record closed or pending status.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-17T08:48:11.320Z — VERIFY — ok
+
+By: CODER
+
+Note: Local verification passed for process execution remediation: run-process now forces argv-only execution and rejects invalid executable names; focused tests, exact-file ESLint, core/agentplane typecheck, and policy routing passed. GitHub Code scanning alerts #7-#17 remain open until this branch is published and CodeQL reruns.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T08:26:55.984Z, excerpt_hash=sha256:37f5dc2e72ba8ff0c1062b0db5bdb1cfa04ff260b0f295b10e870700c754c841
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605170811-8DPCYD-codeql-security-fixes/.agentplane/tasks/202605170812-J4R55A/blueprint/resolved-snapshot.json
+- old_digest: 5f4d86c1ec0f7d9f79cfc5a9aecefe1e6f131bdc7335681912a7128dea6bf6a5
+- current_digest: 5f4d86c1ec0f7d9f79cfc5a9aecefe1e6f131bdc7335681912a7128dea6bf6a5
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605170812-J4R55A
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: GitHub Code scanning still reports alerts #7-#17 on main.
+  Impact: External alert closure is pending hosted CodeQL analysis, not a local test failure.
+  Resolution: Publish PR and re-query code scanning after GitHub CodeQL completes.

--- a/.agentplane/tasks/202605170812-J4R55A/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605170812-J4R55A/blueprint/resolved-snapshot.json
@@ -1,0 +1,528 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605170812-J4R55A",
+    "title": "Fix CodeQL process execution alerts",
+    "description": "Harden process and git command execution contracts for CodeQL shell command alerts #7-#17.",
+    "tags": [
+      "code",
+      "process",
+      "security"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605170812-J4R55A",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "5f4d86c1ec0f7d9f79cfc5a9aecefe1e6f131bdc7335681912a7128dea6bf6a5"
+  }
+}

--- a/.agentplane/tasks/202605170812-Q06434/README.md
+++ b/.agentplane/tasks/202605170812-Q06434/README.md
@@ -1,0 +1,150 @@
+---
+id: "202605170812-Q06434"
+title: "Fix CodeQL upgrade source URL validation"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "security"
+  - "upgrade"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-17T08:14:38.026Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-17T08:48:27.465Z"
+  updated_by: "CODER"
+  note: "Local verification passed for upgrade source URL validation: host validation now parses URL and requires https://github.com; hostile github.com-in-path/subdomain cases are rejected. Focused tests, exact-file ESLint, agentplane typecheck, and policy routing passed. GitHub Code scanning alert #18 remains open until this branch is published and CodeQL reruns."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: replacing substring GitHub source validation with parsed URL host validation and focused upgrade-source tests for the approved CodeQL remediation batch."
+events:
+  -
+    type: "status"
+    at: "2026-05-17T08:27:10.371Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: replacing substring GitHub source validation with parsed URL host validation and focused upgrade-source tests for the approved CodeQL remediation batch."
+  -
+    type: "verify"
+    at: "2026-05-17T08:48:27.465Z"
+    author: "CODER"
+    state: "ok"
+    note: "Local verification passed for upgrade source URL validation: host validation now parses URL and requires https://github.com; hostile github.com-in-path/subdomain cases are rejected. Focused tests, exact-file ESLint, agentplane typecheck, and policy routing passed. GitHub Code scanning alert #18 remains open until this branch is published and CodeQL reruns."
+doc_version: 3
+doc_updated_at: "2026-05-17T08:48:27.513Z"
+doc_updated_by: "CODER"
+description: "Replace substring GitHub URL validation with parsed host validation for CodeQL alert #18."
+sections:
+  Summary: |-
+    Fix CodeQL upgrade source URL validation
+    
+    Replace substring GitHub URL validation with parsed host validation for CodeQL alert #18.
+  Scope: |-
+    - In scope: Replace substring GitHub URL validation with parsed host validation for CodeQL alert #18.
+    - Out of scope: unrelated refactors not required for "Fix CodeQL upgrade source URL validation".
+  Plan: "Scope: fix CodeQL alert #18 by replacing substring GitHub URL validation with parsed URL host validation in upgrade source handling. Coordinate implementation in the primary batch worktree owned by 202605170811-8DPCYD."
+  Verify Steps: |-
+    - Add or update focused tests for normalizeFrameworkSourceForUpgrade/parseGitHubRepo behavior.
+    - Verify valid https://github.com/owner/repo(.git) URLs still normalize correctly.
+    - Verify hostile URLs containing github.com outside the hostname are rejected.
+    - Re-query Code scanning alert #18 after GitHub CodeQL runs and record closed or pending status.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-17T08:48:27.465Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Local verification passed for upgrade source URL validation: host validation now parses URL and requires https://github.com; hostile github.com-in-path/subdomain cases are rejected. Focused tests, exact-file ESLint, agentplane typecheck, and policy routing passed. GitHub Code scanning alert #18 remains open until this branch is published and CodeQL reruns.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T08:27:10.371Z, excerpt_hash=sha256:366af10f34a07a7ada91af06ad50358d7cd7c14f4e278f6d51fcfa091a38dc3f
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605170811-8DPCYD-codeql-security-fixes/.agentplane/tasks/202605170812-Q06434/blueprint/resolved-snapshot.json
+    - old_digest: b1025ce6b668d01758d4e1421b84d287a4f81df3c467025a12c60e1f45305ac5
+    - current_digest: b1025ce6b668d01758d4e1421b84d287a4f81df3c467025a12c60e1f45305ac5
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605170812-Q06434
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: GitHub Code scanning still reports alert #18 on main.
+      Impact: External alert closure is pending hosted CodeQL analysis, not a local test failure.
+      Resolution: Publish PR and re-query code scanning after GitHub CodeQL completes.
+id_source: "generated"
+---
+## Summary
+
+Fix CodeQL upgrade source URL validation
+
+Replace substring GitHub URL validation with parsed host validation for CodeQL alert #18.
+
+## Scope
+
+- In scope: Replace substring GitHub URL validation with parsed host validation for CodeQL alert #18.
+- Out of scope: unrelated refactors not required for "Fix CodeQL upgrade source URL validation".
+
+## Plan
+
+Scope: fix CodeQL alert #18 by replacing substring GitHub URL validation with parsed URL host validation in upgrade source handling. Coordinate implementation in the primary batch worktree owned by 202605170811-8DPCYD.
+
+## Verify Steps
+
+- Add or update focused tests for normalizeFrameworkSourceForUpgrade/parseGitHubRepo behavior.
+- Verify valid https://github.com/owner/repo(.git) URLs still normalize correctly.
+- Verify hostile URLs containing github.com outside the hostname are rejected.
+- Re-query Code scanning alert #18 after GitHub CodeQL runs and record closed or pending status.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-17T08:48:27.465Z — VERIFY — ok
+
+By: CODER
+
+Note: Local verification passed for upgrade source URL validation: host validation now parses URL and requires https://github.com; hostile github.com-in-path/subdomain cases are rejected. Focused tests, exact-file ESLint, agentplane typecheck, and policy routing passed. GitHub Code scanning alert #18 remains open until this branch is published and CodeQL reruns.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T08:27:10.371Z, excerpt_hash=sha256:366af10f34a07a7ada91af06ad50358d7cd7c14f4e278f6d51fcfa091a38dc3f
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605170811-8DPCYD-codeql-security-fixes/.agentplane/tasks/202605170812-Q06434/blueprint/resolved-snapshot.json
+- old_digest: b1025ce6b668d01758d4e1421b84d287a4f81df3c467025a12c60e1f45305ac5
+- current_digest: b1025ce6b668d01758d4e1421b84d287a4f81df3c467025a12c60e1f45305ac5
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605170812-Q06434
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: GitHub Code scanning still reports alert #18 on main.
+  Impact: External alert closure is pending hosted CodeQL analysis, not a local test failure.
+  Resolution: Publish PR and re-query code scanning after GitHub CodeQL completes.

--- a/.agentplane/tasks/202605170812-Q06434/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605170812-Q06434/blueprint/resolved-snapshot.json
@@ -1,0 +1,528 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605170812-Q06434",
+    "title": "Fix CodeQL upgrade source URL validation",
+    "description": "Replace substring GitHub URL validation with parsed host validation for CodeQL alert #18.",
+    "tags": [
+      "code",
+      "security",
+      "upgrade"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605170812-Q06434",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "b1025ce6b668d01758d4e1421b84d287a4f81df3c467025a12c60e1f45305ac5"
+  }
+}

--- a/.agentplane/tasks/202605170812-X4C8DJ/README.md
+++ b/.agentplane/tasks/202605170812-X4C8DJ/README.md
@@ -1,0 +1,150 @@
+---
+id: "202605170812-X4C8DJ"
+title: "Fix CodeQL config prototype pollution alerts"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "config"
+  - "security"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-17T08:14:46.206Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-17T08:48:49.666Z"
+  updated_by: "CODER"
+  note: "Local verification passed for config prototype pollution remediation: setByDottedKey now rejects __proto__, prototype, and constructor path segments while preserving valid nested key behavior. Focused config tests, exact-file ESLint, core typecheck, and policy routing passed. GitHub Code scanning alerts #5 and #6 remain open until this branch is published and CodeQL reruns."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: rejecting unsafe dotted config key segments and adding focused config mutation coverage for the approved CodeQL remediation batch."
+events:
+  -
+    type: "status"
+    at: "2026-05-17T08:27:21.491Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: rejecting unsafe dotted config key segments and adding focused config mutation coverage for the approved CodeQL remediation batch."
+  -
+    type: "verify"
+    at: "2026-05-17T08:48:49.666Z"
+    author: "CODER"
+    state: "ok"
+    note: "Local verification passed for config prototype pollution remediation: setByDottedKey now rejects __proto__, prototype, and constructor path segments while preserving valid nested key behavior. Focused config tests, exact-file ESLint, core typecheck, and policy routing passed. GitHub Code scanning alerts #5 and #6 remain open until this branch is published and CodeQL reruns."
+doc_version: 3
+doc_updated_at: "2026-05-17T08:48:49.830Z"
+doc_updated_by: "CODER"
+description: "Reject unsafe dotted config keys for CodeQL prototype pollution alerts #5 and #6."
+sections:
+  Summary: |-
+    Fix CodeQL config prototype pollution alerts
+    
+    Reject unsafe dotted config keys for CodeQL prototype pollution alerts #5 and #6.
+  Scope: |-
+    - In scope: Reject unsafe dotted config keys for CodeQL prototype pollution alerts #5 and #6.
+    - Out of scope: unrelated refactors not required for "Fix CodeQL config prototype pollution alerts".
+  Plan: "Scope: fix CodeQL prototype pollution alerts #5 and #6 by rejecting unsafe path segments in dotted config keys before object assignment. Coordinate implementation in the primary batch worktree owned by 202605170811-8DPCYD."
+  Verify Steps: |-
+    - Add or update focused tests for setByDottedKey unsafe segments: __proto__, prototype, and constructor.
+    - Verify valid nested config keys still parse scalar values and create normal objects.
+    - Run the focused config/defaults tests.
+    - Re-query Code scanning alerts #5 and #6 after GitHub CodeQL runs and record closed or pending status.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-17T08:48:49.666Z — VERIFY — ok
+    
+    By: CODER
+    
+    Note: Local verification passed for config prototype pollution remediation: setByDottedKey now rejects __proto__, prototype, and constructor path segments while preserving valid nested key behavior. Focused config tests, exact-file ESLint, core typecheck, and policy routing passed. GitHub Code scanning alerts #5 and #6 remain open until this branch is published and CodeQL reruns.
+    Attempts: 0
+    
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T08:27:21.491Z, excerpt_hash=sha256:f6f9b8eef3842348998d5af172be97345a59f963d0c0aebb0012b43e0b34da8d
+    
+    Details:
+    
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605170811-8DPCYD-codeql-security-fixes/.agentplane/tasks/202605170812-X4C8DJ/blueprint/resolved-snapshot.json
+    - old_digest: 86183173cf5355b9f0b8aba6140d196c909f29aeffd4b5d1595203fcbf65a5c2
+    - current_digest: 86183173cf5355b9f0b8aba6140d196c909f29aeffd4b5d1595203fcbf65a5c2
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605170812-X4C8DJ
+    
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: GitHub Code scanning still reports alerts #5 and #6 on main.
+      Impact: External alert closure is pending hosted CodeQL analysis, not a local test failure.
+      Resolution: Publish PR and re-query code scanning after GitHub CodeQL completes.
+id_source: "generated"
+---
+## Summary
+
+Fix CodeQL config prototype pollution alerts
+
+Reject unsafe dotted config keys for CodeQL prototype pollution alerts #5 and #6.
+
+## Scope
+
+- In scope: Reject unsafe dotted config keys for CodeQL prototype pollution alerts #5 and #6.
+- Out of scope: unrelated refactors not required for "Fix CodeQL config prototype pollution alerts".
+
+## Plan
+
+Scope: fix CodeQL prototype pollution alerts #5 and #6 by rejecting unsafe path segments in dotted config keys before object assignment. Coordinate implementation in the primary batch worktree owned by 202605170811-8DPCYD.
+
+## Verify Steps
+
+- Add or update focused tests for setByDottedKey unsafe segments: __proto__, prototype, and constructor.
+- Verify valid nested config keys still parse scalar values and create normal objects.
+- Run the focused config/defaults tests.
+- Re-query Code scanning alerts #5 and #6 after GitHub CodeQL runs and record closed or pending status.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-17T08:48:49.666Z — VERIFY — ok
+
+By: CODER
+
+Note: Local verification passed for config prototype pollution remediation: setByDottedKey now rejects __proto__, prototype, and constructor path segments while preserving valid nested key behavior. Focused config tests, exact-file ESLint, core typecheck, and policy routing passed. GitHub Code scanning alerts #5 and #6 remain open until this branch is published and CodeQL reruns.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T08:27:21.491Z, excerpt_hash=sha256:f6f9b8eef3842348998d5af172be97345a59f963d0c0aebb0012b43e0b34da8d
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605170811-8DPCYD-codeql-security-fixes/.agentplane/tasks/202605170812-X4C8DJ/blueprint/resolved-snapshot.json
+- old_digest: 86183173cf5355b9f0b8aba6140d196c909f29aeffd4b5d1595203fcbf65a5c2
+- current_digest: 86183173cf5355b9f0b8aba6140d196c909f29aeffd4b5d1595203fcbf65a5c2
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605170812-X4C8DJ
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: GitHub Code scanning still reports alerts #5 and #6 on main.
+  Impact: External alert closure is pending hosted CodeQL analysis, not a local test failure.
+  Resolution: Publish PR and re-query code scanning after GitHub CodeQL completes.

--- a/.agentplane/tasks/202605170812-X4C8DJ/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605170812-X4C8DJ/blueprint/resolved-snapshot.json
@@ -1,0 +1,392 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605170812-X4C8DJ",
+    "title": "Fix CodeQL config prototype pollution alerts",
+    "description": "Reject unsafe dotted config keys for CodeQL prototype pollution alerts #5 and #6.",
+    "tags": [
+      "code",
+      "config",
+      "security"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "ops",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "ops.approval",
+    "version": 1,
+    "title": "Approval-gated operations",
+    "taskKinds": [
+      "ops"
+    ],
+    "workflowModes": []
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "ops.approval",
+    "blueprintVersion": 1,
+    "title": "Approval-gated operations",
+    "taskId": "202605170812-X4C8DJ",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "ops"
+    },
+    "whySelected": [
+      "task kind resolved to ops",
+      "workflow mode: branch_pr",
+      "mutation scope: ops"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions",
+          "rollback"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "rollback"
+        ]
+      },
+      {
+        "id": "deterministic_check",
+        "kind": "deterministic_check",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "ops.approval",
+        "kind": "approval",
+        "producedBy": "approval_gate",
+        "required": true,
+        "description": "Operational approval."
+      },
+      {
+        "id": "ops.rollback",
+        "kind": "rollback",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Rollback or recovery path."
+      },
+      {
+        "id": "ops.action",
+        "kind": "artifact",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Action log or operational artifact."
+      },
+      {
+        "id": "ops.check",
+        "kind": "check_result",
+        "producedBy": "deterministic_check",
+        "required": true,
+        "description": "Post-action check."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md"
+    ],
+    "allowedCommands": [
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "approved operational command"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 2,
+      "maxPromptBlocks": 12,
+      "rationale": "Ops work needs security and rollback context before any external action."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions",
+        "rollback"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "rollback"
+      ]
+    },
+    {
+      "id": "deterministic_check",
+      "kind": "deterministic_check",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "ops.approval",
+      "kind": "approval",
+      "producedBy": "approval_gate",
+      "required": true,
+      "description": "Operational approval."
+    },
+    {
+      "id": "ops.rollback",
+      "kind": "rollback",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Rollback or recovery path."
+    },
+    {
+      "id": "ops.action",
+      "kind": "artifact",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Action log or operational artifact."
+    },
+    {
+      "id": "ops.check",
+      "kind": "check_result",
+      "producedBy": "deterministic_check",
+      "required": true,
+      "description": "Post-action check."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md"
+  ],
+  "allowedCommands": [
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "approved operational command"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 2,
+    "maxPromptBlocks": 12,
+    "rationale": "Ops work needs security and rollback context before any external action."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to ops",
+    "workflow mode: branch_pr",
+    "mutation scope: ops"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "86183173cf5355b9f0b8aba6140d196c909f29aeffd4b5d1595203fcbf65a5c2"
+  }
+}

--- a/.github/workflows/task-hosted-close.yml
+++ b/.github/workflows/task-hosted-close.yml
@@ -96,15 +96,6 @@ jobs:
           steps.prepare.outputs.actionable == 'true' &&
           steps.existing.outputs.pr_url == '' &&
           steps.existing.outputs.branch_exists != 'true'
-        run: |
-          set -euo pipefail
-          git fetch --no-tags origin \
-            "pull/${{ steps.prepare.outputs.pr_number }}/head:${{ steps.prepare.outputs.source_branch }}"
-      - name: Apply hosted task closure on a local base checkout
-        if: |
-          steps.prepare.outputs.actionable == 'true' &&
-          steps.existing.outputs.pr_url == '' &&
-          steps.existing.outputs.branch_exists != 'true'
         id: close
         run: |
           set -euo pipefail

--- a/packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
+++ b/packages/agentplane/src/commands/task/hosted-close-workflow-contract.test.ts
@@ -18,10 +18,7 @@ describe("Task hosted-close workflow contract", () => {
     expect(workflow).toContain("pull-requests: write");
     expect(workflow).toContain("fetch-depth: 0");
     expect(workflow).toContain("node scripts/prepare-hosted-task-closure.mjs");
-    expect(workflow).toContain("git fetch --no-tags origin");
-    expect(workflow).toContain(
-      "pull/${{ steps.prepare.outputs.pr_number }}/head:${{ steps.prepare.outputs.source_branch",
-    );
+    expect(workflow).not.toContain("pull/${{ steps.prepare.outputs.pr_number }}/head");
     expect(workflow).toContain("task hosted-close");
     expect(workflow).toContain("gh pr create");
     expect(workflow).toContain('if gh pr merge --merge --delete-branch "$pr_url"; then');

--- a/packages/agentplane/src/commands/upgrade.unit.test.ts
+++ b/packages/agentplane/src/commands/upgrade.unit.test.ts
@@ -18,4 +18,17 @@ describe("upgrade source normalization", () => {
     expect(out.repo).toBe("example-repo");
     expect(out.source).toBe("https://github.com/example-org/example-repo");
   });
+
+  it("rejects URLs that only contain github.com outside the host", () => {
+    expect(() =>
+      normalizeFrameworkSourceForUpgrade(
+        "https://evil.example/github.com/basilisk-labs/agentplane",
+      ),
+    ).toThrow(/GitHub repo URL/);
+    expect(() =>
+      normalizeFrameworkSourceForUpgrade(
+        "https://github.com.evil.example/basilisk-labs/agentplane",
+      ),
+    ).toThrow(/GitHub repo URL/);
+  });
 });

--- a/packages/agentplane/src/commands/upgrade.unit.test.ts
+++ b/packages/agentplane/src/commands/upgrade.unit.test.ts
@@ -24,11 +24,11 @@ describe("upgrade source normalization", () => {
       normalizeFrameworkSourceForUpgrade(
         "https://evil.example/github.com/basilisk-labs/agentplane",
       ),
-    ).toThrow(/GitHub repo URL/);
+    ).toThrow(/config\.framework\.source/);
     expect(() =>
       normalizeFrameworkSourceForUpgrade(
         "https://github.com.evil.example/basilisk-labs/agentplane",
       ),
-    ).toThrow(/GitHub repo URL/);
+    ).toThrow(/config\.framework\.source/);
   });
 });

--- a/packages/agentplane/src/commands/upgrade/source.ts
+++ b/packages/agentplane/src/commands/upgrade/source.ts
@@ -41,18 +41,19 @@ export async function loadFrameworkManifestFromPath(
 function parseGitHubRepo(source: string): { owner: string; repo: string } {
   const trimmed = source.trim();
   if (!trimmed) throw new Error(requiredFieldMessage("config.framework.source"));
+  let url: URL;
   try {
-    const url = new URL(trimmed);
-    if (url.protocol !== "https:" || url.hostname !== "github.com") {
-      throw new Error(invalidFieldMessage("config.framework.source", "GitHub URL"));
-    }
-    const parts = url.pathname.replaceAll(".git", "").split("/").filter(Boolean);
-    if (parts.length < 2)
-      throw new Error(invalidValueMessage("GitHub repo URL", trimmed, "owner/repo"));
-    return { owner: parts[0], repo: parts[1] };
+    url = new URL(trimmed);
   } catch {
     throw new Error(invalidValueMessage("GitHub repo URL", trimmed, "owner/repo"));
   }
+  if (url.protocol !== "https:" || url.hostname !== "github.com") {
+    throw new Error(invalidFieldMessage("config.framework.source", "GitHub URL"));
+  }
+  const parts = url.pathname.replaceAll(".git", "").split("/").filter(Boolean);
+  if (parts.length < 2)
+    throw new Error(invalidValueMessage("GitHub repo URL", trimmed, "owner/repo"));
+  return { owner: parts[0], repo: parts[1] };
 }
 
 export function normalizeFrameworkSourceForUpgrade(source: string): {

--- a/packages/agentplane/src/commands/upgrade/source.ts
+++ b/packages/agentplane/src/commands/upgrade/source.ts
@@ -41,11 +41,11 @@ export async function loadFrameworkManifestFromPath(
 function parseGitHubRepo(source: string): { owner: string; repo: string } {
   const trimmed = source.trim();
   if (!trimmed) throw new Error(requiredFieldMessage("config.framework.source"));
-  if (!trimmed.includes("github.com")) {
-    throw new Error(invalidFieldMessage("config.framework.source", "GitHub URL"));
-  }
   try {
     const url = new URL(trimmed);
+    if (url.protocol !== "https:" || url.hostname !== "github.com") {
+      throw new Error(invalidFieldMessage("config.framework.source", "GitHub URL"));
+    }
     const parts = url.pathname.replaceAll(".git", "").split("/").filter(Boolean);
     if (parts.length < 2)
       throw new Error(invalidValueMessage("GitHub repo URL", trimmed, "owner/repo"));

--- a/packages/core/src/commit/commit-policy.test.ts
+++ b/packages/core/src/commit/commit-policy.test.ts
@@ -124,6 +124,17 @@ describe("commit-policy", () => {
     expect(allowed.ok).toBe(true);
   });
 
+  it("parses long malformed subjects without regex backtracking", () => {
+    const longSubject = `✨ ABCDEF ${"scope/".repeat(5000)}: add guarded parsing`;
+    expect(parseTaskSubjectTemplate(longSubject)).toBeNull();
+
+    const valid = parseTaskSubjectTemplate(
+      `✨ ABCDEF core/parser: ${"tighten ".repeat(5000)}subject parsing`,
+    );
+    expect(valid?.scope).toBe("core/parser");
+    expect(valid?.summary).toContain("subject parsing");
+  });
+
   it("validates allowed human-readable task subject scopes against task intent", () => {
     const allowedByTag = validateCommitSubject({
       subject: "git: render human-readable merge messages",

--- a/packages/core/src/commit/commit-policy.ts
+++ b/packages/core/src/commit/commit-policy.ts
@@ -23,7 +23,6 @@ export type CommitTaskIntent = {
 };
 
 const NON_TASK_SUFFIX = "DEV";
-const SCOPE_PATTERN = "[a-z][a-z0-9_-]*(?:/[a-z0-9_-]+)*";
 export const TASK_INTENT_COMMIT_SCOPES = [
   "analysis",
   "content",
@@ -58,6 +57,33 @@ function rootScope(scope: string): string {
   return scope.trim().toLowerCase().split("/")[0] ?? "";
 }
 
+function isScopeSegment(segment: string): boolean {
+  if (!segment) return false;
+  const first = segment.codePointAt(0) ?? 0;
+  if (first < 97 || first > 122) return false;
+  for (let i = 1; i < segment.length; i += 1) {
+    const code = segment.codePointAt(i) ?? 0;
+    const isLower = code >= 97 && code <= 122;
+    const isDigit = code >= 48 && code <= 57;
+    if (!isLower && !isDigit && segment[i] !== "_" && segment[i] !== "-") return false;
+  }
+  return true;
+}
+
+function isCommitScope(scope: string): boolean {
+  const segments = scope.split("/");
+  return segments.length > 0 && segments.every((segment) => isScopeSegment(segment));
+}
+
+function splitScopeSummary(rest: string): { scope: string; summary: string } | null {
+  const separator = rest.indexOf(":");
+  if (separator <= 0) return null;
+  const scope = rest.slice(0, separator).trim();
+  const summary = rest.slice(separator + 1).trim();
+  if (!scope || !summary || !isCommitScope(scope)) return null;
+  return { scope, summary };
+}
+
 export function commitScopesForTaskIntent(intent: CommitTaskIntent): string[] {
   const scopes = new Set<string>();
   if (
@@ -71,7 +97,7 @@ export function commitScopesForTaskIntent(intent: CommitTaskIntent): string[] {
   if (intent.blueprintRequest) scopes.add(intent.blueprintRequest.split(".")[0] ?? "");
   for (const tag of intent.tags ?? []) {
     const normalized = rootScope(tag);
-    if (normalized && new RegExp(`^${SCOPE_PATTERN}$`).test(normalized)) scopes.add(normalized);
+    if (normalized && isCommitScope(normalized)) scopes.add(normalized);
   }
   return [...scopes].filter(Boolean).toSorted();
 }
@@ -111,21 +137,17 @@ export function parseTaskSubjectTemplate(subject: string): {
   const trimmed = subject.trim();
   if (!trimmed) return null;
 
-  const match = /^(\S+)\s+(\S+)\s+(.+)$/.exec(trimmed);
-  if (!match) return null;
-
-  const emoji = match[1] ?? "";
-  const suffix = match[2] ?? "";
-  const rest = (match[3] ?? "").trim();
+  const tokens = trimmed.split(/\s+/u, 3);
+  const emoji = tokens[0] ?? "";
+  const suffix = tokens[1] ?? "";
+  const restStart = emoji.length + trimmed.slice(emoji.length).search(/\S/u);
+  const suffixEnd = restStart + suffix.length;
+  const restOffset = suffixEnd + trimmed.slice(suffixEnd).search(/\S/u);
+  const rest = restOffset >= suffixEnd ? trimmed.slice(restOffset).trim() : "";
   if (!emoji || !suffix || !rest) return null;
 
-  const scopeMatch = new RegExp(String.raw`^(${SCOPE_PATTERN}):\s+(.+)$`).exec(rest);
-  if (!scopeMatch) return null;
-  const scope = scopeMatch[1] ?? "";
-  const summary = (scopeMatch[2] ?? "").trim();
-  if (!scope || !summary) return null;
-
-  return { emoji, suffix, scope, summary };
+  const parsed = splitScopeSummary(rest);
+  return parsed ? { emoji, suffix, ...parsed } : null;
 }
 
 const TASK_ARTIFACT_REFRESH_SUMMARY = "refresh task artifacts after commit";
@@ -166,13 +188,12 @@ function parseNonTaskSubjectTemplate(subject: string): {
   if (!trimmed) return null;
 
   // Non-task: `<emoji> <scope>: <summary>`
-  const match = new RegExp(String.raw`^(\S+)\s+(${SCOPE_PATTERN}):\s+(.+)$`).exec(trimmed);
-  if (!match) return null;
-  const emoji = match[1] ?? "";
-  const scope = match[2] ?? "";
-  const summary = (match[3] ?? "").trim();
-  if (!emoji || !scope || !summary) return null;
-  return { emoji, scope, summary };
+  const firstSpace = trimmed.search(/\s/u);
+  if (firstSpace <= 0) return null;
+  const emoji = trimmed.slice(0, firstSpace);
+  const rest = trimmed.slice(firstSpace).trim();
+  const parsed = splitScopeSummary(rest);
+  return parsed ? { emoji, ...parsed } : null;
 }
 
 function parseHumanTaskSubjectTemplate(subject: string): {
@@ -182,12 +203,7 @@ function parseHumanTaskSubjectTemplate(subject: string): {
   const trimmed = subject.trim();
   if (!trimmed) return null;
 
-  const match = new RegExp(String.raw`^(${SCOPE_PATTERN}):\s+(.+)$`).exec(trimmed);
-  if (!match) return null;
-  const scope = match[1] ?? "";
-  const summary = (match[2] ?? "").trim();
-  if (!scope || !summary) return null;
-  return { scope, summary };
+  return splitScopeSummary(trimmed);
 }
 
 export function validateCommitSubject(opts: {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -284,6 +284,16 @@ describe("config", () => {
     expect(() => setByDottedKey(cfg, ".", "x")).toThrow(/non-empty/);
   });
 
+  it("setByDottedKey rejects prototype-polluting path segments", () => {
+    const cfg = defaultConfig() as unknown as Record<string, unknown>;
+    expect(() => setByDottedKey(cfg, "__proto__.polluted", "true")).toThrow(/not allowed/);
+    expect(() => setByDottedKey(cfg, "constructor.prototype.polluted", "true")).toThrow(
+      /not allowed/,
+    );
+    expect(() => setByDottedKey(cfg, "safe.prototype.polluted", "true")).toThrow(/not allowed/);
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+  });
+
   it("saveConfig writes WORKFLOW.md, removes config.json, and loadConfig reads it back", async () => {
     const tmp = await mkdtemp(path.join(os.tmpdir(), "agentplane-config-test-"));
     const agentplaneDir = path.join(tmp, ".agentplane");

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -2,6 +2,8 @@ import type { AgentplaneConfig as AgentplaneConfigShape } from "./schema.impl.js
 
 export { defaultAgentplaneConfig as defaultConfig } from "./schema.impl.js";
 
+const PROTOTYPE_POLLUTION_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
 export function isConfigRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
@@ -29,6 +31,11 @@ export function setByDottedKey(
 ): void {
   const parts = dottedKey.split(".").filter(Boolean);
   if (parts.length === 0) throw new Error("config key must be non-empty");
+  for (const part of parts) {
+    if (PROTOTYPE_POLLUTION_KEYS.has(part)) {
+      throw new Error(`config key segment "${part}" is not allowed`);
+    }
+  }
   let current: Record<string, unknown> = obj;
   for (let i = 0; i < parts.length - 1; i++) {
     const part = parts[i];

--- a/packages/core/src/process/run-process.test.ts
+++ b/packages/core/src/process/run-process.test.ts
@@ -41,4 +41,13 @@ describe("run-process", () => {
     });
     expect(result.stdout).toBe("sync");
   });
+
+  it("rejects executable names that cannot be passed safely as argv", async () => {
+    await expect(
+      runProcess({
+        command: "node\necho unsafe",
+        args: ["-e", "process.stdout.write('nope')"],
+      }),
+    ).rejects.toThrow(/invalid characters/);
+  });
 });

--- a/packages/core/src/process/run-process.ts
+++ b/packages/core/src/process/run-process.ts
@@ -26,7 +26,6 @@ export type RunProcessOptions = {
   stdout?: ProcessStdioOption;
   stderr?: ProcessStdioOption;
   stdio?: StdioOptions;
-  shell?: boolean | string;
   cleanup?: boolean;
   reject?: boolean;
   extendEnv?: boolean;
@@ -107,7 +106,13 @@ function resolveCwd(cwd: string | URL | undefined): string | undefined {
   return cwd instanceof URL ? fileURLToPath(cwd) : cwd;
 }
 
+function assertSafeExecutable(command: string): void {
+  if (!command.trim()) throw new Error("process command must be non-empty");
+  if (/[\0\r\n]/u.test(command)) throw new Error("process command contains invalid characters");
+}
+
 function buildProcessOptions(opts: RunProcessOptions) {
+  assertSafeExecutable(opts.command);
   return {
     cwd: resolveCwd(opts.cwd),
     env: opts.env ?? process.env,
@@ -124,7 +129,7 @@ function buildProcessOptions(opts: RunProcessOptions) {
     ...(opts.stdout === undefined ? {} : { stdout: opts.stdout }),
     ...(opts.stderr === undefined ? {} : { stderr: opts.stderr }),
     ...(opts.stdio === undefined ? {} : { stdio: opts.stdio }),
-    ...(opts.shell === undefined ? {} : { shell: opts.shell }),
+    shell: false,
     ...(opts.detached === undefined ? {} : { detached: opts.detached }),
     ...(opts.buffer === undefined ? {} : { buffer: opts.buffer }),
   };
@@ -199,7 +204,6 @@ const execFileAsyncImpl = async (
             encoding: null,
             maxBuffer: resolved.options.maxBuffer,
             timeoutMs: resolved.options.timeout,
-            shell: resolved.options.shell,
             windowsHide: resolved.options.windowsHide,
           })
         : await runProcess({
@@ -210,7 +214,6 @@ const execFileAsyncImpl = async (
             encoding,
             maxBuffer: resolved.options.maxBuffer,
             timeoutMs: resolved.options.timeout,
-            shell: resolved.options.shell,
             windowsHide: resolved.options.windowsHide,
           });
     return { stdout: result.stdout, stderr: result.stderr };

--- a/packages/core/src/tasks/task-doc.test.ts
+++ b/packages/core/src/tasks/task-doc.test.ts
@@ -67,6 +67,11 @@ describe("task-doc", () => {
     expect(extractTaskDoc(body)).toBe(["## Summary", "", "Hello"].join("\n"));
   });
 
+  it("extractTaskDoc handles long non-heading prefixes with linear header checks", () => {
+    const body = ["x".repeat(50_000), "## Summary", "Hello"].join("\n");
+    expect(extractTaskDoc(body)).toBe(["## Summary", "", "Hello"].join("\n"));
+  });
+
   it("extractTaskDoc returns empty when body is empty or missing a Summary header", () => {
     expect(extractTaskDoc("")).toBe("");
     expect(extractTaskDoc("# Task\n\n## Context\nx\n")).toBe("");

--- a/packages/core/src/tasks/task-doc.ts
+++ b/packages/core/src/tasks/task-doc.ts
@@ -1,5 +1,4 @@
 const DOC_SECTION_HEADER = "## Summary";
-const DOC_SECTION_HEADER_RE = /^##\s+Summary(?:\s|$|#)/;
 const AUTO_SUMMARY_HEADER = "## Changes Summary (auto)";
 import { TASK_DOC_SECTION_ORDER } from "./task-doc-contract.js";
 
@@ -12,9 +11,18 @@ export function normalizeDocSectionName(section: string): string {
 function normalizeDoc(text: string): string {
   return (text ?? "")
     .split("\n")
-    .map((line) => line.replaceAll(/\s+$/gu, ""))
+    .map((line) => line.trimEnd())
     .join("\n")
     .trim();
+}
+
+function isSummarySectionHeader(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("##")) return false;
+  const rest = trimmed.slice(2);
+  if (!rest?.startsWith(" ")) return false;
+  const title = rest.trimStart();
+  return title === "Summary" || title.startsWith("Summary ") || title.startsWith("Summary#");
 }
 
 export function splitCombinedHeadingLines(doc: string): string[] {
@@ -173,7 +181,7 @@ export function extractTaskDoc(body: string): string {
   const lines = body.split("\n");
   let startIdx: number | null = null;
   for (const [idx, line] of lines.entries()) {
-    if (DOC_SECTION_HEADER_RE.test(line.trim())) {
+    if (isSummarySectionHeader(line)) {
       startIdx = idx;
       break;
     }
@@ -199,7 +207,7 @@ export function mergeTaskDoc(body: string, doc: string): string {
     const lines = body ? body.split("\n") : [];
     let prefixIdx: number | null = null;
     for (const [idx, line] of lines.entries()) {
-      if (DOC_SECTION_HEADER_RE.test(line.trim())) {
+      if (isSummarySectionHeader(line)) {
         prefixIdx = idx;
         break;
       }

--- a/packages/core/src/tasks/task-readme.test.ts
+++ b/packages/core/src/tasks/task-readme.test.ts
@@ -511,6 +511,46 @@ Hello world.
     expect(rendered).not.toContain("stale");
   });
 
+  it("preserves CRLF preamble text before canonical headings", () => {
+    const rendered = renderTaskReadme(
+      {
+        id: "202603130006-TEST",
+        title: "Schema sample",
+        status: "TODO",
+        priority: "med",
+        owner: "CODER",
+        revision: 1,
+        depends_on: [],
+        tags: [],
+        verify: [],
+        plan_approval: { state: "pending", updated_at: null, updated_by: null, note: null },
+        verification: { state: "pending", updated_at: null, updated_by: null, note: null },
+        comments: [],
+        doc_version: 3,
+        doc_updated_at: "2026-03-13T00:00:00.000Z",
+        doc_updated_by: "CODER",
+        description: "sample",
+        sections: { Summary: "Canonical summary", Findings: "Canonical finding" },
+      },
+      [
+        "line1",
+        "line2",
+        "line3",
+        "## Summary",
+        "",
+        "stale",
+        "",
+        "## References",
+        "",
+        "- docs/ref",
+      ].join("\r\n"),
+    );
+
+    expect(rendered).toContain("line1\nline2\nline3\n\n## References");
+    expect(rendered).not.toContain("line\n\n## Summary");
+    expect(rendered).not.toContain("stale");
+  });
+
   it("finds the first markdown section without regex search backtracking", () => {
     const rendered = renderTaskReadme(
       {

--- a/packages/core/src/tasks/task-readme.test.ts
+++ b/packages/core/src/tasks/task-readme.test.ts
@@ -510,4 +510,32 @@ Hello world.
     expect(rendered).toContain("## References\n\n- docs/ref");
     expect(rendered).not.toContain("stale");
   });
+
+  it("finds the first markdown section without regex search backtracking", () => {
+    const rendered = renderTaskReadme(
+      {
+        id: "202603130005-TEST",
+        title: "Schema sample",
+        status: "TODO",
+        priority: "med",
+        owner: "CODER",
+        revision: 1,
+        depends_on: [],
+        tags: [],
+        verify: [],
+        plan_approval: { state: "pending", updated_at: null, updated_by: null, note: null },
+        verification: { state: "pending", updated_at: null, updated_by: null, note: null },
+        comments: [],
+        doc_version: 3,
+        doc_updated_at: "2026-03-13T00:00:00.000Z",
+        doc_updated_by: "CODER",
+        description: "sample",
+        sections: { Summary: "Canonical summary", Findings: "Canonical finding" },
+      },
+      ["## References", "x".repeat(50_000), "## Summary", "", "stale"].join("\n"),
+    );
+
+    expect(rendered).toContain("## References");
+    expect(rendered).not.toContain("stale");
+  });
 });

--- a/packages/core/src/tasks/task-readme.ts
+++ b/packages/core/src/tasks/task-readme.ts
@@ -344,7 +344,17 @@ function pushContextSection(
 
 function renderContextSections(body: string, docVersion: unknown): string {
   const canonicalTitles = canonicalTaskDocSectionTitles(docVersion);
-  const preambleEnd = body.search(/^##\s+.*$/mu);
+  const bodyLines = body.replaceAll("\r\n", "\n").split("\n");
+  let preambleEnd = -1;
+  let offset = 0;
+  for (const line of bodyLines) {
+    const trimmedStart = line.trimStart();
+    if (trimmedStart.startsWith("##") && trimmedStart[2] === " ") {
+      preambleEnd = offset;
+      break;
+    }
+    offset += line.length + 1;
+  }
   const preamble = preambleEnd === -1 ? body : body.slice(0, preambleEnd);
   const parsed = parseDocSections(body);
   const lines: string[] = [];

--- a/packages/core/src/tasks/task-readme.ts
+++ b/packages/core/src/tasks/task-readme.ts
@@ -342,25 +342,29 @@ function pushContextSection(
   lines.push("");
 }
 
+function firstMarkdownSectionOffset(body: string): number {
+  let lineStart = 0;
+  while (lineStart < body.length) {
+    const newline = body.indexOf("\n", lineStart);
+    const lineEnd = newline === -1 ? body.length : newline;
+    const line = body.slice(lineStart, lineEnd).replaceAll("\r", "");
+    const trimmedStart = line.trimStart();
+    if (trimmedStart.startsWith("##") && trimmedStart[2] === " ") return lineStart;
+    if (newline === -1) break;
+    lineStart = newline + 1;
+  }
+  return -1;
+}
+
 function renderContextSections(body: string, docVersion: unknown): string {
   const canonicalTitles = canonicalTaskDocSectionTitles(docVersion);
-  const bodyLines = body.replaceAll("\r\n", "\n").split("\n");
-  let preambleEnd = -1;
-  let offset = 0;
-  for (const line of bodyLines) {
-    const trimmedStart = line.trimStart();
-    if (trimmedStart.startsWith("##") && trimmedStart[2] === " ") {
-      preambleEnd = offset;
-      break;
-    }
-    offset += line.length + 1;
-  }
+  const preambleEnd = firstMarkdownSectionOffset(body);
   const preamble = preambleEnd === -1 ? body : body.slice(0, preambleEnd);
   const parsed = parseDocSections(body);
   const lines: string[] = [];
   const preambleText = preamble.trimEnd();
   if (preambleText) {
-    lines.push(...preambleText.split("\n"), "");
+    lines.push(...preambleText.replaceAll("\r\n", "\n").split("\n"), "");
   }
   for (const key of parsed.order) {
     const section = parsed.sections.get(key);


### PR DESCRIPTION
Task: `202605170811-8DPCYD`
Title: Fix CodeQL hosted close checkout alert
Canonical task record: `.agentplane/tasks/202605170811-8DPCYD/README.md`

## Summary

Fix CodeQL hosted close checkout alert

Harden GitHub Actions hosted-close checkout/fetch handling for CodeQL alert #1.

## Scope

- In scope: Harden GitHub Actions hosted-close checkout/fetch handling for CodeQL alert #1.
- Out of scope: unrelated refactors not required for "Fix CodeQL hosted close checkout alert".

## Verification

- State: ok
- Note:

```text
Local verification passed for hosted-close workflow remediation: removed the pull_request_target
PR-head fetch, updated the workflow contract test, ran targeted tests (93 pass), exact-file ESLint,
core and agentplane typecheck, workflow lint, and policy routing. GitHub Code scanning alert #1
remains open until this branch is published and CodeQL reruns.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-17T08:51:27.708Z
- Branch: task/202605170811-8DPCYD/codeql-security-fixes
- Head: afede7721e4b

```text
 .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
 .agentplane/tasks/202605170812-9FFE6Y/README.md    | 150 ++++++
 .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
 .agentplane/tasks/202605170812-J4R55A/README.md    | 150 ++++++
 .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
 .agentplane/tasks/202605170812-Q06434/README.md    | 150 ++++++
 .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
 .agentplane/tasks/202605170812-X4C8DJ/README.md    | 150 ++++++
 .../blueprint/resolved-snapshot.json               | 392 +++++++++++++++
 .github/workflows/task-hosted-close.yml            |   9 -
 .../task/hosted-close-workflow-contract.test.ts    |   5 +-
 .../agentplane/src/commands/upgrade.unit.test.ts   |  13 +
 packages/agentplane/src/commands/upgrade/source.ts |   6 +-
 packages/core/src/commit/commit-policy.test.ts     |  11 +
 packages/core/src/commit/commit-policy.ts          |  72 +--
 packages/core/src/config/config.test.ts            |  10 +
 packages/core/src/config/defaults.ts               |   7 +
 packages/core/src/process/run-process.test.ts      |   9 +
 packages/core/src/process/run-process.ts           |  11 +-
 packages/core/src/tasks/task-doc.test.ts           |   5 +
 packages/core/src/tasks/task-doc.ts                |  16 +-
 packages/core/src/tasks/task-readme.test.ts        |  28 ++
 packages/core/src/tasks/task-readme.ts             |  12 +-
 23 files changed, 3265 insertions(+), 53 deletions(-)
```

</details>
