### PR TITLE
🚧 Z88S1G task: Harden paths-filter checkout depth [202605171738-Z88S1G]

### DIFF
--- a/.agentplane/tasks/202605171738-Z88S1G/README.md
+++ b/.agentplane/tasks/202605171738-Z88S1G/README.md
@@ -1,0 +1,143 @@
+---
+id: "202605171738-Z88S1G"
+title: "Harden paths-filter checkout depth"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "ci"
+  - "code"
+  - "github"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-17T17:39:27.199Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-17T17:40:44.273Z"
+  updated_by: "CODER"
+  note: "Added fetch-depth: 0 to dorny/paths-filter changes jobs in Core CI, Docs CI, and Pre-publish workflows. Local verification passed: targeted rg inspection, workflow command contract, policy routing, and git diff --check. Remote PR checks will validate GitHub Actions behavior."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Harden GitHub Actions path-filter changes jobs by making checkout history complete before dorny/paths-filter runs, addressing the observed shallow fetch race on main push CI."
+events:
+  -
+    type: "status"
+    at: "2026-05-17T17:39:53.907Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Harden GitHub Actions path-filter changes jobs by making checkout history complete before dorny/paths-filter runs, addressing the observed shallow fetch race on main push CI."
+  -
+    type: "verify"
+    at: "2026-05-17T17:40:44.273Z"
+    author: "CODER"
+    state: "ok"
+    note: "Added fetch-depth: 0 to dorny/paths-filter changes jobs in Core CI, Docs CI, and Pre-publish workflows. Local verification passed: targeted rg inspection, workflow command contract, policy routing, and git diff --check. Remote PR checks will validate GitHub Actions behavior."
+doc_version: 3
+doc_updated_at: "2026-05-17T17:40:44.284Z"
+doc_updated_by: "CODER"
+description: "Fix GitHub Actions dorny/paths-filter shallow fetch race on main push runs by ensuring changes jobs checkout full history before path filtering."
+sections:
+  Summary: |-
+    Harden paths-filter checkout depth
+
+    Fix GitHub Actions dorny/paths-filter shallow fetch race on main push runs by ensuring changes jobs checkout full history before path filtering.
+  Scope: |-
+    - In scope: Fix GitHub Actions dorny/paths-filter shallow fetch race on main push runs by ensuring changes jobs checkout full history before path filtering.
+    - Out of scope: unrelated refactors not required for "Harden paths-filter checkout depth".
+  Plan: "Update GitHub Actions changes jobs that use dorny/paths-filter to checkout with full history before path filtering, preventing shallow fetch races on push runs. Scope is limited to CI workflow YAML files. Verify with YAML inspection, targeted text search, and policy routing; remote validation is the follow-up PR Core CI run."
+  Verify Steps: |-
+    - Inspect `.github/workflows/ci.yml`, `.github/workflows/docs-ci.yml`, and `.github/workflows/prepublish.yml` to confirm each `dorny/paths-filter@v4` changes job has an immediately preceding `actions/checkout@v6` with `fetch-depth: 0`.
+    - Run `rg -n "dorny/paths-filter|fetch-depth" .github/workflows` and review output for the changed jobs.
+    - Run `node .agentplane/policy/check-routing.mjs`.
+    - Open the task PR and confirm GitHub Core CI no longer fails in the `changes` job with `fatal: shallow file has changed since we read it`.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-17T17:40:44.273Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Added fetch-depth: 0 to dorny/paths-filter changes jobs in Core CI, Docs CI, and Pre-publish workflows. Local verification passed: targeted rg inspection, workflow command contract, policy routing, and git diff --check. Remote PR checks will validate GitHub Actions behavior.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T17:39:53.907Z, excerpt_hash=sha256:b9277e464899fbc340c0d8d4931a3964fd25a4a47340ca602878c234a24013b1
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605171738-Z88S1G-paths-filter-fetch-depth/.agentplane/tasks/202605171738-Z88S1G/blueprint/resolved-snapshot.json
+    - old_digest: 915c31faa2d554a690eb379f33d1ecab743135fe6d3abcd6316de012fbe6f689
+    - current_digest: 915c31faa2d554a690eb379f33d1ecab743135fe6d3abcd6316de012fbe6f689
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605171738-Z88S1G
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Harden paths-filter checkout depth
+
+Fix GitHub Actions dorny/paths-filter shallow fetch race on main push runs by ensuring changes jobs checkout full history before path filtering.
+
+## Scope
+
+- In scope: Fix GitHub Actions dorny/paths-filter shallow fetch race on main push runs by ensuring changes jobs checkout full history before path filtering.
+- Out of scope: unrelated refactors not required for "Harden paths-filter checkout depth".
+
+## Plan
+
+Update GitHub Actions changes jobs that use dorny/paths-filter to checkout with full history before path filtering, preventing shallow fetch races on push runs. Scope is limited to CI workflow YAML files. Verify with YAML inspection, targeted text search, and policy routing; remote validation is the follow-up PR Core CI run.
+
+## Verify Steps
+
+- Inspect `.github/workflows/ci.yml`, `.github/workflows/docs-ci.yml`, and `.github/workflows/prepublish.yml` to confirm each `dorny/paths-filter@v4` changes job has an immediately preceding `actions/checkout@v6` with `fetch-depth: 0`.
+- Run `rg -n "dorny/paths-filter|fetch-depth" .github/workflows` and review output for the changed jobs.
+- Run `node .agentplane/policy/check-routing.mjs`.
+- Open the task PR and confirm GitHub Core CI no longer fails in the `changes` job with `fatal: shallow file has changed since we read it`.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-17T17:40:44.273Z — VERIFY — ok
+
+By: CODER
+
+Note: Added fetch-depth: 0 to dorny/paths-filter changes jobs in Core CI, Docs CI, and Pre-publish workflows. Local verification passed: targeted rg inspection, workflow command contract, policy routing, and git diff --check. Remote PR checks will validate GitHub Actions behavior.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T17:39:53.907Z, excerpt_hash=sha256:b9277e464899fbc340c0d8d4931a3964fd25a4a47340ca602878c234a24013b1
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605171738-Z88S1G-paths-filter-fetch-depth/.agentplane/tasks/202605171738-Z88S1G/blueprint/resolved-snapshot.json
+- old_digest: 915c31faa2d554a690eb379f33d1ecab743135fe6d3abcd6316de012fbe6f689
+- current_digest: 915c31faa2d554a690eb379f33d1ecab743135fe6d3abcd6316de012fbe6f689
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605171738-Z88S1G
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605171738-Z88S1G/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605171738-Z88S1G/blueprint/resolved-snapshot.json
@@ -1,0 +1,554 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605171738-Z88S1G",
+    "title": "Harden paths-filter checkout depth",
+    "description": "Fix GitHub Actions dorny/paths-filter shallow fetch race on main push runs by ensuring changes jobs checkout full history before path filtering.",
+    "tags": [
+      "ci",
+      "code",
+      "github"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "quality.regression",
+    "version": 1,
+    "title": "Quality regression",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "quality.regression",
+    "blueprintVersion": 1,
+    "title": "Quality regression",
+    "taskId": "202605171738-Z88S1G",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to quality.regression",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest",
+          "artifact"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "check_result"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "weak_links"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "regression.original_failure",
+        "kind": "artifact",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Original failure log or check output."
+      },
+      {
+        "id": "regression.reproduction",
+        "kind": "check_result",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Local reproduction or explicit non-reproduction result."
+      },
+      {
+        "id": "regression.focused_check",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Focused regression check."
+      },
+      {
+        "id": "regression.matrix_or_scope",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Affected test/check matrix or bounded scope."
+      },
+      {
+        "id": "regression.full_gate",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Full relevant gate or hosted check evidence."
+      },
+      {
+        "id": "regression.flake_classification",
+        "kind": "weak_links",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Flake classification or residual risk."
+      },
+      {
+        "id": "regression.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "affected matrix or full relevant gate",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "failure reproduction command",
+      "focused regression check",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest",
+        "artifact"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "check_result"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "weak_links"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "regression.original_failure",
+      "kind": "artifact",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Original failure log or check output."
+    },
+    {
+      "id": "regression.reproduction",
+      "kind": "check_result",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Local reproduction or explicit non-reproduction result."
+    },
+    {
+      "id": "regression.focused_check",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Focused regression check."
+    },
+    {
+      "id": "regression.matrix_or_scope",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Affected test/check matrix or bounded scope."
+    },
+    {
+      "id": "regression.full_gate",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Full relevant gate or hosted check evidence."
+    },
+    {
+      "id": "regression.flake_classification",
+      "kind": "weak_links",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Flake classification or residual risk."
+    },
+    {
+      "id": "regression.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "affected matrix or full relevant gate",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "failure reproduction command",
+    "focused regression check",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to quality.regression",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "915c31faa2d554a690eb379f33d1ecab743135fe6d3abcd6316de012fbe6f689"
+  }
+}

--- a/.agentplane/tasks/202605171738-Z88S1G/pr/diffstat.txt
+++ b/.agentplane/tasks/202605171738-Z88S1G/pr/diffstat.txt
@@ -1,0 +1,5 @@
+ .../blueprint/resolved-snapshot.json               | 554 +++++++++++++++++++++
+ .github/workflows/ci.yml                           |   1 +
+ .github/workflows/docs-ci.yml                      |   2 +
+ .github/workflows/prepublish.yml                   |   2 +
+ 4 files changed, 559 insertions(+)

--- a/.agentplane/tasks/202605171738-Z88S1G/pr/github-body.md
+++ b/.agentplane/tasks/202605171738-Z88S1G/pr/github-body.md
@@ -1,0 +1,43 @@
+Task: `202605171738-Z88S1G`
+Title: Harden paths-filter checkout depth
+Canonical task record: `.agentplane/tasks/202605171738-Z88S1G/README.md`
+
+## Summary
+
+Harden paths-filter checkout depth
+
+Fix GitHub Actions dorny/paths-filter shallow fetch race on main push runs by ensuring changes jobs checkout full history before path filtering.
+
+## Scope
+
+- In scope: Fix GitHub Actions dorny/paths-filter shallow fetch race on main push runs by ensuring changes jobs checkout full history before path filtering.
+- Out of scope: unrelated refactors not required for "Harden paths-filter checkout depth".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Added fetch-depth: 0 to dorny/paths-filter changes jobs in Core CI, Docs CI, and Pre-publish
+workflows. Local verification passed: targeted rg inspection, workflow command contract, policy
+routing, and git diff --check. Remote PR checks will validate GitHub Actions behavior.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-17T17:41:23.606Z
+- Branch: task/202605171738-Z88S1G/paths-filter-fetch-depth
+- Head: 2821cb1d05a6
+
+```text
+ .../blueprint/resolved-snapshot.json               | 554 +++++++++++++++++++++
+ .github/workflows/ci.yml                           |   1 +
+ .github/workflows/docs-ci.yml                      |   2 +
+ .github/workflows/prepublish.yml                   |   2 +
+ 4 files changed, 559 insertions(+)
+```
+
+</details>

--- a/.agentplane/tasks/202605171738-Z88S1G/pr/github-title.txt
+++ b/.agentplane/tasks/202605171738-Z88S1G/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 Z88S1G task: Harden paths-filter checkout depth [202605171738-Z88S1G]

--- a/.agentplane/tasks/202605171738-Z88S1G/pr/meta.json
+++ b/.agentplane/tasks/202605171738-Z88S1G/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605171738-Z88S1G/paths-filter-fetch-depth",
+  "created_at": "2026-05-17T17:39:54.087Z",
+  "head_sha": "2821cb1d05a6bd6d04c700852a0cc904856fa97e",
+  "last_verified_at": "2026-05-17T17:40:44.273Z",
+  "last_verified_sha": "59a507f34063a995bdab0faa057af678575a6e9a",
+  "schema_version": 1,
+  "task_id": "202605171738-Z88S1G",
+  "updated_at": "2026-05-17T17:41:23.606Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605171738-Z88S1G/pr/review.md
+++ b/.agentplane/tasks/202605171738-Z88S1G/pr/review.md
@@ -1,0 +1,40 @@
+# PR Review
+
+Created: 2026-05-17T17:39:54.087Z
+
+## Task
+
+- Task: `202605171738-Z88S1G`
+- Title: Harden paths-filter checkout depth
+- Status: DOING
+- Branch: `task/202605171738-Z88S1G/paths-filter-fetch-depth`
+- Canonical task record: `.agentplane/tasks/202605171738-Z88S1G/README.md`
+
+## Verification
+
+- State: ok
+- Note: Added fetch-depth: 0 to dorny/paths-filter changes jobs in Core CI, Docs CI, and Pre-publish workflows. Local verification passed: targeted rg inspection, workflow command contract, policy routing, and git diff --check. Remote PR checks will validate GitHub Actions behavior.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-17T17:41:23.606Z
+- Branch: task/202605171738-Z88S1G/paths-filter-fetch-depth
+- Head: 2821cb1d05a6
+
+```text
+ .../blueprint/resolved-snapshot.json               | 554 +++++++++++++++++++++
+ .github/workflows/ci.yml                           |   1 +
+ .github/workflows/docs-ci.yml                      |   2 +
+ .github/workflows/prepublish.yml                   |   2 +
+ 4 files changed, 559 insertions(+)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ env.AGENTPLANE_CI_REF }}
+          fetch-depth: 0
       - uses: dorny/paths-filter@v4
         id: filter
         with:

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -20,6 +20,8 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: dorny/paths-filter@v4
         id: filter
         with:

--- a/.github/workflows/prepublish.yml
+++ b/.github/workflows/prepublish.yml
@@ -21,6 +21,8 @@ jobs:
       core: ${{ steps.filter.outputs.core }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: dorny/paths-filter@v4
         id: filter
         with:


### PR DESCRIPTION
Task: `202605171738-Z88S1G`
Title: Harden paths-filter checkout depth
Canonical task record: `.agentplane/tasks/202605171738-Z88S1G/README.md`

## Summary

Harden paths-filter checkout depth

Fix GitHub Actions dorny/paths-filter shallow fetch race on main push runs by ensuring changes jobs checkout full history before path filtering.

## Scope

- In scope: Fix GitHub Actions dorny/paths-filter shallow fetch race on main push runs by ensuring changes jobs checkout full history before path filtering.
- Out of scope: unrelated refactors not required for "Harden paths-filter checkout depth".

## Verification

- State: ok
- Note:

```text
Added fetch-depth: 0 to dorny/paths-filter changes jobs in Core CI, Docs CI, and Pre-publish
workflows. Local verification passed: targeted rg inspection, workflow command contract, policy
routing, and git diff --check. Remote PR checks will validate GitHub Actions behavior.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-17T17:41:23.606Z
- Branch: task/202605171738-Z88S1G/paths-filter-fetch-depth
- Head: 2821cb1d05a6

```text
 .../blueprint/resolved-snapshot.json               | 554 +++++++++++++++++++++
 .github/workflows/ci.yml                           |   1 +
 .github/workflows/docs-ci.yml                      |   2 +
 .github/workflows/prepublish.yml                   |   2 +
 4 files changed, 559 insertions(+)
```

</details>
