### PR TITLE
🚧 4FGDND task: Add integration queue stale handoff recovery [202605221726-4FGDND]

### DIFF
--- a/.agentplane/tasks/202605221726-4FGDND/README.md
+++ b/.agentplane/tasks/202605221726-4FGDND/README.md
@@ -1,10 +1,10 @@
 ---
 id: "202605221726-4FGDND"
 title: "Add integration queue stale handoff recovery"
-status: "TODO"
+status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 4
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -22,17 +22,50 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-22T22:05:16.211Z"
+  updated_by: "EVALUATOR"
+  note: "Evaluator check: recovery is bounded to provider-terminal states; OPEN provider PRs are retained, MERGED waits for close-tail evidence, and CLOSED/not_found become rework instead of being silently released."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-22T22:05:16.211Z"
+  updated_by: "EVALUATOR"
+  note: "Evaluator check: recovery is bounded to provider-terminal states; OPEN provider PRs are retained, MERGED waits for close-tail evidence, and CLOSED/not_found become rework instead of being silently released."
+  evaluated_sha: "e1c9780a32dccac41b01e8989ae970b547bfa5c5"
+  blueprint_digest: "46b46ca09503dfa2e2e14c248c3c27ebdd91e9cd5de3c1def7899312f2a2bd56"
+  evidence_refs:
+    - ".agentplane/tasks/202605221726-4FGDND/README.md"
+    - "/Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221726-4FGDND-integration-queue-handoff-recovery/.agentplane/tasks/202605221726-4FGDND/blueprint/resolved-snapshot.json"
+  findings: []
 commit: null
-comments: []
-events: []
+comments:
+  -
+    author: "CODER"
+    body: "Start: adding bounded stale handoff recovery for integration queue provider states."
+events:
+  -
+    type: "status"
+    at: "2026-05-22T22:00:49.354Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: adding bounded stale handoff recovery for integration queue provider states."
+  -
+    type: "verify"
+    at: "2026-05-22T22:05:04.828Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified integration queue recovery decisions: stale claimed/handoff lanes recover only for terminal provider states, live OPEN PR lanes stay occupied, targeted queue tests pass, and typecheck/lint/docs/knip/bootstrap are green."
+  -
+    type: "verify"
+    at: "2026-05-22T22:05:16.211Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Evaluator check: recovery is bounded to provider-terminal states; OPEN provider PRs are retained, MERGED waits for close-tail evidence, and CLOSED/not_found become rework instead of being silently released."
 doc_version: 3
-doc_updated_at: "2026-05-22T17:27:53.354Z"
-doc_updated_by: "PLANNER"
+doc_updated_at: "2026-05-22T22:05:16.239Z"
+doc_updated_by: "CODER"
 description: "Detect and recover integration queue entries stuck in claimed or handoff when the provider PR is already merged, closed, missing, or blocked by stale metadata."
 sections:
   Summary: |-
@@ -49,6 +82,44 @@ sections:
     3. Confirm live active PRs are not auto-released from the queue.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-22T22:05:04.828Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified integration queue recovery decisions: stale claimed/handoff lanes recover only for terminal provider states, live OPEN PR lanes stay occupied, targeted queue tests pass, and typecheck/lint/docs/knip/bootstrap are green.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T22:00:49.354Z, excerpt_hash=sha256:987ba39221120300ead3df35598c843a4f7a535cf93250348066a9f95b3b1df2
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221726-4FGDND-integration-queue-handoff-recovery/.agentplane/tasks/202605221726-4FGDND/blueprint/resolved-snapshot.json
+    - old_digest: 46b46ca09503dfa2e2e14c248c3c27ebdd91e9cd5de3c1def7899312f2a2bd56
+    - current_digest: 46b46ca09503dfa2e2e14c248c3c27ebdd91e9cd5de3c1def7899312f2a2bd56
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605221726-4FGDND
+
+    ### 2026-05-22T22:05:16.211Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Evaluator check: recovery is bounded to provider-terminal states; OPEN provider PRs are retained, MERGED waits for close-tail evidence, and CLOSED/not_found become rework instead of being silently released.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T22:05:04.854Z, excerpt_hash=sha256:987ba39221120300ead3df35598c843a4f7a535cf93250348066a9f95b3b1df2
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221726-4FGDND-integration-queue-handoff-recovery/.agentplane/tasks/202605221726-4FGDND/blueprint/resolved-snapshot.json
+    - old_digest: 46b46ca09503dfa2e2e14c248c3c27ebdd91e9cd5de3c1def7899312f2a2bd56
+    - current_digest: 46b46ca09503dfa2e2e14c248c3c27ebdd91e9cd5de3c1def7899312f2a2bd56
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605221726-4FGDND
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -80,6 +151,44 @@ Add bounded stale-handoff classification and recovery guidance for the branch_pr
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-22T22:05:04.828Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified integration queue recovery decisions: stale claimed/handoff lanes recover only for terminal provider states, live OPEN PR lanes stay occupied, targeted queue tests pass, and typecheck/lint/docs/knip/bootstrap are green.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T22:00:49.354Z, excerpt_hash=sha256:987ba39221120300ead3df35598c843a4f7a535cf93250348066a9f95b3b1df2
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221726-4FGDND-integration-queue-handoff-recovery/.agentplane/tasks/202605221726-4FGDND/blueprint/resolved-snapshot.json
+- old_digest: 46b46ca09503dfa2e2e14c248c3c27ebdd91e9cd5de3c1def7899312f2a2bd56
+- current_digest: 46b46ca09503dfa2e2e14c248c3c27ebdd91e9cd5de3c1def7899312f2a2bd56
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605221726-4FGDND
+
+### 2026-05-22T22:05:16.211Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Evaluator check: recovery is bounded to provider-terminal states; OPEN provider PRs are retained, MERGED waits for close-tail evidence, and CLOSED/not_found become rework instead of being silently released.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T22:05:04.854Z, excerpt_hash=sha256:987ba39221120300ead3df35598c843a4f7a535cf93250348066a9f95b3b1df2
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221726-4FGDND-integration-queue-handoff-recovery/.agentplane/tasks/202605221726-4FGDND/blueprint/resolved-snapshot.json
+- old_digest: 46b46ca09503dfa2e2e14c248c3c27ebdd91e9cd5de3c1def7899312f2a2bd56
+- current_digest: 46b46ca09503dfa2e2e14c248c3c27ebdd91e9cd5de3c1def7899312f2a2bd56
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605221726-4FGDND
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605221726-4FGDND/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605221726-4FGDND/blueprint/resolved-snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605221726-4FGDND",
+    "title": "Add integration queue stale handoff recovery",
+    "description": "Detect and recover integration queue entries stuck in claimed or handoff when the provider PR is already merged, closed, missing, or blocked by stale metadata.",
+    "tags": [
+      "code",
+      "github",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605221726-4FGDND",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "46b46ca09503dfa2e2e14c248c3c27ebdd91e9cd5de3c1def7899312f2a2bd56"
+  }
+}

--- a/.agentplane/tasks/202605221726-4FGDND/pr/diffstat.txt
+++ b/.agentplane/tasks/202605221726-4FGDND/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ .../src/commands/integrate-queue-recovery.test.ts  | 127 +++++++++++++++++++++
+ .../src/commands/integrate-queue-recovery.ts       |  51 +++++++++
+ .../src/commands/integrate-queue.command.ts        |  56 +++++++++
+ 3 files changed, 234 insertions(+)

--- a/.agentplane/tasks/202605221726-4FGDND/pr/github-body.md
+++ b/.agentplane/tasks/202605221726-4FGDND/pr/github-body.md
@@ -1,0 +1,42 @@
+Task: `202605221726-4FGDND`
+Title: Add integration queue stale handoff recovery
+Canonical task record: `.agentplane/tasks/202605221726-4FGDND/README.md`
+
+## Summary
+
+Add integration queue stale handoff recovery
+
+Detect and recover integration queue entries stuck in claimed or handoff when the provider PR is already merged, closed, missing, or blocked by stale metadata.
+
+## Scope
+
+- In scope: Detect and recover integration queue entries stuck in claimed or handoff when the provider PR is already merged, closed, missing, or blocked by stale metadata.
+- Out of scope: unrelated refactors not required for "Add integration queue stale handoff recovery".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Evaluator check: recovery is bounded to provider-terminal states; OPEN provider PRs are retained,
+MERGED waits for close-tail evidence, and CLOSED/not_found become rework instead of being silently
+released.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-22T22:00:49.427Z
+- Branch: task/202605221726-4FGDND/integration-queue-handoff-recovery
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/commands/integrate-queue-recovery.test.ts  | 127 +++++++++++++++++++++
+ .../src/commands/integrate-queue-recovery.ts       |  51 +++++++++
+ .../src/commands/integrate-queue.command.ts        |  56 +++++++++
+ 3 files changed, 234 insertions(+)
+```
+
+</details>

--- a/.agentplane/tasks/202605221726-4FGDND/pr/github-title.txt
+++ b/.agentplane/tasks/202605221726-4FGDND/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 4FGDND task: Add integration queue stale handoff recovery [202605221726-4FGDND]

--- a/.agentplane/tasks/202605221726-4FGDND/pr/meta.json
+++ b/.agentplane/tasks/202605221726-4FGDND/pr/meta.json
@@ -1,0 +1,17 @@
+{
+  "base": "main",
+  "branch": "task/202605221726-4FGDND/integration-queue-handoff-recovery",
+  "created_at": "2026-05-22T22:00:49.427Z",
+  "diffstat_sha256": "sha256:97e820f00f909ac77402d1ebccfa2f12d83b0d87a07b6a872d5d7b12baa2fac0",
+  "last_verified_at": "2026-05-22T22:05:16.211Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "pr_number": 4040,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4040",
+  "schema_version": 1,
+  "status": "OPEN",
+  "task_id": "202605221726-4FGDND",
+  "updated_at": "2026-05-22T22:05:45.166Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605221726-4FGDND/pr/review.md
+++ b/.agentplane/tasks/202605221726-4FGDND/pr/review.md
@@ -1,0 +1,39 @@
+# PR Review
+
+Created: 2026-05-22T22:00:49.427Z
+
+## Task
+
+- Task: `202605221726-4FGDND`
+- Title: Add integration queue stale handoff recovery
+- Status: DOING
+- Branch: `task/202605221726-4FGDND/integration-queue-handoff-recovery`
+- Canonical task record: `.agentplane/tasks/202605221726-4FGDND/README.md`
+
+## Verification
+
+- State: ok
+- Note: Evaluator check: recovery is bounded to provider-terminal states; OPEN provider PRs are retained, MERGED waits for close-tail evidence, and CLOSED/not_found become rework instead of being silently released.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-22T22:00:49.427Z
+- Branch: task/202605221726-4FGDND/integration-queue-handoff-recovery
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/commands/integrate-queue-recovery.test.ts  | 127 +++++++++++++++++++++
+ .../src/commands/integrate-queue-recovery.ts       |  51 +++++++++
+ .../src/commands/integrate-queue.command.ts        |  56 +++++++++
+ 3 files changed, 234 insertions(+)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/integrate-queue-recovery.test.ts
+++ b/packages/agentplane/src/commands/integrate-queue-recovery.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import { decideIntegrationQueueRecovery } from "./integrate-queue-recovery.js";
+import type { PrFlowStatusReport } from "./pr/flow-status.js";
+import type { IntegrationQueueEntry } from "./pr/integrate/queue-state.js";
+
+function queueEntry(status: IntegrationQueueEntry["status"] = "handoff"): IntegrationQueueEntry {
+  return {
+    task_id: "T-1",
+    branch: "task/T-1/work",
+    base: "main",
+    head_sha: "head",
+    base_sha: "base",
+    changed_paths: ["src/work.ts"],
+    pr_number: 101,
+    pr_url: "https://example.invalid/pull/101",
+    priority: 0,
+    status,
+    enqueued_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+const entry = queueEntry();
+
+function report(overrides: Partial<PrFlowStatusReport>): PrFlowStatusReport {
+  return {
+    task: { id: "T-1", status: "DOING", verification: "ok" },
+    branch: { name: "task/T-1/work", headSha: "head", metaHeadSha: null },
+    pr: {
+      provider: "github",
+      state: "OPEN",
+      source: "lookup",
+      prNumber: 101,
+      prUrl: "https://example.invalid/pull/101",
+      base: "main",
+      headSha: "head",
+      mergeCommit: null,
+    },
+    closeTail: {
+      state: "not_applicable",
+      reason: "implementation PR is not merged or merge commit is unavailable",
+    },
+    nextAction: "wait hosted checks",
+    ...overrides,
+  };
+}
+
+describe("integration queue recovery decisions", () => {
+  it("keeps live open PR lanes occupied", () => {
+    expect(decideIntegrationQueueRecovery({ entry, report: report({}) })).toMatchObject({
+      action: "keep",
+    });
+  });
+
+  it("keeps active claimed lanes occupied even when provider state is terminal", () => {
+    expect(
+      decideIntegrationQueueRecovery({
+        entry: queueEntry("claimed"),
+        report: report({
+          pr: {
+            provider: "github",
+            state: "MERGED",
+            source: "lookup",
+            prNumber: 101,
+            prUrl: "https://example.invalid/pull/101",
+            base: "main",
+            headSha: "head",
+            mergeCommit: "merge",
+          },
+          closeTail: { state: "recorded_on_base", base: "main" },
+        }),
+      }),
+    ).toMatchObject({ action: "keep" });
+  });
+
+  it("marks stale handoff lanes done only after close-tail evidence is recorded", () => {
+    expect(
+      decideIntegrationQueueRecovery({
+        entry: queueEntry("handoff"),
+        report: report({
+          pr: {
+            provider: "github",
+            state: "MERGED",
+            source: "lookup",
+            prNumber: 101,
+            prUrl: "https://example.invalid/pull/101",
+            base: "main",
+            headSha: "head",
+            mergeCommit: "merge",
+          },
+          closeTail: { state: "recorded_on_base", base: "main" },
+        }),
+      }),
+    ).toMatchObject({ action: "mark", status: "done" });
+  });
+
+  it("keeps merged lanes in handoff until close-tail work completes", () => {
+    expect(
+      decideIntegrationQueueRecovery({
+        entry,
+        report: report({
+          pr: {
+            provider: "github",
+            state: "MERGED",
+            source: "lookup",
+            prNumber: 101,
+            prUrl: "https://example.invalid/pull/101",
+            base: "main",
+            headSha: "head",
+            mergeCommit: "merge",
+          },
+          closeTail: {
+            state: "not_found",
+            provider: "github",
+            branch: "task-close/T-1/merge",
+            prNumber: null,
+            prUrl: null,
+          },
+          nextAction: "agentplane task hosted-close-pr T-1",
+        }),
+      }),
+    ).toMatchObject({ action: "keep" });
+  });
+
+  it.each(["CLOSED", "not_found"] as const)("marks %s provider state as rework", (state) => {
+    const pr =
+      state === "not_found"
+        ? { provider: "github" as const, state, source: "lookup" as const }
+        : {
+            provider: "github" as const,
+            state,
+            source: "lookup" as const,
+            prNumber: 101,
+            prUrl: "https://example.invalid/pull/101",
+            base: "main",
+            headSha: "head",
+            mergeCommit: null,
+          };
+    expect(decideIntegrationQueueRecovery({ entry, report: report({ pr }) })).toMatchObject({
+      action: "mark",
+      status: "rework",
+    });
+  });
+});

--- a/packages/agentplane/src/commands/integrate-queue-recovery.ts
+++ b/packages/agentplane/src/commands/integrate-queue-recovery.ts
@@ -1,0 +1,57 @@
+import type { PrFlowStatusReport } from "./pr/flow-status.js";
+import type { IntegrationQueueEntry, IntegrationQueueStatus } from "./pr/integrate/queue-state.js";
+
+export type IntegrationQueueRecoveryDecision =
+  | {
+      action: "keep";
+      reason: string;
+    }
+  | {
+      action: "mark";
+      status: Extract<IntegrationQueueStatus, "done" | "rework">;
+      reason: string;
+    };
+
+export function decideIntegrationQueueRecovery(opts: {
+  entry: IntegrationQueueEntry;
+  report: PrFlowStatusReport;
+}): IntegrationQueueRecoveryDecision {
+  const { report } = opts;
+  if (opts.entry.status === "claimed") {
+    return {
+      action: "keep",
+      reason: "integration claim is still active; waiting for claim owner or lease expiry",
+    };
+  }
+  if (report.pr.state === "OPEN") {
+    return {
+      action: "keep",
+      reason: "remote PR is still open; keeping live integration lane occupied",
+    };
+  }
+  if (report.pr.state === "not_found") {
+    return {
+      action: "mark",
+      status: "rework",
+      reason: "remote PR is missing; stale queue lane needs operator recovery",
+    };
+  }
+  if (report.pr.state === "CLOSED") {
+    return {
+      action: "mark",
+      status: "rework",
+      reason: "remote PR is closed without merge; stale queue lane needs operator recovery",
+    };
+  }
+  if (report.closeTail.state === "recorded_on_base" || report.closeTail.state === "merged") {
+    return {
+      action: "mark",
+      status: "done",
+      reason: "remote PR merged and close-tail evidence is already recorded",
+    };
+  }
+  return {
+    action: "keep",
+    reason: `remote PR merged but close-tail is not complete; ${report.nextAction}`,
+  };
+}

--- a/packages/agentplane/src/commands/integrate-queue.command.ts
+++ b/packages/agentplane/src/commands/integrate-queue.command.ts
@@ -13,6 +13,7 @@ import { sleep } from "../backends/task-backend/shared/concurrency.js";
 import type { CommandContext } from "./shared/task-backend.js";
 import { gitRevParse } from "./shared/git-ops.js";
 import { cmdIntegrate } from "./pr/integrate/cmd.js";
+import { resolvePrFlowStatus } from "./pr/flow-status.js";
 import { prepareIntegrate } from "./pr/integrate/internal/prepare.js";
 import {
   claimNextQueuedEntry,
@@ -32,6 +33,7 @@ import type {
   IntegrateQueueRunNextParsed,
 } from "./integrate-queue.spec.js";
 import { integrateQueueSpec } from "./integrate-queue.spec.js";
+import { decideIntegrationQueueRecovery } from "./integrate-queue-recovery.js";
 
 const DEFAULT_QUEUE_POLL_INTERVAL_MS = 30_000;
 const DEFAULT_QUEUE_WAIT_TIMEOUT_MS = 10 * 60_000;
@@ -116,6 +118,49 @@ async function rejectIfQueuedEntryIsStale(opts: {
   entry: IntegrationQueueEntry;
 }): Promise<IntegrationQueueEntry | null> {
   return (await rejectIfQueuedHeadChanged(opts)) ?? (await rejectIfQueuedBaseConflicts(opts));
+}
+
+async function recoverStaleActiveLane(opts: {
+  ctx: CommandContext;
+  cwd: string;
+  rootOverride?: string | null;
+  gitRoot: string;
+  entry: IntegrationQueueEntry;
+  quiet: boolean;
+}): Promise<boolean> {
+  const report = await resolvePrFlowStatus({
+    ctx: opts.ctx,
+    cwd: opts.cwd,
+    rootOverride: opts.rootOverride ?? undefined,
+    taskId: opts.entry.task_id,
+  });
+  const decision = decideIntegrationQueueRecovery({ entry: opts.entry, report });
+  if (decision.action === "keep") {
+    if (!opts.quiet) {
+      createCliEmitter().line(
+        `integration queue lane retained: task=${opts.entry.task_id} status=${opts.entry.status} reason=${decision.reason}`,
+      );
+    }
+    return false;
+  }
+
+  const updated = await withIntegrationQueueMutex(opts.gitRoot, async () => {
+    const queue = await readIntegrationQueue(opts.gitRoot);
+    const current = queue.entries.find((entry) => entry.task_id === opts.entry.task_id);
+    if (current?.status !== "handoff") return false;
+    await writeIntegrationQueue(
+      opts.gitRoot,
+      markQueueEntry(queue, opts.entry.task_id, decision.status, decision.reason),
+    );
+    return true;
+  });
+  if (!updated) return false;
+  if (!opts.quiet) {
+    createCliEmitter().line(
+      `integration queue recovered: task=${opts.entry.task_id} status=${decision.status} reason=${decision.reason}`,
+    );
+  }
+  return true;
 }
 
 export function makeRunIntegrateQueueHandler(
@@ -287,6 +332,19 @@ export function makeRunIntegrateQueueRunNextHandler(
       if (!claimed.entry) {
         const activeLane = findActiveLane(claimed.state.entries);
         if (p.wait && (activeLane || hasQueuedEntries(claimed.state.entries))) {
+          if (
+            activeLane &&
+            (await recoverStaleActiveLane({
+              ctx: commandCtx,
+              cwd: ctx.cwd,
+              rootOverride: ctx.rootOverride,
+              gitRoot,
+              entry: activeLane,
+              quiet: p.quiet,
+            }))
+          ) {
+            continue;
+          }
           const elapsedMs = Date.now() - startedAt;
           if (elapsedMs >= timeoutMs) {
             throw new CliError({


### PR DESCRIPTION
Task: `202605221726-4FGDND`
Title: Add integration queue stale handoff recovery
Canonical task record: `.agentplane/tasks/202605221726-4FGDND/README.md`

## Summary

Add integration queue stale handoff recovery

Detect and recover integration queue entries stuck in claimed or handoff when the provider PR is already merged, closed, missing, or blocked by stale metadata.

## Scope

- In scope: Detect and recover integration queue entries stuck in claimed or handoff when the provider PR is already merged, closed, missing, or blocked by stale metadata.
- Out of scope: unrelated refactors not required for "Add integration queue stale handoff recovery".

## Verification

- State: ok
- Note:

```text
Evaluator check: recovery is bounded to provider-terminal states; OPEN provider PRs are retained,
MERGED waits for close-tail evidence, and CLOSED/not_found become rework instead of being silently
released.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-22T22:00:49.427Z
- Branch: task/202605221726-4FGDND/integration-queue-handoff-recovery
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/commands/integrate-queue-recovery.test.ts  | 127 +++++++++++++++++++++
 .../src/commands/integrate-queue-recovery.ts       |  51 +++++++++
 .../src/commands/integrate-queue.command.ts        |  56 +++++++++
 3 files changed, 234 insertions(+)
```

</details>
