### PR TITLE
✅ R90HC5 task: restore open backlog tasks

### DIFF
--- a/.agentplane/tasks/202605221726-1DX1BA/README.md
+++ b/.agentplane/tasks/202605221726-1DX1BA/README.md
@@ -1,0 +1,90 @@
+---
+id: "202605221726-1DX1BA"
+title: "Make flow repair apply safe branch_pr repairs"
+status: "TODO"
+priority: "high"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "cli"
+  - "code"
+  - "workflow"
+verify:
+  - "Confirm provider merge and approval actions are never executed by safe-apply."
+  - "Run branch_pr route-decision tests for missing branch, stale PR metadata, missing close-tail, and stale cleanup."
+  - "Run flow repair unit tests for dry-run and safe-apply modes."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-22T17:26:31.553Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-22T17:27:51.701Z"
+doc_updated_by: "PLANNER"
+description: "Extend flow repair beyond dry-run for safe mechanical branch_pr repairs such as PR metadata refresh, branch fetch, hosted close-tail opening, and stale worktree cleanup while keeping merge/publish/provider actions approval-gated."
+sections:
+  Summary: |-
+    Make flow repair apply safe branch_pr repairs
+
+    Extend flow repair beyond dry-run for safe mechanical branch_pr repairs such as PR metadata refresh, branch fetch, hosted close-tail opening, and stale worktree cleanup while keeping merge/publish/provider actions approval-gated.
+  Scope: |-
+    - In scope: Extend flow repair beyond dry-run for safe mechanical branch_pr repairs such as PR metadata refresh, branch fetch, hosted close-tail opening, and stale worktree cleanup while keeping merge/publish/provider actions approval-gated.
+    - Out of scope: unrelated refactors not required for "Make flow repair apply safe branch_pr repairs".
+  Plan: "Add an explicit safe-apply mode for flow repair. Limit mutation to deterministic local or lifecycle repairs that are already printed by dry-run. Keep provider merges, approvals, verification verdicts, and scope changes out of automatic repair. Verify every repair class separately."
+  Verify Steps: |-
+    1. Run flow repair unit tests for dry-run and safe-apply modes.
+    2. Run branch_pr route-decision tests for missing branch, stale PR metadata, missing close-tail, and stale cleanup.
+    3. Confirm provider merge and approval actions are never executed by safe-apply.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Make flow repair apply safe branch_pr repairs
+
+Extend flow repair beyond dry-run for safe mechanical branch_pr repairs such as PR metadata refresh, branch fetch, hosted close-tail opening, and stale worktree cleanup while keeping merge/publish/provider actions approval-gated.
+
+## Scope
+
+- In scope: Extend flow repair beyond dry-run for safe mechanical branch_pr repairs such as PR metadata refresh, branch fetch, hosted close-tail opening, and stale worktree cleanup while keeping merge/publish/provider actions approval-gated.
+- Out of scope: unrelated refactors not required for "Make flow repair apply safe branch_pr repairs".
+
+## Plan
+
+Add an explicit safe-apply mode for flow repair. Limit mutation to deterministic local or lifecycle repairs that are already printed by dry-run. Keep provider merges, approvals, verification verdicts, and scope changes out of automatic repair. Verify every repair class separately.
+
+## Verify Steps
+
+1. Run flow repair unit tests for dry-run and safe-apply modes.
+2. Run branch_pr route-decision tests for missing branch, stale PR metadata, missing close-tail, and stale cleanup.
+3. Confirm provider merge and approval actions are never executed by safe-apply.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605221726-4FGDND/README.md
+++ b/.agentplane/tasks/202605221726-4FGDND/README.md
@@ -1,0 +1,90 @@
+---
+id: "202605221726-4FGDND"
+title: "Add integration queue stale handoff recovery"
+status: "TODO"
+priority: "med"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "github"
+  - "workflow"
+verify:
+  - "Confirm live active PRs are not auto-released from the queue."
+  - "Run integration queue tests for stale claimed and handoff entries."
+  - "Run provider-state classification tests for merged, closed, missing, and blocked PRs."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-22T17:27:02.456Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-22T17:27:53.354Z"
+doc_updated_by: "PLANNER"
+description: "Detect and recover integration queue entries stuck in claimed or handoff when the provider PR is already merged, closed, missing, or blocked by stale metadata."
+sections:
+  Summary: |-
+    Add integration queue stale handoff recovery
+
+    Detect and recover integration queue entries stuck in claimed or handoff when the provider PR is already merged, closed, missing, or blocked by stale metadata.
+  Scope: |-
+    - In scope: Detect and recover integration queue entries stuck in claimed or handoff when the provider PR is already merged, closed, missing, or blocked by stale metadata.
+    - Out of scope: unrelated refactors not required for "Add integration queue stale handoff recovery".
+  Plan: "Add bounded stale-handoff classification and recovery guidance for the branch_pr integration queue. Do not auto-merge or discard live work; classify provider truth and offer safe repair commands for stale handoff, merged pending close, closed-unmerged, and missing PR states."
+  Verify Steps: |-
+    1. Run integration queue tests for stale claimed and handoff entries.
+    2. Run provider-state classification tests for merged, closed, missing, and blocked PRs.
+    3. Confirm live active PRs are not auto-released from the queue.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add integration queue stale handoff recovery
+
+Detect and recover integration queue entries stuck in claimed or handoff when the provider PR is already merged, closed, missing, or blocked by stale metadata.
+
+## Scope
+
+- In scope: Detect and recover integration queue entries stuck in claimed or handoff when the provider PR is already merged, closed, missing, or blocked by stale metadata.
+- Out of scope: unrelated refactors not required for "Add integration queue stale handoff recovery".
+
+## Plan
+
+Add bounded stale-handoff classification and recovery guidance for the branch_pr integration queue. Do not auto-merge or discard live work; classify provider truth and offer safe repair commands for stale handoff, merged pending close, closed-unmerged, and missing PR states.
+
+## Verify Steps
+
+1. Run integration queue tests for stale claimed and handoff entries.
+2. Run provider-state classification tests for merged, closed, missing, and blocked PRs.
+3. Confirm live active PRs are not auto-released from the queue.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605221726-8SA692/README.md
+++ b/.agentplane/tasks/202605221726-8SA692/README.md
@@ -1,0 +1,91 @@
+---
+id: "202605221726-8SA692"
+title: "Add combined hosted lifecycle status report"
+status: "TODO"
+priority: "high"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "cli"
+  - "code"
+  - "github"
+  - "workflow"
+verify:
+  - "Confirm command degrades clearly when GitHub auth or network is unavailable."
+  - "Run command output tests with mocked GitHub/provider data."
+  - "Run route-decision tests that include queue, handoff, PR, checks, review, and close-tail state."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-22T17:26:36.210Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-22T17:27:52.436Z"
+doc_updated_by: "PLANNER"
+description: "Expose local AgentPlane lifecycle, queue/handoff state, GitHub PR state, hosted checks, review threads, and close-tail state in one command for branch_pr tasks."
+sections:
+  Summary: |-
+    Add combined hosted lifecycle status report
+
+    Expose local AgentPlane lifecycle, queue/handoff state, GitHub PR state, hosted checks, review threads, and close-tail state in one command for branch_pr tasks.
+  Scope: |-
+    - In scope: Expose local AgentPlane lifecycle, queue/handoff state, GitHub PR state, hosted checks, review threads, and close-tail state in one command for branch_pr tasks.
+    - Out of scope: unrelated refactors not required for "Add combined hosted lifecycle status report".
+  Plan: "Add a combined hosted lifecycle status surface that keeps ap as lifecycle truth and gh/GitHub as provider truth. The command should show PR number, merge state, checks, unresolved review-thread count, queue/handoff occupancy, close-tail PR, and next safe action without requiring manual command stitching."
+  Verify Steps: |-
+    1. Run command output tests with mocked GitHub/provider data.
+    2. Run route-decision tests that include queue, handoff, PR, checks, review, and close-tail state.
+    3. Confirm command degrades clearly when GitHub auth or network is unavailable.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add combined hosted lifecycle status report
+
+Expose local AgentPlane lifecycle, queue/handoff state, GitHub PR state, hosted checks, review threads, and close-tail state in one command for branch_pr tasks.
+
+## Scope
+
+- In scope: Expose local AgentPlane lifecycle, queue/handoff state, GitHub PR state, hosted checks, review threads, and close-tail state in one command for branch_pr tasks.
+- Out of scope: unrelated refactors not required for "Add combined hosted lifecycle status report".
+
+## Plan
+
+Add a combined hosted lifecycle status surface that keeps ap as lifecycle truth and gh/GitHub as provider truth. The command should show PR number, merge state, checks, unresolved review-thread count, queue/handoff occupancy, close-tail PR, and next safe action without requiring manual command stitching.
+
+## Verify Steps
+
+1. Run command output tests with mocked GitHub/provider data.
+2. Run route-decision tests that include queue, handoff, PR, checks, review, and close-tail state.
+3. Confirm command degrades clearly when GitHub auth or network is unavailable.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605221726-N6CQ5A/README.md
+++ b/.agentplane/tasks/202605221726-N6CQ5A/README.md
@@ -1,0 +1,91 @@
+---
+id: "202605221726-N6CQ5A"
+title: "Add compact active task route summary"
+status: "TODO"
+priority: "high"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "cli"
+  - "code"
+  - "performance"
+  - "workflow"
+verify:
+  - "Confirm full historical task listing remains available through an explicit option."
+  - "Run CLI cold-path benchmark or focused performance check for active task listing."
+  - "Run targeted task list route-summary tests."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-22T17:26:29.477Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-22T17:27:51.395Z"
+doc_updated_by: "PLANNER"
+description: "Make read-only startup and active-work inspection avoid full historical task scans by default while still surfacing anomalies, route blockers, and active branch_pr work."
+sections:
+  Summary: |-
+    Add compact active task route summary
+
+    Make read-only startup and active-work inspection avoid full historical task scans by default while still surfacing anomalies, route blockers, and active branch_pr work.
+  Scope: |-
+    - In scope: Make read-only startup and active-work inspection avoid full historical task scans by default while still surfacing anomalies, route blockers, and active branch_pr work.
+    - Out of scope: unrelated refactors not required for "Add compact active task route summary".
+  Plan: "Add a compact active route summary for task list/startup surfaces. Keep full historical listing available behind an explicit flag. Verify that DOING, BLOCKED, MERGED_PENDING_CLOSE, unreadable tasks, stale PR metadata, and stale worktrees are summarized without printing thousands of DONE tasks."
+  Verify Steps: |-
+    1. Run targeted task list route-summary tests.
+    2. Run a CLI cold-path benchmark or focused performance check for active task listing.
+    3. Confirm full historical task listing remains available through an explicit option.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add compact active task route summary
+
+Make read-only startup and active-work inspection avoid full historical task scans by default while still surfacing anomalies, route blockers, and active branch_pr work.
+
+## Scope
+
+- In scope: Make read-only startup and active-work inspection avoid full historical task scans by default while still surfacing anomalies, route blockers, and active branch_pr work.
+- Out of scope: unrelated refactors not required for "Add compact active task route summary".
+
+## Plan
+
+Add a compact active route summary for task list/startup surfaces. Keep full historical listing available behind an explicit flag. Verify that DOING, BLOCKED, MERGED_PENDING_CLOSE, unreadable tasks, stale PR metadata, and stale worktrees are summarized without printing thousands of DONE tasks.
+
+## Verify Steps
+
+1. Run targeted task list route-summary tests.
+2. Run a CLI cold-path benchmark or focused performance check for active task listing.
+3. Confirm full historical task listing remains available through an explicit option.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605221726-QRQFM9/README.md
+++ b/.agentplane/tasks/202605221726-QRQFM9/README.md
@@ -1,0 +1,90 @@
+---
+id: "202605221726-QRQFM9"
+title: "Promote MERGED_PENDING_CLOSE to first-class task state"
+status: "TODO"
+priority: "high"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "tasks"
+  - "workflow"
+verify:
+  - "Confirm DONE remains terminal only after hosted close evidence lands."
+  - "Run release task readiness tests with merged-pending-close tasks present."
+  - "Run task list/search/next tests for merged-pending-close projection."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-22T17:26:33.692Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-22T17:27:52.126Z"
+doc_updated_by: "PLANNER"
+description: "Represent implementation-merged-but-not-hosted-closed branch_pr tasks as a distinct queue/list/release-gate state instead of ordinary DOING work."
+sections:
+  Summary: |-
+    Promote MERGED_PENDING_CLOSE to first-class task state
+
+    Represent implementation-merged-but-not-hosted-closed branch_pr tasks as a distinct queue/list/release-gate state instead of ordinary DOING work.
+  Scope: |-
+    - In scope: Represent implementation-merged-but-not-hosted-closed branch_pr tasks as a distinct queue/list/release-gate state instead of ordinary DOING work.
+    - Out of scope: unrelated refactors not required for "Promote MERGED_PENDING_CLOSE to first-class task state".
+  Plan: "Make merged pending close a first-class projected lifecycle state across task list, task search, task next, release readiness, and route status. Preserve canonical terminal DONE semantics while preventing already-merged tasks from reappearing as active implementation work."
+  Verify Steps: |-
+    1. Run task list/search/next tests for merged-pending-close projection.
+    2. Run release task readiness tests with merged-pending-close tasks present.
+    3. Confirm DONE remains terminal only after hosted close evidence lands.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Promote MERGED_PENDING_CLOSE to first-class task state
+
+Represent implementation-merged-but-not-hosted-closed branch_pr tasks as a distinct queue/list/release-gate state instead of ordinary DOING work.
+
+## Scope
+
+- In scope: Represent implementation-merged-but-not-hosted-closed branch_pr tasks as a distinct queue/list/release-gate state instead of ordinary DOING work.
+- Out of scope: unrelated refactors not required for "Promote MERGED_PENDING_CLOSE to first-class task state".
+
+## Plan
+
+Make merged pending close a first-class projected lifecycle state across task list, task search, task next, release readiness, and route status. Preserve canonical terminal DONE semantics while preventing already-merged tasks from reappearing as active implementation work.
+
+## Verify Steps
+
+1. Run task list/search/next tests for merged-pending-close projection.
+2. Run release task readiness tests with merged-pending-close tasks present.
+3. Confirm DONE remains terminal only after hosted close evidence lands.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605221726-R90HC5/README.md
+++ b/.agentplane/tasks/202605221726-R90HC5/README.md
@@ -1,0 +1,90 @@
+---
+id: "202605221726-R90HC5"
+title: "Enforce batch primary task artifact scaffold"
+status: "TODO"
+priority: "high"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "tasks"
+  - "workflow"
+verify:
+  - "Confirm included tasks point to a valid primary task before start-ready."
+  - "Run batch worktree scaffold tests for primary README and included-task manifest."
+  - "Run task scanner tests for unreadable primary batch task diagnostics."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-22T17:26:40.882Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-22T17:27:52.749Z"
+doc_updated_by: "PLANNER"
+description: "Prevent shared batch worktrees from referencing a primary task that lacks a readable task README and explicit included-task manifest."
+sections:
+  Summary: |-
+    Enforce batch primary task artifact scaffold
+
+    Prevent shared batch worktrees from referencing a primary task that lacks a readable task README and explicit included-task manifest.
+  Scope: |-
+    - In scope: Prevent shared batch worktrees from referencing a primary task that lacks a readable task README and explicit included-task manifest.
+    - Out of scope: unrelated refactors not required for "Enforce batch primary task artifact scaffold".
+  Plan: "Add validation and repair guidance for batch worktrees so the primary task always has a readable README, approved plan, included task ids, and batch ownership metadata before included tasks are started. Detect missing primary artifacts during task list/status and work resume."
+  Verify Steps: |-
+    1. Run batch worktree scaffold tests for primary README and included-task manifest.
+    2. Run task scanner tests for unreadable primary batch task diagnostics.
+    3. Confirm included tasks point to a valid primary task before start-ready.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Enforce batch primary task artifact scaffold
+
+Prevent shared batch worktrees from referencing a primary task that lacks a readable task README and explicit included-task manifest.
+
+## Scope
+
+- In scope: Prevent shared batch worktrees from referencing a primary task that lacks a readable task README and explicit included-task manifest.
+- Out of scope: unrelated refactors not required for "Enforce batch primary task artifact scaffold".
+
+## Plan
+
+Add validation and repair guidance for batch worktrees so the primary task always has a readable README, approved plan, included task ids, and batch ownership metadata before included tasks are started. Detect missing primary artifacts during task list/status and work resume.
+
+## Verify Steps
+
+1. Run batch worktree scaffold tests for primary README and included-task manifest.
+2. Run task scanner tests for unreadable primary batch task diagnostics.
+3. Confirm included tasks point to a valid primary task before start-ready.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605221726-WY8F98/README.md
+++ b/.agentplane/tasks/202605221726-WY8F98/README.md
@@ -1,0 +1,90 @@
+---
+id: "202605221726-WY8F98"
+title: "Batch close-tail evidence for related tasks"
+status: "TODO"
+priority: "med"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "github"
+  - "workflow"
+verify:
+  - "Confirm duplicate close-tail PRs are not opened for sibling tasks in the batch."
+  - "Confirm each included task receives independent finish evidence."
+  - "Run hosted-close and hosted-close-pr tests for multi-task batch closure."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-22T17:26:50.678Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-22T17:27:53.051Z"
+doc_updated_by: "PLANNER"
+description: "Allow one hosted close-tail PR to close a verified related task batch while preserving per-task verification and finish evidence."
+sections:
+  Summary: |-
+    Batch close-tail evidence for related tasks
+
+    Allow one hosted close-tail PR to close a verified related task batch while preserving per-task verification and finish evidence.
+  Scope: |-
+    - In scope: Allow one hosted close-tail PR to close a verified related task batch while preserving per-task verification and finish evidence.
+    - Out of scope: unrelated refactors not required for "Batch close-tail evidence for related tasks".
+  Plan: "Optimize branch_pr close-tail for approved related batches. The implementation PR should be able to produce one evidence-only close-tail PR that records every included task, avoids duplicate close PRs, and keeps per-task verification/final result records intact."
+  Verify Steps: |-
+    1. Run hosted-close and hosted-close-pr tests for multi-task batch closure.
+    2. Confirm each included task receives independent finish evidence.
+    3. Confirm duplicate close-tail PRs are not opened for sibling tasks in the batch.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Batch close-tail evidence for related tasks
+
+Allow one hosted close-tail PR to close a verified related task batch while preserving per-task verification and finish evidence.
+
+## Scope
+
+- In scope: Allow one hosted close-tail PR to close a verified related task batch while preserving per-task verification and finish evidence.
+- Out of scope: unrelated refactors not required for "Batch close-tail evidence for related tasks".
+
+## Plan
+
+Optimize branch_pr close-tail for approved related batches. The implementation PR should be able to produce one evidence-only close-tail PR that records every included task, avoids duplicate close PRs, and keeps per-task verification/final result records intact.
+
+## Verify Steps
+
+1. Run hosted-close and hosted-close-pr tests for multi-task batch closure.
+2. Confirm each included task receives independent finish evidence.
+3. Confirm duplicate close-tail PRs are not opened for sibling tasks in the batch.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605221727-7KQE04/README.md
+++ b/.agentplane/tasks/202605221727-7KQE04/README.md
@@ -1,0 +1,90 @@
+---
+id: "202605221727-7KQE04"
+title: "Split mutable hosted metadata from tracked evidence"
+status: "TODO"
+priority: "high"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "git"
+  - "workflow"
+verify:
+  - "Confirm quality review freshness can be checked without self-invalidating evidence commits."
+  - "Run PR artifact schema and migration tests."
+  - "Run pr open/update tests confirming no tracked volatile metadata churn."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-22T17:27:13.512Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-22T17:27:53.657Z"
+doc_updated_by: "PLANNER"
+description: "Move volatile PR/check/head metadata out of tracked task artifacts or make it computed live so evidence updates do not invalidate reviewed implementation commits."
+sections:
+  Summary: |-
+    Split mutable hosted metadata from tracked evidence
+
+    Move volatile PR/check/head metadata out of tracked task artifacts or make it computed live so evidence updates do not invalidate reviewed implementation commits.
+  Scope: |-
+    - In scope: Move volatile PR/check/head metadata out of tracked task artifacts or make it computed live so evidence updates do not invalidate reviewed implementation commits.
+    - Out of scope: unrelated refactors not required for "Split mutable hosted metadata from tracked evidence".
+  Plan: "Define and implement a boundary between immutable tracked evidence and mutable hosted/runtime metadata. Tracked task artifacts should not store volatile fields that force artifact-only commits or quality-review SHA churn after implementation review."
+  Verify Steps: |-
+    1. Run PR artifact schema and migration tests.
+    2. Run pr open/update tests confirming no tracked volatile metadata churn.
+    3. Confirm quality review freshness can be checked without self-invalidating evidence commits.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Split mutable hosted metadata from tracked evidence
+
+Move volatile PR/check/head metadata out of tracked task artifacts or make it computed live so evidence updates do not invalidate reviewed implementation commits.
+
+## Scope
+
+- In scope: Move volatile PR/check/head metadata out of tracked task artifacts or make it computed live so evidence updates do not invalidate reviewed implementation commits.
+- Out of scope: unrelated refactors not required for "Split mutable hosted metadata from tracked evidence".
+
+## Plan
+
+Define and implement a boundary between immutable tracked evidence and mutable hosted/runtime metadata. Tracked task artifacts should not store volatile fields that force artifact-only commits or quality-review SHA churn after implementation review.
+
+## Verify Steps
+
+1. Run PR artifact schema and migration tests.
+2. Run pr open/update tests confirming no tracked volatile metadata churn.
+3. Confirm quality review freshness can be checked without self-invalidating evidence commits.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605221744-GF25D1/README.md
+++ b/.agentplane/tasks/202605221744-GF25D1/README.md
@@ -1,0 +1,103 @@
+---
+id: "202605221744-GF25D1"
+title: "Add agent task brief command"
+status: "TODO"
+priority: "high"
+owner: "CODER"
+revision: 3
+origin:
+  system: "manual"
+depends_on:
+  - "202605221726-N6CQ5A"
+tags:
+  - "cli"
+  - "code"
+  - "context"
+  - "workflow"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "Confirm task brief avoids remote network lookups unless an explicit remote flag is used."
+  - "Confirm task brief includes route decision, Verify Steps, blueprint evidence, blockers, and next command for branch_pr tasks."
+  - "Run targeted CLI tests for task brief text and JSON output."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-22T17:44:17.206Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-22T17:44:14.273Z"
+doc_updated_by: "PLANNER"
+description: "Add a compact task brief surface that merges route decision, checkout role, next action, blockers, Verify Steps, blueprint evidence, and stop rules into one agent-ready view."
+sections:
+  Summary: |-
+    Add agent task brief command
+
+    Add a compact task brief surface that merges route decision, checkout role, next action, blockers, Verify Steps, blueprint evidence, and stop rules into one agent-ready view.
+  Scope: |-
+    - In scope: Add a compact task brief surface that merges route decision, checkout role, next action, blockers, Verify Steps, blueprint evidence, and stop rules into one agent-ready view.
+    - Out of scope: unrelated refactors not required for "Add agent task brief command".
+  Plan: "Implement an agent-ready task brief command by reusing route-decision and Verify Steps/blueprint evidence surfaces. Keep default output compact and local-only; provide JSON output for agents and an explicit remote mode for hosted truth."
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Run `Run targeted CLI tests for task brief text and JSON output.`. Expected: it succeeds and confirms the requested outcome for this task.
+    2. Run `Confirm task brief includes route decision, Verify Steps, blueprint evidence, blockers, and next command for branch_pr tasks.`. Expected: it succeeds and confirms the requested outcome for this task.
+    3. Run `Confirm task brief avoids remote network lookups unless an explicit remote flag is used.`. Expected: it succeeds and confirms the requested outcome for this task.
+    4. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add agent task brief command
+
+Add a compact task brief surface that merges route decision, checkout role, next action, blockers, Verify Steps, blueprint evidence, and stop rules into one agent-ready view.
+
+## Scope
+
+- In scope: Add a compact task brief surface that merges route decision, checkout role, next action, blockers, Verify Steps, blueprint evidence, and stop rules into one agent-ready view.
+- Out of scope: unrelated refactors not required for "Add agent task brief command".
+
+## Plan
+
+Implement an agent-ready task brief command by reusing route-decision and Verify Steps/blueprint evidence surfaces. Keep default output compact and local-only; provide JSON output for agents and an explicit remote mode for hosted truth.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Run `Run targeted CLI tests for task brief text and JSON output.`. Expected: it succeeds and confirms the requested outcome for this task.
+2. Run `Confirm task brief includes route decision, Verify Steps, blueprint evidence, blockers, and next command for branch_pr tasks.`. Expected: it succeeds and confirms the requested outcome for this task.
+3. Run `Confirm task brief avoids remote network lookups unless an explicit remote flag is used.`. Expected: it succeeds and confirms the requested outcome for this task.
+4. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605221744-VW5E95/README.md
+++ b/.agentplane/tasks/202605221744-VW5E95/README.md
@@ -1,0 +1,103 @@
+---
+id: "202605221744-VW5E95"
+title: "Define machine-readable agent work context contract"
+status: "TODO"
+priority: "high"
+owner: "CODER"
+revision: 3
+origin:
+  system: "manual"
+depends_on:
+  - "202605221744-GF25D1"
+tags:
+  - "cli"
+  - "code"
+  - "context"
+  - "workflow"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "Add contract tests for the agent work context JSON shape and required fields."
+  - "Confirm existing task status and verify-show JSON/text behavior remains backward compatible."
+  - "Confirm the JSON contract exposes route, next_action, verify_steps, blueprint, policy_modules, evidence_required, source_confidence, and stop_rules."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-22T17:44:36.865Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-22T17:44:32.537Z"
+doc_updated_by: "PLANNER"
+description: "Define and test a stable JSON contract that combines task route, next action, verification contract, blueprint evidence, policy modules, source confidence, and stop rules for agent consumers."
+sections:
+  Summary: |-
+    Define machine-readable agent work context contract
+
+    Define and test a stable JSON contract that combines task route, next action, verification contract, blueprint evidence, policy modules, source confidence, and stop rules for agent consumers.
+  Scope: |-
+    - In scope: Define and test a stable JSON contract that combines task route, next action, verification contract, blueprint evidence, policy modules, source confidence, and stop rules for agent consumers.
+    - Out of scope: unrelated refactors not required for "Define machine-readable agent work context contract".
+  Plan: "Create a stable machine-readable agent work context contract shared by task brief and future runner/agent integrations. The contract must distinguish local, cached, and remote-derived fields so agents do not overtrust stale context."
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Run `Add contract tests for the agent work context JSON shape and required fields.`. Expected: it succeeds and confirms the requested outcome for this task.
+    2. Run `Confirm the JSON contract exposes route, next_action, verify_steps, blueprint, policy_modules, evidence_required, source_confidence, and stop_rules.`. Expected: it succeeds and confirms the requested outcome for this task.
+    3. Run `Confirm existing task status and verify-show JSON/text behavior remains backward compatible.`. Expected: it succeeds and confirms the requested outcome for this task.
+    4. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Define machine-readable agent work context contract
+
+Define and test a stable JSON contract that combines task route, next action, verification contract, blueprint evidence, policy modules, source confidence, and stop rules for agent consumers.
+
+## Scope
+
+- In scope: Define and test a stable JSON contract that combines task route, next action, verification contract, blueprint evidence, policy modules, source confidence, and stop rules for agent consumers.
+- Out of scope: unrelated refactors not required for "Define machine-readable agent work context contract".
+
+## Plan
+
+Create a stable machine-readable agent work context contract shared by task brief and future runner/agent integrations. The contract must distinguish local, cached, and remote-derived fields so agents do not overtrust stale context.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Run `Add contract tests for the agent work context JSON shape and required fields.`. Expected: it succeeds and confirms the requested outcome for this task.
+2. Run `Confirm the JSON contract exposes route, next_action, verify_steps, blueprint, policy_modules, evidence_required, source_confidence, and stop_rules.`. Expected: it succeeds and confirms the requested outcome for this task.
+3. Run `Confirm existing task status and verify-show JSON/text behavior remains backward compatible.`. Expected: it succeeds and confirms the requested outcome for this task.
+4. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605221744-XBKXEW/README.md
+++ b/.agentplane/tasks/202605221744-XBKXEW/README.md
@@ -1,0 +1,103 @@
+---
+id: "202605221744-XBKXEW"
+title: "Add active work selector for agents"
+status: "TODO"
+priority: "high"
+owner: "CODER"
+revision: 3
+origin:
+  system: "manual"
+depends_on:
+  - "202605221726-N6CQ5A"
+tags:
+  - "cli"
+  - "code"
+  - "performance"
+  - "workflow"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "performance.benchmark"
+verify:
+  - "Confirm selector output includes next action, owner, dependency readiness, blocker count, and source freshness without printing historical DONE tasks."
+  - "Run a focused cold-path or projection-cache performance check for the selector."
+  - "Run targeted tests for active work selector ordering and filters."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-22T17:44:58.141Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-22T17:44:55.129Z"
+doc_updated_by: "PLANNER"
+description: "Add an agent-oriented active work selector that ranks TODO, DOING, BLOCKED, and anomaly tasks by actionable next step, ownership, dependency readiness, and route blockers instead of forcing agents to scan the full backlog."
+sections:
+  Summary: |-
+    Add active work selector for agents
+
+    Add an agent-oriented active work selector that ranks TODO, DOING, BLOCKED, and anomaly tasks by actionable next step, ownership, dependency readiness, and route blockers instead of forcing agents to scan the full backlog.
+  Scope: |-
+    - In scope: Add an agent-oriented active work selector that ranks TODO, DOING, BLOCKED, and anomaly tasks by actionable next step, ownership, dependency readiness, and route blockers instead of forcing agents to scan the full backlog.
+    - Out of scope: unrelated refactors not required for "Add active work selector for agents".
+  Plan: "Build a compact active work selector for agents on top of the active task route summary. It should make the safest next task/action obvious, preserve explicit filters, and keep full historical listing behind the existing explicit path."
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Run `Run targeted tests for active work selector ordering and filters.`. Expected: it succeeds and confirms the requested outcome for this task.
+    2. Run `Confirm selector output includes next action, owner, dependency readiness, blocker count, and source freshness without printing historical DONE tasks.`. Expected: it succeeds and confirms the requested outcome for this task.
+    3. Run `Run a focused cold-path or projection-cache performance check for the selector.`. Expected: it succeeds and confirms the requested outcome for this task.
+    4. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add active work selector for agents
+
+Add an agent-oriented active work selector that ranks TODO, DOING, BLOCKED, and anomaly tasks by actionable next step, ownership, dependency readiness, and route blockers instead of forcing agents to scan the full backlog.
+
+## Scope
+
+- In scope: Add an agent-oriented active work selector that ranks TODO, DOING, BLOCKED, and anomaly tasks by actionable next step, ownership, dependency readiness, and route blockers instead of forcing agents to scan the full backlog.
+- Out of scope: unrelated refactors not required for "Add active work selector for agents".
+
+## Plan
+
+Build a compact active work selector for agents on top of the active task route summary. It should make the safest next task/action obvious, preserve explicit filters, and keep full historical listing behind the existing explicit path.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Run `Run targeted tests for active work selector ordering and filters.`. Expected: it succeeds and confirms the requested outcome for this task.
+2. Run `Confirm selector output includes next action, owner, dependency readiness, blocker count, and source freshness without printing historical DONE tasks.`. Expected: it succeeds and confirms the requested outcome for this task.
+3. Run `Run a focused cold-path or projection-cache performance check for the selector.`. Expected: it succeeds and confirms the requested outcome for this task.
+4. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605221745-8BHZSX/README.md
+++ b/.agentplane/tasks/202605221745-8BHZSX/README.md
@@ -1,0 +1,99 @@
+---
+id: "202605221745-8BHZSX"
+title: "Route quickstart and role guidance to agent context surfaces"
+status: "TODO"
+priority: "med"
+owner: "DOCS"
+revision: 3
+origin:
+  system: "manual"
+depends_on:
+  - "202605221744-GF25D1"
+  - "202605221744-XBKXEW"
+tags:
+  - "cli"
+  - "docs"
+  - "workflow"
+task_kind: "docs"
+mutation_scope: "docs"
+blueprint_request: "docs.change"
+verify:
+  - "Confirm guidance points to active work and task brief surfaces without removing command-specific recovery paths."
+  - "Regenerate CLI docs if generated reference output changes."
+  - "Run command-guide or help snapshot tests covering quickstart and role guidance."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-22T17:45:49.015Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-22T17:45:45.967Z"
+doc_updated_by: "PLANNER"
+description: "Update installed quickstart, role supplements, and generated docs guidance to direct agents toward active work and task brief surfaces instead of manual command stitching."
+sections:
+  Summary: |-
+    Route quickstart and role guidance to agent context surfaces
+
+    Update installed quickstart, role supplements, and generated docs guidance to direct agents toward active work and task brief surfaces instead of manual command stitching.
+  Scope: |-
+    - In scope: Update installed quickstart, role supplements, and generated docs guidance to direct agents toward active work and task brief surfaces instead of manual command stitching.
+    - Out of scope: unrelated refactors not required for "Route quickstart and role guidance to agent context surfaces".
+  Plan: "After the active work and task brief surfaces exist, update quickstart, role supplements, and generated user docs so agents start from those context-rich commands rather than manually combining task list, status, work resume, verify-show, and docs lookup."
+  Verify Steps: |-
+    PLANNER fallback scaffold for "Route quickstart and role guidance to agent context surfaces". Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the requested outcome for "Route quickstart and role guidance to agent context surfaces". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Route quickstart and role guidance to agent context surfaces
+
+Update installed quickstart, role supplements, and generated docs guidance to direct agents toward active work and task brief surfaces instead of manual command stitching.
+
+## Scope
+
+- In scope: Update installed quickstart, role supplements, and generated docs guidance to direct agents toward active work and task brief surfaces instead of manual command stitching.
+- Out of scope: unrelated refactors not required for "Route quickstart and role guidance to agent context surfaces".
+
+## Plan
+
+After the active work and task brief surfaces exist, update quickstart, role supplements, and generated user docs so agents start from those context-rich commands rather than manually combining task list, status, work resume, verify-show, and docs lookup.
+
+## Verify Steps
+
+PLANNER fallback scaffold for "Route quickstart and role guidance to agent context surfaces". Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the requested outcome for "Route quickstart and role guidance to agent context surfaces". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605221745-8W56N1/README.md
+++ b/.agentplane/tasks/202605221745-8W56N1/README.md
@@ -1,0 +1,103 @@
+---
+id: "202605221745-8W56N1"
+title: "Add source confidence labels to agent route output"
+status: "TODO"
+priority: "high"
+owner: "CODER"
+revision: 3
+origin:
+  system: "manual"
+depends_on:
+  - "202605221726-8SA692"
+tags:
+  - "cli"
+  - "code"
+  - "github"
+  - "workflow"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "Confirm default route commands remain local-only and remote checks require an explicit flag."
+  - "Confirm text output stays compact while JSON output exposes source_confidence per critical field."
+  - "Run route-decision tests covering local, cached metadata, stale metadata, and remote-checked source confidence labels."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-22T17:45:14.504Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-22T17:45:11.478Z"
+doc_updated_by: "PLANNER"
+description: "Label route, PR, close-tail, task, and verification fields by source and freshness so agents can tell local, cached, stale, and remote-checked context apart before mutating state."
+sections:
+  Summary: |-
+    Add source confidence labels to agent route output
+
+    Label route, PR, close-tail, task, and verification fields by source and freshness so agents can tell local, cached, stale, and remote-checked context apart before mutating state.
+  Scope: |-
+    - In scope: Label route, PR, close-tail, task, and verification fields by source and freshness so agents can tell local, cached, stale, and remote-checked context apart before mutating state.
+    - Out of scope: unrelated refactors not required for "Add source confidence labels to agent route output".
+  Plan: "Extend route and hosted lifecycle output with explicit source confidence labels. The goal is to reduce false certainty: agents should know whether a field came from local task metadata, local git, cached PR artifacts, or an explicit remote check."
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Run `Run route-decision tests covering local, cached metadata, stale metadata, and remote-checked source confidence labels.`. Expected: it succeeds and confirms the requested outcome for this task.
+    2. Run `Confirm text output stays compact while JSON output exposes source_confidence per critical field.`. Expected: it succeeds and confirms the requested outcome for this task.
+    3. Run `Confirm default route commands remain local-only and remote checks require an explicit flag.`. Expected: it succeeds and confirms the requested outcome for this task.
+    4. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add source confidence labels to agent route output
+
+Label route, PR, close-tail, task, and verification fields by source and freshness so agents can tell local, cached, stale, and remote-checked context apart before mutating state.
+
+## Scope
+
+- In scope: Label route, PR, close-tail, task, and verification fields by source and freshness so agents can tell local, cached, stale, and remote-checked context apart before mutating state.
+- Out of scope: unrelated refactors not required for "Add source confidence labels to agent route output".
+
+## Plan
+
+Extend route and hosted lifecycle output with explicit source confidence labels. The goal is to reduce false certainty: agents should know whether a field came from local task metadata, local git, cached PR artifacts, or an explicit remote check.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Run `Run route-decision tests covering local, cached metadata, stale metadata, and remote-checked source confidence labels.`. Expected: it succeeds and confirms the requested outcome for this task.
+2. Run `Confirm text output stays compact while JSON output exposes source_confidence per critical field.`. Expected: it succeeds and confirms the requested outcome for this task.
+3. Run `Confirm default route commands remain local-only and remote checks require an explicit flag.`. Expected: it succeeds and confirms the requested outcome for this task.
+4. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605221745-CH6ENY/README.md
+++ b/.agentplane/tasks/202605221745-CH6ENY/README.md
@@ -1,0 +1,104 @@
+---
+id: "202605221745-CH6ENY"
+title: "Expose batch ownership in agent context"
+status: "TODO"
+priority: "med"
+owner: "CODER"
+revision: 3
+origin:
+  system: "manual"
+depends_on:
+  - "202605221726-R90HC5"
+  - "202605221726-WY8F98"
+tags:
+  - "cli"
+  - "code"
+  - "tasks"
+  - "workflow"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "Add tests for route or brief output when a task is part of a related batch worktree."
+  - "Confirm primary task, included task ids, branch owner, and per-task verification states are visible in JSON output."
+  - "Confirm text output gives one safe next action and does not instruct satellite tasks to open conflicting PRs."
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-22T17:45:32.206Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-05-22T17:45:27.556Z"
+doc_updated_by: "PLANNER"
+description: "Expose primary batch task, included task ids, shared worktree branch, per-task verification state, and next owner action in route/brief output so agents do not confuse satellite tasks with integration owners."
+sections:
+  Summary: |-
+    Expose batch ownership in agent context
+
+    Expose primary batch task, included task ids, shared worktree branch, per-task verification state, and next owner action in route/brief output so agents do not confuse satellite tasks with integration owners.
+  Scope: |-
+    - In scope: Expose primary batch task, included task ids, shared worktree branch, per-task verification state, and next owner action in route/brief output so agents do not confuse satellite tasks with integration owners.
+    - Out of scope: unrelated refactors not required for "Expose batch ownership in agent context".
+  Plan: "Teach route/brief output about related task batch ownership. A satellite task should point agents to the primary task/worktree and its own verification duty, instead of encouraging duplicate branches, PRs, or close-tail actions."
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Run `Add tests for route or brief output when a task is part of a related batch worktree.`. Expected: it succeeds and confirms the requested outcome for this task.
+    2. Run `Confirm primary task, included task ids, branch owner, and per-task verification states are visible in JSON output.`. Expected: it succeeds and confirms the requested outcome for this task.
+    3. Run `Confirm text output gives one safe next action and does not instruct satellite tasks to open conflicting PRs.`. Expected: it succeeds and confirms the requested outcome for this task.
+    4. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Expose batch ownership in agent context
+
+Expose primary batch task, included task ids, shared worktree branch, per-task verification state, and next owner action in route/brief output so agents do not confuse satellite tasks with integration owners.
+
+## Scope
+
+- In scope: Expose primary batch task, included task ids, shared worktree branch, per-task verification state, and next owner action in route/brief output so agents do not confuse satellite tasks with integration owners.
+- Out of scope: unrelated refactors not required for "Expose batch ownership in agent context".
+
+## Plan
+
+Teach route/brief output about related task batch ownership. A satellite task should point agents to the primary task/worktree and its own verification duty, instead of encouraging duplicate branches, PRs, or close-tail actions.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Run `Add tests for route or brief output when a task is part of a related batch worktree.`. Expected: it succeeds and confirms the requested outcome for this task.
+2. Run `Confirm primary task, included task ids, branch owner, and per-task verification states are visible in JSON output.`. Expected: it succeeds and confirms the requested outcome for this task.
+3. Run `Confirm text output gives one safe next action and does not instruct satellite tasks to open conflicting PRs.`. Expected: it succeeds and confirms the requested outcome for this task.
+4. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings


### PR DESCRIPTION
Restores the approved open backlog task READMEs that were temporarily stashed while reconciling the release hardening merge.\n\nScope: task registry artifacts only.\n\nPre-push evidence: docs-only fast route passed format, schemas, agent templates, policy routing, release parity, scripts README, onboarding scenario, hotspot baseline, and vitest project routing.