### PR TITLE
🚧 TFMY22 task: Fix feedback opt-in and direct finish recovery issues [202605181205-TFMY22]

### DIFF
--- a/.agentplane/tasks/202605181205-TFMY22/README.md
+++ b/.agentplane/tasks/202605181205-TFMY22/README.md
@@ -1,0 +1,153 @@
+---
+id: "202605181205-TFMY22"
+title: "Fix feedback opt-in and direct finish recovery issues"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "bug"
+  - "code"
+  - "diagnostics"
+  - "workflow"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-18T12:05:31.498Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-18T12:15:26.551Z"
+  updated_by: "CODER"
+  note: "Implemented one-shot feedback issue opt-in and direct close-commit preflight hardening. Checks passed: focused insights/error tests, finish validation Vitest, typecheck, docs:cli:check, format:changed, lint:core, task scope, policy routing."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Implement code fixes for GitHub issues #3872 and #3873: feedback issue publication must support explicit one-shot opt-in without workflow drift, and direct-mode finish/git staging blockers must surface deterministic recovery diagnostics."
+events:
+  -
+    type: "status"
+    at: "2026-05-18T12:05:54.145Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Implement code fixes for GitHub issues #3872 and #3873: feedback issue publication must support explicit one-shot opt-in without workflow drift, and direct-mode finish/git staging blockers must surface deterministic recovery diagnostics."
+  -
+    type: "verify"
+    at: "2026-05-18T12:15:26.551Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented one-shot feedback issue opt-in and direct close-commit preflight hardening. Checks passed: focused insights/error tests, finish validation Vitest, typecheck, docs:cli:check, format:changed, lint:core, task scope, policy routing."
+doc_version: 3
+doc_updated_at: "2026-05-18T12:15:26.559Z"
+doc_updated_by: "CODER"
+description: "Fix GitHub issues #3872 and #3873 without runner scope: make feedback issue publication safe without mutating workflow config in-session, and harden direct-mode finish/git staging diagnostics/recovery around dirty index and staged state."
+sections:
+  Summary: |-
+    Fix feedback opt-in and direct finish recovery issues
+
+    Fix GitHub issues #3872 and #3873 without runner scope: make feedback issue publication safe without mutating workflow config in-session, and harden direct-mode finish/git staging diagnostics/recovery around dirty index and staged state.
+  Scope: |-
+    - In scope: Fix GitHub issues #3872 and #3873 without runner scope: make feedback issue publication safe without mutating workflow config in-session, and harden direct-mode finish/git staging diagnostics/recovery around dirty index and staged state.
+    - Out of scope: unrelated refactors not required for "Fix feedback opt-in and direct finish recovery issues".
+  Plan: |-
+    1. Reproduce/inspect #3872 feedback opt-in path and #3873 direct finish/git staging path from current code and tests.
+    2. Implement narrow CLI/runtime fixes: feedback issue publication must allow explicit one-shot publication without editing workflow config, and direct finish/git blockers must produce deterministic diagnostics/recovery without corrupting task state.
+    3. Add focused tests for feedback opt-in override/offline behavior and direct finish dirty/staged/lock recovery diagnostics.
+    4. Run targeted Vitest, lint/typecheck/docs freshness as needed, publish PR, wait for GitHub checks, merge to main, close #3872/#3873 only after merged proof.
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-18T12:15:26.551Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Implemented one-shot feedback issue opt-in and direct close-commit preflight hardening. Checks passed: focused insights/error tests, finish validation Vitest, typecheck, docs:cli:check, format:changed, lint:core, task scope, policy routing.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-18T12:05:54.145Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605181205-TFMY22-fix-feedback-finish-recovery/.agentplane/tasks/202605181205-TFMY22/blueprint/resolved-snapshot.json
+    - old_digest: 56ac4fb9dd78574e2bcdd05567c8a53b4a57f099e0ddeff97ae63980bfd9dc13
+    - current_digest: 56ac4fb9dd78574e2bcdd05567c8a53b4a57f099e0ddeff97ae63980bfd9dc13
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605181205-TFMY22
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Fix feedback opt-in and direct finish recovery issues
+
+Fix GitHub issues #3872 and #3873 without runner scope: make feedback issue publication safe without mutating workflow config in-session, and harden direct-mode finish/git staging diagnostics/recovery around dirty index and staged state.
+
+## Scope
+
+- In scope: Fix GitHub issues #3872 and #3873 without runner scope: make feedback issue publication safe without mutating workflow config in-session, and harden direct-mode finish/git staging diagnostics/recovery around dirty index and staged state.
+- Out of scope: unrelated refactors not required for "Fix feedback opt-in and direct finish recovery issues".
+
+## Plan
+
+1. Reproduce/inspect #3872 feedback opt-in path and #3873 direct finish/git staging path from current code and tests.
+2. Implement narrow CLI/runtime fixes: feedback issue publication must allow explicit one-shot publication without editing workflow config, and direct finish/git blockers must produce deterministic diagnostics/recovery without corrupting task state.
+3. Add focused tests for feedback opt-in override/offline behavior and direct finish dirty/staged/lock recovery diagnostics.
+4. Run targeted Vitest, lint/typecheck/docs freshness as needed, publish PR, wait for GitHub checks, merge to main, close #3872/#3873 only after merged proof.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-18T12:15:26.551Z — VERIFY — ok
+
+By: CODER
+
+Note: Implemented one-shot feedback issue opt-in and direct close-commit preflight hardening. Checks passed: focused insights/error tests, finish validation Vitest, typecheck, docs:cli:check, format:changed, lint:core, task scope, policy routing.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-18T12:05:54.145Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605181205-TFMY22-fix-feedback-finish-recovery/.agentplane/tasks/202605181205-TFMY22/blueprint/resolved-snapshot.json
+- old_digest: 56ac4fb9dd78574e2bcdd05567c8a53b4a57f099e0ddeff97ae63980bfd9dc13
+- current_digest: 56ac4fb9dd78574e2bcdd05567c8a53b4a57f099e0ddeff97ae63980bfd9dc13
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605181205-TFMY22
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605181205-TFMY22/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605181205-TFMY22/blueprint/resolved-snapshot.json
@@ -1,0 +1,529 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605181205-TFMY22",
+    "title": "Fix feedback opt-in and direct finish recovery issues",
+    "description": "Fix GitHub issues #3872 and #3873 without runner scope: make feedback issue publication safe without mutating workflow config in-session, and harden direct-mode finish/git staging diagnostics/recovery around dirty index and staged state.",
+    "tags": [
+      "bug",
+      "code",
+      "diagnostics",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605181205-TFMY22",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "56ac4fb9dd78574e2bcdd05567c8a53b4a57f099e0ddeff97ae63980bfd9dc13"
+  }
+}

--- a/.agentplane/tasks/202605181205-TFMY22/pr/diffstat.txt
+++ b/.agentplane/tasks/202605181205-TFMY22/pr/diffstat.txt
@@ -1,0 +1,14 @@
+ .../blueprint/resolved-snapshot.json               | 529 +++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |   7 +
+ docs/user/configuration.mdx                        |   6 +
+ packages/agentplane/src/cli/error-map.test.ts      |   1 +
+ packages/agentplane/src/cli/error-map.ts           |  13 +-
+ packages/agentplane/src/cli/reason-codes.ts        |   2 +-
+ .../src/cli/run-cli.core.insights-report.test.ts   |  46 ++
+ .../src/commands/insights/insights.command.ts      |   8 +-
+ .../src/commands/insights/insights.spec.ts         |  13 +
+ .../agentplane/src/commands/task/finish-execute.ts |  44 +-
+ .../commands/task/finish.close-tail.unit.test.ts   |   1 +
+ .../src/commands/task/finish.state.unit.test.ts    |  81 +++-
+ .../commands/task/finish.validation.unit.test.ts   |   2 +-
+ 13 files changed, 744 insertions(+), 9 deletions(-)

--- a/.agentplane/tasks/202605181205-TFMY22/pr/github-body.md
+++ b/.agentplane/tasks/202605181205-TFMY22/pr/github-body.md
@@ -1,0 +1,52 @@
+Task: `202605181205-TFMY22`
+Title: Fix feedback opt-in and direct finish recovery issues
+Canonical task record: `.agentplane/tasks/202605181205-TFMY22/README.md`
+
+## Summary
+
+Fix feedback opt-in and direct finish recovery issues
+
+Fix GitHub issues #3872 and #3873 without runner scope: make feedback issue publication safe without mutating workflow config in-session, and harden direct-mode finish/git staging diagnostics/recovery around dirty index and staged state.
+
+## Scope
+
+- In scope: Fix GitHub issues #3872 and #3873 without runner scope: make feedback issue publication safe without mutating workflow config in-session, and harden direct-mode finish/git staging diagnostics/recovery around dirty index and staged state.
+- Out of scope: unrelated refactors not required for "Fix feedback opt-in and direct finish recovery issues".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Implemented one-shot feedback issue opt-in and direct close-commit preflight hardening. Checks
+passed: focused insights/error tests, finish validation Vitest, typecheck, docs:cli:check,
+format:changed, lint:core, task scope, policy routing.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-18T12:43:59.196Z
+- Branch: task/202605181205-TFMY22/fix-feedback-finish-recovery
+- Head: 4e7581a1312b
+
+```text
+ .../blueprint/resolved-snapshot.json               | 529 +++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |   7 +
+ docs/user/configuration.mdx                        |   6 +
+ packages/agentplane/src/cli/error-map.test.ts      |   1 +
+ packages/agentplane/src/cli/error-map.ts           |  13 +-
+ packages/agentplane/src/cli/reason-codes.ts        |   2 +-
+ .../src/cli/run-cli.core.insights-report.test.ts   |  46 ++
+ .../src/commands/insights/insights.command.ts      |   8 +-
+ .../src/commands/insights/insights.spec.ts         |  13 +
+ .../agentplane/src/commands/task/finish-execute.ts |  44 +-
+ .../commands/task/finish.close-tail.unit.test.ts   |   1 +
+ .../src/commands/task/finish.state.unit.test.ts    |  81 +++-
+ .../commands/task/finish.validation.unit.test.ts   |   2 +-
+ 13 files changed, 744 insertions(+), 9 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605181205-TFMY22/pr/github-title.txt
+++ b/.agentplane/tasks/202605181205-TFMY22/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 TFMY22 task: Fix feedback opt-in and direct finish recovery issues [202605181205-TFMY22]

--- a/.agentplane/tasks/202605181205-TFMY22/pr/meta.json
+++ b/.agentplane/tasks/202605181205-TFMY22/pr/meta.json
@@ -1,0 +1,17 @@
+{
+  "base": "main",
+  "branch": "task/202605181205-TFMY22/fix-feedback-finish-recovery",
+  "created_at": "2026-05-18T12:05:54.253Z",
+  "head_sha": "4e7581a1312ba4ffb2098026218e9b95a243938a",
+  "last_verified_at": "2026-05-18T12:15:26.551Z",
+  "last_verified_sha": "5afb869b8492c4e44d69484aa3e061dec40b9d5d",
+  "pr_number": 3892,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3892",
+  "schema_version": 1,
+  "status": "OPEN",
+  "task_id": "202605181205-TFMY22",
+  "updated_at": "2026-05-18T12:43:59.196Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605181205-TFMY22/pr/review.md
+++ b/.agentplane/tasks/202605181205-TFMY22/pr/review.md
@@ -1,0 +1,49 @@
+# PR Review
+
+Created: 2026-05-18T12:05:54.253Z
+
+## Task
+
+- Task: `202605181205-TFMY22`
+- Title: Fix feedback opt-in and direct finish recovery issues
+- Status: DOING
+- Branch: `task/202605181205-TFMY22/fix-feedback-finish-recovery`
+- Canonical task record: `.agentplane/tasks/202605181205-TFMY22/README.md`
+
+## Verification
+
+- State: ok
+- Note: Implemented one-shot feedback issue opt-in and direct close-commit preflight hardening. Checks passed: focused insights/error tests, finish validation Vitest, typecheck, docs:cli:check, format:changed, lint:core, task scope, policy routing.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-18T12:43:59.196Z
+- Branch: task/202605181205-TFMY22/fix-feedback-finish-recovery
+- Head: 4e7581a1312b
+
+```text
+ .../blueprint/resolved-snapshot.json               | 529 +++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |   7 +
+ docs/user/configuration.mdx                        |   6 +
+ packages/agentplane/src/cli/error-map.test.ts      |   1 +
+ packages/agentplane/src/cli/error-map.ts           |  13 +-
+ packages/agentplane/src/cli/reason-codes.ts        |   2 +-
+ .../src/cli/run-cli.core.insights-report.test.ts   |  46 ++
+ .../src/commands/insights/insights.command.ts      |   8 +-
+ .../src/commands/insights/insights.spec.ts         |  13 +
+ .../agentplane/src/commands/task/finish-execute.ts |  44 +-
+ .../commands/task/finish.close-tail.unit.test.ts   |   1 +
+ .../src/commands/task/finish.state.unit.test.ts    |  81 +++-
+ .../commands/task/finish.validation.unit.test.ts   |   2 +-
+ 13 files changed, 744 insertions(+), 9 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -2122,6 +2122,7 @@ Options:
 - `--failure-message-class <class>`: Privacy-safe error message class, not the raw error message.
 - `--failure-argv-shape <token>`: Repeatable sanitized argv shape token; values must not include raw secrets. (repeatable)
 - `--transport <github|cloud|auto>`: Issue transport. github uses the user's gh auth, cloud uses anonymous AgentPlane intake, auto falls back to cloud when GitHub publishing fails. (choices=github|cloud|auto)
+- `--allow-disabled-feedback`: Allow this one issue creation when feedback.github_issues.enabled=false without modifying project config. (default=false)
 - `--dry-run`: Print the GitHub issue payload without creating an issue. (default=false)
 
 Examples:
@@ -2137,6 +2138,12 @@ agentplane insights issue --dry-run --error-code E_INTERNAL
 ```
 
 - Preview the privacy-bounded issue payload without network access.
+
+```sh
+agentplane insights issue --allow-disabled-feedback --error-code E_INTERNAL
+```
+
+- Create one issue from an explicitly opted-out project without changing config.
 
 ### insights report
 

--- a/docs/user/configuration.mdx
+++ b/docs/user/configuration.mdx
@@ -143,6 +143,12 @@ To opt in, ask your agent to enable feedback issue prompts or run:
 agentplane config set feedback.github_issues.enabled true
 ```
 
+For a one-shot issue without changing project config, pass an explicit command opt-in:
+
+```bash
+agentplane insights issue --allow-disabled-feedback --error-code E_INTERNAL
+```
+
 To allow anonymous cloud fallback:
 
 ```bash

--- a/packages/agentplane/src/cli/error-map.test.ts
+++ b/packages/agentplane/src/cli/error-map.test.ts
@@ -151,6 +151,7 @@ describe("core error mapping", () => {
     expect(stderr).toContain("privacy-bounded GitHub issue");
     expect(stderr).toContain("agentplane insights issue --error-code E_INTERNAL --dry-run");
     expect(stderr).toContain("feedback.github_issues.enabled true");
+    expect(stderr).toContain("--allow-disabled-feedback");
     expect(stderr).toContain("reason_code: feedback_internal_error_report");
   });
 
@@ -202,5 +203,33 @@ describe("core error mapping", () => {
     expect(stderr).toContain("error [E_INTERNAL]: unexpected invariant");
     expect(stderr).not.toContain("agentplane insights issue");
     expect(stderr).not.toContain("feedback_internal_error_report");
+  });
+
+  it("suggests an executable one-shot command when feedback issue creation is disabled", () => {
+    let stderr = "";
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderr += String(chunk);
+      return true;
+    });
+
+    try {
+      writeError(
+        new CliError({
+          code: "E_USAGE",
+          message: "Feedback GitHub issues are disabled.",
+          context: {
+            command: "insights issue",
+            reason_code: "feedback_github_issues_disabled",
+          },
+        }),
+        false,
+      );
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(stderr).toContain(
+      "agentplane insights issue --allow-disabled-feedback --allow-missing-agent-context --error-code E_INTERNAL",
+    );
   });
 });

--- a/packages/agentplane/src/cli/error-map.ts
+++ b/packages/agentplane/src/cli/error-map.ts
@@ -173,12 +173,24 @@ function resolveErrorGuidance(err: CliError): ErrorGuidance {
         nextAction: {
           command: "agentplane insights issue --error-code E_INTERNAL --dry-run",
           reason:
-            "preview the GitHub issue payload; enable with `agentplane config set feedback.github_issues.enabled true` before creating it",
+            "preview the GitHub issue payload; enable with `agentplane config set feedback.github_issues.enabled true` before creating it, or pass `--allow-disabled-feedback` for one issue only",
           reasonCode: "feedback_internal_error_report",
         },
       });
     }
     case "E_USAGE": {
+      if (reasonCode === "feedback_github_issues_disabled") {
+        return withExplicit({
+          hint: "Feedback GitHub issue creation requires either project opt-in or an explicit one-shot command opt-in.",
+          nextAction: {
+            command:
+              "agentplane insights issue --allow-disabled-feedback --allow-missing-agent-context --error-code E_INTERNAL",
+            reason:
+              "create one privacy-bounded issue without changing feedback.github_issues.enabled",
+            reasonCode,
+          },
+        });
+      }
       if (reasonCode === "sync_backend_mismatch") {
         return withExplicit({
           hint: "Configured backend id mismatch. Check active backend and retry with a matching id.",

--- a/packages/agentplane/src/cli/reason-codes.ts
+++ b/packages/agentplane/src/cli/reason-codes.ts
@@ -86,7 +86,7 @@ const REASON_CODE_MAP: Readonly<Record<string, ReasonCodeMeta>> = {
     code: "git_close_commit_dirty_index",
     category: "git",
     summary: "close commit cannot proceed while unrelated paths are already staged",
-    action: "clear the git index and rerun the close commit flow",
+    action: "clear the git index or rerun the close commit flow with an explicit unstage option",
   },
   git_pre_commit_format: {
     code: "git_pre_commit_format",

--- a/packages/agentplane/src/cli/run-cli.core.insights-report.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.insights-report.test.ts
@@ -1,5 +1,6 @@
 import { describe, vi } from "vitest";
 import { defaultConfig } from "@agentplaneorg/core/config";
+import { readFile } from "node:fs/promises";
 
 import {
   captureStdIO,
@@ -284,9 +285,54 @@ describe("runCli insights report", () => {
       expect(code).toBe(2);
       expect(io.stderr).toContain("Feedback GitHub issues are disabled");
       expect(io.stderr).toContain("feedback.github_issues.enabled true");
+      expect(io.stderr).toContain("--allow-disabled-feedback");
       expect(io.stderr).toContain("reason_code: feedback_github_issues_disabled");
     } finally {
       io.restore();
+    }
+  });
+
+  it("allows one-shot feedback issue creation without changing disabled project config", async () => {
+    const root = await mkGitRepoRoot();
+    const config = defaultConfig();
+    config.feedback.github_issues.enabled = false;
+    config.feedback.github_issues.transport = "cloud";
+    config.feedback.github_issues.allow_anonymous_cloud = true;
+    config.feedback.github_issues.cloud_endpoint = "https://cloud.example/api/feedback/issues";
+    await writeConfig(root, config);
+
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn(() => Response.json({ intake_id: "fb_override", status: "accepted" }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const io = captureStdIO();
+    try {
+      const code = await runCli([
+        "insights",
+        "issue",
+        "--allow-disabled-feedback",
+        "--error-code",
+        "E_INTERNAL",
+        "--agent-context",
+        "Intent: test one-shot feedback issue creation. Sensitive data omitted: task prose, env, remotes, and raw output.",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(0);
+      expect(io.stdout).toContain("feedback issue created");
+      expect(io.stdout).toContain("intake:fb_override");
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const request = fetchMock.mock.calls[0]?.[1] as { body?: string } | undefined;
+      const body = JSON.parse(String(request?.body ?? "{}")) as {
+        failure?: { error_code?: string | null };
+      };
+      expect(body.failure?.error_code).toBe("E_INTERNAL");
+      const configText = await readFile(path.join(root, ".agentplane", "WORKFLOW.md"), "utf8");
+      expect(configText).toContain("feedback:");
+      expect(configText).toContain("  github_issues:");
+      expect(configText).toContain("    enabled: false");
+    } finally {
+      io.restore();
+      globalThis.fetch = originalFetch;
     }
   });
 

--- a/packages/agentplane/src/commands/insights/insights.command.ts
+++ b/packages/agentplane/src/commands/insights/insights.command.ts
@@ -477,12 +477,14 @@ export function makeRunInsightsIssueHandler(deps: RunDeps): CommandHandler<Insig
       ]);
       const settings = (loaded.config.feedback as { github_issues: FeedbackGithubIssuesSettings })
         .github_issues;
-      if (!settings.enabled && !parsed.dryRun) {
+      if (!settings.enabled && !parsed.dryRun && !parsed.allowDisabledFeedback) {
         throw new CliError({
           exitCode: exitCodeForError("E_USAGE"),
           code: "E_USAGE",
-          message:
-            "Feedback GitHub issues are disabled. Enable with `agentplane config set feedback.github_issues.enabled true`, then retry.",
+          message: [
+            "Feedback GitHub issues are disabled.",
+            "Fix: enable with `agentplane config set feedback.github_issues.enabled true`, or pass `--allow-disabled-feedback` for this issue only.",
+          ].join("\n"),
           context: {
             command: "insights issue",
             reason_code: "feedback_github_issues_disabled",

--- a/packages/agentplane/src/commands/insights/insights.spec.ts
+++ b/packages/agentplane/src/commands/insights/insights.spec.ts
@@ -19,6 +19,7 @@ export type InsightsIssueParsed = {
   failureMessageClass?: string;
   failureArgvShape: string[];
   transport?: "github" | "cloud" | "auto";
+  allowDisabledFeedback: boolean;
   dryRun: boolean;
 };
 
@@ -167,6 +168,13 @@ export const insightsIssueSpec: CommandSpec<InsightsIssueParsed> = {
     },
     {
       kind: "boolean",
+      name: "allow-disabled-feedback",
+      default: false,
+      description:
+        "Allow this one issue creation when feedback.github_issues.enabled=false without modifying project config.",
+    },
+    {
+      kind: "boolean",
       name: "dry-run",
       default: false,
       description: "Print the GitHub issue payload without creating an issue.",
@@ -180,6 +188,10 @@ export const insightsIssueSpec: CommandSpec<InsightsIssueParsed> = {
     {
       cmd: "agentplane insights issue --dry-run --error-code E_INTERNAL",
       why: "Preview the privacy-bounded issue payload without network access.",
+    },
+    {
+      cmd: "agentplane insights issue --allow-disabled-feedback --error-code E_INTERNAL",
+      why: "Create one issue from an explicitly opted-out project without changing config.",
     },
   ],
   parse: (raw) => ({
@@ -197,6 +209,7 @@ export const insightsIssueSpec: CommandSpec<InsightsIssueParsed> = {
       ? (raw.opts["failure-argv-shape"] as string[])
       : [],
     transport: raw.opts.transport as InsightsIssueParsed["transport"],
+    allowDisabledFeedback: raw.opts["allow-disabled-feedback"] === true,
     dryRun: raw.opts["dry-run"] === true,
   }),
 };

--- a/packages/agentplane/src/commands/task/finish-execute.ts
+++ b/packages/agentplane/src/commands/task/finish-execute.ts
@@ -29,6 +29,11 @@ import {
   runTaskTransitionCommentCommit,
 } from "./shared.js";
 import type { FinishExecutionPlan, FinishOptions } from "./finish-types.js";
+import { exitCodeForError } from "../../cli/exit-codes.js";
+import {
+  gitMutationDiagnosticContext,
+  resolveGitIndexLockInfo,
+} from "../../shared/git-mutation.js";
 
 export async function executeFinishPlan(opts: {
   ctx: CommandContext;
@@ -403,7 +408,33 @@ async function assertCloseCommitCanMutateTaskState(opts: {
 }): Promise<void> {
   const { ctx, options, plan } = opts;
   if (!plan.shouldCloseCommit) return;
-  if (ctx.config.workflow_mode !== "branch_pr") return;
+
+  const taskId = plan.primaryTaskId ?? options.taskIds[0];
+  const lockInfo = await resolveGitIndexLockInfo({ repoRoot: ctx.resolvedProject.gitRoot });
+  if (lockInfo) {
+    throw new CliError({
+      exitCode: exitCodeForError("E_GIT_LOCKED"),
+      code: "E_GIT_LOCKED",
+      message: [
+        "finish close commit cannot proceed while a Git index lock file exists.",
+        "Why: close commit creation would fail after the task is marked DONE.",
+        "Fix: inspect the active git process or run `agentplane doctor git-locks` before rerunning finish.",
+        `Lock: ${lockInfo.lockPath}`,
+      ].join("\n"),
+      context: gitMutationDiagnosticContext({
+        command: "finish",
+        cwd: options.cwd,
+        repoRoot: ctx.resolvedProject.gitRoot,
+        gitDir: lockInfo.gitDir,
+        workflowMode: ctx.config.workflow_mode,
+        mutationKind: "close_tail",
+        taskId,
+        indexLockPath: lockInfo.lockPath,
+        indexLockAgeMs: lockInfo.ageMs,
+        remediation: "Inspect or clear the git index lock before rerunning finish.",
+      }),
+    });
+  }
 
   const staged = await ctx.git.statusStagedPaths();
   if (staged.length > 0 && options.closeUnstageOthers !== true) {
@@ -413,11 +444,20 @@ async function assertCloseCommitCanMutateTaskState(opts: {
       message: [
         "finish --close-commit cannot proceed with a non-empty index.",
         "Why: close commit creation would fail after the task is marked DONE.",
-        "Fix: clear the index or rerun with --close-unstage-others.",
+        `Staged paths: ${staged.slice(0, 12).join(", ")}${staged.length > 12 ? ` (+${staged.length - 12} more)` : ""}`,
+        "Fix: commit or unstage unrelated paths before rerunning finish, or pass --close-unstage-others to let finish unstage non-task paths first.",
         "Safe command: git status --short --untracked-files=no",
       ].join("\n"),
+      context: {
+        command: "finish",
+        task_id: taskId,
+        reason_code: "git_close_commit_dirty_index",
+        staged_paths: staged,
+      },
     });
   }
+
+  if (ctx.config.workflow_mode !== "branch_pr") return;
 
   const unstaged = await ctx.git.statusUnstagedTrackedPaths();
   if (unstaged.length === 0) return;

--- a/packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts
+++ b/packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts
@@ -58,6 +58,7 @@ vi.mock("@agentplaneorg/core/git", async () => {
   return {
     ...actual,
     gitEnv: () => ({}),
+    gitRevParse: vi.fn().mockResolvedValue(".git"),
     resolveBaseBranch: mocks.resolveBaseBranch,
   };
 });

--- a/packages/agentplane/src/commands/task/finish.state.unit.test.ts
+++ b/packages/agentplane/src/commands/task/finish.state.unit.test.ts
@@ -25,6 +25,7 @@ function makeMocks() {
     execFileAsync: vi.fn(),
     gitBranchExists: vi.fn(),
     gitCurrentBranch: vi.fn(),
+    resolveGitIndexLockInfo: vi.fn(),
   };
 }
 
@@ -56,6 +57,17 @@ vi.mock("../shared/git-ops.js", () => ({
 vi.mock("@agentplaneorg/core/process", () => ({
   execFileAsync: mocks.execFileAsync,
 }));
+vi.mock("../../shared/git-mutation.js", async (importOriginal?: () => Promise<unknown>) => {
+  const actualUnknown: unknown = typeof importOriginal === "function" ? await importOriginal() : {};
+  const actual =
+    actualUnknown && typeof actualUnknown === "object"
+      ? (actualUnknown as Record<string, unknown>)
+      : {};
+  return {
+    ...actual,
+    resolveGitIndexLockInfo: mocks.resolveGitIndexLockInfo,
+  };
+});
 vi.mock("@agentplaneorg/core/git", async () => {
   const actualUnknown: unknown =
     typeof (vi as unknown as { importActual?: unknown }).importActual === "function"
@@ -171,7 +183,12 @@ function mkCtx(overrides?: Partial<CommandContext>): CommandContext {
     taskBackend: backend,
     backendId: "mock",
     backendConfigPath: "/repo/.agentplane/backends/local/backend.json",
-    git: new GitContext({ gitRoot: "/repo" }),
+    git: {
+      ...new GitContext({ gitRoot: "/repo" }),
+      statusStagedPaths: vi.fn().mockResolvedValue([]),
+      statusUnstagedTrackedPaths: vi.fn().mockResolvedValue([]),
+      invalidateStatus: vi.fn(),
+    } as unknown as CommandContext["git"],
     memo: {},
     resolved,
     backend,
@@ -229,6 +246,7 @@ describeCompatible("task finish state and errors", () => {
     mocks.execFileAsync.mockReset();
     mocks.gitBranchExists.mockReset();
     mocks.gitCurrentBranch.mockReset();
+    mocks.resolveGitIndexLockInfo.mockReset();
 
     mocks.backendIsLocalFileBackend.mockReturnValue(false);
     mocks.readCommitInfo.mockResolvedValue({ hash: "hc", message: "mc" });
@@ -243,6 +261,7 @@ describeCompatible("task finish state and errors", () => {
     });
     mocks.gitBranchExists.mockResolvedValue(false);
     mocks.gitCurrentBranch.mockResolvedValue("main");
+    mocks.resolveGitIndexLockInfo.mockResolvedValue(null);
     mocks.commitFromComment.mockResolvedValue({
       hash: "new-hash",
       message: "✅ T-1 task: verified",
@@ -293,6 +312,66 @@ describeCompatible("task finish state and errors", () => {
         quiet: true,
       }),
     ).rejects.toMatchObject({ code: "E_USAGE" });
+  });
+
+  it("rejects direct close commit before mutating task state when the index is staged", async () => {
+    const task = mkTask({
+      id: "T-1",
+      status: "DOING",
+      tags: ["docs"],
+      commit: { hash: "impl-hash", message: "feat: implement T-1" },
+    });
+    const storeMutate = vi.fn((id: string, mutate: (task: TaskData) => TaskStorePatch[]) => {
+      const patches = mutate(task);
+      for (const patch of patches) Object.assign(task, applyStorePatch(task, patch));
+      return { changed: patches.length > 0, task };
+    });
+    const store = { mutate: storeMutate };
+    mocks.backendIsLocalFileBackend.mockReturnValue(true);
+    mocks.getTaskStore.mockReturnValue(store);
+    mocks.loadTaskFromContext.mockResolvedValue(task);
+    const ctx = mkCtx();
+    ctx.config.workflow_mode = "direct";
+    ctx.git = {
+      statusStagedPaths: vi.fn().mockResolvedValue([".agentplane/tasks/T-2/README.md"]),
+      statusUnstagedTrackedPaths: vi.fn().mockResolvedValue([]),
+      invalidateStatus: vi.fn(),
+    } as unknown as CommandContext["git"];
+
+    const { cmdFinish } = await import("./finish-command.js");
+    await expect(
+      cmdFinish({
+        ctx,
+        cwd: "/repo",
+        taskIds: ["T-1"],
+        author: "A",
+        body: "Verified: direct finish should reject staged index before task mutation.",
+        result: "done",
+        breaking: false,
+        force: false,
+        commitFromComment: false,
+        commitAllow: [],
+        commitAutoAllow: false,
+        commitAllowTasks: false,
+        commitRequireClean: false,
+        statusCommit: false,
+        statusCommitAllow: [],
+        statusCommitAutoAllow: false,
+        statusCommitRequireClean: false,
+        confirmStatusCommit: false,
+        quiet: true,
+      }),
+    ).rejects.toMatchObject({
+      code: "E_GIT",
+      context: {
+        reason_code: "git_close_commit_dirty_index",
+        staged_paths: [".agentplane/tasks/T-2/README.md"],
+      },
+    });
+
+    expect(storeMutate).toHaveBeenCalledTimes(1);
+    expect(task.status).toBe("DOING");
+    expect(mocks.cmdCommit).not.toHaveBeenCalled();
   });
 
   it("preserves fresher README content and comments when store update sees newer task data", async () => {

--- a/packages/agentplane/src/commands/task/finish.validation.unit.test.ts
+++ b/packages/agentplane/src/commands/task/finish.validation.unit.test.ts
@@ -2,7 +2,6 @@ import type { ResolvedProject } from "@agentplaneorg/core/project";
 import { defaultConfig } from "@agentplaneorg/core/config";
 import { ensureDocSections, setMarkdownSection } from "@agentplaneorg/core/tasks";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
 import type { TaskBackend, TaskData } from "../../backends/task-backend.js";
 import type { CommandContext } from "../shared/task-backend.js";
 import { GitContext } from "@agentplaneorg/core/git";
@@ -68,6 +67,7 @@ vi.mock("@agentplaneorg/core/git", async () => {
   return {
     ...actual,
     gitEnv: () => ({}),
+    gitRevParse: vi.fn().mockResolvedValue(".git"),
     resolveBaseBranch: mocks.resolveBaseBranch,
   };
 });


### PR DESCRIPTION
Task: `202605181205-TFMY22`
Title: Fix feedback opt-in and direct finish recovery issues
Canonical task record: `.agentplane/tasks/202605181205-TFMY22/README.md`

## Summary

Fix feedback opt-in and direct finish recovery issues

Fix GitHub issues #3872 and #3873 without runner scope: make feedback issue publication safe without mutating workflow config in-session, and harden direct-mode finish/git staging diagnostics/recovery around dirty index and staged state.

## Scope

- In scope: Fix GitHub issues #3872 and #3873 without runner scope: make feedback issue publication safe without mutating workflow config in-session, and harden direct-mode finish/git staging diagnostics/recovery around dirty index and staged state.
- Out of scope: unrelated refactors not required for "Fix feedback opt-in and direct finish recovery issues".

## Verification

- State: ok
- Note:

```text
Implemented one-shot feedback issue opt-in and direct close-commit preflight hardening. Checks
passed: focused insights/error tests, finish validation Vitest, typecheck, docs:cli:check,
format:changed, lint:core, task scope, policy routing.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-18T12:16:28.027Z
- Branch: task/202605181205-TFMY22/fix-feedback-finish-recovery
- Head: e928d7bd24a0

```text
 .../blueprint/resolved-snapshot.json               | 529 +++++++++++++++++++++
 docs/user/cli-reference.generated.mdx              |   7 +
 docs/user/configuration.mdx                        |   6 +
 packages/agentplane/src/cli/error-map.test.ts      |   1 +
 packages/agentplane/src/cli/error-map.ts           |  13 +-
 packages/agentplane/src/cli/reason-codes.ts        |   2 +-
 .../src/cli/run-cli.core.insights-report.test.ts   |  46 ++
 .../src/commands/insights/insights.command.ts      |   8 +-
 .../src/commands/insights/insights.spec.ts         |  13 +
 .../agentplane/src/commands/task/finish-execute.ts |  44 +-
 .../commands/task/finish.validation.unit.test.ts   |  78 +++
 11 files changed, 740 insertions(+), 7 deletions(-)
```

</details>
