### PR TITLE
✅ action close: finish done next-action task

### DIFF
--- a/.agentplane/tasks/202605201656-J68MDT/README.md
+++ b/.agentplane/tasks/202605201656-J68MDT/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202605201656-J68MDT"
 title: "Fix done task next-action route"
-status: "DOING"
+result_summary: "Merged PR #3976 and closed release-blocking lifecycle tail."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 9
+revision: 11
 origin:
   system: "manual"
 depends_on: []
@@ -20,26 +21,31 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-05-20T17:20:21.455Z"
+  updated_at: "2026-05-20T17:43:12.290Z"
   updated_by: "EVALUATOR"
-  note: "Review fix accepted locally: branch_pr DONE tasks keep cleanup guidance, direct DONE tasks now return a direct-safe terminal action with null command; no branch_pr recovery blockers for DONE tasks."
+  note: "Quality gate passed for merged PR #3976 at e747ce59: review comments resolved, hosted PR checks passed, and release task check only awaits task closure."
   attempts: 0
 quality_review:
   state: "pass"
-  updated_at: "2026-05-20T17:20:21.455Z"
+  updated_at: "2026-05-20T17:43:12.290Z"
   updated_by: "EVALUATOR"
-  note: "Review fix accepted locally: branch_pr DONE tasks keep cleanup guidance, direct DONE tasks now return a direct-safe terminal action with null command; no branch_pr recovery blockers for DONE tasks."
-  evaluated_sha: "3250fc77cb404f5061d2df3bd4667ed2caa6833f"
+  note: "Quality gate passed for merged PR #3976 at e747ce59: review comments resolved, hosted PR checks passed, and release task check only awaits task closure."
+  evaluated_sha: "e747ce59acdd641d7dfab547e8ea7b49f0931d02"
   blueprint_digest: "38273f1ed23e94202d4316a91a1e63a558b7eccf0a157a989d5d511fbd1d76c1"
   evidence_refs:
     - ".agentplane/tasks/202605201656-J68MDT/README.md"
-    - "/Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605201656-J68MDT-done-next-action/.agentplane/tasks/202605201656-J68MDT/blueprint/resolved-snapshot.json"
+    - "/Users/densmirnov/Github/agentplane/.agentplane/tasks/202605201656-J68MDT/blueprint/resolved-snapshot.json"
   findings: []
-commit: null
+commit:
+  hash: "e747ce59acdd641d7dfab547e8ea7b49f0931d02"
+  message: "🐛 J68MDT workflow: stop done task recovery routing"
 comments:
   -
     author: "CODER"
     body: "Start: Fixing DONE task route decisions so closed branch_pr tasks do not suggest worktree recovery, with focused CLI regression coverage."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: PR #3976 merged after review fix and green hosted checks; DONE routing is branch_pr/direct aware."
 events:
   -
     type: "status"
@@ -78,9 +84,22 @@ events:
     author: "EVALUATOR"
     state: "ok"
     note: "Review fix accepted locally: branch_pr DONE tasks keep cleanup guidance, direct DONE tasks now return a direct-safe terminal action with null command; no branch_pr recovery blockers for DONE tasks."
+  -
+    type: "verify"
+    at: "2026-05-20T17:43:12.290Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Quality gate passed for merged PR #3976 at e747ce59: review comments resolved, hosted PR checks passed, and release task check only awaits task closure."
+  -
+    type: "status"
+    at: "2026-05-20T17:43:23.298Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: PR #3976 merged after review fix and green hosted checks; DONE routing is branch_pr/direct aware."
 doc_version: 3
-doc_updated_at: "2026-05-20T17:20:21.486Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-20T17:43:23.298Z"
+doc_updated_by: "INTEGRATOR"
 description: "Stop task next-action and task status route output from suggesting branch_pr worktree recovery for tasks that are already DONE, especially included batch tasks closed after their primary PR merged."
 sections:
   Summary: |-
@@ -193,6 +212,25 @@ sections:
     BlueprintSnapshotRef:
     - state: current
     - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605201656-J68MDT-done-next-action/.agentplane/tasks/202605201656-J68MDT/blueprint/resolved-snapshot.json
+    - old_digest: 38273f1ed23e94202d4316a91a1e63a558b7eccf0a157a989d5d511fbd1d76c1
+    - current_digest: 38273f1ed23e94202d4316a91a1e63a558b7eccf0a157a989d5d511fbd1d76c1
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605201656-J68MDT
+
+    ### 2026-05-20T17:43:12.290Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Quality gate passed for merged PR #3976 at e747ce59: review comments resolved, hosted PR checks passed, and release task check only awaits task closure.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-20T17:20:21.486Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tasks/202605201656-J68MDT/blueprint/resolved-snapshot.json
     - old_digest: 38273f1ed23e94202d4316a91a1e63a558b7eccf0a157a989d5d511fbd1d76c1
     - current_digest: 38273f1ed23e94202d4316a91a1e63a558b7eccf0a157a989d5d511fbd1d76c1
     - route_changed: no
@@ -324,6 +362,25 @@ Details:
 BlueprintSnapshotRef:
 - state: current
 - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605201656-J68MDT-done-next-action/.agentplane/tasks/202605201656-J68MDT/blueprint/resolved-snapshot.json
+- old_digest: 38273f1ed23e94202d4316a91a1e63a558b7eccf0a157a989d5d511fbd1d76c1
+- current_digest: 38273f1ed23e94202d4316a91a1e63a558b7eccf0a157a989d5d511fbd1d76c1
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605201656-J68MDT
+
+### 2026-05-20T17:43:12.290Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Quality gate passed for merged PR #3976 at e747ce59: review comments resolved, hosted PR checks passed, and release task check only awaits task closure.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-20T17:20:21.486Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/tasks/202605201656-J68MDT/blueprint/resolved-snapshot.json
 - old_digest: 38273f1ed23e94202d4316a91a1e63a558b7eccf0a157a989d5d511fbd1d76c1
 - current_digest: 38273f1ed23e94202d4316a91a1e63a558b7eccf0a157a989d5d511fbd1d76c1
 - route_changed: no

--- a/.agentplane/tasks/202605201656-J68MDT/pr/diffstat.txt
+++ b/.agentplane/tasks/202605201656-J68MDT/pr/diffstat.txt
@@ -1,4 +1,0 @@
- .../blueprint/resolved-snapshot.json               | 572 +++++++++++++++++++++
- .../src/cli/run-cli.core.route-decision.test.ts    |  54 +-
- .../src/commands/shared/route-decision.ts          |  18 +-
- 3 files changed, 633 insertions(+), 11 deletions(-)

--- a/.agentplane/tasks/202605201656-J68MDT/pr/github-body.md
+++ b/.agentplane/tasks/202605201656-J68MDT/pr/github-body.md
@@ -19,24 +19,20 @@ Stop task next-action and task status route output from suggesting branch_pr wor
 - Note:
 
 ```text
-Review fix accepted locally: branch_pr DONE tasks keep cleanup guidance, direct DONE tasks now
-return a direct-safe terminal action with null command; no branch_pr recovery blockers for DONE
-tasks.
+Quality gate passed for merged PR #3976 at e747ce59: review comments resolved, hosted PR checks
+passed, and release task check only awaits task closure.
 ```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-20T17:02:42.798Z
+- Updated: 2026-05-20T17:43:12.348Z
 - Branch: task/202605201656-J68MDT/done-next-action
-- Head: bf2f3e28a4f8
+- Head: 847e2b6d2e9e
 
 ```text
- .../blueprint/resolved-snapshot.json               | 572 +++++++++++++++++++++
- .../src/cli/run-cli.core.route-decision.test.ts    |  54 +-
- .../src/commands/shared/route-decision.ts          |  18 +-
- 3 files changed, 633 insertions(+), 11 deletions(-)
+No changes detected.
 ```
 
 </details>

--- a/.agentplane/tasks/202605201656-J68MDT/pr/meta.json
+++ b/.agentplane/tasks/202605201656-J68MDT/pr/meta.json
@@ -1,16 +1,20 @@
 {
+  "artifact_state": "merged",
+  "artifact_state_updated_at": "2026-05-20T17:43:12.348Z",
   "base": "main",
   "branch": "task/202605201656-J68MDT/done-next-action",
   "created_at": "2026-05-20T16:57:11.337Z",
-  "head_sha": "bf2f3e28a4f83c8150d158c98b60728902c3708d",
-  "last_verified_at": "2026-05-20T17:20:21.455Z",
-  "last_verified_sha": "bf2f3e28a4f83c8150d158c98b60728902c3708d",
+  "head_sha": "847e2b6d2e9e035fe72aa50c66193572710e26b4",
+  "last_verified_at": "2026-05-20T17:43:12.290Z",
+  "last_verified_sha": "847e2b6d2e9e035fe72aa50c66193572710e26b4",
+  "merge_commit": "e747ce59acdd641d7dfab547e8ea7b49f0931d02",
+  "merged_at": "2026-05-20T17:41:45Z",
   "pr_number": 3976,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/3976",
   "schema_version": 1,
-  "status": "OPEN",
+  "status": "MERGED",
   "task_id": "202605201656-J68MDT",
-  "updated_at": "2026-05-20T17:02:42.798Z",
+  "updated_at": "2026-05-20T17:43:12.348Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605201656-J68MDT/pr/review.md
+++ b/.agentplane/tasks/202605201656-J68MDT/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-05-20T16:57:11.337Z
 ## Verification
 
 - State: ok
-- Note: Review fix accepted locally: branch_pr DONE tasks keep cleanup guidance, direct DONE tasks now return a direct-safe terminal action with null command; no branch_pr recovery blockers for DONE tasks.
+- Note: Quality gate passed for merged PR #3976 at e747ce59: review comments resolved, hosted PR checks passed, and release task check only awaits task closure.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,15 +24,12 @@ Created: 2026-05-20T16:57:11.337Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-05-20T17:02:42.798Z
+- Updated: 2026-05-20T17:43:12.348Z
 - Branch: task/202605201656-J68MDT/done-next-action
-- Head: bf2f3e28a4f8
+- Head: 847e2b6d2e9e
 
 ```text
- .../blueprint/resolved-snapshot.json               | 572 +++++++++++++++++++++
- .../src/cli/run-cli.core.route-decision.test.ts    |  54 +-
- .../src/commands/shared/route-decision.ts          |  18 +-
- 3 files changed, 633 insertions(+), 11 deletions(-)
+No changes detected.
 ```
 
 </details>


### PR DESCRIPTION
Closes the release-blocking task lifecycle tail for 202605201656-J68MDT after PR #3976 merged.\n\nVerification:\n- bun run release:tasks:check\n- pre-push fast docs-only checks passed