### PR TITLE
🚧 D566XJ task: Add deterministic evidence bundle commands [202605191421-D566XJ]

### DIFF
--- a/.agentplane/tasks/202605191421-D566XJ/README.md
+++ b/.agentplane/tasks/202605191421-D566XJ/README.md
@@ -4,7 +4,7 @@ title: "Add deterministic evidence bundle commands"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -26,9 +26,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-19T14:54:23.894Z"
-  updated_by: "EVALUATOR"
-  note: "Quality gate passed for deterministic evidence bundle implementation. Reviewed route evidence, focused tests, typecheck, lint, docs checks, ACR validation, strict evidence verification, and GitHub PR linkage. Hosted checks are still tracked separately on PR #3937."
+  updated_at: "2026-05-19T15:29:40.496Z"
+  updated_by: "CODER"
+  note: "Fixed hosted Linux format gate by applying Prettier to evidence command files. Local checks passed: format:check, focused evidence/ACR tests, agentplane typecheck, targeted eslint, docs:cli:check, docs:ia:check."
   attempts: 0
 quality_review:
   state: "pass"
@@ -66,8 +66,14 @@ events:
     author: "EVALUATOR"
     state: "ok"
     note: "Quality gate passed for deterministic evidence bundle implementation. Reviewed route evidence, focused tests, typecheck, lint, docs checks, ACR validation, strict evidence verification, and GitHub PR linkage. Hosted checks are still tracked separately on PR #3937."
+  -
+    type: "verify"
+    at: "2026-05-19T15:29:40.496Z"
+    author: "CODER"
+    state: "ok"
+    note: "Fixed hosted Linux format gate by applying Prettier to evidence command files. Local checks passed: format:check, focused evidence/ACR tests, agentplane typecheck, targeted eslint, docs:cli:check, docs:ia:check."
 doc_version: 3
-doc_updated_at: "2026-05-19T14:54:23.947Z"
+doc_updated_at: "2026-05-19T15:29:40.578Z"
 doc_updated_by: "CODER"
 description: "Implement a deterministic evidence bundle and verification CLI surface, with ACR trust extension metadata for generated bundles. Scope excludes Sigstore signing, S3 Object Lock preservation, and capability proposal flows."
 sections:
@@ -116,6 +122,25 @@ sections:
     Attempts: 0
 
     VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:49:33.056Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191421-D566XJ-evidence-bundle/.agentplane/tasks/202605191421-D566XJ/blueprint/resolved-snapshot.json
+    - old_digest: 343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4
+    - current_digest: 343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605191421-D566XJ
+
+    ### 2026-05-19T15:29:40.496Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Fixed hosted Linux format gate by applying Prettier to evidence command files. Local checks passed: format:check, focused evidence/ACR tests, agentplane typecheck, targeted eslint, docs:cli:check, docs:ia:check.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:54:23.947Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
 
     Details:
 
@@ -189,6 +214,25 @@ Note: Quality gate passed for deterministic evidence bundle implementation. Revi
 Attempts: 0
 
 VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:49:33.056Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191421-D566XJ-evidence-bundle/.agentplane/tasks/202605191421-D566XJ/blueprint/resolved-snapshot.json
+- old_digest: 343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4
+- current_digest: 343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605191421-D566XJ
+
+### 2026-05-19T15:29:40.496Z — VERIFY — ok
+
+By: CODER
+
+Note: Fixed hosted Linux format gate by applying Prettier to evidence command files. Local checks passed: format:check, focused evidence/ACR tests, agentplane typecheck, targeted eslint, docs:cli:check, docs:ia:check.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:54:23.947Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
 
 Details:
 

--- a/.agentplane/tasks/202605191421-D566XJ/README.md
+++ b/.agentplane/tasks/202605191421-D566XJ/README.md
@@ -1,0 +1,107 @@
+---
+id: "202605191421-D566XJ"
+title: "Add deterministic evidence bundle commands"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "acr"
+  - "code"
+  - "trust"
+verify:
+  - "bun test packages/agentplane/src/commands/evidence/evidence.command.test.ts packages/agentplane/src/commands/acr/acr.command.test.ts"
+  - "bun run --filter=agentplane typecheck"
+  - "bun run docs:cli:check"
+  - "bun run docs:ia:check"
+  - "agentplane evidence bundle 202605191421-D566XJ"
+  - "agentplane evidence verify 202605191421-D566XJ"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-19T14:22:15.293Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Implement deterministic evidence bundle and verification commands inside the task worktree, preserving the approved scope and excluding signing or preservation integrations."
+events:
+  -
+    type: "status"
+    at: "2026-05-19T14:23:12.271Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Implement deterministic evidence bundle and verification commands inside the task worktree, preserving the approved scope and excluding signing or preservation integrations."
+doc_version: 3
+doc_updated_at: "2026-05-19T14:23:12.271Z"
+doc_updated_by: "CODER"
+description: "Implement a deterministic evidence bundle and verification CLI surface, with ACR trust extension metadata for generated bundles. Scope excludes Sigstore signing, S3 Object Lock preservation, and capability proposal flows."
+sections:
+  Summary: |-
+    Add deterministic evidence bundle commands
+
+    Implement a deterministic evidence bundle and verification CLI surface, with ACR trust extension metadata for generated bundles. Scope excludes Sigstore signing, S3 Object Lock preservation, and capability proposal flows.
+  Scope: |-
+    - In scope: Implement a deterministic evidence bundle and verification CLI surface, with ACR trust extension metadata for generated bundles. Scope excludes Sigstore signing, S3 Object Lock preservation, and capability proposal flows.
+    - Out of scope: unrelated refactors not required for "Add deterministic evidence bundle commands".
+  Plan: "Implement the deterministic evidence bundle MVP in the AgentPlane framework repo. Scope: add an evidence CLI group with bundle and verify subcommands; create stable manifest/digest generation for task README, task ACR, blueprint snapshot when present, and selected task-local evidence; add ACR trust extension metadata when a task-local bundle manifest exists; add focused unit tests and command specs; update user/reference docs for the new commands. Non-goals: Sigstore signing, S3 Object Lock preservation, OpenSSF workflow changes, capability proposal flow."
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add deterministic evidence bundle commands
+
+Implement a deterministic evidence bundle and verification CLI surface, with ACR trust extension metadata for generated bundles. Scope excludes Sigstore signing, S3 Object Lock preservation, and capability proposal flows.
+
+## Scope
+
+- In scope: Implement a deterministic evidence bundle and verification CLI surface, with ACR trust extension metadata for generated bundles. Scope excludes Sigstore signing, S3 Object Lock preservation, and capability proposal flows.
+- Out of scope: unrelated refactors not required for "Add deterministic evidence bundle commands".
+
+## Plan
+
+Implement the deterministic evidence bundle MVP in the AgentPlane framework repo. Scope: add an evidence CLI group with bundle and verify subcommands; create stable manifest/digest generation for task README, task ACR, blueprint snapshot when present, and selected task-local evidence; add ACR trust extension metadata when a task-local bundle manifest exists; add focused unit tests and command specs; update user/reference docs for the new commands. Non-goals: Sigstore signing, S3 Object Lock preservation, OpenSSF workflow changes, capability proposal flow.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605191421-D566XJ/README.md
+++ b/.agentplane/tasks/202605191421-D566XJ/README.md
@@ -35,7 +35,7 @@ quality_review:
   updated_at: "2026-05-19T15:54:39.502Z"
   updated_by: "EVALUATOR"
   note: "EVALUATOR quality gate passed for current implementation commit 08db6b47. Reviewed fixes for configured workflow_dir evidence paths and deterministic bundle reruns; local checks passed: focused evidence/ACR tests, typecheck, format:check, targeted eslint, framework bootstrap; hosted PR checks are green on PR #3937."
-  evaluated_sha: "b4de91888f2a4db53aa0e00cd20972170882085d"
+  evaluated_sha: "08db6b47a4528e5e50155378c65a5e299da2966e"
   blueprint_digest: "343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4"
   evidence_refs:
     - ".agentplane/tasks/202605191421-D566XJ/README.md"

--- a/.agentplane/tasks/202605191421-D566XJ/README.md
+++ b/.agentplane/tasks/202605191421-D566XJ/README.md
@@ -4,7 +4,7 @@ title: "Add deterministic evidence bundle commands"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 8
+revision: 9
 origin:
   system: "manual"
 depends_on: []
@@ -26,16 +26,16 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-19T15:45:54.344Z"
-  updated_by: "CODER"
-  note: "Addressed PR review threads: evidence bundle now respects configured workflow_dir and preserves existing created_at to keep unchanged bundle reruns deterministic. Local checks passed: focused evidence/ACR tests, agentplane typecheck, targeted eslint, format:check, framework:dev:bootstrap."
+  updated_at: "2026-05-19T15:54:39.502Z"
+  updated_by: "EVALUATOR"
+  note: "EVALUATOR quality gate passed for current implementation commit 08db6b47. Reviewed fixes for configured workflow_dir evidence paths and deterministic bundle reruns; local checks passed: focused evidence/ACR tests, typecheck, format:check, targeted eslint, framework bootstrap; hosted PR checks are green on PR #3937."
   attempts: 0
 quality_review:
   state: "pass"
-  updated_at: "2026-05-19T14:54:23.894Z"
+  updated_at: "2026-05-19T15:54:39.502Z"
   updated_by: "EVALUATOR"
-  note: "Quality gate passed for deterministic evidence bundle implementation. Reviewed route evidence, focused tests, typecheck, lint, docs checks, ACR validation, strict evidence verification, and GitHub PR linkage. Hosted checks are still tracked separately on PR #3937."
-  evaluated_sha: "96c50097d9834eed7a02f0bc8cf84d1754802c02"
+  note: "EVALUATOR quality gate passed for current implementation commit 08db6b47. Reviewed fixes for configured workflow_dir evidence paths and deterministic bundle reruns; local checks passed: focused evidence/ACR tests, typecheck, format:check, targeted eslint, framework bootstrap; hosted PR checks are green on PR #3937."
+  evaluated_sha: "b4de91888f2a4db53aa0e00cd20972170882085d"
   blueprint_digest: "343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4"
   evidence_refs:
     - ".agentplane/tasks/202605191421-D566XJ/README.md"
@@ -78,8 +78,14 @@ events:
     author: "CODER"
     state: "ok"
     note: "Addressed PR review threads: evidence bundle now respects configured workflow_dir and preserves existing created_at to keep unchanged bundle reruns deterministic. Local checks passed: focused evidence/ACR tests, agentplane typecheck, targeted eslint, format:check, framework:dev:bootstrap."
+  -
+    type: "verify"
+    at: "2026-05-19T15:54:39.502Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "EVALUATOR quality gate passed for current implementation commit 08db6b47. Reviewed fixes for configured workflow_dir evidence paths and deterministic bundle reruns; local checks passed: focused evidence/ACR tests, typecheck, format:check, targeted eslint, framework bootstrap; hosted PR checks are green on PR #3937."
 doc_version: 3
-doc_updated_at: "2026-05-19T15:45:54.484Z"
+doc_updated_at: "2026-05-19T15:54:39.561Z"
 doc_updated_by: "CODER"
 description: "Implement a deterministic evidence bundle and verification CLI surface, with ACR trust extension metadata for generated bundles. Scope excludes Sigstore signing, S3 Object Lock preservation, and capability proposal flows."
 sections:
@@ -166,6 +172,25 @@ sections:
     Attempts: 0
 
     VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T15:29:40.578Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191421-D566XJ-evidence-bundle/.agentplane/tasks/202605191421-D566XJ/blueprint/resolved-snapshot.json
+    - old_digest: 343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4
+    - current_digest: 343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605191421-D566XJ
+
+    ### 2026-05-19T15:54:39.502Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: EVALUATOR quality gate passed for current implementation commit 08db6b47. Reviewed fixes for configured workflow_dir evidence paths and deterministic bundle reruns; local checks passed: focused evidence/ACR tests, typecheck, format:check, targeted eslint, framework bootstrap; hosted PR checks are green on PR #3937.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T15:45:54.484Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
 
     Details:
 
@@ -277,6 +302,25 @@ Note: Addressed PR review threads: evidence bundle now respects configured workf
 Attempts: 0
 
 VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T15:29:40.578Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191421-D566XJ-evidence-bundle/.agentplane/tasks/202605191421-D566XJ/blueprint/resolved-snapshot.json
+- old_digest: 343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4
+- current_digest: 343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605191421-D566XJ
+
+### 2026-05-19T15:54:39.502Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: EVALUATOR quality gate passed for current implementation commit 08db6b47. Reviewed fixes for configured workflow_dir evidence paths and deterministic bundle reruns; local checks passed: focused evidence/ACR tests, typecheck, format:check, targeted eslint, framework bootstrap; hosted PR checks are green on PR #3937.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T15:45:54.484Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
 
 Details:
 

--- a/.agentplane/tasks/202605191421-D566XJ/README.md
+++ b/.agentplane/tasks/202605191421-D566XJ/README.md
@@ -4,7 +4,7 @@ title: "Add deterministic evidence bundle commands"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 4
+revision: 5
 origin:
   system: "manual"
 depends_on: []
@@ -25,10 +25,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-19T14:49:32.970Z"
+  updated_by: "CODER"
+  note: "Implemented deterministic evidence bundle and verify commands with ACR trust pointer and docs. Checks passed: focused evidence/ACR tests, agentplane typecheck, lint:core, docs:cli:check, docs:ia:check, evidence bundle, evidence verify --strict."
   attempts: 0
 commit: null
 comments:
@@ -43,8 +43,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: Implement deterministic evidence bundle and verification commands inside the task worktree, preserving the approved scope and excluding signing or preservation integrations."
+  -
+    type: "verify"
+    at: "2026-05-19T14:49:32.970Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented deterministic evidence bundle and verify commands with ACR trust pointer and docs. Checks passed: focused evidence/ACR tests, agentplane typecheck, lint:core, docs:cli:check, docs:ia:check, evidence bundle, evidence verify --strict."
 doc_version: 3
-doc_updated_at: "2026-05-19T14:23:12.271Z"
+doc_updated_at: "2026-05-19T14:49:33.056Z"
 doc_updated_by: "CODER"
 description: "Implement a deterministic evidence bundle and verification CLI surface, with ACR trust extension metadata for generated bundles. Scope excludes Sigstore signing, S3 Object Lock preservation, and capability proposal flows."
 sections:
@@ -64,6 +70,27 @@ sections:
     3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-19T14:49:32.970Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Implemented deterministic evidence bundle and verify commands with ACR trust pointer and docs. Checks passed: focused evidence/ACR tests, agentplane typecheck, lint:core, docs:cli:check, docs:ia:check, evidence bundle, evidence verify --strict.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:23:12.271Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    Command: bun test packages/agentplane/src/commands/evidence/evidence.command.test.ts packages/agentplane/src/commands/acr/acr.command.test.ts -> pass, 13 tests. Command: bun run --filter=agentplane typecheck -> pass. Command: bun run lint:core -> pass. Command: bun run docs:cli:check and bun run docs:ia:check -> pass. Command: agentplane evidence bundle 202605191421-D566XJ and agentplane evidence verify 202605191421-D566XJ --strict -> pass, manifest includes 8 files.
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191421-D566XJ-evidence-bundle/.agentplane/tasks/202605191421-D566XJ/blueprint/resolved-snapshot.json
+    - old_digest: 343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4
+    - current_digest: 343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605191421-D566XJ
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -97,6 +124,27 @@ PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLA
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-19T14:49:32.970Z — VERIFY — ok
+
+By: CODER
+
+Note: Implemented deterministic evidence bundle and verify commands with ACR trust pointer and docs. Checks passed: focused evidence/ACR tests, agentplane typecheck, lint:core, docs:cli:check, docs:ia:check, evidence bundle, evidence verify --strict.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:23:12.271Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+Command: bun test packages/agentplane/src/commands/evidence/evidence.command.test.ts packages/agentplane/src/commands/acr/acr.command.test.ts -> pass, 13 tests. Command: bun run --filter=agentplane typecheck -> pass. Command: bun run lint:core -> pass. Command: bun run docs:cli:check and bun run docs:ia:check -> pass. Command: agentplane evidence bundle 202605191421-D566XJ and agentplane evidence verify 202605191421-D566XJ --strict -> pass, manifest includes 8 files.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191421-D566XJ-evidence-bundle/.agentplane/tasks/202605191421-D566XJ/blueprint/resolved-snapshot.json
+- old_digest: 343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4
+- current_digest: 343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605191421-D566XJ
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605191421-D566XJ/README.md
+++ b/.agentplane/tasks/202605191421-D566XJ/README.md
@@ -4,7 +4,7 @@ title: "Add deterministic evidence bundle commands"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 7
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -26,9 +26,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-19T15:29:40.496Z"
+  updated_at: "2026-05-19T15:45:54.344Z"
   updated_by: "CODER"
-  note: "Fixed hosted Linux format gate by applying Prettier to evidence command files. Local checks passed: format:check, focused evidence/ACR tests, agentplane typecheck, targeted eslint, docs:cli:check, docs:ia:check."
+  note: "Addressed PR review threads: evidence bundle now respects configured workflow_dir and preserves existing created_at to keep unchanged bundle reruns deterministic. Local checks passed: focused evidence/ACR tests, agentplane typecheck, targeted eslint, format:check, framework:dev:bootstrap."
   attempts: 0
 quality_review:
   state: "pass"
@@ -72,8 +72,14 @@ events:
     author: "CODER"
     state: "ok"
     note: "Fixed hosted Linux format gate by applying Prettier to evidence command files. Local checks passed: format:check, focused evidence/ACR tests, agentplane typecheck, targeted eslint, docs:cli:check, docs:ia:check."
+  -
+    type: "verify"
+    at: "2026-05-19T15:45:54.344Z"
+    author: "CODER"
+    state: "ok"
+    note: "Addressed PR review threads: evidence bundle now respects configured workflow_dir and preserves existing created_at to keep unchanged bundle reruns deterministic. Local checks passed: focused evidence/ACR tests, agentplane typecheck, targeted eslint, format:check, framework:dev:bootstrap."
 doc_version: 3
-doc_updated_at: "2026-05-19T15:29:40.578Z"
+doc_updated_at: "2026-05-19T15:45:54.484Z"
 doc_updated_by: "CODER"
 description: "Implement a deterministic evidence bundle and verification CLI surface, with ACR trust extension metadata for generated bundles. Scope excludes Sigstore signing, S3 Object Lock preservation, and capability proposal flows."
 sections:
@@ -141,6 +147,25 @@ sections:
     Attempts: 0
 
     VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:54:23.947Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191421-D566XJ-evidence-bundle/.agentplane/tasks/202605191421-D566XJ/blueprint/resolved-snapshot.json
+    - old_digest: 343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4
+    - current_digest: 343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605191421-D566XJ
+
+    ### 2026-05-19T15:45:54.344Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Addressed PR review threads: evidence bundle now respects configured workflow_dir and preserves existing created_at to keep unchanged bundle reruns deterministic. Local checks passed: focused evidence/ACR tests, agentplane typecheck, targeted eslint, format:check, framework:dev:bootstrap.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T15:29:40.578Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
 
     Details:
 
@@ -233,6 +258,25 @@ Note: Fixed hosted Linux format gate by applying Prettier to evidence command fi
 Attempts: 0
 
 VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:54:23.947Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191421-D566XJ-evidence-bundle/.agentplane/tasks/202605191421-D566XJ/blueprint/resolved-snapshot.json
+- old_digest: 343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4
+- current_digest: 343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605191421-D566XJ
+
+### 2026-05-19T15:45:54.344Z — VERIFY — ok
+
+By: CODER
+
+Note: Addressed PR review threads: evidence bundle now respects configured workflow_dir and preserves existing created_at to keep unchanged bundle reruns deterministic. Local checks passed: focused evidence/ACR tests, agentplane typecheck, targeted eslint, format:check, framework:dev:bootstrap.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T15:29:40.578Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
 
 Details:
 

--- a/.agentplane/tasks/202605191421-D566XJ/README.md
+++ b/.agentplane/tasks/202605191421-D566XJ/README.md
@@ -4,7 +4,7 @@ title: "Add deterministic evidence bundle commands"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -26,10 +26,21 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-19T14:49:32.970Z"
-  updated_by: "CODER"
-  note: "Implemented deterministic evidence bundle and verify commands with ACR trust pointer and docs. Checks passed: focused evidence/ACR tests, agentplane typecheck, lint:core, docs:cli:check, docs:ia:check, evidence bundle, evidence verify --strict."
+  updated_at: "2026-05-19T14:54:23.894Z"
+  updated_by: "EVALUATOR"
+  note: "Quality gate passed for deterministic evidence bundle implementation. Reviewed route evidence, focused tests, typecheck, lint, docs checks, ACR validation, strict evidence verification, and GitHub PR linkage. Hosted checks are still tracked separately on PR #3937."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-19T14:54:23.894Z"
+  updated_by: "EVALUATOR"
+  note: "Quality gate passed for deterministic evidence bundle implementation. Reviewed route evidence, focused tests, typecheck, lint, docs checks, ACR validation, strict evidence verification, and GitHub PR linkage. Hosted checks are still tracked separately on PR #3937."
+  evaluated_sha: "96c50097d9834eed7a02f0bc8cf84d1754802c02"
+  blueprint_digest: "343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4"
+  evidence_refs:
+    - ".agentplane/tasks/202605191421-D566XJ/README.md"
+    - "/Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191421-D566XJ-evidence-bundle/.agentplane/tasks/202605191421-D566XJ/blueprint/resolved-snapshot.json"
+  findings: []
 commit: null
 comments:
   -
@@ -49,8 +60,14 @@ events:
     author: "CODER"
     state: "ok"
     note: "Implemented deterministic evidence bundle and verify commands with ACR trust pointer and docs. Checks passed: focused evidence/ACR tests, agentplane typecheck, lint:core, docs:cli:check, docs:ia:check, evidence bundle, evidence verify --strict."
+  -
+    type: "verify"
+    at: "2026-05-19T14:54:23.894Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Quality gate passed for deterministic evidence bundle implementation. Reviewed route evidence, focused tests, typecheck, lint, docs checks, ACR validation, strict evidence verification, and GitHub PR linkage. Hosted checks are still tracked separately on PR #3937."
 doc_version: 3
-doc_updated_at: "2026-05-19T14:49:33.056Z"
+doc_updated_at: "2026-05-19T14:54:23.947Z"
 doc_updated_by: "CODER"
 description: "Implement a deterministic evidence bundle and verification CLI surface, with ACR trust extension metadata for generated bundles. Scope excludes Sigstore signing, S3 Object Lock preservation, and capability proposal flows."
 sections:
@@ -82,6 +99,25 @@ sections:
     Details:
 
     Command: bun test packages/agentplane/src/commands/evidence/evidence.command.test.ts packages/agentplane/src/commands/acr/acr.command.test.ts -> pass, 13 tests. Command: bun run --filter=agentplane typecheck -> pass. Command: bun run lint:core -> pass. Command: bun run docs:cli:check and bun run docs:ia:check -> pass. Command: agentplane evidence bundle 202605191421-D566XJ and agentplane evidence verify 202605191421-D566XJ --strict -> pass, manifest includes 8 files.
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191421-D566XJ-evidence-bundle/.agentplane/tasks/202605191421-D566XJ/blueprint/resolved-snapshot.json
+    - old_digest: 343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4
+    - current_digest: 343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605191421-D566XJ
+
+    ### 2026-05-19T14:54:23.894Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Quality gate passed for deterministic evidence bundle implementation. Reviewed route evidence, focused tests, typecheck, lint, docs checks, ACR validation, strict evidence verification, and GitHub PR linkage. Hosted checks are still tracked separately on PR #3937.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:49:33.056Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
 
     BlueprintSnapshotRef:
     - state: current
@@ -136,6 +172,25 @@ VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:23:12.271Z, excerpt_
 Details:
 
 Command: bun test packages/agentplane/src/commands/evidence/evidence.command.test.ts packages/agentplane/src/commands/acr/acr.command.test.ts -> pass, 13 tests. Command: bun run --filter=agentplane typecheck -> pass. Command: bun run lint:core -> pass. Command: bun run docs:cli:check and bun run docs:ia:check -> pass. Command: agentplane evidence bundle 202605191421-D566XJ and agentplane evidence verify 202605191421-D566XJ --strict -> pass, manifest includes 8 files.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191421-D566XJ-evidence-bundle/.agentplane/tasks/202605191421-D566XJ/blueprint/resolved-snapshot.json
+- old_digest: 343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4
+- current_digest: 343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605191421-D566XJ
+
+### 2026-05-19T14:54:23.894Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Quality gate passed for deterministic evidence bundle implementation. Reviewed route evidence, focused tests, typecheck, lint, docs checks, ACR validation, strict evidence verification, and GitHub PR linkage. Hosted checks are still tracked separately on PR #3937.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T14:49:33.056Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
 
 BlueprintSnapshotRef:
 - state: current

--- a/.agentplane/tasks/202605191421-D566XJ/acr.json
+++ b/.agentplane/tasks/202605191421-D566XJ/acr.json
@@ -1,0 +1,402 @@
+{
+  "acr_version": "0.1.0",
+  "record_type": "agent_change_record",
+  "record_id": "acr_202605191421-D566XJ",
+  "created_at": "2026-05-19T14:51:37.546Z",
+  "producer": {
+    "name": "agentplane",
+    "version": "0.6.3"
+  },
+  "repository": {
+    "vcs": "git",
+    "remote": "https://github.com/basilisk-labs/agentplane.git",
+    "base_ref": "main",
+    "base_commit": "81a3ed59446b0e0fbdf663711e789c53ec915369",
+    "work_ref": "task/202605191421-D566XJ/evidence-bundle",
+    "work_commit": "a89b99bfe360becc2e5b22f3395a84d70db43257"
+  },
+  "task": {
+    "task_id": "202605191421-D566XJ",
+    "title": "Add deterministic evidence bundle commands",
+    "intent": "Implement a deterministic evidence bundle and verification CLI surface, with ACR trust extension metadata for generated bundles. Scope excludes Sigstore signing, S3 Object Lock preservation, and capability proposal flows.",
+    "requested_by": {
+      "type": "agentplane_role",
+      "id": "ORCHESTRATOR"
+    }
+  },
+  "agent": {
+    "id": "CODER",
+    "name": "CODER",
+    "agent_type": "coding_agent",
+    "model": {
+      "provider": "unknown",
+      "name": "unknown",
+      "version": "unknown"
+    },
+    "toolchain": [
+      {
+        "name": "agentplane",
+        "version": "0.6.3"
+      }
+    ]
+  },
+  "plan": {
+    "status": "approved",
+    "artifact": {
+      "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
+      "sha256": "sha256:535082acffa4ff21da7d6d8351a23ea61400d72329e49bb185b59f6a910e1bd0"
+    },
+    "approved_at": "2026-05-19T14:22:15.293Z",
+    "approved_by": {
+      "type": "agentplane_role",
+      "id": "ORCHESTRATOR"
+    }
+  },
+  "permissions": {
+    "network": {
+      "mode": "unknown"
+    },
+    "secrets": {
+      "access": "none"
+    },
+    "tools": [
+      {
+        "name": "shell",
+        "allowed": true
+      }
+    ]
+  },
+  "policy": {
+    "policy_version": "0.1.0",
+    "decisions": [
+      {
+        "rule_id": "plan.required",
+        "decision": "pass",
+        "reason": "Approved plan exists."
+      },
+      {
+        "rule_id": "verification.required",
+        "decision": "pass",
+        "reason": "Verification is recorded as ok."
+      }
+    ]
+  },
+  "changes": {
+    "summary": "Implement a deterministic evidence bundle and verification CLI surface, with ACR trust extension metadata for generated bundles. Scope excludes Sigstore signing, S3 Object Lock preservation, and capability proposal flows.",
+    "diff_stats": {
+      "files_changed": 17,
+      "insertions": 1562,
+      "deletions": 4
+    },
+    "files": [
+      {
+        "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
+        "status": "added",
+        "risk_categories": [
+          "tooling"
+        ]
+      },
+      {
+        "path": ".agentplane/tasks/202605191421-D566XJ/blueprint/resolved-snapshot.json",
+        "status": "added",
+        "risk_categories": [
+          "tooling"
+        ]
+      },
+      {
+        "path": ".agentplane/tasks/202605191421-D566XJ/evidence/manifest.json",
+        "status": "added",
+        "risk_categories": [
+          "tooling"
+        ]
+      },
+      {
+        "path": ".agentplane/tasks/202605191421-D566XJ/pr/diffstat.txt",
+        "status": "added",
+        "risk_categories": [
+          "tooling"
+        ]
+      },
+      {
+        "path": ".agentplane/tasks/202605191421-D566XJ/pr/github-body.md",
+        "status": "added",
+        "risk_categories": [
+          "tooling"
+        ]
+      },
+      {
+        "path": ".agentplane/tasks/202605191421-D566XJ/pr/github-title.txt",
+        "status": "added",
+        "risk_categories": [
+          "tooling"
+        ]
+      },
+      {
+        "path": ".agentplane/tasks/202605191421-D566XJ/pr/meta.json",
+        "status": "added",
+        "risk_categories": [
+          "tooling"
+        ]
+      },
+      {
+        "path": ".agentplane/tasks/202605191421-D566XJ/pr/review.md",
+        "status": "added",
+        "risk_categories": [
+          "tooling"
+        ]
+      },
+      {
+        "path": "docs/reference/acr.mdx",
+        "status": "modified",
+        "risk_categories": [
+          "docs"
+        ]
+      },
+      {
+        "path": "docs/reference/evidence.mdx",
+        "status": "added",
+        "risk_categories": [
+          "docs"
+        ]
+      },
+      {
+        "path": "docs/user/cli-reference.generated.mdx",
+        "status": "modified",
+        "risk_categories": [
+          "docs"
+        ]
+      },
+      {
+        "path": "packages/agentplane/src/cli/run-cli/command-catalog/project.ts",
+        "status": "modified",
+        "risk_categories": [
+          "tooling"
+        ]
+      },
+      {
+        "path": "packages/agentplane/src/cli/run-cli/command-loaders/project.ts",
+        "status": "modified",
+        "risk_categories": [
+          "tooling"
+        ]
+      },
+      {
+        "path": "packages/agentplane/src/commands/acr/generate.ts",
+        "status": "modified",
+        "risk_categories": [
+          "cli"
+        ]
+      },
+      {
+        "path": "packages/agentplane/src/commands/evidence/evidence.command.test.ts",
+        "status": "added",
+        "risk_categories": [
+          "tests",
+          "cli"
+        ]
+      },
+      {
+        "path": "packages/agentplane/src/commands/evidence/evidence.command.ts",
+        "status": "added",
+        "risk_categories": [
+          "cli"
+        ]
+      },
+      {
+        "path": "website/sidebars.ts",
+        "status": "modified",
+        "risk_categories": [
+          "tooling"
+        ]
+      }
+    ],
+    "risk": {
+      "level": "medium",
+      "categories": [
+        "tooling",
+        "docs",
+        "cli",
+        "tests"
+      ],
+      "protected_paths_touched": false
+    }
+  },
+  "verification": {
+    "status": "passed",
+    "checks": [
+      {
+        "check_id": "verify-1",
+        "type": "test",
+        "command": "bun test packages/agentplane/src/commands/evidence/evidence.command.test.ts packages/agentplane/src/commands/acr/acr.command.test.ts",
+        "status": "passed"
+      },
+      {
+        "check_id": "verify-2",
+        "type": "typecheck",
+        "command": "bun run --filter=agentplane typecheck",
+        "status": "passed"
+      },
+      {
+        "check_id": "verify-3",
+        "type": "other",
+        "command": "bun run docs:cli:check",
+        "status": "passed"
+      },
+      {
+        "check_id": "verify-4",
+        "type": "other",
+        "command": "bun run docs:ia:check",
+        "status": "passed"
+      },
+      {
+        "check_id": "verify-5",
+        "type": "other",
+        "command": "agentplane evidence bundle 202605191421-D566XJ",
+        "status": "passed"
+      },
+      {
+        "check_id": "verify-6",
+        "type": "other",
+        "command": "agentplane evidence verify 202605191421-D566XJ",
+        "status": "passed"
+      }
+    ]
+  },
+  "approvals": [
+    {
+      "approval_id": "approval_202605191421-D566XJ_plan",
+      "type": "plan_approval",
+      "decision": "approved",
+      "approved_by": {
+        "type": "agentplane_role",
+        "id": "ORCHESTRATOR"
+      },
+      "approved_at": "2026-05-19T14:22:15.293Z",
+      "scope": "task"
+    }
+  ],
+  "evidence": [
+    {
+      "type": "task",
+      "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
+      "sha256": "sha256:535082acffa4ff21da7d6d8351a23ea61400d72329e49bb185b59f6a910e1bd0"
+    },
+    {
+      "type": "plan",
+      "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
+      "sha256": "sha256:535082acffa4ff21da7d6d8351a23ea61400d72329e49bb185b59f6a910e1bd0"
+    },
+    {
+      "type": "verification_log",
+      "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
+      "sha256": "sha256:535082acffa4ff21da7d6d8351a23ea61400d72329e49bb185b59f6a910e1bd0"
+    },
+    {
+      "type": "other",
+      "path": ".agentplane/tasks/202605191421-D566XJ/blueprint/resolved-snapshot.json",
+      "sha256": "sha256:fed075464bed838ed32854e5c1f4576ab307811a84d84f696662650d6887e61b"
+    }
+  ],
+  "result": {
+    "status": "verified",
+    "merge_ready": true,
+    "residual_risks": [],
+    "rollback": {
+      "available": true,
+      "notes": "Revert work_commit a89b99bfe360becc2e5b22f3395a84d70db43257 if downstream validation fails."
+    }
+  },
+  "integrity": {
+    "digest_algorithm": "sha256",
+    "record_digest": "sha256:5faa98944696bff12e72b490007ffa6481b718584b7dbb513700720a886bea0a",
+    "canonicalization": "rfc8785-jcs",
+    "signatures": []
+  },
+  "extensions": {
+    "agentplane.blueprint": {
+      "blueprint_id": "code.branch_pr",
+      "blueprint_version": 1,
+      "workflow_mode": "branch_pr",
+      "route": [
+        "intake",
+        "scope",
+        "approval_gate",
+        "context_resolve",
+        "worktree_start",
+        "work_unit",
+        "fast_local_checks",
+        "pr_artifact",
+        "verify_record",
+        "quality_gate",
+        "hosted_checks",
+        "publish_or_integrate",
+        "finish"
+      ],
+      "required_evidence": [
+        {
+          "id": "code_pr.paths",
+          "kind": "changed_paths",
+          "produced_by": "work_unit",
+          "required": true
+        },
+        {
+          "id": "code_pr.fast_checks",
+          "kind": "check_result",
+          "produced_by": "fast_local_checks",
+          "required": true
+        },
+        {
+          "id": "code_pr.pr",
+          "kind": "external_link",
+          "produced_by": "pr_artifact",
+          "required": true
+        },
+        {
+          "id": "code_pr.verify",
+          "kind": "check_result",
+          "produced_by": "verify_record",
+          "required": true
+        },
+        {
+          "id": "code_pr.quality",
+          "kind": "quality_report",
+          "produced_by": "quality_gate",
+          "required": true
+        },
+        {
+          "id": "code_pr.hosted",
+          "kind": "check_result",
+          "produced_by": "hosted_checks",
+          "required": true
+        },
+        {
+          "id": "code_pr.commit",
+          "kind": "commit",
+          "produced_by": "publish_or_integrate",
+          "required": true
+        }
+      ],
+      "accepted_recipe_extensions": [],
+      "rejected_recipe_extensions": [],
+      "stop_reasons": [],
+      "snapshot": {
+        "state": "current",
+        "path": ".agentplane/tasks/202605191421-D566XJ/blueprint/resolved-snapshot.json",
+        "digest": "343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4",
+        "current_digest": "343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4",
+        "route_changed": false,
+        "artifact_sha256": "sha256:fed075464bed838ed32854e5c1f4576ab307811a84d84f696662650d6887e61b",
+        "safe_command": "agentplane blueprint snapshot 202605191421-D566XJ"
+      }
+    },
+    "agentplane.trust": {
+      "schema_version": 1,
+      "evidence_bundle": {
+        "path": ".agentplane/tasks/202605191421-D566XJ/evidence/manifest.json",
+        "digest_algorithm": "sha256",
+        "verification_command": "agentplane evidence verify 202605191421-D566XJ",
+        "status": "available"
+      }
+    }
+  }
+}

--- a/.agentplane/tasks/202605191421-D566XJ/acr.json
+++ b/.agentplane/tasks/202605191421-D566XJ/acr.json
@@ -2,7 +2,7 @@
   "acr_version": "0.1.0",
   "record_type": "agent_change_record",
   "record_id": "acr_202605191421-D566XJ",
-  "created_at": "2026-05-19T14:51:37.546Z",
+  "created_at": "2026-05-19T14:54:34.480Z",
   "producer": {
     "name": "agentplane",
     "version": "0.6.3"
@@ -13,7 +13,7 @@
     "base_ref": "main",
     "base_commit": "81a3ed59446b0e0fbdf663711e789c53ec915369",
     "work_ref": "task/202605191421-D566XJ/evidence-bundle",
-    "work_commit": "a89b99bfe360becc2e5b22f3395a84d70db43257"
+    "work_commit": "96c50097d9834eed7a02f0bc8cf84d1754802c02"
   },
   "task": {
     "task_id": "202605191421-D566XJ",
@@ -44,7 +44,7 @@
     "status": "approved",
     "artifact": {
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
-      "sha256": "sha256:535082acffa4ff21da7d6d8351a23ea61400d72329e49bb185b59f6a910e1bd0"
+      "sha256": "sha256:c2172e902b303ad763f569235b9c6b354f3d9c3f68b5338c58164ed4d703a493"
     },
     "approved_at": "2026-05-19T14:22:15.293Z",
     "approved_by": {
@@ -84,13 +84,20 @@
   "changes": {
     "summary": "Implement a deterministic evidence bundle and verification CLI surface, with ACR trust extension metadata for generated bundles. Scope excludes Sigstore signing, S3 Object Lock preservation, and capability proposal flows.",
     "diff_stats": {
-      "files_changed": 17,
-      "insertions": 1562,
+      "files_changed": 18,
+      "insertions": 2064,
       "deletions": 4
     },
     "files": [
       {
         "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
+        "status": "added",
+        "risk_categories": [
+          "tooling"
+        ]
+      },
+      {
+        "path": ".agentplane/tasks/202605191421-D566XJ/acr.json",
         "status": "added",
         "risk_categories": [
           "tooling"
@@ -279,17 +286,17 @@
     {
       "type": "task",
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
-      "sha256": "sha256:535082acffa4ff21da7d6d8351a23ea61400d72329e49bb185b59f6a910e1bd0"
+      "sha256": "sha256:c2172e902b303ad763f569235b9c6b354f3d9c3f68b5338c58164ed4d703a493"
     },
     {
       "type": "plan",
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
-      "sha256": "sha256:535082acffa4ff21da7d6d8351a23ea61400d72329e49bb185b59f6a910e1bd0"
+      "sha256": "sha256:c2172e902b303ad763f569235b9c6b354f3d9c3f68b5338c58164ed4d703a493"
     },
     {
       "type": "verification_log",
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
-      "sha256": "sha256:535082acffa4ff21da7d6d8351a23ea61400d72329e49bb185b59f6a910e1bd0"
+      "sha256": "sha256:c2172e902b303ad763f569235b9c6b354f3d9c3f68b5338c58164ed4d703a493"
     },
     {
       "type": "other",
@@ -303,12 +310,12 @@
     "residual_risks": [],
     "rollback": {
       "available": true,
-      "notes": "Revert work_commit a89b99bfe360becc2e5b22f3395a84d70db43257 if downstream validation fails."
+      "notes": "Revert work_commit 96c50097d9834eed7a02f0bc8cf84d1754802c02 if downstream validation fails."
     }
   },
   "integrity": {
     "digest_algorithm": "sha256",
-    "record_digest": "sha256:5faa98944696bff12e72b490007ffa6481b718584b7dbb513700720a886bea0a",
+    "record_digest": "sha256:7cbe463af4864690547a893bca3a44035ffb4f8fa54616a320eb06a7efa7f9dd",
     "canonicalization": "rfc8785-jcs",
     "signatures": []
   },

--- a/.agentplane/tasks/202605191421-D566XJ/acr.json
+++ b/.agentplane/tasks/202605191421-D566XJ/acr.json
@@ -2,7 +2,7 @@
   "acr_version": "0.1.0",
   "record_type": "agent_change_record",
   "record_id": "acr_202605191421-D566XJ",
-  "created_at": "2026-05-19T15:29:50.875Z",
+  "created_at": "2026-05-19T15:46:14.915Z",
   "producer": {
     "name": "agentplane",
     "version": "0.6.3"
@@ -13,7 +13,7 @@
     "base_ref": "main",
     "base_commit": "81a3ed59446b0e0fbdf663711e789c53ec915369",
     "work_ref": "task/202605191421-D566XJ/evidence-bundle",
-    "work_commit": "f0df96e155d146e4a27af504d0c79071ea1c0802"
+    "work_commit": "08db6b47a4528e5e50155378c65a5e299da2966e"
   },
   "task": {
     "task_id": "202605191421-D566XJ",
@@ -44,7 +44,7 @@
     "status": "approved",
     "artifact": {
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
-      "sha256": "sha256:5979974073c5bbcf349380b5c8bf65fbac5dbe0c34bff6b2c4b9044acebae6c2"
+      "sha256": "sha256:fa813e50373df208cdc22c44a5bb6222ae98e504142868df1c8dfe7bbac8461a"
     },
     "approved_at": "2026-05-19T14:22:15.293Z",
     "approved_by": {
@@ -85,7 +85,7 @@
     "summary": "Implement a deterministic evidence bundle and verification CLI surface, with ACR trust extension metadata for generated bundles. Scope excludes Sigstore signing, S3 Object Lock preservation, and capability proposal flows.",
     "diff_stats": {
       "files_changed": 18,
-      "insertions": 2123,
+      "insertions": 2246,
       "deletions": 4
     },
     "files": [
@@ -286,17 +286,17 @@
     {
       "type": "task",
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
-      "sha256": "sha256:5979974073c5bbcf349380b5c8bf65fbac5dbe0c34bff6b2c4b9044acebae6c2"
+      "sha256": "sha256:fa813e50373df208cdc22c44a5bb6222ae98e504142868df1c8dfe7bbac8461a"
     },
     {
       "type": "plan",
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
-      "sha256": "sha256:5979974073c5bbcf349380b5c8bf65fbac5dbe0c34bff6b2c4b9044acebae6c2"
+      "sha256": "sha256:fa813e50373df208cdc22c44a5bb6222ae98e504142868df1c8dfe7bbac8461a"
     },
     {
       "type": "verification_log",
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
-      "sha256": "sha256:5979974073c5bbcf349380b5c8bf65fbac5dbe0c34bff6b2c4b9044acebae6c2"
+      "sha256": "sha256:fa813e50373df208cdc22c44a5bb6222ae98e504142868df1c8dfe7bbac8461a"
     },
     {
       "type": "other",
@@ -310,12 +310,12 @@
     "residual_risks": [],
     "rollback": {
       "available": true,
-      "notes": "Revert work_commit f0df96e155d146e4a27af504d0c79071ea1c0802 if downstream validation fails."
+      "notes": "Revert work_commit 08db6b47a4528e5e50155378c65a5e299da2966e if downstream validation fails."
     }
   },
   "integrity": {
     "digest_algorithm": "sha256",
-    "record_digest": "sha256:15bb11d545ad33d4302927f8f14b6f0cb80fdba259a63dc7f649a06353891fc4",
+    "record_digest": "sha256:c1fc0816df423cb1976f7b3b46ef04b7411b1aecdd091d5eff91472291e96158",
     "canonicalization": "rfc8785-jcs",
     "signatures": []
   },

--- a/.agentplane/tasks/202605191421-D566XJ/acr.json
+++ b/.agentplane/tasks/202605191421-D566XJ/acr.json
@@ -2,7 +2,7 @@
   "acr_version": "0.1.0",
   "record_type": "agent_change_record",
   "record_id": "acr_202605191421-D566XJ",
-  "created_at": "2026-05-19T14:54:34.480Z",
+  "created_at": "2026-05-19T15:29:50.875Z",
   "producer": {
     "name": "agentplane",
     "version": "0.6.3"
@@ -13,7 +13,7 @@
     "base_ref": "main",
     "base_commit": "81a3ed59446b0e0fbdf663711e789c53ec915369",
     "work_ref": "task/202605191421-D566XJ/evidence-bundle",
-    "work_commit": "96c50097d9834eed7a02f0bc8cf84d1754802c02"
+    "work_commit": "f0df96e155d146e4a27af504d0c79071ea1c0802"
   },
   "task": {
     "task_id": "202605191421-D566XJ",
@@ -44,7 +44,7 @@
     "status": "approved",
     "artifact": {
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
-      "sha256": "sha256:c2172e902b303ad763f569235b9c6b354f3d9c3f68b5338c58164ed4d703a493"
+      "sha256": "sha256:5979974073c5bbcf349380b5c8bf65fbac5dbe0c34bff6b2c4b9044acebae6c2"
     },
     "approved_at": "2026-05-19T14:22:15.293Z",
     "approved_by": {
@@ -85,7 +85,7 @@
     "summary": "Implement a deterministic evidence bundle and verification CLI surface, with ACR trust extension metadata for generated bundles. Scope excludes Sigstore signing, S3 Object Lock preservation, and capability proposal flows.",
     "diff_stats": {
       "files_changed": 18,
-      "insertions": 2064,
+      "insertions": 2123,
       "deletions": 4
     },
     "files": [
@@ -286,17 +286,17 @@
     {
       "type": "task",
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
-      "sha256": "sha256:c2172e902b303ad763f569235b9c6b354f3d9c3f68b5338c58164ed4d703a493"
+      "sha256": "sha256:5979974073c5bbcf349380b5c8bf65fbac5dbe0c34bff6b2c4b9044acebae6c2"
     },
     {
       "type": "plan",
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
-      "sha256": "sha256:c2172e902b303ad763f569235b9c6b354f3d9c3f68b5338c58164ed4d703a493"
+      "sha256": "sha256:5979974073c5bbcf349380b5c8bf65fbac5dbe0c34bff6b2c4b9044acebae6c2"
     },
     {
       "type": "verification_log",
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
-      "sha256": "sha256:c2172e902b303ad763f569235b9c6b354f3d9c3f68b5338c58164ed4d703a493"
+      "sha256": "sha256:5979974073c5bbcf349380b5c8bf65fbac5dbe0c34bff6b2c4b9044acebae6c2"
     },
     {
       "type": "other",
@@ -310,12 +310,12 @@
     "residual_risks": [],
     "rollback": {
       "available": true,
-      "notes": "Revert work_commit 96c50097d9834eed7a02f0bc8cf84d1754802c02 if downstream validation fails."
+      "notes": "Revert work_commit f0df96e155d146e4a27af504d0c79071ea1c0802 if downstream validation fails."
     }
   },
   "integrity": {
     "digest_algorithm": "sha256",
-    "record_digest": "sha256:7cbe463af4864690547a893bca3a44035ffb4f8fa54616a320eb06a7efa7f9dd",
+    "record_digest": "sha256:15bb11d545ad33d4302927f8f14b6f0cb80fdba259a63dc7f649a06353891fc4",
     "canonicalization": "rfc8785-jcs",
     "signatures": []
   },

--- a/.agentplane/tasks/202605191421-D566XJ/acr.json
+++ b/.agentplane/tasks/202605191421-D566XJ/acr.json
@@ -2,7 +2,7 @@
   "acr_version": "0.1.0",
   "record_type": "agent_change_record",
   "record_id": "acr_202605191421-D566XJ",
-  "created_at": "2026-05-19T15:46:14.915Z",
+  "created_at": "2026-05-19T15:55:09.267Z",
   "producer": {
     "name": "agentplane",
     "version": "0.6.3"
@@ -44,7 +44,7 @@
     "status": "approved",
     "artifact": {
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
-      "sha256": "sha256:fa813e50373df208cdc22c44a5bb6222ae98e504142868df1c8dfe7bbac8461a"
+      "sha256": "sha256:bb93feee5226ad0f762c192d6b08c2f35dec913dbfdbdf91013fb0bc8364a60c"
     },
     "approved_at": "2026-05-19T14:22:15.293Z",
     "approved_by": {
@@ -286,17 +286,17 @@
     {
       "type": "task",
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
-      "sha256": "sha256:fa813e50373df208cdc22c44a5bb6222ae98e504142868df1c8dfe7bbac8461a"
+      "sha256": "sha256:bb93feee5226ad0f762c192d6b08c2f35dec913dbfdbdf91013fb0bc8364a60c"
     },
     {
       "type": "plan",
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
-      "sha256": "sha256:fa813e50373df208cdc22c44a5bb6222ae98e504142868df1c8dfe7bbac8461a"
+      "sha256": "sha256:bb93feee5226ad0f762c192d6b08c2f35dec913dbfdbdf91013fb0bc8364a60c"
     },
     {
       "type": "verification_log",
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
-      "sha256": "sha256:fa813e50373df208cdc22c44a5bb6222ae98e504142868df1c8dfe7bbac8461a"
+      "sha256": "sha256:bb93feee5226ad0f762c192d6b08c2f35dec913dbfdbdf91013fb0bc8364a60c"
     },
     {
       "type": "other",
@@ -315,7 +315,7 @@
   },
   "integrity": {
     "digest_algorithm": "sha256",
-    "record_digest": "sha256:c1fc0816df423cb1976f7b3b46ef04b7411b1aecdd091d5eff91472291e96158",
+    "record_digest": "sha256:50db8e531d154181e8440f8d4445eb4089e29576c8bb1cdb043f45592810c7fa",
     "canonicalization": "rfc8785-jcs",
     "signatures": []
   },

--- a/.agentplane/tasks/202605191421-D566XJ/acr.json
+++ b/.agentplane/tasks/202605191421-D566XJ/acr.json
@@ -2,7 +2,7 @@
   "acr_version": "0.1.0",
   "record_type": "agent_change_record",
   "record_id": "acr_202605191421-D566XJ",
-  "created_at": "2026-05-19T15:55:09.267Z",
+  "created_at": "2026-05-19T16:03:59.974Z",
   "producer": {
     "name": "agentplane",
     "version": "0.6.3"
@@ -44,7 +44,7 @@
     "status": "approved",
     "artifact": {
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
-      "sha256": "sha256:bb93feee5226ad0f762c192d6b08c2f35dec913dbfdbdf91013fb0bc8364a60c"
+      "sha256": "sha256:8a2bc2c3d465faecd46b9773842f2ccb023d04da18374bc839b751b5233b46a0"
     },
     "approved_at": "2026-05-19T14:22:15.293Z",
     "approved_by": {
@@ -286,17 +286,17 @@
     {
       "type": "task",
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
-      "sha256": "sha256:bb93feee5226ad0f762c192d6b08c2f35dec913dbfdbdf91013fb0bc8364a60c"
+      "sha256": "sha256:8a2bc2c3d465faecd46b9773842f2ccb023d04da18374bc839b751b5233b46a0"
     },
     {
       "type": "plan",
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
-      "sha256": "sha256:bb93feee5226ad0f762c192d6b08c2f35dec913dbfdbdf91013fb0bc8364a60c"
+      "sha256": "sha256:8a2bc2c3d465faecd46b9773842f2ccb023d04da18374bc839b751b5233b46a0"
     },
     {
       "type": "verification_log",
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
-      "sha256": "sha256:bb93feee5226ad0f762c192d6b08c2f35dec913dbfdbdf91013fb0bc8364a60c"
+      "sha256": "sha256:8a2bc2c3d465faecd46b9773842f2ccb023d04da18374bc839b751b5233b46a0"
     },
     {
       "type": "other",
@@ -315,7 +315,7 @@
   },
   "integrity": {
     "digest_algorithm": "sha256",
-    "record_digest": "sha256:50db8e531d154181e8440f8d4445eb4089e29576c8bb1cdb043f45592810c7fa",
+    "record_digest": "sha256:44afda3d7dcb65e307ad2c039c202b861c54bc60721690dd16f3f7b6e5d1055c",
     "canonicalization": "rfc8785-jcs",
     "signatures": []
   },

--- a/.agentplane/tasks/202605191421-D566XJ/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605191421-D566XJ/blueprint/resolved-snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605191421-D566XJ",
+    "title": "Add deterministic evidence bundle commands",
+    "description": "Implement a deterministic evidence bundle and verification CLI surface, with ACR trust extension metadata for generated bundles. Scope excludes Sigstore signing, S3 Object Lock preservation, and capability proposal flows.",
+    "tags": [
+      "acr",
+      "code",
+      "trust"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605191421-D566XJ",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "343e2d15f7e61a5cf9827383ac870b6ead273d6b8ef487f4a2fa3a4c6607b6f4"
+  }
+}

--- a/.agentplane/tasks/202605191421-D566XJ/evidence/manifest.json
+++ b/.agentplane/tasks/202605191421-D566XJ/evidence/manifest.json
@@ -1,0 +1,63 @@
+{
+  "artifact_root": ".agentplane/tasks/202605191421-D566XJ",
+  "created_at": "2026-05-19T14:32:35.182Z",
+  "files": [
+    {
+      "path": ".agentplane/tasks/202605191421-D566XJ/blueprint/resolved-snapshot.json",
+      "role": "blueprint_snapshot",
+      "sha256": "sha256:fed075464bed838ed32854e5c1f4576ab307811a84d84f696662650d6887e61b",
+      "size_bytes": 15112
+    },
+    {
+      "path": ".agentplane/tasks/202605191421-D566XJ/pr/diffstat.txt",
+      "role": "pr_artifact",
+      "sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size_bytes": 0
+    },
+    {
+      "path": ".agentplane/tasks/202605191421-D566XJ/pr/github-body.md",
+      "role": "pr_artifact",
+      "sha256": "sha256:b8a114477333e6caee68176b0584bf631d57bcea796c104968d3518c7c337aa4",
+      "size_bytes": 1086
+    },
+    {
+      "path": ".agentplane/tasks/202605191421-D566XJ/pr/github-title.txt",
+      "role": "pr_artifact",
+      "sha256": "sha256:c2e2443f60d5dd5b263a34c7c287251da247d3f1df936b1694987ac074814048",
+      "size_bytes": 83
+    },
+    {
+      "path": ".agentplane/tasks/202605191421-D566XJ/pr/meta.json",
+      "role": "pr_artifact",
+      "sha256": "sha256:98c3161cbb402c1177f4b830ef0698ed0a69147e4d58f8c5ac7048f6aab481c6",
+      "size_bytes": 382
+    },
+    {
+      "path": ".agentplane/tasks/202605191421-D566XJ/pr/review.md",
+      "role": "pr_artifact",
+      "sha256": "sha256:ec0ad05ab3f6ffe0fd19516f0f40b2b81c59dde41cfc5bd5b8f2d9077fca0f76",
+      "size_bytes": 745
+    },
+    {
+      "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
+      "role": "task_readme",
+      "sha256": "sha256:52ebac6f0d5c8aa858e45c84dde1a4f7eff742c9f94159a8a36979dcb76f66af",
+      "size_bytes": 5605
+    }
+  ],
+  "integrity": {
+    "canonicalization": "agentplane-canonical-json-v1",
+    "digest_algorithm": "sha256",
+    "manifest_digest": "sha256:12c80787894b06a4a7d19c383a8e1a9b4a7b6ef9832957a710a7294d9f6a7515"
+  },
+  "kind": "agentplane_evidence_bundle",
+  "producer": {
+    "name": "agentplane",
+    "version": "0.6.3"
+  },
+  "schema_version": 1,
+  "task_id": "202605191421-D566XJ",
+  "verification": {
+    "command": "agentplane evidence verify 202605191421-D566XJ"
+  }
+}

--- a/.agentplane/tasks/202605191421-D566XJ/evidence/manifest.json
+++ b/.agentplane/tasks/202605191421-D566XJ/evidence/manifest.json
@@ -1,11 +1,11 @@
 {
   "artifact_root": ".agentplane/tasks/202605191421-D566XJ",
-  "created_at": "2026-05-19T14:54:41.727Z",
+  "created_at": "2026-05-19T15:30:07.409Z",
   "files": [
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/acr.json",
       "role": "acr",
-      "sha256": "sha256:6c42311bf29bc973b5ae27f60ff6c381e93620e10506d688f75e1dff90b4ac1e",
+      "sha256": "sha256:edc5b5f3b3e6a5bec52b7dda10a6a564b3dfa5270a6eb619d76cb8607a7694b2",
       "size_bytes": 11195
     },
     {
@@ -17,14 +17,14 @@
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/diffstat.txt",
       "role": "pr_artifact",
-      "sha256": "sha256:d613e9fc7e0d37597ed10c11f5d429762579e0a9e5eabbe50e3ba45e8f9516de",
-      "size_bytes": 833
+      "sha256": "sha256:c63900159227ae823709e0f1775dde2d14bfb3c789a47b8d625a841fb2b54e4e",
+      "size_bytes": 832
     },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/github-body.md",
       "role": "pr_artifact",
-      "sha256": "sha256:f23cd475c21a5e06c351d1796e201a36f55ce465ff1f8732d7ad28ee77b0a935",
-      "size_bytes": 2153
+      "sha256": "sha256:e5e478ccb7515a967fac8c1a7862a0e40733750ef7662f8d558ba3f55874eb27",
+      "size_bytes": 2099
     },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/github-title.txt",
@@ -35,26 +35,26 @@
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/meta.json",
       "role": "pr_artifact",
-      "sha256": "sha256:e048cba7cd3bf83d3b45723453c87732b5d0df060d4dd8c2703794935aaff3a0",
+      "sha256": "sha256:782f3616edb2c90fe3546bf887764222c1f082b547f1a184954dfe1a02e6db8a",
       "size_bytes": 549
     },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/review.md",
       "role": "pr_artifact",
-      "sha256": "sha256:f34eec19c080efdd3da67ef83b216916fe259efacfcc068cd0afec52124176ab",
-      "size_bytes": 1799
+      "sha256": "sha256:7cd69fd8c7067b94ce95d13c09cac5e06e65850ef369d42d08d820b643b10893",
+      "size_bytes": 1745
     },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
       "role": "task_readme",
-      "sha256": "sha256:c2172e902b303ad763f569235b9c6b354f3d9c3f68b5338c58164ed4d703a493",
-      "size_bytes": 12309
+      "sha256": "sha256:5979974073c5bbcf349380b5c8bf65fbac5dbe0c34bff6b2c4b9044acebae6c2",
+      "size_bytes": 14460
     }
   ],
   "integrity": {
     "canonicalization": "agentplane-canonical-json-v1",
     "digest_algorithm": "sha256",
-    "manifest_digest": "sha256:a0e33b531661994e830213205e4d29632332de75304f968d65ca58ef734b4270"
+    "manifest_digest": "sha256:7fb774dbe00207d293891043f8e4e955142c232af1efb5504ecb90a56495722e"
   },
   "kind": "agentplane_evidence_bundle",
   "producer": {

--- a/.agentplane/tasks/202605191421-D566XJ/evidence/manifest.json
+++ b/.agentplane/tasks/202605191421-D566XJ/evidence/manifest.json
@@ -1,7 +1,13 @@
 {
   "artifact_root": ".agentplane/tasks/202605191421-D566XJ",
-  "created_at": "2026-05-19T14:32:35.182Z",
+  "created_at": "2026-05-19T14:51:44.218Z",
   "files": [
+    {
+      "path": ".agentplane/tasks/202605191421-D566XJ/acr.json",
+      "role": "acr",
+      "sha256": "sha256:a22c5a31d28e0b7cee0f8f217a1e7c7cd30295dac2b14dcb3a2e4aacd1050559",
+      "size_bytes": 11026
+    },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/blueprint/resolved-snapshot.json",
       "role": "blueprint_snapshot",
@@ -11,14 +17,14 @@
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/diffstat.txt",
       "role": "pr_artifact",
-      "sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "size_bytes": 0
+      "sha256": "sha256:5e978ac150ecab40f394945afb235e82bf0f8fcc17bb2ea08cee6403f5780aec",
+      "size_bytes": 759
     },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/github-body.md",
       "role": "pr_artifact",
-      "sha256": "sha256:b8a114477333e6caee68176b0584bf631d57bcea796c104968d3518c7c337aa4",
-      "size_bytes": 1086
+      "sha256": "sha256:b5f575f8dabe7e52ba49591c4f437c4d16320df8431eac091932f270ebde8f38",
+      "size_bytes": 2059
     },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/github-title.txt",
@@ -29,26 +35,26 @@
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/meta.json",
       "role": "pr_artifact",
-      "sha256": "sha256:98c3161cbb402c1177f4b830ef0698ed0a69147e4d58f8c5ac7048f6aab481c6",
-      "size_bytes": 382
+      "sha256": "sha256:a1e447bd6dd2e21c486d8a83350cd8f2f7d1df8f555cd329c90f5c2a7ebcf32c",
+      "size_bytes": 439
     },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/review.md",
       "role": "pr_artifact",
-      "sha256": "sha256:ec0ad05ab3f6ffe0fd19516f0f40b2b81c59dde41cfc5bd5b8f2d9077fca0f76",
-      "size_bytes": 745
+      "sha256": "sha256:107c62ce5b7ef2471785ece3fb601c206641ee24ec4679af37baa53f3f2aa057",
+      "size_bytes": 1705
     },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
       "role": "task_readme",
-      "sha256": "sha256:52ebac6f0d5c8aa858e45c84dde1a4f7eff742c9f94159a8a36979dcb76f66af",
-      "size_bytes": 5605
+      "sha256": "sha256:535082acffa4ff21da7d6d8351a23ea61400d72329e49bb185b59f6a910e1bd0",
+      "size_bytes": 9124
     }
   ],
   "integrity": {
     "canonicalization": "agentplane-canonical-json-v1",
     "digest_algorithm": "sha256",
-    "manifest_digest": "sha256:12c80787894b06a4a7d19c383a8e1a9b4a7b6ef9832957a710a7294d9f6a7515"
+    "manifest_digest": "sha256:340c4a8a64fd0c36545272cac8c3cc961413ea1de1c63a78447273a10df01f43"
   },
   "kind": "agentplane_evidence_bundle",
   "producer": {

--- a/.agentplane/tasks/202605191421-D566XJ/evidence/manifest.json
+++ b/.agentplane/tasks/202605191421-D566XJ/evidence/manifest.json
@@ -1,12 +1,12 @@
 {
   "artifact_root": ".agentplane/tasks/202605191421-D566XJ",
-  "created_at": "2026-05-19T14:51:44.218Z",
+  "created_at": "2026-05-19T14:54:41.727Z",
   "files": [
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/acr.json",
       "role": "acr",
-      "sha256": "sha256:a22c5a31d28e0b7cee0f8f217a1e7c7cd30295dac2b14dcb3a2e4aacd1050559",
-      "size_bytes": 11026
+      "sha256": "sha256:6c42311bf29bc973b5ae27f60ff6c381e93620e10506d688f75e1dff90b4ac1e",
+      "size_bytes": 11195
     },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/blueprint/resolved-snapshot.json",
@@ -17,14 +17,14 @@
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/diffstat.txt",
       "role": "pr_artifact",
-      "sha256": "sha256:5e978ac150ecab40f394945afb235e82bf0f8fcc17bb2ea08cee6403f5780aec",
-      "size_bytes": 759
+      "sha256": "sha256:d613e9fc7e0d37597ed10c11f5d429762579e0a9e5eabbe50e3ba45e8f9516de",
+      "size_bytes": 833
     },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/github-body.md",
       "role": "pr_artifact",
-      "sha256": "sha256:b5f575f8dabe7e52ba49591c4f437c4d16320df8431eac091932f270ebde8f38",
-      "size_bytes": 2059
+      "sha256": "sha256:f23cd475c21a5e06c351d1796e201a36f55ce465ff1f8732d7ad28ee77b0a935",
+      "size_bytes": 2153
     },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/github-title.txt",
@@ -35,26 +35,26 @@
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/meta.json",
       "role": "pr_artifact",
-      "sha256": "sha256:a1e447bd6dd2e21c486d8a83350cd8f2f7d1df8f555cd329c90f5c2a7ebcf32c",
-      "size_bytes": 439
+      "sha256": "sha256:e048cba7cd3bf83d3b45723453c87732b5d0df060d4dd8c2703794935aaff3a0",
+      "size_bytes": 549
     },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/review.md",
       "role": "pr_artifact",
-      "sha256": "sha256:107c62ce5b7ef2471785ece3fb601c206641ee24ec4679af37baa53f3f2aa057",
-      "size_bytes": 1705
+      "sha256": "sha256:f34eec19c080efdd3da67ef83b216916fe259efacfcc068cd0afec52124176ab",
+      "size_bytes": 1799
     },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
       "role": "task_readme",
-      "sha256": "sha256:535082acffa4ff21da7d6d8351a23ea61400d72329e49bb185b59f6a910e1bd0",
-      "size_bytes": 9124
+      "sha256": "sha256:c2172e902b303ad763f569235b9c6b354f3d9c3f68b5338c58164ed4d703a493",
+      "size_bytes": 12309
     }
   ],
   "integrity": {
     "canonicalization": "agentplane-canonical-json-v1",
     "digest_algorithm": "sha256",
-    "manifest_digest": "sha256:340c4a8a64fd0c36545272cac8c3cc961413ea1de1c63a78447273a10df01f43"
+    "manifest_digest": "sha256:a0e33b531661994e830213205e4d29632332de75304f968d65ca58ef734b4270"
   },
   "kind": "agentplane_evidence_bundle",
   "producer": {

--- a/.agentplane/tasks/202605191421-D566XJ/evidence/manifest.json
+++ b/.agentplane/tasks/202605191421-D566XJ/evidence/manifest.json
@@ -5,7 +5,7 @@
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/acr.json",
       "role": "acr",
-      "sha256": "sha256:edc5b5f3b3e6a5bec52b7dda10a6a564b3dfa5270a6eb619d76cb8607a7694b2",
+      "sha256": "sha256:65012c9ae516ea1d2a04540e83fbac39accdcf868df8cecda5dda5d68fdd9359",
       "size_bytes": 11195
     },
     {
@@ -17,14 +17,14 @@
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/diffstat.txt",
       "role": "pr_artifact",
-      "sha256": "sha256:c63900159227ae823709e0f1775dde2d14bfb3c789a47b8d625a841fb2b54e4e",
-      "size_bytes": 832
+      "sha256": "sha256:62eb7b297fa38739c207cdb8c307319f44261f7d9f872904c10edd8721ff1374",
+      "size_bytes": 836
     },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/github-body.md",
       "role": "pr_artifact",
-      "sha256": "sha256:e5e478ccb7515a967fac8c1a7862a0e40733750ef7662f8d558ba3f55874eb27",
-      "size_bytes": 2099
+      "sha256": "sha256:919d642a4120a791f649ed7a4108b3b7df1851b8a93d0b429c0b0a399506dfe8",
+      "size_bytes": 2181
     },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/github-title.txt",
@@ -35,26 +35,26 @@
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/meta.json",
       "role": "pr_artifact",
-      "sha256": "sha256:782f3616edb2c90fe3546bf887764222c1f082b547f1a184954dfe1a02e6db8a",
+      "sha256": "sha256:d405b7c0fbd49f61f1e2664a2f350c4e0af2acf50b0faeb1b362127f56c5cf0a",
       "size_bytes": 549
     },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/review.md",
       "role": "pr_artifact",
-      "sha256": "sha256:7cd69fd8c7067b94ce95d13c09cac5e06e65850ef369d42d08d820b643b10893",
-      "size_bytes": 1745
+      "sha256": "sha256:bb188f821622d6499d4edea822283a74dd5934b6ca33580b0c73868dfb87b65b",
+      "size_bytes": 1827
     },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
       "role": "task_readme",
-      "sha256": "sha256:5979974073c5bbcf349380b5c8bf65fbac5dbe0c34bff6b2c4b9044acebae6c2",
-      "size_bytes": 14460
+      "sha256": "sha256:fa813e50373df208cdc22c44a5bb6222ae98e504142868df1c8dfe7bbac8461a",
+      "size_bytes": 16980
     }
   ],
   "integrity": {
     "canonicalization": "agentplane-canonical-json-v1",
     "digest_algorithm": "sha256",
-    "manifest_digest": "sha256:7fb774dbe00207d293891043f8e4e955142c232af1efb5504ecb90a56495722e"
+    "manifest_digest": "sha256:35cf480f6b2a5c1ffd144167609ed0fe2d2972dd807846085dee96a560002abf"
   },
   "kind": "agentplane_evidence_bundle",
   "producer": {

--- a/.agentplane/tasks/202605191421-D566XJ/evidence/manifest.json
+++ b/.agentplane/tasks/202605191421-D566XJ/evidence/manifest.json
@@ -5,7 +5,7 @@
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/acr.json",
       "role": "acr",
-      "sha256": "sha256:65012c9ae516ea1d2a04540e83fbac39accdcf868df8cecda5dda5d68fdd9359",
+      "sha256": "sha256:02fa77c93c3b42b380a655e7b1b1ea0e5f4c5d0c51f1d255c284b11922ff87d9",
       "size_bytes": 11195
     },
     {
@@ -23,8 +23,8 @@
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/github-body.md",
       "role": "pr_artifact",
-      "sha256": "sha256:919d642a4120a791f649ed7a4108b3b7df1851b8a93d0b429c0b0a399506dfe8",
-      "size_bytes": 2181
+      "sha256": "sha256:2d995b32c2932452e903529be3acd6faad4308f8587602f9254d0c61466eb5f3",
+      "size_bytes": 2208
     },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/github-title.txt",
@@ -35,26 +35,26 @@
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/meta.json",
       "role": "pr_artifact",
-      "sha256": "sha256:d405b7c0fbd49f61f1e2664a2f350c4e0af2acf50b0faeb1b362127f56c5cf0a",
+      "sha256": "sha256:e00db3c4135ffb1361bc369f141d630418b17d072df5b17e766dd3997b5595b6",
       "size_bytes": 549
     },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/pr/review.md",
       "role": "pr_artifact",
-      "sha256": "sha256:bb188f821622d6499d4edea822283a74dd5934b6ca33580b0c73868dfb87b65b",
-      "size_bytes": 1827
+      "sha256": "sha256:de61772b30dee3fb8626232b9f295495f8b292c2508659442586b30cfd9db6bd",
+      "size_bytes": 1854
     },
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
       "role": "task_readme",
-      "sha256": "sha256:fa813e50373df208cdc22c44a5bb6222ae98e504142868df1c8dfe7bbac8461a",
-      "size_bytes": 16980
+      "sha256": "sha256:bb93feee5226ad0f762c192d6b08c2f35dec913dbfdbdf91013fb0bc8364a60c",
+      "size_bytes": 19598
     }
   ],
   "integrity": {
     "canonicalization": "agentplane-canonical-json-v1",
     "digest_algorithm": "sha256",
-    "manifest_digest": "sha256:35cf480f6b2a5c1ffd144167609ed0fe2d2972dd807846085dee96a560002abf"
+    "manifest_digest": "sha256:f35336eacc9899756ceeb8e6e93a48377d9e58c77f8a332060ce5ab4ebf17e51"
   },
   "kind": "agentplane_evidence_bundle",
   "producer": {

--- a/.agentplane/tasks/202605191421-D566XJ/evidence/manifest.json
+++ b/.agentplane/tasks/202605191421-D566XJ/evidence/manifest.json
@@ -5,7 +5,7 @@
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/acr.json",
       "role": "acr",
-      "sha256": "sha256:02fa77c93c3b42b380a655e7b1b1ea0e5f4c5d0c51f1d255c284b11922ff87d9",
+      "sha256": "sha256:c60c22850919cc47a8834e813c7731e11c721c91322b4a4935f21a6efe63fe52",
       "size_bytes": 11195
     },
     {
@@ -47,14 +47,14 @@
     {
       "path": ".agentplane/tasks/202605191421-D566XJ/README.md",
       "role": "task_readme",
-      "sha256": "sha256:bb93feee5226ad0f762c192d6b08c2f35dec913dbfdbdf91013fb0bc8364a60c",
+      "sha256": "sha256:8a2bc2c3d465faecd46b9773842f2ccb023d04da18374bc839b751b5233b46a0",
       "size_bytes": 19598
     }
   ],
   "integrity": {
     "canonicalization": "agentplane-canonical-json-v1",
     "digest_algorithm": "sha256",
-    "manifest_digest": "sha256:f35336eacc9899756ceeb8e6e93a48377d9e58c77f8a332060ce5ab4ebf17e51"
+    "manifest_digest": "sha256:00364747149e3c7e8d68c444cfafbc6ffbf82e298028cc04ed699819f847a32e"
   },
   "kind": "agentplane_evidence_bundle",
   "producer": {

--- a/.agentplane/tasks/202605191421-D566XJ/pr/diffstat.txt
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/diffstat.txt
@@ -1,4 +1,4 @@
- .agentplane/tasks/202605191421-D566XJ/acr.json     | 402 +++++++++++++++
+ .agentplane/tasks/202605191421-D566XJ/acr.json     | 409 +++++++++++++++
  .../blueprint/resolved-snapshot.json               | 572 +++++++++++++++++++++
  .../202605191421-D566XJ/evidence/manifest.json     |  69 +++
  docs/reference/acr.mdx                             |   8 +
@@ -10,4 +10,4 @@
  .../src/commands/evidence/evidence.command.test.ts | 111 ++++
  .../src/commands/evidence/evidence.command.ts      | 487 ++++++++++++++++++
  website/sidebars.ts                                |   2 +
- 12 files changed, 1779 insertions(+), 4 deletions(-)
+ 12 files changed, 1786 insertions(+), 4 deletions(-)

--- a/.agentplane/tasks/202605191421-D566XJ/pr/diffstat.txt
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/diffstat.txt
@@ -8,6 +8,6 @@
  .../src/cli/run-cli/command-loaders/project.ts     |  11 +
  packages/agentplane/src/commands/acr/generate.ts   |  15 +-
  .../src/commands/evidence/evidence.command.test.ts | 111 ++++
- .../src/commands/evidence/evidence.command.ts      | 487 ++++++++++++++++++
+ .../src/commands/evidence/evidence.command.ts      | 484 +++++++++++++++++
  website/sidebars.ts                                |   2 +
- 12 files changed, 1786 insertions(+), 4 deletions(-)
+ 12 files changed, 1783 insertions(+), 4 deletions(-)

--- a/.agentplane/tasks/202605191421-D566XJ/pr/diffstat.txt
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/diffstat.txt
@@ -7,7 +7,7 @@
  .../src/cli/run-cli/command-catalog/project.ts     |  11 +
  .../src/cli/run-cli/command-loaders/project.ts     |  11 +
  packages/agentplane/src/commands/acr/generate.ts   |  15 +-
- .../src/commands/evidence/evidence.command.test.ts | 111 ++++
- .../src/commands/evidence/evidence.command.ts      | 484 +++++++++++++++++
+ .../src/commands/evidence/evidence.command.test.ts | 158 ++++++
+ .../src/commands/evidence/evidence.command.ts      | 516 +++++++++++++++++++
  website/sidebars.ts                                |   2 +
- 12 files changed, 1783 insertions(+), 4 deletions(-)
+ 12 files changed, 1862 insertions(+), 4 deletions(-)

--- a/.agentplane/tasks/202605191421-D566XJ/pr/diffstat.txt
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/diffstat.txt
@@ -1,5 +1,6 @@
+ .agentplane/tasks/202605191421-D566XJ/acr.json     | 402 +++++++++++++++
  .../blueprint/resolved-snapshot.json               | 572 +++++++++++++++++++++
- .../202605191421-D566XJ/evidence/manifest.json     |  63 +++
+ .../202605191421-D566XJ/evidence/manifest.json     |  69 +++
  docs/reference/acr.mdx                             |   8 +
  docs/reference/evidence.mdx                        |  44 ++
  docs/user/cli-reference.generated.mdx              |  51 ++
@@ -9,4 +10,4 @@
  .../src/commands/evidence/evidence.command.test.ts | 111 ++++
  .../src/commands/evidence/evidence.command.ts      | 487 ++++++++++++++++++
  website/sidebars.ts                                |   2 +
- 11 files changed, 1371 insertions(+), 4 deletions(-)
+ 12 files changed, 1779 insertions(+), 4 deletions(-)

--- a/.agentplane/tasks/202605191421-D566XJ/pr/diffstat.txt
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/diffstat.txt
@@ -1,0 +1,12 @@
+ .../blueprint/resolved-snapshot.json               | 572 +++++++++++++++++++++
+ .../202605191421-D566XJ/evidence/manifest.json     |  63 +++
+ docs/reference/acr.mdx                             |   8 +
+ docs/reference/evidence.mdx                        |  44 ++
+ docs/user/cli-reference.generated.mdx              |  51 ++
+ .../src/cli/run-cli/command-catalog/project.ts     |  11 +
+ .../src/cli/run-cli/command-loaders/project.ts     |  11 +
+ packages/agentplane/src/commands/acr/generate.ts   |  15 +-
+ .../src/commands/evidence/evidence.command.test.ts | 111 ++++
+ .../src/commands/evidence/evidence.command.ts      | 487 ++++++++++++++++++
+ website/sidebars.ts                                |   2 +
+ 11 files changed, 1371 insertions(+), 4 deletions(-)

--- a/.agentplane/tasks/202605191421-D566XJ/pr/github-body.md
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/github-body.md
@@ -19,18 +19,18 @@ Implement a deterministic evidence bundle and verification CLI surface, with ACR
 - Note:
 
 ```text
-Quality gate passed for deterministic evidence bundle implementation. Reviewed route evidence,
-focused tests, typecheck, lint, docs checks, ACR validation, strict evidence verification, and
-GitHub PR linkage. Hosted checks are still tracked separately on PR #3937.
+Fixed hosted Linux format gate by applying Prettier to evidence command files. Local checks passed:
+format:check, focused evidence/ACR tests, agentplane typecheck, targeted eslint, docs:cli:check,
+docs:ia:check.
 ```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-19T14:52:54.635Z
+- Updated: 2026-05-19T15:29:40.686Z
 - Branch: task/202605191421-D566XJ/evidence-bundle
-- Head: a89b99bfe360
+- Head: f0df96e155d1
 
 ```text
  .agentplane/tasks/202605191421-D566XJ/acr.json     | 409 +++++++++++++++
@@ -43,9 +43,9 @@ GitHub PR linkage. Hosted checks are still tracked separately on PR #3937.
  .../src/cli/run-cli/command-loaders/project.ts     |  11 +
  packages/agentplane/src/commands/acr/generate.ts   |  15 +-
  .../src/commands/evidence/evidence.command.test.ts | 111 ++++
- .../src/commands/evidence/evidence.command.ts      | 487 ++++++++++++++++++
+ .../src/commands/evidence/evidence.command.ts      | 484 +++++++++++++++++
  website/sidebars.ts                                |   2 +
- 12 files changed, 1786 insertions(+), 4 deletions(-)
+ 12 files changed, 1783 insertions(+), 4 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605191421-D566XJ/pr/github-body.md
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/github-body.md
@@ -33,7 +33,7 @@ GitHub PR linkage. Hosted checks are still tracked separately on PR #3937.
 - Head: a89b99bfe360
 
 ```text
- .agentplane/tasks/202605191421-D566XJ/acr.json     | 402 +++++++++++++++
+ .agentplane/tasks/202605191421-D566XJ/acr.json     | 409 +++++++++++++++
  .../blueprint/resolved-snapshot.json               | 572 +++++++++++++++++++++
  .../202605191421-D566XJ/evidence/manifest.json     |  69 +++
  docs/reference/acr.mdx                             |   8 +
@@ -45,7 +45,7 @@ GitHub PR linkage. Hosted checks are still tracked separately on PR #3937.
  .../src/commands/evidence/evidence.command.test.ts | 111 ++++
  .../src/commands/evidence/evidence.command.ts      | 487 ++++++++++++++++++
  website/sidebars.ts                                |   2 +
- 12 files changed, 1779 insertions(+), 4 deletions(-)
+ 12 files changed, 1786 insertions(+), 4 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605191421-D566XJ/pr/github-body.md
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605191421-D566XJ`
+Title: Add deterministic evidence bundle commands
+Canonical task record: `.agentplane/tasks/202605191421-D566XJ/README.md`
+
+## Summary
+
+Add deterministic evidence bundle commands
+
+Implement a deterministic evidence bundle and verification CLI surface, with ACR trust extension metadata for generated bundles. Scope excludes Sigstore signing, S3 Object Lock preservation, and capability proposal flows.
+
+## Scope
+
+- In scope: Implement a deterministic evidence bundle and verification CLI surface, with ACR trust extension metadata for generated bundles. Scope excludes Sigstore signing, S3 Object Lock preservation, and capability proposal flows.
+- Out of scope: unrelated refactors not required for "Add deterministic evidence bundle commands".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-19T14:23:12.633Z
+- Branch: task/202605191421-D566XJ/evidence-bundle
+- Head: 81a3ed59446b
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605191421-D566XJ/pr/github-body.md
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/github-body.md
@@ -33,8 +33,9 @@ docs:ia:check, evidence bundle, evidence verify --strict.
 - Head: a89b99bfe360
 
 ```text
+ .agentplane/tasks/202605191421-D566XJ/acr.json     | 402 +++++++++++++++
  .../blueprint/resolved-snapshot.json               | 572 +++++++++++++++++++++
- .../202605191421-D566XJ/evidence/manifest.json     |  63 +++
+ .../202605191421-D566XJ/evidence/manifest.json     |  69 +++
  docs/reference/acr.mdx                             |   8 +
  docs/reference/evidence.mdx                        |  44 ++
  docs/user/cli-reference.generated.mdx              |  51 ++
@@ -44,7 +45,7 @@ docs:ia:check, evidence bundle, evidence verify --strict.
  .../src/commands/evidence/evidence.command.test.ts | 111 ++++
  .../src/commands/evidence/evidence.command.ts      | 487 ++++++++++++++++++
  website/sidebars.ts                                |   2 +
- 11 files changed, 1371 insertions(+), 4 deletions(-)
+ 12 files changed, 1779 insertions(+), 4 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605191421-D566XJ/pr/github-body.md
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/github-body.md
@@ -28,7 +28,7 @@ docs:ia:check, evidence bundle, evidence verify --strict.
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-19T14:49:33.248Z
+- Updated: 2026-05-19T14:52:54.635Z
 - Branch: task/202605191421-D566XJ/evidence-bundle
 - Head: a89b99bfe360
 

--- a/.agentplane/tasks/202605191421-D566XJ/pr/github-body.md
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/github-body.md
@@ -19,18 +19,18 @@ Implement a deterministic evidence bundle and verification CLI surface, with ACR
 - Note:
 
 ```text
-Fixed hosted Linux format gate by applying Prettier to evidence command files. Local checks passed:
-format:check, focused evidence/ACR tests, agentplane typecheck, targeted eslint, docs:cli:check,
-docs:ia:check.
+Addressed PR review threads: evidence bundle now respects configured workflow_dir and preserves
+existing created_at to keep unchanged bundle reruns deterministic. Local checks passed: focused
+evidence/ACR tests, agentplane typecheck, targeted eslint, format:check, framework:dev:bootstrap.
 ```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-19T15:29:40.686Z
+- Updated: 2026-05-19T15:45:54.714Z
 - Branch: task/202605191421-D566XJ/evidence-bundle
-- Head: f0df96e155d1
+- Head: 08db6b47a452
 
 ```text
  .agentplane/tasks/202605191421-D566XJ/acr.json     | 409 +++++++++++++++
@@ -42,10 +42,10 @@ docs:ia:check.
  .../src/cli/run-cli/command-catalog/project.ts     |  11 +
  .../src/cli/run-cli/command-loaders/project.ts     |  11 +
  packages/agentplane/src/commands/acr/generate.ts   |  15 +-
- .../src/commands/evidence/evidence.command.test.ts | 111 ++++
- .../src/commands/evidence/evidence.command.ts      | 484 +++++++++++++++++
+ .../src/commands/evidence/evidence.command.test.ts | 158 ++++++
+ .../src/commands/evidence/evidence.command.ts      | 516 +++++++++++++++++++
  website/sidebars.ts                                |   2 +
- 12 files changed, 1783 insertions(+), 4 deletions(-)
+ 12 files changed, 1862 insertions(+), 4 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605191421-D566XJ/pr/github-body.md
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/github-body.md
@@ -19,9 +19,10 @@ Implement a deterministic evidence bundle and verification CLI surface, with ACR
 - Note:
 
 ```text
-Addressed PR review threads: evidence bundle now respects configured workflow_dir and preserves
-existing created_at to keep unchanged bundle reruns deterministic. Local checks passed: focused
-evidence/ACR tests, agentplane typecheck, targeted eslint, format:check, framework:dev:bootstrap.
+EVALUATOR quality gate passed for current implementation commit 08db6b47. Reviewed fixes for
+configured workflow_dir evidence paths and deterministic bundle reruns; local checks passed: focused
+evidence/ACR tests, typecheck, format:check, targeted eslint, framework bootstrap; hosted PR checks
+are green on PR #3937.
 ```
 - Canonical workflow state lives in the task README.
 

--- a/.agentplane/tasks/202605191421-D566XJ/pr/github-body.md
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/github-body.md
@@ -19,9 +19,9 @@ Implement a deterministic evidence bundle and verification CLI surface, with ACR
 - Note:
 
 ```text
-Implemented deterministic evidence bundle and verify commands with ACR trust pointer and docs.
-Checks passed: focused evidence/ACR tests, agentplane typecheck, lint:core, docs:cli:check,
-docs:ia:check, evidence bundle, evidence verify --strict.
+Quality gate passed for deterministic evidence bundle implementation. Reviewed route evidence,
+focused tests, typecheck, lint, docs checks, ACR validation, strict evidence verification, and
+GitHub PR linkage. Hosted checks are still tracked separately on PR #3937.
 ```
 - Canonical workflow state lives in the task README.
 

--- a/.agentplane/tasks/202605191421-D566XJ/pr/github-body.md
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/github-body.md
@@ -15,19 +15,36 @@ Implement a deterministic evidence bundle and verification CLI surface, with ACR
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Implemented deterministic evidence bundle and verify commands with ACR trust pointer and docs.
+Checks passed: focused evidence/ACR tests, agentplane typecheck, lint:core, docs:cli:check,
+docs:ia:check, evidence bundle, evidence verify --strict.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-19T14:23:12.633Z
+- Updated: 2026-05-19T14:49:33.248Z
 - Branch: task/202605191421-D566XJ/evidence-bundle
-- Head: 81a3ed59446b
+- Head: a89b99bfe360
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 572 +++++++++++++++++++++
+ .../202605191421-D566XJ/evidence/manifest.json     |  63 +++
+ docs/reference/acr.mdx                             |   8 +
+ docs/reference/evidence.mdx                        |  44 ++
+ docs/user/cli-reference.generated.mdx              |  51 ++
+ .../src/cli/run-cli/command-catalog/project.ts     |  11 +
+ .../src/cli/run-cli/command-loaders/project.ts     |  11 +
+ packages/agentplane/src/commands/acr/generate.ts   |  15 +-
+ .../src/commands/evidence/evidence.command.test.ts | 111 ++++
+ .../src/commands/evidence/evidence.command.ts      | 487 ++++++++++++++++++
+ website/sidebars.ts                                |   2 +
+ 11 files changed, 1371 insertions(+), 4 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605191421-D566XJ/pr/github-title.txt
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 D566XJ task: Add deterministic evidence bundle commands [202605191421-D566XJ]

--- a/.agentplane/tasks/202605191421-D566XJ/pr/meta.json
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/meta.json
@@ -2,15 +2,15 @@
   "base": "main",
   "branch": "task/202605191421-D566XJ/evidence-bundle",
   "created_at": "2026-05-19T14:23:12.633Z",
-  "head_sha": "f0df96e155d146e4a27af504d0c79071ea1c0802",
-  "last_verified_at": "2026-05-19T15:29:40.496Z",
-  "last_verified_sha": "f0df96e155d146e4a27af504d0c79071ea1c0802",
+  "head_sha": "08db6b47a4528e5e50155378c65a5e299da2966e",
+  "last_verified_at": "2026-05-19T15:45:54.344Z",
+  "last_verified_sha": "08db6b47a4528e5e50155378c65a5e299da2966e",
   "pr_number": 3937,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3937",
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202605191421-D566XJ",
-  "updated_at": "2026-05-19T15:29:40.686Z",
+  "updated_at": "2026-05-19T15:45:54.714Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605191421-D566XJ/pr/meta.json
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/meta.json
@@ -3,7 +3,7 @@
   "branch": "task/202605191421-D566XJ/evidence-bundle",
   "created_at": "2026-05-19T14:23:12.633Z",
   "head_sha": "08db6b47a4528e5e50155378c65a5e299da2966e",
-  "last_verified_at": "2026-05-19T15:45:54.344Z",
+  "last_verified_at": "2026-05-19T15:54:39.502Z",
   "last_verified_sha": "08db6b47a4528e5e50155378c65a5e299da2966e",
   "pr_number": 3937,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3937",

--- a/.agentplane/tasks/202605191421-D566XJ/pr/meta.json
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "a89b99bfe360becc2e5b22f3395a84d70db43257",
   "last_verified_at": "2026-05-19T14:49:32.970Z",
   "last_verified_sha": "a89b99bfe360becc2e5b22f3395a84d70db43257",
+  "pr_number": 3937,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3937",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605191421-D566XJ",
-  "updated_at": "2026-05-19T14:49:33.248Z",
+  "updated_at": "2026-05-19T14:52:54.635Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605191421-D566XJ/pr/meta.json
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/meta.json
@@ -2,13 +2,13 @@
   "base": "main",
   "branch": "task/202605191421-D566XJ/evidence-bundle",
   "created_at": "2026-05-19T14:23:12.633Z",
-  "head_sha": "81a3ed59446b0e0fbdf663711e789c53ec915369",
-  "last_verified_at": null,
-  "last_verified_sha": null,
+  "head_sha": "a89b99bfe360becc2e5b22f3395a84d70db43257",
+  "last_verified_at": "2026-05-19T14:49:32.970Z",
+  "last_verified_sha": "a89b99bfe360becc2e5b22f3395a84d70db43257",
   "schema_version": 1,
   "task_id": "202605191421-D566XJ",
-  "updated_at": "2026-05-19T14:23:12.633Z",
+  "updated_at": "2026-05-19T14:49:33.248Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605191421-D566XJ/pr/meta.json
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/meta.json
@@ -2,15 +2,15 @@
   "base": "main",
   "branch": "task/202605191421-D566XJ/evidence-bundle",
   "created_at": "2026-05-19T14:23:12.633Z",
-  "head_sha": "a89b99bfe360becc2e5b22f3395a84d70db43257",
-  "last_verified_at": "2026-05-19T14:54:23.894Z",
-  "last_verified_sha": "a89b99bfe360becc2e5b22f3395a84d70db43257",
+  "head_sha": "f0df96e155d146e4a27af504d0c79071ea1c0802",
+  "last_verified_at": "2026-05-19T15:29:40.496Z",
+  "last_verified_sha": "f0df96e155d146e4a27af504d0c79071ea1c0802",
   "pr_number": 3937,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3937",
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202605191421-D566XJ",
-  "updated_at": "2026-05-19T14:52:54.635Z",
+  "updated_at": "2026-05-19T15:29:40.686Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605191421-D566XJ/pr/meta.json
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605191421-D566XJ/evidence-bundle",
+  "created_at": "2026-05-19T14:23:12.633Z",
+  "head_sha": "81a3ed59446b0e0fbdf663711e789c53ec915369",
+  "last_verified_at": null,
+  "last_verified_sha": null,
+  "schema_version": 1,
+  "task_id": "202605191421-D566XJ",
+  "updated_at": "2026-05-19T14:23:12.633Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605191421-D566XJ/pr/meta.json
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/meta.json
@@ -3,7 +3,7 @@
   "branch": "task/202605191421-D566XJ/evidence-bundle",
   "created_at": "2026-05-19T14:23:12.633Z",
   "head_sha": "a89b99bfe360becc2e5b22f3395a84d70db43257",
-  "last_verified_at": "2026-05-19T14:49:32.970Z",
+  "last_verified_at": "2026-05-19T14:54:23.894Z",
   "last_verified_sha": "a89b99bfe360becc2e5b22f3395a84d70db43257",
   "pr_number": 3937,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3937",

--- a/.agentplane/tasks/202605191421-D566XJ/pr/review.md
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-05-19T14:23:12.633Z
 ## Verification
 
 - State: ok
-- Note: Quality gate passed for deterministic evidence bundle implementation. Reviewed route evidence, focused tests, typecheck, lint, docs checks, ACR validation, strict evidence verification, and GitHub PR linkage. Hosted checks are still tracked separately on PR #3937.
+- Note: Fixed hosted Linux format gate by applying Prettier to evidence command files. Local checks passed: format:check, focused evidence/ACR tests, agentplane typecheck, targeted eslint, docs:cli:check, docs:ia:check.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,9 +24,9 @@ Created: 2026-05-19T14:23:12.633Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-19T14:52:54.635Z
+- Updated: 2026-05-19T15:29:40.686Z
 - Branch: task/202605191421-D566XJ/evidence-bundle
-- Head: a89b99bfe360
+- Head: f0df96e155d1
 
 ```text
  .agentplane/tasks/202605191421-D566XJ/acr.json     | 409 +++++++++++++++
@@ -39,9 +39,9 @@ Created: 2026-05-19T14:23:12.633Z
  .../src/cli/run-cli/command-loaders/project.ts     |  11 +
  packages/agentplane/src/commands/acr/generate.ts   |  15 +-
  .../src/commands/evidence/evidence.command.test.ts | 111 ++++
- .../src/commands/evidence/evidence.command.ts      | 487 ++++++++++++++++++
+ .../src/commands/evidence/evidence.command.ts      | 484 +++++++++++++++++
  website/sidebars.ts                                |   2 +
- 12 files changed, 1786 insertions(+), 4 deletions(-)
+ 12 files changed, 1783 insertions(+), 4 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605191421-D566XJ/pr/review.md
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-05-19T14:23:12.633Z
 ## Verification
 
 - State: ok
-- Note: Implemented deterministic evidence bundle and verify commands with ACR trust pointer and docs. Checks passed: focused evidence/ACR tests, agentplane typecheck, lint:core, docs:cli:check, docs:ia:check, evidence bundle, evidence verify --strict.
+- Note: Quality gate passed for deterministic evidence bundle implementation. Reviewed route evidence, focused tests, typecheck, lint, docs checks, ACR validation, strict evidence verification, and GitHub PR linkage. Hosted checks are still tracked separately on PR #3937.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes

--- a/.agentplane/tasks/202605191421-D566XJ/pr/review.md
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/review.md
@@ -29,7 +29,7 @@ Created: 2026-05-19T14:23:12.633Z
 - Head: a89b99bfe360
 
 ```text
- .agentplane/tasks/202605191421-D566XJ/acr.json     | 402 +++++++++++++++
+ .agentplane/tasks/202605191421-D566XJ/acr.json     | 409 +++++++++++++++
  .../blueprint/resolved-snapshot.json               | 572 +++++++++++++++++++++
  .../202605191421-D566XJ/evidence/manifest.json     |  69 +++
  docs/reference/acr.mdx                             |   8 +
@@ -41,7 +41,7 @@ Created: 2026-05-19T14:23:12.633Z
  .../src/commands/evidence/evidence.command.test.ts | 111 ++++
  .../src/commands/evidence/evidence.command.ts      | 487 ++++++++++++++++++
  website/sidebars.ts                                |   2 +
- 12 files changed, 1779 insertions(+), 4 deletions(-)
+ 12 files changed, 1786 insertions(+), 4 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605191421-D566XJ/pr/review.md
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/review.md
@@ -24,7 +24,7 @@ Created: 2026-05-19T14:23:12.633Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-19T14:49:33.248Z
+- Updated: 2026-05-19T14:52:54.635Z
 - Branch: task/202605191421-D566XJ/evidence-bundle
 - Head: a89b99bfe360
 

--- a/.agentplane/tasks/202605191421-D566XJ/pr/review.md
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/review.md
@@ -29,8 +29,9 @@ Created: 2026-05-19T14:23:12.633Z
 - Head: a89b99bfe360
 
 ```text
+ .agentplane/tasks/202605191421-D566XJ/acr.json     | 402 +++++++++++++++
  .../blueprint/resolved-snapshot.json               | 572 +++++++++++++++++++++
- .../202605191421-D566XJ/evidence/manifest.json     |  63 +++
+ .../202605191421-D566XJ/evidence/manifest.json     |  69 +++
  docs/reference/acr.mdx                             |   8 +
  docs/reference/evidence.mdx                        |  44 ++
  docs/user/cli-reference.generated.mdx              |  51 ++
@@ -40,7 +41,7 @@ Created: 2026-05-19T14:23:12.633Z
  .../src/commands/evidence/evidence.command.test.ts | 111 ++++
  .../src/commands/evidence/evidence.command.ts      | 487 ++++++++++++++++++
  website/sidebars.ts                                |   2 +
- 11 files changed, 1371 insertions(+), 4 deletions(-)
+ 12 files changed, 1779 insertions(+), 4 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605191421-D566XJ/pr/review.md
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-05-19T14:23:12.633Z
 ## Verification
 
 - State: ok
-- Note: Addressed PR review threads: evidence bundle now respects configured workflow_dir and preserves existing created_at to keep unchanged bundle reruns deterministic. Local checks passed: focused evidence/ACR tests, agentplane typecheck, targeted eslint, format:check, framework:dev:bootstrap.
+- Note: EVALUATOR quality gate passed for current implementation commit 08db6b47. Reviewed fixes for configured workflow_dir evidence paths and deterministic bundle reruns; local checks passed: focused evidence/ACR tests, typecheck, format:check, targeted eslint, framework bootstrap; hosted PR checks are green on PR #3937.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes

--- a/.agentplane/tasks/202605191421-D566XJ/pr/review.md
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-05-19T14:23:12.633Z
 ## Verification
 
 - State: ok
-- Note: Fixed hosted Linux format gate by applying Prettier to evidence command files. Local checks passed: format:check, focused evidence/ACR tests, agentplane typecheck, targeted eslint, docs:cli:check, docs:ia:check.
+- Note: Addressed PR review threads: evidence bundle now respects configured workflow_dir and preserves existing created_at to keep unchanged bundle reruns deterministic. Local checks passed: focused evidence/ACR tests, agentplane typecheck, targeted eslint, format:check, framework:dev:bootstrap.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,9 +24,9 @@ Created: 2026-05-19T14:23:12.633Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-19T15:29:40.686Z
+- Updated: 2026-05-19T15:45:54.714Z
 - Branch: task/202605191421-D566XJ/evidence-bundle
-- Head: f0df96e155d1
+- Head: 08db6b47a452
 
 ```text
  .agentplane/tasks/202605191421-D566XJ/acr.json     | 409 +++++++++++++++
@@ -38,10 +38,10 @@ Created: 2026-05-19T14:23:12.633Z
  .../src/cli/run-cli/command-catalog/project.ts     |  11 +
  .../src/cli/run-cli/command-loaders/project.ts     |  11 +
  packages/agentplane/src/commands/acr/generate.ts   |  15 +-
- .../src/commands/evidence/evidence.command.test.ts | 111 ++++
- .../src/commands/evidence/evidence.command.ts      | 484 +++++++++++++++++
+ .../src/commands/evidence/evidence.command.test.ts | 158 ++++++
+ .../src/commands/evidence/evidence.command.ts      | 516 +++++++++++++++++++
  website/sidebars.ts                                |   2 +
- 12 files changed, 1783 insertions(+), 4 deletions(-)
+ 12 files changed, 1862 insertions(+), 4 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605191421-D566XJ/pr/review.md
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-05-19T14:23:12.633Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Implemented deterministic evidence bundle and verify commands with ACR trust pointer and docs. Checks passed: focused evidence/ACR tests, agentplane typecheck, lint:core, docs:cli:check, docs:ia:check, evidence bundle, evidence verify --strict.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,12 +24,23 @@ Created: 2026-05-19T14:23:12.633Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-19T14:23:12.633Z
+- Updated: 2026-05-19T14:49:33.248Z
 - Branch: task/202605191421-D566XJ/evidence-bundle
-- Head: 81a3ed59446b
+- Head: a89b99bfe360
 
 ```text
-No changes detected.
+ .../blueprint/resolved-snapshot.json               | 572 +++++++++++++++++++++
+ .../202605191421-D566XJ/evidence/manifest.json     |  63 +++
+ docs/reference/acr.mdx                             |   8 +
+ docs/reference/evidence.mdx                        |  44 ++
+ docs/user/cli-reference.generated.mdx              |  51 ++
+ .../src/cli/run-cli/command-catalog/project.ts     |  11 +
+ .../src/cli/run-cli/command-loaders/project.ts     |  11 +
+ packages/agentplane/src/commands/acr/generate.ts   |  15 +-
+ .../src/commands/evidence/evidence.command.test.ts | 111 ++++
+ .../src/commands/evidence/evidence.command.ts      | 487 ++++++++++++++++++
+ website/sidebars.ts                                |   2 +
+ 11 files changed, 1371 insertions(+), 4 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605191421-D566XJ/pr/review.md
+++ b/.agentplane/tasks/202605191421-D566XJ/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-19T14:23:12.633Z
+
+## Task
+
+- Task: `202605191421-D566XJ`
+- Title: Add deterministic evidence bundle commands
+- Status: DOING
+- Branch: `task/202605191421-D566XJ/evidence-bundle`
+- Canonical task record: `.agentplane/tasks/202605191421-D566XJ/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-19T14:23:12.633Z
+- Branch: task/202605191421-D566XJ/evidence-bundle
+- Head: 81a3ed59446b
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/docs/reference/acr.mdx
+++ b/docs/reference/acr.mdx
@@ -52,6 +52,13 @@ agentplane acr check <task-id> --mode ci
 agentplane acr explain <task-id>
 ```
 
+For portable task-local evidence, create and verify an evidence bundle:
+
+```bash
+agentplane evidence bundle <task-id>
+agentplane evidence verify <task-id>
+```
+
 ## Use ACR with Git
 
 Keep ACR task-local:
@@ -74,3 +81,4 @@ private tokens, raw prompts, or full model transcripts by default.
 ## Schema reference
 
 See [ACR schema](acr-schema) for field-level reference and validation notes.
+See [Evidence bundles](evidence) for deterministic task artifact manifests.

--- a/docs/reference/evidence.mdx
+++ b/docs/reference/evidence.mdx
@@ -1,0 +1,44 @@
+---
+title: "Evidence bundles"
+description: "Deterministic task-local evidence bundle manifests for AgentPlane tasks."
+---
+
+# Evidence bundles
+
+Evidence bundles make task evidence portable without turning AgentPlane into a hosted archive. The
+bundle is a deterministic manifest under the task directory. It records task-local artifact paths,
+SHA-256 hashes, file sizes, and roles.
+
+```bash
+agentplane evidence bundle <task-id>
+agentplane evidence verify <task-id>
+```
+
+Default output:
+
+```text
+.agentplane/tasks/<task-id>/evidence/manifest.json
+```
+
+The manifest excludes itself to avoid self-referential hashes. It includes task-local artifacts such
+as `README.md`, `acr.json`, blueprint snapshots, PR notes, and verification logs when those files
+exist.
+
+## Verify
+
+```bash
+agentplane evidence verify <task-id>
+agentplane evidence verify .agentplane/tasks/<task-id>/evidence/manifest.json
+```
+
+Verification fails when a referenced file is missing, its SHA-256 hash changed, the manifest digest
+does not match, or `--strict` is used and the bundle has no ACR artifact.
+
+## ACR trust metadata
+
+When a task-local evidence manifest already exists, `agentplane acr generate <task-id> --write
+--refresh` adds an `agentplane.trust` extension pointing to the bundle manifest and the verification
+command. The manifest keeps its own digest; the ACR does not copy that digest because the manifest
+may include `acr.json`, and copying the digest into the ACR would create a self-referential hash
+cycle. Signing and WORM preservation are separate future layers; the current bundle is local,
+hash-verifiable evidence.

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -146,6 +146,9 @@ This page is generated from the CLI command specs. Do not edit it by hand; edit 
 - Evaluators
   - [evaluator list](#evaluator-list)
   - [evaluator show](#evaluator-show)
+- Evidence
+  - [evidence bundle](#evidence-bundle)
+  - [evidence verify](#evidence-verify)
 - Workflow
   - [flow repair](#flow-repair)
 
@@ -3559,6 +3562,54 @@ agentplane evaluator show recovery-context
 ```
 
 - Print the recovery-context evaluator prompt.
+
+## Evidence
+
+### evidence bundle
+
+Write a deterministic task evidence bundle manifest.
+
+Usage:
+
+```text
+agentplane evidence bundle <task-id> [options]
+```
+
+Options:
+
+- `--out <path>`: Write manifest to a custom repository-relative path.
+- `--json`: Emit machine-readable result. (default=false)
+
+Examples:
+
+```sh
+agentplane evidence bundle 202605031625-886KZ6
+```
+
+- Write \`.agentplane/tasks/&lt;task-id&gt;/evidence/manifest.json\`.
+
+### evidence verify
+
+Verify a task evidence bundle manifest and referenced file hashes.
+
+Usage:
+
+```text
+agentplane evidence verify <task-id-or-manifest> [options]
+```
+
+Options:
+
+- `--json`: Emit machine-readable result. (default=false)
+- `--strict`: Fail when the manifest contains no ACR evidence. (default=false)
+
+Examples:
+
+```sh
+agentplane evidence verify 202605031625-886KZ6
+```
+
+- Verify the task-local evidence manifest.
 
 ## Workflow
 

--- a/packages/agentplane/src/cli/run-cli/command-catalog/project.ts
+++ b/packages/agentplane/src/cli/run-cli/command-catalog/project.ts
@@ -8,6 +8,11 @@ import {
   acrValidateSpec,
 } from "../../../commands/acr/acr.command.js";
 import {
+  evidenceBundleSpec,
+  evidenceSpec,
+  evidenceVerifySpec,
+} from "../../../commands/evidence/evidence.command.js";
+import {
   blueprintDriftSpec,
   blueprintExamplesSpec,
   blueprintExplainSpec,
@@ -176,6 +181,9 @@ import {
   loadAcrValidateSpec,
   loadAcrCheckSpec,
   loadAcrExplainSpec,
+  fromCommandsEvidenceCommand,
+  loadEvidenceBundleSpec,
+  loadEvidenceVerifySpec,
   loadBlueprintSpec,
   loadBlueprintListSpec,
   loadBlueprintExamplesSpec,
@@ -198,6 +206,9 @@ export const PROJECT_COMMANDS = [
   declareCommand(acrValidateSpec, { load: loadAcrValidateSpec }),
   declareCommand(acrCheckSpec, { load: loadAcrCheckSpec }),
   declareCommand(acrExplainSpec, { load: loadAcrExplainSpec }),
+  fromCommandsEvidenceCommand(evidenceSpec, "runEvidenceGroup", { needs: "none" }),
+  declareCommand(evidenceBundleSpec, { load: loadEvidenceBundleSpec }),
+  declareCommand(evidenceVerifySpec, { load: loadEvidenceVerifySpec }),
   declareCommand(blueprintSpec, { load: loadBlueprintSpec, needs: "none" }),
   declareCommand(blueprintListSpec, { load: loadBlueprintListSpec, needs: "none" }),
   declareCommand(blueprintExamplesSpec, { load: loadBlueprintExamplesSpec, needs: "none" }),

--- a/packages/agentplane/src/cli/run-cli/command-loaders/project.ts
+++ b/packages/agentplane/src/cli/run-cli/command-loaders/project.ts
@@ -18,6 +18,17 @@ export const loadAcrExplainSpec = (deps: RunDeps) =>
   import("../../../commands/acr/acr.command.js").then((m) =>
     m.makeRunAcrExplainHandler(deps.getCtx),
   );
+export const fromCommandsEvidenceCommand = commandModule(
+  () => import("../../../commands/evidence/evidence.command.js"),
+);
+export const loadEvidenceBundleSpec = (deps: RunDeps) =>
+  import("../../../commands/evidence/evidence.command.js").then((m) =>
+    m.makeRunEvidenceBundleHandler(deps.getCtx),
+  );
+export const loadEvidenceVerifySpec = (deps: RunDeps) =>
+  import("../../../commands/evidence/evidence.command.js").then((m) =>
+    m.makeRunEvidenceVerifyHandler(deps.getCtx),
+  );
 
 export const loadBlueprintSpec = (deps: RunDeps) =>
   import("../../../commands/blueprint/blueprint.command.js").then((m) =>

--- a/packages/agentplane/src/commands/acr/generate.ts
+++ b/packages/agentplane/src/commands/acr/generate.ts
@@ -19,6 +19,7 @@ import { getVersion } from "../../meta/version.js";
 import { isRecord } from "../../shared/guards.js";
 import { blueprintResolveInputFromTask } from "../blueprint/task-input.js";
 import { checkTaskBlueprintSnapshotDrift } from "../blueprint/snapshot-artifact.js";
+import { readTaskEvidenceBundleTrustExtension } from "../evidence/evidence.command.js";
 import { loadTaskFromContext, type CommandContext } from "../shared/task-backend.js";
 import { readDiffSummary } from "./diff.js";
 import { defaultAcrPath } from "./validate.js";
@@ -113,6 +114,10 @@ export async function generateAcr(opts: {
     task,
     ctx: opts.ctx,
   });
+  const trust = await readTaskEvidenceBundleTrustExtension({
+    ctx: opts.ctx,
+    taskId: task.id,
+  });
   const evidence = [
     ...taskEvidence,
     ...(blueprint.snapshot?.state === "current" &&
@@ -141,6 +146,11 @@ export async function generateAcr(opts: {
     evidence,
   });
   const mergeReady = residualRisks.length === 0;
+  const extensions = {
+    "agentplane.blueprint": blueprint,
+    ...buildAcrContextExtension(task),
+  };
+  if (trust) Object.assign(extensions, trust);
   const recordWithoutDigest: AgentChangeRecord = {
     acr_version: ACR_VERSION,
     record_type: "agent_change_record",
@@ -263,10 +273,7 @@ export async function generateAcr(opts: {
       canonicalization: "rfc8785-jcs",
       signatures: [],
     },
-    extensions: {
-      "agentplane.blueprint": blueprint,
-      ...buildAcrContextExtension(task),
-    },
+    extensions,
   };
   const record = {
     ...recordWithoutDigest,

--- a/packages/agentplane/src/commands/evidence/evidence.command.test.ts
+++ b/packages/agentplane/src/commands/evidence/evidence.command.test.ts
@@ -1,0 +1,111 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { CommandContext } from "../shared/task-backend.js";
+import {
+  cmdEvidenceBundle,
+  cmdEvidenceVerify,
+  evidenceBundleSpec,
+  evidenceVerifySpec,
+  readTaskEvidenceBundleTrustExtension,
+} from "./evidence.command.js";
+
+function fakeCommandContext(root: string): CommandContext {
+  return {
+    resolvedProject: { gitRoot: root },
+    config: { paths: { workflow_dir: ".agentplane/tasks" } },
+    taskBackend: {
+      getTask: (taskId: string) =>
+        Promise.resolve({
+        id: taskId,
+        title: "Evidence task",
+        description: "Create evidence bundle.",
+        status: "TODO",
+        priority: "med",
+        owner: "CODER",
+        }),
+    },
+    backendId: "local",
+    backendConfigPath: path.join(root, ".agentplane/backends/local/backend.json"),
+    git: {} as CommandContext["git"],
+    memo: {},
+  } as CommandContext;
+}
+
+describe("evidence command specs", () => {
+  it("parses bundle and verify flags", () => {
+    expect(
+      evidenceBundleSpec.parse({
+        args: { "task-id": "202605031625-886KZ6" },
+        opts: { json: true },
+      }),
+    ).toMatchObject({ taskId: "202605031625-886KZ6", json: true });
+
+    expect(
+      evidenceVerifySpec.parse({
+        args: { "task-id-or-manifest": "202605031625-886KZ6" },
+        opts: { strict: true },
+      }),
+    ).toMatchObject({ target: "202605031625-886KZ6", strict: true });
+  });
+});
+
+describe("evidence bundle manifest", () => {
+  it("writes and verifies deterministic task-local file hashes", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "agentplane-evidence-"));
+    const taskId = "202605031625-886KZ6";
+    const taskRoot = path.join(root, ".agentplane/tasks", taskId);
+    await mkdir(path.join(taskRoot, "blueprint"), { recursive: true });
+    await writeFile(path.join(taskRoot, "README.md"), "# Task\n", "utf8");
+    await writeFile(path.join(taskRoot, "acr.json"), "{}\n", "utf8");
+    await writeFile(path.join(taskRoot, "blueprint/resolved-snapshot.json"), "{}\n", "utf8");
+
+    const ctx = fakeCommandContext(root);
+    await cmdEvidenceBundle({
+      commandCtx: ctx,
+      cwd: root,
+      parsed: { taskId, json: false },
+    });
+
+    const manifestPath = path.join(taskRoot, "evidence/manifest.json");
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
+      files: { path: string; role: string }[];
+      integrity: { manifest_digest: string };
+    };
+    expect(manifest.integrity.manifest_digest).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(manifest.files.map((file) => file.role)).toEqual([
+      "acr",
+      "blueprint_snapshot",
+      "task_readme",
+    ]);
+
+    await expect(
+      cmdEvidenceVerify({
+        commandCtx: ctx,
+        cwd: root,
+        parsed: { target: taskId, json: false, strict: true },
+      }),
+    ).resolves.toBe(0);
+    await expect(readTaskEvidenceBundleTrustExtension({ ctx, taskId })).resolves.toMatchObject({
+      "agentplane.trust": {
+        schema_version: 1,
+        evidence_bundle: {
+          path: `.agentplane/tasks/${taskId}/evidence/manifest.json`,
+          status: "available",
+        },
+      },
+    });
+
+    await writeFile(path.join(taskRoot, "acr.json"), "{\"changed\":true}\n", "utf8");
+    await expect(
+      cmdEvidenceVerify({
+        commandCtx: ctx,
+        cwd: root,
+        parsed: { target: taskId, json: false, strict: true },
+      }),
+    ).rejects.toThrow("hash mismatch");
+  });
+});

--- a/packages/agentplane/src/commands/evidence/evidence.command.test.ts
+++ b/packages/agentplane/src/commands/evidence/evidence.command.test.ts
@@ -20,12 +20,12 @@ function fakeCommandContext(root: string): CommandContext {
     taskBackend: {
       getTask: (taskId: string) =>
         Promise.resolve({
-        id: taskId,
-        title: "Evidence task",
-        description: "Create evidence bundle.",
-        status: "TODO",
-        priority: "med",
-        owner: "CODER",
+          id: taskId,
+          title: "Evidence task",
+          description: "Create evidence bundle.",
+          status: "TODO",
+          priority: "med",
+          owner: "CODER",
         }),
     },
     backendId: "local",
@@ -99,7 +99,7 @@ describe("evidence bundle manifest", () => {
       },
     });
 
-    await writeFile(path.join(taskRoot, "acr.json"), "{\"changed\":true}\n", "utf8");
+    await writeFile(path.join(taskRoot, "acr.json"), '{"changed":true}\n', "utf8");
     await expect(
       cmdEvidenceVerify({
         commandCtx: ctx,

--- a/packages/agentplane/src/commands/evidence/evidence.command.test.ts
+++ b/packages/agentplane/src/commands/evidence/evidence.command.test.ts
@@ -13,10 +13,10 @@ import {
   readTaskEvidenceBundleTrustExtension,
 } from "./evidence.command.js";
 
-function fakeCommandContext(root: string): CommandContext {
+function fakeCommandContext(root: string, workflowDir = ".agentplane/tasks"): CommandContext {
   return {
     resolvedProject: { gitRoot: root },
-    config: { paths: { workflow_dir: ".agentplane/tasks" } },
+    config: { paths: { workflow_dir: workflowDir } },
     taskBackend: {
       getTask: (taskId: string) =>
         Promise.resolve({
@@ -72,9 +72,12 @@ describe("evidence bundle manifest", () => {
 
     const manifestPath = path.join(taskRoot, "evidence/manifest.json");
     const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
+      created_at: string;
       files: { path: string; role: string }[];
       integrity: { manifest_digest: string };
     };
+    const firstCreatedAt = manifest.created_at;
+    const firstDigest = manifest.integrity.manifest_digest;
     expect(manifest.integrity.manifest_digest).toMatch(/^sha256:[0-9a-f]{64}$/);
     expect(manifest.files.map((file) => file.role)).toEqual([
       "acr",
@@ -99,6 +102,18 @@ describe("evidence bundle manifest", () => {
       },
     });
 
+    await cmdEvidenceBundle({
+      commandCtx: ctx,
+      cwd: root,
+      parsed: { taskId, json: false },
+    });
+    const rerunManifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
+      created_at: string;
+      integrity: { manifest_digest: string };
+    };
+    expect(rerunManifest.created_at).toBe(firstCreatedAt);
+    expect(rerunManifest.integrity.manifest_digest).toBe(firstDigest);
+
     await writeFile(path.join(taskRoot, "acr.json"), '{"changed":true}\n', "utf8");
     await expect(
       cmdEvidenceVerify({
@@ -107,5 +122,37 @@ describe("evidence bundle manifest", () => {
         parsed: { target: taskId, json: false, strict: true },
       }),
     ).rejects.toThrow("hash mismatch");
+  });
+
+  it("uses the configured workflow directory for default evidence paths", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "agentplane-evidence-"));
+    const taskId = "202605031625-886KZ6";
+    const workflowDir = ".custom-agentplane/tasks";
+    const taskRoot = path.join(root, workflowDir, taskId);
+    await mkdir(taskRoot, { recursive: true });
+    await writeFile(path.join(taskRoot, "README.md"), "# Task\n", "utf8");
+
+    const ctx = fakeCommandContext(root, workflowDir);
+    await cmdEvidenceBundle({
+      commandCtx: ctx,
+      cwd: root,
+      parsed: { taskId, json: false },
+    });
+
+    const manifestPath = path.join(taskRoot, "evidence/manifest.json");
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
+      artifact_root: string;
+      files: { path: string }[];
+    };
+    expect(manifest.artifact_root).toBe(`${workflowDir}/${taskId}`);
+    expect(manifest.files.map((file) => file.path)).toEqual([`${workflowDir}/${taskId}/README.md`]);
+
+    await expect(
+      cmdEvidenceVerify({
+        commandCtx: ctx,
+        cwd: root,
+        parsed: { target: taskId, json: false, strict: false },
+      }),
+    ).resolves.toBe(0);
   });
 });

--- a/packages/agentplane/src/commands/evidence/evidence.command.ts
+++ b/packages/agentplane/src/commands/evidence/evidence.command.ts
@@ -1,0 +1,487 @@
+import { canonicalizeJson } from "@agentplaneorg/core/tasks";
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { mkdir, readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  loadDirectSubcommandNames,
+  parseGroupCommand,
+  throwGroupCommandUsage,
+  type GroupCommandParsed,
+} from "../../cli/group-command.js";
+import type { CommandCtx, CommandHandler, CommandSpec } from "../../cli/spec/spec.js";
+import { getVersion } from "../../meta/version.js";
+import { CliError } from "../../shared/errors.js";
+import { writeJsonStableIfChanged } from "../../shared/write-if-changed.js";
+import { loadTaskFromContext, type CommandContext } from "../shared/task-backend.js";
+
+export type EvidenceBundleParsed = {
+  taskId: string;
+  out?: string;
+  json: boolean;
+};
+
+export type EvidenceVerifyParsed = {
+  target: string;
+  json: boolean;
+  strict: boolean;
+};
+
+type EvidenceFileRole =
+  | "task_readme"
+  | "acr"
+  | "blueprint_snapshot"
+  | "verification_log"
+  | "pr_artifact"
+  | "task_artifact";
+
+type EvidenceManifestFile = {
+  path: string;
+  sha256: string;
+  size_bytes: number;
+  role: EvidenceFileRole;
+};
+
+export type EvidenceBundleManifest = {
+  schema_version: 1;
+  kind: "agentplane_evidence_bundle";
+  task_id: string;
+  created_at: string;
+  producer: {
+    name: "agentplane";
+    version: string;
+  };
+  artifact_root: string;
+  files: EvidenceManifestFile[];
+  verification: {
+    command: string;
+  };
+  integrity: {
+    digest_algorithm: "sha256";
+    canonicalization: "agentplane-canonical-json-v1";
+    manifest_digest: string | null;
+  };
+};
+
+export const evidenceSpec: CommandSpec<GroupCommandParsed> = {
+  id: ["evidence"],
+  group: "Evidence",
+  summary: "Create and verify deterministic task evidence bundle manifests.",
+  description:
+    "This is a command group. Use `agentplane evidence bundle <task-id>` or `agentplane evidence verify <task-id-or-manifest>`.",
+  args: [{ name: "cmd", required: false, variadic: true, valueHint: "<cmd>" }],
+  examples: [
+    {
+      cmd: "agentplane evidence bundle 202605031625-886KZ6",
+      why: "Write a task-local deterministic evidence manifest.",
+    },
+  ],
+  parse: (raw) => parseGroupCommand(raw),
+};
+
+export const evidenceBundleSpec: CommandSpec<EvidenceBundleParsed> = {
+  id: ["evidence", "bundle"],
+  group: "Evidence",
+  summary: "Write a deterministic task evidence bundle manifest.",
+  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
+  options: [
+    {
+      kind: "string",
+      name: "out",
+      valueHint: "<path>",
+      description: "Write manifest to a custom repository-relative path.",
+    },
+    { kind: "boolean", name: "json", default: false, description: "Emit machine-readable result." },
+  ],
+  examples: [
+    {
+      cmd: "agentplane evidence bundle 202605031625-886KZ6",
+      why: "Write `.agentplane/tasks/<task-id>/evidence/manifest.json`.",
+    },
+  ],
+  parse: (raw) => ({
+    taskId: String(raw.args["task-id"]),
+    out: typeof raw.opts.out === "string" ? raw.opts.out : undefined,
+    json: raw.opts.json === true,
+  }),
+};
+
+export const evidenceVerifySpec: CommandSpec<EvidenceVerifyParsed> = {
+  id: ["evidence", "verify"],
+  group: "Evidence",
+  summary: "Verify a task evidence bundle manifest and referenced file hashes.",
+  args: [{ name: "task-id-or-manifest", required: true, valueHint: "<task-id-or-manifest>" }],
+  options: [
+    { kind: "boolean", name: "json", default: false, description: "Emit machine-readable result." },
+    {
+      kind: "boolean",
+      name: "strict",
+      default: false,
+      description: "Fail when the manifest contains no ACR evidence.",
+    },
+  ],
+  examples: [
+    {
+      cmd: "agentplane evidence verify 202605031625-886KZ6",
+      why: "Verify the task-local evidence manifest.",
+    },
+  ],
+  parse: (raw) => ({
+    target: String(raw.args["task-id-or-manifest"]),
+    json: raw.opts.json === true,
+    strict: raw.opts.strict === true,
+  }),
+};
+
+export async function runEvidenceGroup(
+  _ctx: CommandCtx,
+  p: GroupCommandParsed,
+): Promise<number> {
+  return throwGroupCommandUsage({
+    spec: evidenceSpec,
+    cmd: p.cmd,
+    subcommands: await loadDirectSubcommandNames(["evidence"]),
+    command: "evidence",
+    contextCommand: "evidence",
+  });
+}
+
+export function makeRunEvidenceBundleHandler(
+  getCtx: (command: string) => Promise<CommandContext>,
+): CommandHandler<EvidenceBundleParsed> {
+  return async (ctx, parsed) => {
+    const commandCtx = await getCtx("evidence bundle");
+    return await cmdEvidenceBundle({ commandCtx, cwd: ctx.cwd, parsed });
+  };
+}
+
+export function makeRunEvidenceVerifyHandler(
+  getCtx: (command: string) => Promise<CommandContext>,
+): CommandHandler<EvidenceVerifyParsed> {
+  return async (ctx, parsed) => {
+    const commandCtx = await getCtx("evidence verify");
+    return await cmdEvidenceVerify({ commandCtx, cwd: ctx.cwd, parsed });
+  };
+}
+
+export async function cmdEvidenceBundle(opts: {
+  commandCtx: CommandContext;
+  cwd: string;
+  parsed: EvidenceBundleParsed;
+}): Promise<number> {
+  await loadTaskFromContext({ ctx: opts.commandCtx, taskId: opts.parsed.taskId });
+  const root = opts.commandCtx.resolvedProject.gitRoot;
+  const manifestPath = resolveManifestPath(root, opts.cwd, opts.parsed.taskId, opts.parsed.out);
+  const manifest = await buildEvidenceBundleManifest({
+    root,
+    taskId: opts.parsed.taskId,
+    manifestPath,
+  });
+  await mkdir(path.dirname(manifestPath), { recursive: true });
+  await writeJsonStableIfChanged(manifestPath, manifest);
+
+  const relative = toPosix(path.relative(root, manifestPath));
+  if (opts.parsed.json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          task_id: opts.parsed.taskId,
+          manifest_path: relative,
+          manifest_digest: manifest.integrity.manifest_digest,
+          files: manifest.files.length,
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    return 0;
+  }
+  process.stdout.write(
+    `evidence bundle: ${relative}\n` +
+      `manifest_digest: ${manifest.integrity.manifest_digest}\n` +
+      `files: ${manifest.files.length}\n`,
+  );
+  return 0;
+}
+
+export async function cmdEvidenceVerify(opts: {
+  commandCtx: CommandContext;
+  cwd: string;
+  parsed: EvidenceVerifyParsed;
+}): Promise<number> {
+  const root = opts.commandCtx.resolvedProject.gitRoot;
+  const manifestPath = resolveVerifyTarget(root, opts.cwd, opts.parsed.target);
+  const manifest = await readEvidenceManifest(manifestPath);
+  const errors = await verifyEvidenceManifest({ root, manifest, strict: opts.parsed.strict });
+  const relative = toPosix(path.relative(root, manifestPath));
+  const ok = errors.length === 0;
+  if (opts.parsed.json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          ok,
+          manifest_path: relative,
+          task_id: manifest.task_id,
+          manifest_digest: manifest.integrity.manifest_digest,
+          files: manifest.files.length,
+          errors,
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    if (!ok) {
+      throw new CliError({
+        exitCode: 3,
+        code: "E_VALIDATION",
+        message: `evidence verify failed: ${errors.length} issue(s)`,
+      });
+    }
+    return 0;
+  }
+  if (!ok) {
+    throw new CliError({
+      exitCode: 3,
+      code: "E_VALIDATION",
+      message: `evidence verify failed for ${relative}: ${errors.length} issue(s)\n- ${errors.join("\n- ")}`,
+    });
+  }
+  process.stdout.write(`evidence verify ${relative}: ok (${manifest.files.length} files)\n`);
+  return 0;
+}
+
+export function defaultEvidenceManifestPath(ctx: CommandContext, taskId: string): string {
+  return path.join(
+    ctx.resolvedProject.gitRoot,
+    ctx.config.paths.workflow_dir,
+    taskId,
+    "evidence",
+    "manifest.json",
+  );
+}
+
+export async function readTaskEvidenceBundleTrustExtension(opts: {
+  ctx: CommandContext;
+  taskId: string;
+}): Promise<Record<string, unknown> | null> {
+  const manifestPath = defaultEvidenceManifestPath(opts.ctx, opts.taskId);
+  try {
+    await readEvidenceManifest(manifestPath);
+    return {
+      "agentplane.trust": {
+        schema_version: 1,
+        evidence_bundle: {
+          path: toPosix(path.relative(opts.ctx.resolvedProject.gitRoot, manifestPath)),
+          digest_algorithm: "sha256",
+          verification_command: `agentplane evidence verify ${opts.taskId}`,
+          status: "available",
+        },
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function buildEvidenceBundleManifest(opts: {
+  root: string;
+  taskId: string;
+  manifestPath: string;
+}): Promise<EvidenceBundleManifest> {
+  const taskRoot = path.join(opts.root, ".agentplane", "tasks", opts.taskId);
+  const files = await collectTaskEvidenceFiles({
+    root: opts.root,
+    taskRoot,
+    manifestPath: opts.manifestPath,
+  });
+  const manifestWithoutDigest: EvidenceBundleManifest = {
+    schema_version: 1,
+    kind: "agentplane_evidence_bundle",
+    task_id: opts.taskId,
+    created_at: new Date().toISOString(),
+    producer: {
+      name: "agentplane",
+      version: getVersion(),
+    },
+    artifact_root: toPosix(path.relative(opts.root, taskRoot)),
+    files,
+    verification: {
+      command: `agentplane evidence verify ${opts.taskId}`,
+    },
+    integrity: {
+      digest_algorithm: "sha256",
+      canonicalization: "agentplane-canonical-json-v1",
+      manifest_digest: null,
+    },
+  };
+  return {
+    ...manifestWithoutDigest,
+    integrity: {
+      ...manifestWithoutDigest.integrity,
+      manifest_digest: computeManifestDigest(manifestWithoutDigest),
+    },
+  };
+}
+
+async function collectTaskEvidenceFiles(opts: {
+  root: string;
+  taskRoot: string;
+  manifestPath: string;
+}): Promise<EvidenceManifestFile[]> {
+  const files: EvidenceManifestFile[] = [];
+  for (const filePath of await walkFiles(opts.taskRoot)) {
+    if (path.resolve(filePath) === path.resolve(opts.manifestPath)) continue;
+    const relativeToTask = toPosix(path.relative(opts.taskRoot, filePath));
+    if (relativeToTask === ".DS_Store") continue;
+    if (relativeToTask.startsWith("evidence/")) continue;
+    files.push({
+      path: toPosix(path.relative(opts.root, filePath)),
+      sha256: await sha256File(filePath),
+      size_bytes: (await fileStatSize(filePath)) ?? 0,
+      role: inferEvidenceRole(relativeToTask),
+    });
+  }
+  return files.toSorted((left, right) => left.path.localeCompare(right.path));
+}
+
+async function walkFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const out: string[] = [];
+  for (const entry of entries) {
+    const next = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...(await walkFiles(next)));
+      continue;
+    }
+    if (entry.isFile()) out.push(next);
+  }
+  return out;
+}
+
+function inferEvidenceRole(relativeToTask: string): EvidenceFileRole {
+  if (relativeToTask === "README.md") return "task_readme";
+  if (relativeToTask === "acr.json") return "acr";
+  if (relativeToTask === "blueprint/resolved-snapshot.json") return "blueprint_snapshot";
+  if (relativeToTask.includes("verify")) return "verification_log";
+  if (relativeToTask.startsWith("pr/")) return "pr_artifact";
+  return "task_artifact";
+}
+
+async function verifyEvidenceManifest(opts: {
+  root: string;
+  manifest: EvidenceBundleManifest;
+  strict: boolean;
+}): Promise<string[]> {
+  const errors: string[] = [];
+  if (opts.manifest.schema_version !== 1) errors.push("schema_version must be 1");
+  if (opts.manifest.kind !== "agentplane_evidence_bundle") {
+    errors.push("kind must be agentplane_evidence_bundle");
+  }
+  if (!opts.manifest.task_id) errors.push("task_id is required");
+  const expectedDigest = computeManifestDigest({
+    ...opts.manifest,
+    integrity: { ...opts.manifest.integrity, manifest_digest: null },
+  });
+  if (opts.manifest.integrity.manifest_digest !== expectedDigest) {
+    errors.push(
+      `manifest digest mismatch: expected ${expectedDigest}, found ${opts.manifest.integrity.manifest_digest ?? "null"}`,
+    );
+  }
+  if (opts.manifest.files.length === 0) errors.push("manifest contains no files");
+  if (opts.strict && !opts.manifest.files.some((file) => file.role === "acr")) {
+    errors.push("strict verification requires acr evidence");
+  }
+  const seen = new Set<string>();
+  for (const file of opts.manifest.files) {
+    if (seen.has(file.path)) errors.push(`duplicate file path: ${file.path}`);
+    seen.add(file.path);
+    if (!isRepositoryRelativePath(file.path)) {
+      errors.push(`invalid repository-relative path: ${file.path}`);
+      continue;
+    }
+    const abs = path.join(opts.root, file.path);
+    let actual: string;
+    try {
+      actual = await sha256File(abs);
+    } catch {
+      errors.push(`missing file: ${file.path}`);
+      continue;
+    }
+    if (actual !== file.sha256) {
+      errors.push(`hash mismatch for ${file.path}: expected ${file.sha256}, found ${actual}`);
+    }
+  }
+  return errors;
+}
+
+async function readEvidenceManifest(filePath: string): Promise<EvidenceBundleManifest> {
+  const parsed = JSON.parse(await readFile(filePath, "utf8")) as EvidenceBundleManifest;
+  return {
+    ...parsed,
+    files: Array.isArray(parsed.files) ? parsed.files : [],
+  };
+}
+
+function resolveManifestPath(
+  root: string,
+  cwd: string,
+  taskId: string,
+  out: string | undefined,
+): string {
+  if (out) return ensureWithinRoot(root, path.resolve(cwd, out));
+  return path.join(root, ".agentplane", "tasks", taskId, "evidence", "manifest.json");
+}
+
+function resolveVerifyTarget(root: string, cwd: string, target: string): string {
+  if (target.includes("/") || target.endsWith(".json")) {
+    return ensureWithinRoot(root, path.resolve(cwd, target));
+  }
+  return path.join(root, ".agentplane", "tasks", target, "evidence", "manifest.json");
+}
+
+function ensureWithinRoot(root: string, candidate: string): string {
+  const absRoot = path.resolve(root);
+  const abs = path.resolve(candidate);
+  if (abs === absRoot || abs.startsWith(`${absRoot}${path.sep}`)) return abs;
+  throw new CliError({
+    exitCode: 3,
+    code: "E_VALIDATION",
+    message: `evidence path outside repository root: ${candidate}`,
+  });
+}
+
+function computeManifestDigest(manifest: EvidenceBundleManifest): string {
+  const canonical = JSON.stringify(canonicalizeJson(manifest));
+  return `sha256:${createHash("sha256").update(canonical).digest("hex")}`;
+}
+
+function isRepositoryRelativePath(value: string): boolean {
+  return (
+    value.length > 0 &&
+    !value.startsWith("/") &&
+    !value.startsWith("\\") &&
+    !/^[A-Za-z]:/.test(value) &&
+    !value.includes("\\") &&
+    !value.split("/").includes("..")
+  );
+}
+
+async function sha256File(filePath: string): Promise<string> {
+  const hash = createHash("sha256");
+  return await new Promise((resolve, reject) => {
+    const stream = createReadStream(filePath);
+    stream.on("data", (chunk: Buffer) => hash.update(chunk));
+    stream.on("error", (err) => reject(err));
+    stream.on("end", () => resolve(`sha256:${hash.digest("hex")}`));
+  });
+}
+
+async function fileStatSize(filePath: string): Promise<number | null> {
+  const bytes = await readFile(filePath);
+  return bytes.byteLength;
+}
+
+function toPosix(value: string): string {
+  return value.split(path.sep).join("/");
+}

--- a/packages/agentplane/src/commands/evidence/evidence.command.ts
+++ b/packages/agentplane/src/commands/evidence/evidence.command.ts
@@ -169,11 +169,21 @@ export async function cmdEvidenceBundle(opts: {
 }): Promise<number> {
   await loadTaskFromContext({ ctx: opts.commandCtx, taskId: opts.parsed.taskId });
   const root = opts.commandCtx.resolvedProject.gitRoot;
-  const manifestPath = resolveManifestPath(root, opts.cwd, opts.parsed.taskId, opts.parsed.out);
+  const workflowDir = opts.commandCtx.config.paths.workflow_dir;
+  const manifestPath = resolveManifestPath(
+    root,
+    opts.cwd,
+    workflowDir,
+    opts.parsed.taskId,
+    opts.parsed.out,
+  );
+  const existingManifest = await readEvidenceManifestOrNull(manifestPath);
   const manifest = await buildEvidenceBundleManifest({
     root,
+    taskRoot: path.join(root, workflowDir, opts.parsed.taskId),
     taskId: opts.parsed.taskId,
     manifestPath,
+    existingManifest,
   });
   await mkdir(path.dirname(manifestPath), { recursive: true });
   await writeJsonStableIfChanged(manifestPath, manifest);
@@ -208,7 +218,12 @@ export async function cmdEvidenceVerify(opts: {
   parsed: EvidenceVerifyParsed;
 }): Promise<number> {
   const root = opts.commandCtx.resolvedProject.gitRoot;
-  const manifestPath = resolveVerifyTarget(root, opts.cwd, opts.parsed.target);
+  const manifestPath = resolveVerifyTarget(
+    root,
+    opts.cwd,
+    opts.commandCtx.config.paths.workflow_dir,
+    opts.parsed.target,
+  );
   const manifest = await readEvidenceManifest(manifestPath);
   const errors = await verifyEvidenceManifest({ root, manifest, strict: opts.parsed.strict });
   const relative = toPosix(path.relative(root, manifestPath));
@@ -283,25 +298,26 @@ export async function readTaskEvidenceBundleTrustExtension(opts: {
 
 async function buildEvidenceBundleManifest(opts: {
   root: string;
+  taskRoot: string;
   taskId: string;
   manifestPath: string;
+  existingManifest: EvidenceBundleManifest | null;
 }): Promise<EvidenceBundleManifest> {
-  const taskRoot = path.join(opts.root, ".agentplane", "tasks", opts.taskId);
   const files = await collectTaskEvidenceFiles({
     root: opts.root,
-    taskRoot,
+    taskRoot: opts.taskRoot,
     manifestPath: opts.manifestPath,
   });
   const manifestWithoutDigest: EvidenceBundleManifest = {
     schema_version: 1,
     kind: "agentplane_evidence_bundle",
     task_id: opts.taskId,
-    created_at: new Date().toISOString(),
+    created_at: opts.existingManifest?.created_at ?? new Date().toISOString(),
     producer: {
       name: "agentplane",
       version: getVersion(),
     },
-    artifact_root: toPosix(path.relative(opts.root, taskRoot)),
+    artifact_root: toPosix(path.relative(opts.root, opts.taskRoot)),
     files,
     verification: {
       command: `agentplane evidence verify ${opts.taskId}`,
@@ -420,21 +436,37 @@ async function readEvidenceManifest(filePath: string): Promise<EvidenceBundleMan
   };
 }
 
+async function readEvidenceManifestOrNull(
+  filePath: string,
+): Promise<EvidenceBundleManifest | null> {
+  try {
+    return await readEvidenceManifest(filePath);
+  } catch {
+    return null;
+  }
+}
+
 function resolveManifestPath(
   root: string,
   cwd: string,
+  workflowDir: string,
   taskId: string,
   out: string | undefined,
 ): string {
   if (out) return ensureWithinRoot(root, path.resolve(cwd, out));
-  return path.join(root, ".agentplane", "tasks", taskId, "evidence", "manifest.json");
+  return path.join(root, workflowDir, taskId, "evidence", "manifest.json");
 }
 
-function resolveVerifyTarget(root: string, cwd: string, target: string): string {
+function resolveVerifyTarget(
+  root: string,
+  cwd: string,
+  workflowDir: string,
+  target: string,
+): string {
   if (target.includes("/") || target.endsWith(".json")) {
     return ensureWithinRoot(root, path.resolve(cwd, target));
   }
-  return path.join(root, ".agentplane", "tasks", target, "evidence", "manifest.json");
+  return path.join(root, workflowDir, target, "evidence", "manifest.json");
 }
 
 function ensureWithinRoot(root: string, candidate: string): string {

--- a/packages/agentplane/src/commands/evidence/evidence.command.ts
+++ b/packages/agentplane/src/commands/evidence/evidence.command.ts
@@ -134,10 +134,7 @@ export const evidenceVerifySpec: CommandSpec<EvidenceVerifyParsed> = {
   }),
 };
 
-export async function runEvidenceGroup(
-  _ctx: CommandCtx,
-  p: GroupCommandParsed,
-): Promise<number> {
+export async function runEvidenceGroup(_ctx: CommandCtx, p: GroupCommandParsed): Promise<number> {
   return throwGroupCommandUsage({
     spec: evidenceSpec,
     cmd: p.cmd,

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -61,6 +61,7 @@ const sidebars: SidebarsConfig = {
         "concepts/context-engineering",
         "recipes/index",
         "reference/acr",
+        "reference/evidence",
       ],
     },
     {
@@ -83,6 +84,7 @@ const sidebars: SidebarsConfig = {
         "reference/workflow-file",
         "reference/trace-schema",
         "reference/acr",
+        "reference/evidence",
         "reference/acr-schema",
       ],
     },


### PR DESCRIPTION
Task: `202605191421-D566XJ`
Title: Add deterministic evidence bundle commands
Canonical task record: `.agentplane/tasks/202605191421-D566XJ/README.md`

## Summary

Add deterministic evidence bundle commands

Implement a deterministic evidence bundle and verification CLI surface, with ACR trust extension metadata for generated bundles. Scope excludes Sigstore signing, S3 Object Lock preservation, and capability proposal flows.

## Scope

- In scope: Implement a deterministic evidence bundle and verification CLI surface, with ACR trust extension metadata for generated bundles. Scope excludes Sigstore signing, S3 Object Lock preservation, and capability proposal flows.
- Out of scope: unrelated refactors not required for "Add deterministic evidence bundle commands".

## Verification

- State: ok
- Note:

```text
Implemented deterministic evidence bundle and verify commands with ACR trust pointer and docs.
Checks passed: focused evidence/ACR tests, agentplane typecheck, lint:core, docs:cli:check,
docs:ia:check, evidence bundle, evidence verify --strict.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-19T14:49:33.248Z
- Branch: task/202605191421-D566XJ/evidence-bundle
- Head: a89b99bfe360

```text
 .agentplane/tasks/202605191421-D566XJ/acr.json     | 402 +++++++++++++++
 .../blueprint/resolved-snapshot.json               | 572 +++++++++++++++++++++
 .../202605191421-D566XJ/evidence/manifest.json     |  69 +++
 docs/reference/acr.mdx                             |   8 +
 docs/reference/evidence.mdx                        |  44 ++
 docs/user/cli-reference.generated.mdx              |  51 ++
 .../src/cli/run-cli/command-catalog/project.ts     |  11 +
 .../src/cli/run-cli/command-loaders/project.ts     |  11 +
 packages/agentplane/src/commands/acr/generate.ts   |  15 +-
 .../src/commands/evidence/evidence.command.test.ts | 111 ++++
 .../src/commands/evidence/evidence.command.ts      | 487 ++++++++++++++++++
 website/sidebars.ts                                |   2 +
 12 files changed, 1779 insertions(+), 4 deletions(-)
```

</details>
