### PR TITLE
🚧 7KQE04 task: Split mutable hosted metadata from tracked evidence [202605221727-7KQE04]

### DIFF
--- a/.agentplane/tasks/202605221727-7KQE04/README.md
+++ b/.agentplane/tasks/202605221727-7KQE04/README.md
@@ -1,10 +1,10 @@
 ---
 id: "202605221727-7KQE04"
 title: "Split mutable hosted metadata from tracked evidence"
-status: "TODO"
+status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 4
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -22,17 +22,50 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-22T20:28:40.042Z"
+  updated_by: "EVALUATOR"
+  note: "Verified: reviewed recovery closure for 7KQE04; implementation contract is already in main commit 77531d807 and targeted PR metadata suites passed in this worktree."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-22T20:28:40.042Z"
+  updated_by: "EVALUATOR"
+  note: "Verified: reviewed recovery closure for 7KQE04; implementation contract is already in main commit 77531d807 and targeted PR metadata suites passed in this worktree."
+  evaluated_sha: "21a786bf2f1bddd5bee5b0cbd8964783a2601cad"
+  blueprint_digest: "154387313e8f512cb84f4cd55f15ff66f7c6302a80d5879af33db073b91ae459"
+  evidence_refs:
+    - ".agentplane/tasks/202605221727-7KQE04/README.md"
+    - "/Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221727-7KQE04-hosted-metadata-split/.agentplane/tasks/202605221727-7KQE04/blueprint/resolved-snapshot.json"
+  findings: []
 commit: null
-comments: []
-events: []
+comments:
+  -
+    author: "CODER"
+    body: "Start: splitting mutable hosted PR metadata from tracked evidence so artifact refresh does not self-invalidate reviewed implementation commits."
+events:
+  -
+    type: "status"
+    at: "2026-05-22T20:22:37.972Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: splitting mutable hosted PR metadata from tracked evidence so artifact refresh does not self-invalidate reviewed implementation commits."
+  -
+    type: "verify"
+    at: "2026-05-22T20:27:15.793Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: PR metadata builders omit tracked live head SHA and use diffstat freshness; targeted PR metadata tests pass against current main implementation commit 77531d807."
+  -
+    type: "verify"
+    at: "2026-05-22T20:28:40.042Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Verified: reviewed recovery closure for 7KQE04; implementation contract is already in main commit 77531d807 and targeted PR metadata suites passed in this worktree."
 doc_version: 3
-doc_updated_at: "2026-05-22T17:27:53.657Z"
-doc_updated_by: "PLANNER"
+doc_updated_at: "2026-05-22T20:28:40.071Z"
+doc_updated_by: "CODER"
 description: "Move volatile PR/check/head metadata out of tracked task artifacts or make it computed live so evidence updates do not invalidate reviewed implementation commits."
 sections:
   Summary: |-
@@ -49,11 +82,56 @@ sections:
     3. Confirm quality review freshness can be checked without self-invalidating evidence commits.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-22T20:27:15.793Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified: PR metadata builders omit tracked live head SHA and use diffstat freshness; targeted PR metadata tests pass against current main implementation commit 77531d807.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T20:22:37.972Z, excerpt_hash=sha256:4bc8b045966d52cf3ee4cb7b8ce09883a1f2bcc2e083d4ffc9c207c76226bbdd
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221727-7KQE04-hosted-metadata-split/.agentplane/tasks/202605221727-7KQE04/blueprint/resolved-snapshot.json
+    - old_digest: 154387313e8f512cb84f4cd55f15ff66f7c6302a80d5879af33db073b91ae459
+    - current_digest: 154387313e8f512cb84f4cd55f15ff66f7c6302a80d5879af33db073b91ae459
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605221727-7KQE04
+
+    ### 2026-05-22T20:28:40.042Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Verified: reviewed recovery closure for 7KQE04; implementation contract is already in main commit 77531d807 and targeted PR metadata suites passed in this worktree.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T20:27:15.865Z, excerpt_hash=sha256:4bc8b045966d52cf3ee4cb7b8ce09883a1f2bcc2e083d4ffc9c207c76226bbdd
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221727-7KQE04-hosted-metadata-split/.agentplane/tasks/202605221727-7KQE04/blueprint/resolved-snapshot.json
+    - old_digest: 154387313e8f512cb84f4cd55f15ff66f7c6302a80d5879af33db073b91ae459
+    - current_digest: 154387313e8f512cb84f4cd55f15ff66f7c6302a80d5879af33db073b91ae459
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605221727-7KQE04
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
     - Re-run required checks to confirm rollback safety.
-  Findings: ""
+  Findings: |-
+    - Observation: The approved contract is already present on main from commit 77531d807; this recovery branch records task-local verification and PR evidence without adding a duplicate implementation diff.
+      Impact: Task can be closed against the existing implementation while preserving one-commit task artifact discipline.
+      Resolution: Recorded verification after targeted pr-meta/pr-flow/integrate tests passed.
+
+    - Observation: PR #4034 carries task-local evidence only; no duplicate implementation diff is required because the tracked-head removal was merged earlier.
+      Impact: The backlog task can close without adding self-referential head metadata back into tracked artifacts.
+      Resolution: Proceed with one amended task evidence commit and hosted checks on PR #4034.
 id_source: "generated"
 ---
 ## Summary
@@ -80,6 +158,44 @@ Define and implement a boundary between immutable tracked evidence and mutable h
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-22T20:27:15.793Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: PR metadata builders omit tracked live head SHA and use diffstat freshness; targeted PR metadata tests pass against current main implementation commit 77531d807.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T20:22:37.972Z, excerpt_hash=sha256:4bc8b045966d52cf3ee4cb7b8ce09883a1f2bcc2e083d4ffc9c207c76226bbdd
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221727-7KQE04-hosted-metadata-split/.agentplane/tasks/202605221727-7KQE04/blueprint/resolved-snapshot.json
+- old_digest: 154387313e8f512cb84f4cd55f15ff66f7c6302a80d5879af33db073b91ae459
+- current_digest: 154387313e8f512cb84f4cd55f15ff66f7c6302a80d5879af33db073b91ae459
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605221727-7KQE04
+
+### 2026-05-22T20:28:40.042Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Verified: reviewed recovery closure for 7KQE04; implementation contract is already in main commit 77531d807 and targeted PR metadata suites passed in this worktree.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T20:27:15.865Z, excerpt_hash=sha256:4bc8b045966d52cf3ee4cb7b8ce09883a1f2bcc2e083d4ffc9c207c76226bbdd
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221727-7KQE04-hosted-metadata-split/.agentplane/tasks/202605221727-7KQE04/blueprint/resolved-snapshot.json
+- old_digest: 154387313e8f512cb84f4cd55f15ff66f7c6302a80d5879af33db073b91ae459
+- current_digest: 154387313e8f512cb84f4cd55f15ff66f7c6302a80d5879af33db073b91ae459
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605221727-7KQE04
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -88,3 +204,11 @@ Define and implement a boundary between immutable tracked evidence and mutable h
 - Re-run required checks to confirm rollback safety.
 
 ## Findings
+
+- Observation: The approved contract is already present on main from commit 77531d807; this recovery branch records task-local verification and PR evidence without adding a duplicate implementation diff.
+  Impact: Task can be closed against the existing implementation while preserving one-commit task artifact discipline.
+  Resolution: Recorded verification after targeted pr-meta/pr-flow/integrate tests passed.
+
+- Observation: PR #4034 carries task-local evidence only; no duplicate implementation diff is required because the tracked-head removal was merged earlier.
+  Impact: The backlog task can close without adding self-referential head metadata back into tracked artifacts.
+  Resolution: Proceed with one amended task evidence commit and hosted checks on PR #4034.

--- a/.agentplane/tasks/202605221727-7KQE04/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605221727-7KQE04/blueprint/resolved-snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605221727-7KQE04",
+    "title": "Split mutable hosted metadata from tracked evidence",
+    "description": "Move volatile PR/check/head metadata out of tracked task artifacts or make it computed live so evidence updates do not invalidate reviewed implementation commits.",
+    "tags": [
+      "code",
+      "git",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605221727-7KQE04",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "154387313e8f512cb84f4cd55f15ff66f7c6302a80d5879af33db073b91ae459"
+  }
+}

--- a/.agentplane/tasks/202605221727-7KQE04/pr/github-body.md
+++ b/.agentplane/tasks/202605221727-7KQE04/pr/github-body.md
@@ -1,0 +1,38 @@
+Task: `202605221727-7KQE04`
+Title: Split mutable hosted metadata from tracked evidence
+Canonical task record: `.agentplane/tasks/202605221727-7KQE04/README.md`
+
+## Summary
+
+Split mutable hosted metadata from tracked evidence
+
+Move volatile PR/check/head metadata out of tracked task artifacts or make it computed live so evidence updates do not invalidate reviewed implementation commits.
+
+## Scope
+
+- In scope: Move volatile PR/check/head metadata out of tracked task artifacts or make it computed live so evidence updates do not invalidate reviewed implementation commits.
+- Out of scope: unrelated refactors not required for "Split mutable hosted metadata from tracked evidence".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Verified: reviewed recovery closure for 7KQE04; implementation contract is already in main commit
+77531d807 and targeted PR metadata suites passed in this worktree.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-22T20:28:15.540Z
+- Branch: task/202605221727-7KQE04/hosted-metadata-split
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605221727-7KQE04/pr/github-title.txt
+++ b/.agentplane/tasks/202605221727-7KQE04/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 7KQE04 task: Split mutable hosted metadata from tracked evidence [202605221727-7KQE04]

--- a/.agentplane/tasks/202605221727-7KQE04/pr/meta.json
+++ b/.agentplane/tasks/202605221727-7KQE04/pr/meta.json
@@ -1,0 +1,17 @@
+{
+  "base": "main",
+  "branch": "task/202605221727-7KQE04/hosted-metadata-split",
+  "created_at": "2026-05-22T20:22:38.312Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": "2026-05-22T20:28:40.042Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "pr_number": 4034,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4034",
+  "schema_version": 1,
+  "status": "OPEN",
+  "task_id": "202605221727-7KQE04",
+  "updated_at": "2026-05-22T20:28:15.540Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605221727-7KQE04/pr/review.md
+++ b/.agentplane/tasks/202605221727-7KQE04/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-22T20:22:38.312Z
+
+## Task
+
+- Task: `202605221727-7KQE04`
+- Title: Split mutable hosted metadata from tracked evidence
+- Status: DOING
+- Branch: `task/202605221727-7KQE04/hosted-metadata-split`
+- Canonical task record: `.agentplane/tasks/202605221727-7KQE04/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified: reviewed recovery closure for 7KQE04; implementation contract is already in main commit 77531d807 and targeted PR metadata suites passed in this worktree.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-22T20:28:15.540Z
+- Branch: task/202605221727-7KQE04/hosted-metadata-split
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->


### PR DESCRIPTION
Task: `202605221727-7KQE04`
Title: Split mutable hosted metadata from tracked evidence
Canonical task record: `.agentplane/tasks/202605221727-7KQE04/README.md`

## Summary

Split mutable hosted metadata from tracked evidence

Move volatile PR/check/head metadata out of tracked task artifacts or make it computed live so evidence updates do not invalidate reviewed implementation commits.

## Scope

- In scope: Move volatile PR/check/head metadata out of tracked task artifacts or make it computed live so evidence updates do not invalidate reviewed implementation commits.
- Out of scope: unrelated refactors not required for "Split mutable hosted metadata from tracked evidence".

## Verification

- State: ok
- Note:

```text
Verified: PR metadata builders omit tracked live head SHA and use diffstat freshness; targeted PR
metadata tests pass against current main implementation commit 77531d807.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-22T20:22:38.312Z
- Branch: task/202605221727-7KQE04/hosted-metadata-split
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
No changes detected.
```

</details>
