### PR TITLE
🚧 ARB2JV task: Fix task README trailing whitespace generation [202605171021-ARB2JV]

### DIFF
--- a/.agentplane/tasks/202605171021-ARB2JV/README.md
+++ b/.agentplane/tasks/202605171021-ARB2JV/README.md
@@ -1,0 +1,167 @@
+---
+id: "202605171021-ARB2JV"
+title: "Fix task README trailing whitespace generation"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 9
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "workflow"
+verify:
+  - "bunx vitest --config vitest.workspace.ts run --project core packages/core/src/tasks/task-readme.test.ts packages/core/src/tasks/task-doc.test.ts"
+  - "bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/task/workflow-transition-service.unit.test.ts packages/agentplane/src/commands/task/shared.unit.test.ts"
+  - "git diff --check"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-17T10:22:08.916Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-17T10:30:19.552Z"
+  updated_by: "CODER"
+  note: "Verified: task README block scalar rendering no longer creates whitespace-only blank lines; verification entries trim per-line tails. Checks passed: focused core task README/doc tests, focused agentplane workflow transition/shared tests, Prettier on touched files, git diff --check, policy routing, and repo-local runtime bootstrap."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement task README whitespace normalization in the isolated task worktree, add focused regression coverage, and audit adjacent generated artifact renderers without touching unrelated base conflicts."
+events:
+  -
+    type: "status"
+    at: "2026-05-17T10:23:34.609Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement task README whitespace normalization in the isolated task worktree, add focused regression coverage, and audit adjacent generated artifact renderers without touching unrelated base conflicts."
+  -
+    type: "verify"
+    at: "2026-05-17T10:30:19.552Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: task README block scalar rendering no longer creates whitespace-only blank lines; verification entries trim per-line tails. Checks passed: focused core task README/doc tests, focused agentplane workflow transition/shared tests, Prettier on touched files, git diff --check, policy routing, and repo-local runtime bootstrap."
+doc_version: 3
+doc_updated_at: "2026-05-17T10:30:19.595Z"
+doc_updated_by: "CODER"
+description: "Task README rendering can emit lines containing only indentation spaces in YAML block scalars and may preserve trailing spaces in verification entries. Fix canonical rendering so generated task artifacts pass git diff --check without manual whitespace cleanup, and audit adjacent renderer paths for the same class."
+sections:
+  Summary: |-
+    Fix task README trailing whitespace generation
+
+    Task README rendering can emit lines containing only indentation spaces in YAML block scalars and may preserve trailing spaces in verification entries. Fix canonical rendering so generated task artifacts pass git diff --check without manual whitespace cleanup, and audit adjacent renderer paths for the same class.
+  Scope: |-
+    - In scope: Task README rendering can emit lines containing only indentation spaces in YAML block scalars and may preserve trailing spaces in verification entries. Fix canonical rendering so generated task artifacts pass git diff --check without manual whitespace cleanup, and audit adjacent renderer paths for the same class.
+    - Out of scope: unrelated refactors not required for "Fix task README trailing whitespace generation".
+  Plan: |-
+    1. Fix canonical task README rendering so generated YAML block scalar blank lines do not become whitespace-only lines.
+    2. Normalize verification entry rendering so generated `## Verification` entries do not preserve trailing spaces from notes or details.
+    3. Add focused regression coverage for block scalar blank lines and verification entry whitespace handling.
+    4. Run focused task README/task doc tests, focused verification lifecycle tests where available, `git diff --check`, and policy/runtime sanity checks that are not blocked by unrelated checkout conflicts.
+    5. Audit adjacent generated artifact renderers for the same whitespace-only-line class and record remaining risks in Findings.
+  Verify Steps: |-
+    1. Run `bunx vitest --config vitest.workspace.ts run --project core packages/core/src/tasks/task-readme.test.ts packages/core/src/tasks/task-doc.test.ts`. Expected: task README/task doc rendering tests pass, including regression coverage for whitespace-only generated lines.
+    2. Run `bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/task/workflow-transition-service.unit.test.ts packages/agentplane/src/commands/task/shared.unit.test.ts`. Expected: verification entry rendering and adjacent task shared helper tests pass.
+    3. Run `git diff --check`. Expected: no whitespace errors in the task worktree diff.
+    4. Run `node .agentplane/policy/check-routing.mjs`. Expected: policy routing still passes.
+    5. Audit generated Markdown/YAML renderers for the same blank-line indentation/trailing-space class and record any remaining risks in `## Findings`.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-17T10:30:19.552Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified: task README block scalar rendering no longer creates whitespace-only blank lines; verification entries trim per-line tails. Checks passed: focused core task README/doc tests, focused agentplane workflow transition/shared tests, Prettier on touched files, git diff --check, policy routing, and repo-local runtime bootstrap.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T10:29:59.052Z, excerpt_hash=sha256:9e5fee9c57fa680aa5a663781e9cad51d0f6121431440fa3b21e759e0620946b
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605171021-ARB2JV-fix-task-readme-whitespace/.agentplane/tasks/202605171021-ARB2JV/blueprint/resolved-snapshot.json
+    - old_digest: 62fe3851dc3faf18a622ef94c1cdc3400c6251acf272eab3df49982294bea0f5
+    - current_digest: 62fe3851dc3faf18a622ef94c1cdc3400c6251acf272eab3df49982294bea0f5
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605171021-ARB2JV
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Root cause fixed here: `renderBlockScalar()` emitted indentation for blank YAML block scalar lines, creating whitespace-only lines in generated task READMEs. It now trims line endings and renders blank block-scalar lines as empty lines.
+    - Adjacent fixed path: verification entries now normalize per-line trailing whitespace for generated `## Verification` entries, including multiline details.
+    - Audit result: `git diff --check` does not cover untracked task artifacts until they are staged; task README rendering was re-run through the repo-local CLI after `framework:dev:bootstrap` to validate the fixed renderer on the task artifact itself.
+    - Related risk class: Markdown renderers that join arrays of generated lines while interpolating user-provided fields can preserve trailing whitespace. Higher-risk adjacent surfaces are runner outcome history (`packages/agentplane/src/runner/task-state-render.ts`) and PR review/handoff body rendering (`packages/agentplane/src/commands/pr/internal/review-template.ts`). They do not share the YAML blank-line indentation bug fixed here, so they are follow-up audit candidates rather than part of this narrow fix.
+    - Lower-risk adjacent surface: `packages/agentplane/src/commands/recipes/impl/format.ts` indents JSON.stringify output; JSON pretty output does not produce blank lines, so it matches the syntactic pattern but not the same failure mode.
+id_source: "generated"
+---
+## Summary
+
+Fix task README trailing whitespace generation
+
+Task README rendering can emit lines containing only indentation spaces in YAML block scalars and may preserve trailing spaces in verification entries. Fix canonical rendering so generated task artifacts pass git diff --check without manual whitespace cleanup, and audit adjacent renderer paths for the same class.
+
+## Scope
+
+- In scope: Task README rendering can emit lines containing only indentation spaces in YAML block scalars and may preserve trailing spaces in verification entries. Fix canonical rendering so generated task artifacts pass git diff --check without manual whitespace cleanup, and audit adjacent renderer paths for the same class.
+- Out of scope: unrelated refactors not required for "Fix task README trailing whitespace generation".
+
+## Plan
+
+1. Fix canonical task README rendering so generated YAML block scalar blank lines do not become whitespace-only lines.
+2. Normalize verification entry rendering so generated `## Verification` entries do not preserve trailing spaces from notes or details.
+3. Add focused regression coverage for block scalar blank lines and verification entry whitespace handling.
+4. Run focused task README/task doc tests, focused verification lifecycle tests where available, `git diff --check`, and policy/runtime sanity checks that are not blocked by unrelated checkout conflicts.
+5. Audit adjacent generated artifact renderers for the same whitespace-only-line class and record remaining risks in Findings.
+
+## Verify Steps
+
+1. Run `bunx vitest --config vitest.workspace.ts run --project core packages/core/src/tasks/task-readme.test.ts packages/core/src/tasks/task-doc.test.ts`. Expected: task README/task doc rendering tests pass, including regression coverage for whitespace-only generated lines.
+2. Run `bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/task/workflow-transition-service.unit.test.ts packages/agentplane/src/commands/task/shared.unit.test.ts`. Expected: verification entry rendering and adjacent task shared helper tests pass.
+3. Run `git diff --check`. Expected: no whitespace errors in the task worktree diff.
+4. Run `node .agentplane/policy/check-routing.mjs`. Expected: policy routing still passes.
+5. Audit generated Markdown/YAML renderers for the same blank-line indentation/trailing-space class and record any remaining risks in `## Findings`.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-17T10:30:19.552Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: task README block scalar rendering no longer creates whitespace-only blank lines; verification entries trim per-line tails. Checks passed: focused core task README/doc tests, focused agentplane workflow transition/shared tests, Prettier on touched files, git diff --check, policy routing, and repo-local runtime bootstrap.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T10:29:59.052Z, excerpt_hash=sha256:9e5fee9c57fa680aa5a663781e9cad51d0f6121431440fa3b21e759e0620946b
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605171021-ARB2JV-fix-task-readme-whitespace/.agentplane/tasks/202605171021-ARB2JV/blueprint/resolved-snapshot.json
+- old_digest: 62fe3851dc3faf18a622ef94c1cdc3400c6251acf272eab3df49982294bea0f5
+- current_digest: 62fe3851dc3faf18a622ef94c1cdc3400c6251acf272eab3df49982294bea0f5
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605171021-ARB2JV
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Root cause fixed here: `renderBlockScalar()` emitted indentation for blank YAML block scalar lines, creating whitespace-only lines in generated task READMEs. It now trims line endings and renders blank block-scalar lines as empty lines.
+- Adjacent fixed path: verification entries now normalize per-line trailing whitespace for generated `## Verification` entries, including multiline details.
+- Audit result: `git diff --check` does not cover untracked task artifacts until they are staged; task README rendering was re-run through the repo-local CLI after `framework:dev:bootstrap` to validate the fixed renderer on the task artifact itself.
+- Related risk class: Markdown renderers that join arrays of generated lines while interpolating user-provided fields can preserve trailing whitespace. Higher-risk adjacent surfaces are runner outcome history (`packages/agentplane/src/runner/task-state-render.ts`) and PR review/handoff body rendering (`packages/agentplane/src/commands/pr/internal/review-template.ts`). They do not share the YAML blank-line indentation bug fixed here, so they are follow-up audit candidates rather than part of this narrow fix.
+- Lower-risk adjacent surface: `packages/agentplane/src/commands/recipes/impl/format.ts` indents JSON.stringify output; JSON pretty output does not produce blank lines, so it matches the syntactic pattern but not the same failure mode.

--- a/.agentplane/tasks/202605171021-ARB2JV/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605171021-ARB2JV/blueprint/resolved-snapshot.json
@@ -1,0 +1,527 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605171021-ARB2JV",
+    "title": "Fix task README trailing whitespace generation",
+    "description": "Task README rendering can emit lines containing only indentation spaces in YAML block scalars and may preserve trailing spaces in verification entries. Fix canonical rendering so generated task artifacts pass git diff --check without manual whitespace cleanup, and audit adjacent renderer paths for the same class.",
+    "tags": [
+      "code",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605171021-ARB2JV",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "62fe3851dc3faf18a622ef94c1cdc3400c6251acf272eab3df49982294bea0f5"
+  }
+}

--- a/.agentplane/tasks/202605171021-ARB2JV/pr/diffstat.txt
+++ b/.agentplane/tasks/202605171021-ARB2JV/pr/diffstat.txt
@@ -1,0 +1,6 @@
+ .../blueprint/resolved-snapshot.json               | 527 +++++++++++++++++++++
+ .../task/shared/workflow-transition-service.ts     |  13 +-
+ .../task/workflow-transition-service.unit.test.ts  |  21 +
+ packages/core/src/tasks/task-readme.test.ts        |  11 +-
+ packages/core/src/tasks/task-readme.ts             |   8 +-
+ 5 files changed, 572 insertions(+), 8 deletions(-)

--- a/.agentplane/tasks/202605171021-ARB2JV/pr/github-body.md
+++ b/.agentplane/tasks/202605171021-ARB2JV/pr/github-body.md
@@ -1,0 +1,45 @@
+Task: `202605171021-ARB2JV`
+Title: Fix task README trailing whitespace generation
+Canonical task record: `.agentplane/tasks/202605171021-ARB2JV/README.md`
+
+## Summary
+
+Fix task README trailing whitespace generation
+
+Task README rendering can emit lines containing only indentation spaces in YAML block scalars and may preserve trailing spaces in verification entries. Fix canonical rendering so generated task artifacts pass git diff --check without manual whitespace cleanup, and audit adjacent renderer paths for the same class.
+
+## Scope
+
+- In scope: Task README rendering can emit lines containing only indentation spaces in YAML block scalars and may preserve trailing spaces in verification entries. Fix canonical rendering so generated task artifacts pass git diff --check without manual whitespace cleanup, and audit adjacent renderer paths for the same class.
+- Out of scope: unrelated refactors not required for "Fix task README trailing whitespace generation".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Verified: task README block scalar rendering no longer creates whitespace-only blank lines;
+verification entries trim per-line tails. Checks passed: focused core task README/doc tests, focused
+agentplane workflow transition/shared tests, Prettier on touched files, git diff --check, policy
+routing, and repo-local runtime bootstrap.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-17T10:33:00.195Z
+- Branch: task/202605171021-ARB2JV/fix-task-readme-whitespace
+- Head: 43b4ccf19267
+
+```text
+ .../blueprint/resolved-snapshot.json               | 527 +++++++++++++++++++++
+ .../task/shared/workflow-transition-service.ts     |  13 +-
+ .../task/workflow-transition-service.unit.test.ts  |  21 +
+ packages/core/src/tasks/task-readme.test.ts        |  11 +-
+ packages/core/src/tasks/task-readme.ts             |   8 +-
+ 5 files changed, 572 insertions(+), 8 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605171021-ARB2JV/pr/github-title.txt
+++ b/.agentplane/tasks/202605171021-ARB2JV/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 ARB2JV task: Fix task README trailing whitespace generation [202605171021-ARB2JV]

--- a/.agentplane/tasks/202605171021-ARB2JV/pr/meta.json
+++ b/.agentplane/tasks/202605171021-ARB2JV/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "43b4ccf192673bfcfbbfea89e3b4f4bf64526d7a",
   "last_verified_at": "2026-05-17T10:30:19.552Z",
   "last_verified_sha": "c4ca9d1cc587e7a636059e9125bf462d79bc750b",
+  "pr_number": 3820,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3820",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605171021-ARB2JV",
-  "updated_at": "2026-05-17T10:33:00.195Z",
+  "updated_at": "2026-05-17T10:54:28.080Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605171021-ARB2JV/pr/meta.json
+++ b/.agentplane/tasks/202605171021-ARB2JV/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605171021-ARB2JV/fix-task-readme-whitespace",
+  "created_at": "2026-05-17T10:23:34.761Z",
+  "head_sha": "43b4ccf192673bfcfbbfea89e3b4f4bf64526d7a",
+  "last_verified_at": "2026-05-17T10:30:19.552Z",
+  "last_verified_sha": "c4ca9d1cc587e7a636059e9125bf462d79bc750b",
+  "schema_version": 1,
+  "task_id": "202605171021-ARB2JV",
+  "updated_at": "2026-05-17T10:33:00.195Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605171021-ARB2JV/pr/review.md
+++ b/.agentplane/tasks/202605171021-ARB2JV/pr/review.md
@@ -1,0 +1,41 @@
+# PR Review
+
+Created: 2026-05-17T10:23:34.761Z
+
+## Task
+
+- Task: `202605171021-ARB2JV`
+- Title: Fix task README trailing whitespace generation
+- Status: DOING
+- Branch: `task/202605171021-ARB2JV/fix-task-readme-whitespace`
+- Canonical task record: `.agentplane/tasks/202605171021-ARB2JV/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified: task README block scalar rendering no longer creates whitespace-only blank lines; verification entries trim per-line tails. Checks passed: focused core task README/doc tests, focused agentplane workflow transition/shared tests, Prettier on touched files, git diff --check, policy routing, and repo-local runtime bootstrap.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-17T10:33:00.195Z
+- Branch: task/202605171021-ARB2JV/fix-task-readme-whitespace
+- Head: 43b4ccf19267
+
+```text
+ .../blueprint/resolved-snapshot.json               | 527 +++++++++++++++++++++
+ .../task/shared/workflow-transition-service.ts     |  13 +-
+ .../task/workflow-transition-service.unit.test.ts  |  21 +
+ packages/core/src/tasks/task-readme.test.ts        |  11 +-
+ packages/core/src/tasks/task-readme.ts             |   8 +-
+ 5 files changed, 572 insertions(+), 8 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/task/shared/workflow-transition-service.ts
+++ b/packages/agentplane/src/commands/task/shared/workflow-transition-service.ts
@@ -155,6 +155,15 @@ function appendVerificationEntryBetweenMarkers(
   return parts.join("\n").trimEnd();
 }
 
+function trimLineEndings(text: string): string {
+  return text
+    .replaceAll("\r\n", "\n")
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .trim();
+}
+
 function renderVerificationEntry(opts: {
   at: string;
   state: "ok" | "needs_rework" | "blocked_external";
@@ -176,11 +185,11 @@ function renderVerificationEntry(opts: {
   if (verifyStepsRef) {
     lines.push("", `VerifyStepsRef: ${verifyStepsRef}`);
   }
-  const details = (opts.details ?? "").trim();
+  const details = trimLineEndings(opts.details ?? "");
   if (details) {
     lines.push("", "Details:", "", details);
   }
-  return `${lines.join("\n").trimEnd()}\n`;
+  return `${trimLineEndings(lines.join("\n"))}\n`;
 }
 
 function sha256Hex(text: string): string {

--- a/packages/agentplane/src/commands/task/workflow-transition-service.unit.test.ts
+++ b/packages/agentplane/src/commands/task/workflow-transition-service.unit.test.ts
@@ -260,6 +260,27 @@ describe("workflow transition service", () => {
     ]);
   });
 
+  it("trims generated verification entry line endings", () => {
+    const execution = executeTaskVerificationTransitionRequest({
+      task: mkTask({
+        doc_updated_at: "2026-03-27T00:00:00.000Z",
+      }),
+      at: "2026-03-27T02:10:00.000Z",
+      by: "REVIEWER",
+      note: "Looks good after focused checks.  ",
+      state: "ok",
+      details: ["Command: git diff --check  ", "", "Result: pass  "].join("\n"),
+      doc: mkTask().doc ?? "",
+      requiredSections: ["Summary", "Verify Steps", "Verification"],
+    });
+
+    expect(execution.verificationSection).toContain("Note: Looks good after focused checks.");
+    expect(execution.verificationSection).toContain("Command: git diff --check\n\nResult: pass");
+    expect(execution.verificationSection.split("\n").filter((line) => /^\s+$/u.test(line))).toEqual(
+      [],
+    );
+  });
+
   it("keeps rework DOING through the configured max and blocks when the next attempt exceeds it", () => {
     const withinLimit = executeTaskVerificationTransitionRequest({
       task: mkTask({

--- a/packages/core/src/tasks/task-readme.test.ts
+++ b/packages/core/src/tasks/task-readme.test.ts
@@ -113,18 +113,18 @@ Hello world.
     const parsed = parseTaskReadme(sample);
     const withMultiline = {
       ...parsed.frontmatter,
-      description: String.raw`Line one\n\nLine two`,
+      description: String.raw`Line one\n\nLine two  `,
       comments: [
         {
           author: "CODER",
-          body: String.raw`Start line 1\nStart line 2\nStart line 3`,
+          body: String.raw`Start line 1\n\nStart line 3  `,
         },
       ],
       verification: {
         state: "ok",
         updated_at: "2026-03-08T13:00:00.000Z",
         updated_by: "TESTER",
-        note: String.raw`First line\nSecond line\nThird line`,
+        note: String.raw`First line\n\nThird line  `,
       },
     };
 
@@ -134,14 +134,15 @@ Hello world.
     expect(rendered).toContain("  Line two");
     expect(rendered).toContain("body: |-");
     expect(rendered).toContain("note: |-");
+    expect(rendered.split("\n").filter((line) => /^\s+$/u.test(line))).toEqual([]);
 
     const roundtrip = parseTaskReadme(rendered).frontmatter;
     expect(roundtrip.description).toBe("Line one\n\nLine two");
     expect((roundtrip.comments as Record<string, unknown>[])[0]?.body).toBe(
-      "Start line 1\nStart line 2\nStart line 3",
+      "Start line 1\n\nStart line 3",
     );
     expect((roundtrip.verification as Record<string, unknown>).note).toBe(
-      "First line\nSecond line\nThird line",
+      "First line\n\nThird line",
     );
   });
 

--- a/packages/core/src/tasks/task-readme.ts
+++ b/packages/core/src/tasks/task-readme.ts
@@ -113,7 +113,13 @@ function normalizeReadableMultilineString(key: string, value: string): string {
 function renderBlockScalar(key: string, value: string, indent: string): string[] {
   const normalized = normalizeReadableMultilineString(key, value);
   const lines = normalized.split("\n");
-  return [`${indent}${key}: |-`, ...lines.map((line) => `${indent}  ${line}`)];
+  return [
+    `${indent}${key}: |-`,
+    ...lines.map((line) => {
+      const trimmed = line.trimEnd();
+      return trimmed ? `${indent}  ${trimmed}` : "";
+    }),
+  ];
 }
 
 function renderFlowSeq(value: unknown[]): string {


### PR DESCRIPTION
Task: `202605171021-ARB2JV`
Title: Fix task README trailing whitespace generation
Canonical task record: `.agentplane/tasks/202605171021-ARB2JV/README.md`

## Summary

Fix task README trailing whitespace generation

Task README rendering can emit lines containing only indentation spaces in YAML block scalars and may preserve trailing spaces in verification entries. Fix canonical rendering so generated task artifacts pass git diff --check without manual whitespace cleanup, and audit adjacent renderer paths for the same class.

## Scope

- In scope: Task README rendering can emit lines containing only indentation spaces in YAML block scalars and may preserve trailing spaces in verification entries. Fix canonical rendering so generated task artifacts pass git diff --check without manual whitespace cleanup, and audit adjacent renderer paths for the same class.
- Out of scope: unrelated refactors not required for "Fix task README trailing whitespace generation".

## Verification

- State: ok
- Note:

```text
Verified: task README block scalar rendering no longer creates whitespace-only blank lines;
verification entries trim per-line tails. Checks passed: focused core task README/doc tests, focused
agentplane workflow transition/shared tests, Prettier on touched files, git diff --check, policy
routing, and repo-local runtime bootstrap.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-17T10:33:00.195Z
- Branch: task/202605171021-ARB2JV/fix-task-readme-whitespace
- Head: 43b4ccf19267

```text
 .../blueprint/resolved-snapshot.json               | 527 +++++++++++++++++++++
 .../task/shared/workflow-transition-service.ts     |  13 +-
 .../task/workflow-transition-service.unit.test.ts  |  21 +
 packages/core/src/tasks/task-readme.test.ts        |  11 +-
 packages/core/src/tasks/task-readme.ts             |   8 +-
 5 files changed, 572 insertions(+), 8 deletions(-)
```

</details>
