### PR TITLE
🚧 BBZQQ1 task: Add feedback issue publish transports [202605171746-BBZQQ1]

### DIFF
--- a/.agentplane/tasks/202605171746-BBZQQ1/README.md
+++ b/.agentplane/tasks/202605171746-BBZQQ1/README.md
@@ -1,0 +1,188 @@
+---
+id: "202605171746-BBZQQ1"
+title: "Add feedback issue publish transports"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 7
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "diagnostics"
+  - "github"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-17T17:46:57.017Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-17T18:04:35.770Z"
+  updated_by: "CODER"
+  note: "Implemented controlled feedback issue transports and verified focused CLI/config coverage plus generated artifacts."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement controlled feedback issue publishing transports, preserving dry-run privacy bounds and adding targeted tests/docs for GitHub and cloud fallback behavior."
+events:
+  -
+    type: "status"
+    at: "2026-05-17T17:47:24.388Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement controlled feedback issue publishing transports, preserving dry-run privacy bounds and adding targeted tests/docs for GitHub and cloud fallback behavior."
+  -
+    type: "verify"
+    at: "2026-05-17T18:04:35.770Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented controlled feedback issue transports and verified focused CLI/config coverage plus generated artifacts."
+doc_version: 3
+doc_updated_at: "2026-05-17T18:04:35.779Z"
+doc_updated_by: "CODER"
+description: "Extend the AgentPlane feedback issue flow from privacy-bounded draft creation to controlled publish transports, including GitHub publishing ergonomics and an anonymous cloud intake fallback."
+sections:
+  Summary: |-
+    Add feedback issue publish transports
+
+    Extend the AgentPlane feedback issue flow from privacy-bounded draft creation to controlled publish transports, including GitHub publishing ergonomics and an anonymous cloud intake fallback.
+  Scope: |-
+    - In scope: Extend the AgentPlane feedback issue flow from privacy-bounded draft creation to controlled publish transports, including GitHub publishing ergonomics and an anonymous cloud intake fallback.
+    - Out of scope: unrelated refactors not required for "Add feedback issue publish transports".
+  Plan: |-
+    1. Preserve the existing privacy-bounded issue payload builder and dry-run behavior.
+    2. Add explicit publish transport selection to insights issue: GitHub via current gh API path, cloud anonymous intake via configured endpoint, and auto fallback that prefers GitHub when available.
+    3. Extend config/init/docs with minimal opt-in settings while keeping existing feedback.github_issues.enabled compatibility.
+    4. Add targeted tests for dry-run payload, disabled feedback, cloud transport, and missing GitHub auth fallback behavior.
+    5. Verify with task verify-show and focused CLI/config tests.
+  Verify Steps: |-
+    1. Run focused feedback/init/config tests:
+     RUN  v4.1.6 /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605171746-BBZQQ1-feedback-issue-transports
+
+     Test Files  4 passed (4)
+          Tests  67 passed (67)
+       Start at  00:56:39
+       Duration  178.34s (transform 8.66s, setup 0ms, import 10.75s, tests 178.57s, environment 1ms). Expected: all selected tests pass.
+    2. Run generated artifact checks: schemas OK, /var/folders/80/hzx36fdd7ps2j5gbpwm5mcjr0000gn/T/agentplane-cli-docs-AsM22j/cli-reference.generated.mdx
+    ../../../../../../../var/folders/80/hzx36fdd7ps2j5gbpwm5mcjr0000gn/T/agentplane-cli-docs-AsM22j/cli-reference.generated.mdx 148ms (unchanged)
+    ok: docs/user/cli-reference.generated.mdx is up to date, and Checking 24 changed file(s) with Prettier
+    Checking formatting...
+    All matched files use Prettier code style!. Expected: generated schemas/docs are fresh and changed files are formatted.
+    3. Run . Expected: TypeScript project references compile.
+    4. Run framework safety checks: doctor (OK) and policy routing OK. Expected: repo-local runtime and routing policy pass.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-17T18:04:35.770Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Implemented controlled feedback issue transports and verified focused CLI/config coverage plus generated artifacts.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T18:00:15.790Z, excerpt_hash=sha256:a0e7a41edcefd36499031bbb439f72891248cfec59421b0d99b448e12ffac3b9
+
+    Details:
+
+    Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/cli/run-cli.core.insights-report.test.ts packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/prompt-steps.test.ts packages/core/src/config/config.test.ts. Result: pass. Evidence: 4 test files passed, 67 tests passed. Scope: feedback issue transport behavior, init flags, prompt defaults, config defaults.
+    Command: bun run schemas:check. Result: pass. Evidence: schemas OK. Scope: generated config schema artifacts.
+    Command: bun run docs:cli:check. Result: pass. Evidence: cli-reference.generated.mdx is up to date. Scope: generated CLI reference.
+    Command: bun run format:changed. Result: pass. Evidence: All matched files use Prettier code style. Scope: changed files.
+    Command: bun run typecheck. Result: pass. Evidence: tsc -b completed with exit 0. Scope: TypeScript project references.
+    Command: ap doctor. Result: pass. Evidence: doctor (OK), errors=0 warnings=0. Scope: repo-local runtime/workflow health.
+    Command: node .agentplane/policy/check-routing.mjs. Result: pass. Evidence: policy routing OK. Scope: policy routing.
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605171746-BBZQQ1-feedback-issue-transports/.agentplane/tasks/202605171746-BBZQQ1/blueprint/resolved-snapshot.json
+    - old_digest: 8938d12698dccde93c32aec6ccffb808135de7bd20085ccb99882f721377f3b5
+    - current_digest: 8938d12698dccde93c32aec6ccffb808135de7bd20085ccb99882f721377f3b5
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605171746-BBZQQ1
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add feedback issue publish transports
+
+Extend the AgentPlane feedback issue flow from privacy-bounded draft creation to controlled publish transports, including GitHub publishing ergonomics and an anonymous cloud intake fallback.
+
+## Scope
+
+- In scope: Extend the AgentPlane feedback issue flow from privacy-bounded draft creation to controlled publish transports, including GitHub publishing ergonomics and an anonymous cloud intake fallback.
+- Out of scope: unrelated refactors not required for "Add feedback issue publish transports".
+
+## Plan
+
+1. Preserve the existing privacy-bounded issue payload builder and dry-run behavior.
+2. Add explicit publish transport selection to insights issue: GitHub via current gh API path, cloud anonymous intake via configured endpoint, and auto fallback that prefers GitHub when available.
+3. Extend config/init/docs with minimal opt-in settings while keeping existing feedback.github_issues.enabled compatibility.
+4. Add targeted tests for dry-run payload, disabled feedback, cloud transport, and missing GitHub auth fallback behavior.
+5. Verify with task verify-show and focused CLI/config tests.
+
+## Verify Steps
+
+1. Run focused feedback/init/config tests:
+ RUN  v4.1.6 /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605171746-BBZQQ1-feedback-issue-transports
+
+ Test Files  4 passed (4)
+      Tests  67 passed (67)
+   Start at  00:56:39
+   Duration  178.34s (transform 8.66s, setup 0ms, import 10.75s, tests 178.57s, environment 1ms). Expected: all selected tests pass.
+2. Run generated artifact checks: schemas OK, /var/folders/80/hzx36fdd7ps2j5gbpwm5mcjr0000gn/T/agentplane-cli-docs-AsM22j/cli-reference.generated.mdx
+../../../../../../../var/folders/80/hzx36fdd7ps2j5gbpwm5mcjr0000gn/T/agentplane-cli-docs-AsM22j/cli-reference.generated.mdx 148ms (unchanged)
+ok: docs/user/cli-reference.generated.mdx is up to date, and Checking 24 changed file(s) with Prettier
+Checking formatting...
+All matched files use Prettier code style!. Expected: generated schemas/docs are fresh and changed files are formatted.
+3. Run . Expected: TypeScript project references compile.
+4. Run framework safety checks: doctor (OK) and policy routing OK. Expected: repo-local runtime and routing policy pass.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-17T18:04:35.770Z — VERIFY — ok
+
+By: CODER
+
+Note: Implemented controlled feedback issue transports and verified focused CLI/config coverage plus generated artifacts.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T18:00:15.790Z, excerpt_hash=sha256:a0e7a41edcefd36499031bbb439f72891248cfec59421b0d99b448e12ffac3b9
+
+Details:
+
+Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/cli/run-cli.core.insights-report.test.ts packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/prompt-steps.test.ts packages/core/src/config/config.test.ts. Result: pass. Evidence: 4 test files passed, 67 tests passed. Scope: feedback issue transport behavior, init flags, prompt defaults, config defaults.
+Command: bun run schemas:check. Result: pass. Evidence: schemas OK. Scope: generated config schema artifacts.
+Command: bun run docs:cli:check. Result: pass. Evidence: cli-reference.generated.mdx is up to date. Scope: generated CLI reference.
+Command: bun run format:changed. Result: pass. Evidence: All matched files use Prettier code style. Scope: changed files.
+Command: bun run typecheck. Result: pass. Evidence: tsc -b completed with exit 0. Scope: TypeScript project references.
+Command: ap doctor. Result: pass. Evidence: doctor (OK), errors=0 warnings=0. Scope: repo-local runtime/workflow health.
+Command: node .agentplane/policy/check-routing.mjs. Result: pass. Evidence: policy routing OK. Scope: policy routing.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605171746-BBZQQ1-feedback-issue-transports/.agentplane/tasks/202605171746-BBZQQ1/blueprint/resolved-snapshot.json
+- old_digest: 8938d12698dccde93c32aec6ccffb808135de7bd20085ccb99882f721377f3b5
+- current_digest: 8938d12698dccde93c32aec6ccffb808135de7bd20085ccb99882f721377f3b5
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605171746-BBZQQ1
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605171746-BBZQQ1/README.md
+++ b/.agentplane/tasks/202605171746-BBZQQ1/README.md
@@ -4,7 +4,7 @@ title: "Add feedback issue publish transports"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 7
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -20,9 +20,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-17T18:04:35.770Z"
+  updated_at: "2026-05-17T18:13:31.941Z"
   updated_by: "CODER"
-  note: "Implemented controlled feedback issue transports and verified focused CLI/config coverage plus generated artifacts."
+  note: "Post-refactor verification: split feedback issue publishing helpers below hotspot threshold after pre-push hotspot gate caught oversized command module."
   attempts: 0
 commit: null
 comments:
@@ -43,8 +43,14 @@ events:
     author: "CODER"
     state: "ok"
     note: "Implemented controlled feedback issue transports and verified focused CLI/config coverage plus generated artifacts."
+  -
+    type: "verify"
+    at: "2026-05-17T18:13:31.941Z"
+    author: "CODER"
+    state: "ok"
+    note: "Post-refactor verification: split feedback issue publishing helpers below hotspot threshold after pre-push hotspot gate caught oversized command module."
 doc_version: 3
-doc_updated_at: "2026-05-17T18:04:35.779Z"
+doc_updated_at: "2026-05-17T18:13:31.947Z"
 doc_updated_by: "CODER"
 description: "Extend the AgentPlane feedback issue flow from privacy-bounded draft creation to controlled publish transports, including GitHub publishing ergonomics and an anonymous cloud intake fallback."
 sections:
@@ -96,6 +102,29 @@ sections:
     Command: bun run typecheck. Result: pass. Evidence: tsc -b completed with exit 0. Scope: TypeScript project references.
     Command: ap doctor. Result: pass. Evidence: doctor (OK), errors=0 warnings=0. Scope: repo-local runtime/workflow health.
     Command: node .agentplane/policy/check-routing.mjs. Result: pass. Evidence: policy routing OK. Scope: policy routing.
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605171746-BBZQQ1-feedback-issue-transports/.agentplane/tasks/202605171746-BBZQQ1/blueprint/resolved-snapshot.json
+    - old_digest: 8938d12698dccde93c32aec6ccffb808135de7bd20085ccb99882f721377f3b5
+    - current_digest: 8938d12698dccde93c32aec6ccffb808135de7bd20085ccb99882f721377f3b5
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605171746-BBZQQ1
+
+    ### 2026-05-17T18:13:31.941Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Post-refactor verification: split feedback issue publishing helpers below hotspot threshold after pre-push hotspot gate caught oversized command module.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T18:04:35.779Z, excerpt_hash=sha256:a0e7a41edcefd36499031bbb439f72891248cfec59421b0d99b448e12ffac3b9
+
+    Details:
+
+    Command: node scripts/checks/hotspot-report.mjs --check --warning-lines 400 --oversized-lines 600 --test-warning-lines 1000 --oversized-test-lines 1300. Result: pass. Evidence: hotspot threshold check passed; insights.command.ts is below the 600-line error threshold. Scope: feedback issue publish helper split.
+    Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/cli/run-cli.core.insights-report.test.ts packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/prompt-steps.test.ts packages/core/src/config/config.test.ts. Result: pass. Evidence: 4 test files passed, 67 tests passed. Scope: feedback issue transport behavior after helper split.
+    Command: bun run typecheck. Result: pass. Evidence: tsc -b completed with exit 0. Scope: TypeScript project references after helper split.
 
     BlueprintSnapshotRef:
     - state: current
@@ -169,6 +198,29 @@ Command: bun run format:changed. Result: pass. Evidence: All matched files use P
 Command: bun run typecheck. Result: pass. Evidence: tsc -b completed with exit 0. Scope: TypeScript project references.
 Command: ap doctor. Result: pass. Evidence: doctor (OK), errors=0 warnings=0. Scope: repo-local runtime/workflow health.
 Command: node .agentplane/policy/check-routing.mjs. Result: pass. Evidence: policy routing OK. Scope: policy routing.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605171746-BBZQQ1-feedback-issue-transports/.agentplane/tasks/202605171746-BBZQQ1/blueprint/resolved-snapshot.json
+- old_digest: 8938d12698dccde93c32aec6ccffb808135de7bd20085ccb99882f721377f3b5
+- current_digest: 8938d12698dccde93c32aec6ccffb808135de7bd20085ccb99882f721377f3b5
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605171746-BBZQQ1
+
+### 2026-05-17T18:13:31.941Z — VERIFY — ok
+
+By: CODER
+
+Note: Post-refactor verification: split feedback issue publishing helpers below hotspot threshold after pre-push hotspot gate caught oversized command module.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-17T18:04:35.779Z, excerpt_hash=sha256:a0e7a41edcefd36499031bbb439f72891248cfec59421b0d99b448e12ffac3b9
+
+Details:
+
+Command: node scripts/checks/hotspot-report.mjs --check --warning-lines 400 --oversized-lines 600 --test-warning-lines 1000 --oversized-test-lines 1300. Result: pass. Evidence: hotspot threshold check passed; insights.command.ts is below the 600-line error threshold. Scope: feedback issue publish helper split.
+Command: bunx vitest --config vitest.workspace.ts run packages/agentplane/src/cli/run-cli.core.insights-report.test.ts packages/agentplane/src/cli/run-cli.core.init.test.ts packages/agentplane/src/cli/run-cli/commands/init/steps/prompt-steps.test.ts packages/core/src/config/config.test.ts. Result: pass. Evidence: 4 test files passed, 67 tests passed. Scope: feedback issue transport behavior after helper split.
+Command: bun run typecheck. Result: pass. Evidence: tsc -b completed with exit 0. Scope: TypeScript project references after helper split.
 
 BlueprintSnapshotRef:
 - state: current

--- a/.agentplane/tasks/202605171746-BBZQQ1/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605171746-BBZQQ1/blueprint/resolved-snapshot.json
@@ -1,0 +1,528 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605171746-BBZQQ1",
+    "title": "Add feedback issue publish transports",
+    "description": "Extend the AgentPlane feedback issue flow from privacy-bounded draft creation to controlled publish transports, including GitHub publishing ergonomics and an anonymous cloud intake fallback.",
+    "tags": [
+      "code",
+      "diagnostics",
+      "github"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605171746-BBZQQ1",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "8938d12698dccde93c32aec6ccffb808135de7bd20085ccb99882f721377f3b5"
+  }
+}

--- a/.agentplane/tasks/202605171746-BBZQQ1/pr/diffstat.txt
+++ b/.agentplane/tasks/202605171746-BBZQQ1/pr/diffstat.txt
@@ -16,11 +16,12 @@
  .../cli/run-cli/commands/init/steps/contracts.ts   |   1 +
  .../commands/init/steps/prompt-steps.test.ts       |   5 +-
  .../src/cli/run-cli/commands/init/write-config.ts  |   6 +
- .../src/commands/insights/insights.command.ts      | 165 ++++++-
+ .../commands/insights/insights-issue-publish.ts    | 161 +++++++
+ .../src/commands/insights/insights.command.ts      |  70 +--
  .../src/commands/insights/insights.spec.ts         |  10 +
  packages/core/schemas/config.schema.json           |  20 +
  packages/core/src/config/config.test.ts            |   3 +
  packages/core/src/config/schema.impl.ts            |  24 +-
  packages/spec/schemas/config.schema.json           |  20 +
  schemas/config.schema.json                         |  20 +
- 25 files changed, 986 insertions(+), 20 deletions(-)
+ 26 files changed, 1038 insertions(+), 34 deletions(-)

--- a/.agentplane/tasks/202605171746-BBZQQ1/pr/diffstat.txt
+++ b/.agentplane/tasks/202605171746-BBZQQ1/pr/diffstat.txt
@@ -16,12 +16,13 @@
  .../cli/run-cli/commands/init/steps/contracts.ts   |   1 +
  .../commands/init/steps/prompt-steps.test.ts       |   5 +-
  .../src/cli/run-cli/commands/init/write-config.ts  |   6 +
- .../commands/insights/insights-issue-publish.ts    | 161 +++++++
- .../src/commands/insights/insights.command.ts      |  70 +--
+ .../insights/insights-issue-publish.test.ts        | 121 +++++
+ .../commands/insights/insights-issue-publish.ts    | 189 ++++++++
+ .../src/commands/insights/insights.command.ts      |  67 +--
  .../src/commands/insights/insights.spec.ts         |  10 +
  packages/core/schemas/config.schema.json           |  20 +
  packages/core/src/config/config.test.ts            |   3 +
  packages/core/src/config/schema.impl.ts            |  24 +-
  packages/spec/schemas/config.schema.json           |  20 +
  schemas/config.schema.json                         |  20 +
- 26 files changed, 1038 insertions(+), 34 deletions(-)
+ 27 files changed, 1184 insertions(+), 34 deletions(-)

--- a/.agentplane/tasks/202605171746-BBZQQ1/pr/diffstat.txt
+++ b/.agentplane/tasks/202605171746-BBZQQ1/pr/diffstat.txt
@@ -1,0 +1,26 @@
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |   2 +
+ docs/user/commands.mdx                             |   1 +
+ docs/user/configuration.mdx                        |  15 +-
+ docs/user/setup.mdx                                |  12 +-
+ packages/agentplane/src/cli/error-map.ts           |  10 +
+ packages/agentplane/src/cli/reason-codes.ts        |   6 +
+ .../agentplane/src/cli/run-cli.core.init.test.ts   |  27 ++
+ .../src/cli/run-cli.core.insights-report.test.ts   |  85 +++-
+ .../src/cli/run-cli/commands/init/answers.ts       |   3 +
+ .../src/cli/run-cli/commands/init/execution.ts     |   3 +
+ .../src/cli/run-cli/commands/init/model.ts         |   3 +
+ .../src/cli/run-cli/commands/init/presets.ts       |   5 +
+ .../src/cli/run-cli/commands/init/spec.ts          |  16 +
+ .../commands/init/steps/advanced-settings.ts       |  16 +
+ .../cli/run-cli/commands/init/steps/contracts.ts   |   1 +
+ .../commands/init/steps/prompt-steps.test.ts       |   5 +-
+ .../src/cli/run-cli/commands/init/write-config.ts  |   6 +
+ .../src/commands/insights/insights.command.ts      | 165 ++++++-
+ .../src/commands/insights/insights.spec.ts         |  10 +
+ packages/core/schemas/config.schema.json           |  20 +
+ packages/core/src/config/config.test.ts            |   3 +
+ packages/core/src/config/schema.impl.ts            |  24 +-
+ packages/spec/schemas/config.schema.json           |  20 +
+ schemas/config.schema.json                         |  20 +
+ 25 files changed, 986 insertions(+), 20 deletions(-)

--- a/.agentplane/tasks/202605171746-BBZQQ1/pr/github-body.md
+++ b/.agentplane/tasks/202605171746-BBZQQ1/pr/github-body.md
@@ -27,9 +27,9 @@ pre-push hotspot gate caught oversized command module.
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-18T05:15:33.173Z
+- Updated: 2026-05-18T05:20:52.881Z
 - Branch: task/202605171746-BBZQQ1/feedback-issue-transports
-- Head: 7f934bface54
+- Head: 8842fa2a06c2
 
 ```text
  .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
@@ -50,15 +50,16 @@ pre-push hotspot gate caught oversized command module.
  .../cli/run-cli/commands/init/steps/contracts.ts   |   1 +
  .../commands/init/steps/prompt-steps.test.ts       |   5 +-
  .../src/cli/run-cli/commands/init/write-config.ts  |   6 +
- .../commands/insights/insights-issue-publish.ts    | 161 +++++++
- .../src/commands/insights/insights.command.ts      |  70 +--
+ .../insights/insights-issue-publish.test.ts        | 121 +++++
+ .../commands/insights/insights-issue-publish.ts    | 189 ++++++++
+ .../src/commands/insights/insights.command.ts      |  67 +--
  .../src/commands/insights/insights.spec.ts         |  10 +
  packages/core/schemas/config.schema.json           |  20 +
  packages/core/src/config/config.test.ts            |   3 +
  packages/core/src/config/schema.impl.ts            |  24 +-
  packages/spec/schemas/config.schema.json           |  20 +
  schemas/config.schema.json                         |  20 +
- 26 files changed, 1038 insertions(+), 34 deletions(-)
+ 27 files changed, 1184 insertions(+), 34 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605171746-BBZQQ1/pr/github-body.md
+++ b/.agentplane/tasks/202605171746-BBZQQ1/pr/github-body.md
@@ -19,17 +19,17 @@ Extend the AgentPlane feedback issue flow from privacy-bounded draft creation to
 - Note:
 
 ```text
-Implemented controlled feedback issue transports and verified focused CLI/config coverage plus
-generated artifacts.
+Post-refactor verification: split feedback issue publishing helpers below hotspot threshold after
+pre-push hotspot gate caught oversized command module.
 ```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-17T18:07:49.881Z
+- Updated: 2026-05-17T18:13:31.970Z
 - Branch: task/202605171746-BBZQQ1/feedback-issue-transports
-- Head: 7f613c054a17
+- Head: 7ea69411035f
 
 ```text
  .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
@@ -50,14 +50,15 @@ generated artifacts.
  .../cli/run-cli/commands/init/steps/contracts.ts   |   1 +
  .../commands/init/steps/prompt-steps.test.ts       |   5 +-
  .../src/cli/run-cli/commands/init/write-config.ts  |   6 +
- .../src/commands/insights/insights.command.ts      | 165 ++++++-
+ .../commands/insights/insights-issue-publish.ts    | 161 +++++++
+ .../src/commands/insights/insights.command.ts      |  70 +--
  .../src/commands/insights/insights.spec.ts         |  10 +
  packages/core/schemas/config.schema.json           |  20 +
  packages/core/src/config/config.test.ts            |   3 +
  packages/core/src/config/schema.impl.ts            |  24 +-
  packages/spec/schemas/config.schema.json           |  20 +
  schemas/config.schema.json                         |  20 +
- 25 files changed, 986 insertions(+), 20 deletions(-)
+ 26 files changed, 1038 insertions(+), 34 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605171746-BBZQQ1/pr/github-body.md
+++ b/.agentplane/tasks/202605171746-BBZQQ1/pr/github-body.md
@@ -27,12 +27,37 @@ generated artifacts.
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-17T17:47:24.453Z
+- Updated: 2026-05-17T18:07:49.881Z
 - Branch: task/202605171746-BBZQQ1/feedback-issue-transports
-- Head: 59a507f34063
+- Head: 7f613c054a17
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |   2 +
+ docs/user/commands.mdx                             |   1 +
+ docs/user/configuration.mdx                        |  15 +-
+ docs/user/setup.mdx                                |  12 +-
+ packages/agentplane/src/cli/error-map.ts           |  10 +
+ packages/agentplane/src/cli/reason-codes.ts        |   6 +
+ .../agentplane/src/cli/run-cli.core.init.test.ts   |  27 ++
+ .../src/cli/run-cli.core.insights-report.test.ts   |  85 +++-
+ .../src/cli/run-cli/commands/init/answers.ts       |   3 +
+ .../src/cli/run-cli/commands/init/execution.ts     |   3 +
+ .../src/cli/run-cli/commands/init/model.ts         |   3 +
+ .../src/cli/run-cli/commands/init/presets.ts       |   5 +
+ .../src/cli/run-cli/commands/init/spec.ts          |  16 +
+ .../commands/init/steps/advanced-settings.ts       |  16 +
+ .../cli/run-cli/commands/init/steps/contracts.ts   |   1 +
+ .../commands/init/steps/prompt-steps.test.ts       |   5 +-
+ .../src/cli/run-cli/commands/init/write-config.ts  |   6 +
+ .../src/commands/insights/insights.command.ts      | 165 ++++++-
+ .../src/commands/insights/insights.spec.ts         |  10 +
+ packages/core/schemas/config.schema.json           |  20 +
+ packages/core/src/config/config.test.ts            |   3 +
+ packages/core/src/config/schema.impl.ts            |  24 +-
+ packages/spec/schemas/config.schema.json           |  20 +
+ schemas/config.schema.json                         |  20 +
+ 25 files changed, 986 insertions(+), 20 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605171746-BBZQQ1/pr/github-body.md
+++ b/.agentplane/tasks/202605171746-BBZQQ1/pr/github-body.md
@@ -27,9 +27,9 @@ pre-push hotspot gate caught oversized command module.
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-17T18:13:31.970Z
+- Updated: 2026-05-18T05:15:33.173Z
 - Branch: task/202605171746-BBZQQ1/feedback-issue-transports
-- Head: 7ea69411035f
+- Head: 7f934bface54
 
 ```text
  .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++

--- a/.agentplane/tasks/202605171746-BBZQQ1/pr/github-body.md
+++ b/.agentplane/tasks/202605171746-BBZQQ1/pr/github-body.md
@@ -1,0 +1,38 @@
+Task: `202605171746-BBZQQ1`
+Title: Add feedback issue publish transports
+Canonical task record: `.agentplane/tasks/202605171746-BBZQQ1/README.md`
+
+## Summary
+
+Add feedback issue publish transports
+
+Extend the AgentPlane feedback issue flow from privacy-bounded draft creation to controlled publish transports, including GitHub publishing ergonomics and an anonymous cloud intake fallback.
+
+## Scope
+
+- In scope: Extend the AgentPlane feedback issue flow from privacy-bounded draft creation to controlled publish transports, including GitHub publishing ergonomics and an anonymous cloud intake fallback.
+- Out of scope: unrelated refactors not required for "Add feedback issue publish transports".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Implemented controlled feedback issue transports and verified focused CLI/config coverage plus
+generated artifacts.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-17T17:47:24.453Z
+- Branch: task/202605171746-BBZQQ1/feedback-issue-transports
+- Head: 59a507f34063
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605171746-BBZQQ1/pr/github-title.txt
+++ b/.agentplane/tasks/202605171746-BBZQQ1/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 BBZQQ1 task: Add feedback issue publish transports [202605171746-BBZQQ1]

--- a/.agentplane/tasks/202605171746-BBZQQ1/pr/meta.json
+++ b/.agentplane/tasks/202605171746-BBZQQ1/pr/meta.json
@@ -2,15 +2,15 @@
   "base": "main",
   "branch": "task/202605171746-BBZQQ1/feedback-issue-transports",
   "created_at": "2026-05-17T17:47:24.453Z",
-  "head_sha": "7f613c054a174f94404eabdf904073e7632c90d9",
-  "last_verified_at": "2026-05-17T18:04:35.770Z",
-  "last_verified_sha": "59a507f34063a995bdab0faa057af678575a6e9a",
+  "head_sha": "7ea69411035fdeb2eff92855918ed588e6c8e8d5",
+  "last_verified_at": "2026-05-17T18:13:31.941Z",
+  "last_verified_sha": "7ea69411035fdeb2eff92855918ed588e6c8e8d5",
   "pr_number": 3855,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3855",
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202605171746-BBZQQ1",
-  "updated_at": "2026-05-17T18:08:07.178Z",
+  "updated_at": "2026-05-17T18:13:31.970Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605171746-BBZQQ1/pr/meta.json
+++ b/.agentplane/tasks/202605171746-BBZQQ1/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605171746-BBZQQ1/feedback-issue-transports",
   "created_at": "2026-05-17T17:47:24.453Z",
-  "head_sha": "59a507f34063a995bdab0faa057af678575a6e9a",
+  "head_sha": "7f613c054a174f94404eabdf904073e7632c90d9",
   "last_verified_at": "2026-05-17T18:04:35.770Z",
   "last_verified_sha": "59a507f34063a995bdab0faa057af678575a6e9a",
   "schema_version": 1,
   "task_id": "202605171746-BBZQQ1",
-  "updated_at": "2026-05-17T17:47:24.453Z",
+  "updated_at": "2026-05-17T18:07:49.881Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605171746-BBZQQ1/pr/meta.json
+++ b/.agentplane/tasks/202605171746-BBZQQ1/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605171746-BBZQQ1/feedback-issue-transports",
   "created_at": "2026-05-17T17:47:24.453Z",
-  "head_sha": "7f934bface540730a299d5e50c604d3342f5a1f0",
+  "head_sha": "8842fa2a06c25c6e94151e49637db3ba7b91263d",
   "last_verified_at": "2026-05-17T18:13:31.941Z",
   "last_verified_sha": "7ea69411035fdeb2eff92855918ed588e6c8e8d5",
   "pr_number": 3855,
@@ -10,7 +10,7 @@
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202605171746-BBZQQ1",
-  "updated_at": "2026-05-18T05:15:33.173Z",
+  "updated_at": "2026-05-18T05:20:52.881Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605171746-BBZQQ1/pr/meta.json
+++ b/.agentplane/tasks/202605171746-BBZQQ1/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605171746-BBZQQ1/feedback-issue-transports",
+  "created_at": "2026-05-17T17:47:24.453Z",
+  "head_sha": "59a507f34063a995bdab0faa057af678575a6e9a",
+  "last_verified_at": "2026-05-17T18:04:35.770Z",
+  "last_verified_sha": "59a507f34063a995bdab0faa057af678575a6e9a",
+  "schema_version": 1,
+  "task_id": "202605171746-BBZQQ1",
+  "updated_at": "2026-05-17T17:47:24.453Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605171746-BBZQQ1/pr/meta.json
+++ b/.agentplane/tasks/202605171746-BBZQQ1/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "7f613c054a174f94404eabdf904073e7632c90d9",
   "last_verified_at": "2026-05-17T18:04:35.770Z",
   "last_verified_sha": "59a507f34063a995bdab0faa057af678575a6e9a",
+  "pr_number": 3855,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3855",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605171746-BBZQQ1",
-  "updated_at": "2026-05-17T18:07:49.881Z",
+  "updated_at": "2026-05-17T18:08:07.178Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605171746-BBZQQ1/pr/meta.json
+++ b/.agentplane/tasks/202605171746-BBZQQ1/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605171746-BBZQQ1/feedback-issue-transports",
   "created_at": "2026-05-17T17:47:24.453Z",
-  "head_sha": "7ea69411035fdeb2eff92855918ed588e6c8e8d5",
+  "head_sha": "7f934bface540730a299d5e50c604d3342f5a1f0",
   "last_verified_at": "2026-05-17T18:13:31.941Z",
   "last_verified_sha": "7ea69411035fdeb2eff92855918ed588e6c8e8d5",
   "pr_number": 3855,
@@ -10,7 +10,7 @@
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202605171746-BBZQQ1",
-  "updated_at": "2026-05-17T18:13:31.970Z",
+  "updated_at": "2026-05-18T05:15:33.173Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605171746-BBZQQ1/pr/review.md
+++ b/.agentplane/tasks/202605171746-BBZQQ1/pr/review.md
@@ -24,12 +24,37 @@ Created: 2026-05-17T17:47:24.453Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-17T17:47:24.453Z
+- Updated: 2026-05-17T18:07:49.881Z
 - Branch: task/202605171746-BBZQQ1/feedback-issue-transports
-- Head: 59a507f34063
+- Head: 7f613c054a17
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |   2 +
+ docs/user/commands.mdx                             |   1 +
+ docs/user/configuration.mdx                        |  15 +-
+ docs/user/setup.mdx                                |  12 +-
+ packages/agentplane/src/cli/error-map.ts           |  10 +
+ packages/agentplane/src/cli/reason-codes.ts        |   6 +
+ .../agentplane/src/cli/run-cli.core.init.test.ts   |  27 ++
+ .../src/cli/run-cli.core.insights-report.test.ts   |  85 +++-
+ .../src/cli/run-cli/commands/init/answers.ts       |   3 +
+ .../src/cli/run-cli/commands/init/execution.ts     |   3 +
+ .../src/cli/run-cli/commands/init/model.ts         |   3 +
+ .../src/cli/run-cli/commands/init/presets.ts       |   5 +
+ .../src/cli/run-cli/commands/init/spec.ts          |  16 +
+ .../commands/init/steps/advanced-settings.ts       |  16 +
+ .../cli/run-cli/commands/init/steps/contracts.ts   |   1 +
+ .../commands/init/steps/prompt-steps.test.ts       |   5 +-
+ .../src/cli/run-cli/commands/init/write-config.ts  |   6 +
+ .../src/commands/insights/insights.command.ts      | 165 ++++++-
+ .../src/commands/insights/insights.spec.ts         |  10 +
+ packages/core/schemas/config.schema.json           |  20 +
+ packages/core/src/config/config.test.ts            |   3 +
+ packages/core/src/config/schema.impl.ts            |  24 +-
+ packages/spec/schemas/config.schema.json           |  20 +
+ schemas/config.schema.json                         |  20 +
+ 25 files changed, 986 insertions(+), 20 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605171746-BBZQQ1/pr/review.md
+++ b/.agentplane/tasks/202605171746-BBZQQ1/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-17T17:47:24.453Z
+
+## Task
+
+- Task: `202605171746-BBZQQ1`
+- Title: Add feedback issue publish transports
+- Status: DOING
+- Branch: `task/202605171746-BBZQQ1/feedback-issue-transports`
+- Canonical task record: `.agentplane/tasks/202605171746-BBZQQ1/README.md`
+
+## Verification
+
+- State: ok
+- Note: Implemented controlled feedback issue transports and verified focused CLI/config coverage plus generated artifacts.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-17T17:47:24.453Z
+- Branch: task/202605171746-BBZQQ1/feedback-issue-transports
+- Head: 59a507f34063
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605171746-BBZQQ1/pr/review.md
+++ b/.agentplane/tasks/202605171746-BBZQQ1/pr/review.md
@@ -24,9 +24,9 @@ Created: 2026-05-17T17:47:24.453Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-18T05:15:33.173Z
+- Updated: 2026-05-18T05:20:52.881Z
 - Branch: task/202605171746-BBZQQ1/feedback-issue-transports
-- Head: 7f934bface54
+- Head: 8842fa2a06c2
 
 ```text
  .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
@@ -47,15 +47,16 @@ Created: 2026-05-17T17:47:24.453Z
  .../cli/run-cli/commands/init/steps/contracts.ts   |   1 +
  .../commands/init/steps/prompt-steps.test.ts       |   5 +-
  .../src/cli/run-cli/commands/init/write-config.ts  |   6 +
- .../commands/insights/insights-issue-publish.ts    | 161 +++++++
- .../src/commands/insights/insights.command.ts      |  70 +--
+ .../insights/insights-issue-publish.test.ts        | 121 +++++
+ .../commands/insights/insights-issue-publish.ts    | 189 ++++++++
+ .../src/commands/insights/insights.command.ts      |  67 +--
  .../src/commands/insights/insights.spec.ts         |  10 +
  packages/core/schemas/config.schema.json           |  20 +
  packages/core/src/config/config.test.ts            |   3 +
  packages/core/src/config/schema.impl.ts            |  24 +-
  packages/spec/schemas/config.schema.json           |  20 +
  schemas/config.schema.json                         |  20 +
- 26 files changed, 1038 insertions(+), 34 deletions(-)
+ 27 files changed, 1184 insertions(+), 34 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605171746-BBZQQ1/pr/review.md
+++ b/.agentplane/tasks/202605171746-BBZQQ1/pr/review.md
@@ -24,9 +24,9 @@ Created: 2026-05-17T17:47:24.453Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-17T18:13:31.970Z
+- Updated: 2026-05-18T05:15:33.173Z
 - Branch: task/202605171746-BBZQQ1/feedback-issue-transports
-- Head: 7ea69411035f
+- Head: 7f934bface54
 
 ```text
  .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++

--- a/.agentplane/tasks/202605171746-BBZQQ1/pr/review.md
+++ b/.agentplane/tasks/202605171746-BBZQQ1/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-05-17T17:47:24.453Z
 ## Verification
 
 - State: ok
-- Note: Implemented controlled feedback issue transports and verified focused CLI/config coverage plus generated artifacts.
+- Note: Post-refactor verification: split feedback issue publishing helpers below hotspot threshold after pre-push hotspot gate caught oversized command module.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,9 +24,9 @@ Created: 2026-05-17T17:47:24.453Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-17T18:07:49.881Z
+- Updated: 2026-05-17T18:13:31.970Z
 - Branch: task/202605171746-BBZQQ1/feedback-issue-transports
-- Head: 7f613c054a17
+- Head: 7ea69411035f
 
 ```text
  .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
@@ -47,14 +47,15 @@ Created: 2026-05-17T17:47:24.453Z
  .../cli/run-cli/commands/init/steps/contracts.ts   |   1 +
  .../commands/init/steps/prompt-steps.test.ts       |   5 +-
  .../src/cli/run-cli/commands/init/write-config.ts  |   6 +
- .../src/commands/insights/insights.command.ts      | 165 ++++++-
+ .../commands/insights/insights-issue-publish.ts    | 161 +++++++
+ .../src/commands/insights/insights.command.ts      |  70 +--
  .../src/commands/insights/insights.spec.ts         |  10 +
  packages/core/schemas/config.schema.json           |  20 +
  packages/core/src/config/config.test.ts            |   3 +
  packages/core/src/config/schema.impl.ts            |  24 +-
  packages/spec/schemas/config.schema.json           |  20 +
  schemas/config.schema.json                         |  20 +
- 25 files changed, 986 insertions(+), 20 deletions(-)
+ 26 files changed, 1038 insertions(+), 34 deletions(-)
 ```
 
 </details>

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -1885,6 +1885,7 @@ Options:
 - `--require-network-approval <true|false>`: Require explicit approval before any network operation.
 - `--require-verify-approval <true|false>`: Require explicit approval before recording verification.
 - `--feedback-github-issues <true|false>`: Opt in to AgentPlane GitHub issue prompts for internal AgentPlane errors (default: false).
+- `--feedback-anonymous-cloud <true|false>`: Allow anonymous AgentPlane Cloud issue intake fallback when GitHub issue publishing is unavailable (default: false).
 - `--execution-profile <conservative|balanced|aggressive>`: Execution profile preset controlling autonomy, reasoning, and tool budgets. (choices=conservative|balanced|aggressive)
 - `--strict-unsafe-confirm <true|false>`: Require strict explicit confirmations for additional unsafe actions.
 - `--recipes <none|id1,id2,...>`: Optional cached recipes to vendor during init (comma-separated), or 'none'.
@@ -2124,6 +2125,7 @@ Options:
 - `--failure-reason-code <code>`: Privacy-safe reason code associated with the failure.
 - `--failure-message-class <class>`: Privacy-safe error message class, not the raw error message.
 - `--failure-argv-shape <token>`: Repeatable sanitized argv shape token; values must not include raw secrets. (repeatable)
+- `--transport <github|cloud|auto>`: Issue transport. github uses the user's gh auth, cloud uses anonymous AgentPlane intake, auto falls back to cloud when GitHub publishing fails. (choices=github|cloud|auto)
 - `--dry-run`: Print the GitHub issue payload without creating an issue. (default=false)
 
 Examples:

--- a/docs/user/commands.mdx
+++ b/docs/user/commands.mdx
@@ -78,6 +78,7 @@ init or later:
 ```bash
 agentplane init --feedback-github-issues false --yes
 agentplane config set feedback.github_issues.enabled false
+agentplane init --feedback-github-issues true --feedback-anonymous-cloud true --yes
 ```
 
 Workflow diagnostics and repair:

--- a/docs/user/configuration.mdx
+++ b/docs/user/configuration.mdx
@@ -129,13 +129,19 @@ without requiring a manual read of `bundle.json`.
 
 - `feedback.github_issues.enabled`
 - `feedback.github_issues.repository`
+- `feedback.github_issues.transport`
+- `feedback.github_issues.cloud_endpoint`
+- `feedback.github_issues.allow_anonymous_cloud`
 - `feedback.github_issues.prompt_on_internal_error`
 - `feedback.github_issues.include_insights_report`
 - `feedback.github_issues.dedupe`
 - `feedback.github_issues.labels`
 
 GitHub issue feedback defaults to disabled. Enable it when you want internal AgentPlane errors to
-offer a privacy-bounded GitHub issue path for maintainers.
+offer a privacy-bounded issue path for maintainers. `transport=github` uses the user's GitHub auth,
+`transport=cloud` sends an anonymous intake to AgentPlane Cloud, and `transport=auto` tries GitHub
+first before falling back to cloud. Cloud intake requires
+`feedback.github_issues.allow_anonymous_cloud=true`.
 
 Preview the issue payload before creating anything:
 
@@ -147,6 +153,13 @@ To opt in, ask your agent to enable feedback issue prompts or run:
 
 ```bash
 agentplane config set feedback.github_issues.enabled true
+```
+
+To allow anonymous cloud fallback:
+
+```bash
+agentplane config set feedback.github_issues.allow_anonymous_cloud true
+agentplane config set feedback.github_issues.transport auto
 ```
 
 ### acr

--- a/docs/user/setup.mdx
+++ b/docs/user/setup.mdx
@@ -56,9 +56,9 @@ AgentPlane-related files.
 
 ## Feedback issue prompts
 
-New projects enable AgentPlane GitHub issue prompts for internal AgentPlane errors by default. This
-is intentional: feedback issues help the framework improve faster, and the generated payload stays
-privacy-bounded.
+New projects keep AgentPlane feedback issue publishing disabled until explicit opt-in. When enabled,
+AgentPlane can prepare a privacy-bounded GitHub issue for internal AgentPlane errors. Publishing uses
+the user's GitHub session by default; anonymous AgentPlane Cloud intake is a separate opt-in fallback.
 
 Preview the issue payload:
 
@@ -70,6 +70,12 @@ To initialize with the mode disabled:
 
 ```bash
 agentplane init --feedback-github-issues false
+```
+
+To initialize with GitHub issue prompts and anonymous cloud fallback enabled:
+
+```bash
+agentplane init --feedback-github-issues true --feedback-anonymous-cloud true
 ```
 
 To disable it later:

--- a/packages/agentplane/src/cli/error-map.ts
+++ b/packages/agentplane/src/cli/error-map.ts
@@ -189,6 +189,16 @@ function resolveErrorGuidance(err: CliError): ErrorGuidance {
           },
         });
       }
+      if (reasonCode === "feedback_anonymous_cloud_disabled") {
+        return withExplicit({
+          hint: "Anonymous AgentPlane Cloud feedback intake requires explicit project opt-in.",
+          nextAction: {
+            command: "agentplane config set feedback.github_issues.allow_anonymous_cloud true",
+            reason: "enable anonymous cloud feedback intake before using cloud or auto transport",
+            reasonCode,
+          },
+        });
+      }
       return withExplicit({
         hint: `See \`${usage}\` for usage.`,
         nextAction: {

--- a/packages/agentplane/src/cli/reason-codes.ts
+++ b/packages/agentplane/src/cli/reason-codes.ts
@@ -150,6 +150,12 @@ const REASON_CODE_MAP: Readonly<Record<string, ReasonCodeMeta>> = {
     summary: "E_INTERNAL feedback issues need sanitized agent context for actionable triage",
     action: "pass --agent-context, --agent-context-file, or --allow-missing-agent-context",
   },
+  feedback_anonymous_cloud_disabled: {
+    code: "feedback_anonymous_cloud_disabled",
+    category: "feedback",
+    summary: "anonymous AgentPlane Cloud feedback intake is disabled for this project",
+    action: "enable feedback.github_issues.allow_anonymous_cloud before using cloud transport",
+  },
 };
 
 export function getReasonCodeMeta(code: string | undefined): ReasonCodeMeta | undefined {

--- a/packages/agentplane/src/cli/run-cli.core.init.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.init.test.ts
@@ -856,6 +856,33 @@ describe("runCli", () => {
     }
   });
 
+  it("init plan records explicit anonymous cloud feedback fallback opt-in", async () => {
+    const root = await mkTempDir();
+    const io = captureStdIO();
+    try {
+      const code = await runCli([
+        "init",
+        "--dry-run",
+        "--yes",
+        "--feedback-github-issues",
+        "true",
+        "--feedback-anonymous-cloud",
+        "true",
+        "--root",
+        root,
+        "--output",
+        "json",
+      ]);
+      expect(code).toBe(0);
+      const envelope = JSON.parse(io.stdout) as {
+        data?: { answers?: { feedbackAnonymousCloud?: boolean } };
+      };
+      expect(envelope.data?.answers?.feedbackAnonymousCloud).toBe(true);
+    } finally {
+      io.restore();
+    }
+  });
+
   it("init dry-run reports parent git context without writing nested state", async () => {
     const parent = await mkGitRepoRoot();
     const nested = path.join(parent, "packages", "api");

--- a/packages/agentplane/src/cli/run-cli.core.insights-report.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.insights-report.test.ts
@@ -300,7 +300,7 @@ describe("runCli insights report", () => {
     await writeConfig(root, config);
 
     const originalFetch = globalThis.fetch;
-    const fetchMock = vi.fn(async () => Response.json({ intake_id: "fb_123", status: "accepted" }));
+    const fetchMock = vi.fn(() => Response.json({ intake_id: "fb_123", status: "accepted" }));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
     const io = captureStdIO();
     try {

--- a/packages/agentplane/src/cli/run-cli.core.insights-report.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.insights-report.test.ts
@@ -1,4 +1,4 @@
-import { describe } from "vitest";
+import { describe, vi } from "vitest";
 import { defaultConfig } from "@agentplaneorg/core/config";
 
 import {
@@ -216,12 +216,14 @@ describe("runCli insights report", () => {
       expect(code).toBe(0);
       const payload = JSON.parse(io.stdout) as {
         dry_run?: boolean;
+        transport?: string;
         repository?: string;
         title?: string;
         body?: string;
         labels?: string[];
       };
       expect(payload.dry_run).toBe(true);
+      expect(payload.transport).toBe("github");
       expect(payload.repository).toBe("basilisk-labs/agentplane");
       expect(payload.title).toContain("E_INTERNAL");
       expect(payload.labels).toEqual(["agentplane-feedback", "bug"]);
@@ -283,6 +285,87 @@ describe("runCli insights report", () => {
       expect(io.stderr).toContain("Feedback GitHub issues are disabled");
       expect(io.stderr).toContain("feedback.github_issues.enabled true");
       expect(io.stderr).toContain("reason_code: feedback_github_issues_disabled");
+    } finally {
+      io.restore();
+    }
+  });
+
+  it("creates anonymous cloud feedback intake only after explicit opt-in", async () => {
+    const root = await mkGitRepoRoot();
+    const config = defaultConfig();
+    config.feedback.github_issues.enabled = true;
+    config.feedback.github_issues.transport = "cloud";
+    config.feedback.github_issues.allow_anonymous_cloud = true;
+    config.feedback.github_issues.cloud_endpoint = "https://cloud.example/api/feedback/issues";
+    await writeConfig(root, config);
+
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn(async () => Response.json({ intake_id: "fb_123", status: "accepted" }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const io = captureStdIO();
+    try {
+      const code = await runCli([
+        "insights",
+        "issue",
+        "--error-code",
+        "E_INTERNAL",
+        "--agent-context",
+        "Intent: test anonymous cloud intake. Sensitive data omitted: task prose, env, remotes, and raw output.",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(0);
+      expect(io.stdout).toContain("transport:");
+      expect(io.stdout).toContain("cloud");
+      expect(io.stdout).toContain("intake:fb_123");
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://cloud.example/api/feedback/issues",
+        expect.objectContaining({
+          method: "POST",
+          headers: { "content-type": "application/json" },
+        }),
+      );
+      const request = fetchMock.mock.calls[0]?.[1] as { body?: string } | undefined;
+      const body = JSON.parse(String(request?.body ?? "{}")) as {
+        schema?: string;
+        anonymous?: boolean;
+        failure?: { error_code?: string | null; dedupe_signature?: string };
+        privacy?: { excludes?: string[] };
+      };
+      expect(body.schema).toBe("agentplane.feedback.issue.v1");
+      expect(body.anonymous).toBe(true);
+      expect(body.failure?.error_code).toBe("E_INTERNAL");
+      expect(body.failure?.dedupe_signature).toMatch(/^sha256:/);
+      expect(body.privacy?.excludes).toContain("environment variables");
+    } finally {
+      io.restore();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("blocks anonymous cloud feedback intake when fallback is not enabled", async () => {
+    const root = await mkGitRepoRoot();
+    const config = defaultConfig();
+    config.feedback.github_issues.enabled = true;
+    config.feedback.github_issues.transport = "cloud";
+    config.feedback.github_issues.allow_anonymous_cloud = false;
+    await writeConfig(root, config);
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli([
+        "insights",
+        "issue",
+        "--error-code",
+        "E_INTERNAL",
+        "--agent-context",
+        "Intent: test disabled anonymous cloud intake. Sensitive data omitted.",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(2);
+      expect(io.stderr).toContain("Anonymous cloud feedback issue intake is disabled");
+      expect(io.stderr).toContain("feedback_anonymous_cloud_disabled");
     } finally {
       io.restore();
     }

--- a/packages/agentplane/src/cli/run-cli/commands/init/answers.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/answers.ts
@@ -40,6 +40,7 @@ export type InitAnswers = {
   requireNetworkApproval: boolean;
   requireVerifyApproval: boolean;
   feedbackGithubIssues: boolean;
+  feedbackAnonymousCloud: boolean;
   executionProfile: ExecutionProfile;
   strictUnsafeConfirm: boolean;
   blueprints: string[];
@@ -70,6 +71,7 @@ export function buildNonInteractiveAnswers(flags: InitParsed): InitAnswers {
     requireNetworkApproval: flags.requireNetworkApproval ?? preset.defaultRequireNetworkApproval,
     requireVerifyApproval: flags.requireVerifyApproval ?? preset.defaultRequireVerifyApproval,
     feedbackGithubIssues: flags.feedbackGithubIssues ?? preset.defaultFeedbackGithubIssues,
+    feedbackAnonymousCloud: flags.feedbackAnonymousCloud ?? preset.defaultFeedbackAnonymousCloud,
     executionProfile: flags.executionProfile ?? preset.defaultExecutionProfile,
     strictUnsafeConfirm: flags.strictUnsafeConfirm ?? preset.defaultStrictUnsafeConfirm,
     blueprints: flags.blueprints ?? INIT_DEFAULTS.blueprints,
@@ -144,6 +146,7 @@ export async function promptInteractiveAnswers(opts: {
     requireNetworkApproval: advanced.requireNetworkApproval,
     requireVerifyApproval: advanced.requireVerifyApproval,
     feedbackGithubIssues: advanced.feedbackGithubIssues,
+    feedbackAnonymousCloud: advanced.feedbackAnonymousCloud,
     executionProfile: advanced.executionProfile,
     strictUnsafeConfirm: advanced.strictUnsafeConfirm,
     blueprints: blueprintSelection.blueprints,

--- a/packages/agentplane/src/cli/run-cli/commands/init/execution.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/execution.ts
@@ -300,6 +300,7 @@ export function buildInitPlan(opts: {
       requireNetworkApproval: opts.answers.requireNetworkApproval,
       requireVerifyApproval: opts.answers.requireVerifyApproval,
       feedbackGithubIssues: opts.answers.feedbackGithubIssues,
+      feedbackAnonymousCloud: opts.answers.feedbackAnonymousCloud,
       executionProfile: opts.answers.executionProfile,
       strictUnsafeConfirm: opts.answers.strictUnsafeConfirm,
       recipes: [...opts.answers.recipes],
@@ -334,6 +335,7 @@ export async function maybeConfirmInteractiveApply(opts: {
     { label: "Backend", value: opts.answers.backend },
     { label: "Hooks", value: opts.answers.hooks },
     { label: "Feedback issues", value: opts.answers.feedbackGithubIssues },
+    { label: "Anonymous feedback fallback", value: opts.answers.feedbackAnonymousCloud },
     { label: "IDE", value: opts.answers.ide },
     { label: "Recipes", value: opts.answers.recipes.join(", ") || "none" },
     { label: "Blueprints", value: opts.answers.blueprints.join(", ") || "none" },
@@ -423,6 +425,7 @@ export async function applyInitPlan(opts: {
           requireNetworkApproval: opts.answers.requireNetworkApproval,
           requireVerifyApproval: opts.answers.requireVerifyApproval,
           feedbackGithubIssues: opts.answers.feedbackGithubIssues,
+          feedbackAnonymousCloud: opts.answers.feedbackAnonymousCloud,
           execution: buildExecutionProfile(opts.answers.executionProfile, {
             strictUnsafeConfirm: opts.answers.strictUnsafeConfirm,
           }),

--- a/packages/agentplane/src/cli/run-cli/commands/init/model.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/model.ts
@@ -26,6 +26,7 @@ export type InitFlags = {
   requireNetworkApproval?: boolean;
   requireVerifyApproval?: boolean;
   feedbackGithubIssues?: boolean;
+  feedbackAnonymousCloud?: boolean;
   executionProfile?: ExecutionProfile;
   strictUnsafeConfirm?: boolean;
   recipes?: string[];
@@ -50,6 +51,7 @@ export type InitDefaults = {
   requireNetworkApproval: boolean;
   requireVerifyApproval: boolean;
   feedbackGithubIssues: boolean;
+  feedbackAnonymousCloud: boolean;
   executionProfile: ExecutionProfile;
   strictUnsafeConfirm: boolean;
   blueprints: string[];
@@ -97,6 +99,7 @@ export type InitPlan = {
     requireNetworkApproval: boolean;
     requireVerifyApproval: boolean;
     feedbackGithubIssues: boolean;
+    feedbackAnonymousCloud: boolean;
     executionProfile: ExecutionProfile;
     strictUnsafeConfirm: boolean;
     recipes: string[];

--- a/packages/agentplane/src/cli/run-cli/commands/init/presets.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/presets.ts
@@ -12,6 +12,7 @@ export const INIT_DEFAULTS: InitDefaults = {
   requireNetworkApproval: true,
   requireVerifyApproval: true,
   feedbackGithubIssues: false,
+  feedbackAnonymousCloud: false,
   executionProfile: "balanced",
   strictUnsafeConfirm: false,
   blueprints: [],
@@ -28,6 +29,7 @@ export const setupProfilePresets: Record<
     defaultRequireNetworkApproval: boolean;
     defaultRequireVerifyApproval: boolean;
     defaultFeedbackGithubIssues: boolean;
+    defaultFeedbackAnonymousCloud: boolean;
     defaultExecutionProfile: InitDefaults["executionProfile"];
     defaultRecipes: string[];
   }
@@ -41,6 +43,7 @@ export const setupProfilePresets: Record<
     defaultRequireNetworkApproval: false,
     defaultRequireVerifyApproval: false,
     defaultFeedbackGithubIssues: false,
+    defaultFeedbackAnonymousCloud: false,
     defaultExecutionProfile: "aggressive",
     defaultRecipes: [],
   },
@@ -54,6 +57,7 @@ export const setupProfilePresets: Record<
     defaultRequireNetworkApproval: true,
     defaultRequireVerifyApproval: true,
     defaultFeedbackGithubIssues: false,
+    defaultFeedbackAnonymousCloud: false,
     defaultExecutionProfile: "balanced",
     defaultRecipes: [],
   },
@@ -67,6 +71,7 @@ export const setupProfilePresets: Record<
     defaultRequireNetworkApproval: true,
     defaultRequireVerifyApproval: true,
     defaultFeedbackGithubIssues: false,
+    defaultFeedbackAnonymousCloud: false,
     defaultExecutionProfile: "conservative",
     defaultRecipes: [],
   },

--- a/packages/agentplane/src/cli/run-cli/commands/init/spec.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/spec.ts
@@ -136,6 +136,13 @@ export const initSpec: CommandSpec<InitParsed> = {
     },
     {
       kind: "string",
+      name: "feedback-anonymous-cloud",
+      valueHint: "<true|false>",
+      description:
+        "Allow anonymous AgentPlane Cloud issue intake fallback when GitHub issue publishing is unavailable (default: false).",
+    },
+    {
+      kind: "string",
       name: "execution-profile",
       valueHint: "<conservative|balanced|aggressive>",
       choices: ["conservative", "balanced", "aggressive"],
@@ -255,6 +262,7 @@ export const initSpec: CommandSpec<InitParsed> = {
     const requireNetworkRaw = raw.opts["require-network-approval"] as string | undefined;
     const requireVerifyRaw = raw.opts["require-verify-approval"] as string | undefined;
     const feedbackGithubIssuesRaw = raw.opts["feedback-github-issues"] as string | undefined;
+    const feedbackAnonymousCloudRaw = raw.opts["feedback-anonymous-cloud"] as string | undefined;
     const recipesRaw = raw.opts.recipes as string | undefined;
     const blueprintsRaw = raw.opts.blueprints as string | undefined;
 
@@ -301,6 +309,14 @@ export const initSpec: CommandSpec<InitParsed> = {
         feedbackGithubIssuesRaw === undefined
           ? undefined
           : parseBooleanValueForInit(initSpec, "--feedback-github-issues", feedbackGithubIssuesRaw),
+      feedbackAnonymousCloud:
+        feedbackAnonymousCloudRaw === undefined
+          ? undefined
+          : parseBooleanValueForInit(
+              initSpec,
+              "--feedback-anonymous-cloud",
+              feedbackAnonymousCloudRaw,
+            ),
       executionProfile: raw.opts["execution-profile"] as InitFlags["executionProfile"],
       strictUnsafeConfirm:
         (raw.opts["strict-unsafe-confirm"] as string | undefined) === undefined

--- a/packages/agentplane/src/cli/run-cli/commands/init/steps/advanced-settings.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/steps/advanced-settings.ts
@@ -25,6 +25,7 @@ export async function promptAdvancedSettingsStep(opts: {
     | "requireNetworkApproval"
     | "requireVerifyApproval"
     | "feedbackGithubIssues"
+    | "feedbackAnonymousCloud"
     | "executionProfile"
     | "strictUnsafeConfirm"
   >;
@@ -37,6 +38,8 @@ export async function promptAdvancedSettingsStep(opts: {
   const requireVerifyApproval =
     opts.flags.requireVerifyApproval ?? preset.defaultRequireVerifyApproval;
   let feedbackGithubIssues = opts.flags.feedbackGithubIssues ?? preset.defaultFeedbackGithubIssues;
+  let feedbackAnonymousCloud =
+    opts.flags.feedbackAnonymousCloud ?? preset.defaultFeedbackAnonymousCloud;
   let requireNetworkApproval =
     opts.flags.requireNetworkApproval ?? preset.defaultRequireNetworkApproval;
   let executionProfile = opts.flags.executionProfile ?? preset.defaultExecutionProfile;
@@ -73,6 +76,18 @@ export async function promptAdvancedSettingsStep(opts: {
       cancelMessage: "Feedback issue opt-in selection cancelled.",
     });
   }
+  if (
+    opts.setupProfileMode === "full" &&
+    feedbackGithubIssues &&
+    opts.flags.feedbackAnonymousCloud === undefined
+  ) {
+    feedbackAnonymousCloud = await confirmStepValue(opts.clack, {
+      message:
+        "Allow anonymous AgentPlane Cloud fallback when GitHub issue publishing is unavailable?",
+      initialValue: feedbackAnonymousCloud,
+      cancelMessage: "Feedback cloud fallback selection cancelled.",
+    });
+  }
 
   return {
     hooks,
@@ -80,6 +95,7 @@ export async function promptAdvancedSettingsStep(opts: {
     requireNetworkApproval,
     requireVerifyApproval,
     feedbackGithubIssues,
+    feedbackAnonymousCloud,
     executionProfile,
     strictUnsafeConfirm,
   };

--- a/packages/agentplane/src/cli/run-cli/commands/init/steps/contracts.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/steps/contracts.ts
@@ -56,6 +56,7 @@ export type AdvancedSettingsStepAnswers = {
   requireNetworkApproval: boolean;
   requireVerifyApproval: boolean;
   feedbackGithubIssues: boolean;
+  feedbackAnonymousCloud: boolean;
   executionProfile: ExecutionProfile;
   strictUnsafeConfirm: boolean;
 };

--- a/packages/agentplane/src/cli/run-cli/commands/init/steps/prompt-steps.test.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/steps/prompt-steps.test.ts
@@ -58,7 +58,8 @@ describe("init prompt steps", () => {
     mocks.confirmMock
       .mockResolvedValueOnce(false)
       .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce(true);
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
     mocks.textMock
       .mockResolvedValueOnce("recipe-a, recipe-b")
       .mockResolvedValueOnce("pack:enterprise-baseline");
@@ -108,6 +109,7 @@ describe("init prompt steps", () => {
       requireNetworkApproval: true,
       requireVerifyApproval: true,
       feedbackGithubIssues: true,
+      feedbackAnonymousCloud: false,
       executionProfile: "aggressive",
       strictUnsafeConfirm: false,
     });
@@ -154,6 +156,7 @@ describe("init prompt steps", () => {
       requireNetworkApproval: false,
       requireVerifyApproval: false,
       feedbackGithubIssues: false,
+      feedbackAnonymousCloud: false,
       executionProfile: "aggressive",
       strictUnsafeConfirm: false,
     });

--- a/packages/agentplane/src/cli/run-cli/commands/init/write-config.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/write-config.ts
@@ -42,6 +42,7 @@ export async function writeInitConfig(opts: {
   requireNetworkApproval: boolean;
   requireVerifyApproval: boolean;
   feedbackGithubIssues: boolean;
+  feedbackAnonymousCloud: boolean;
   execution: InitExecutionConfig;
 }): Promise<void> {
   const rawConfig = defaultConfig() as unknown as Record<string, unknown>;
@@ -68,6 +69,11 @@ export async function writeInitConfig(opts: {
   );
   setByDottedKey(rawConfig, "agents.approvals.require_verify", String(opts.requireVerifyApproval));
   setByDottedKey(rawConfig, "feedback.github_issues.enabled", String(opts.feedbackGithubIssues));
+  setByDottedKey(
+    rawConfig,
+    "feedback.github_issues.allow_anonymous_cloud",
+    String(opts.feedbackAnonymousCloud),
+  );
   setByDottedKey(rawConfig, "framework.cli.expected_version", getVersion());
   setByDottedKey(rawConfig, "execution", JSON.stringify(opts.execution));
   await saveConfig(opts.agentplaneDir, rawConfig);

--- a/packages/agentplane/src/commands/insights/insights-issue-publish.test.ts
+++ b/packages/agentplane/src/commands/insights/insights-issue-publish.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const gh = vi.hoisted(() => ({
+  runGhApiJson: vi.fn<() => Promise<{ number: number; html_url?: string }>>(),
+}));
+
+vi.mock("../pr/internal/gh-api.js", () => gh);
+
+import { createFeedbackIssue } from "./insights-issue-publish.js";
+
+import type { InsightsReport } from "./insights.command.js";
+
+function reportFixture(): InsightsReport {
+  return {
+    schema: "agentplane.insights.report.v1",
+    generated_at: "2026-05-17T00:00:00.000Z",
+    local_only: true,
+    network: "not_used",
+    environment: {
+      agentplane_version: "0.0.0-test",
+      node_major: 20,
+      platform: "darwin",
+      arch: "arm64",
+    },
+    project: {
+      workflow_mode: "branch_pr",
+      backend: { id: "local", config_path: ".agentplane/backends/local/backend.json" },
+      initialized: true,
+    },
+    git: {
+      branch: "main",
+      dirty: false,
+      remotes: "redacted",
+    },
+    tasks: {
+      total: 0,
+      by_status: {},
+      by_owner: {},
+      by_tag: {},
+    },
+    failure: {
+      error_code: "E_INTERNAL",
+      command_id: "task start-ready",
+      phase: "resolve_context",
+      reason_code: "test_failure",
+      message_class: "internal",
+      argv_shape: ["task", "start-ready"],
+      dedupe_signature: "sha256:test",
+    },
+    privacy: {
+      excludes: ["environment variables"],
+      redactions: ["remotes"],
+    },
+  };
+}
+
+describe("insights issue publishing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lets auto transport publish through GitHub without anonymous cloud opt-in", async () => {
+    gh.runGhApiJson.mockResolvedValue({ number: 42, html_url: "https://github.test/issues/42" });
+
+    await expect(
+      createFeedbackIssue({
+        root: "/repo",
+        settings: {
+          enabled: true,
+          repository: "example/repo",
+          transport: "auto",
+          allow_anonymous_cloud: false,
+          include_insights_report: true,
+          labels: ["agentplane-feedback"],
+        },
+        payload: {
+          repository: "example/repo",
+          title: "Feedback issue",
+          body: "Body",
+          labels: ["agentplane-feedback"],
+        },
+        report: reportFixture(),
+        transport: "auto",
+        endpoint: "https://cloud.example/feedback",
+      }),
+    ).resolves.toEqual({
+      transport: "github",
+      issue: "#42",
+      url: "https://github.test/issues/42",
+    });
+    expect(gh.runGhApiJson).toHaveBeenCalledOnce();
+  });
+
+  it("blocks auto transport cloud fallback only after GitHub publishing fails", async () => {
+    gh.runGhApiJson.mockRejectedValue(new Error("gh auth missing"));
+
+    await expect(
+      createFeedbackIssue({
+        root: "/repo",
+        settings: {
+          enabled: true,
+          repository: "example/repo",
+          transport: "auto",
+          allow_anonymous_cloud: false,
+          include_insights_report: true,
+          labels: ["agentplane-feedback"],
+        },
+        payload: {
+          repository: "example/repo",
+          title: "Feedback issue",
+          body: "Body",
+          labels: ["agentplane-feedback"],
+        },
+        report: reportFixture(),
+        transport: "auto",
+        endpoint: "https://cloud.example/feedback",
+      }),
+    ).rejects.toThrow("GitHub feedback issue publishing failed");
+    expect(gh.runGhApiJson).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/agentplane/src/commands/insights/insights-issue-publish.ts
+++ b/packages/agentplane/src/commands/insights/insights-issue-publish.ts
@@ -1,0 +1,161 @@
+import { exitCodeForError } from "../../cli/exit-codes.js";
+import { CliError } from "../../shared/errors.js";
+import { runGhApiJson } from "../pr/internal/gh-api.js";
+
+import type { InsightsReport } from "./insights.command.js";
+
+export type FeedbackIssueTransport = "github" | "cloud" | "auto";
+
+export type FeedbackGithubIssuesSettings = {
+  enabled: boolean;
+  repository: string;
+  transport?: FeedbackIssueTransport;
+  cloud_endpoint?: string;
+  allow_anonymous_cloud?: boolean;
+  include_insights_report: boolean;
+  labels: string[];
+};
+
+export type FeedbackIssuePayload = {
+  repository: string;
+  title: string;
+  body: string;
+  labels: string[];
+};
+
+type GithubIssueResponse = {
+  number: number;
+  html_url?: string;
+};
+
+type CloudIssueResponse = {
+  intake_id?: string;
+  issue_url?: string;
+  status?: string;
+};
+
+export type CreatedFeedbackIssue = {
+  transport: "github" | "cloud";
+  issue: string;
+  url: string;
+};
+
+function trimOptional(value: string | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed || null;
+}
+
+export function normalizeIssueTransport(raw: string | undefined): FeedbackIssueTransport {
+  return raw === "cloud" || raw === "auto" || raw === "github" ? raw : "github";
+}
+
+export function feedbackCloudEndpoint(settings: FeedbackGithubIssuesSettings): string {
+  return trimOptional(settings.cloud_endpoint) ?? "https://agentplane.cloud/api/feedback/issues";
+}
+
+function cloudIntakeBody(opts: {
+  payload: FeedbackIssuePayload;
+  report: InsightsReport;
+  anonymous: boolean;
+}): Record<string, unknown> {
+  return {
+    schema: "agentplane.feedback.issue.v1",
+    anonymous: opts.anonymous,
+    repository: opts.payload.repository,
+    title: opts.payload.title,
+    body: opts.payload.body,
+    labels: opts.payload.labels,
+    client: {
+      agentplane_version: opts.report.environment.agentplane_version,
+      node_major: opts.report.environment.node_major,
+      platform: opts.report.environment.platform,
+      arch: opts.report.environment.arch,
+    },
+    failure: opts.report.failure,
+    diagnostics: {
+      workflow_mode: opts.report.project.workflow_mode,
+      backend: opts.report.project.backend.id,
+      git_branch: opts.report.git.branch,
+      git_dirty: opts.report.git.dirty,
+      dedupe_signature: opts.report.failure.dedupe_signature,
+    },
+    privacy: opts.report.privacy,
+  };
+}
+
+async function createGithubIssue(
+  root: string,
+  settings: FeedbackGithubIssuesSettings,
+  payload: FeedbackIssuePayload,
+): Promise<CreatedFeedbackIssue> {
+  const issue = await runGhApiJson<GithubIssueResponse>(root, [
+    `repos/${settings.repository}/issues`,
+    "-X",
+    "POST",
+    "-f",
+    `title=${payload.title}`,
+    "-f",
+    `body=${payload.body}`,
+    ...settings.labels.flatMap((label) => ["-f", `labels[]=${label}`]),
+  ]);
+  return {
+    transport: "github",
+    issue: `#${issue.number}`,
+    url: issue.html_url ?? "unknown",
+  };
+}
+
+async function createCloudIssue(opts: {
+  endpoint: string;
+  payload: FeedbackIssuePayload;
+  report: InsightsReport;
+}): Promise<CreatedFeedbackIssue> {
+  const response = await fetch(opts.endpoint, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(
+      cloudIntakeBody({ payload: opts.payload, report: opts.report, anonymous: true }),
+    ),
+  });
+  const text = await response.text();
+  const parsed = text.trim() ? (JSON.parse(text) as CloudIssueResponse) : {};
+  if (!response.ok) {
+    throw new CliError({
+      exitCode: exitCodeForError("E_NETWORK"),
+      code: "E_NETWORK",
+      message: `Feedback cloud intake failed with HTTP ${response.status}.`,
+      context: {
+        command: "insights issue",
+        reason_code: "feedback_cloud_intake_failed",
+      },
+    });
+  }
+  return {
+    transport: "cloud",
+    issue: parsed.intake_id ? `intake:${parsed.intake_id}` : (parsed.status ?? "accepted"),
+    url: parsed.issue_url ?? "pending",
+  };
+}
+
+export async function createFeedbackIssue(opts: {
+  root: string;
+  settings: FeedbackGithubIssuesSettings;
+  payload: FeedbackIssuePayload;
+  report: InsightsReport;
+  transport: FeedbackIssueTransport;
+  endpoint: string;
+}): Promise<CreatedFeedbackIssue> {
+  if (opts.transport === "cloud") {
+    return await createCloudIssue({
+      endpoint: opts.endpoint,
+      payload: opts.payload,
+      report: opts.report,
+    });
+  }
+  if (opts.transport === "auto") {
+    return await createGithubIssue(opts.root, opts.settings, opts.payload).catch(() =>
+      createCloudIssue({ endpoint: opts.endpoint, payload: opts.payload, report: opts.report }),
+    );
+  }
+  return await createGithubIssue(opts.root, opts.settings, opts.payload);
+}

--- a/packages/agentplane/src/commands/insights/insights-issue-publish.ts
+++ b/packages/agentplane/src/commands/insights/insights-issue-publish.ts
@@ -83,6 +83,18 @@ function cloudIntakeBody(opts: {
   };
 }
 
+function anonymousCloudDisabledError(message: string): CliError {
+  return new CliError({
+    exitCode: exitCodeForError("E_USAGE"),
+    code: "E_USAGE",
+    message,
+    context: {
+      command: "insights issue",
+      reason_code: "feedback_anonymous_cloud_disabled",
+    },
+  });
+}
+
 async function createGithubIssue(
   root: string,
   settings: FeedbackGithubIssuesSettings,
@@ -146,6 +158,11 @@ export async function createFeedbackIssue(opts: {
   endpoint: string;
 }): Promise<CreatedFeedbackIssue> {
   if (opts.transport === "cloud") {
+    if (opts.settings.allow_anonymous_cloud !== true) {
+      throw anonymousCloudDisabledError(
+        "Anonymous cloud feedback issue intake is disabled. Enable with `agentplane config set feedback.github_issues.allow_anonymous_cloud true`, then retry.",
+      );
+    }
     return await createCloudIssue({
       endpoint: opts.endpoint,
       payload: opts.payload,
@@ -153,9 +170,20 @@ export async function createFeedbackIssue(opts: {
     });
   }
   if (opts.transport === "auto") {
-    return await createGithubIssue(opts.root, opts.settings, opts.payload).catch(() =>
-      createCloudIssue({ endpoint: opts.endpoint, payload: opts.payload, report: opts.report }),
-    );
+    try {
+      return await createGithubIssue(opts.root, opts.settings, opts.payload);
+    } catch (error) {
+      if (opts.settings.allow_anonymous_cloud !== true) {
+        throw anonymousCloudDisabledError(
+          `GitHub feedback issue publishing failed and anonymous cloud fallback is disabled. Enable with \`agentplane config set feedback.github_issues.allow_anonymous_cloud true\`, then retry. Cause: ${String(error instanceof Error ? error.message : error)}`,
+        );
+      }
+      return await createCloudIssue({
+        endpoint: opts.endpoint,
+        payload: opts.payload,
+        report: opts.report,
+      });
+    }
   }
   return await createGithubIssue(opts.root, opts.settings, opts.payload);
 }

--- a/packages/agentplane/src/commands/insights/insights.command.ts
+++ b/packages/agentplane/src/commands/insights/insights.command.ts
@@ -554,10 +554,7 @@ export function makeRunInsightsIssueHandler(deps: RunDeps): CommandHandler<Insig
         return 0;
       }
 
-      if (
-        (transport === "cloud" || transport === "auto") &&
-        settings.allow_anonymous_cloud !== true
-      ) {
+      if (transport === "cloud" && settings.allow_anonymous_cloud !== true) {
         throw new CliError({
           exitCode: exitCodeForError("E_USAGE"),
           code: "E_USAGE",

--- a/packages/agentplane/src/commands/insights/insights.command.ts
+++ b/packages/agentplane/src/commands/insights/insights.command.ts
@@ -346,8 +346,24 @@ type GithubIssueResponse = {
 type FeedbackGithubIssuesSettings = {
   enabled: boolean;
   repository: string;
+  transport?: "github" | "cloud" | "auto";
+  cloud_endpoint?: string;
+  allow_anonymous_cloud?: boolean;
   include_insights_report: boolean;
   labels: string[];
+};
+
+type FeedbackIssuePayload = {
+  repository: string;
+  title: string;
+  body: string;
+  labels: string[];
+};
+
+type CloudIssueResponse = {
+  intake_id?: string;
+  issue_url?: string;
+  status?: string;
 };
 
 function trimOptional(value: string | undefined): string | null {
@@ -390,6 +406,106 @@ function renderIssueBody(opts: {
     sections.push("", "## Insights report", "```json", JSON.stringify(opts.report, null, 2), "```");
   }
   return `${sections.join("\n")}\n`;
+}
+
+function normalizeIssueTransport(raw: string | undefined): "github" | "cloud" | "auto" {
+  return raw === "cloud" || raw === "auto" || raw === "github" ? raw : "github";
+}
+
+function cloudEndpoint(settings: FeedbackGithubIssuesSettings): string {
+  return trimOptional(settings.cloud_endpoint) ?? "https://agentplane.cloud/api/feedback/issues";
+}
+
+function cloudIntakeBody(opts: {
+  payload: FeedbackIssuePayload;
+  report: InsightsReport;
+  anonymous: boolean;
+}): Record<string, unknown> {
+  return {
+    schema: "agentplane.feedback.issue.v1",
+    anonymous: opts.anonymous,
+    repository: opts.payload.repository,
+    title: opts.payload.title,
+    body: opts.payload.body,
+    labels: opts.payload.labels,
+    client: {
+      agentplane_version: opts.report.environment.agentplane_version,
+      node_major: opts.report.environment.node_major,
+      platform: opts.report.environment.platform,
+      arch: opts.report.environment.arch,
+    },
+    failure: opts.report.failure,
+    diagnostics: {
+      workflow_mode: opts.report.project.workflow_mode,
+      backend: opts.report.project.backend.id,
+      git_branch: opts.report.git.branch,
+      git_dirty: opts.report.git.dirty,
+      dedupe_signature: opts.report.failure.dedupe_signature,
+    },
+    privacy: opts.report.privacy,
+  };
+}
+
+async function createGithubIssue(
+  root: string,
+  settings: FeedbackGithubIssuesSettings,
+  payload: FeedbackIssuePayload,
+): Promise<{
+  transport: "github";
+  issue: string;
+  url: string;
+}> {
+  const issue = await runGhApiJson<GithubIssueResponse>(root, [
+    `repos/${settings.repository}/issues`,
+    "-X",
+    "POST",
+    "-f",
+    `title=${payload.title}`,
+    "-f",
+    `body=${payload.body}`,
+    ...settings.labels.flatMap((label) => ["-f", `labels[]=${label}`]),
+  ]);
+  return {
+    transport: "github",
+    issue: `#${issue.number}`,
+    url: issue.html_url ?? "unknown",
+  };
+}
+
+async function createCloudIssue(opts: {
+  endpoint: string;
+  payload: FeedbackIssuePayload;
+  report: InsightsReport;
+}): Promise<{
+  transport: "cloud";
+  issue: string;
+  url: string;
+}> {
+  const response = await fetch(opts.endpoint, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(
+      cloudIntakeBody({ payload: opts.payload, report: opts.report, anonymous: true }),
+    ),
+  });
+  const text = await response.text();
+  const parsed = text.trim() ? (JSON.parse(text) as CloudIssueResponse) : {};
+  if (!response.ok) {
+    throw new CliError({
+      exitCode: exitCodeForError("E_NETWORK"),
+      code: "E_NETWORK",
+      message: `Feedback cloud intake failed with HTTP ${response.status}.`,
+      context: {
+        command: "insights issue",
+        reason_code: "feedback_cloud_intake_failed",
+      },
+    });
+  }
+  return {
+    transport: "cloud",
+    issue: parsed.intake_id ? `intake:${parsed.intake_id}` : (parsed.status ?? "accepted"),
+    url: parsed.issue_url ?? "pending",
+  };
 }
 
 function renderCountMap(map: CountMap, limit?: number): string {
@@ -547,27 +663,50 @@ export function makeRunInsightsIssueHandler(deps: RunDeps): CommandHandler<Insig
         body,
         labels: settings.labels,
       };
+      const transport = parsed.transport ?? normalizeIssueTransport(settings.transport);
+      const endpoint = cloudEndpoint(settings);
 
       if (parsed.dryRun) {
-        output.json({ dry_run: true, ...payload });
+        output.json({
+          dry_run: true,
+          transport,
+          cloud_endpoint: transport === "cloud" || transport === "auto" ? endpoint : undefined,
+          anonymous_cloud_allowed: settings.allow_anonymous_cloud === true,
+          ...payload,
+        });
         return 0;
       }
 
-      const issue = await runGhApiJson<GithubIssueResponse>(resolved.gitRoot, [
-        `repos/${settings.repository}/issues`,
-        "-X",
-        "POST",
-        "-f",
-        `title=${title}`,
-        "-f",
-        `body=${body}`,
-        ...settings.labels.flatMap((label) => ["-f", `labels[]=${label}`]),
-      ]);
+      if (
+        (transport === "cloud" || transport === "auto") &&
+        settings.allow_anonymous_cloud !== true
+      ) {
+        throw new CliError({
+          exitCode: exitCodeForError("E_USAGE"),
+          code: "E_USAGE",
+          message:
+            "Anonymous cloud feedback issue intake is disabled. Enable with `agentplane config set feedback.github_issues.allow_anonymous_cloud true`, then retry.",
+          context: {
+            command: "insights issue",
+            reason_code: "feedback_anonymous_cloud_disabled",
+          },
+        });
+      }
+
+      const created =
+        transport === "cloud"
+          ? await createCloudIssue({ endpoint, payload, report })
+          : transport === "auto"
+            ? await createGithubIssue(resolved.gitRoot, settings, payload).catch(() =>
+                createCloudIssue({ endpoint, payload, report }),
+              )
+            : await createGithubIssue(resolved.gitRoot, settings, payload);
       output.report(
         [
+          { label: "transport", value: created.transport },
           { label: "repository", value: settings.repository },
-          { label: "issue", value: `#${issue.number}` },
-          { label: "url", value: issue.html_url ?? "unknown" },
+          { label: "issue", value: created.issue },
+          { label: "url", value: created.url },
         ],
         { header: infoMessage("feedback issue created") },
       );

--- a/packages/agentplane/src/commands/insights/insights.command.ts
+++ b/packages/agentplane/src/commands/insights/insights.command.ts
@@ -19,7 +19,6 @@ import { isRecord } from "../../shared/guards.js";
 import { wrapCommand } from "../../cli/run-cli/commands/wrap-command.js";
 import { exitCodeForError } from "../../cli/exit-codes.js";
 import { CliError } from "../../shared/errors.js";
-import { runGhApiJson } from "../pr/internal/gh-api.js";
 
 import {
   insightsSpec,
@@ -33,6 +32,12 @@ import {
   type FailureContextInput,
   type InsightsFailure,
 } from "./insights-issue-context.js";
+import {
+  createFeedbackIssue,
+  feedbackCloudEndpoint,
+  normalizeIssueTransport,
+  type FeedbackGithubIssuesSettings,
+} from "./insights-issue-publish.js";
 
 export { insightsIssueSpec, insightsReportSpec, insightsSpec } from "./insights.spec.js";
 
@@ -41,7 +46,7 @@ const output = createCliEmitter();
 
 type CountMap = Record<string, number>;
 
-type InsightsReport = {
+export type InsightsReport = {
   schema: "agentplane.insights.report.v1";
   generated_at: string;
   privacy: {
@@ -338,34 +343,6 @@ export async function buildInsightsReport(opts: {
   };
 }
 
-type GithubIssueResponse = {
-  number: number;
-  html_url?: string;
-};
-
-type FeedbackGithubIssuesSettings = {
-  enabled: boolean;
-  repository: string;
-  transport?: "github" | "cloud" | "auto";
-  cloud_endpoint?: string;
-  allow_anonymous_cloud?: boolean;
-  include_insights_report: boolean;
-  labels: string[];
-};
-
-type FeedbackIssuePayload = {
-  repository: string;
-  title: string;
-  body: string;
-  labels: string[];
-};
-
-type CloudIssueResponse = {
-  intake_id?: string;
-  issue_url?: string;
-  status?: string;
-};
-
 function trimOptional(value: string | undefined): string | null {
   const trimmed = value?.trim() ?? "";
   return trimmed || null;
@@ -406,106 +383,6 @@ function renderIssueBody(opts: {
     sections.push("", "## Insights report", "```json", JSON.stringify(opts.report, null, 2), "```");
   }
   return `${sections.join("\n")}\n`;
-}
-
-function normalizeIssueTransport(raw: string | undefined): "github" | "cloud" | "auto" {
-  return raw === "cloud" || raw === "auto" || raw === "github" ? raw : "github";
-}
-
-function cloudEndpoint(settings: FeedbackGithubIssuesSettings): string {
-  return trimOptional(settings.cloud_endpoint) ?? "https://agentplane.cloud/api/feedback/issues";
-}
-
-function cloudIntakeBody(opts: {
-  payload: FeedbackIssuePayload;
-  report: InsightsReport;
-  anonymous: boolean;
-}): Record<string, unknown> {
-  return {
-    schema: "agentplane.feedback.issue.v1",
-    anonymous: opts.anonymous,
-    repository: opts.payload.repository,
-    title: opts.payload.title,
-    body: opts.payload.body,
-    labels: opts.payload.labels,
-    client: {
-      agentplane_version: opts.report.environment.agentplane_version,
-      node_major: opts.report.environment.node_major,
-      platform: opts.report.environment.platform,
-      arch: opts.report.environment.arch,
-    },
-    failure: opts.report.failure,
-    diagnostics: {
-      workflow_mode: opts.report.project.workflow_mode,
-      backend: opts.report.project.backend.id,
-      git_branch: opts.report.git.branch,
-      git_dirty: opts.report.git.dirty,
-      dedupe_signature: opts.report.failure.dedupe_signature,
-    },
-    privacy: opts.report.privacy,
-  };
-}
-
-async function createGithubIssue(
-  root: string,
-  settings: FeedbackGithubIssuesSettings,
-  payload: FeedbackIssuePayload,
-): Promise<{
-  transport: "github";
-  issue: string;
-  url: string;
-}> {
-  const issue = await runGhApiJson<GithubIssueResponse>(root, [
-    `repos/${settings.repository}/issues`,
-    "-X",
-    "POST",
-    "-f",
-    `title=${payload.title}`,
-    "-f",
-    `body=${payload.body}`,
-    ...settings.labels.flatMap((label) => ["-f", `labels[]=${label}`]),
-  ]);
-  return {
-    transport: "github",
-    issue: `#${issue.number}`,
-    url: issue.html_url ?? "unknown",
-  };
-}
-
-async function createCloudIssue(opts: {
-  endpoint: string;
-  payload: FeedbackIssuePayload;
-  report: InsightsReport;
-}): Promise<{
-  transport: "cloud";
-  issue: string;
-  url: string;
-}> {
-  const response = await fetch(opts.endpoint, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(
-      cloudIntakeBody({ payload: opts.payload, report: opts.report, anonymous: true }),
-    ),
-  });
-  const text = await response.text();
-  const parsed = text.trim() ? (JSON.parse(text) as CloudIssueResponse) : {};
-  if (!response.ok) {
-    throw new CliError({
-      exitCode: exitCodeForError("E_NETWORK"),
-      code: "E_NETWORK",
-      message: `Feedback cloud intake failed with HTTP ${response.status}.`,
-      context: {
-        command: "insights issue",
-        reason_code: "feedback_cloud_intake_failed",
-      },
-    });
-  }
-  return {
-    transport: "cloud",
-    issue: parsed.intake_id ? `intake:${parsed.intake_id}` : (parsed.status ?? "accepted"),
-    url: parsed.issue_url ?? "pending",
-  };
 }
 
 function renderCountMap(map: CountMap, limit?: number): string {
@@ -664,7 +541,7 @@ export function makeRunInsightsIssueHandler(deps: RunDeps): CommandHandler<Insig
         labels: settings.labels,
       };
       const transport = parsed.transport ?? normalizeIssueTransport(settings.transport);
-      const endpoint = cloudEndpoint(settings);
+      const endpoint = feedbackCloudEndpoint(settings);
 
       if (parsed.dryRun) {
         output.json({
@@ -693,14 +570,14 @@ export function makeRunInsightsIssueHandler(deps: RunDeps): CommandHandler<Insig
         });
       }
 
-      const created =
-        transport === "cloud"
-          ? await createCloudIssue({ endpoint, payload, report })
-          : transport === "auto"
-            ? await createGithubIssue(resolved.gitRoot, settings, payload).catch(() =>
-                createCloudIssue({ endpoint, payload, report }),
-              )
-            : await createGithubIssue(resolved.gitRoot, settings, payload);
+      const created = await createFeedbackIssue({
+        root: resolved.gitRoot,
+        settings,
+        payload,
+        report,
+        transport,
+        endpoint,
+      });
       output.report(
         [
           { label: "transport", value: created.transport },

--- a/packages/agentplane/src/commands/insights/insights.spec.ts
+++ b/packages/agentplane/src/commands/insights/insights.spec.ts
@@ -18,6 +18,7 @@ export type InsightsIssueParsed = {
   failureReasonCode?: string;
   failureMessageClass?: string;
   failureArgvShape: string[];
+  transport?: "github" | "cloud" | "auto";
   dryRun: boolean;
 };
 
@@ -157,6 +158,14 @@ export const insightsIssueSpec: CommandSpec<InsightsIssueParsed> = {
       description: "Repeatable sanitized argv shape token; values must not include raw secrets.",
     },
     {
+      kind: "string",
+      name: "transport",
+      valueHint: "<github|cloud|auto>",
+      choices: ["github", "cloud", "auto"],
+      description:
+        "Issue transport. github uses the user's gh auth, cloud uses anonymous AgentPlane intake, auto falls back to cloud when GitHub publishing fails.",
+    },
+    {
       kind: "boolean",
       name: "dry-run",
       default: false,
@@ -187,6 +196,7 @@ export const insightsIssueSpec: CommandSpec<InsightsIssueParsed> = {
     failureArgvShape: Array.isArray(raw.opts["failure-argv-shape"])
       ? (raw.opts["failure-argv-shape"] as string[])
       : [],
+    transport: raw.opts.transport as InsightsIssueParsed["transport"],
     dryRun: raw.opts["dry-run"] === true,
   }),
 };

--- a/packages/core/schemas/config.schema.json
+++ b/packages/core/schemas/config.schema.json
@@ -355,6 +355,20 @@
               "minLength": 1,
               "default": "basilisk-labs/agentplane"
             },
+            "transport": {
+              "type": "string",
+              "enum": ["github", "cloud", "auto"],
+              "default": "github"
+            },
+            "cloud_endpoint": {
+              "type": "string",
+              "minLength": 1,
+              "default": "https://agentplane.cloud/api/feedback/issues"
+            },
+            "allow_anonymous_cloud": {
+              "type": "boolean",
+              "default": false
+            },
             "prompt_on_internal_error": {
               "type": "boolean",
               "default": true
@@ -380,6 +394,9 @@
           "default": {
             "enabled": false,
             "repository": "basilisk-labs/agentplane",
+            "transport": "github",
+            "cloud_endpoint": "https://agentplane.cloud/api/feedback/issues",
+            "allow_anonymous_cloud": false,
             "prompt_on_internal_error": true,
             "include_insights_report": true,
             "dedupe": true,
@@ -392,6 +409,9 @@
         "github_issues": {
           "enabled": false,
           "repository": "basilisk-labs/agentplane",
+          "transport": "github",
+          "cloud_endpoint": "https://agentplane.cloud/api/feedback/issues",
+          "allow_anonymous_cloud": false,
           "prompt_on_internal_error": true,
           "include_insights_report": true,
           "dedupe": true,

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -38,6 +38,9 @@ describe("config", () => {
     expect(cfg.feedback.github_issues).toMatchObject({
       enabled: false,
       repository: "basilisk-labs/agentplane",
+      transport: "github",
+      cloud_endpoint: "https://agentplane.cloud/api/feedback/issues",
+      allow_anonymous_cloud: false,
       prompt_on_internal_error: true,
       include_insights_report: true,
       dedupe: true,

--- a/packages/core/src/config/schema.impl.ts
+++ b/packages/core/src/config/schema.impl.ts
@@ -166,9 +166,22 @@ const RUNNER_TIMEOUTS_SCHEMA = z
   .strict()
   .default({ ...RUNNER_TIMEOUT_DEFAULTS });
 
-const FEEDBACK_GITHUB_ISSUES_DEFAULTS = {
+const FEEDBACK_GITHUB_ISSUES_DEFAULTS: {
+  enabled: boolean;
+  repository: string;
+  transport: "github" | "cloud" | "auto";
+  cloud_endpoint: string;
+  allow_anonymous_cloud: boolean;
+  prompt_on_internal_error: boolean;
+  include_insights_report: boolean;
+  dedupe: boolean;
+  labels: string[];
+} = {
   enabled: false,
   repository: "basilisk-labs/agentplane",
+  transport: "github",
+  cloud_endpoint: "https://agentplane.cloud/api/feedback/issues",
+  allow_anonymous_cloud: false,
   prompt_on_internal_error: true,
   include_insights_report: true,
   dedupe: true,
@@ -290,6 +303,15 @@ export const AgentplaneConfigSchema = z
           .object({
             enabled: z.boolean().default(FEEDBACK_GITHUB_ISSUES_DEFAULTS.enabled),
             repository: nonEmptyString().default(FEEDBACK_GITHUB_ISSUES_DEFAULTS.repository),
+            transport: z
+              .enum(["github", "cloud", "auto"])
+              .default(FEEDBACK_GITHUB_ISSUES_DEFAULTS.transport),
+            cloud_endpoint: nonEmptyString().default(
+              FEEDBACK_GITHUB_ISSUES_DEFAULTS.cloud_endpoint,
+            ),
+            allow_anonymous_cloud: z
+              .boolean()
+              .default(FEEDBACK_GITHUB_ISSUES_DEFAULTS.allow_anonymous_cloud),
             prompt_on_internal_error: z
               .boolean()
               .default(FEEDBACK_GITHUB_ISSUES_DEFAULTS.prompt_on_internal_error),

--- a/packages/spec/schemas/config.schema.json
+++ b/packages/spec/schemas/config.schema.json
@@ -355,6 +355,20 @@
               "minLength": 1,
               "default": "basilisk-labs/agentplane"
             },
+            "transport": {
+              "type": "string",
+              "enum": ["github", "cloud", "auto"],
+              "default": "github"
+            },
+            "cloud_endpoint": {
+              "type": "string",
+              "minLength": 1,
+              "default": "https://agentplane.cloud/api/feedback/issues"
+            },
+            "allow_anonymous_cloud": {
+              "type": "boolean",
+              "default": false
+            },
             "prompt_on_internal_error": {
               "type": "boolean",
               "default": true
@@ -380,6 +394,9 @@
           "default": {
             "enabled": false,
             "repository": "basilisk-labs/agentplane",
+            "transport": "github",
+            "cloud_endpoint": "https://agentplane.cloud/api/feedback/issues",
+            "allow_anonymous_cloud": false,
             "prompt_on_internal_error": true,
             "include_insights_report": true,
             "dedupe": true,
@@ -392,6 +409,9 @@
         "github_issues": {
           "enabled": false,
           "repository": "basilisk-labs/agentplane",
+          "transport": "github",
+          "cloud_endpoint": "https://agentplane.cloud/api/feedback/issues",
+          "allow_anonymous_cloud": false,
           "prompt_on_internal_error": true,
           "include_insights_report": true,
           "dedupe": true,

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -355,6 +355,20 @@
               "minLength": 1,
               "default": "basilisk-labs/agentplane"
             },
+            "transport": {
+              "type": "string",
+              "enum": ["github", "cloud", "auto"],
+              "default": "github"
+            },
+            "cloud_endpoint": {
+              "type": "string",
+              "minLength": 1,
+              "default": "https://agentplane.cloud/api/feedback/issues"
+            },
+            "allow_anonymous_cloud": {
+              "type": "boolean",
+              "default": false
+            },
             "prompt_on_internal_error": {
               "type": "boolean",
               "default": true
@@ -380,6 +394,9 @@
           "default": {
             "enabled": false,
             "repository": "basilisk-labs/agentplane",
+            "transport": "github",
+            "cloud_endpoint": "https://agentplane.cloud/api/feedback/issues",
+            "allow_anonymous_cloud": false,
             "prompt_on_internal_error": true,
             "include_insights_report": true,
             "dedupe": true,
@@ -392,6 +409,9 @@
         "github_issues": {
           "enabled": false,
           "repository": "basilisk-labs/agentplane",
+          "transport": "github",
+          "cloud_endpoint": "https://agentplane.cloud/api/feedback/issues",
+          "allow_anonymous_cloud": false,
           "prompt_on_internal_error": true,
           "include_insights_report": true,
           "dedupe": true,


### PR DESCRIPTION
Task: `202605171746-BBZQQ1`
Title: Add feedback issue publish transports
Canonical task record: `.agentplane/tasks/202605171746-BBZQQ1/README.md`

## Summary

Add feedback issue publish transports

Extend the AgentPlane feedback issue flow from privacy-bounded draft creation to controlled publish transports, including GitHub publishing ergonomics and an anonymous cloud intake fallback.

## Scope

- In scope: Extend the AgentPlane feedback issue flow from privacy-bounded draft creation to controlled publish transports, including GitHub publishing ergonomics and an anonymous cloud intake fallback.
- Out of scope: unrelated refactors not required for "Add feedback issue publish transports".

## Verification

- State: ok
- Note:

```text
Implemented controlled feedback issue transports and verified focused CLI/config coverage plus
generated artifacts.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-17T18:07:49.881Z
- Branch: task/202605171746-BBZQQ1/feedback-issue-transports
- Head: 7f613c054a17

```text
 .../blueprint/resolved-snapshot.json               | 528 +++++++++++++++++++++
 docs/user/cli-reference.generated.mdx              |   2 +
 docs/user/commands.mdx                             |   1 +
 docs/user/configuration.mdx                        |  15 +-
 docs/user/setup.mdx                                |  12 +-
 packages/agentplane/src/cli/error-map.ts           |  10 +
 packages/agentplane/src/cli/reason-codes.ts        |   6 +
 .../agentplane/src/cli/run-cli.core.init.test.ts   |  27 ++
 .../src/cli/run-cli.core.insights-report.test.ts   |  85 +++-
 .../src/cli/run-cli/commands/init/answers.ts       |   3 +
 .../src/cli/run-cli/commands/init/execution.ts     |   3 +
 .../src/cli/run-cli/commands/init/model.ts         |   3 +
 .../src/cli/run-cli/commands/init/presets.ts       |   5 +
 .../src/cli/run-cli/commands/init/spec.ts          |  16 +
 .../commands/init/steps/advanced-settings.ts       |  16 +
 .../cli/run-cli/commands/init/steps/contracts.ts   |   1 +
 .../commands/init/steps/prompt-steps.test.ts       |   5 +-
 .../src/cli/run-cli/commands/init/write-config.ts  |   6 +
 .../src/commands/insights/insights.command.ts      | 165 ++++++-
 .../src/commands/insights/insights.spec.ts         |  10 +
 packages/core/schemas/config.schema.json           |  20 +
 packages/core/src/config/config.test.ts            |   3 +
 packages/core/src/config/schema.impl.ts            |  24 +-
 packages/spec/schemas/config.schema.json           |  20 +
 schemas/config.schema.json                         |  20 +
 25 files changed, 986 insertions(+), 20 deletions(-)
```

</details>
