### PR TITLE
🚧 MM3AH5 task: Visualize built-in blueprint routes in docs [202605191735-MM3AH5]

### DIFF
--- a/.agentplane/tasks/202605191735-MM3AH5/README.md
+++ b/.agentplane/tasks/202605191735-MM3AH5/README.md
@@ -1,0 +1,287 @@
+---
+id: "202605191735-MM3AH5"
+title: "Visualize built-in blueprint routes in docs"
+status: "DOING"
+priority: "med"
+owner: "DOCS"
+revision: 8
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "blueprint"
+  - "docs"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-19T17:36:04.660Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-19T17:40:36.019Z"
+  updated_by: "EVALUATOR"
+  note: "Quality review pass on final commit b9c5c6edafb8: docs-only change matches current built-in blueprint definitions, adds visual route map plus matrix, and Docusaurus build validates the MDX/Mermaid page. No unintended tracked changes remain in the task worktree."
+  attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-19T17:40:36.019Z"
+  updated_by: "EVALUATOR"
+  note: "Quality review pass on final commit b9c5c6edafb8: docs-only change matches current built-in blueprint definitions, adds visual route map plus matrix, and Docusaurus build validates the MDX/Mermaid page. No unintended tracked changes remain in the task worktree."
+  evaluated_sha: "b9c5c6edafb8b38043051eef89611330a937bfae"
+  blueprint_digest: "a80d0aee7217fbd82293d1ea70a6f0020773294b2e70cfca2a27fdac04e5883d"
+  evidence_refs:
+    - ".agentplane/tasks/202605191735-MM3AH5/README.md"
+    - "/Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191735-MM3AH5-blueprint-visual-map/.agentplane/tasks/202605191735-MM3AH5/blueprint/resolved-snapshot.json"
+  findings: []
+commit: null
+comments:
+  -
+    author: "DOCS"
+    body: "Start: Documenting the current built-in blueprint route map from the runtime definitions, scoped to docs/developer/blueprints.mdx and task artifacts only."
+events:
+  -
+    type: "status"
+    at: "2026-05-19T17:36:37.673Z"
+    author: "DOCS"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Documenting the current built-in blueprint route map from the runtime definitions, scoped to docs/developer/blueprints.mdx and task artifacts only."
+  -
+    type: "verify"
+    at: "2026-05-19T17:39:22.365Z"
+    author: "DOCS"
+    state: "ok"
+    note: "Docs update verified: added built-in blueprint route map and matrix grounded in packages/agentplane/src/blueprints/builtins*.ts and model.ts. Checks passed: node .agentplane/policy/check-routing.mjs; ap doctor; bun run docs:ia:check; bun run docs:site:typecheck after bun install --frozen-lockfile --ignore-scripts; git diff --check; bun run --cwd website docusaurus build. Residual: bun run docs:site:build:check stops on pre-existing stale social image static/img/social/docs/reference/evidence.png, outside this task scope."
+  -
+    type: "verify"
+    at: "2026-05-19T17:39:32.255Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Quality review pass: documentation change is scoped to docs/developer/blueprints.mdx, uses current built-in blueprint/model sources as evidence, and verified MDX/Mermaid through Docusaurus build. Residual docs:site:build:check social-image drift is outside the changed page and tracked diff."
+  -
+    type: "verify"
+    at: "2026-05-19T17:40:28.615Z"
+    author: "DOCS"
+    state: "ok"
+    note: "Verified final task-branch commit b9c5c6edafb8. Checks passed: node .agentplane/policy/check-routing.mjs; ap doctor; bun run docs:ia:check; bun run docs:site:typecheck after lockfile install; git diff --check; bun run --cwd website docusaurus build. docs:site:build:check still stops on unrelated stale social image static/img/social/docs/reference/evidence.png."
+  -
+    type: "verify"
+    at: "2026-05-19T17:40:36.019Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Quality review pass on final commit b9c5c6edafb8: docs-only change matches current built-in blueprint definitions, adds visual route map plus matrix, and Docusaurus build validates the MDX/Mermaid page. No unintended tracked changes remain in the task worktree."
+doc_version: 3
+doc_updated_at: "2026-05-19T17:40:36.054Z"
+doc_updated_by: "DOCS"
+description: "Add a visual representation of existing built-in AgentPlane blueprints and the route modules/nodes they consist of to the developer blueprints documentation."
+sections:
+  Summary: |-
+    Visualize built-in blueprint routes in docs
+
+    Add a visual representation of existing built-in AgentPlane blueprints and the route modules/nodes they consist of to the developer blueprints documentation.
+  Scope: |-
+    - In scope: Add a visual representation of existing built-in AgentPlane blueprints and the route modules/nodes they consist of to the developer blueprints documentation.
+    - Out of scope: unrelated refactors not required for "Visualize built-in blueprint routes in docs".
+  Plan: "1. Use the current built-in blueprint definitions as the source of truth. 2. Update docs/developer/blueprints.mdx with a Mermaid visual map of built-in blueprints and their shared route modules/nodes. 3. Add a compact matrix that names each built-in blueprint, task kind, workflow mode, route spine, and distinctive evidence/module contract. 4. Run docs/policy verification checks: node .agentplane/policy/check-routing.mjs and agentplane doctor, plus a targeted docs content check if available."
+  Verify Steps: |-
+    PLANNER fallback scaffold for "Visualize built-in blueprint routes in docs". Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the requested outcome for "Visualize built-in blueprint routes in docs". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-19T17:39:22.365Z — VERIFY — ok
+
+    By: DOCS
+
+    Note: Docs update verified: added built-in blueprint route map and matrix grounded in packages/agentplane/src/blueprints/builtins*.ts and model.ts. Checks passed: node .agentplane/policy/check-routing.mjs; ap doctor; bun run docs:ia:check; bun run docs:site:typecheck after bun install --frozen-lockfile --ignore-scripts; git diff --check; bun run --cwd website docusaurus build. Residual: bun run docs:site:build:check stops on pre-existing stale social image static/img/social/docs/reference/evidence.png, outside this task scope.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T17:36:37.673Z, excerpt_hash=sha256:74198295066a2a742d58cf8f8c5ef0e9f33981a550d515f4dd43af990ef74a83
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191735-MM3AH5-blueprint-visual-map/.agentplane/tasks/202605191735-MM3AH5/blueprint/resolved-snapshot.json
+    - old_digest: a80d0aee7217fbd82293d1ea70a6f0020773294b2e70cfca2a27fdac04e5883d
+    - current_digest: a80d0aee7217fbd82293d1ea70a6f0020773294b2e70cfca2a27fdac04e5883d
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605191735-MM3AH5
+
+    ### 2026-05-19T17:39:32.255Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Quality review pass: documentation change is scoped to docs/developer/blueprints.mdx, uses current built-in blueprint/model sources as evidence, and verified MDX/Mermaid through Docusaurus build. Residual docs:site:build:check social-image drift is outside the changed page and tracked diff.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T17:39:22.404Z, excerpt_hash=sha256:74198295066a2a742d58cf8f8c5ef0e9f33981a550d515f4dd43af990ef74a83
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191735-MM3AH5-blueprint-visual-map/.agentplane/tasks/202605191735-MM3AH5/blueprint/resolved-snapshot.json
+    - old_digest: a80d0aee7217fbd82293d1ea70a6f0020773294b2e70cfca2a27fdac04e5883d
+    - current_digest: a80d0aee7217fbd82293d1ea70a6f0020773294b2e70cfca2a27fdac04e5883d
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605191735-MM3AH5
+
+    ### 2026-05-19T17:40:28.615Z — VERIFY — ok
+
+    By: DOCS
+
+    Note: Verified final task-branch commit b9c5c6edafb8. Checks passed: node .agentplane/policy/check-routing.mjs; ap doctor; bun run docs:ia:check; bun run docs:site:typecheck after lockfile install; git diff --check; bun run --cwd website docusaurus build. docs:site:build:check still stops on unrelated stale social image static/img/social/docs/reference/evidence.png.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T17:39:32.289Z, excerpt_hash=sha256:74198295066a2a742d58cf8f8c5ef0e9f33981a550d515f4dd43af990ef74a83
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191735-MM3AH5-blueprint-visual-map/.agentplane/tasks/202605191735-MM3AH5/blueprint/resolved-snapshot.json
+    - old_digest: a80d0aee7217fbd82293d1ea70a6f0020773294b2e70cfca2a27fdac04e5883d
+    - current_digest: a80d0aee7217fbd82293d1ea70a6f0020773294b2e70cfca2a27fdac04e5883d
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605191735-MM3AH5
+
+    ### 2026-05-19T17:40:36.019Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Quality review pass on final commit b9c5c6edafb8: docs-only change matches current built-in blueprint definitions, adds visual route map plus matrix, and Docusaurus build validates the MDX/Mermaid page. No unintended tracked changes remain in the task worktree.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T17:40:28.644Z, excerpt_hash=sha256:74198295066a2a742d58cf8f8c5ef0e9f33981a550d515f4dd43af990ef74a83
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191735-MM3AH5-blueprint-visual-map/.agentplane/tasks/202605191735-MM3AH5/blueprint/resolved-snapshot.json
+    - old_digest: a80d0aee7217fbd82293d1ea70a6f0020773294b2e70cfca2a27fdac04e5883d
+    - current_digest: a80d0aee7217fbd82293d1ea70a6f0020773294b2e70cfca2a27fdac04e5883d
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605191735-MM3AH5
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Visualize built-in blueprint routes in docs
+
+Add a visual representation of existing built-in AgentPlane blueprints and the route modules/nodes they consist of to the developer blueprints documentation.
+
+## Scope
+
+- In scope: Add a visual representation of existing built-in AgentPlane blueprints and the route modules/nodes they consist of to the developer blueprints documentation.
+- Out of scope: unrelated refactors not required for "Visualize built-in blueprint routes in docs".
+
+## Plan
+
+1. Use the current built-in blueprint definitions as the source of truth. 2. Update docs/developer/blueprints.mdx with a Mermaid visual map of built-in blueprints and their shared route modules/nodes. 3. Add a compact matrix that names each built-in blueprint, task kind, workflow mode, route spine, and distinctive evidence/module contract. 4. Run docs/policy verification checks: node .agentplane/policy/check-routing.mjs and agentplane doctor, plus a targeted docs content check if available.
+
+## Verify Steps
+
+PLANNER fallback scaffold for "Visualize built-in blueprint routes in docs". Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the requested outcome for "Visualize built-in blueprint routes in docs". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-19T17:39:22.365Z — VERIFY — ok
+
+By: DOCS
+
+Note: Docs update verified: added built-in blueprint route map and matrix grounded in packages/agentplane/src/blueprints/builtins*.ts and model.ts. Checks passed: node .agentplane/policy/check-routing.mjs; ap doctor; bun run docs:ia:check; bun run docs:site:typecheck after bun install --frozen-lockfile --ignore-scripts; git diff --check; bun run --cwd website docusaurus build. Residual: bun run docs:site:build:check stops on pre-existing stale social image static/img/social/docs/reference/evidence.png, outside this task scope.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T17:36:37.673Z, excerpt_hash=sha256:74198295066a2a742d58cf8f8c5ef0e9f33981a550d515f4dd43af990ef74a83
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191735-MM3AH5-blueprint-visual-map/.agentplane/tasks/202605191735-MM3AH5/blueprint/resolved-snapshot.json
+- old_digest: a80d0aee7217fbd82293d1ea70a6f0020773294b2e70cfca2a27fdac04e5883d
+- current_digest: a80d0aee7217fbd82293d1ea70a6f0020773294b2e70cfca2a27fdac04e5883d
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605191735-MM3AH5
+
+### 2026-05-19T17:39:32.255Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Quality review pass: documentation change is scoped to docs/developer/blueprints.mdx, uses current built-in blueprint/model sources as evidence, and verified MDX/Mermaid through Docusaurus build. Residual docs:site:build:check social-image drift is outside the changed page and tracked diff.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T17:39:22.404Z, excerpt_hash=sha256:74198295066a2a742d58cf8f8c5ef0e9f33981a550d515f4dd43af990ef74a83
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191735-MM3AH5-blueprint-visual-map/.agentplane/tasks/202605191735-MM3AH5/blueprint/resolved-snapshot.json
+- old_digest: a80d0aee7217fbd82293d1ea70a6f0020773294b2e70cfca2a27fdac04e5883d
+- current_digest: a80d0aee7217fbd82293d1ea70a6f0020773294b2e70cfca2a27fdac04e5883d
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605191735-MM3AH5
+
+### 2026-05-19T17:40:28.615Z — VERIFY — ok
+
+By: DOCS
+
+Note: Verified final task-branch commit b9c5c6edafb8. Checks passed: node .agentplane/policy/check-routing.mjs; ap doctor; bun run docs:ia:check; bun run docs:site:typecheck after lockfile install; git diff --check; bun run --cwd website docusaurus build. docs:site:build:check still stops on unrelated stale social image static/img/social/docs/reference/evidence.png.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T17:39:32.289Z, excerpt_hash=sha256:74198295066a2a742d58cf8f8c5ef0e9f33981a550d515f4dd43af990ef74a83
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191735-MM3AH5-blueprint-visual-map/.agentplane/tasks/202605191735-MM3AH5/blueprint/resolved-snapshot.json
+- old_digest: a80d0aee7217fbd82293d1ea70a6f0020773294b2e70cfca2a27fdac04e5883d
+- current_digest: a80d0aee7217fbd82293d1ea70a6f0020773294b2e70cfca2a27fdac04e5883d
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605191735-MM3AH5
+
+### 2026-05-19T17:40:36.019Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Quality review pass on final commit b9c5c6edafb8: docs-only change matches current built-in blueprint definitions, adds visual route map plus matrix, and Docusaurus build validates the MDX/Mermaid page. No unintended tracked changes remain in the task worktree.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-19T17:40:28.644Z, excerpt_hash=sha256:74198295066a2a742d58cf8f8c5ef0e9f33981a550d515f4dd43af990ef74a83
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605191735-MM3AH5-blueprint-visual-map/.agentplane/tasks/202605191735-MM3AH5/blueprint/resolved-snapshot.json
+- old_digest: a80d0aee7217fbd82293d1ea70a6f0020773294b2e70cfca2a27fdac04e5883d
+- current_digest: a80d0aee7217fbd82293d1ea70a6f0020773294b2e70cfca2a27fdac04e5883d
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605191735-MM3AH5
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605191735-MM3AH5/pr/diffstat.txt
+++ b/.agentplane/tasks/202605191735-MM3AH5/pr/diffstat.txt
@@ -1,0 +1,2 @@
+ docs/developer/blueprints.mdx | 82 ++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 81 insertions(+), 1 deletion(-)

--- a/.agentplane/tasks/202605191735-MM3AH5/pr/github-body.md
+++ b/.agentplane/tasks/202605191735-MM3AH5/pr/github-body.md
@@ -1,0 +1,40 @@
+Task: `202605191735-MM3AH5`
+Title: Visualize built-in blueprint routes in docs
+Canonical task record: `.agentplane/tasks/202605191735-MM3AH5/README.md`
+
+## Summary
+
+Visualize built-in blueprint routes in docs
+
+Add a visual representation of existing built-in AgentPlane blueprints and the route modules/nodes they consist of to the developer blueprints documentation.
+
+## Scope
+
+- In scope: Add a visual representation of existing built-in AgentPlane blueprints and the route modules/nodes they consist of to the developer blueprints documentation.
+- Out of scope: unrelated refactors not required for "Visualize built-in blueprint routes in docs".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Quality review pass on final commit b9c5c6edafb8: docs-only change matches current built-in
+blueprint definitions, adds visual route map plus matrix, and Docusaurus build validates the
+MDX/Mermaid page. No unintended tracked changes remain in the task worktree.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-19T17:40:28.691Z
+- Branch: task/202605191735-MM3AH5/blueprint-visual-map
+- Head: b9c5c6edafb8
+
+```text
+ docs/developer/blueprints.mdx | 82 ++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 81 insertions(+), 1 deletion(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605191735-MM3AH5/pr/github-title.txt
+++ b/.agentplane/tasks/202605191735-MM3AH5/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 MM3AH5 task: Visualize built-in blueprint routes in docs [202605191735-MM3AH5]

--- a/.agentplane/tasks/202605191735-MM3AH5/pr/meta.json
+++ b/.agentplane/tasks/202605191735-MM3AH5/pr/meta.json
@@ -5,9 +5,12 @@
   "head_sha": "b9c5c6edafb8b38043051eef89611330a937bfae",
   "last_verified_at": "2026-05-19T17:40:36.019Z",
   "last_verified_sha": "b9c5c6edafb8b38043051eef89611330a937bfae",
+  "pr_number": 3949,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3949",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202605191735-MM3AH5",
-  "updated_at": "2026-05-19T17:40:28.691Z",
+  "updated_at": "2026-05-19T17:40:50.312Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605191735-MM3AH5/pr/meta.json
+++ b/.agentplane/tasks/202605191735-MM3AH5/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605191735-MM3AH5/blueprint-visual-map",
+  "created_at": "2026-05-19T17:36:37.873Z",
+  "head_sha": "b9c5c6edafb8b38043051eef89611330a937bfae",
+  "last_verified_at": "2026-05-19T17:40:36.019Z",
+  "last_verified_sha": "b9c5c6edafb8b38043051eef89611330a937bfae",
+  "schema_version": 1,
+  "task_id": "202605191735-MM3AH5",
+  "updated_at": "2026-05-19T17:40:28.691Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605191735-MM3AH5/pr/review.md
+++ b/.agentplane/tasks/202605191735-MM3AH5/pr/review.md
@@ -1,0 +1,37 @@
+# PR Review
+
+Created: 2026-05-19T17:36:37.873Z
+
+## Task
+
+- Task: `202605191735-MM3AH5`
+- Title: Visualize built-in blueprint routes in docs
+- Status: DOING
+- Branch: `task/202605191735-MM3AH5/blueprint-visual-map`
+- Canonical task record: `.agentplane/tasks/202605191735-MM3AH5/README.md`
+
+## Verification
+
+- State: ok
+- Note: Quality review pass on final commit b9c5c6edafb8: docs-only change matches current built-in blueprint definitions, adds visual route map plus matrix, and Docusaurus build validates the MDX/Mermaid page. No unintended tracked changes remain in the task worktree.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-19T17:40:28.691Z
+- Branch: task/202605191735-MM3AH5/blueprint-visual-map
+- Head: b9c5c6edafb8
+
+```text
+ docs/developer/blueprints.mdx | 82 ++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 81 insertions(+), 1 deletion(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/docs/developer/blueprints.mdx
+++ b/docs/developer/blueprints.mdx
@@ -62,10 +62,16 @@ Expected shape:
 - `quality.regression`: branch PR code route for tests, CI, coverage, lint, knip, or flaky-check
   work that must preserve the original failure, reproduction, focused check, affected gate, and
   flake classification.
+- `context.assimilation`: context curation route that locks selected sources, reconciles before
+  wiki writes, reindexes, validates graph/wiki state, and records residual gaps.
+- `context.maximum_assimilation`: stricter context route for line-addressed provenance, coverage
+  reporting, glossary normalization, entity/relation extraction, and raw-deletion resilience.
 - `post_run.improvement_review`: branch PR route for long/complex task retrospectives that inspect
   work logs, identify code-fixable errors, create atomic follow-up tasks, and ask whether to execute
   those tasks immediately or defer them.
 - `release.strict`: release/publish route with version, parity, manifest, and publish safety gates.
+- `ops.approval`: operational route with explicit approval and rollback evidence before external
+  system work.
 
 For project-local blueprints, inspect trust and compatibility before task execution:
 
@@ -117,6 +123,76 @@ agentplane init --setup-profile full-harness --blueprints pack:team-baseline --y
 
 Full-harness init may install cached catalog blueprints or packs. Basic/default init keeps using the
 built-in registry and does not prompt for external blueprint installs.
+
+## Built-in Route Map
+
+The built-in registry is a small route ontology. Blueprints reuse shared node sequences and then add
+evidence, policy modules, stop rules, or workflow-mode gates where the task class requires them.
+
+```mermaid
+flowchart LR
+  subgraph ReadOnly["Read-only and content routes"]
+    AL["analysis.light"]
+    CL["content.light"]
+  end
+
+  subgraph Docs["Documentation route"]
+    DC["docs.change"]
+  end
+
+  subgraph Code["Code routes"]
+    CD["code.direct"]
+    CB["code.branch_pr"]
+    PB["performance.benchmark"]
+    QR["quality.regression"]
+  end
+
+  subgraph Context["Context routes"]
+    CA["context.assimilation"]
+    CMA["context.maximum_assimilation"]
+  end
+
+  subgraph ReleaseOps["Release, operations, and review routes"]
+    RS["release.strict"]
+    OA["ops.approval"]
+    PIR["post_run.improvement_review"]
+  end
+
+  AL --> R1["intake -> scope -> context_resolve -> work_unit -> artifact_write -> verify_record -> quality_gate -> finish"]
+  CL --> R2["intake -> scope -> context_resolve -> work_unit -> deterministic_check -> artifact_write -> verify_record -> quality_gate -> finish"]
+  DC --> R2
+  CA --> R2
+  CMA --> R2
+  RS --> R3["intake -> scope -> approval_gate -> context_resolve -> work_unit -> deterministic_check -> publish_or_integrate -> verify_record -> quality_gate -> finish"]
+  OA --> R4["intake -> scope -> approval_gate -> context_resolve -> work_unit -> deterministic_check -> artifact_write -> verify_record -> quality_gate -> finish"]
+  PIR --> R5["intake -> scope -> context_resolve -> work_unit -> artifact_write -> approval_gate -> verify_record -> quality_gate -> handoff -> finish"]
+
+  CD --> CRD["direct code lifecycle nodes"]
+  CB --> CRB["branch_pr code lifecycle nodes"]
+  PB --> CRB
+  QR --> CRB
+
+  CRD --> LC["workflow-lifecycle contract"]
+  CRB --> LC
+```
+
+| Blueprint                      | Task kind          | Workflow modes        | Route spine                                   | Distinctive contract                                                                |
+| ------------------------------ | ------------------ | --------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `analysis.light`               | `analysis`         | any                   | read-only analysis spine                      | sources, assumptions, weak links, final output; no policy modules                   |
+| `content.light`                | `content`          | any                   | content spine with deterministic check        | editorial/style check and final artifact without code lifecycle                     |
+| `docs.change`                  | `docs`             | `direct`, `branch_pr` | docs/content spine                            | `security.must`, `dod.core`, `dod.docs`; changed docs paths and docs checks         |
+| `code.direct`                  | `code`             | `direct`              | direct code lifecycle                         | focused checks and close commit in the current checkout                             |
+| `code.branch_pr`               | `code`             | `branch_pr`           | branch PR code lifecycle                      | worktree, PR artifact, fast local checks, hosted checks, integration commit         |
+| `performance.benchmark`        | `code`             | `branch_pr`           | branch PR code lifecycle                      | baseline, method, run count, threshold, comparison, and performance verdict         |
+| `quality.regression`           | `code`             | `branch_pr`           | branch PR code lifecycle                      | original failure, reproduction, focused check, full gate, flake classification      |
+| `context.assimilation`         | `context`          | `direct`, `branch_pr` | context/docs spine                            | source lock, pre-write reconciliation, wiki/graph/index checks, recovery gaps       |
+| `context.maximum_assimilation` | `context`          | `direct`, `branch_pr` | context/docs spine                            | coverage map, line refs, entity graph, glossary, raw-deletion resilience            |
+| `post_run.improvement_review`  | `code`, `analysis` | `branch_pr`           | post-run review spine                         | inspected work logs, fixable errors, atomic follow-up tasks, execute/defer decision |
+| `release.strict`               | `release`          | `direct`, `branch_pr` | approval plus publish/integrate spine         | version, manifest/parity, external links, publish or integration proof              |
+| `ops.approval`                 | `ops`              | `direct`, `branch_pr` | approval plus rollback-aware operations spine | explicit approval, rollback evidence, operational check result                      |
+
+The diagram intentionally shows route spines rather than every evidence field. The authoritative
+evidence list remains the typed registry and `agentplane blueprint explain <task-id>` output.
 
 ## Task Lifecycle Visibility
 
@@ -299,11 +375,13 @@ export type BlueprintId =
   | "code.branch_pr"
   | "performance.benchmark"
   | "quality.regression"
+  | "context.assimilation"
+  | "context.maximum_assimilation"
   | "post_run.improvement_review"
   | "release.strict"
   | "ops.approval";
 
-export type TaskKind = "analysis" | "content" | "docs" | "code" | "release" | "ops";
+export type TaskKind = "analysis" | "content" | "docs" | "code" | "release" | "ops" | "context";
 
 export type WorkflowMode = "direct" | "branch_pr";
 
@@ -321,6 +399,7 @@ export type BlueprintNodeKind =
   | "hosted_checks"
   | "publish_or_integrate"
   | "verify_record"
+  | "quality_gate"
   | "handoff"
   | "finish";
 
@@ -338,6 +417,7 @@ export type EvidenceKind =
   | "commit"
   | "final_output"
   | "weak_links"
+  | "quality_report"
   | "rollback";
 
 export type Blueprint = {


### PR DESCRIPTION
Task: `202605191735-MM3AH5`
Title: Visualize built-in blueprint routes in docs
Canonical task record: `.agentplane/tasks/202605191735-MM3AH5/README.md`

## Summary

Visualize built-in blueprint routes in docs

Add a visual representation of existing built-in AgentPlane blueprints and the route modules/nodes they consist of to the developer blueprints documentation.

## Scope

- In scope: Add a visual representation of existing built-in AgentPlane blueprints and the route modules/nodes they consist of to the developer blueprints documentation.
- Out of scope: unrelated refactors not required for "Visualize built-in blueprint routes in docs".

## Verification

- State: ok
- Note:

```text
Quality review pass on final commit b9c5c6edafb8: docs-only change matches current built-in
blueprint definitions, adds visual route map plus matrix, and Docusaurus build validates the
MDX/Mermaid page. No unintended tracked changes remain in the task worktree.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-19T17:40:28.691Z
- Branch: task/202605191735-MM3AH5/blueprint-visual-map
- Head: b9c5c6edafb8

```text
 docs/developer/blueprints.mdx | 82 ++++++++++++++++++++++++++++++++++++++++++-
 1 file changed, 81 insertions(+), 1 deletion(-)
```

</details>
