### PR TITLE
🚧 VE5WTR task: Bound local CI targeted test process duration [202605221926-VE5WTR]

### DIFF
--- a/.agentplane/tasks/202605221926-VE5WTR/README.md
+++ b/.agentplane/tasks/202605221926-VE5WTR/README.md
@@ -1,0 +1,215 @@
+---
+id: "202605221926-VE5WTR"
+title: "Bound local CI targeted test process duration"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "ci"
+  - "code"
+  - "workflow"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-22T19:26:24.876Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-22T19:31:44.772Z"
+  updated_by: "EVALUATOR"
+  note: "Reviewed one-commit branch after PR artifact refresh; local focused checks passed and PR diff contains the intended run-local-ci timeout guard."
+  attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-22T19:31:44.772Z"
+  updated_by: "EVALUATOR"
+  note: "Reviewed one-commit branch after PR artifact refresh; local focused checks passed and PR diff contains the intended run-local-ci timeout guard."
+  evaluated_sha: "71ed752f93ed4820406508f87c2703e4b0291be9"
+  blueprint_digest: "66eb194094c56e60bfbf0ad69546c66de0e100ece0e6556dbcfff0433a4bb5c6"
+  evidence_refs:
+    - ".agentplane/tasks/202605221926-VE5WTR/README.md"
+    - "/Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221926-VE5WTR-local-ci-vitest-timeout/.agentplane/tasks/202605221926-VE5WTR/blueprint/resolved-snapshot.json"
+  findings: []
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: adding suite-level timeout supervision around local CI Vitest invocations after pre-push exposed a hung targeted PR suite."
+events:
+  -
+    type: "status"
+    at: "2026-05-22T19:26:34.397Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: adding suite-level timeout supervision around local CI Vitest invocations after pre-push exposed a hung targeted PR suite."
+  -
+    type: "verify"
+    at: "2026-05-22T19:29:50.989Z"
+    author: "CODER"
+    state: "ok"
+    note: "Bound run-local-ci Vitest subprocesses with AGENTPLANE_LOCAL_VITEST_SUITE_TIMEOUT_MS and verified focused local CI checks."
+  -
+    type: "verify"
+    at: "2026-05-22T19:31:44.772Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Reviewed one-commit branch after PR artifact refresh; local focused checks passed and PR diff contains the intended run-local-ci timeout guard."
+doc_version: 3
+doc_updated_at: "2026-05-22T19:31:44.787Z"
+doc_updated_by: "CODER"
+description: "Prevent local pre-push and run-local-ci targeted Vitest suites from hanging indefinitely by adding a bounded process timeout and actionable diagnostics for suite-level stalls."
+sections:
+  Summary: |-
+    Bound local CI targeted test process duration
+
+    Prevent local pre-push and run-local-ci targeted Vitest suites from hanging indefinitely by adding a bounded process timeout and actionable diagnostics for suite-level stalls.
+  Scope: |-
+    - In scope: Prevent local pre-push and run-local-ci targeted Vitest suites from hanging indefinitely by adding a bounded process timeout and actionable diagnostics for suite-level stalls.
+    - Out of scope: unrelated refactors not required for "Bound local CI targeted test process duration".
+  Plan: "Add suite-level timeout supervision to scripts/checks/run-local-ci.mjs Vitest invocations so a hung targeted suite exits with a clear diagnostic instead of blocking pre-push indefinitely. Cover timeout argument construction or process invocation behavior with focused tests, then verify local CI selection still routes normally."
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-22T19:29:50.989Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Bound run-local-ci Vitest subprocesses with AGENTPLANE_LOCAL_VITEST_SUITE_TIMEOUT_MS and verified focused local CI checks.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T19:26:34.397Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221926-VE5WTR-local-ci-vitest-timeout/.agentplane/tasks/202605221926-VE5WTR/blueprint/resolved-snapshot.json
+    - old_digest: 66eb194094c56e60bfbf0ad69546c66de0e100ece0e6556dbcfff0433a4bb5c6
+    - current_digest: 66eb194094c56e60bfbf0ad69546c66de0e100ece0e6556dbcfff0433a4bb5c6
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605221926-VE5WTR
+
+    ### 2026-05-22T19:31:44.772Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Reviewed one-commit branch after PR artifact refresh; local focused checks passed and PR diff contains the intended run-local-ci timeout guard.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T19:29:51.005Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221926-VE5WTR-local-ci-vitest-timeout/.agentplane/tasks/202605221926-VE5WTR/blueprint/resolved-snapshot.json
+    - old_digest: 66eb194094c56e60bfbf0ad69546c66de0e100ece0e6556dbcfff0433a4bb5c6
+    - current_digest: 66eb194094c56e60bfbf0ad69546c66de0e100ece0e6556dbcfff0433a4bb5c6
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605221926-VE5WTR
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Local pre-push previously reached Unit tests (targeted:pr) and left the Vitest process running for minutes without output; --testTimeout only bounds individual tests/hooks, not a wedged subprocess.
+      Impact: A hung targeted suite could block pushes and slow PR publication indefinitely.
+      Resolution: Added suite-level execFileSync timeout for run-local-ci Vitest invocations, with an actionable stderr diagnostic and env override.
+
+    - Observation: Branch diff is one implementation commit with scripts/checks/run-local-ci.mjs timeout supervision and release CI contract coverage.
+      Impact: The task branch now has current verification evidence after PR artifact generation.
+      Resolution: Proceed to hosted PR checks and integration.
+id_source: "generated"
+---
+## Summary
+
+Bound local CI targeted test process duration
+
+Prevent local pre-push and run-local-ci targeted Vitest suites from hanging indefinitely by adding a bounded process timeout and actionable diagnostics for suite-level stalls.
+
+## Scope
+
+- In scope: Prevent local pre-push and run-local-ci targeted Vitest suites from hanging indefinitely by adding a bounded process timeout and actionable diagnostics for suite-level stalls.
+- Out of scope: unrelated refactors not required for "Bound local CI targeted test process duration".
+
+## Plan
+
+Add suite-level timeout supervision to scripts/checks/run-local-ci.mjs Vitest invocations so a hung targeted suite exits with a clear diagnostic instead of blocking pre-push indefinitely. Cover timeout argument construction or process invocation behavior with focused tests, then verify local CI selection still routes normally.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-22T19:29:50.989Z — VERIFY — ok
+
+By: CODER
+
+Note: Bound run-local-ci Vitest subprocesses with AGENTPLANE_LOCAL_VITEST_SUITE_TIMEOUT_MS and verified focused local CI checks.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T19:26:34.397Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221926-VE5WTR-local-ci-vitest-timeout/.agentplane/tasks/202605221926-VE5WTR/blueprint/resolved-snapshot.json
+- old_digest: 66eb194094c56e60bfbf0ad69546c66de0e100ece0e6556dbcfff0433a4bb5c6
+- current_digest: 66eb194094c56e60bfbf0ad69546c66de0e100ece0e6556dbcfff0433a4bb5c6
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605221926-VE5WTR
+
+### 2026-05-22T19:31:44.772Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Reviewed one-commit branch after PR artifact refresh; local focused checks passed and PR diff contains the intended run-local-ci timeout guard.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T19:29:51.005Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221926-VE5WTR-local-ci-vitest-timeout/.agentplane/tasks/202605221926-VE5WTR/blueprint/resolved-snapshot.json
+- old_digest: 66eb194094c56e60bfbf0ad69546c66de0e100ece0e6556dbcfff0433a4bb5c6
+- current_digest: 66eb194094c56e60bfbf0ad69546c66de0e100ece0e6556dbcfff0433a4bb5c6
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605221926-VE5WTR
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Local pre-push previously reached Unit tests (targeted:pr) and left the Vitest process running for minutes without output; --testTimeout only bounds individual tests/hooks, not a wedged subprocess.
+  Impact: A hung targeted suite could block pushes and slow PR publication indefinitely.
+  Resolution: Added suite-level execFileSync timeout for run-local-ci Vitest invocations, with an actionable stderr diagnostic and env override.
+
+- Observation: Branch diff is one implementation commit with scripts/checks/run-local-ci.mjs timeout supervision and release CI contract coverage.
+  Impact: The task branch now has current verification evidence after PR artifact generation.
+  Resolution: Proceed to hosted PR checks and integration.

--- a/.agentplane/tasks/202605221926-VE5WTR/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605221926-VE5WTR/blueprint/resolved-snapshot.json
@@ -1,0 +1,598 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605221926-VE5WTR",
+    "title": "Bound local CI targeted test process duration",
+    "description": "Prevent local pre-push and run-local-ci targeted Vitest suites from hanging indefinitely by adding a bounded process timeout and actionable diagnostics for suite-level stalls.",
+    "tags": [
+      "ci",
+      "code",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "quality.regression",
+    "version": 1,
+    "title": "Quality regression",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "quality.regression",
+    "blueprintVersion": 1,
+    "title": "Quality regression",
+    "taskId": "202605221926-VE5WTR",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to quality.regression",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest",
+          "artifact"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "check_result"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "weak_links"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "regression.original_failure",
+        "kind": "artifact",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Original failure log or check output."
+      },
+      {
+        "id": "regression.reproduction",
+        "kind": "check_result",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Local reproduction or explicit non-reproduction result."
+      },
+      {
+        "id": "regression.focused_check",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Focused regression check."
+      },
+      {
+        "id": "regression.matrix_or_scope",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Affected test/check matrix or bounded scope."
+      },
+      {
+        "id": "regression.full_gate",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Full relevant gate or hosted check evidence."
+      },
+      {
+        "id": "regression.flake_classification",
+        "kind": "weak_links",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Flake classification or residual risk."
+      },
+      {
+        "id": "regression.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "regression.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "affected matrix or full relevant gate",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "failure reproduction command",
+      "focused regression check",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest",
+        "artifact"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "check_result"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "weak_links"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "regression.original_failure",
+      "kind": "artifact",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Original failure log or check output."
+    },
+    {
+      "id": "regression.reproduction",
+      "kind": "check_result",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Local reproduction or explicit non-reproduction result."
+    },
+    {
+      "id": "regression.focused_check",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Focused regression check."
+    },
+    {
+      "id": "regression.matrix_or_scope",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Affected test/check matrix or bounded scope."
+    },
+    {
+      "id": "regression.full_gate",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Full relevant gate or hosted check evidence."
+    },
+    {
+      "id": "regression.flake_classification",
+      "kind": "weak_links",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Flake classification or residual risk."
+    },
+    {
+      "id": "regression.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "regression.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "affected matrix or full relevant gate",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "failure reproduction command",
+    "focused regression check",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to quality.regression",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "66eb194094c56e60bfbf0ad69546c66de0e100ece0e6556dbcfff0433a4bb5c6"
+  }
+}

--- a/.agentplane/tasks/202605221926-VE5WTR/pr/diffstat.txt
+++ b/.agentplane/tasks/202605221926-VE5WTR/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../commands/release/release-ci-contract.test.ts   | 12 ++++++
+ scripts/checks/run-local-ci.mjs                    | 46 +++++++++++++++++++---
+ 2 files changed, 53 insertions(+), 5 deletions(-)

--- a/.agentplane/tasks/202605221926-VE5WTR/pr/github-body.md
+++ b/.agentplane/tasks/202605221926-VE5WTR/pr/github-body.md
@@ -1,0 +1,40 @@
+Task: `202605221926-VE5WTR`
+Title: Bound local CI targeted test process duration
+Canonical task record: `.agentplane/tasks/202605221926-VE5WTR/README.md`
+
+## Summary
+
+Bound local CI targeted test process duration
+
+Prevent local pre-push and run-local-ci targeted Vitest suites from hanging indefinitely by adding a bounded process timeout and actionable diagnostics for suite-level stalls.
+
+## Scope
+
+- In scope: Prevent local pre-push and run-local-ci targeted Vitest suites from hanging indefinitely by adding a bounded process timeout and actionable diagnostics for suite-level stalls.
+- Out of scope: unrelated refactors not required for "Bound local CI targeted test process duration".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Reviewed one-commit branch after PR artifact refresh; local focused checks passed and PR diff
+contains the intended run-local-ci timeout guard.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-22T19:30:34.074Z
+- Branch: task/202605221926-VE5WTR/local-ci-vitest-timeout
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../commands/release/release-ci-contract.test.ts   | 12 ++++++
+ scripts/checks/run-local-ci.mjs                    | 46 +++++++++++++++++++---
+ 2 files changed, 53 insertions(+), 5 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605221926-VE5WTR/pr/github-title.txt
+++ b/.agentplane/tasks/202605221926-VE5WTR/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 VE5WTR task: Bound local CI targeted test process duration [202605221926-VE5WTR]

--- a/.agentplane/tasks/202605221926-VE5WTR/pr/meta.json
+++ b/.agentplane/tasks/202605221926-VE5WTR/pr/meta.json
@@ -1,0 +1,17 @@
+{
+  "base": "main",
+  "branch": "task/202605221926-VE5WTR/local-ci-vitest-timeout",
+  "created_at": "2026-05-22T19:26:34.440Z",
+  "diffstat_sha256": "sha256:14fd6f7ac8fdf0588fba98d5b7c449bb414b303a001b76941d4f1621f07ff83d",
+  "last_verified_at": "2026-05-22T19:31:44.772Z",
+  "last_verified_diffstat_sha256": "sha256:14fd6f7ac8fdf0588fba98d5b7c449bb414b303a001b76941d4f1621f07ff83d",
+  "pr_number": 4030,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4030",
+  "schema_version": 1,
+  "status": "OPEN",
+  "task_id": "202605221926-VE5WTR",
+  "updated_at": "2026-05-22T19:30:34.074Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605221926-VE5WTR/pr/review.md
+++ b/.agentplane/tasks/202605221926-VE5WTR/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-05-22T19:26:34.440Z
+
+## Task
+
+- Task: `202605221926-VE5WTR`
+- Title: Bound local CI targeted test process duration
+- Status: DOING
+- Branch: `task/202605221926-VE5WTR/local-ci-vitest-timeout`
+- Canonical task record: `.agentplane/tasks/202605221926-VE5WTR/README.md`
+
+## Verification
+
+- State: ok
+- Note: Reviewed one-commit branch after PR artifact refresh; local focused checks passed and PR diff contains the intended run-local-ci timeout guard.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-22T19:30:34.074Z
+- Branch: task/202605221926-VE5WTR/local-ci-vitest-timeout
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../commands/release/release-ci-contract.test.ts   | 12 ++++++
+ scripts/checks/run-local-ci.mjs                    | 46 +++++++++++++++++++---
+ 2 files changed, 53 insertions(+), 5 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/release/release-ci-contract.test.ts
+++ b/packages/agentplane/src/commands/release/release-ci-contract.test.ts
@@ -111,6 +111,18 @@ describe("release CI contract", () => {
     );
   });
 
+  it("bounds local CI Vitest subprocesses with an operator-tunable suite timeout", async () => {
+    const localCi = await readRootText("scripts/checks/run-local-ci.mjs");
+
+    expect(localCi).toContain("AGENTPLANE_LOCAL_VITEST_SUITE_TIMEOUT_MS");
+    expect(localCi).toContain("DEFAULT_LOCAL_VITEST_SUITE_TIMEOUT_MS = 10 * 60 * 1000");
+    expect(localCi).toContain("timeout: options.timeoutMs");
+    expect(localCi).toContain('timeoutLabel: "Vitest suite"');
+    expect(localCi.indexOf("timeout: options.timeoutMs")).toBeLessThan(
+      localCi.indexOf("Set AGENTPLANE_LOCAL_VITEST_SUITE_TIMEOUT_MS"),
+    );
+  });
+
   it("keeps the developer reinstall helper on the minimal runtime build path", async () => {
     const wrapper = await readRootText("scripts/reinstall-global-agentplane.sh");
     const reinstall = await readRootText("scripts/workflow/reinstall-global-agentplane.sh");

--- a/scripts/checks/run-local-ci.mjs
+++ b/scripts/checks/run-local-ci.mjs
@@ -38,9 +38,19 @@ const testEnv = {
   GIT_COMMITTER_EMAIL: "agentplane-ci@example.com",
 };
 const VITEST_TIMEOUT_MS = "60000";
+const DEFAULT_LOCAL_VITEST_SUITE_TIMEOUT_MS = 10 * 60 * 1000;
+const LOCAL_VITEST_SUITE_TIMEOUT_MS = parsePositiveIntegerEnv(
+  baseEnv.AGENTPLANE_LOCAL_VITEST_SUITE_TIMEOUT_MS,
+  DEFAULT_LOCAL_VITEST_SUITE_TIMEOUT_MS,
+);
 const LOCAL_FAST_VITEST_MAX_WORKERS =
   String(baseEnv.AGENTPLANE_FAST_VITEST_MAX_WORKERS ?? "").trim() || "4";
 const FAST_TEST_EXCLUDES = ["**/cli-smoke.test.ts", "**/run-cli*.test.ts"];
+
+function parsePositiveIntegerEnv(rawValue, fallback) {
+  const value = Number.parseInt(String(rawValue ?? "").trim(), 10);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
 
 function parseListValue(rawValue) {
   return String(rawValue ?? "")
@@ -109,8 +119,31 @@ function renderExecutionPlan(report) {
   }
 }
 
-function run(cmd, args, env = baseEnv) {
-  execFileSync(cmd, args, { stdio: "inherit", env });
+function formatCommand(cmd, args) {
+  return [cmd, ...args].join(" ");
+}
+
+function isTimeoutFailure(error) {
+  return error?.code === "ETIMEDOUT" || (error?.killed === true && error?.signal);
+}
+
+function run(cmd, args, env = baseEnv, options = {}) {
+  try {
+    execFileSync(cmd, args, {
+      stdio: "inherit",
+      env,
+      ...(options.timeoutMs ? { timeout: options.timeoutMs } : {}),
+    });
+  } catch (error) {
+    if (options.timeoutMs && isTimeoutFailure(error)) {
+      const label = options.timeoutLabel ?? "Command";
+      process.stderr.write(
+        `${label} timed out after ${options.timeoutMs}ms: ${formatCommand(cmd, args)}\n` +
+          "Set AGENTPLANE_LOCAL_VITEST_SUITE_TIMEOUT_MS to adjust the local Vitest process timeout.\n",
+      );
+    }
+    throw error;
+  }
 }
 
 function runStep(label, fn) {
@@ -118,8 +151,8 @@ function runStep(label, fn) {
   fn();
 }
 
-function runCommand(cmd, args, env = baseEnv) {
-  run(cmd, args, env);
+function runCommand(cmd, args, env = baseEnv, options = {}) {
+  run(cmd, args, env, options);
 }
 
 function buildVitestRunArgs({
@@ -147,7 +180,10 @@ function buildVitestRunArgs({
 }
 
 function runVitestSuite(options, env = baseEnv) {
-  runCommand("bunx", buildVitestRunArgs(options), env);
+  runCommand("bunx", buildVitestRunArgs(options), env, {
+    timeoutLabel: "Vitest suite",
+    timeoutMs: LOCAL_VITEST_SUITE_TIMEOUT_MS,
+  });
 }
 
 function existingLintTargets(targets) {


### PR DESCRIPTION
Task: `202605221926-VE5WTR`
Title: Bound local CI targeted test process duration
Canonical task record: `.agentplane/tasks/202605221926-VE5WTR/README.md`

## Summary

Bound local CI targeted test process duration

Prevent local pre-push and run-local-ci targeted Vitest suites from hanging indefinitely by adding a bounded process timeout and actionable diagnostics for suite-level stalls.

## Scope

- In scope: Prevent local pre-push and run-local-ci targeted Vitest suites from hanging indefinitely by adding a bounded process timeout and actionable diagnostics for suite-level stalls.
- Out of scope: unrelated refactors not required for "Bound local CI targeted test process duration".

## Verification

- State: ok
- Note:

```text
Bound run-local-ci Vitest subprocesses with AGENTPLANE_LOCAL_VITEST_SUITE_TIMEOUT_MS and verified
focused local CI checks.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-22T19:26:34.440Z
- Branch: task/202605221926-VE5WTR/local-ci-vitest-timeout
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../commands/release/release-ci-contract.test.ts   | 12 ++++++
 scripts/checks/run-local-ci.mjs                    | 46 +++++++++++++++++++---
 2 files changed, 53 insertions(+), 5 deletions(-)
```

</details>
