### PR TITLE
ci: use Bun ecosystem for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
         patterns:
           - "*"
 
-  - package-ecosystem: "npm"
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -39,7 +39,7 @@ updates:
           - "minor"
           - "patch"
 
-  - package-ecosystem: "npm"
+  - package-ecosystem: "bun"
     directory: "/website"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,13 +28,9 @@ updates:
       - "dependencies"
       - "javascript"
     groups:
-      production-dependencies:
-        dependency-type: "production"
-        update-types:
-          - "minor"
-          - "patch"
-      development-dependencies:
-        dependency-type: "development"
+      root-dependencies:
+        patterns:
+          - "*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Summary
- Switch Dependabot root and website JavaScript dependency updates from the npm ecosystem to the Bun ecosystem.
- Keep the GitHub Actions Dependabot entry unchanged.
- This lets Dependabot work against bun.lock and website/bun.lock instead of producing manifest-only updates that fail frozen Bun installs.

## Verification
- ruby YAML parse and entry check for .github/dependabot.yml
- node .agentplane/policy/check-routing.mjs
- bun install --frozen-lockfile --ignore-scripts
- bun install --cwd website --frozen-lockfile --ignore-scripts
- pre-push full-fast: 310 test files passed; 1839 tests passed, 2 skipped
- critical CLI suite: 5/5 chunks passed