### PR TITLE
Plan v0.6.2 follow-up bug tasks

### DIFF
--- a/.agentplane/tasks/202605171325-7P2VM4/README.md
+++ b/.agentplane/tasks/202605171325-7P2VM4/README.md
@@ -1,0 +1,91 @@
+---
+id: "202605171325-7P2VM4"
+title: "Fix task scanner handling of invalid legacy README frontmatter"
+status: "TODO"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "bug"
+  - "code"
+  - "tasks"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-17T13:28:02.519Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-17T13:27:47.438Z"
+doc_updated_by: "PLANNER"
+description: "Make task scanning and diagnostics robust when a historical or generated task README has non-canonical frontmatter, using 202605151620-CTXIN as the regression case. The CLI should not silently lose the task from release planning; it should either repair, migrate, or emit actionable diagnostics without hiding the rest of the task registry."
+sections:
+  Summary: |-
+    Fix task scanner handling of invalid legacy README frontmatter
+
+    Make task scanning and diagnostics robust when a historical or generated task README has non-canonical frontmatter, using 202605151620-CTXIN as the regression case. The CLI should not silently lose the task from release planning; it should either repair, migrate, or emit actionable diagnostics without hiding the rest of the task registry.
+  Scope: |-
+    - In scope: Make task scanning and diagnostics robust when a historical or generated task README has non-canonical frontmatter, using 202605151620-CTXIN as the regression case. The CLI should not silently lose the task from release planning; it should either repair, migrate, or emit actionable diagnostics without hiding the rest of the task registry.
+    - Out of scope: unrelated refactors not required for "Fix task scanner handling of invalid legacy README frontmatter".
+  Plan: "Plan: 1. Reproduce the current scanner failure with historical task 202605151620-CTXIN or an equivalent fixture containing non-canonical README frontmatter. 2. Decide the intended behavior: tolerant scan with actionable warning, explicit repair command, or migration path; do not silently hide the task from registry views. 3. Implement the smallest robust parser/diagnostic change in the task backend or scanner layer. 4. Add regression coverage for invalid verification state/frontmatter so task list and release-planning reads remain usable. 5. Verify focused task scanner tests, task list behavior, routing policy, and doctor output."
+  Verify Steps: |-
+    1. Add or update a fixture/task README with invalid legacy frontmatter equivalent to 202605151620-CTXIN. Expected: the scanner test proves the task is not silently lost.
+    2. Run the focused task backend/scanner tests that cover README frontmatter parsing and task list projection. Expected: invalid legacy frontmatter produces actionable diagnostics or repair guidance while other tasks still list normally.
+    3. Run ap task list in a fixture or controlled repo containing the invalid task. Expected: output includes a clear warning tied to the task id and preserves registry visibility for remaining tasks.
+    4. Run node .agentplane/policy/check-routing.mjs. Expected: routing policy passes.
+    5. Run ap doctor. Expected: doctor passes or reports only pre-existing unrelated warnings with evidence recorded.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Fix task scanner handling of invalid legacy README frontmatter
+
+Make task scanning and diagnostics robust when a historical or generated task README has non-canonical frontmatter, using 202605151620-CTXIN as the regression case. The CLI should not silently lose the task from release planning; it should either repair, migrate, or emit actionable diagnostics without hiding the rest of the task registry.
+
+## Scope
+
+- In scope: Make task scanning and diagnostics robust when a historical or generated task README has non-canonical frontmatter, using 202605151620-CTXIN as the regression case. The CLI should not silently lose the task from release planning; it should either repair, migrate, or emit actionable diagnostics without hiding the rest of the task registry.
+- Out of scope: unrelated refactors not required for "Fix task scanner handling of invalid legacy README frontmatter".
+
+## Plan
+
+Plan: 1. Reproduce the current scanner failure with historical task 202605151620-CTXIN or an equivalent fixture containing non-canonical README frontmatter. 2. Decide the intended behavior: tolerant scan with actionable warning, explicit repair command, or migration path; do not silently hide the task from registry views. 3. Implement the smallest robust parser/diagnostic change in the task backend or scanner layer. 4. Add regression coverage for invalid verification state/frontmatter so task list and release-planning reads remain usable. 5. Verify focused task scanner tests, task list behavior, routing policy, and doctor output.
+
+## Verify Steps
+
+1. Add or update a fixture/task README with invalid legacy frontmatter equivalent to 202605151620-CTXIN. Expected: the scanner test proves the task is not silently lost.
+2. Run the focused task backend/scanner tests that cover README frontmatter parsing and task list projection. Expected: invalid legacy frontmatter produces actionable diagnostics or repair guidance while other tasks still list normally.
+3. Run ap task list in a fixture or controlled repo containing the invalid task. Expected: output includes a clear warning tied to the task id and preserves registry visibility for remaining tasks.
+4. Run node .agentplane/policy/check-routing.mjs. Expected: routing policy passes.
+5. Run ap doctor. Expected: doctor passes or reports only pre-existing unrelated warnings with evidence recorded.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605171325-7P5M3V/README.md
+++ b/.agentplane/tasks/202605171325-7P5M3V/README.md
@@ -1,0 +1,91 @@
+---
+id: "202605171325-7P5M3V"
+title: "Warn when local task state is stale relative to origin main"
+status: "TODO"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "release"
+  - "workflow"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-17T13:28:05.930Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-17T13:27:57.362Z"
+doc_updated_by: "PLANNER"
+description: "Add a release-planning guardrail so read-heavy startup surfaces such as quickstart or task list warn when the current base checkout is behind origin/main and local task state may be stale. The regression case is local task records showing TODO/DOING for work already merged on GitHub, which can mislead v0.6.2 scope decisions."
+sections:
+  Summary: |-
+    Warn when local task state is stale relative to origin main
+
+    Add a release-planning guardrail so read-heavy startup surfaces such as quickstart or task list warn when the current base checkout is behind origin/main and local task state may be stale. The regression case is local task records showing TODO/DOING for work already merged on GitHub, which can mislead v0.6.2 scope decisions.
+  Scope: |-
+    - In scope: Add a release-planning guardrail so read-heavy startup surfaces such as quickstart or task list warn when the current base checkout is behind origin/main and local task state may be stale. The regression case is local task records showing TODO/DOING for work already merged on GitHub, which can mislead v0.6.2 scope decisions.
+    - Out of scope: unrelated refactors not required for "Warn when local task state is stale relative to origin main".
+  Plan: "Plan: 1. Identify the startup/read-heavy command path where AgentPlane can cheaply compare the current checkout against origin/main or the configured upstream without requiring mutation. 2. Add a bounded stale-state diagnostic for quickstart/task-list/release-planning surfaces when HEAD is behind upstream and task records may be stale. 3. Ensure the warning is actionable and does not block normal offline/local workflows when no upstream is configured. 4. Add tests for behind-upstream, no-upstream, and clean/current states. 5. Verify focused CLI tests, release-planning behavior if touched, routing policy, and doctor output."
+  Verify Steps: |-
+    1. Add focused CLI/runtime tests for a repository whose HEAD is behind its configured upstream. Expected: the selected startup or task-list surface emits a clear stale-state warning with local and upstream refs.
+    2. Add tests for no-upstream/offline/current-checkout cases. Expected: commands remain usable and do not emit misleading network-dependent failures.
+    3. Run the focused CLI tests covering the changed command surface. Expected: all tests pass.
+    4. Run a controlled smoke command equivalent to ap task list or ap quickstart in the behind-upstream fixture. Expected: the warning explains that local task state may be stale relative to origin/main.
+    5. Run node .agentplane/policy/check-routing.mjs and ap doctor. Expected: routing passes; doctor has no new warnings beyond documented pre-existing drift.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Warn when local task state is stale relative to origin main
+
+Add a release-planning guardrail so read-heavy startup surfaces such as quickstart or task list warn when the current base checkout is behind origin/main and local task state may be stale. The regression case is local task records showing TODO/DOING for work already merged on GitHub, which can mislead v0.6.2 scope decisions.
+
+## Scope
+
+- In scope: Add a release-planning guardrail so read-heavy startup surfaces such as quickstart or task list warn when the current base checkout is behind origin/main and local task state may be stale. The regression case is local task records showing TODO/DOING for work already merged on GitHub, which can mislead v0.6.2 scope decisions.
+- Out of scope: unrelated refactors not required for "Warn when local task state is stale relative to origin main".
+
+## Plan
+
+Plan: 1. Identify the startup/read-heavy command path where AgentPlane can cheaply compare the current checkout against origin/main or the configured upstream without requiring mutation. 2. Add a bounded stale-state diagnostic for quickstart/task-list/release-planning surfaces when HEAD is behind upstream and task records may be stale. 3. Ensure the warning is actionable and does not block normal offline/local workflows when no upstream is configured. 4. Add tests for behind-upstream, no-upstream, and clean/current states. 5. Verify focused CLI tests, release-planning behavior if touched, routing policy, and doctor output.
+
+## Verify Steps
+
+1. Add focused CLI/runtime tests for a repository whose HEAD is behind its configured upstream. Expected: the selected startup or task-list surface emits a clear stale-state warning with local and upstream refs.
+2. Add tests for no-upstream/offline/current-checkout cases. Expected: commands remain usable and do not emit misleading network-dependent failures.
+3. Run the focused CLI tests covering the changed command surface. Expected: all tests pass.
+4. Run a controlled smoke command equivalent to ap task list or ap quickstart in the behind-upstream fixture. Expected: the warning explains that local task state may be stale relative to origin/main.
+5. Run node .agentplane/policy/check-routing.mjs and ap doctor. Expected: routing passes; doctor has no new warnings beyond documented pre-existing drift.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605171326-FXRVNW/README.md
+++ b/.agentplane/tasks/202605171326-FXRVNW/README.md
@@ -1,0 +1,91 @@
+---
+id: "202605171326-FXRVNW"
+title: "Freeze release candidate base and scope after late merges"
+status: "TODO"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "release"
+  - "workflow"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-17T13:28:09.705Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-17T13:27:32.880Z"
+doc_updated_by: "PLANNER"
+description: "Harden release candidate planning so a patch release cannot claim to exclude work that is already merged into the candidate base. The v0.6.2 regression case is a release task that planned to exclude route-decision CLI work while PR #3823 later landed on origin/main. Release tooling should pin the base SHA, detect late merges, and require explicit revert, branch cut, or re-scope before candidate generation."
+sections:
+  Summary: |-
+    Freeze release candidate base and scope after late merges
+
+    Harden release candidate planning so a patch release cannot claim to exclude work that is already merged into the candidate base. The v0.6.2 regression case is a release task that planned to exclude route-decision CLI work while PR #3823 later landed on origin/main. Release tooling should pin the base SHA, detect late merges, and require explicit revert, branch cut, or re-scope before candidate generation.
+  Scope: |-
+    - In scope: Harden release candidate planning so a patch release cannot claim to exclude work that is already merged into the candidate base. The v0.6.2 regression case is a release task that planned to exclude route-decision CLI work while PR #3823 later landed on origin/main. Release tooling should pin the base SHA, detect late merges, and require explicit revert, branch cut, or re-scope before candidate generation.
+    - Out of scope: unrelated refactors not required for "Freeze release candidate base and scope after late merges".
+  Plan: "Plan: 1. Inspect the release candidate planning path and identify where candidate base SHA and excluded work are represented. 2. Add a release-scope guard that records the base SHA and detects when an excluded PR/task is already reachable from the candidate base. 3. Make the failure mode explicit: require re-scope, revert, or release-branch cut before candidate generation proceeds. 4. Add regression coverage using a fixture equivalent to the v0.6.2 route-decision CLI late-merge case. 5. Verify focused release-planning tests, release notes/candidate checks if affected, routing policy, and doctor output."
+  Verify Steps: |-
+    1. Add focused release-planning tests for an excluded PR/task that is already reachable from the selected candidate base SHA. Expected: release candidate generation fails closed with explicit re-scope/revert/branch-cut guidance.
+    2. Add a positive test where excluded work is not reachable from the base SHA. Expected: release planning proceeds and records the pinned base.
+    3. Run the focused release candidate/planning tests. Expected: all tests pass.
+    4. If release manifest or notes generation is touched, run the relevant release check such as bun run release:check or a narrower documented substitute. Expected: pass, or skipped with concrete blocker and risk.
+    5. Run node .agentplane/policy/check-routing.mjs and ap doctor. Expected: routing passes; doctor has no new warnings beyond documented pre-existing drift.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Freeze release candidate base and scope after late merges
+
+Harden release candidate planning so a patch release cannot claim to exclude work that is already merged into the candidate base. The v0.6.2 regression case is a release task that planned to exclude route-decision CLI work while PR #3823 later landed on origin/main. Release tooling should pin the base SHA, detect late merges, and require explicit revert, branch cut, or re-scope before candidate generation.
+
+## Scope
+
+- In scope: Harden release candidate planning so a patch release cannot claim to exclude work that is already merged into the candidate base. The v0.6.2 regression case is a release task that planned to exclude route-decision CLI work while PR #3823 later landed on origin/main. Release tooling should pin the base SHA, detect late merges, and require explicit revert, branch cut, or re-scope before candidate generation.
+- Out of scope: unrelated refactors not required for "Freeze release candidate base and scope after late merges".
+
+## Plan
+
+Plan: 1. Inspect the release candidate planning path and identify where candidate base SHA and excluded work are represented. 2. Add a release-scope guard that records the base SHA and detects when an excluded PR/task is already reachable from the candidate base. 3. Make the failure mode explicit: require re-scope, revert, or release-branch cut before candidate generation proceeds. 4. Add regression coverage using a fixture equivalent to the v0.6.2 route-decision CLI late-merge case. 5. Verify focused release-planning tests, release notes/candidate checks if affected, routing policy, and doctor output.
+
+## Verify Steps
+
+1. Add focused release-planning tests for an excluded PR/task that is already reachable from the selected candidate base SHA. Expected: release candidate generation fails closed with explicit re-scope/revert/branch-cut guidance.
+2. Add a positive test where excluded work is not reachable from the base SHA. Expected: release planning proceeds and records the pinned base.
+3. Run the focused release candidate/planning tests. Expected: all tests pass.
+4. If release manifest or notes generation is touched, run the relevant release check such as bun run release:check or a narrower documented substitute. Expected: pass, or skipped with concrete blocker and risk.
+5. Run node .agentplane/policy/check-routing.mjs and ap doctor. Expected: routing passes; doctor has no new warnings beyond documented pre-existing drift.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings


### PR DESCRIPTION
## Summary
- Add three executable AgentPlane task records for v0.6.2 follow-up bugs
- Split scanner/frontmatter, stale local task state, and release candidate scope drift into separate CODER-owned TODO tasks
- Keep this PR limited to task README artifacts only

## Tasks
- 202605171325-7P2VM4: Fix task scanner handling of invalid legacy README frontmatter
- 202605171325-7P5M3V: Warn when local task state is stale relative to origin main
- 202605171326-FXRVNW: Freeze release candidate base and scope after late merges

## Verification
- ap task list shows all three tasks as TODO
- node .agentplane/policy/check-routing.mjs
- git diff --cached --check before commit
- pre-push fast CI passed during git push
