### PR TITLE
🚧 83R8S3 task: Classify amended task-branch pre-push scope from base [202605221941-83R8S3]

### DIFF
--- a/.agentplane/tasks/202605221941-83R8S3/README.md
+++ b/.agentplane/tasks/202605221941-83R8S3/README.md
@@ -1,0 +1,372 @@
+---
+id: "202605221941-83R8S3"
+title: "Classify amended task-branch pre-push scope from base"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 9
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "ci"
+  - "code"
+  - "hooks"
+  - "workflow"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-22T19:41:15.690Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-22T20:00:44.465Z"
+  updated_by: "EVALUATOR"
+  note: "Reworked regression tests to avoid process.chdir in worker threads; focused selection test, eslint, and typecheck pass locally."
+  attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-22T20:00:44.465Z"
+  updated_by: "EVALUATOR"
+  note: "Reworked regression tests to avoid process.chdir in worker threads; focused selection test, eslint, and typecheck pass locally."
+  evaluated_sha: "1b11ad6597568e8d814d473de7c28e22783a6fe3"
+  blueprint_digest: "bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f"
+  evidence_refs:
+    - ".agentplane/tasks/202605221941-83R8S3/README.md"
+    - "/Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221941-83R8S3-task-branch-prepush-base-scope/.agentplane/tasks/202605221941-83R8S3/blueprint/resolved-snapshot.json"
+  findings: []
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: fixing pre-push changed-file scope for amended task branch force-pushes so local CI does not miss code changes shared by the old and new branch heads."
+events:
+  -
+    type: "status"
+    at: "2026-05-22T19:41:28.266Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: fixing pre-push changed-file scope for amended task branch force-pushes so local CI does not miss code changes shared by the old and new branch heads."
+  -
+    type: "verify"
+    at: "2026-05-22T19:43:41.059Z"
+    author: "CODER"
+    state: "ok"
+    note: "Fixed pre-push scope selection for amended task branches and verified focused selection, lint, explain, and typecheck paths."
+  -
+    type: "verify"
+    at: "2026-05-22T19:44:23.867Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Reviewed refreshed PR artifacts; diffstat now covers pre-push scope code and local-ci selection test updates."
+  -
+    type: "verify"
+    at: "2026-05-22T19:49:59.196Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Fixed CI-only test assumption about origin/main availability; focused selection test, eslint, and typecheck pass locally."
+  -
+    type: "verify"
+    at: "2026-05-22T19:57:01.371Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Addressed review by limiting base-scope fallback to force-push or missing remote old SHA; focused tests now cover fast-forward and amended task-branch cases."
+  -
+    type: "verify"
+    at: "2026-05-22T20:00:44.465Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Reworked regression tests to avoid process.chdir in worker threads; focused selection test, eslint, and typecheck pass locally."
+doc_version: 3
+doc_updated_at: "2026-05-22T20:00:44.495Z"
+doc_updated_by: "CODER"
+description: "Prevent pre-push local CI from misclassifying amended or force-pushed task branches as docs-only when the branch still contains code changes by selecting changed files against the task branch base/merge-base instead of only remoteSha..localSha."
+sections:
+  Summary: |-
+    Classify amended task-branch pre-push scope from base
+
+    Prevent pre-push local CI from misclassifying amended or force-pushed task branches as docs-only when the branch still contains code changes by selecting changed files against the task branch base/merge-base instead of only remoteSha..localSha.
+  Scope: |-
+    - In scope: Prevent pre-push local CI from misclassifying amended or force-pushed task branches as docs-only when the branch still contains code changes by selecting changed files against the task branch base/merge-base instead of only remoteSha..localSha.
+    - Out of scope: unrelated refactors not required for "Classify amended task-branch pre-push scope from base".
+  Plan: "Fix pre-push changed-file selection for amended/force-pushed task branches. Select local CI changed files against the task branch base/merge-base when the pushed branch is an AgentPlane task branch, while preserving delete-only, release tag, and ordinary branch update behavior. Add focused tests that reproduce an amended task branch where remoteSha..localSha contains only task artifacts but base..localSha contains code, and verify local CI selection routes to a code bucket instead of docs-only."
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-22T19:43:41.059Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Fixed pre-push scope selection for amended task branches and verified focused selection, lint, explain, and typecheck paths.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T19:41:28.266Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221941-83R8S3-task-branch-prepush-base-scope/.agentplane/tasks/202605221941-83R8S3/blueprint/resolved-snapshot.json
+    - old_digest: bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f
+    - current_digest: bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605221941-83R8S3
+
+    ### 2026-05-22T19:44:23.867Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Reviewed refreshed PR artifacts; diffstat now covers pre-push scope code and local-ci selection test updates.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T19:43:41.086Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221941-83R8S3-task-branch-prepush-base-scope/.agentplane/tasks/202605221941-83R8S3/blueprint/resolved-snapshot.json
+    - old_digest: bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f
+    - current_digest: bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605221941-83R8S3
+
+    ### 2026-05-22T19:49:59.196Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Fixed CI-only test assumption about origin/main availability; focused selection test, eslint, and typecheck pass locally.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T19:44:23.901Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221941-83R8S3-task-branch-prepush-base-scope/.agentplane/tasks/202605221941-83R8S3/blueprint/resolved-snapshot.json
+    - old_digest: bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f
+    - current_digest: bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605221941-83R8S3
+
+    ### 2026-05-22T19:57:01.371Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Addressed review by limiting base-scope fallback to force-push or missing remote old SHA; focused tests now cover fast-forward and amended task-branch cases.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T19:49:59.229Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221941-83R8S3-task-branch-prepush-base-scope/.agentplane/tasks/202605221941-83R8S3/blueprint/resolved-snapshot.json
+    - old_digest: bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f
+    - current_digest: bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605221941-83R8S3
+
+    ### 2026-05-22T20:00:44.465Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Reworked regression tests to avoid process.chdir in worker threads; focused selection test, eslint, and typecheck pass locally.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T19:57:01.403Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221941-83R8S3-task-branch-prepush-base-scope/.agentplane/tasks/202605221941-83R8S3/blueprint/resolved-snapshot.json
+    - old_digest: bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f
+    - current_digest: bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605221941-83R8S3
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: pre-push used remoteSha..localSha for existing task branch pushes; after amend/force-push this can show only task artifact deltas while the PR branch still contains code changes relative to main.
+      Impact: Local pre-push can run docs-only fast CI for a code PR, delaying failures until hosted CI and weakening local safety.
+      Resolution: Task/task-close branch pushes now select changed files from merge-base(default base, localSha) when a default base is available; ordinary no-fallback branch updates keep the previous remoteSha..localSha behavior.
+
+    - Observation: PR #4032 diff is task-scoped and includes task branch base-scope selection plus regression coverage.
+      Impact: The task branch has current verification evidence after PR artifact generation.
+      Resolution: Squash artifact refresh into the implementation commit and run hosted checks.
+
+    - Observation: GitHub verify-routed failed because the regression test directly called git merge-base origin/main HEAD in a shallow detached checkout where origin/main was not present.
+      Impact: The implementation still needs a CI-portable assertion so hosted routed checks can pass.
+      Resolution: Changed the test helper to mirror production behavior: use merge-base when available and fallback to the provided base ref otherwise.
+
+    - Observation: The review identified that unconditional task branch base-scope would re-audit historical commits on ordinary fast-forward pushes.
+      Impact: Unconditional base-scope could block valid incremental pushes with unrelated historical commits.
+      Resolution: Added ancestor detection: fast-forward task pushes keep remoteSha..localSha, amended task force-pushes use merge-base(base, localSha), and missing old SHA keeps fallback base behavior.
+
+    - Observation: Targeted hook suite runs in worker threads, so temp-repo tests must not mutate process cwd.
+      Impact: Using process.chdir made the regression tests fail in the same targeted route that protects this change.
+      Resolution: Added explicit gitCwd plumbing for selection tests and kept production default behavior unchanged when gitCwd is absent.
+id_source: "generated"
+---
+## Summary
+
+Classify amended task-branch pre-push scope from base
+
+Prevent pre-push local CI from misclassifying amended or force-pushed task branches as docs-only when the branch still contains code changes by selecting changed files against the task branch base/merge-base instead of only remoteSha..localSha.
+
+## Scope
+
+- In scope: Prevent pre-push local CI from misclassifying amended or force-pushed task branches as docs-only when the branch still contains code changes by selecting changed files against the task branch base/merge-base instead of only remoteSha..localSha.
+- Out of scope: unrelated refactors not required for "Classify amended task-branch pre-push scope from base".
+
+## Plan
+
+Fix pre-push changed-file selection for amended/force-pushed task branches. Select local CI changed files against the task branch base/merge-base when the pushed branch is an AgentPlane task branch, while preserving delete-only, release tag, and ordinary branch update behavior. Add focused tests that reproduce an amended task branch where remoteSha..localSha contains only task artifacts but base..localSha contains code, and verify local CI selection routes to a code bucket instead of docs-only.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-22T19:43:41.059Z — VERIFY — ok
+
+By: CODER
+
+Note: Fixed pre-push scope selection for amended task branches and verified focused selection, lint, explain, and typecheck paths.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T19:41:28.266Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221941-83R8S3-task-branch-prepush-base-scope/.agentplane/tasks/202605221941-83R8S3/blueprint/resolved-snapshot.json
+- old_digest: bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f
+- current_digest: bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605221941-83R8S3
+
+### 2026-05-22T19:44:23.867Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Reviewed refreshed PR artifacts; diffstat now covers pre-push scope code and local-ci selection test updates.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T19:43:41.086Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221941-83R8S3-task-branch-prepush-base-scope/.agentplane/tasks/202605221941-83R8S3/blueprint/resolved-snapshot.json
+- old_digest: bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f
+- current_digest: bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605221941-83R8S3
+
+### 2026-05-22T19:49:59.196Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Fixed CI-only test assumption about origin/main availability; focused selection test, eslint, and typecheck pass locally.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T19:44:23.901Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221941-83R8S3-task-branch-prepush-base-scope/.agentplane/tasks/202605221941-83R8S3/blueprint/resolved-snapshot.json
+- old_digest: bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f
+- current_digest: bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605221941-83R8S3
+
+### 2026-05-22T19:57:01.371Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Addressed review by limiting base-scope fallback to force-push or missing remote old SHA; focused tests now cover fast-forward and amended task-branch cases.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T19:49:59.229Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221941-83R8S3-task-branch-prepush-base-scope/.agentplane/tasks/202605221941-83R8S3/blueprint/resolved-snapshot.json
+- old_digest: bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f
+- current_digest: bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605221941-83R8S3
+
+### 2026-05-22T20:00:44.465Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Reworked regression tests to avoid process.chdir in worker threads; focused selection test, eslint, and typecheck pass locally.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T19:57:01.403Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221941-83R8S3-task-branch-prepush-base-scope/.agentplane/tasks/202605221941-83R8S3/blueprint/resolved-snapshot.json
+- old_digest: bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f
+- current_digest: bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605221941-83R8S3
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: pre-push used remoteSha..localSha for existing task branch pushes; after amend/force-push this can show only task artifact deltas while the PR branch still contains code changes relative to main.
+  Impact: Local pre-push can run docs-only fast CI for a code PR, delaying failures until hosted CI and weakening local safety.
+  Resolution: Task/task-close branch pushes now select changed files from merge-base(default base, localSha) when a default base is available; ordinary no-fallback branch updates keep the previous remoteSha..localSha behavior.
+
+- Observation: PR #4032 diff is task-scoped and includes task branch base-scope selection plus regression coverage.
+  Impact: The task branch has current verification evidence after PR artifact generation.
+  Resolution: Squash artifact refresh into the implementation commit and run hosted checks.
+
+- Observation: GitHub verify-routed failed because the regression test directly called git merge-base origin/main HEAD in a shallow detached checkout where origin/main was not present.
+  Impact: The implementation still needs a CI-portable assertion so hosted routed checks can pass.
+  Resolution: Changed the test helper to mirror production behavior: use merge-base when available and fallback to the provided base ref otherwise.
+
+- Observation: The review identified that unconditional task branch base-scope would re-audit historical commits on ordinary fast-forward pushes.
+  Impact: Unconditional base-scope could block valid incremental pushes with unrelated historical commits.
+  Resolution: Added ancestor detection: fast-forward task pushes keep remoteSha..localSha, amended task force-pushes use merge-base(base, localSha), and missing old SHA keeps fallback base behavior.
+
+- Observation: Targeted hook suite runs in worker threads, so temp-repo tests must not mutate process cwd.
+  Impact: Using process.chdir made the regression tests fail in the same targeted route that protects this change.
+  Resolution: Added explicit gitCwd plumbing for selection tests and kept production default behavior unchanged when gitCwd is absent.

--- a/.agentplane/tasks/202605221941-83R8S3/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605221941-83R8S3/blueprint/resolved-snapshot.json
@@ -1,0 +1,599 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605221941-83R8S3",
+    "title": "Classify amended task-branch pre-push scope from base",
+    "description": "Prevent pre-push local CI from misclassifying amended or force-pushed task branches as docs-only when the branch still contains code changes by selecting changed files against the task branch base/merge-base instead of only remoteSha..localSha.",
+    "tags": [
+      "ci",
+      "code",
+      "hooks",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "quality.regression",
+    "version": 1,
+    "title": "Quality regression",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "quality.regression",
+    "blueprintVersion": 1,
+    "title": "Quality regression",
+    "taskId": "202605221941-83R8S3",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to quality.regression",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest",
+          "artifact"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "check_result"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "weak_links"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "regression.original_failure",
+        "kind": "artifact",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Original failure log or check output."
+      },
+      {
+        "id": "regression.reproduction",
+        "kind": "check_result",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Local reproduction or explicit non-reproduction result."
+      },
+      {
+        "id": "regression.focused_check",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Focused regression check."
+      },
+      {
+        "id": "regression.matrix_or_scope",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Affected test/check matrix or bounded scope."
+      },
+      {
+        "id": "regression.full_gate",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Full relevant gate or hosted check evidence."
+      },
+      {
+        "id": "regression.flake_classification",
+        "kind": "weak_links",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Flake classification or residual risk."
+      },
+      {
+        "id": "regression.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "regression.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "affected matrix or full relevant gate",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "failure reproduction command",
+      "focused regression check",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest",
+        "artifact"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "check_result"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "weak_links"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "regression.original_failure",
+      "kind": "artifact",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Original failure log or check output."
+    },
+    {
+      "id": "regression.reproduction",
+      "kind": "check_result",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Local reproduction or explicit non-reproduction result."
+    },
+    {
+      "id": "regression.focused_check",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Focused regression check."
+    },
+    {
+      "id": "regression.matrix_or_scope",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Affected test/check matrix or bounded scope."
+    },
+    {
+      "id": "regression.full_gate",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Full relevant gate or hosted check evidence."
+    },
+    {
+      "id": "regression.flake_classification",
+      "kind": "weak_links",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Flake classification or residual risk."
+    },
+    {
+      "id": "regression.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "regression.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "affected matrix or full relevant gate",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "failure reproduction command",
+    "focused regression check",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to quality.regression",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "bae81a38dfa36298149c949e6a28832a1827427b46faf52fa466ecac85f9b55f"
+  }
+}

--- a/.agentplane/tasks/202605221941-83R8S3/pr/diffstat.txt
+++ b/.agentplane/tasks/202605221941-83R8S3/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../agentplane/src/cli/local-ci-selection.test.ts  | 77 ++++++++++++++++++++++
+ scripts/lib/pre-push-scope.mjs                     | 40 ++++++++++-
+ 2 files changed, 115 insertions(+), 2 deletions(-)

--- a/.agentplane/tasks/202605221941-83R8S3/pr/github-body.md
+++ b/.agentplane/tasks/202605221941-83R8S3/pr/github-body.md
@@ -1,0 +1,40 @@
+Task: `202605221941-83R8S3`
+Title: Classify amended task-branch pre-push scope from base
+Canonical task record: `.agentplane/tasks/202605221941-83R8S3/README.md`
+
+## Summary
+
+Classify amended task-branch pre-push scope from base
+
+Prevent pre-push local CI from misclassifying amended or force-pushed task branches as docs-only when the branch still contains code changes by selecting changed files against the task branch base/merge-base instead of only remoteSha..localSha.
+
+## Scope
+
+- In scope: Prevent pre-push local CI from misclassifying amended or force-pushed task branches as docs-only when the branch still contains code changes by selecting changed files against the task branch base/merge-base instead of only remoteSha..localSha.
+- Out of scope: unrelated refactors not required for "Classify amended task-branch pre-push scope from base".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Reworked regression tests to avoid process.chdir in worker threads; focused selection test, eslint,
+and typecheck pass locally.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-22T19:44:05.424Z
+- Branch: task/202605221941-83R8S3/task-branch-prepush-base-scope
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../agentplane/src/cli/local-ci-selection.test.ts  | 77 ++++++++++++++++++++++
+ scripts/lib/pre-push-scope.mjs                     | 40 ++++++++++-
+ 2 files changed, 115 insertions(+), 2 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605221941-83R8S3/pr/github-title.txt
+++ b/.agentplane/tasks/202605221941-83R8S3/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 83R8S3 task: Classify amended task-branch pre-push scope from base [202605221941-83R8S3]

--- a/.agentplane/tasks/202605221941-83R8S3/pr/meta.json
+++ b/.agentplane/tasks/202605221941-83R8S3/pr/meta.json
@@ -1,0 +1,17 @@
+{
+  "base": "main",
+  "branch": "task/202605221941-83R8S3/task-branch-prepush-base-scope",
+  "created_at": "2026-05-22T19:41:28.337Z",
+  "diffstat_sha256": "sha256:da6f9b65a3bdd4574a96a70f3a22f30aeede1ac05dffd17de47bb0eda2f919eb",
+  "last_verified_at": "2026-05-22T20:00:44.465Z",
+  "last_verified_diffstat_sha256": "sha256:da6f9b65a3bdd4574a96a70f3a22f30aeede1ac05dffd17de47bb0eda2f919eb",
+  "pr_number": 4032,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4032",
+  "schema_version": 1,
+  "status": "OPEN",
+  "task_id": "202605221941-83R8S3",
+  "updated_at": "2026-05-22T19:44:05.424Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605221941-83R8S3/pr/review.md
+++ b/.agentplane/tasks/202605221941-83R8S3/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-05-22T19:41:28.337Z
+
+## Task
+
+- Task: `202605221941-83R8S3`
+- Title: Classify amended task-branch pre-push scope from base
+- Status: DOING
+- Branch: `task/202605221941-83R8S3/task-branch-prepush-base-scope`
+- Canonical task record: `.agentplane/tasks/202605221941-83R8S3/README.md`
+
+## Verification
+
+- State: ok
+- Note: Reworked regression tests to avoid process.chdir in worker threads; focused selection test, eslint, and typecheck pass locally.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-22T19:44:05.424Z
+- Branch: task/202605221941-83R8S3/task-branch-prepush-base-scope
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../agentplane/src/cli/local-ci-selection.test.ts  | 77 ++++++++++++++++++++++
+ scripts/lib/pre-push-scope.mjs                     | 40 ++++++++++-
+ 2 files changed, 115 insertions(+), 2 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/cli/local-ci-selection.test.ts
+++ b/packages/agentplane/src/cli/local-ci-selection.test.ts
@@ -1,3 +1,8 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import * as localCiSelectionModule from "../../../../scripts/lib/local-ci-selection.mjs";
@@ -84,9 +89,37 @@ const {
   readChangedFilesForRange: (range: { from: string; to: string } | null) => string[];
   selectBranchDiffRange: (
     updates: PrePushUpdate[],
-    opts?: { newBranchFallbackRef?: string | null },
+    opts?: { gitCwd?: string; newBranchFallbackRef?: string | null },
   ) => { from: string; to: string } | null;
 };
+
+function git(args: string[], options: { cwd?: string } = {}): string {
+  return execFileSync("git", args, {
+    cwd: options.cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+}
+
+function withTempGitRepo<T>(fn: (repoPath: string) => T): T {
+  const repoPath = mkdtempSync(path.join(os.tmpdir(), "agentplane-prepush-scope-"));
+  try {
+    git(["init", "-b", "main"], { cwd: repoPath });
+    git(["config", "user.name", "Test User"], { cwd: repoPath });
+    git(["config", "user.email", "test@example.com"], { cwd: repoPath });
+    return fn(repoPath);
+  } finally {
+    rmSync(repoPath, { force: true, recursive: true });
+  }
+}
+
+function commitFile(repoPath: string, filePath: string, contents: string, message: string): string {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, contents);
+  git(["add", "."], { cwd: repoPath });
+  git(["commit", "-m", message], { cwd: repoPath });
+  return git(["rev-parse", "HEAD"], { cwd: repoPath });
+}
 
 describe("local CI fast selection", () => {
   it("treats docs and policy changes as docs-only", () => {
@@ -573,6 +606,56 @@ describe("pre-push scope selection", () => {
   it("selects a diff range when pushing HEAD to a branch", () => {
     const updates = parsePrePushStdin("HEAD aaa refs/heads/task/T-1/fix bbb\n");
     expect(selectBranchDiffRange(updates)).toEqual({ from: "bbb", to: "aaa" });
+  });
+
+  it("selects task branch push scope from the base ref when a fallback is available", () => {
+    const updates = parsePrePushStdin("HEAD aaa refs/heads/task/T-1/fix bbb\n");
+    expect(selectBranchDiffRange(updates, { newBranchFallbackRef: "origin/main" })).toEqual({
+      from: "origin/main",
+      to: "aaa",
+    });
+  });
+
+  it("keeps fast-forward task branch pushes scoped to outgoing commits", () => {
+    withTempGitRepo((repoPath) => {
+      const baseSha = commitFile(repoPath, path.join(repoPath, "README.md"), "base\n", "base");
+      git(["checkout", "-b", "task/T-1/fix"], { cwd: repoPath });
+      const remoteSha = commitFile(repoPath, path.join(repoPath, "src/index.ts"), "one\n", "one");
+      const localSha = commitFile(repoPath, path.join(repoPath, "src/index.ts"), "two\n", "two");
+
+      const updates = parsePrePushStdin(`HEAD ${localSha} refs/heads/task/T-1/fix ${remoteSha}\n`);
+
+      expect(
+        selectBranchDiffRange(updates, { gitCwd: repoPath, newBranchFallbackRef: baseSha }),
+      ).toEqual({
+        from: remoteSha,
+        to: localSha,
+      });
+    });
+  });
+
+  it("uses base scope for amended task branch force-pushes", () => {
+    withTempGitRepo((repoPath) => {
+      const baseSha = commitFile(repoPath, path.join(repoPath, "README.md"), "base\n", "base");
+      git(["checkout", "-b", "task/T-1/fix"], { cwd: repoPath });
+      const remoteSha = commitFile(repoPath, path.join(repoPath, "src/index.ts"), "code\n", "old");
+      git(["reset", "--hard", baseSha], { cwd: repoPath });
+      const localSha = commitFile(
+        repoPath,
+        path.join(repoPath, "src/index.ts"),
+        "code\n",
+        "amended",
+      );
+
+      const updates = parsePrePushStdin(`HEAD ${localSha} refs/heads/task/T-1/fix ${remoteSha}\n`);
+
+      expect(
+        selectBranchDiffRange(updates, { gitCwd: repoPath, newBranchFallbackRef: baseSha }),
+      ).toEqual({
+        from: baseSha,
+        to: localSha,
+      });
+    });
   });
 
   it("does not select a diff range for new branch pushes", () => {

--- a/scripts/lib/pre-push-scope.d.ts
+++ b/scripts/lib/pre-push-scope.d.ts
@@ -9,5 +9,6 @@ export function parsePrePushStdin(rawStdin: unknown): PrePushUpdate[];
 export function hasReleaseTagPush(updates: PrePushUpdate[]): boolean;
 export function selectBranchDiffRange(
   updates: PrePushUpdate[],
+  opts?: { gitCwd?: string; newBranchFallbackRef?: string | null },
 ): { from: string; to: string } | null;
 export function readChangedFilesForRange(range: { from: string; to: string } | null): string[];

--- a/scripts/lib/pre-push-scope.mjs
+++ b/scripts/lib/pre-push-scope.mjs
@@ -19,16 +19,42 @@ function isBranchRef(ref) {
   return String(ref ?? "").startsWith("refs/heads/");
 }
 
-function readGitText(args) {
+function isAgentPlaneTaskBranchRef(ref) {
+  const branch = String(ref ?? "").replace(/^refs\/heads\//, "");
+  return branch.startsWith("task/") || branch.startsWith("task-close/");
+}
+
+function readGitText(args, cwd) {
   try {
-    return execFileSync("git", args, { encoding: "utf8" }).trim();
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
   } catch {
     return "";
   }
 }
 
-function gitRefExists(ref) {
-  return readGitText(["rev-parse", "--verify", "--quiet", ref]).length > 0;
+function gitRefExists(ref, cwd) {
+  return readGitText(["rev-parse", "--verify", "--quiet", ref], cwd).length > 0;
+}
+
+function isAncestorRef(ancestorRef, descendantRef, cwd) {
+  try {
+    execFileSync("git", ["merge-base", "--is-ancestor", ancestorRef, descendantRef], {
+      cwd,
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveMergeBase(baseRef, headRef, cwd) {
+  if (!baseRef || !headRef) return "";
+  return readGitText(["merge-base", baseRef, headRef], cwd);
 }
 
 export function hasReleaseTagPush(updates) {
@@ -68,10 +94,23 @@ export function selectBranchDiffRange(updates, opts = {}) {
   if (isAllZeroSha(update.localSha)) return null;
   const fallbackRef =
     typeof opts.newBranchFallbackRef === "string" ? opts.newBranchFallbackRef.trim() : "";
+  const gitCwd = typeof opts.gitCwd === "string" && opts.gitCwd.trim() ? opts.gitCwd : undefined;
   if (isAllZeroSha(update.remoteSha)) {
     return fallbackRef ? { from: fallbackRef, to: update.localSha } : null;
   }
-  if (!gitRefExists(update.remoteSha) && fallbackRef) {
+  const remoteRefExists = gitRefExists(update.remoteSha, gitCwd);
+  if (
+    fallbackRef &&
+    isAgentPlaneTaskBranchRef(update.remoteRef) &&
+    remoteRefExists &&
+    !isAncestorRef(update.remoteSha, update.localSha, gitCwd)
+  ) {
+    return {
+      from: resolveMergeBase(fallbackRef, update.localSha, gitCwd) || fallbackRef,
+      to: update.localSha,
+    };
+  }
+  if (!remoteRefExists && fallbackRef) {
     return { from: fallbackRef, to: update.localSha };
   }
   return { from: update.remoteSha, to: update.localSha };


### PR DESCRIPTION
Task: `202605221941-83R8S3`
Title: Classify amended task-branch pre-push scope from base
Canonical task record: `.agentplane/tasks/202605221941-83R8S3/README.md`

## Summary

Classify amended task-branch pre-push scope from base

Prevent pre-push local CI from misclassifying amended or force-pushed task branches as docs-only when the branch still contains code changes by selecting changed files against the task branch base/merge-base instead of only remoteSha..localSha.

## Scope

- In scope: Prevent pre-push local CI from misclassifying amended or force-pushed task branches as docs-only when the branch still contains code changes by selecting changed files against the task branch base/merge-base instead of only remoteSha..localSha.
- Out of scope: unrelated refactors not required for "Classify amended task-branch pre-push scope from base".

## Verification

- State: ok
- Note:

```text
Fixed pre-push scope selection for amended task branches and verified focused selection, lint,
explain, and typecheck paths.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-22T19:41:28.337Z
- Branch: task/202605221941-83R8S3/task-branch-prepush-base-scope
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../agentplane/src/cli/local-ci-selection.test.ts   | 15 ++++++++++++++-
 scripts/lib/pre-push-scope.mjs                      | 21 ++++++++++++++++++++-
 2 files changed, 34 insertions(+), 2 deletions(-)
```

</details>
