### PR TITLE
🚧 F281KQ task: Add guided task begin and complete shortcuts [202605171345-F281KQ]

### DIFF
--- a/.agentplane/WORKFLOW.md
+++ b/.agentplane/WORKFLOW.md
@@ -63,6 +63,9 @@ framework:
   last_update: null
   cli:
     expected_version: 0.6.1
+feedback:
+  github_issues:
+    enabled: true
 commit:
   generic_tokens:
     - start
@@ -107,6 +110,7 @@ timeouts:
 in_scope_paths:
   - "**"
 ---
+
 
 
 

--- a/.agentplane/tasks/202605171345-F281KQ/README.md
+++ b/.agentplane/tasks/202605171345-F281KQ/README.md
@@ -1,0 +1,151 @@
+---
+id: "202605171345-F281KQ"
+title: "Add guided task begin and complete shortcuts"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "cli"
+  - "code"
+  - "workflow"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "bun test packages/agentplane/src/cli/run-cli.core.task-guided.test.ts --runInBand"
+  - "bun test packages/agentplane/src/commands/task/start.unit.test.ts packages/agentplane/src/commands/task/finish.state.unit.test.ts --runInBand"
+  - "node .agentplane/policy/check-routing.mjs"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-17T13:46:51.810Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-17T17:43:31.493Z"
+  updated_by: "CODER"
+  note: "Implemented guided task begin and complete shortcuts. Checks passed: guided CLI tests; command-guide/help snapshots; docs freshness; policy routing; typecheck; lint; lifecycle unit tests via Vitest after bun-test runner mismatch was reported as issue #3845; clean temp-repo smoke for init -> task begin -> task complete."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement guided task begin and complete shortcuts over existing lifecycle primitives."
+events:
+  -
+    type: "status"
+    at: "2026-05-17T17:27:08.951Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement guided task begin and complete shortcuts over existing lifecycle primitives."
+  -
+    type: "verify"
+    at: "2026-05-17T17:43:31.493Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented guided task begin and complete shortcuts. Checks passed: guided CLI tests; command-guide/help snapshots; docs freshness; policy routing; typecheck; lint; lifecycle unit tests via Vitest after bun-test runner mismatch was reported as issue #3845; clean temp-repo smoke for init -> task begin -> task complete."
+doc_version: 3
+doc_updated_at: "2026-05-17T17:43:31.507Z"
+doc_updated_by: "CODER"
+description: "Add thin user-facing workflow shortcuts over existing task lifecycle primitives so users can begin and complete a task through policy-aware commands while preserving the generated audit trail and explicit stop gates."
+sections:
+  Summary: |-
+    Add guided task begin and complete shortcuts
+
+    Add thin user-facing workflow shortcuts over existing task lifecycle primitives so users can begin and complete a task through policy-aware commands while preserving the generated audit trail and explicit stop gates.
+  Scope: |-
+    - In scope: Add thin user-facing workflow shortcuts over existing task lifecycle primitives so users can begin and complete a task through policy-aware commands while preserving the generated audit trail and explicit stop gates.
+    - Out of scope: unrelated refactors not required for "Add guided task begin and complete shortcuts".
+  Plan: "Implement policy-aware guided workflow shortcuts over existing primitives, not a new lifecycle model. `task begin` should create/update the normal task record, write a minimal plan, approve/start only when policy allows, and print the next concrete command. `task complete` should verify/finish only when required evidence exists; otherwise it must report the exact missing gate. Both commands must preserve task README/ACR traceability and expose the underlying primitive commands in output or JSON."
+  Verify Steps: |-
+    1. Run `bun test packages/agentplane/src/cli/run-cli.core.task-guided.test.ts --runInBand`. Expected: `task begin` and `task complete` cover direct and branch_pr policy-aware paths, JSON/text output, and stop-gate behavior.
+    2. Run `bun test packages/agentplane/src/commands/task/start.unit.test.ts packages/agentplane/src/commands/task/finish.state.unit.test.ts --runInBand`. Expected: guided shortcuts preserve existing lifecycle transition invariants.
+    3. Run `bun test packages/agentplane/src/cli/command-guide.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --runInBand`. Expected: help teaches guided shortcuts as the default first real task path while keeping primitives available.
+    4. Run `node .agentplane/policy/check-routing.mjs`. Expected: policy routing remains valid.
+    5. Smoke `task begin` and `task complete` in a temp initialized repository when the repo-local runtime is bootstrapped. Expected: artifacts are normal task docs/ACR records, not a parallel scenario/run state.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-17T17:43:31.493Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Implemented guided task begin and complete shortcuts. Checks passed: guided CLI tests; command-guide/help snapshots; docs freshness; policy routing; typecheck; lint; lifecycle unit tests via Vitest after bun-test runner mismatch was reported as issue #3845; clean temp-repo smoke for init -> task begin -> task complete.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T17:27:08.951Z, excerpt_hash=sha256:b86a0ae677275882c6afe6831edc560ea4a00ccea90717b6acf9b77694c34bf4
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605171345-F281KQ-guided-task-shortcuts/.agentplane/tasks/202605171345-F281KQ/blueprint/resolved-snapshot.json
+    - old_digest: 738c33e32278a4116473284579128c420531c9cbcc52cc319fc9140d7e8b91dd
+    - current_digest: 738c33e32278a4116473284579128c420531c9cbcc52cc319fc9140d7e8b91dd
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605171345-F281KQ
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add guided task begin and complete shortcuts
+
+Add thin user-facing workflow shortcuts over existing task lifecycle primitives so users can begin and complete a task through policy-aware commands while preserving the generated audit trail and explicit stop gates.
+
+## Scope
+
+- In scope: Add thin user-facing workflow shortcuts over existing task lifecycle primitives so users can begin and complete a task through policy-aware commands while preserving the generated audit trail and explicit stop gates.
+- Out of scope: unrelated refactors not required for "Add guided task begin and complete shortcuts".
+
+## Plan
+
+Implement policy-aware guided workflow shortcuts over existing primitives, not a new lifecycle model. `task begin` should create/update the normal task record, write a minimal plan, approve/start only when policy allows, and print the next concrete command. `task complete` should verify/finish only when required evidence exists; otherwise it must report the exact missing gate. Both commands must preserve task README/ACR traceability and expose the underlying primitive commands in output or JSON.
+
+## Verify Steps
+
+1. Run `bun test packages/agentplane/src/cli/run-cli.core.task-guided.test.ts --runInBand`. Expected: `task begin` and `task complete` cover direct and branch_pr policy-aware paths, JSON/text output, and stop-gate behavior.
+2. Run `bun test packages/agentplane/src/commands/task/start.unit.test.ts packages/agentplane/src/commands/task/finish.state.unit.test.ts --runInBand`. Expected: guided shortcuts preserve existing lifecycle transition invariants.
+3. Run `bun test packages/agentplane/src/cli/command-guide.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --runInBand`. Expected: help teaches guided shortcuts as the default first real task path while keeping primitives available.
+4. Run `node .agentplane/policy/check-routing.mjs`. Expected: policy routing remains valid.
+5. Smoke `task begin` and `task complete` in a temp initialized repository when the repo-local runtime is bootstrapped. Expected: artifacts are normal task docs/ACR records, not a parallel scenario/run state.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-17T17:43:31.493Z — VERIFY — ok
+
+By: CODER
+
+Note: Implemented guided task begin and complete shortcuts. Checks passed: guided CLI tests; command-guide/help snapshots; docs freshness; policy routing; typecheck; lint; lifecycle unit tests via Vitest after bun-test runner mismatch was reported as issue #3845; clean temp-repo smoke for init -> task begin -> task complete.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T17:27:08.951Z, excerpt_hash=sha256:b86a0ae677275882c6afe6831edc560ea4a00ccea90717b6acf9b77694c34bf4
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605171345-F281KQ-guided-task-shortcuts/.agentplane/tasks/202605171345-F281KQ/blueprint/resolved-snapshot.json
+- old_digest: 738c33e32278a4116473284579128c420531c9cbcc52cc319fc9140d7e8b91dd
+- current_digest: 738c33e32278a4116473284579128c420531c9cbcc52cc319fc9140d7e8b91dd
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605171345-F281KQ
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605171345-F281KQ/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605171345-F281KQ/blueprint/resolved-snapshot.json
@@ -1,0 +1,535 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605171345-F281KQ",
+    "title": "Add guided task begin and complete shortcuts",
+    "description": "Add thin user-facing workflow shortcuts over existing task lifecycle primitives so users can begin and complete a task through policy-aware commands while preserving the generated audit trail and explicit stop gates.",
+    "tags": [
+      "cli",
+      "code",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605171345-F281KQ",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "738c33e32278a4116473284579128c420531c9cbcc52cc319fc9140d7e8b91dd"
+  }
+}

--- a/.agentplane/tasks/202605171345-F281KQ/pr/diffstat.txt
+++ b/.agentplane/tasks/202605171345-F281KQ/pr/diffstat.txt
@@ -1,0 +1,16 @@
+ .agentplane/WORKFLOW.md                            |   4 +
+ .../blueprint/resolved-snapshot.json               | 535 +++++++++++++++++++++
+ .agentplane/workflows/last-known-good.md           |   4 +
+ docs/user/cli-reference.generated.mdx              |  63 +++
+ .../run-cli.core.help-snap.test.ts.snap            | 113 +++--
+ packages/agentplane/src/cli/command-guide.test.ts  |   4 +-
+ packages/agentplane/src/cli/command-guide.ts       |  10 +-
+ packages/agentplane/src/cli/command-invocations.ts |   2 +
+ packages/agentplane/src/cli/command-snippets.ts    |   2 +
+ .../src/cli/run-cli.core.task-guided.test.ts       | 228 +++++++++
+ .../src/cli/run-cli/command-catalog/task.ts        |   6 +
+ .../src/cli/run-cli/command-loaders/task.ts        |   8 +
+ .../agentplane/src/commands/task/begin.command.ts  | 270 +++++++++++
+ .../src/commands/task/complete.command.ts          | 185 +++++++
+ .../agentplane/src/commands/task/task.command.ts   |  11 +-
+ 15 files changed, 1385 insertions(+), 60 deletions(-)

--- a/.agentplane/tasks/202605171345-F281KQ/pr/github-body.md
+++ b/.agentplane/tasks/202605171345-F281KQ/pr/github-body.md
@@ -1,0 +1,40 @@
+Task: `202605171345-F281KQ`
+Title: Add guided task begin and complete shortcuts
+Canonical task record: `.agentplane/tasks/202605171345-F281KQ/README.md`
+
+## Summary
+
+Add guided task begin and complete shortcuts
+
+Add thin user-facing workflow shortcuts over existing task lifecycle primitives so users can begin and complete a task through policy-aware commands while preserving the generated audit trail and explicit stop gates.
+
+## Scope
+
+- In scope: Add thin user-facing workflow shortcuts over existing task lifecycle primitives so users can begin and complete a task through policy-aware commands while preserving the generated audit trail and explicit stop gates.
+- Out of scope: unrelated refactors not required for "Add guided task begin and complete shortcuts".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Implemented guided task begin and complete shortcuts. Checks passed: guided CLI tests;
+command-guide/help snapshots; docs freshness; policy routing; typecheck; lint; lifecycle unit tests
+via Vitest after bun-test runner mismatch was reported as issue #3845; clean temp-repo smoke for
+init -> task begin -> task complete.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-17T17:27:09.110Z
+- Branch: task/202605171345-F281KQ/guided-task-shortcuts
+- Head: 4dbbe339e38d
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605171345-F281KQ/pr/github-body.md
+++ b/.agentplane/tasks/202605171345-F281KQ/pr/github-body.md
@@ -29,12 +29,27 @@ init -> task begin -> task complete.
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-17T17:27:09.110Z
+- Updated: 2026-05-17T17:44:32.929Z
 - Branch: task/202605171345-F281KQ/guided-task-shortcuts
-- Head: 4dbbe339e38d
+- Head: 06ba4e225b95
 
 ```text
-No changes detected.
+ .agentplane/WORKFLOW.md                            |   4 +
+ .../blueprint/resolved-snapshot.json               | 535 +++++++++++++++++++++
+ .agentplane/workflows/last-known-good.md           |   4 +
+ docs/user/cli-reference.generated.mdx              |  63 +++
+ .../run-cli.core.help-snap.test.ts.snap            | 113 +++--
+ packages/agentplane/src/cli/command-guide.test.ts  |   4 +-
+ packages/agentplane/src/cli/command-guide.ts       |  10 +-
+ packages/agentplane/src/cli/command-invocations.ts |   2 +
+ packages/agentplane/src/cli/command-snippets.ts    |   2 +
+ .../src/cli/run-cli.core.task-guided.test.ts       | 228 +++++++++
+ .../src/cli/run-cli/command-catalog/task.ts        |   6 +
+ .../src/cli/run-cli/command-loaders/task.ts        |   8 +
+ .../agentplane/src/commands/task/begin.command.ts  | 270 +++++++++++
+ .../src/commands/task/complete.command.ts          | 185 +++++++
+ .../agentplane/src/commands/task/task.command.ts   |  11 +-
+ 15 files changed, 1385 insertions(+), 60 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605171345-F281KQ/pr/github-title.txt
+++ b/.agentplane/tasks/202605171345-F281KQ/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 F281KQ task: Add guided task begin and complete shortcuts [202605171345-F281KQ]

--- a/.agentplane/tasks/202605171345-F281KQ/pr/meta.json
+++ b/.agentplane/tasks/202605171345-F281KQ/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605171345-F281KQ/guided-task-shortcuts",
+  "created_at": "2026-05-17T17:27:09.110Z",
+  "head_sha": "4dbbe339e38dd3e7127fc59f45b0867e6207a464",
+  "last_verified_at": "2026-05-17T17:43:31.493Z",
+  "last_verified_sha": "4dbbe339e38dd3e7127fc59f45b0867e6207a464",
+  "schema_version": 1,
+  "task_id": "202605171345-F281KQ",
+  "updated_at": "2026-05-17T17:27:09.110Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605171345-F281KQ/pr/meta.json
+++ b/.agentplane/tasks/202605171345-F281KQ/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605171345-F281KQ/guided-task-shortcuts",
   "created_at": "2026-05-17T17:27:09.110Z",
-  "head_sha": "4dbbe339e38dd3e7127fc59f45b0867e6207a464",
+  "head_sha": "06ba4e225b95cfea26a0907912405f3c3cc6e41a",
   "last_verified_at": "2026-05-17T17:43:31.493Z",
   "last_verified_sha": "4dbbe339e38dd3e7127fc59f45b0867e6207a464",
   "schema_version": 1,
   "task_id": "202605171345-F281KQ",
-  "updated_at": "2026-05-17T17:27:09.110Z",
+  "updated_at": "2026-05-17T17:44:32.929Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605171345-F281KQ/pr/meta.json
+++ b/.agentplane/tasks/202605171345-F281KQ/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "06ba4e225b95cfea26a0907912405f3c3cc6e41a",
   "last_verified_at": "2026-05-17T17:43:31.493Z",
   "last_verified_sha": "4dbbe339e38dd3e7127fc59f45b0867e6207a464",
+  "pr_number": 3848,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3848",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605171345-F281KQ",
-  "updated_at": "2026-05-17T17:44:32.929Z",
+  "updated_at": "2026-05-17T17:44:42.994Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605171345-F281KQ/pr/review.md
+++ b/.agentplane/tasks/202605171345-F281KQ/pr/review.md
@@ -24,12 +24,27 @@ Created: 2026-05-17T17:27:09.110Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-17T17:27:09.110Z
+- Updated: 2026-05-17T17:44:32.929Z
 - Branch: task/202605171345-F281KQ/guided-task-shortcuts
-- Head: 4dbbe339e38d
+- Head: 06ba4e225b95
 
 ```text
-No changes detected.
+ .agentplane/WORKFLOW.md                            |   4 +
+ .../blueprint/resolved-snapshot.json               | 535 +++++++++++++++++++++
+ .agentplane/workflows/last-known-good.md           |   4 +
+ docs/user/cli-reference.generated.mdx              |  63 +++
+ .../run-cli.core.help-snap.test.ts.snap            | 113 +++--
+ packages/agentplane/src/cli/command-guide.test.ts  |   4 +-
+ packages/agentplane/src/cli/command-guide.ts       |  10 +-
+ packages/agentplane/src/cli/command-invocations.ts |   2 +
+ packages/agentplane/src/cli/command-snippets.ts    |   2 +
+ .../src/cli/run-cli.core.task-guided.test.ts       | 228 +++++++++
+ .../src/cli/run-cli/command-catalog/task.ts        |   6 +
+ .../src/cli/run-cli/command-loaders/task.ts        |   8 +
+ .../agentplane/src/commands/task/begin.command.ts  | 270 +++++++++++
+ .../src/commands/task/complete.command.ts          | 185 +++++++
+ .../agentplane/src/commands/task/task.command.ts   |  11 +-
+ 15 files changed, 1385 insertions(+), 60 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605171345-F281KQ/pr/review.md
+++ b/.agentplane/tasks/202605171345-F281KQ/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-17T17:27:09.110Z
+
+## Task
+
+- Task: `202605171345-F281KQ`
+- Title: Add guided task begin and complete shortcuts
+- Status: DOING
+- Branch: `task/202605171345-F281KQ/guided-task-shortcuts`
+- Canonical task record: `.agentplane/tasks/202605171345-F281KQ/README.md`
+
+## Verification
+
+- State: ok
+- Note: Implemented guided task begin and complete shortcuts. Checks passed: guided CLI tests; command-guide/help snapshots; docs freshness; policy routing; typecheck; lint; lifecycle unit tests via Vitest after bun-test runner mismatch was reported as issue #3845; clean temp-repo smoke for init -> task begin -> task complete.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-17T17:27:09.110Z
+- Branch: task/202605171345-F281KQ/guided-task-shortcuts
+- Head: 4dbbe339e38d
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/workflows/last-known-good.md
+++ b/.agentplane/workflows/last-known-good.md
@@ -63,6 +63,9 @@ framework:
   last_update: null
   cli:
     expected_version: 0.6.1
+feedback:
+  github_issues:
+    enabled: true
 commit:
   generic_tokens:
     - start
@@ -107,6 +110,7 @@ timeouts:
 in_scope_paths:
   - "**"
 ---
+
 
 
 

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -13,7 +13,9 @@ This page is generated from the CLI command specs. Do not edit it by hand; edit 
   - [role](#role)
 - Task
   - [ready](#ready)
+  - [task begin](#task-begin)
   - [task comment](#task-comment)
+  - [task complete](#task-complete)
   - [task doc set](#task-doc-set)
   - [task doc show](#task-doc-show)
   - [task list](#task-list)
@@ -333,6 +335,37 @@ agentplane ready 202602030608-F1Q8AB
 
 - Print readiness details.
 
+### task begin
+
+Create, plan, approve, and start or route a task through the normal lifecycle.
+
+Usage:
+
+```text
+agentplane task begin <title> [options]
+```
+
+Options:
+
+- `--description <text>`: Task description. Defaults to the title.
+- `--owner <id>`: Task owner id. (default=CODER)
+- `--priority <low|normal|med|high>`: Task priority. (choices=low|normal|med|high, default=med)
+- `--tag <tag>`: Repeatable. Adds a tag. Defaults to code. (repeatable)
+- `--plan <text>`: Plan text. Defaults to a minimal generated plan; escaped newlines (\n) are supported by task plan set.
+- `--verify <command>`: Repeatable. Verification commands/checks to seed on the task. (repeatable)
+- `--task-kind <analysis|content|docs|code|release|ops|context>`: Structured blueprint task-kind intent. (choices=analysis|content|docs|code|release|ops|context)
+- `--mutation-scope <none|docs|code|release|ops|context|unknown>`: Structured mutation scope used by blueprint resolution. (choices=none|docs|code|release|ops|context|unknown)
+- `--blueprint-request <id>`: Explicit blueprint request stored on the task. (choices=analysis.light|content.light|docs.change|code.direct|code.branch_pr|performance.benchmark|quality.regression|context.assimilation|runner.execution|post_run.improvement_review|release.strict|ops.approval)
+- `--json`: Emit machine-readable JSON. (default=false)
+
+Examples:
+
+```sh
+agentplane task begin "Fix parser edge case" --tag code --verify "bun test"
+```
+
+- Create the task, seed a minimal plan, approve it, then start or print the branch_pr worktree route.
+
 ### task comment
 
 Append a comment to a task.
@@ -356,6 +389,36 @@ agentplane task comment 202602030608-F1Q8AB --author CODER --body "Investigated 
 ```
 
 - Add a comment and bump doc metadata.
+
+### task complete
+
+Record OK verification and finish a direct task, or print the branch_pr close route.
+
+Usage:
+
+```text
+agentplane task complete <task-id> --result <text> [options]
+```
+
+Options:
+
+- `--result <text>`: One-line result summary. (required)
+- `--commit <hash>`: Implementation commit hash to record when finish is allowed.
+- `--by <id>`: Verifier id. (default=CODER)
+- `--author <id>`: Finish author id for direct-mode finish. (default=CODER)
+- `--note <text>`: Verification note. Defaults to the result.
+- `--body <text>`: Finish body. Defaults to Verified: &lt;result&gt;.
+- `--force`: Forward --force to finish. (default=false)
+- `--yes`: Auto-approve force gates. (default=false)
+- `--json`: Emit machine-readable JSON. (default=false)
+
+Examples:
+
+```sh
+agentplane task complete 202602030608-F1Q8AB --result "Parser edge case fixed" --commit abcdef1
+```
+
+- Record verification and finish when the current workflow route allows it.
 
 ### task doc set
 

--- a/packages/agentplane/src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap
+++ b/packages/agentplane/src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap
@@ -1,6 +1,6 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`runCli help snapshots (cli2) > help (registry) snapshot 1`] = `
+exports[`runCli help snapshots (cli2) help (registry) snapshot 1`] = `
 "Usage:
   agentplane help [<cmd...>] [--compact] [--json]
 
@@ -14,13 +14,16 @@ Commands:
   Task:
     ready  Report dependency readiness details for a task.
     task  Task lifecycle and task-store commands.
+    task begin  Create, plan, approve, and start or route a task through the normal lifecycle.
     task comment  Append a comment to a task.
+    task complete  Record OK verification and finish a direct task, or print the branch_pr close route.
     task doc  Task doc commands (show/set).
     task doc set  Update a task README section.
     task doc show  Print task README content (entire doc or one section).
     task list  List tasks with compact resolved blueprint route hints.
     task new  Create a new task (prints the generated task id).
     task next  List ready tasks (default status=TODO) with optional filters.
+    task next-action  Print the single safest next command for a task route.
     task plan  Task plan commands (set/approve/reject).
     task plan approve  Approve the current task plan (enforces Verify Steps gating when configured).
     task plan set  Set a task plan (writes the Plan section and resets plan approval to pending).
@@ -30,6 +33,7 @@ Commands:
     task search  Search tasks by text or regex with optional filters.
     task show  Print task metadata and resolved blueprint route as JSON.
     task start-ready  Run readiness checks and start a task in one deterministic command.
+    task status  Show task lifecycle state with optional branch_pr route decision details.
     task verify  Record verification results (ok/rework).
     task verify ok  Record verification as OK (updates Verification section and verification frontmatter).
     task verify rework  Record verification as needs rework (resets commit, sets status to DOING, updates Verification).
@@ -40,6 +44,7 @@ Commands:
     start  Transition a task to DOING and record a structured Start comment.
     verify  Record a verification outcome for a task; incident candidates stay task-local unless collected explicitly.
   Work:
+    work resume  Diagnose how to resume a task in the correct checkout/worktree.
     work start  Prepare the workspace for a task (direct: single-stream on current branch; branch_pr: task branch/worktree).
   PR:
     integrate  Integrate a task branch into the base branch (branch_pr workflow).
@@ -168,6 +173,9 @@ Commands:
     evaluator  List and inspect evaluator prompt modules.
     evaluator list  List evaluator prompt modules from .agentplane/evaluators.
     evaluator show  Print an evaluator prompt module.
+  Workflow:
+    flow  Inspect and repair high-level task workflow routes.
+    flow repair  Print a dry-run repair plan for task workflow drift.
   Framework Dev:
     codex  Codex integration commands.
     codex plugin  Install and inspect bundled Codex plugin integrations.
@@ -186,62 +194,7 @@ Commands:
 "
 `;
 
-exports[`runCli help snapshots (cli2) > help codex plugin install --compact snapshot 1`] = `
-"codex plugin install - Install the bundled AgentPlane plugin into a local Codex marketplace.
-
-Usage:
-  agentplane codex plugin install [options]
-
-Options:
-  --scope <user|repo>  Install to the user home marketplace or the current repository marketplace. (choices=user|repo, default=user)
-"
-`;
-
-exports[`runCli help snapshots (cli2) > help recipes install --compact snapshot 1`] = `
-"recipes install - Install a recipe into the global cache from remote index, local archive, or URL.
-
-Usage:
-  agentplane recipes install <id|path|url> [--index <path|url>] [--refresh] [--yes] [--on-conflict <fail|rename|overwrite>]
-  agentplane recipes install --name <id> [--index <path|url>] [--refresh] [--yes] [--on-conflict <fail|rename|overwrite>]
-  agentplane recipes install --path <path> [--yes] [--on-conflict <fail|rename|overwrite>]
-  agentplane recipes install --url <url> [--yes] [--on-conflict <fail|rename|overwrite>]
-
-Options:
-  --name <id>  Cache from remote index by recipe id.
-  --path <path>  Cache from local recipe archive path.
-  --url <url>  Cache from recipe archive URL.
-  --index <path|url>  Override recipes index location (used when installing by name / auto-name).
-  --refresh  Refresh remote index cache before installing. (default=false)
-  --yes  Auto-approve network prompts when allowed by config. (default=false)
-  --on-conflict <fail|rename|overwrite>  Deprecated compatibility no-op; recipe installs stay self-contained. (choices=fail|rename|overwrite, default=fail)
-"
-`;
-
-exports[`runCli help snapshots (cli2) > help task --compact snapshot 1`] = `
-"task - Task lifecycle and task-store commands.
-
-Usage:
-  agentplane task <subcommand> [args] [options]
-"
-`;
-
-exports[`runCli help snapshots (cli2) > help task doc set --compact snapshot 1`] = `
-"task doc set - Update a task README section.
-
-Usage:
-  agentplane task doc set <task-id> --section <name> (--text <text> | --file <path>) [--updated-by <id>]
-  agentplane task doc set <task-id> --full-doc (--text <text> | --file <path>) [--updated-by <id>]
-
-Options:
-  --section <name>  Target section heading (must be one of config.tasks.doc.sections). Required unless --full-doc is set.
-  --full-doc  Treat the provided text/file as the full task README payload. (default=false)
-  --text <text>  Section content (mutually exclusive with --file). Literal escaped newlines (\\n) are normalized for inline text.
-  --file <path>  Read section content from a file (mutually exclusive with --text).
-  --updated-by <id>  Optional. Override doc_updated_by metadata (must be non-empty).
-"
-`;
-
-exports[`runCli help snapshots (cli2) > help task new --compact snapshot 1`] = `
+exports[`runCli help snapshots (cli2) help task new --compact snapshot 1`] = `
 "task new - Create a new task (prints the generated task id).
 
 Usage:
@@ -264,15 +217,15 @@ Options:
 "
 `;
 
-exports[`runCli help snapshots (cli2) > help task plan --compact snapshot 1`] = `
-"task plan - Task plan commands (set/approve/reject).
+exports[`runCli help snapshots (cli2) help task --compact snapshot 1`] = `
+"task - Task lifecycle and task-store commands.
 
 Usage:
-  agentplane task plan <set|approve|reject> [args] [options]
+  agentplane task <subcommand> [args] [options]
 "
 `;
 
-exports[`runCli help snapshots (cli2) > help task run --compact snapshot 1`] = `
+exports[`runCli help snapshots (cli2) help task run --compact snapshot 1`] = `
 "task run - Prepare or run a task through the shared runner contract.
 
 Usage:
@@ -283,7 +236,62 @@ Options:
 "
 `;
 
-exports[`runCli help snapshots (cli2) > help work start --json snapshot 1`] = `
+exports[`runCli help snapshots (cli2) help task plan --compact snapshot 1`] = `
+"task plan - Task plan commands (set/approve/reject).
+
+Usage:
+  agentplane task plan <set|approve|reject> [args] [options]
+"
+`;
+
+exports[`runCli help snapshots (cli2) help task doc set --compact snapshot 1`] = `
+"task doc set - Update a task README section.
+
+Usage:
+  agentplane task doc set <task-id> --section <name> (--text <text> | --file <path>) [--updated-by <id>]
+  agentplane task doc set <task-id> --full-doc (--text <text> | --file <path>) [--updated-by <id>]
+
+Options:
+  --section <name>  Target section heading (must be one of config.tasks.doc.sections). Required unless --full-doc is set.
+  --full-doc  Treat the provided text/file as the full task README payload. (default=false)
+  --text <text>  Section content (mutually exclusive with --file). Literal escaped newlines (\\n) are normalized for inline text.
+  --file <path>  Read section content from a file (mutually exclusive with --text).
+  --updated-by <id>  Optional. Override doc_updated_by metadata (must be non-empty).
+"
+`;
+
+exports[`runCli help snapshots (cli2) help recipes install --compact snapshot 1`] = `
+"recipes install - Install a recipe into the global cache from remote index, local archive, or URL.
+
+Usage:
+  agentplane recipes install <id|path|url> [--index <path|url>] [--refresh] [--yes] [--on-conflict <fail|rename|overwrite>]
+  agentplane recipes install --name <id> [--index <path|url>] [--refresh] [--yes] [--on-conflict <fail|rename|overwrite>]
+  agentplane recipes install --path <path> [--yes] [--on-conflict <fail|rename|overwrite>]
+  agentplane recipes install --url <url> [--yes] [--on-conflict <fail|rename|overwrite>]
+
+Options:
+  --name <id>  Cache from remote index by recipe id.
+  --path <path>  Cache from local recipe archive path.
+  --url <url>  Cache from recipe archive URL.
+  --index <path|url>  Override recipes index location (used when installing by name / auto-name).
+  --refresh  Refresh remote index cache before installing. (default=false)
+  --yes  Auto-approve network prompts when allowed by config. (default=false)
+  --on-conflict <fail|rename|overwrite>  Deprecated compatibility no-op; recipe installs stay self-contained. (choices=fail|rename|overwrite, default=fail)
+"
+`;
+
+exports[`runCli help snapshots (cli2) help codex plugin install --compact snapshot 1`] = `
+"codex plugin install - Install the bundled AgentPlane plugin into a local Codex marketplace.
+
+Usage:
+  agentplane codex plugin install [options]
+
+Options:
+  --scope <user|repo>  Install to the user home marketplace or the current repository marketplace. (choices=user|repo, default=user)
+"
+`;
+
+exports[`runCli help snapshots (cli2) help work start --json snapshot 1`] = `
 {
   "args": [
     {
@@ -308,6 +316,7 @@ exports[`runCli help snapshots (cli2) > help work start --json snapshot 1`] = `
     "When workflow_mode=direct, agentplane does not create task branches; it records a single active task for the workspace.",
     "When workflow_mode=branch_pr, --worktree is required and the command must be run on the base branch.",
     "After branch_pr work starts, run owner-scoped task commands from the created worktree so task README/PR artifacts stay attached to one checkout.",
+    "After interruption, use \`agentplane work resume <task-id>\` to diagnose the correct checkout, branch, PR, and repair route.",
   ],
   "options": [
     {

--- a/packages/agentplane/src/cli/command-guide.test.ts
+++ b/packages/agentplane/src/cli/command-guide.test.ts
@@ -73,6 +73,8 @@ describe("command-guide", () => {
     expect(text).toContain("## First visible payoff");
     expect(text).toContain("agentplane demo");
     expect(text).toContain("agentplane acr validate <task-id> --mode local");
+    expect(text).toContain('agentplane task begin "Inspect AgentPlane artifacts"');
+    expect(text).toContain("agentplane task complete <task-id>");
     expect(text).toContain(".agentplane/tasks/<task-id>/");
     expect(text).toContain("acr.json");
     expect(text).toContain("## Go deeper");

--- a/packages/agentplane/src/cli/command-guide.ts
+++ b/packages/agentplane/src/cli/command-guide.ts
@@ -41,6 +41,7 @@ const ROLE_GUIDES: RoleGuide[] = [
     role: "PLANNER",
     lines: [
       SHARED_STARTUP_NOTE,
+      '- For a normal first task, prefer `agentplane task begin "..." --tag <tag> --verify "<check>"`; it creates the task, writes a minimal plan, approves it, and either starts direct mode or prints the branch_pr worktree command.',
       '- Create executable tasks with `agentplane task new --title "..." --description "..." --priority med --owner <ROLE> --tag <tag>`.',
       '- Fill docs with `agentplane task doc set <task-id> --section <name> --text "..."` and set plan text with `agentplane task plan set <task-id> --text "..." --updated-by <ROLE>`.',
       '- Append task-local Findings via `agentplane task findings add <task-id> --observation "..." --impact "..." --resolution "..."`; add `--promote --external` or `--repo-fixable` only for real reusable incidents.',
@@ -53,6 +54,7 @@ const ROLE_GUIDES: RoleGuide[] = [
       SHARED_STARTUP_NOTE,
       "- direct: stay in the current checkout; branch_pr: start a task branch/worktree first, create implementation commits there, keep local PR artifacts current, and wait for hosted required checks before handing off to INTEGRATOR.",
       "- If branch_pr state is ambiguous after interruption, run `agentplane task status <task-id> --route` or `agentplane work resume <task-id>` before choosing a checkout or opening/updating a PR.",
+      `- For the common path, use \`${COMMAND_SNIPPETS.core.taskBegin}\` to create/approve/start-or-route and \`${COMMAND_SNIPPETS.core.taskComplete}\` after checks pass.`,
       `- Start deterministically with \`${COMMAND_SNIPPETS.core.startTask}\` after plan approval.`,
       `- Treat \`${COMMAND_SNIPPETS.core.taskVerifyShow}\` as the verification contract, then record \`${COMMAND_SNIPPETS.core.verifyTask}\`.`,
       `- Preferred direct close path: \`${COMMAND_SNIPPETS.core.finishTask}\` with \`--result-file ./result.txt\`; add \`--no-close-commit\` only for explicit manual close handling.`,
@@ -209,6 +211,14 @@ export function renderQuickstart(): string {
     ...renderQuickstartCommandBlock([
       "agentplane demo",
       "agentplane acr validate <task-id> --mode local",
+    ]),
+    "",
+    "For a real first task, use the guided task path:",
+    "",
+    ...renderQuickstartCommandBlock([
+      'agentplane task begin "Inspect AgentPlane artifacts" --tag docs --verify "agentplane task verify-show <task-id>"',
+      "agentplane task verify-show <task-id>",
+      'agentplane task complete <task-id> --result "Inspected generated artifacts" --commit <git-rev>',
     ]),
     "",
     "The payoff is a repo-visible task record:",

--- a/packages/agentplane/src/cli/command-invocations.ts
+++ b/packages/agentplane/src/cli/command-invocations.ts
@@ -14,6 +14,8 @@ const COMMAND_INVOCATIONS = new Map<string, string>([
   ["quickstart", "agentplane quickstart"],
   ["role", "agentplane role <ROLE>"],
   ["task list", "agentplane task list"],
+  ["task begin", 'agentplane task begin "..." --tag <tag> --verify "<check>"'],
+  ["task complete", 'agentplane task complete <task-id> --result "..." --commit <git-rev>'],
   [
     "task new",
     'agentplane task new --title "..." --description "..." --priority med --owner <ROLE> --tag <tag>',

--- a/packages/agentplane/src/cli/command-snippets.ts
+++ b/packages/agentplane/src/cli/command-snippets.ts
@@ -9,6 +9,8 @@ export const COMMAND_SNIPPETS = {
     incidentsCollect: invoke(["incidents", "collect"]),
     taskList: invoke(["task", "list"]),
     taskShow: invoke(["task", "show"]),
+    taskBegin: invoke(["task", "begin"]),
+    taskComplete: invoke(["task", "complete"]),
     taskNew: invoke(["task", "new"]),
     taskPlanSet: invoke(["task", "plan", "set"]),
     taskPlanApprove: invoke(["task", "plan", "approve"]),

--- a/packages/agentplane/src/cli/run-cli.core.task-guided.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.task-guided.test.ts
@@ -1,0 +1,228 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+import { defaultConfig } from "./core-imports.js";
+import { runCli } from "./run-cli.js";
+import {
+  captureStdIO,
+  commitAll,
+  configureGitUser,
+  installRunCliIntegrationHarness,
+  mkGitRepoRoot,
+  writeConfig,
+} from "@agentplane/testkit";
+
+installRunCliIntegrationHarness();
+
+describe("runCli task guided shortcuts", { timeout: 180_000 }, () => {
+  it("task begin creates, plans, approves, and starts a direct task", async () => {
+    const root = await mkGitRepoRoot();
+    const config = defaultConfig();
+    config.workflow_mode = "direct";
+    await writeConfig(root, config);
+
+    const io = captureStdIO();
+    let payload: { task_id: string; status: string; next_command: string };
+    try {
+      const code = await runCli([
+        "task",
+        "begin",
+        "Fix parser edge case",
+        "--tag",
+        "code",
+        "--verify",
+        "bun test",
+        "--json",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(0);
+      payload = JSON.parse(io.stdout.trim()) as typeof payload;
+    } finally {
+      io.restore();
+    }
+
+    expect(payload!.status).toBe("started");
+    expect(payload!.next_command).toContain("task verify-show");
+    const readme = await readFile(
+      path.join(root, ".agentplane", "tasks", payload!.task_id, "README.md"),
+      "utf8",
+    );
+    expect(readme).toContain('status: "DOING"');
+    expect(readme).toContain('state: "approved"');
+    expect(readme).toContain("Fix parser edge case");
+    expect(readme).toContain("bun test");
+  });
+
+  it("task begin keeps branch_pr on the worktree route instead of starting on base", async () => {
+    const root = await mkGitRepoRoot();
+    const config = defaultConfig();
+    config.workflow_mode = "branch_pr";
+    await writeConfig(root, config);
+
+    const io = captureStdIO();
+    let payload: { task_id: string; status: string; next_command: string };
+    try {
+      const code = await runCli([
+        "task",
+        "begin",
+        "Fix branch route",
+        "--tag",
+        "code",
+        "--json",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(0);
+      payload = JSON.parse(io.stdout.trim()) as typeof payload;
+    } finally {
+      io.restore();
+    }
+
+    expect(payload!.status).toBe("routed");
+    expect(payload!.next_command).toContain(`work start ${payload!.task_id}`);
+    const readme = await readFile(
+      path.join(root, ".agentplane", "tasks", payload!.task_id, "README.md"),
+      "utf8",
+    );
+    expect(readme).toContain('status: "TODO"');
+    expect(readme).toContain('state: "approved"');
+  });
+
+  it("task complete records verification and finishes a direct task", async () => {
+    const root = await mkGitRepoRoot();
+    const config = defaultConfig();
+    config.workflow_mode = "direct";
+    await writeConfig(root, config);
+    await configureGitUser(root);
+    const execFileAsync = promisify(execFile);
+    await execFileAsync("git", ["checkout", "-b", "main"], { cwd: root });
+    await commitAll(root, "seed");
+
+    const ioBegin = captureStdIO();
+    let taskId = "";
+    try {
+      await runCli([
+        "task",
+        "begin",
+        "Complete shortcut",
+        "--tag",
+        "code",
+        "--json",
+        "--root",
+        root,
+      ]);
+      taskId = (JSON.parse(ioBegin.stdout.trim()) as { task_id: string }).task_id;
+    } finally {
+      ioBegin.restore();
+    }
+    const { stdout: commit } = await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: root });
+
+    const ioComplete = captureStdIO();
+    try {
+      const code = await runCli([
+        "task",
+        "complete",
+        taskId,
+        "--result",
+        "Shortcut finished",
+        "--commit",
+        commit.trim(),
+        "--json",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(0);
+      expect(JSON.parse(ioComplete.stdout.trim())).toMatchObject({
+        task_id: taskId,
+        status: "finished",
+      });
+    } finally {
+      ioComplete.restore();
+    }
+
+    const readme = await readFile(
+      path.join(root, ".agentplane", "tasks", taskId, "README.md"),
+      "utf8",
+    );
+    expect(readme).toContain('status: "DONE"');
+    expect(readme).toContain('state: "ok"');
+    expect(readme).toContain("Shortcut finished");
+  });
+
+  it("task complete records branch_pr verification and prints the PR route", async () => {
+    const root = await mkGitRepoRoot();
+    const config = defaultConfig();
+    config.workflow_mode = "branch_pr";
+    await writeConfig(root, config);
+    const ioNew = captureStdIO();
+    let taskId = "";
+    try {
+      const code = await runCli([
+        "task",
+        "new",
+        "--title",
+        "Branch complete shortcut",
+        "--description",
+        "verify only",
+        "--owner",
+        "CODER",
+        "--tag",
+        "code",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(0);
+      taskId = ioNew.stdout.trim();
+    } finally {
+      ioNew.restore();
+    }
+    expect(
+      await runCli([
+        "task",
+        "plan",
+        "set",
+        taskId,
+        "--text",
+        "1. Verify the route.",
+        "--updated-by",
+        "ORCHESTRATOR",
+        "--root",
+        root,
+      ]),
+    ).toBe(0);
+    expect(
+      await runCli(["task", "plan", "approve", taskId, "--by", "ORCHESTRATOR", "--root", root]),
+    ).toBe(0);
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli([
+        "task",
+        "complete",
+        taskId,
+        "--result",
+        "Ready for PR",
+        "--json",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(0);
+      expect(JSON.parse(io.stdout.trim())).toMatchObject({
+        task_id: taskId,
+        status: "verified",
+      });
+    } finally {
+      io.restore();
+    }
+    const readme = await readFile(
+      path.join(root, ".agentplane", "tasks", taskId, "README.md"),
+      "utf8",
+    );
+    expect(readme).toContain('status: "TODO"');
+    expect(readme).toContain('state: "ok"');
+  });
+});

--- a/packages/agentplane/src/cli/run-cli.core.task-guided.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.task-guided.test.ts
@@ -153,6 +153,57 @@ describe("runCli task guided shortcuts", { timeout: 180_000 }, () => {
     expect(readme).toContain("Shortcut finished");
   });
 
+  it("task complete validates direct finish commit before recording verification", async () => {
+    const root = await mkGitRepoRoot();
+    const config = defaultConfig();
+    config.workflow_mode = "direct";
+    await writeConfig(root, config);
+
+    const ioBegin = captureStdIO();
+    let taskId = "";
+    try {
+      await runCli([
+        "task",
+        "begin",
+        "Missing commit shortcut",
+        "--tag",
+        "code",
+        "--json",
+        "--root",
+        root,
+      ]);
+      taskId = (JSON.parse(ioBegin.stdout.trim()) as { task_id: string }).task_id;
+    } finally {
+      ioBegin.restore();
+    }
+
+    const ioComplete = captureStdIO();
+    try {
+      const code = await runCli([
+        "task",
+        "complete",
+        taskId,
+        "--result",
+        "Shortcut should fail before verify",
+        "--json",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(2);
+      expect(ioComplete.stderr).toContain("task complete requires --commit <hash>");
+    } finally {
+      ioComplete.restore();
+    }
+
+    const readme = await readFile(
+      path.join(root, ".agentplane", "tasks", taskId, "README.md"),
+      "utf8",
+    );
+    expect(readme).toContain('status: "DOING"');
+    expect(readme).toContain('state: "pending"');
+    expect(readme).not.toContain("Shortcut should fail before verify");
+  });
+
   it("task complete records branch_pr verification and prints the PR route", async () => {
     const root = await mkGitRepoRoot();
     const config = defaultConfig();

--- a/packages/agentplane/src/cli/run-cli/command-catalog/task.ts
+++ b/packages/agentplane/src/cli/run-cli/command-catalog/task.ts
@@ -18,6 +18,8 @@ import { taskListSpec } from "../../../commands/task/list.spec.js";
 import { taskMigrateDocSpec } from "../../../commands/task/migrate-doc.command.js";
 import { taskMigrateSpec } from "../../../commands/task/migrate.command.js";
 import { taskNewSpec } from "../../../commands/task/new.spec.js";
+import { taskBeginSpec } from "../../../commands/task/begin.command.js";
+import { taskCompleteSpec } from "../../../commands/task/complete.command.js";
 import { taskNextSpec } from "../../../commands/task/next.spec.js";
 import {
   taskObsidianCleanSpec,
@@ -82,6 +84,8 @@ import {
   fromTaskRunSpec,
   fromTaskRunResumeSpec,
   loadTaskNewSpec,
+  loadTaskBeginSpec,
+  loadTaskCompleteSpec,
   loadTaskDeriveSpec,
   loadTaskCloseDuplicateSpec,
   loadTaskStartReadySpec,
@@ -170,6 +174,8 @@ export const TASK_COMMANDS = [
     load: loadTaskNewSpec,
     invocation: requireCanonicalCommandInvocation(["task", "new"]),
   }),
+  declareCommand(taskBeginSpec, { load: loadTaskBeginSpec }),
+  declareCommand(taskCompleteSpec, { load: loadTaskCompleteSpec }),
   declareCommand(taskDeriveSpec, {
     load: loadTaskDeriveSpec,
     surface: "advanced",

--- a/packages/agentplane/src/cli/run-cli/command-loaders/task.ts
+++ b/packages/agentplane/src/cli/run-cli/command-loaders/task.ts
@@ -77,6 +77,14 @@ export const fromTaskRunResumeSpec = commandModule(
 );
 export const loadTaskNewSpec = (deps: RunDeps) =>
   import("../../../commands/task/new.command.js").then((m) => m.makeRunTaskNewHandler(deps.getCtx));
+export const loadTaskBeginSpec = (deps: RunDeps) =>
+  import("../../../commands/task/begin.command.js").then((m) =>
+    m.makeRunTaskBeginHandler(deps.getCtx),
+  );
+export const loadTaskCompleteSpec = (deps: RunDeps) =>
+  import("../../../commands/task/complete.command.js").then((m) =>
+    m.makeRunTaskCompleteHandler(deps.getCtx),
+  );
 export const loadTaskDeriveSpec = (deps: RunDeps) =>
   import("../../../commands/task/derive.command.js").then((m) =>
     m.makeRunTaskDeriveHandler(deps.getCtx),

--- a/packages/agentplane/src/commands/task/begin.command.ts
+++ b/packages/agentplane/src/commands/task/begin.command.ts
@@ -1,0 +1,270 @@
+import type { CommandCtx, CommandHandler, CommandSpec } from "../../cli/spec/spec.js";
+import { usageError } from "../../cli/spec/errors.js";
+import { createCliEmitter } from "../../cli/output.js";
+import type { CommandContext } from "../shared/task-backend.js";
+
+import { runTaskNewParsed, type TaskNewParsed } from "./new.js";
+import { cmdTaskPlanApprove, cmdTaskPlanSet } from "./plan.js";
+import { cmdTaskStartReady } from "./start-ready.js";
+
+const output = createCliEmitter();
+
+export type TaskBeginParsed = {
+  title: string;
+  description?: string;
+  owner: string;
+  priority: "low" | "normal" | "med" | "high";
+  tags: string[];
+  plan?: string;
+  verify: string[];
+  taskKind?: TaskNewParsed["taskKind"];
+  mutationScope?: TaskNewParsed["mutationScope"];
+  blueprintRequest?: TaskNewParsed["blueprintRequest"];
+  json: boolean;
+};
+
+export const taskBeginSpec: CommandSpec<TaskBeginParsed> = {
+  id: ["task", "begin"],
+  group: "Task",
+  summary: "Create, plan, approve, and start or route a task through the normal lifecycle.",
+  args: [{ name: "title", required: true, valueHint: "<title>" }],
+  options: [
+    {
+      kind: "string",
+      name: "description",
+      valueHint: "<text>",
+      description: "Task description. Defaults to the title.",
+    },
+    {
+      kind: "string",
+      name: "owner",
+      valueHint: "<id>",
+      default: "CODER",
+      description: "Task owner id.",
+    },
+    {
+      kind: "string",
+      name: "priority",
+      valueHint: "<low|normal|med|high>",
+      choices: ["low", "normal", "med", "high"],
+      default: "med",
+      description: "Task priority.",
+    },
+    {
+      kind: "string",
+      name: "tag",
+      valueHint: "<tag>",
+      repeatable: true,
+      description: "Repeatable. Adds a tag. Defaults to code.",
+    },
+    {
+      kind: "string",
+      name: "plan",
+      valueHint: "<text>",
+      description: String.raw`Plan text. Defaults to a minimal generated plan; escaped newlines (\n) are supported by task plan set.`,
+    },
+    {
+      kind: "string",
+      name: "verify",
+      valueHint: "<command>",
+      repeatable: true,
+      description: "Repeatable. Verification commands/checks to seed on the task.",
+    },
+    {
+      kind: "string",
+      name: "task-kind",
+      valueHint: "<analysis|content|docs|code|release|ops|context>",
+      choices: ["analysis", "content", "docs", "code", "release", "ops", "context"],
+      description: "Structured blueprint task-kind intent.",
+    },
+    {
+      kind: "string",
+      name: "mutation-scope",
+      valueHint: "<none|docs|code|release|ops|context|unknown>",
+      choices: ["none", "docs", "code", "release", "ops", "context", "unknown"],
+      description: "Structured mutation scope used by blueprint resolution.",
+    },
+    {
+      kind: "string",
+      name: "blueprint-request",
+      valueHint: "<id>",
+      choices: [
+        "analysis.light",
+        "content.light",
+        "docs.change",
+        "code.direct",
+        "code.branch_pr",
+        "performance.benchmark",
+        "quality.regression",
+        "context.assimilation",
+        "runner.execution",
+        "post_run.improvement_review",
+        "release.strict",
+        "ops.approval",
+      ],
+      description: "Explicit blueprint request stored on the task.",
+    },
+    { kind: "boolean", name: "json", default: false, description: "Emit machine-readable JSON." },
+  ],
+  examples: [
+    {
+      cmd: 'agentplane task begin "Fix parser edge case" --tag code --verify "bun test"',
+      why: "Create the task, seed a minimal plan, approve it, then start or print the branch_pr worktree route.",
+    },
+  ],
+  validateRaw: (raw) => {
+    const title = typeof raw.args.title === "string" ? raw.args.title.trim() : "";
+    if (!title) {
+      throw usageError({ spec: taskBeginSpec, message: "Invalid value for title: empty." });
+    }
+    const owner = typeof raw.opts.owner === "string" ? raw.opts.owner.trim() : "CODER";
+    if (!owner) {
+      throw usageError({ spec: taskBeginSpec, message: "Invalid value for --owner: empty." });
+    }
+  },
+  parse: (raw) => ({
+    title: String(raw.args.title),
+    description:
+      typeof raw.opts.description === "string" ? String(raw.opts.description) : undefined,
+    owner: typeof raw.opts.owner === "string" ? String(raw.opts.owner) : "CODER",
+    priority: (raw.opts.priority ?? "med") as TaskBeginParsed["priority"],
+    tags: Array.isArray(raw.opts.tag) ? (raw.opts.tag as string[]) : ["code"],
+    plan: typeof raw.opts.plan === "string" ? String(raw.opts.plan) : undefined,
+    verify: Array.isArray(raw.opts.verify) ? (raw.opts.verify as string[]) : [],
+    taskKind: raw.opts["task-kind"] as TaskBeginParsed["taskKind"],
+    mutationScope: raw.opts["mutation-scope"] as TaskBeginParsed["mutationScope"],
+    blueprintRequest: raw.opts["blueprint-request"] as TaskBeginParsed["blueprintRequest"],
+    json: raw.opts.json === true,
+  }),
+};
+
+function defaultPlan(title: string): string {
+  return [
+    `1. Clarify the smallest safe implementation scope for: ${title}.`,
+    "2. Make the scoped change using existing project conventions.",
+    "3. Run the task Verify Steps and record the result before finishing.",
+  ].join("\n");
+}
+
+async function captureStdout(fn: () => Promise<number>): Promise<{ code: number; stdout: string }> {
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  let stdout = "";
+  process.stdout.write = ((chunk: unknown, ...args: unknown[]) => {
+    stdout += typeof chunk === "string" ? chunk : Buffer.isBuffer(chunk) ? chunk.toString() : "";
+    void originalWrite;
+    void args;
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    const code = await fn();
+    return { code, stdout };
+  } finally {
+    process.stdout.write = originalWrite as typeof process.stdout.write;
+  }
+}
+
+function extractTaskId(stdout: string): string {
+  const match = /\b\d{12}-[A-Z0-9]{6}\b/.exec(stdout);
+  if (!match) {
+    throw usageError({
+      spec: taskBeginSpec,
+      message: "task begin could not determine the task id created by task new.",
+    });
+  }
+  return match[0];
+}
+
+export function makeRunTaskBeginHandler(
+  getCtx: (cmd: string) => Promise<CommandContext>,
+): CommandHandler<TaskBeginParsed> {
+  return async (ctx: CommandCtx, p: TaskBeginParsed): Promise<number> => {
+    const command = await getCtx("task begin");
+    const workflowMode = command.config.workflow_mode;
+    const trimmedDescription = p.description?.trim();
+    const description =
+      typeof trimmedDescription === "string" && trimmedDescription.length > 0
+        ? trimmedDescription
+        : p.title.trim();
+    const tags = p.tags.length > 0 ? p.tags : ["code"];
+    const created = await captureStdout(() =>
+      runTaskNewParsed({
+        ctx: command,
+        cwd: ctx.cwd,
+        rootOverride: ctx.rootOverride,
+        parsed: {
+          title: p.title,
+          description,
+          owner: p.owner,
+          priority: p.priority,
+          tags,
+          taskKind: p.taskKind,
+          mutationScope: p.mutationScope,
+          riskFlags: [],
+          blueprintRequest: p.blueprintRequest,
+          dependsOn: [],
+          verify: p.verify,
+          showBlueprint: false,
+          allowDuplicate: false,
+        },
+      }),
+    );
+    if (created.code !== 0) return created.code;
+    const taskId = extractTaskId(created.stdout);
+    await captureStdout(() =>
+      cmdTaskPlanSet({
+        ctx: command,
+        cwd: ctx.cwd,
+        rootOverride: ctx.rootOverride,
+        taskId,
+        text: p.plan ?? defaultPlan(p.title),
+        updatedBy: "ORCHESTRATOR",
+      }),
+    );
+    await cmdTaskPlanApprove({
+      ctx: command,
+      cwd: ctx.cwd,
+      rootOverride: ctx.rootOverride,
+      taskId,
+      by: "ORCHESTRATOR",
+    });
+
+    let status: "started" | "routed" = "routed";
+    let nextCommand = `agentplane work start ${taskId} --agent ${p.owner} --slug <slug> --worktree`;
+    if (workflowMode === "direct") {
+      await cmdTaskStartReady({
+        ctx: command,
+        cwd: ctx.cwd,
+        rootOverride: ctx.rootOverride,
+        taskId,
+        author: p.owner,
+        body: `Start: ${p.title}. Guided shortcut created the task, approved the plan, and entered execution.`,
+        force: false,
+        yes: false,
+        quiet: true,
+      });
+      status = "started";
+      nextCommand = `agentplane task verify-show ${taskId}`;
+    }
+
+    const payload = {
+      task_id: taskId,
+      status,
+      workflow_mode: workflowMode,
+      next_command: nextCommand,
+    };
+    if (p.json) {
+      output.json(payload);
+    } else {
+      output.report(
+        [
+          { label: "task", value: taskId },
+          { label: "status", value: status },
+          { label: "workflow_mode", value: workflowMode },
+          { label: "next", value: nextCommand },
+        ],
+        { header: "task begin" },
+      );
+    }
+    return 0;
+  };
+}

--- a/packages/agentplane/src/commands/task/complete.command.ts
+++ b/packages/agentplane/src/commands/task/complete.command.ts
@@ -1,0 +1,185 @@
+import type { CommandCtx, CommandHandler, CommandSpec } from "../../cli/spec/spec.js";
+import { usageError } from "../../cli/spec/errors.js";
+import { createCliEmitter } from "../../cli/output.js";
+import type { CommandContext } from "../shared/task-backend.js";
+
+import { cmdFinish } from "./finish-command.js";
+import { cmdVerifyParsed } from "./verify-record.js";
+
+const output = createCliEmitter();
+
+export type TaskCompleteParsed = {
+  taskId: string;
+  result: string;
+  commit?: string;
+  by: string;
+  author: string;
+  note?: string;
+  body?: string;
+  force: boolean;
+  yes: boolean;
+  json: boolean;
+};
+
+export const taskCompleteSpec: CommandSpec<TaskCompleteParsed> = {
+  id: ["task", "complete"],
+  group: "Task",
+  summary: "Record OK verification and finish a direct task, or print the branch_pr close route.",
+  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
+  options: [
+    {
+      kind: "string",
+      name: "result",
+      valueHint: "<text>",
+      required: true,
+      description: "One-line result summary.",
+    },
+    {
+      kind: "string",
+      name: "commit",
+      valueHint: "<hash>",
+      description: "Implementation commit hash to record when finish is allowed.",
+    },
+    {
+      kind: "string",
+      name: "by",
+      valueHint: "<id>",
+      default: "CODER",
+      description: "Verifier id.",
+    },
+    {
+      kind: "string",
+      name: "author",
+      valueHint: "<id>",
+      default: "CODER",
+      description: "Finish author id for direct-mode finish.",
+    },
+    {
+      kind: "string",
+      name: "note",
+      valueHint: "<text>",
+      description: "Verification note. Defaults to the result.",
+    },
+    {
+      kind: "string",
+      name: "body",
+      valueHint: "<text>",
+      description: "Finish body. Defaults to Verified: <result>.",
+    },
+    { kind: "boolean", name: "force", default: false, description: "Forward --force to finish." },
+    { kind: "boolean", name: "yes", default: false, description: "Auto-approve force gates." },
+    { kind: "boolean", name: "json", default: false, description: "Emit machine-readable JSON." },
+  ],
+  examples: [
+    {
+      cmd: 'agentplane task complete 202602030608-F1Q8AB --result "Parser edge case fixed" --commit abcdef1',
+      why: "Record verification and finish when the current workflow route allows it.",
+    },
+  ],
+  validateRaw: (raw) => {
+    const taskId = typeof raw.args["task-id"] === "string" ? raw.args["task-id"].trim() : "";
+    if (!taskId) {
+      throw usageError({ spec: taskCompleteSpec, message: "Invalid value for task-id: empty." });
+    }
+    const result = typeof raw.opts.result === "string" ? raw.opts.result.trim() : "";
+    if (!result) {
+      throw usageError({ spec: taskCompleteSpec, message: "Invalid value for --result: empty." });
+    }
+  },
+  parse: (raw) => ({
+    taskId: String(raw.args["task-id"]),
+    result: String(raw.opts.result),
+    commit: typeof raw.opts.commit === "string" ? String(raw.opts.commit) : undefined,
+    by: typeof raw.opts.by === "string" ? String(raw.opts.by) : "CODER",
+    author: typeof raw.opts.author === "string" ? String(raw.opts.author) : "CODER",
+    note: typeof raw.opts.note === "string" ? String(raw.opts.note) : undefined,
+    body: typeof raw.opts.body === "string" ? String(raw.opts.body) : undefined,
+    force: raw.opts.force === true,
+    yes: raw.opts.yes === true,
+    json: raw.opts.json === true,
+  }),
+};
+
+export function makeRunTaskCompleteHandler(
+  getCtx: (cmd: string) => Promise<CommandContext>,
+): CommandHandler<TaskCompleteParsed> {
+  return async (ctx: CommandCtx, p: TaskCompleteParsed): Promise<number> => {
+    const command = await getCtx("task complete");
+    await cmdVerifyParsed({
+      ctx: command,
+      cwd: ctx.cwd,
+      rootOverride: ctx.rootOverride,
+      taskId: p.taskId,
+      state: "ok",
+      by: p.by,
+      note: p.note ?? p.result,
+      quiet: true,
+    });
+
+    const workflowMode = command.config.workflow_mode;
+    if (workflowMode === "branch_pr") {
+      const nextCommand = `agentplane pr open ${p.taskId} --branch task/${p.taskId}/<slug> --author ${p.by}`;
+      const payload = {
+        task_id: p.taskId,
+        status: "verified",
+        workflow_mode: workflowMode,
+        next_command: nextCommand,
+      };
+      if (p.json) {
+        output.json(payload);
+      } else {
+        output.report(
+          [
+            { label: "task", value: p.taskId },
+            { label: "status", value: "verified" },
+            { label: "workflow_mode", value: workflowMode },
+            { label: "next", value: nextCommand },
+          ],
+          { header: "task complete" },
+        );
+      }
+      return 0;
+    }
+
+    await cmdFinish({
+      ctx: command,
+      cwd: ctx.cwd,
+      rootOverride: ctx.rootOverride,
+      taskIds: [p.taskId],
+      author: p.author,
+      body:
+        p.body ??
+        `Verified: ${p.result}. Guided shortcut recorded verification and is closing the direct task with traceable commit metadata.`,
+      result: p.result,
+      commit: p.commit,
+      breaking: false,
+      force: p.force,
+      yes: p.yes,
+      commitFromComment: false,
+      commitAllow: [],
+      commitAutoAllow: false,
+      commitAllowTasks: true,
+      commitRequireClean: false,
+      statusCommit: false,
+      statusCommitAllow: [],
+      statusCommitAutoAllow: false,
+      statusCommitRequireClean: false,
+      confirmStatusCommit: false,
+      quiet: true,
+    });
+    const payload = { task_id: p.taskId, status: "finished", workflow_mode: workflowMode };
+    if (p.json) {
+      output.json(payload);
+    } else {
+      output.report(
+        [
+          { label: "task", value: p.taskId },
+          { label: "status", value: "finished" },
+          { label: "workflow_mode", value: workflowMode },
+        ],
+        { header: "task complete" },
+      );
+    }
+    return 0;
+  };
+}

--- a/packages/agentplane/src/commands/task/complete.command.ts
+++ b/packages/agentplane/src/commands/task/complete.command.ts
@@ -1,10 +1,13 @@
 import type { CommandCtx, CommandHandler, CommandSpec } from "../../cli/spec/spec.js";
 import { usageError } from "../../cli/spec/errors.js";
 import { createCliEmitter } from "../../cli/output.js";
-import type { CommandContext } from "../shared/task-backend.js";
+import { loadTaskFromContext, type CommandContext } from "../shared/task-backend.js";
+import { CliError } from "../../shared/errors.js";
 
 import { cmdFinish } from "./finish-command.js";
 import { cmdVerifyParsed } from "./verify-record.js";
+import { existingCommitInfo } from "./finish-shared.js";
+import { readCommitInfo } from "./shared.js";
 
 const output = createCliEmitter();
 
@@ -105,6 +108,11 @@ export function makeRunTaskCompleteHandler(
 ): CommandHandler<TaskCompleteParsed> {
   return async (ctx: CommandCtx, p: TaskCompleteParsed): Promise<number> => {
     const command = await getCtx("task complete");
+    const workflowMode = command.config.workflow_mode;
+    if (workflowMode !== "branch_pr") {
+      await assertDirectFinishCommitReady({ ctx: command, taskId: p.taskId, commit: p.commit });
+    }
+
     await cmdVerifyParsed({
       ctx: command,
       cwd: ctx.cwd,
@@ -116,7 +124,6 @@ export function makeRunTaskCompleteHandler(
       quiet: true,
     });
 
-    const workflowMode = command.config.workflow_mode;
     if (workflowMode === "branch_pr") {
       const nextCommand = `agentplane pr open ${p.taskId} --branch task/${p.taskId}/<slug> --author ${p.by}`;
       const payload = {
@@ -182,4 +189,30 @@ export function makeRunTaskCompleteHandler(
     }
     return 0;
   };
+}
+
+async function assertDirectFinishCommitReady(opts: {
+  ctx: CommandContext;
+  taskId: string;
+  commit?: string;
+}): Promise<void> {
+  if (typeof opts.commit === "string" && opts.commit.trim()) {
+    await readCommitInfo(opts.ctx.resolvedProject.gitRoot, opts.commit);
+    return;
+  }
+
+  const task = await loadTaskFromContext({ ctx: opts.ctx, taskId: opts.taskId });
+  if (existingCommitInfo(task)) return;
+
+  throw new CliError({
+    exitCode: 2,
+    code: "E_USAGE",
+    message: [
+      "task complete requires --commit <hash> or existing task commit metadata before recording verification.",
+      `task_missing_commit=${opts.taskId}`,
+      "Fix:",
+      "  1) Select the implementation commit explicitly: git log --oneline --decorate -n 10",
+      '  2) Re-run: agentplane task complete <task-id> --result "..." --commit <hash>',
+    ].join("\n"),
+  });
 }

--- a/packages/agentplane/src/commands/task/task.command.ts
+++ b/packages/agentplane/src/commands/task/task.command.ts
@@ -14,6 +14,7 @@ export const taskSpec: CommandSpec<TaskGroupParsed> = {
   synopsis: ["agentplane task <subcommand> [args] [options]"],
   args: [{ name: "cmd", required: false, variadic: true, valueHint: "<subcommand>" }],
   notes: [
+    "Default guided path: task begin -> task verify-show -> task complete. The low-level primitives remain available for explicit audit gates.",
     "Direct task route: task new -> task plan set -> task plan approve -> task start-ready -> task verify-show -> verify -> finish.",
     "Before manually chaining low-level diagnostics, use `agentplane task status <task-id> --route` or `agentplane task next-action <task-id>` for a route decision.",
     "Use `agentplane help task plan`, `agentplane help task doc`, and `agentplane help task verify` to inspect task sub-areas.",
@@ -21,8 +22,16 @@ export const taskSpec: CommandSpec<TaskGroupParsed> = {
   ],
   examples: [
     {
+      cmd: 'agentplane task begin "Fix parser edge case" --tag code --verify "bun test"',
+      why: "Create, plan, approve, and start or route a normal task.",
+    },
+    {
+      cmd: 'agentplane task complete <task-id> --result "Parser edge case fixed" --commit <hash>',
+      why: "Record OK verification and finish when the active workflow route allows it.",
+    },
+    {
       cmd: 'agentplane task new --title "..." --description "..." --owner CODER --tag code',
-      why: "Create a task.",
+      why: "Create a task with the explicit primitive command.",
     },
     {
       cmd: 'agentplane task plan set <task-id> --text "..." --updated-by ORCHESTRATOR',


### PR DESCRIPTION
Task: `202605171345-F281KQ`
Title: Add guided task begin and complete shortcuts
Canonical task record: `.agentplane/tasks/202605171345-F281KQ/README.md`

## Summary

Add guided task begin and complete shortcuts

Add thin user-facing workflow shortcuts over existing task lifecycle primitives so users can begin and complete a task through policy-aware commands while preserving the generated audit trail and explicit stop gates.

## Scope

- In scope: Add thin user-facing workflow shortcuts over existing task lifecycle primitives so users can begin and complete a task through policy-aware commands while preserving the generated audit trail and explicit stop gates.
- Out of scope: unrelated refactors not required for "Add guided task begin and complete shortcuts".

## Verification

- State: ok
- Note:

```text
Implemented guided task begin and complete shortcuts. Checks passed: guided CLI tests;
command-guide/help snapshots; docs freshness; policy routing; typecheck; lint; lifecycle unit tests
via Vitest after bun-test runner mismatch was reported as issue #3845; clean temp-repo smoke for
init -> task begin -> task complete.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-17T17:44:32.929Z
- Branch: task/202605171345-F281KQ/guided-task-shortcuts
- Head: 06ba4e225b95

```text
 .agentplane/WORKFLOW.md                            |   4 +
 .../blueprint/resolved-snapshot.json               | 535 +++++++++++++++++++++
 .agentplane/workflows/last-known-good.md           |   4 +
 docs/user/cli-reference.generated.mdx              |  63 +++
 .../run-cli.core.help-snap.test.ts.snap            | 113 +++--
 packages/agentplane/src/cli/command-guide.test.ts  |   4 +-
 packages/agentplane/src/cli/command-guide.ts       |  10 +-
 packages/agentplane/src/cli/command-invocations.ts |   2 +
 packages/agentplane/src/cli/command-snippets.ts    |   2 +
 .../src/cli/run-cli.core.task-guided.test.ts       | 228 +++++++++
 .../src/cli/run-cli/command-catalog/task.ts        |   6 +
 .../src/cli/run-cli/command-loaders/task.ts        |   8 +
 .../agentplane/src/commands/task/begin.command.ts  | 270 +++++++++++
 .../src/commands/task/complete.command.ts          | 185 +++++++
 .../agentplane/src/commands/task/task.command.ts   |  11 +-
 15 files changed, 1385 insertions(+), 60 deletions(-)
```

</details>
