### PR TITLE
🚧 N6CQ5A task: Add compact active task route summary [202605221726-N6CQ5A]

### DIFF
--- a/.agentplane/tasks/202605221726-N6CQ5A/README.md
+++ b/.agentplane/tasks/202605221726-N6CQ5A/README.md
@@ -1,10 +1,10 @@
 ---
 id: "202605221726-N6CQ5A"
 title: "Add compact active task route summary"
-status: "TODO"
+status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 4
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -23,17 +23,50 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-22T20:50:12.190Z"
+  updated_by: "EVALUATOR"
+  note: "Verified: reviewed active task route summary implementation; --all keeps full history, default listing stays active-only, SQLite projection status filtering is bounded, and full-fast local CI passed."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-22T20:50:12.190Z"
+  updated_by: "EVALUATOR"
+  note: "Verified: reviewed active task route summary implementation; --all keeps full history, default listing stays active-only, SQLite projection status filtering is bounded, and full-fast local CI passed."
+  evaluated_sha: "f5cdf07a0ee3ff13aa0fff0b397b86e8ebc67c49"
+  blueprint_digest: "619487b6e07fee9641f376c44b700d5a7959fb3c8f0d91424bbf0774a61fea50"
+  evidence_refs:
+    - ".agentplane/tasks/202605221726-N6CQ5A/README.md"
+    - "/Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221726-N6CQ5A-active-route-summary/.agentplane/tasks/202605221726-N6CQ5A/blueprint/resolved-snapshot.json"
+  findings: []
 commit: null
-comments: []
-events: []
+comments:
+  -
+    author: "CODER"
+    body: "Start: implementing compact active task route summary to avoid full historical startup scans while preserving explicit full listing access and route blockers."
+events:
+  -
+    type: "status"
+    at: "2026-05-22T20:36:46.543Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implementing compact active task route summary to avoid full historical startup scans while preserving explicit full listing access and route blockers."
+  -
+    type: "verify"
+    at: "2026-05-22T20:49:30.800Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: compact active task list defaults to active statuses with --all preserving historical output; SQLite projection hot path accepts status filters; targeted tests, typecheck, docs freshness, benchmark smoke, and full-fast local CI passed."
+  -
+    type: "verify"
+    at: "2026-05-22T20:50:12.190Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Verified: reviewed active task route summary implementation; --all keeps full history, default listing stays active-only, SQLite projection status filtering is bounded, and full-fast local CI passed."
 doc_version: 3
-doc_updated_at: "2026-05-22T17:27:51.395Z"
-doc_updated_by: "PLANNER"
+doc_updated_at: "2026-05-22T20:50:12.219Z"
+doc_updated_by: "CODER"
 description: "Make read-only startup and active-work inspection avoid full historical task scans by default while still surfacing anomalies, route blockers, and active branch_pr work."
 sections:
   Summary: |-
@@ -50,11 +83,56 @@ sections:
     3. Confirm full historical task listing remains available through an explicit option.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-22T20:49:30.800Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified: compact active task list defaults to active statuses with --all preserving historical output; SQLite projection hot path accepts status filters; targeted tests, typecheck, docs freshness, benchmark smoke, and full-fast local CI passed.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T20:36:46.543Z, excerpt_hash=sha256:844b2ba7bf78d67cfc6b3a321e6fb4cb32a7eb0e00c69f383e15370561066a7a
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221726-N6CQ5A-active-route-summary/.agentplane/tasks/202605221726-N6CQ5A/blueprint/resolved-snapshot.json
+    - old_digest: 619487b6e07fee9641f376c44b700d5a7959fb3c8f0d91424bbf0774a61fea50
+    - current_digest: 619487b6e07fee9641f376c44b700d5a7959fb3c8f0d91424bbf0774a61fea50
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605221726-N6CQ5A
+
+    ### 2026-05-22T20:50:12.190Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Verified: reviewed active task route summary implementation; --all keeps full history, default listing stays active-only, SQLite projection status filtering is bounded, and full-fast local CI passed.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T20:49:30.835Z, excerpt_hash=sha256:844b2ba7bf78d67cfc6b3a321e6fb4cb32a7eb0e00c69f383e15370561066a7a
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221726-N6CQ5A-active-route-summary/.agentplane/tasks/202605221726-N6CQ5A/blueprint/resolved-snapshot.json
+    - old_digest: 619487b6e07fee9641f376c44b700d5a7959fb3c8f0d91424bbf0774a61fea50
+    - current_digest: 619487b6e07fee9641f376c44b700d5a7959fb3c8f0d91424bbf0774a61fea50
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605221726-N6CQ5A
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
     - Re-run required checks to confirm rollback safety.
-  Findings: ""
+  Findings: |-
+    - Observation: Default task list now returns the active route surface only; explicit --all returns the 2799-line historical list in this checkout.
+      Impact: Startup and agent handoff context avoid flooding agents with DONE history while preserving full audit access.
+      Resolution: Implemented active-status projection filters, updated CLI docs, moved the new regression test into a dedicated file to keep oversized baselines stable, and verified with focused plus full-fast checks.
+
+    - Observation: The implementation preserves explicit historical audit access while shrinking default agent startup output.
+      Impact: The change unblocks downstream agent context tasks and reduces repeated active-work inspection noise.
+      Resolution: Proceed with amended one-commit PR #4036 and hosted checks.
 id_source: "generated"
 ---
 ## Summary
@@ -81,6 +159,44 @@ Add a compact active route summary for task list/startup surfaces. Keep full his
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-22T20:49:30.800Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: compact active task list defaults to active statuses with --all preserving historical output; SQLite projection hot path accepts status filters; targeted tests, typecheck, docs freshness, benchmark smoke, and full-fast local CI passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T20:36:46.543Z, excerpt_hash=sha256:844b2ba7bf78d67cfc6b3a321e6fb4cb32a7eb0e00c69f383e15370561066a7a
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221726-N6CQ5A-active-route-summary/.agentplane/tasks/202605221726-N6CQ5A/blueprint/resolved-snapshot.json
+- old_digest: 619487b6e07fee9641f376c44b700d5a7959fb3c8f0d91424bbf0774a61fea50
+- current_digest: 619487b6e07fee9641f376c44b700d5a7959fb3c8f0d91424bbf0774a61fea50
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605221726-N6CQ5A
+
+### 2026-05-22T20:50:12.190Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Verified: reviewed active task route summary implementation; --all keeps full history, default listing stays active-only, SQLite projection status filtering is bounded, and full-fast local CI passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T20:49:30.835Z, excerpt_hash=sha256:844b2ba7bf78d67cfc6b3a321e6fb4cb32a7eb0e00c69f383e15370561066a7a
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221726-N6CQ5A-active-route-summary/.agentplane/tasks/202605221726-N6CQ5A/blueprint/resolved-snapshot.json
+- old_digest: 619487b6e07fee9641f376c44b700d5a7959fb3c8f0d91424bbf0774a61fea50
+- current_digest: 619487b6e07fee9641f376c44b700d5a7959fb3c8f0d91424bbf0774a61fea50
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605221726-N6CQ5A
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -89,3 +205,11 @@ Add a compact active route summary for task list/startup surfaces. Keep full his
 - Re-run required checks to confirm rollback safety.
 
 ## Findings
+
+- Observation: Default task list now returns the active route surface only; explicit --all returns the 2799-line historical list in this checkout.
+  Impact: Startup and agent handoff context avoid flooding agents with DONE history while preserving full audit access.
+  Resolution: Implemented active-status projection filters, updated CLI docs, moved the new regression test into a dedicated file to keep oversized baselines stable, and verified with focused plus full-fast checks.
+
+- Observation: The implementation preserves explicit historical audit access while shrinking default agent startup output.
+  Impact: The change unblocks downstream agent context tasks and reduces repeated active-work inspection noise.
+  Resolution: Proceed with amended one-commit PR #4036 and hosted checks.

--- a/.agentplane/tasks/202605221726-N6CQ5A/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605221726-N6CQ5A/blueprint/resolved-snapshot.json
@@ -1,0 +1,595 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605221726-N6CQ5A",
+    "title": "Add compact active task route summary",
+    "description": "Make read-only startup and active-work inspection avoid full historical task scans by default while still surfacing anomalies, route blockers, and active branch_pr work.",
+    "tags": [
+      "cli",
+      "code",
+      "performance",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "performance.benchmark",
+    "version": 1,
+    "title": "Performance benchmark",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "performance.benchmark",
+    "blueprintVersion": 1,
+    "title": "Performance benchmark",
+    "taskId": "202605221726-N6CQ5A",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to performance.benchmark",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "artifact"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "final_output"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "benchmark.baseline",
+        "kind": "artifact",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Baseline measurement artifact."
+      },
+      {
+        "id": "benchmark.method",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Benchmark method, environment, and warm/cold mode."
+      },
+      {
+        "id": "benchmark.runs",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Run count and raw measurement results."
+      },
+      {
+        "id": "benchmark.threshold",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Accepted threshold or noise tolerance."
+      },
+      {
+        "id": "benchmark.comparison",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Before/after comparison result."
+      },
+      {
+        "id": "benchmark.verdict",
+        "kind": "final_output",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Faster, slower, unchanged, or noisy verdict."
+      },
+      {
+        "id": "benchmark.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "benchmark.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "benchmark baseline command",
+      "benchmark comparison command",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Benchmark work needs normal branch_pr code policy plus room for baseline and comparison artifacts."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "artifact"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "final_output"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "benchmark.baseline",
+      "kind": "artifact",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Baseline measurement artifact."
+    },
+    {
+      "id": "benchmark.method",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Benchmark method, environment, and warm/cold mode."
+    },
+    {
+      "id": "benchmark.runs",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Run count and raw measurement results."
+    },
+    {
+      "id": "benchmark.threshold",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Accepted threshold or noise tolerance."
+    },
+    {
+      "id": "benchmark.comparison",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Before/after comparison result."
+    },
+    {
+      "id": "benchmark.verdict",
+      "kind": "final_output",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Faster, slower, unchanged, or noisy verdict."
+    },
+    {
+      "id": "benchmark.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "benchmark.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "benchmark baseline command",
+    "benchmark comparison command",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Benchmark work needs normal branch_pr code policy plus room for baseline and comparison artifacts."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to performance.benchmark",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "619487b6e07fee9641f376c44b700d5a7959fb3c8f0d91424bbf0774a61fea50"
+  }
+}

--- a/.agentplane/tasks/202605221726-N6CQ5A/pr/diffstat.txt
+++ b/.agentplane/tasks/202605221726-N6CQ5A/pr/diffstat.txt
@@ -1,0 +1,12 @@
+ docs/user/cli-reference.generated.mdx              | 11 +++-
+ .../backends/task-backend/local-backend-read.ts    | 45 +++++++++++----
+ .../src/backends/task-backend/local-backend.ts     |  3 +-
+ .../task-backend/local-task-sqlite-cache.ts        | 23 +++++++-
+ .../src/backends/task-backend/shared/types.ts      |  6 +-
+ .../run-cli.core.tasks.list-active-summary.test.ts | 66 ++++++++++++++++++++++
+ .../agentplane/src/commands/shared/task-backend.ts | 19 ++++++-
+ packages/agentplane/src/commands/task/list.spec.ts | 12 +++-
+ packages/agentplane/src/commands/task/list.ts      | 34 ++++++++++-
+ .../src/commands/task/shared.unit.test.ts          |  2 +
+ .../agentplane/src/commands/task/shared/listing.ts | 14 ++++-
+ 11 files changed, 210 insertions(+), 25 deletions(-)

--- a/.agentplane/tasks/202605221726-N6CQ5A/pr/github-body.md
+++ b/.agentplane/tasks/202605221726-N6CQ5A/pr/github-body.md
@@ -1,0 +1,50 @@
+Task: `202605221726-N6CQ5A`
+Title: Add compact active task route summary
+Canonical task record: `.agentplane/tasks/202605221726-N6CQ5A/README.md`
+
+## Summary
+
+Add compact active task route summary
+
+Make read-only startup and active-work inspection avoid full historical task scans by default while still surfacing anomalies, route blockers, and active branch_pr work.
+
+## Scope
+
+- In scope: Make read-only startup and active-work inspection avoid full historical task scans by default while still surfacing anomalies, route blockers, and active branch_pr work.
+- Out of scope: unrelated refactors not required for "Add compact active task route summary".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Verified: reviewed active task route summary implementation; --all keeps full history, default
+listing stays active-only, SQLite projection status filtering is bounded, and full-fast local CI
+passed.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-22T20:50:01.283Z
+- Branch: task/202605221726-N6CQ5A/active-route-summary
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ docs/user/cli-reference.generated.mdx              | 11 +++-
+ .../backends/task-backend/local-backend-read.ts    | 45 +++++++++++----
+ .../src/backends/task-backend/local-backend.ts     |  3 +-
+ .../task-backend/local-task-sqlite-cache.ts        | 23 +++++++-
+ .../src/backends/task-backend/shared/types.ts      |  6 +-
+ .../run-cli.core.tasks.list-active-summary.test.ts | 66 ++++++++++++++++++++++
+ .../agentplane/src/commands/shared/task-backend.ts | 19 ++++++-
+ packages/agentplane/src/commands/task/list.spec.ts | 12 +++-
+ packages/agentplane/src/commands/task/list.ts      | 34 ++++++++++-
+ .../src/commands/task/shared.unit.test.ts          |  2 +
+ .../agentplane/src/commands/task/shared/listing.ts | 14 ++++-
+ 11 files changed, 210 insertions(+), 25 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605221726-N6CQ5A/pr/github-title.txt
+++ b/.agentplane/tasks/202605221726-N6CQ5A/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 N6CQ5A task: Add compact active task route summary [202605221726-N6CQ5A]

--- a/.agentplane/tasks/202605221726-N6CQ5A/pr/meta.json
+++ b/.agentplane/tasks/202605221726-N6CQ5A/pr/meta.json
@@ -1,0 +1,17 @@
+{
+  "base": "main",
+  "branch": "task/202605221726-N6CQ5A/active-route-summary",
+  "created_at": "2026-05-22T20:36:46.619Z",
+  "diffstat_sha256": "sha256:4b35e337d370bc4fe8e6b9095e472ec14b58f5ef6fff0aff646d43225d9c019c",
+  "last_verified_at": "2026-05-22T20:50:12.190Z",
+  "last_verified_diffstat_sha256": "sha256:4b35e337d370bc4fe8e6b9095e472ec14b58f5ef6fff0aff646d43225d9c019c",
+  "pr_number": 4036,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4036",
+  "schema_version": 1,
+  "status": "OPEN",
+  "task_id": "202605221726-N6CQ5A",
+  "updated_at": "2026-05-22T20:50:01.283Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605221726-N6CQ5A/pr/review.md
+++ b/.agentplane/tasks/202605221726-N6CQ5A/pr/review.md
@@ -1,0 +1,47 @@
+# PR Review
+
+Created: 2026-05-22T20:36:46.619Z
+
+## Task
+
+- Task: `202605221726-N6CQ5A`
+- Title: Add compact active task route summary
+- Status: DOING
+- Branch: `task/202605221726-N6CQ5A/active-route-summary`
+- Canonical task record: `.agentplane/tasks/202605221726-N6CQ5A/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified: reviewed active task route summary implementation; --all keeps full history, default listing stays active-only, SQLite projection status filtering is bounded, and full-fast local CI passed.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-22T20:50:01.283Z
+- Branch: task/202605221726-N6CQ5A/active-route-summary
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ docs/user/cli-reference.generated.mdx              | 11 +++-
+ .../backends/task-backend/local-backend-read.ts    | 45 +++++++++++----
+ .../src/backends/task-backend/local-backend.ts     |  3 +-
+ .../task-backend/local-task-sqlite-cache.ts        | 23 +++++++-
+ .../src/backends/task-backend/shared/types.ts      |  6 +-
+ .../run-cli.core.tasks.list-active-summary.test.ts | 66 ++++++++++++++++++++++
+ .../agentplane/src/commands/shared/task-backend.ts | 19 ++++++-
+ packages/agentplane/src/commands/task/list.spec.ts | 12 +++-
+ packages/agentplane/src/commands/task/list.ts      | 34 ++++++++++-
+ .../src/commands/task/shared.unit.test.ts          |  2 +
+ .../agentplane/src/commands/task/shared/listing.ts | 14 ++++-
+ 11 files changed, 210 insertions(+), 25 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -490,7 +490,7 @@ agentplane task doc show 202602030608-F1Q8AB --section Summary
 
 ### task list
 
-List tasks with compact resolved blueprint route hints.
+List active tasks with compact resolved blueprint route hints.
 
 Usage:
 
@@ -500,6 +500,7 @@ agentplane task list [options]
 
 Options:
 
+- `--all`: Include historical DONE tasks instead of the default active-task view. (default=false)
 - `--status <status>`: Repeatable. Filter by status. (repeatable)
 - `--owner <owner>`: Repeatable. Filter by owner id. (repeatable)
 - `--tag <tag>`: Repeatable. Filter by tag. (repeatable)
@@ -513,7 +514,13 @@ Examples:
 agentplane task list
 ```
 
-- List all tasks.
+- List active tasks.
+
+```sh
+agentplane task list --all
+```
+
+- List all historical tasks.
 
 ```sh
 agentplane task list --status TODO --owner CODER

--- a/packages/agentplane/src/backends/task-backend/local-backend-read.ts
+++ b/packages/agentplane/src/backends/task-backend/local-backend-read.ts
@@ -73,12 +73,23 @@ async function readRequiredTask(context: LocalBackendContext, taskId: string): P
   });
 }
 
-function sortedCachedProjection(cachedIndex: {
-  byId: Record<string, TaskIndexEntry>;
-}): TaskSummary[] {
+function sortedCachedProjection(
+  cachedIndex: { byId: Record<string, TaskIndexEntry> },
+  statuses?: ReadonlySet<string>,
+): TaskSummary[] {
   return Object.values(cachedIndex.byId)
     .map((entry) => entry.task)
+    .filter((task) => !statuses || statuses.has(String(task.status).trim().toUpperCase()))
     .toSorted((a, b) => a.id.localeCompare(b.id));
+}
+
+function normalizeProjectionStatusFilter(statuses?: readonly string[]): Set<string> | undefined {
+  const normalized = new Set(
+    (statuses ?? [])
+      .map((status) => status.trim().toUpperCase())
+      .filter((status) => status.length > 0),
+  );
+  return normalized.size > 0 ? normalized : undefined;
 }
 
 type ReadmeStatEntry = {
@@ -104,22 +115,27 @@ function readFreshCachedProjection(opts: {
   cachedIndex: Awaited<ReturnType<typeof loadTaskIndex>>;
   fingerprint: TaskIndexReadmeFingerprint;
   hasMissingReadmes: boolean;
+  statuses?: ReadonlySet<string>;
 }): TaskSummary[] | null {
   if (!opts.cachedIndex) return null;
   if (opts.hasMissingReadmes) return null;
   if (!taskReadmeFingerprintEquals(opts.cachedIndex.readmes, opts.fingerprint)) return null;
-  return sortedCachedProjection(opts.cachedIndex);
+  return sortedCachedProjection(opts.cachedIndex, opts.statuses);
 }
 
 export async function listLocalTasks(
   context: LocalBackendContext,
   mode: "full" | "projection",
-  opts: { writeIndex?: boolean } = {},
+  opts: { writeIndex?: boolean; status?: readonly string[] } = {},
 ): Promise<TaskData[] | TaskSummary[]> {
   const projectionOnly = mode === "projection";
   const writeIndex = opts.writeIndex ?? true;
+  const projectionStatuses = normalizeProjectionStatusFilter(opts.status);
   if (projectionOnly) {
-    const sqliteProjection = await readFreshSqliteTaskProjection({ tasksDir: context.root });
+    const sqliteProjection = await readFreshSqliteTaskProjection({
+      tasksDir: context.root,
+      status: opts.status,
+    });
     if (sqliteProjection) {
       context.setLastListWarnings?.([]);
       return sqliteProjection;
@@ -163,13 +179,16 @@ export async function listLocalTasks(
       cachedIndex,
       fingerprint: readmeFingerprint,
       hasMissingReadmes,
+      statuses: projectionStatuses,
     });
     if (cachedProjection) {
-      await writeSqliteTaskProjection({
-        tasksDir: context.root,
-        tasks: cachedProjection,
-        fingerprintEntries: readmeFingerprint.entries,
-      });
+      if (!projectionStatuses) {
+        await writeSqliteTaskProjection({
+          tasksDir: context.root,
+          tasks: cachedProjection,
+          fingerprintEntries: readmeFingerprint.entries,
+        });
+      }
       context.setLastListWarnings?.([]);
       return cachedProjection;
     }
@@ -301,7 +320,9 @@ export async function listLocalTasks(
   }
 
   context.setLastListWarnings?.(warnings);
-  return tasks;
+  return projectionOnly && projectionStatuses
+    ? tasks.filter((task) => projectionStatuses.has(String(task.status).trim().toUpperCase()))
+    : tasks;
 }
 
 export async function getLocalTask(

--- a/packages/agentplane/src/backends/task-backend/local-backend.ts
+++ b/packages/agentplane/src/backends/task-backend/local-backend.ts
@@ -65,9 +65,10 @@ export class LocalBackend implements TaskBackend {
     return (await listLocalTasks(this.backendContext(), "full")) as TaskData[];
   }
 
-  async listProjectionTasks(): Promise<TaskSummary[]> {
+  async listProjectionTasks(opts?: { status?: readonly string[] }): Promise<TaskSummary[]> {
     return (await listLocalTasks(this.backendContext(), "projection", {
       writeIndex: false,
+      status: opts?.status,
     })) as TaskSummary[];
   }
 

--- a/packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.ts
+++ b/packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.ts
@@ -308,6 +308,7 @@ function parseTaskSummaryPayload(value: unknown): TaskSummary | null {
 export async function readFreshSqliteTaskProjection(opts: {
   tasksDir: string;
   fingerprintEntries?: readonly { path: string; mtimeMs: number; size: number }[];
+  status?: readonly string[];
 }): Promise<TaskSummary[] | null> {
   const dbPath = resolveTaskProjectionSqlitePath(opts.tasksDir);
   if (!existsSync(dbPath)) return null;
@@ -326,9 +327,25 @@ export async function readFreshSqliteTaskProjection(opts: {
       .get(TASK_SQLITE_CACHE_OWNER) as TaskProjectionMetadataRow | undefined;
     if (!metadataMatches(row, opts.tasksDir, cacheKey)) return null;
 
-    const rows = db
-      .prepare("SELECT payload_json FROM task_projection_summary ORDER BY id")
-      .all() as TaskProjectionRow[];
+    const statuses = [
+      ...new Set(
+        (opts.status ?? [])
+          .map((status) => status.trim().toUpperCase())
+          .filter((status) => status.length > 0),
+      ),
+    ];
+    const rows =
+      statuses.length > 0
+        ? (db
+            .prepare(
+              `SELECT payload_json FROM task_projection_summary WHERE status IN (${statuses
+                .map(() => "?")
+                .join(", ")}) ORDER BY id`,
+            )
+            .all(...statuses) as TaskProjectionRow[])
+        : (db
+            .prepare("SELECT payload_json FROM task_projection_summary ORDER BY id")
+            .all() as TaskProjectionRow[]);
     const tasks: TaskSummary[] = [];
     for (const item of rows) {
       const task = parseTaskSummaryPayload(item.payload_json);

--- a/packages/agentplane/src/backends/task-backend/shared/types.ts
+++ b/packages/agentplane/src/backends/task-backend/shared/types.ts
@@ -199,7 +199,7 @@ export type TaskBackendQueryPort = {
 };
 
 export type TaskBackendProjectionPort = {
-  listProjectionTasks?(): Promise<TaskSummary[]>;
+  listProjectionTasks?(opts?: { status?: readonly string[] }): Promise<TaskSummary[]>;
   getLastListWarnings?(): string[];
 };
 

--- a/packages/agentplane/src/cli/run-cli.core.tasks.list-active-summary.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.tasks.list-active-summary.test.ts
@@ -1,0 +1,108 @@
+import { describe } from "vitest";
+
+import {
+  captureStdIO,
+  expect,
+  it,
+  mkGitRepoRoot,
+  runCli,
+  seedTaskQueryFixture,
+  useRunCliIntegrationHarness,
+} from "@agentplane/testkit/cli-core-tasks-query";
+
+useRunCliIntegrationHarness();
+
+describe("runCli task list active summary", () => {
+  it("defaults to active tasks and keeps full history behind --all", async () => {
+    const root = await mkGitRepoRoot();
+    await seedTaskQueryFixture(root, [
+      {
+        id: "202603010300-AAAAAA",
+        title: "Active task",
+        description: "Visible by default",
+        status: "TODO",
+        priority: "med",
+        owner: "CODER",
+        depends_on: [],
+        tags: ["docs"],
+        verify: [],
+      },
+      {
+        id: "202603010301-BBBBBB",
+        title: "Closed task",
+        description: "Historical task",
+        status: "DONE",
+        priority: "med",
+        owner: "CODER",
+        depends_on: [],
+        tags: ["docs"],
+        verify: [],
+        commit: { hash: "abcdef1", message: "close task" },
+      },
+    ]);
+
+    const activeIo = captureStdIO();
+    try {
+      const code = await runCli(["task", "list", "--root", root]);
+      expect(code).toBe(0);
+      expect(activeIo.stdout).toContain("202603010300-AAAAAA");
+      expect(activeIo.stdout).not.toContain("202603010301-BBBBBB");
+      expect(activeIo.stdout).toContain("Total: 1 (TODO=1)");
+    } finally {
+      activeIo.restore();
+    }
+
+    const allIo = captureStdIO();
+    try {
+      const code = await runCli(["task", "list", "--all", "--root", root]);
+      expect(code).toBe(0);
+      expect(allIo.stdout).toContain("202603010300-AAAAAA");
+      expect(allIo.stdout).toContain("202603010301-BBBBBB");
+      expect(allIo.stdout).toContain("Total: 2 (DONE=1, TODO=1)");
+    } finally {
+      allIo.restore();
+    }
+  });
+
+  it("keeps DONE dependencies available while hiding historical tasks by default", async () => {
+    const root = await mkGitRepoRoot();
+    await seedTaskQueryFixture(root, [
+      {
+        id: "202603010400-AAAAAA",
+        title: "Active task",
+        description: "Depends on completed work",
+        status: "TODO",
+        priority: "med",
+        owner: "CODER",
+        depends_on: ["202603010401-BBBBBB"],
+        tags: ["docs"],
+        verify: [],
+      },
+      {
+        id: "202603010401-BBBBBB",
+        title: "Closed dependency",
+        description: "Historical dependency",
+        status: "DONE",
+        priority: "med",
+        owner: "CODER",
+        depends_on: [],
+        tags: ["docs"],
+        verify: [],
+        commit: { hash: "abcdef1", message: "close dependency" },
+      },
+    ]);
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["task", "list", "--root", root]);
+      expect(code).toBe(0);
+      expect(io.stdout).toContain("202603010400-AAAAAA");
+      expect(io.stdout).toContain("deps=ready");
+      expect(io.stdout).not.toContain("202603010401-BBBBBB");
+      expect(io.stdout).not.toContain("missing:202603010401-BBBBBB");
+      expect(io.stdout).toContain("Total: 1 (TODO=1)");
+    } finally {
+      io.restore();
+    }
+  });
+});

--- a/packages/agentplane/src/commands/shared/task-backend.ts
+++ b/packages/agentplane/src/commands/shared/task-backend.ts
@@ -272,7 +272,24 @@ export async function writeTasksOrFallback(
   }
 }
 
-export async function listTaskSummariesMemo(ctx: CommandContext): Promise<TaskSummary[]> {
+export async function listTaskSummariesMemo(
+  ctx: CommandContext,
+  opts: { projectionStatus?: readonly string[] } = {},
+): Promise<TaskSummary[]> {
+  if (
+    opts.projectionStatus &&
+    opts.projectionStatus.length > 0 &&
+    ctx.taskBackend.capabilities?.projection_read_mode === "native"
+  ) {
+    if (!ctx.taskBackend.listProjectionTasks) {
+      throw new CliError({
+        exitCode: 1,
+        code: "E_INTERNAL",
+        message: `Backend ${ctx.taskBackend.id} advertises native projection reads but does not implement listProjectionTasks()`,
+      });
+    }
+    return await ctx.taskBackend.listProjectionTasks({ status: opts.projectionStatus });
+  }
   ctx.memo.taskProjection ??= (async () => {
     if (ctx.taskBackend.capabilities?.projection_read_mode === "native") {
       if (!ctx.taskBackend.listProjectionTasks) {

--- a/packages/agentplane/src/commands/task/list.spec.ts
+++ b/packages/agentplane/src/commands/task/list.spec.ts
@@ -9,8 +9,14 @@ export type TaskListParsed = { filters: TaskListFilters };
 export const taskListSpec: CommandSpec<TaskListParsed> = {
   id: ["task", "list"],
   group: "Task",
-  summary: "List tasks with compact resolved blueprint route hints.",
+  summary: "List active tasks with compact resolved blueprint route hints.",
   options: [
+    {
+      kind: "boolean",
+      name: "all",
+      default: false,
+      description: "Include historical DONE tasks instead of the default active-task view.",
+    },
     {
       kind: "string",
       name: "status",
@@ -42,7 +48,8 @@ export const taskListSpec: CommandSpec<TaskListParsed> = {
     { kind: "boolean", name: "quiet", default: false, description: "Suppress summary output." },
   ],
   examples: [
-    { cmd: "agentplane task list", why: "List all tasks." },
+    { cmd: "agentplane task list", why: "List active tasks." },
+    { cmd: "agentplane task list --all", why: "List all historical tasks." },
     { cmd: "agentplane task list --status TODO --owner CODER", why: "List filtered tasks." },
   ],
   validateRaw: (raw) => {
@@ -76,6 +83,7 @@ export const taskListSpec: CommandSpec<TaskListParsed> = {
       tag: toStringList(raw.opts.tag),
       limit: typeof raw.opts.limit === "string" ? Number.parseInt(raw.opts.limit, 10) : undefined,
       quiet: raw.opts.quiet === true,
+      all: raw.opts.all === true,
       strictRead: raw.opts["strict-read"] === true,
     },
   }),

--- a/packages/agentplane/src/commands/task/list.ts
+++ b/packages/agentplane/src/commands/task/list.ts
@@ -20,6 +20,32 @@ import {
 } from "./blueprint-summary.js";
 import { annotateBranchPrTaskListState, taskListStatusKey } from "./shared/branch-pr-list-state.js";
 
+const DEFAULT_ACTIVE_TASK_LIST_STATUSES = [
+  "TODO",
+  "DOING",
+  "BLOCKED",
+  "MERGED_PENDING_CLOSE",
+] as const;
+
+function resolveProjectionStatusesForList(filters: TaskListFilters): string[] | undefined {
+  if (filters.all && filters.status.length === 0) return undefined;
+  const requested = filters.status.length > 0 ? filters.status : DEFAULT_ACTIVE_TASK_LIST_STATUSES;
+  const statuses = new Set<string>();
+  for (const status of requested) {
+    const normalized = status.trim().toUpperCase();
+    if (!normalized) continue;
+    if (normalized === "MERGED_PENDING_CLOSE") {
+      statuses.add("TODO");
+      statuses.add("DOING");
+      statuses.add("BLOCKED");
+      continue;
+    }
+    statuses.add(normalized);
+  }
+  if (statuses.size > 0) statuses.add("DONE");
+  return statuses.size > 0 ? [...statuses] : undefined;
+}
+
 export async function warnIfLocalTaskStateBehindUpstream(ctx: CommandContext): Promise<void> {
   try {
     const branch = await gitCurrentBranch(ctx.resolvedProject.gitRoot);
@@ -47,13 +73,18 @@ export async function cmdTaskListWithFilters(opts: {
     const ctx =
       opts.ctx ??
       (await loadCommandContext({ cwd: opts.cwd, rootOverride: opts.rootOverride ?? null }));
+    const projectionStatus = resolveProjectionStatusesForList(opts.filters);
     const tasks = await annotateBranchPrTaskListState({
       ctx,
-      tasks: await listTaskSummariesMemo(ctx),
+      tasks: await listTaskSummariesMemo(ctx, { projectionStatus }),
     });
     await warnIfLocalTaskStateBehindUpstream(ctx);
     handleTaskListWarnings({ backend: ctx.taskBackend, strictRead: opts.filters.strictRead });
-    const { depState, items } = queryTaskProjection({ tasks, filters: opts.filters });
+    const { depState, items } = queryTaskProjection({
+      tasks,
+      filters: opts.filters,
+      defaultStatuses: opts.filters.all ? undefined : [...DEFAULT_ACTIVE_TASK_LIST_STATUSES],
+    });
     const resolveBlueprint = await createTaskBlueprintLifecycleResolver({
       config: ctx.config,
       projectRoot: ctx.resolvedProject.gitRoot,

--- a/packages/agentplane/src/commands/task/shared.unit.test.ts
+++ b/packages/agentplane/src/commands/task/shared.unit.test.ts
@@ -544,9 +544,11 @@ describe("task shared helpers", () => {
       owner: ["me"],
       tag: ["x"],
       quiet: true,
+      all: false,
       strictRead: false,
     });
 
+    expect(parseTaskListFilters(["--all"]).all).toBe(true);
     expect(parseTaskListFilters(["--strict-read"]).strictRead).toBe(true);
     expect(() => parseTaskListFilters(["--status"])).toThrow(CliError);
     expect(() => parseTaskListFilters(["--owner"])).toThrow(CliError);

--- a/packages/agentplane/src/commands/task/shared/listing.ts
+++ b/packages/agentplane/src/commands/task/shared/listing.ts
@@ -15,6 +15,7 @@ export type TaskListFilters = {
   tag: string[];
   limit?: number;
   quiet: boolean;
+  all?: boolean;
   strictRead?: boolean;
 };
 
@@ -22,12 +23,23 @@ export function parseTaskListFilters(
   args: string[],
   opts?: { allowLimit?: boolean },
 ): TaskListFilters {
-  const out: TaskListFilters = { status: [], owner: [], tag: [], quiet: false, strictRead: false };
+  const out: TaskListFilters = {
+    status: [],
+    owner: [],
+    tag: [],
+    quiet: false,
+    all: false,
+    strictRead: false,
+  };
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (!arg) continue;
     if (arg === "--quiet") {
       out.quiet = true;
+      continue;
+    }
+    if (arg === "--all") {
+      out.all = true;
       continue;
     }
     if (arg === "--strict-read") {


### PR DESCRIPTION
Task: `202605221726-N6CQ5A`
Title: Add compact active task route summary
Canonical task record: `.agentplane/tasks/202605221726-N6CQ5A/README.md`

## Summary

Add compact active task route summary

Make read-only startup and active-work inspection avoid full historical task scans by default while still surfacing anomalies, route blockers, and active branch_pr work.

## Scope

- In scope: Make read-only startup and active-work inspection avoid full historical task scans by default while still surfacing anomalies, route blockers, and active branch_pr work.
- Out of scope: unrelated refactors not required for "Add compact active task route summary".

## Verification

- State: ok
- Note:

```text
Verified: compact active task list defaults to active statuses with --all preserving historical
output; SQLite projection hot path accepts status filters; targeted tests, typecheck, docs
freshness, benchmark smoke, and full-fast local CI passed.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-22T20:36:46.619Z
- Branch: task/202605221726-N6CQ5A/active-route-summary
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 docs/user/cli-reference.generated.mdx              | 11 +++-
 .../backends/task-backend/local-backend-read.ts    | 45 +++++++++++----
 .../src/backends/task-backend/local-backend.ts     |  3 +-
 .../task-backend/local-task-sqlite-cache.ts        | 23 +++++++-
 .../src/backends/task-backend/shared/types.ts      |  6 +-
 .../run-cli.core.tasks.list-active-summary.test.ts | 66 ++++++++++++++++++++++
 .../agentplane/src/commands/shared/task-backend.ts | 19 ++++++-
 packages/agentplane/src/commands/task/list.spec.ts | 12 +++-
 packages/agentplane/src/commands/task/list.ts      | 34 ++++++++++-
 .../src/commands/task/shared.unit.test.ts          |  2 +
 .../agentplane/src/commands/task/shared/listing.ts | 14 ++++-
 11 files changed, 210 insertions(+), 25 deletions(-)
```

</details>
