### PR TITLE
🚧 C5AXQ6 task: Improve context recall boundaries [202605191428-C5AXQ6]

### DIFF
--- a/.agentplane/policy/context.must.md
+++ b/.agentplane/policy/context.must.md
@@ -4,7 +4,7 @@
 
 Use this module when a task reads, writes, learns, curates, verifies, or relies on AgentPlane local context.
 
-Local context means `context/wiki/**`, `context/facts/**`, `context/graph/**`, `context/capabilities/**`, `context/raw/**`, and `.agentplane/context/**`.
+Local context means `context/wiki/**`, `context/capabilities/**`, `context/raw/**`, `.agentplane/context/derived/facts/**`, `.agentplane/context/derived/graph/**`, `.agentplane/context/derived/capabilities/**`, and `.agentplane/context/**`.
 
 <!-- /ap:fragment -->
 <!-- ap:fragment id="policy.context.must.hard_constraint.source.first" slot="hard_constraint" mutability="append_only" -->
@@ -27,6 +27,8 @@ ap context search "<query>"
 ap context show <ref>
 ap context learn changes
 ap context learn files <path> [--run]
+ap context ingest --changed|--all|--index-only
+ap context reindex --include-raw
 ap context wiki lint <path>
 ap context wiki explain <path>
 ap context wiki link <path>
@@ -37,7 +39,7 @@ ap context verify-task <task-id>
 ```
 
 - Use `search` for discovery and `show` for exact source readback.
-- Use `learn` to create context assimilation tasks instead of ad hoc memory writes.
+- Use `learn` to create human-facing context assimilation tasks instead of ad hoc memory writes; use `ingest`/`reindex` for lower-level agent and automation pipelines.
 - Use wiki lint/explain/link/index when adding or changing wiki pages.
 - Run `verify-task` before closing tasks that create or rely on context artifacts.
 

--- a/.agentplane/tasks/202605191428-C5AXQ6/README.md
+++ b/.agentplane/tasks/202605191428-C5AXQ6/README.md
@@ -4,7 +4,7 @@ title: "Improve context recall boundaries"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 8
+revision: 9
 origin:
   system: "manual"
 depends_on: []
@@ -19,10 +19,21 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-19T15:38:54.894Z"
-  updated_by: "CODER"
-  note: "Post-rebase verification refreshed on top of origin/main c4b8430f3. Checks rerun after rebase: bun test packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests; bun run agents:check => pass; node .agentplane/policy/check-routing.mjs => pass."
+  updated_at: "2026-05-19T15:51:12.528Z"
+  updated_by: "EVALUATOR"
+  note: "Resolved PR review blocker: fallback context search now filters discovered files through scope path rules, excluding context/raw/private for raw/all scopes. Verification: bun test packages/agentplane/src/commands/context/release-readiness.test.ts --timeout 120000; bunx eslint packages/agentplane/src/context/context-utils.ts packages/agentplane/src/commands/context/release-readiness.test.ts; bunx prettier --check packages/agentplane/src/context/context-utils.ts packages/agentplane/src/commands/context/release-readiness.test.ts; node .agentplane/policy/check-routing.mjs."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-19T15:51:12.528Z"
+  updated_by: "EVALUATOR"
+  note: "Resolved PR review blocker: fallback context search now filters discovered files through scope path rules, excluding context/raw/private for raw/all scopes. Verification: bun test packages/agentplane/src/commands/context/release-readiness.test.ts --timeout 120000; bunx eslint packages/agentplane/src/context/context-utils.ts packages/agentplane/src/commands/context/release-readiness.test.ts; bunx prettier --check packages/agentplane/src/context/context-utils.ts packages/agentplane/src/commands/context/release-readiness.test.ts; node .agentplane/policy/check-routing.mjs."
+  evaluated_sha: "5f0088c288e39fa35b58c4bf63c507f6ef3d3a17"
+  blueprint_digest: "cb9ae9fec21885fb858fa3145f79006624675d400b36c2be32ea44d616e9cbd9"
+  evidence_refs:
+    - ".agentplane/tasks/202605191428-C5AXQ6/README.md"
+    - "/Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191428-C5AXQ6-context-recall-boundaries/.agentplane/tasks/202605191428-C5AXQ6/blueprint/resolved-snapshot.json"
+  findings: []
 commit: null
 comments:
   -
@@ -54,8 +65,14 @@ events:
     author: "CODER"
     state: "ok"
     note: "Post-rebase verification refreshed on top of origin/main c4b8430f3. Checks rerun after rebase: bun test packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests; bun run agents:check => pass; node .agentplane/policy/check-routing.mjs => pass."
+  -
+    type: "verify"
+    at: "2026-05-19T15:51:12.528Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Resolved PR review blocker: fallback context search now filters discovered files through scope path rules, excluding context/raw/private for raw/all scopes. Verification: bun test packages/agentplane/src/commands/context/release-readiness.test.ts --timeout 120000; bunx eslint packages/agentplane/src/context/context-utils.ts packages/agentplane/src/commands/context/release-readiness.test.ts; bunx prettier --check packages/agentplane/src/context/context-utils.ts packages/agentplane/src/commands/context/release-readiness.test.ts; node .agentplane/policy/check-routing.mjs."
 doc_version: 3
-doc_updated_at: "2026-05-19T15:38:55.013Z"
+doc_updated_at: "2026-05-19T15:51:12.608Z"
 doc_updated_by: "CODER"
 description: "Make local context search prefer curated context by default, align context policy module references with actual derived paths and blueprint loading, and verify the context command behavior."
 sections:
@@ -121,6 +138,25 @@ sections:
     Attempts: 0
 
     VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:43:27.853Z, excerpt_hash=sha256:3d0702eb3f1603903ee3a55584030772bf0ce80cc7678484062b17ba871886e1
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191428-C5AXQ6-context-recall-boundaries/.agentplane/tasks/202605191428-C5AXQ6/blueprint/resolved-snapshot.json
+    - old_digest: cb9ae9fec21885fb858fa3145f79006624675d400b36c2be32ea44d616e9cbd9
+    - current_digest: cb9ae9fec21885fb858fa3145f79006624675d400b36c2be32ea44d616e9cbd9
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605191428-C5AXQ6
+
+    ### 2026-05-19T15:51:12.528Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Resolved PR review blocker: fallback context search now filters discovered files through scope path rules, excluding context/raw/private for raw/all scopes. Verification: bun test packages/agentplane/src/commands/context/release-readiness.test.ts --timeout 120000; bunx eslint packages/agentplane/src/context/context-utils.ts packages/agentplane/src/commands/context/release-readiness.test.ts; bunx prettier --check packages/agentplane/src/context/context-utils.ts packages/agentplane/src/commands/context/release-readiness.test.ts; node .agentplane/policy/check-routing.mjs.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T15:38:55.013Z, excerpt_hash=sha256:3d0702eb3f1603903ee3a55584030772bf0ce80cc7678484062b17ba871886e1
 
     Details:
 
@@ -211,6 +247,25 @@ Note: Post-rebase verification refreshed on top of origin/main c4b8430f3. Checks
 Attempts: 0
 
 VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:43:27.853Z, excerpt_hash=sha256:3d0702eb3f1603903ee3a55584030772bf0ce80cc7678484062b17ba871886e1
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191428-C5AXQ6-context-recall-boundaries/.agentplane/tasks/202605191428-C5AXQ6/blueprint/resolved-snapshot.json
+- old_digest: cb9ae9fec21885fb858fa3145f79006624675d400b36c2be32ea44d616e9cbd9
+- current_digest: cb9ae9fec21885fb858fa3145f79006624675d400b36c2be32ea44d616e9cbd9
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605191428-C5AXQ6
+
+### 2026-05-19T15:51:12.528Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Resolved PR review blocker: fallback context search now filters discovered files through scope path rules, excluding context/raw/private for raw/all scopes. Verification: bun test packages/agentplane/src/commands/context/release-readiness.test.ts --timeout 120000; bunx eslint packages/agentplane/src/context/context-utils.ts packages/agentplane/src/commands/context/release-readiness.test.ts; bunx prettier --check packages/agentplane/src/context/context-utils.ts packages/agentplane/src/commands/context/release-readiness.test.ts; node .agentplane/policy/check-routing.mjs.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T15:38:55.013Z, excerpt_hash=sha256:3d0702eb3f1603903ee3a55584030772bf0ce80cc7678484062b17ba871886e1
 
 Details:
 

--- a/.agentplane/tasks/202605191428-C5AXQ6/README.md
+++ b/.agentplane/tasks/202605191428-C5AXQ6/README.md
@@ -1,0 +1,144 @@
+---
+id: "202605191428-C5AXQ6"
+title: "Improve context recall boundaries"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "context"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-19T14:29:31.423Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-19T14:41:29.496Z"
+  updated_by: "CODER"
+  note: "Verified context recall boundary fix. Commands: bun test packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests and 8 snapshots; bunx eslint touched context/search/blueprint files => pass; bunx prettier --check touched docs/source files => pass; bun run --filter=agentplane build => pass; bun run docs:cli:check => pass; node .agentplane/policy/check-routing.mjs => pass; ap context reindex --include-raw => pass rows=16 files=21; ap context check => pass; ap context doctor => pass after serialized re-run; ap doctor => OK; git diff --check => pass. Manual smoke: default context search excludes task history, --scope tasks returns task records."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implementing approved context recall boundary fixes in the task worktree, limited to context search behavior, context policy wording, blueprint policy metadata, docs/help tests, and focused verification."
+events:
+  -
+    type: "status"
+    at: "2026-05-19T14:30:15.052Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implementing approved context recall boundary fixes in the task worktree, limited to context search behavior, context policy wording, blueprint policy metadata, docs/help tests, and focused verification."
+  -
+    type: "verify"
+    at: "2026-05-19T14:41:29.496Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified context recall boundary fix. Commands: bun test packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests and 8 snapshots; bunx eslint touched context/search/blueprint files => pass; bunx prettier --check touched docs/source files => pass; bun run --filter=agentplane build => pass; bun run docs:cli:check => pass; node .agentplane/policy/check-routing.mjs => pass; ap context reindex --include-raw => pass rows=16 files=21; ap context check => pass; ap context doctor => pass after serialized re-run; ap doctor => OK; git diff --check => pass. Manual smoke: default context search excludes task history, --scope tasks returns task records."
+doc_version: 3
+doc_updated_at: "2026-05-19T14:41:29.551Z"
+doc_updated_by: "CODER"
+description: "Make local context search prefer curated context by default, align context policy module references with actual derived paths and blueprint loading, and verify the context command behavior."
+sections:
+  Summary: |-
+    Improve context recall boundaries
+
+    Make local context search prefer curated context by default, align context policy module references with actual derived paths and blueprint loading, and verify the context command behavior.
+  Scope: |-
+    - In scope: Make local context search prefer curated context by default, align context policy module references with actual derived paths and blueprint loading, and verify the context command behavior.
+    - Out of scope: unrelated refactors not required for "Improve context recall boundaries".
+  Plan: "Scope: improve context recall boundaries without broad context ingestion. Steps: (1) adjust context search defaults/scopes so curated context surfaces are searched by default and task history is opt-in, preserving explicit scope support; (2) align context.must local-context path wording and command contract with current derived layout and ingest/reindex routes; (3) include context.must in context assimilation blueprints so blueprint policy metadata matches gateway routing; (4) update CLI help/docs/tests for the new search behavior; (5) verify with focused context tests, policy routing, ap context doctor/check, and task verification."
+  Verify Steps: |-
+    1. Run focused context release-readiness tests. Expected: search scope regression and context guards pass.
+    2. Run CLI help snapshot tests without updating snapshots. Expected: help output matches committed snapshots.
+    3. Run package build and docs CLI freshness check. Expected: generated command reference is current.
+    4. Run policy routing and context health checks. Expected: routing, ap context doctor, and ap context check pass.
+    5. Run task verification contract. Expected: ap task verify-show succeeds and verification is recorded.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-19T14:41:29.496Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified context recall boundary fix. Commands: bun test packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests and 8 snapshots; bunx eslint touched context/search/blueprint files => pass; bunx prettier --check touched docs/source files => pass; bun run --filter=agentplane build => pass; bun run docs:cli:check => pass; node .agentplane/policy/check-routing.mjs => pass; ap context reindex --include-raw => pass rows=16 files=21; ap context check => pass; ap context doctor => pass after serialized re-run; ap doctor => OK; git diff --check => pass. Manual smoke: default context search excludes task history, --scope tasks returns task records.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:35:19.647Z, excerpt_hash=sha256:3d0702eb3f1603903ee3a55584030772bf0ce80cc7678484062b17ba871886e1
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191428-C5AXQ6-context-recall-boundaries/.agentplane/tasks/202605191428-C5AXQ6/blueprint/resolved-snapshot.json
+    - old_digest: cb9ae9fec21885fb858fa3145f79006624675d400b36c2be32ea44d616e9cbd9
+    - current_digest: cb9ae9fec21885fb858fa3145f79006624675d400b36c2be32ea44d616e9cbd9
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605191428-C5AXQ6
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Improve context recall boundaries
+
+Make local context search prefer curated context by default, align context policy module references with actual derived paths and blueprint loading, and verify the context command behavior.
+
+## Scope
+
+- In scope: Make local context search prefer curated context by default, align context policy module references with actual derived paths and blueprint loading, and verify the context command behavior.
+- Out of scope: unrelated refactors not required for "Improve context recall boundaries".
+
+## Plan
+
+Scope: improve context recall boundaries without broad context ingestion. Steps: (1) adjust context search defaults/scopes so curated context surfaces are searched by default and task history is opt-in, preserving explicit scope support; (2) align context.must local-context path wording and command contract with current derived layout and ingest/reindex routes; (3) include context.must in context assimilation blueprints so blueprint policy metadata matches gateway routing; (4) update CLI help/docs/tests for the new search behavior; (5) verify with focused context tests, policy routing, ap context doctor/check, and task verification.
+
+## Verify Steps
+
+1. Run focused context release-readiness tests. Expected: search scope regression and context guards pass.
+2. Run CLI help snapshot tests without updating snapshots. Expected: help output matches committed snapshots.
+3. Run package build and docs CLI freshness check. Expected: generated command reference is current.
+4. Run policy routing and context health checks. Expected: routing, ap context doctor, and ap context check pass.
+5. Run task verification contract. Expected: ap task verify-show succeeds and verification is recorded.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-19T14:41:29.496Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified context recall boundary fix. Commands: bun test packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests and 8 snapshots; bunx eslint touched context/search/blueprint files => pass; bunx prettier --check touched docs/source files => pass; bun run --filter=agentplane build => pass; bun run docs:cli:check => pass; node .agentplane/policy/check-routing.mjs => pass; ap context reindex --include-raw => pass rows=16 files=21; ap context check => pass; ap context doctor => pass after serialized re-run; ap doctor => OK; git diff --check => pass. Manual smoke: default context search excludes task history, --scope tasks returns task records.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:35:19.647Z, excerpt_hash=sha256:3d0702eb3f1603903ee3a55584030772bf0ce80cc7678484062b17ba871886e1
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191428-C5AXQ6-context-recall-boundaries/.agentplane/tasks/202605191428-C5AXQ6/blueprint/resolved-snapshot.json
+- old_digest: cb9ae9fec21885fb858fa3145f79006624675d400b36c2be32ea44d616e9cbd9
+- current_digest: cb9ae9fec21885fb858fa3145f79006624675d400b36c2be32ea44d616e9cbd9
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605191428-C5AXQ6
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605191428-C5AXQ6/README.md
+++ b/.agentplane/tasks/202605191428-C5AXQ6/README.md
@@ -4,7 +4,7 @@ title: "Improve context recall boundaries"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 7
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -19,9 +19,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-19T14:43:27.728Z"
+  updated_at: "2026-05-19T15:38:54.894Z"
   updated_by: "CODER"
-  note: "Post-commit verification refreshed for implementation commit c74d8af24. Previously recorded checks remain valid for this diff: focused context/search tests, help snapshots, lint, formatting, package build, docs CLI freshness, policy routing, context reindex/check/doctor, ap doctor, git diff --check, and manual search smoke passed."
+  note: "Post-rebase verification refreshed on top of origin/main c4b8430f3. Checks rerun after rebase: bun test packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests; bun run agents:check => pass; node .agentplane/policy/check-routing.mjs => pass."
   attempts: 0
 commit: null
 comments:
@@ -48,8 +48,14 @@ events:
     author: "CODER"
     state: "ok"
     note: "Post-commit verification refreshed for implementation commit c74d8af24. Previously recorded checks remain valid for this diff: focused context/search tests, help snapshots, lint, formatting, package build, docs CLI freshness, policy routing, context reindex/check/doctor, ap doctor, git diff --check, and manual search smoke passed."
+  -
+    type: "verify"
+    at: "2026-05-19T15:38:54.894Z"
+    author: "CODER"
+    state: "ok"
+    note: "Post-rebase verification refreshed on top of origin/main c4b8430f3. Checks rerun after rebase: bun test packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests; bun run agents:check => pass; node .agentplane/policy/check-routing.mjs => pass."
 doc_version: 3
-doc_updated_at: "2026-05-19T14:43:27.853Z"
+doc_updated_at: "2026-05-19T15:38:55.013Z"
 doc_updated_by: "CODER"
 description: "Make local context search prefer curated context by default, align context policy module references with actual derived paths and blueprint loading, and verify the context command behavior."
 sections:
@@ -96,6 +102,25 @@ sections:
     Attempts: 0
 
     VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:41:29.551Z, excerpt_hash=sha256:3d0702eb3f1603903ee3a55584030772bf0ce80cc7678484062b17ba871886e1
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191428-C5AXQ6-context-recall-boundaries/.agentplane/tasks/202605191428-C5AXQ6/blueprint/resolved-snapshot.json
+    - old_digest: cb9ae9fec21885fb858fa3145f79006624675d400b36c2be32ea44d616e9cbd9
+    - current_digest: cb9ae9fec21885fb858fa3145f79006624675d400b36c2be32ea44d616e9cbd9
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605191428-C5AXQ6
+
+    ### 2026-05-19T15:38:54.894Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Post-rebase verification refreshed on top of origin/main c4b8430f3. Checks rerun after rebase: bun test packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests; bun run agents:check => pass; node .agentplane/policy/check-routing.mjs => pass.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:43:27.853Z, excerpt_hash=sha256:3d0702eb3f1603903ee3a55584030772bf0ce80cc7678484062b17ba871886e1
 
     Details:
 
@@ -167,6 +192,25 @@ Note: Post-commit verification refreshed for implementation commit c74d8af24. Pr
 Attempts: 0
 
 VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:41:29.551Z, excerpt_hash=sha256:3d0702eb3f1603903ee3a55584030772bf0ce80cc7678484062b17ba871886e1
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191428-C5AXQ6-context-recall-boundaries/.agentplane/tasks/202605191428-C5AXQ6/blueprint/resolved-snapshot.json
+- old_digest: cb9ae9fec21885fb858fa3145f79006624675d400b36c2be32ea44d616e9cbd9
+- current_digest: cb9ae9fec21885fb858fa3145f79006624675d400b36c2be32ea44d616e9cbd9
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605191428-C5AXQ6
+
+### 2026-05-19T15:38:54.894Z — VERIFY — ok
+
+By: CODER
+
+Note: Post-rebase verification refreshed on top of origin/main c4b8430f3. Checks rerun after rebase: bun test packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests; bun run agents:check => pass; node .agentplane/policy/check-routing.mjs => pass.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:43:27.853Z, excerpt_hash=sha256:3d0702eb3f1603903ee3a55584030772bf0ce80cc7678484062b17ba871886e1
 
 Details:
 

--- a/.agentplane/tasks/202605191428-C5AXQ6/README.md
+++ b/.agentplane/tasks/202605191428-C5AXQ6/README.md
@@ -4,7 +4,7 @@ title: "Improve context recall boundaries"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -19,9 +19,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-19T14:41:29.496Z"
+  updated_at: "2026-05-19T14:43:27.728Z"
   updated_by: "CODER"
-  note: "Verified context recall boundary fix. Commands: bun test packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests and 8 snapshots; bunx eslint touched context/search/blueprint files => pass; bunx prettier --check touched docs/source files => pass; bun run --filter=agentplane build => pass; bun run docs:cli:check => pass; node .agentplane/policy/check-routing.mjs => pass; ap context reindex --include-raw => pass rows=16 files=21; ap context check => pass; ap context doctor => pass after serialized re-run; ap doctor => OK; git diff --check => pass. Manual smoke: default context search excludes task history, --scope tasks returns task records."
+  note: "Post-commit verification refreshed for implementation commit c74d8af24. Previously recorded checks remain valid for this diff: focused context/search tests, help snapshots, lint, formatting, package build, docs CLI freshness, policy routing, context reindex/check/doctor, ap doctor, git diff --check, and manual search smoke passed."
   attempts: 0
 commit: null
 comments:
@@ -42,8 +42,14 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified context recall boundary fix. Commands: bun test packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests and 8 snapshots; bunx eslint touched context/search/blueprint files => pass; bunx prettier --check touched docs/source files => pass; bun run --filter=agentplane build => pass; bun run docs:cli:check => pass; node .agentplane/policy/check-routing.mjs => pass; ap context reindex --include-raw => pass rows=16 files=21; ap context check => pass; ap context doctor => pass after serialized re-run; ap doctor => OK; git diff --check => pass. Manual smoke: default context search excludes task history, --scope tasks returns task records."
+  -
+    type: "verify"
+    at: "2026-05-19T14:43:27.728Z"
+    author: "CODER"
+    state: "ok"
+    note: "Post-commit verification refreshed for implementation commit c74d8af24. Previously recorded checks remain valid for this diff: focused context/search tests, help snapshots, lint, formatting, package build, docs CLI freshness, policy routing, context reindex/check/doctor, ap doctor, git diff --check, and manual search smoke passed."
 doc_version: 3
-doc_updated_at: "2026-05-19T14:41:29.551Z"
+doc_updated_at: "2026-05-19T14:43:27.853Z"
 doc_updated_by: "CODER"
 description: "Make local context search prefer curated context by default, align context policy module references with actual derived paths and blueprint loading, and verify the context command behavior."
 sections:
@@ -71,6 +77,25 @@ sections:
     Attempts: 0
 
     VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:35:19.647Z, excerpt_hash=sha256:3d0702eb3f1603903ee3a55584030772bf0ce80cc7678484062b17ba871886e1
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191428-C5AXQ6-context-recall-boundaries/.agentplane/tasks/202605191428-C5AXQ6/blueprint/resolved-snapshot.json
+    - old_digest: cb9ae9fec21885fb858fa3145f79006624675d400b36c2be32ea44d616e9cbd9
+    - current_digest: cb9ae9fec21885fb858fa3145f79006624675d400b36c2be32ea44d616e9cbd9
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605191428-C5AXQ6
+
+    ### 2026-05-19T14:43:27.728Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Post-commit verification refreshed for implementation commit c74d8af24. Previously recorded checks remain valid for this diff: focused context/search tests, help snapshots, lint, formatting, package build, docs CLI freshness, policy routing, context reindex/check/doctor, ap doctor, git diff --check, and manual search smoke passed.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:41:29.551Z, excerpt_hash=sha256:3d0702eb3f1603903ee3a55584030772bf0ce80cc7678484062b17ba871886e1
 
     Details:
 
@@ -123,6 +148,25 @@ Note: Verified context recall boundary fix. Commands: bun test packages/agentpla
 Attempts: 0
 
 VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:35:19.647Z, excerpt_hash=sha256:3d0702eb3f1603903ee3a55584030772bf0ce80cc7678484062b17ba871886e1
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191428-C5AXQ6-context-recall-boundaries/.agentplane/tasks/202605191428-C5AXQ6/blueprint/resolved-snapshot.json
+- old_digest: cb9ae9fec21885fb858fa3145f79006624675d400b36c2be32ea44d616e9cbd9
+- current_digest: cb9ae9fec21885fb858fa3145f79006624675d400b36c2be32ea44d616e9cbd9
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605191428-C5AXQ6
+
+### 2026-05-19T14:43:27.728Z — VERIFY — ok
+
+By: CODER
+
+Note: Post-commit verification refreshed for implementation commit c74d8af24. Previously recorded checks remain valid for this diff: focused context/search tests, help snapshots, lint, formatting, package build, docs CLI freshness, policy routing, context reindex/check/doctor, ap doctor, git diff --check, and manual search smoke passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:41:29.551Z, excerpt_hash=sha256:3d0702eb3f1603903ee3a55584030772bf0ce80cc7678484062b17ba871886e1
 
 Details:
 

--- a/.agentplane/tasks/202605191428-C5AXQ6/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605191428-C5AXQ6/blueprint/resolved-snapshot.json
@@ -1,0 +1,571 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605191428-C5AXQ6",
+    "title": "Improve context recall boundaries",
+    "description": "Make local context search prefer curated context by default, align context policy module references with actual derived paths and blueprint loading, and verify the context command behavior.",
+    "tags": [
+      "code",
+      "context"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605191428-C5AXQ6",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "cb9ae9fec21885fb858fa3145f79006624675d400b36c2be32ea44d616e9cbd9"
+  }
+}

--- a/.agentplane/tasks/202605191428-C5AXQ6/pr/diffstat.txt
+++ b/.agentplane/tasks/202605191428-C5AXQ6/pr/diffstat.txt
@@ -1,0 +1,11 @@
+ .agentplane/policy/context.must.md                 |   6 +-
+ .../blueprint/resolved-snapshot.json               | 571 +++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |   4 +-
+ docs/user/local-context.mdx                        |   4 +
+ packages/agentplane/src/blueprints/builtins.ts     |  24 +-
+ .../run-cli.core.help-snap.test.ts.snap            |  14 +-
+ .../src/commands/context/context.spec.ts           |  10 +-
+ .../src/commands/context/release-readiness.test.ts |  51 ++
+ packages/agentplane/src/commands/context/search.ts |   2 +
+ packages/agentplane/src/context/context-utils.ts   |  55 +-
+ 10 files changed, 711 insertions(+), 30 deletions(-)

--- a/.agentplane/tasks/202605191428-C5AXQ6/pr/diffstat.txt
+++ b/.agentplane/tasks/202605191428-C5AXQ6/pr/diffstat.txt
@@ -2,10 +2,11 @@
  .../blueprint/resolved-snapshot.json               | 571 +++++++++++++++++++++
  docs/user/cli-reference.generated.mdx              |   4 +-
  docs/user/local-context.mdx                        |   4 +
+ packages/agentplane/assets/policy/context.must.md  |   6 +-
  packages/agentplane/src/blueprints/builtins.ts     |  24 +-
  .../run-cli.core.help-snap.test.ts.snap            |  14 +-
  .../src/commands/context/context.spec.ts           |  10 +-
  .../src/commands/context/release-readiness.test.ts |  51 ++
  packages/agentplane/src/commands/context/search.ts |   2 +
  packages/agentplane/src/context/context-utils.ts   |  55 +-
- 10 files changed, 711 insertions(+), 30 deletions(-)
+ 11 files changed, 715 insertions(+), 32 deletions(-)

--- a/.agentplane/tasks/202605191428-C5AXQ6/pr/diffstat.txt
+++ b/.agentplane/tasks/202605191428-C5AXQ6/pr/diffstat.txt
@@ -6,7 +6,7 @@
  packages/agentplane/src/blueprints/builtins.ts     |  24 +-
  .../run-cli.core.help-snap.test.ts.snap            |  14 +-
  .../src/commands/context/context.spec.ts           |  10 +-
- .../src/commands/context/release-readiness.test.ts |  51 ++
+ .../src/commands/context/release-readiness.test.ts |  83 +++
  packages/agentplane/src/commands/context/search.ts |   2 +
- packages/agentplane/src/context/context-utils.ts   |  55 +-
- 11 files changed, 715 insertions(+), 32 deletions(-)
+ packages/agentplane/src/context/context-utils.ts   |  57 +-
+ 11 files changed, 749 insertions(+), 32 deletions(-)

--- a/.agentplane/tasks/202605191428-C5AXQ6/pr/github-body.md
+++ b/.agentplane/tasks/202605191428-C5AXQ6/pr/github-body.md
@@ -34,12 +34,22 @@ doctor => OK; git diff --check => pass. Manual smoke: default context search exc
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-19T14:30:15.673Z
+- Updated: 2026-05-19T14:42:48.918Z
 - Branch: task/202605191428-C5AXQ6/context-recall-boundaries
-- Head: 81a3ed59446b
+- Head: c74d8af24a06
 
 ```text
-No changes detected.
+ .agentplane/policy/context.must.md                 |   6 +-
+ .../blueprint/resolved-snapshot.json               | 571 +++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |   4 +-
+ docs/user/local-context.mdx                        |   4 +
+ packages/agentplane/src/blueprints/builtins.ts     |  24 +-
+ .../run-cli.core.help-snap.test.ts.snap            |  14 +-
+ .../src/commands/context/context.spec.ts           |  10 +-
+ .../src/commands/context/release-readiness.test.ts |  51 ++
+ packages/agentplane/src/commands/context/search.ts |   2 +
+ packages/agentplane/src/context/context-utils.ts   |  55 +-
+ 10 files changed, 711 insertions(+), 30 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605191428-C5AXQ6/pr/github-body.md
+++ b/.agentplane/tasks/202605191428-C5AXQ6/pr/github-body.md
@@ -19,22 +19,17 @@ Make local context search prefer curated context by default, align context polic
 - Note:
 
 ```text
-Verified context recall boundary fix. Commands: bun test
-packages/agentplane/src/commands/context/release-readiness.test.ts
-packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests and 8
-snapshots; bunx eslint touched context/search/blueprint files => pass; bunx prettier --check touched
-docs/source files => pass; bun run --filter=agentplane build => pass; bun run docs:cli:check =>
-pass; node .agentplane/policy/check-routing.mjs => pass; ap context reindex --include-raw => pass
-rows=16 files=21; ap context check => pass; ap context doctor => pass after serialized re-run; ap
-doctor => OK; git diff --check => pass. Manual smoke: default context search excludes task history,
---scope tasks returns task records.
+Post-commit verification refreshed for implementation commit c74d8af24. Previously recorded checks
+remain valid for this diff: focused context/search tests, help snapshots, lint, formatting, package
+build, docs CLI freshness, policy routing, context reindex/check/doctor, ap doctor, git diff
+--check, and manual search smoke passed.
 ```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-19T14:42:48.918Z
+- Updated: 2026-05-19T14:43:02.501Z
 - Branch: task/202605191428-C5AXQ6/context-recall-boundaries
 - Head: c74d8af24a06
 

--- a/.agentplane/tasks/202605191428-C5AXQ6/pr/github-body.md
+++ b/.agentplane/tasks/202605191428-C5AXQ6/pr/github-body.md
@@ -19,19 +19,23 @@ Make local context search prefer curated context by default, align context polic
 - Note:
 
 ```text
-Post-rebase verification refreshed on top of origin/main c4b8430f3. Checks rerun after rebase: bun
-test packages/agentplane/src/commands/context/release-readiness.test.ts
-packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests; bun
-run agents:check => pass; node .agentplane/policy/check-routing.mjs => pass.
+Resolved PR review blocker: fallback context search now filters discovered files through scope path
+rules, excluding context/raw/private for raw/all scopes. Verification: bun test
+packages/agentplane/src/commands/context/release-readiness.test.ts --timeout 120000; bunx eslint
+packages/agentplane/src/context/context-utils.ts
+packages/agentplane/src/commands/context/release-readiness.test.ts; bunx prettier --check
+packages/agentplane/src/context/context-utils.ts
+packages/agentplane/src/commands/context/release-readiness.test.ts; node
+.agentplane/policy/check-routing.mjs.
 ```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-19T15:38:55.225Z
+- Updated: 2026-05-19T15:51:12.702Z
 - Branch: task/202605191428-C5AXQ6/context-recall-boundaries
-- Head: 46ae9f7bffbf
+- Head: 5f0088c288e3
 
 ```text
  .agentplane/policy/context.must.md                 |   6 +-
@@ -42,10 +46,10 @@ run agents:check => pass; node .agentplane/policy/check-routing.mjs => pass.
  packages/agentplane/src/blueprints/builtins.ts     |  24 +-
  .../run-cli.core.help-snap.test.ts.snap            |  14 +-
  .../src/commands/context/context.spec.ts           |  10 +-
- .../src/commands/context/release-readiness.test.ts |  51 ++
+ .../src/commands/context/release-readiness.test.ts |  83 +++
  packages/agentplane/src/commands/context/search.ts |   2 +
- packages/agentplane/src/context/context-utils.ts   |  55 +-
- 11 files changed, 715 insertions(+), 32 deletions(-)
+ packages/agentplane/src/context/context-utils.ts   |  57 +-
+ 11 files changed, 749 insertions(+), 32 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605191428-C5AXQ6/pr/github-body.md
+++ b/.agentplane/tasks/202605191428-C5AXQ6/pr/github-body.md
@@ -1,0 +1,45 @@
+Task: `202605191428-C5AXQ6`
+Title: Improve context recall boundaries
+Canonical task record: `.agentplane/tasks/202605191428-C5AXQ6/README.md`
+
+## Summary
+
+Improve context recall boundaries
+
+Make local context search prefer curated context by default, align context policy module references with actual derived paths and blueprint loading, and verify the context command behavior.
+
+## Scope
+
+- In scope: Make local context search prefer curated context by default, align context policy module references with actual derived paths and blueprint loading, and verify the context command behavior.
+- Out of scope: unrelated refactors not required for "Improve context recall boundaries".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Verified context recall boundary fix. Commands: bun test
+packages/agentplane/src/commands/context/release-readiness.test.ts
+packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests and 8
+snapshots; bunx eslint touched context/search/blueprint files => pass; bunx prettier --check touched
+docs/source files => pass; bun run --filter=agentplane build => pass; bun run docs:cli:check =>
+pass; node .agentplane/policy/check-routing.mjs => pass; ap context reindex --include-raw => pass
+rows=16 files=21; ap context check => pass; ap context doctor => pass after serialized re-run; ap
+doctor => OK; git diff --check => pass. Manual smoke: default context search excludes task history,
+--scope tasks returns task records.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-19T14:30:15.673Z
+- Branch: task/202605191428-C5AXQ6/context-recall-boundaries
+- Head: 81a3ed59446b
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605191428-C5AXQ6/pr/github-body.md
+++ b/.agentplane/tasks/202605191428-C5AXQ6/pr/github-body.md
@@ -19,32 +19,33 @@ Make local context search prefer curated context by default, align context polic
 - Note:
 
 ```text
-Post-commit verification refreshed for implementation commit c74d8af24. Previously recorded checks
-remain valid for this diff: focused context/search tests, help snapshots, lint, formatting, package
-build, docs CLI freshness, policy routing, context reindex/check/doctor, ap doctor, git diff
---check, and manual search smoke passed.
+Post-rebase verification refreshed on top of origin/main c4b8430f3. Checks rerun after rebase: bun
+test packages/agentplane/src/commands/context/release-readiness.test.ts
+packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests; bun
+run agents:check => pass; node .agentplane/policy/check-routing.mjs => pass.
 ```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-19T14:43:02.501Z
+- Updated: 2026-05-19T15:38:55.225Z
 - Branch: task/202605191428-C5AXQ6/context-recall-boundaries
-- Head: c74d8af24a06
+- Head: 46ae9f7bffbf
 
 ```text
  .agentplane/policy/context.must.md                 |   6 +-
  .../blueprint/resolved-snapshot.json               | 571 +++++++++++++++++++++
  docs/user/cli-reference.generated.mdx              |   4 +-
  docs/user/local-context.mdx                        |   4 +
+ packages/agentplane/assets/policy/context.must.md  |   6 +-
  packages/agentplane/src/blueprints/builtins.ts     |  24 +-
  .../run-cli.core.help-snap.test.ts.snap            |  14 +-
  .../src/commands/context/context.spec.ts           |  10 +-
  .../src/commands/context/release-readiness.test.ts |  51 ++
  packages/agentplane/src/commands/context/search.ts |   2 +
  packages/agentplane/src/context/context-utils.ts   |  55 +-
- 10 files changed, 711 insertions(+), 30 deletions(-)
+ 11 files changed, 715 insertions(+), 32 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605191428-C5AXQ6/pr/github-title.txt
+++ b/.agentplane/tasks/202605191428-C5AXQ6/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 C5AXQ6 task: Improve context recall boundaries [202605191428-C5AXQ6]

--- a/.agentplane/tasks/202605191428-C5AXQ6/pr/meta.json
+++ b/.agentplane/tasks/202605191428-C5AXQ6/pr/meta.json
@@ -2,12 +2,12 @@
   "base": "main",
   "branch": "task/202605191428-C5AXQ6/context-recall-boundaries",
   "created_at": "2026-05-19T14:30:15.673Z",
-  "head_sha": "81a3ed59446b0e0fbdf663711e789c53ec915369",
+  "head_sha": "c74d8af24a061c8e7b225e76e8cf6db11621b73b",
   "last_verified_at": "2026-05-19T14:41:29.496Z",
   "last_verified_sha": "81a3ed59446b0e0fbdf663711e789c53ec915369",
   "schema_version": 1,
   "task_id": "202605191428-C5AXQ6",
-  "updated_at": "2026-05-19T14:30:15.673Z",
+  "updated_at": "2026-05-19T14:42:48.918Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605191428-C5AXQ6/pr/meta.json
+++ b/.agentplane/tasks/202605191428-C5AXQ6/pr/meta.json
@@ -3,11 +3,14 @@
   "branch": "task/202605191428-C5AXQ6/context-recall-boundaries",
   "created_at": "2026-05-19T14:30:15.673Z",
   "head_sha": "c74d8af24a061c8e7b225e76e8cf6db11621b73b",
-  "last_verified_at": "2026-05-19T14:41:29.496Z",
-  "last_verified_sha": "81a3ed59446b0e0fbdf663711e789c53ec915369",
+  "last_verified_at": "2026-05-19T14:43:27.728Z",
+  "last_verified_sha": "c74d8af24a061c8e7b225e76e8cf6db11621b73b",
+  "pr_number": 3935,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3935",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605191428-C5AXQ6",
-  "updated_at": "2026-05-19T14:42:48.918Z",
+  "updated_at": "2026-05-19T14:43:02.501Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605191428-C5AXQ6/pr/meta.json
+++ b/.agentplane/tasks/202605191428-C5AXQ6/pr/meta.json
@@ -2,15 +2,15 @@
   "base": "main",
   "branch": "task/202605191428-C5AXQ6/context-recall-boundaries",
   "created_at": "2026-05-19T14:30:15.673Z",
-  "head_sha": "46ae9f7bffbfb28f524f6457c5c1e08ba65f08dd",
-  "last_verified_at": "2026-05-19T15:38:54.894Z",
-  "last_verified_sha": "46ae9f7bffbfb28f524f6457c5c1e08ba65f08dd",
+  "head_sha": "5f0088c288e39fa35b58c4bf63c507f6ef3d3a17",
+  "last_verified_at": "2026-05-19T15:51:12.528Z",
+  "last_verified_sha": "5f0088c288e39fa35b58c4bf63c507f6ef3d3a17",
   "pr_number": 3935,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3935",
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202605191428-C5AXQ6",
-  "updated_at": "2026-05-19T15:38:55.225Z",
+  "updated_at": "2026-05-19T15:51:12.702Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605191428-C5AXQ6/pr/meta.json
+++ b/.agentplane/tasks/202605191428-C5AXQ6/pr/meta.json
@@ -2,15 +2,15 @@
   "base": "main",
   "branch": "task/202605191428-C5AXQ6/context-recall-boundaries",
   "created_at": "2026-05-19T14:30:15.673Z",
-  "head_sha": "c74d8af24a061c8e7b225e76e8cf6db11621b73b",
-  "last_verified_at": "2026-05-19T14:43:27.728Z",
-  "last_verified_sha": "c74d8af24a061c8e7b225e76e8cf6db11621b73b",
+  "head_sha": "46ae9f7bffbfb28f524f6457c5c1e08ba65f08dd",
+  "last_verified_at": "2026-05-19T15:38:54.894Z",
+  "last_verified_sha": "46ae9f7bffbfb28f524f6457c5c1e08ba65f08dd",
   "pr_number": 3935,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3935",
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202605191428-C5AXQ6",
-  "updated_at": "2026-05-19T14:43:02.501Z",
+  "updated_at": "2026-05-19T15:38:55.225Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605191428-C5AXQ6/pr/meta.json
+++ b/.agentplane/tasks/202605191428-C5AXQ6/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605191428-C5AXQ6/context-recall-boundaries",
+  "created_at": "2026-05-19T14:30:15.673Z",
+  "head_sha": "81a3ed59446b0e0fbdf663711e789c53ec915369",
+  "last_verified_at": "2026-05-19T14:41:29.496Z",
+  "last_verified_sha": "81a3ed59446b0e0fbdf663711e789c53ec915369",
+  "schema_version": 1,
+  "task_id": "202605191428-C5AXQ6",
+  "updated_at": "2026-05-19T14:30:15.673Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605191428-C5AXQ6/pr/review.md
+++ b/.agentplane/tasks/202605191428-C5AXQ6/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-05-19T14:30:15.673Z
 ## Verification
 
 - State: ok
-- Note: Post-commit verification refreshed for implementation commit c74d8af24. Previously recorded checks remain valid for this diff: focused context/search tests, help snapshots, lint, formatting, package build, docs CLI freshness, policy routing, context reindex/check/doctor, ap doctor, git diff --check, and manual search smoke passed.
+- Note: Post-rebase verification refreshed on top of origin/main c4b8430f3. Checks rerun after rebase: bun test packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests; bun run agents:check => pass; node .agentplane/policy/check-routing.mjs => pass.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,22 +24,23 @@ Created: 2026-05-19T14:30:15.673Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-19T14:43:02.501Z
+- Updated: 2026-05-19T15:38:55.225Z
 - Branch: task/202605191428-C5AXQ6/context-recall-boundaries
-- Head: c74d8af24a06
+- Head: 46ae9f7bffbf
 
 ```text
  .agentplane/policy/context.must.md                 |   6 +-
  .../blueprint/resolved-snapshot.json               | 571 +++++++++++++++++++++
  docs/user/cli-reference.generated.mdx              |   4 +-
  docs/user/local-context.mdx                        |   4 +
+ packages/agentplane/assets/policy/context.must.md  |   6 +-
  packages/agentplane/src/blueprints/builtins.ts     |  24 +-
  .../run-cli.core.help-snap.test.ts.snap            |  14 +-
  .../src/commands/context/context.spec.ts           |  10 +-
  .../src/commands/context/release-readiness.test.ts |  51 ++
  packages/agentplane/src/commands/context/search.ts |   2 +
  packages/agentplane/src/context/context-utils.ts   |  55 +-
- 10 files changed, 711 insertions(+), 30 deletions(-)
+ 11 files changed, 715 insertions(+), 32 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605191428-C5AXQ6/pr/review.md
+++ b/.agentplane/tasks/202605191428-C5AXQ6/pr/review.md
@@ -24,12 +24,22 @@ Created: 2026-05-19T14:30:15.673Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-19T14:30:15.673Z
+- Updated: 2026-05-19T14:42:48.918Z
 - Branch: task/202605191428-C5AXQ6/context-recall-boundaries
-- Head: 81a3ed59446b
+- Head: c74d8af24a06
 
 ```text
-No changes detected.
+ .agentplane/policy/context.must.md                 |   6 +-
+ .../blueprint/resolved-snapshot.json               | 571 +++++++++++++++++++++
+ docs/user/cli-reference.generated.mdx              |   4 +-
+ docs/user/local-context.mdx                        |   4 +
+ packages/agentplane/src/blueprints/builtins.ts     |  24 +-
+ .../run-cli.core.help-snap.test.ts.snap            |  14 +-
+ .../src/commands/context/context.spec.ts           |  10 +-
+ .../src/commands/context/release-readiness.test.ts |  51 ++
+ packages/agentplane/src/commands/context/search.ts |   2 +
+ packages/agentplane/src/context/context-utils.ts   |  55 +-
+ 10 files changed, 711 insertions(+), 30 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605191428-C5AXQ6/pr/review.md
+++ b/.agentplane/tasks/202605191428-C5AXQ6/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-05-19T14:30:15.673Z
 ## Verification
 
 - State: ok
-- Note: Post-rebase verification refreshed on top of origin/main c4b8430f3. Checks rerun after rebase: bun test packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests; bun run agents:check => pass; node .agentplane/policy/check-routing.mjs => pass.
+- Note: Resolved PR review blocker: fallback context search now filters discovered files through scope path rules, excluding context/raw/private for raw/all scopes. Verification: bun test packages/agentplane/src/commands/context/release-readiness.test.ts --timeout 120000; bunx eslint packages/agentplane/src/context/context-utils.ts packages/agentplane/src/commands/context/release-readiness.test.ts; bunx prettier --check packages/agentplane/src/context/context-utils.ts packages/agentplane/src/commands/context/release-readiness.test.ts; node .agentplane/policy/check-routing.mjs.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,9 +24,9 @@ Created: 2026-05-19T14:30:15.673Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-19T15:38:55.225Z
+- Updated: 2026-05-19T15:51:12.702Z
 - Branch: task/202605191428-C5AXQ6/context-recall-boundaries
-- Head: 46ae9f7bffbf
+- Head: 5f0088c288e3
 
 ```text
  .agentplane/policy/context.must.md                 |   6 +-
@@ -37,10 +37,10 @@ Created: 2026-05-19T14:30:15.673Z
  packages/agentplane/src/blueprints/builtins.ts     |  24 +-
  .../run-cli.core.help-snap.test.ts.snap            |  14 +-
  .../src/commands/context/context.spec.ts           |  10 +-
- .../src/commands/context/release-readiness.test.ts |  51 ++
+ .../src/commands/context/release-readiness.test.ts |  83 +++
  packages/agentplane/src/commands/context/search.ts |   2 +
- packages/agentplane/src/context/context-utils.ts   |  55 +-
- 11 files changed, 715 insertions(+), 32 deletions(-)
+ packages/agentplane/src/context/context-utils.ts   |  57 +-
+ 11 files changed, 749 insertions(+), 32 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605191428-C5AXQ6/pr/review.md
+++ b/.agentplane/tasks/202605191428-C5AXQ6/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-19T14:30:15.673Z
+
+## Task
+
+- Task: `202605191428-C5AXQ6`
+- Title: Improve context recall boundaries
+- Status: DOING
+- Branch: `task/202605191428-C5AXQ6/context-recall-boundaries`
+- Canonical task record: `.agentplane/tasks/202605191428-C5AXQ6/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified context recall boundary fix. Commands: bun test packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests and 8 snapshots; bunx eslint touched context/search/blueprint files => pass; bunx prettier --check touched docs/source files => pass; bun run --filter=agentplane build => pass; bun run docs:cli:check => pass; node .agentplane/policy/check-routing.mjs => pass; ap context reindex --include-raw => pass rows=16 files=21; ap context check => pass; ap context doctor => pass after serialized re-run; ap doctor => OK; git diff --check => pass. Manual smoke: default context search excludes task history, --scope tasks returns task records.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-19T14:30:15.673Z
+- Branch: task/202605191428-C5AXQ6/context-recall-boundaries
+- Head: 81a3ed59446b
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605191428-C5AXQ6/pr/review.md
+++ b/.agentplane/tasks/202605191428-C5AXQ6/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-05-19T14:30:15.673Z
 ## Verification
 
 - State: ok
-- Note: Verified context recall boundary fix. Commands: bun test packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests and 8 snapshots; bunx eslint touched context/search/blueprint files => pass; bunx prettier --check touched docs/source files => pass; bun run --filter=agentplane build => pass; bun run docs:cli:check => pass; node .agentplane/policy/check-routing.mjs => pass; ap context reindex --include-raw => pass rows=16 files=21; ap context check => pass; ap context doctor => pass after serialized re-run; ap doctor => OK; git diff --check => pass. Manual smoke: default context search excludes task history, --scope tasks returns task records.
+- Note: Post-commit verification refreshed for implementation commit c74d8af24. Previously recorded checks remain valid for this diff: focused context/search tests, help snapshots, lint, formatting, package build, docs CLI freshness, policy routing, context reindex/check/doctor, ap doctor, git diff --check, and manual search smoke passed.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,7 +24,7 @@ Created: 2026-05-19T14:30:15.673Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-19T14:42:48.918Z
+- Updated: 2026-05-19T14:43:02.501Z
 - Branch: task/202605191428-C5AXQ6/context-recall-boundaries
 - Head: c74d8af24a06
 

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -3411,7 +3411,7 @@ agentplane context learn tasks --tag branch_pr --batch-size 25 --dry-run
 
 ### context search
 
-Search indexed local context, facts, graph, tasks, and capabilities.
+Search curated local context, facts, graph, and capabilities.
 
 Usage:
 
@@ -3421,7 +3421,7 @@ agentplane context search <query> [options]
 
 Options:
 
-- `--scope <scope>`: Comma-separated scope list. (default=wiki,facts,graph,tasks,capabilities)
+- `--scope <scope>`: Comma-separated scope list. Defaults to curated context; use tasks, raw, or all explicitly for broader recall. (default=wiki,facts,graph,capabilities)
 - `--format <text|json>`: Output format. (choices=text|json, default=text)
 - `--explain`: Include score explanation metadata. (default=false)
 

--- a/docs/user/local-context.mdx
+++ b/docs/user/local-context.mdx
@@ -94,6 +94,10 @@ agentplane context show context/wiki/release.md#section=publish-gate
 agentplane context check
 ```
 
+`context search` defaults to curated context: wiki pages, derived facts, derived graph rows, and
+capability records. Use `--scope tasks`, `--scope raw`, or `--scope all` when you intentionally want
+task-history or raw-source recall mixed into results.
+
 When `agentplane context init` runs in an empty standalone directory, it bootstraps the Agentplane
 project first and then creates the context workspace. In a non-empty directory that is not already an
 Agentplane project, run `agentplane init` explicitly before `agentplane context init` so the project

--- a/packages/agentplane/assets/policy/context.must.md
+++ b/packages/agentplane/assets/policy/context.must.md
@@ -4,7 +4,7 @@
 
 Use this module when a task reads, writes, learns, curates, verifies, or relies on AgentPlane local context.
 
-Local context means `context/wiki/**`, `context/facts/**`, `context/graph/**`, `context/capabilities/**`, `context/raw/**`, and `.agentplane/context/**`.
+Local context means `context/wiki/**`, `context/capabilities/**`, `context/raw/**`, `.agentplane/context/derived/facts/**`, `.agentplane/context/derived/graph/**`, `.agentplane/context/derived/capabilities/**`, and `.agentplane/context/**`.
 
 <!-- /ap:fragment -->
 <!-- ap:fragment id="policy.context.must.hard_constraint.source.first" slot="hard_constraint" mutability="append_only" -->
@@ -27,6 +27,8 @@ ap context search "<query>"
 ap context show <ref>
 ap context learn changes
 ap context learn files <path> [--run]
+ap context ingest --changed|--all|--index-only
+ap context reindex --include-raw
 ap context wiki lint <path>
 ap context wiki explain <path>
 ap context wiki link <path>
@@ -37,7 +39,7 @@ ap context verify-task <task-id>
 ```
 
 - Use `search` for discovery and `show` for exact source readback.
-- Use `learn` to create context assimilation tasks instead of ad hoc memory writes.
+- Use `learn` to create human-facing context assimilation tasks instead of ad hoc memory writes; use `ingest`/`reindex` for lower-level agent and automation pipelines.
 - Use wiki lint/explain/link/index when adding or changing wiki pages.
 - Run `verify-task` before closing tasks that create or rely on context artifacts.
 

--- a/packages/agentplane/src/blueprints/builtins.ts
+++ b/packages/agentplane/src/blueprints/builtins.ts
@@ -99,7 +99,11 @@ const contextAssimilationNodes = [
   node({
     kind: "context_resolve",
     evidence: ["context_manifest", "sources"],
-    policyModules: [".agentplane/policy/security.must.md", ".agentplane/policy/dod.core.md"],
+    policyModules: [
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/context.must.md",
+    ],
   }),
   node({ kind: "work_unit", evidence: ["changed_paths", "artifact", "weak_links"] }),
   node({
@@ -290,12 +294,16 @@ export const BUILTIN_BLUEPRINTS = [
       "agentplane acr check <task-id>",
       "agentplane verify <task-id> --ok|--rework",
     ],
-    policyModules: [".agentplane/policy/security.must.md", ".agentplane/policy/dod.core.md"],
+    policyModules: [
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/context.must.md",
+    ],
     contextBudget: {
-      maxPolicyModules: 2,
+      maxPolicyModules: 3,
       maxPromptBlocks: 14,
       rationale:
-        "Context assimilation needs source-set policy, mutation boundaries, and evidence checks without loading code or release policy by default.",
+        "Context assimilation needs context source-set policy, mutation boundaries, and evidence checks without loading code or release policy by default.",
     },
     nodes: contextAssimilationNodes,
     requiredEvidence: [
@@ -408,9 +416,13 @@ export const BUILTIN_BLUEPRINTS = [
       "agentplane acr generate <task-id> --write",
       "agentplane acr check <task-id>",
     ],
-    policyModules: [".agentplane/policy/security.must.md", ".agentplane/policy/dod.core.md"],
+    policyModules: [
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/context.must.md",
+    ],
     contextBudget: {
-      maxPolicyModules: 2,
+      maxPolicyModules: 3,
       maxPromptBlocks: 16,
       rationale:
         "Maximum assimilation keeps the normal context policy set but reserves prompt budget for coverage, glossary, entity/relation extraction, and raw-deletion resilience checks.",

--- a/packages/agentplane/src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap
+++ b/packages/agentplane/src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap
@@ -159,7 +159,7 @@ Commands:
     context learn changes  Create a context assimilation task from changed context sources.
     context learn files  Create a context assimilation task from explicit files or paths.
     context learn tasks  Create CURATOR extraction tasks from completed task history.
-    context search  Search indexed local context, facts, graph, tasks, and capabilities.
+    context search  Search curated local context, facts, graph, and capabilities.
     context show  Resolve a context source reference and print addressed content.
     context wiki  Create, lint, explain, link, and index local context wiki pages.
     context wiki explain  Print a wiki page's Agentplane context frontmatter.
@@ -342,7 +342,7 @@ exports[`runCli help snapshots (cli2) help (registry) snapshot 1`] = `
 Commands:
   Core:
     agents  List agent definitions under .agentplane/agents.
-    demo  Create a safe first-success AgentPlane demo task with ACR evidence.
+    demo  Create a safe first-success Agentplane demo task with ACR evidence.
     help  Show help for a command.
     preflight  Run aggregated preflight checks and print a deterministic readiness report.
     quickstart  Print the canonical agent bootstrap path and startup guidance.
@@ -425,8 +425,8 @@ Commands:
     doctor git-locks  Check Git index lock state for this repository and suggest cleanup.
   Diagnostics:
     insights  Generate local-only diagnostic insights for support analysis.
-    insights issue  Create an opt-in GitHub issue with privacy-bounded AgentPlane diagnostics.
-    insights report  Print a local-only privacy-bounded AgentPlane diagnostic report.
+    insights issue  Create an opt-in GitHub issue with privacy-bounded Agentplane diagnostics.
+    insights report  Print a local-only privacy-bounded Agentplane diagnostic report.
     runtime  Inspect which agentplane runtime/binary/package sources are active.
     runtime explain  Explain the active binary, runtime mode, and resolved package roots.
   Recipes:
@@ -494,14 +494,14 @@ Commands:
     context learn changes  Create a context assimilation task from changed context sources.
     context learn files  Create a context assimilation task from explicit files or paths.
     context learn tasks  Create CURATOR extraction tasks from completed task history.
-    context search  Search indexed local context, facts, graph, tasks, and capabilities.
+    context search  Search curated local context, facts, graph, and capabilities.
     context show  Resolve a context source reference and print addressed content.
     context wiki  Create, lint, explain, link, and index local context wiki pages.
-    context wiki explain  Print a wiki page's AgentPlane context frontmatter.
+    context wiki explain  Print a wiki page's Agentplane context frontmatter.
     context wiki index  Update generated wiki index sections for pages and subdirectories.
     context wiki link  Suggest existing wiki pages that may deserve cross-links.
     context wiki lint  Validate wiki page frontmatter and source-link hygiene.
-    context wiki new  Create a wiki page with AgentPlane context frontmatter.
+    context wiki new  Create a wiki page with Agentplane context frontmatter.
   Evaluators:
     evaluator  List and inspect evaluator prompt modules.
     evaluator list  List evaluator prompt modules from .agentplane/evaluators.

--- a/packages/agentplane/src/commands/context/context.spec.ts
+++ b/packages/agentplane/src/commands/context/context.spec.ts
@@ -133,14 +133,15 @@ export const contextSearchSpec: CommandSpec<{
 }> = {
   id: ["context", "search"],
   group: "Context",
-  summary: "Search indexed local context, facts, graph, tasks, and capabilities.",
+  summary: "Search curated local context, facts, graph, and capabilities.",
   args: [{ name: "query", required: true, valueHint: "<query>" }],
   options: [
     {
       kind: "string",
       name: "scope",
-      default: "wiki,facts,graph,tasks,capabilities",
-      description: "Comma-separated scope list.",
+      default: "wiki,facts,graph,capabilities",
+      description:
+        "Comma-separated scope list. Defaults to curated context; use tasks, raw, or all explicitly for broader recall.",
       valueHint: "<scope>",
     },
     {
@@ -160,8 +161,7 @@ export const contextSearchSpec: CommandSpec<{
   ],
   parse: (raw) => ({
     query: String(raw.args.query),
-    scope:
-      typeof raw.opts.scope === "string" ? raw.opts.scope : "wiki,facts,graph,tasks,capabilities",
+    scope: typeof raw.opts.scope === "string" ? raw.opts.scope : "wiki,facts,graph,capabilities",
     format: (raw.opts.format as "text" | "json") ?? "text",
     explain: raw.opts.explain === true,
   }),

--- a/packages/agentplane/src/commands/context/release-readiness.test.ts
+++ b/packages/agentplane/src/commands/context/release-readiness.test.ts
@@ -230,6 +230,38 @@ describe("context release readiness guards", () => {
     expect(projection?.rows.some((row) => row.path.includes("context/raw/private"))).toBe(false);
   });
 
+  it("excludes private raw files from fallback search for raw and all scopes", async () => {
+    const root = await tempRoot();
+    await write(root, "context/raw/specs/payment-api.md", "# Payment API\n\nNeedle public.\n");
+    await write(root, "context/raw/private/secret.md", "# Secret\n\nNeedle private.\n");
+    const out = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await cmdContextSearch({
+      cwd: root,
+      parsed: { query: "needle", scope: "raw", format: "json", explain: false },
+    });
+    await cmdContextSearch({
+      cwd: root,
+      parsed: { query: "needle", scope: "all", format: "json", explain: false },
+    });
+
+    const payloads = out.mock.calls
+      .map((call) => String(call[0]))
+      .join("")
+      .trim()
+      .split(/\n(?=\{)/u)
+      .map((chunk) => JSON.parse(chunk) as { results: { ref: string }[] });
+    expect(payloads).toHaveLength(2);
+    for (const payload of payloads) {
+      expect(payload.results.some((result) => result.ref.includes("context/raw/private"))).toBe(
+        false,
+      );
+      expect(
+        payload.results.some((result) => result.ref === "context/raw/specs/payment-api.md"),
+      ).toBe(true);
+    }
+  });
+
   it("does not mark fresh markdown section projection rows as stale", async () => {
     const root = await tempRoot();
     await write(

--- a/packages/agentplane/src/commands/context/release-readiness.test.ts
+++ b/packages/agentplane/src/commands/context/release-readiness.test.ts
@@ -262,6 +262,57 @@ describe("context release readiness guards", () => {
     expect(sectionResult?.freshness.stale).toBe(false);
   });
 
+  it("keeps task history out of default context search unless tasks scope is explicit", async () => {
+    const root = await tempRoot();
+    await write(root, "context/wiki/release.md", "# Release\n\nCurated release checklist.\n");
+    await write(
+      root,
+      ".agentplane/tasks/202605190000-SEARCH1/README.md",
+      "# Task\n\nTask-only release archaeology note.\n",
+    );
+    await cmdContextReindex({
+      cwd: root,
+      parsed: { includeTasks: true, includeRaw: false, reset: false },
+    });
+
+    const out = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    await cmdContextSearch({
+      cwd: root,
+      parsed: {
+        query: "release",
+        scope: "",
+        format: "json",
+        explain: false,
+      },
+    });
+    const defaultPayload = JSON.parse(out.mock.calls.map((call) => String(call[0])).join("")) as {
+      results: { ref: string }[];
+    };
+    expect(defaultPayload.results.some((result) => result.ref.startsWith("context/wiki/"))).toBe(
+      true,
+    );
+    expect(
+      defaultPayload.results.some((result) => result.ref.startsWith(".agentplane/tasks/")),
+    ).toBe(false);
+
+    out.mockClear();
+    await cmdContextSearch({
+      cwd: root,
+      parsed: {
+        query: "task-only release",
+        scope: "tasks",
+        format: "json",
+        explain: false,
+      },
+    });
+    const tasksPayload = JSON.parse(out.mock.calls.map((call) => String(call[0])).join("")) as {
+      results: { ref: string }[];
+    };
+    expect(tasksPayload.results.some((result) => result.ref.startsWith(".agentplane/tasks/"))).toBe(
+      true,
+    );
+  });
+
   it("does not mark fresh JSONL fact and graph projection rows as stale", async () => {
     const root = await tempRoot();
     await write(

--- a/packages/agentplane/src/commands/context/search.ts
+++ b/packages/agentplane/src/commands/context/search.ts
@@ -9,6 +9,7 @@ import {
   buildSnippet,
   fileExists,
   normalizeScopeList,
+  pathMatchesScopes,
   parseJsonlLines,
   readText,
   scoreMatch,
@@ -52,6 +53,7 @@ export async function cmdContextSearch(opts: {
   const projection = await readContextProjection(root);
   if (projection) {
     for (const row of projection.rows) {
+      if (!pathMatchesScopes(row.path, scopes)) continue;
       if (row.body.toLowerCase().includes(query)) {
         usedSQLite = true;
         const freshness = await buildFreshness(root, row.path, row.sha256);

--- a/packages/agentplane/src/context/context-utils.ts
+++ b/packages/agentplane/src/context/context-utils.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 
 export { isRecord } from "../shared/guards.js";
 
-type ScopeName = "wiki" | "facts" | "graph" | "tasks" | "capabilities" | "tasks-acr" | "raw";
+export type ScopeName = "wiki" | "facts" | "graph" | "tasks" | "capabilities" | "tasks-acr" | "raw";
 
 type ParsedSourceRef = {
   path: string;
@@ -81,21 +81,60 @@ export async function collectMatchingFiles(root: string, relPath: string): Promi
 }
 
 export function normalizeScopeList(scopeValue: string): ScopeName[] {
-  const defaultScope: ScopeName[] = ["wiki", "facts", "graph", "tasks", "capabilities"];
+  const defaultScope: ScopeName[] = ["wiki", "facts", "graph", "capabilities"];
   if (!scopeValue.trim()) return defaultScope;
-  return scopeValue
+  const scopes = scopeValue
     .split(",")
     .map((part) => part.trim().toLowerCase())
     .filter(Boolean)
-    .map((part) => {
+    .flatMap((part) => {
+      if (part === "context" || part === "curated") return defaultScope;
       if (part === "capabilities") return "capabilities" as const;
       if (part === "capability") return "capabilities" as const;
-      if (part === "graph" || part === "entities" || part === "facts") return "graph" as const;
-      if (part === "tasks" || part === "acr" || part === "acrs") return "tasks" as const;
+      if (part === "facts" || part === "fact" || part === "claims") return "facts" as const;
+      if (part === "graph" || part === "entities" || part === "entity") return "graph" as const;
+      if (part === "tasks") return "tasks" as const;
+      if (part === "tasks-acr" || part === "acr" || part === "acrs") return "tasks-acr" as const;
       if (part === "wiki") return "wiki" as const;
+      if (part === "raw") return "raw" as const;
+      if (part === "all") return [...defaultScope, "raw", "tasks", "tasks-acr"] as const;
       return "raw" as const;
-    })
-    .filter((part) => part !== "raw");
+    });
+  return [...new Set(scopes)];
+}
+
+export function pathMatchesScopes(rowPath: string, scopes: ScopeName[]): boolean {
+  return scopes.some((scope) => {
+    switch (scope) {
+      case "wiki": {
+        return rowPath.startsWith("context/wiki/");
+      }
+      case "facts": {
+        return rowPath.startsWith(".agentplane/context/derived/facts/");
+      }
+      case "graph": {
+        return rowPath.startsWith(".agentplane/context/derived/graph/");
+      }
+      case "tasks": {
+        return rowPath.startsWith(".agentplane/tasks/");
+      }
+      case "tasks-acr": {
+        return rowPath.startsWith(".agentplane/tasks/") && rowPath.includes("/acr.json");
+      }
+      case "capabilities": {
+        return (
+          rowPath.startsWith("context/capabilities/") ||
+          rowPath.startsWith(".agentplane/context/derived/capabilities/")
+        );
+      }
+      case "raw": {
+        return rowPath.startsWith("context/raw/") && !rowPath.startsWith("context/raw/private/");
+      }
+      default: {
+        return false;
+      }
+    }
+  });
 }
 
 function scopeToFiles(root: string, scope: ScopeName): string[] {

--- a/packages/agentplane/src/context/context-utils.ts
+++ b/packages/agentplane/src/context/context-utils.ts
@@ -203,9 +203,11 @@ export async function walkScopeFiles(root: string, scopes: ScopeName[]): Promise
         if (stats.isDirectory()) {
           const discovered = await collectMatchingFiles(root, item);
           for (const discoveredPath of discovered) {
+            if (!pathMatchesScopes(discoveredPath, scopes)) continue;
             files.add(discoveredPath);
           }
         } else {
+          if (!pathMatchesScopes(item, scopes)) continue;
           files.add(item);
         }
       }


### PR DESCRIPTION
Task: `202605191428-C5AXQ6`
Title: Improve context recall boundaries
Canonical task record: `.agentplane/tasks/202605191428-C5AXQ6/README.md`

## Summary

Improve context recall boundaries

Make local context search prefer curated context by default, align context policy module references with actual derived paths and blueprint loading, and verify the context command behavior.

## Scope

- In scope: Make local context search prefer curated context by default, align context policy module references with actual derived paths and blueprint loading, and verify the context command behavior.
- Out of scope: unrelated refactors not required for "Improve context recall boundaries".

## Verification

- State: ok
- Note:

```text
Verified context recall boundary fix. Commands: bun test
packages/agentplane/src/commands/context/release-readiness.test.ts
packages/agentplane/src/cli/run-cli.core.help-snap.test.ts --timeout 120000 => pass, 30 tests and 8
snapshots; bunx eslint touched context/search/blueprint files => pass; bunx prettier --check touched
docs/source files => pass; bun run --filter=agentplane build => pass; bun run docs:cli:check =>
pass; node .agentplane/policy/check-routing.mjs => pass; ap context reindex --include-raw => pass
rows=16 files=21; ap context check => pass; ap context doctor => pass after serialized re-run; ap
doctor => OK; git diff --check => pass. Manual smoke: default context search excludes task history,
--scope tasks returns task records.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-19T14:42:48.918Z
- Branch: task/202605191428-C5AXQ6/context-recall-boundaries
- Head: c74d8af24a06

```text
 .agentplane/policy/context.must.md                 |   6 +-
 .../blueprint/resolved-snapshot.json               | 571 +++++++++++++++++++++
 docs/user/cli-reference.generated.mdx              |   4 +-
 docs/user/local-context.mdx                        |   4 +
 packages/agentplane/src/blueprints/builtins.ts     |  24 +-
 .../run-cli.core.help-snap.test.ts.snap            |  14 +-
 .../src/commands/context/context.spec.ts           |  10 +-
 .../src/commands/context/release-readiness.test.ts |  51 ++
 packages/agentplane/src/commands/context/search.ts |   2 +
 packages/agentplane/src/context/context-utils.ts   |  55 +-
 10 files changed, 711 insertions(+), 30 deletions(-)
```

</details>
