### PR TITLE
🚧 2B0DJD task: Treat already-merged PR delete-branch failures as integration progress [202605222225-2B0DJD]

### DIFF
--- a/.agentplane/tasks/202605222225-2B0DJD/README.md
+++ b/.agentplane/tasks/202605222225-2B0DJD/README.md
@@ -1,0 +1,207 @@
+---
+id: "202605222225-2B0DJD"
+title: "Treat already-merged PR delete-branch failures as integration progress"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "github"
+  - "workflow"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-22T22:25:50.104Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-22T22:28:37.130Z"
+  updated_by: "EVALUATOR"
+  note: "Evaluator check: already-merged gh output is treated as protected-base merge completion while unrelated gh failures still flow through the existing handoff path; targeted regression, lint, and typecheck passed."
+  attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-22T22:28:37.130Z"
+  updated_by: "EVALUATOR"
+  note: "Evaluator check: already-merged gh output is treated as protected-base merge completion while unrelated gh failures still flow through the existing handoff path; targeted regression, lint, and typecheck passed."
+  evaluated_sha: "249abc668195f7282bb8ad871142b66bcd2f4535"
+  blueprint_digest: "5a7117f0090ab9fe3ac8ce70de6fa4e138603ade61af6498dd22bdb199a86ccf"
+  evidence_refs:
+    - ".agentplane/tasks/202605222225-2B0DJD/README.md"
+    - "/Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605222225-2B0DJD-already-merged-pr-delete-branch/.agentplane/tasks/202605222225-2B0DJD/blueprint/resolved-snapshot.json"
+  findings: []
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: treating already-merged GitHub PR delete-branch failures as successful protected-base merge progress."
+events:
+  -
+    type: "status"
+    at: "2026-05-22T22:25:51.183Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: treating already-merged GitHub PR delete-branch failures as successful protected-base merge progress."
+  -
+    type: "verify"
+    at: "2026-05-22T22:28:13.645Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: gh already-merged delete-branch failures now classify as protected-base merge progress; regression test covers worktree-attached local branch deletion, targeted integrate tests pass, lint passes, and typecheck passes."
+  -
+    type: "verify"
+    at: "2026-05-22T22:28:37.130Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Evaluator check: already-merged gh output is treated as protected-base merge completion while unrelated gh failures still flow through the existing handoff path; targeted regression, lint, and typecheck passed."
+doc_version: 3
+doc_updated_at: "2026-05-22T22:28:37.159Z"
+doc_updated_by: "CODER"
+description: "When branch_pr integrate drives gh pr merge with --delete-branch and GitHub reports the task PR was already merged, local branch deletion can fail because the branch is still attached to a worktree. The integrate command should classify this as progress toward hosted close rather than surfacing E_HANDOFF after the merge has succeeded. Keep true merge failures as handoff/errors."
+sections:
+  Summary: |-
+    Treat already-merged PR delete-branch failures as integration progress
+
+    When branch_pr integrate drives gh pr merge with --delete-branch and GitHub reports the task PR was already merged, local branch deletion can fail because the branch is still attached to a worktree. The integrate command should classify this as progress toward hosted close rather than surfacing E_HANDOFF after the merge has succeeded. Keep true merge failures as handoff/errors.
+  Scope: |-
+    - In scope: When branch_pr integrate drives gh pr merge with --delete-branch and GitHub reports the task PR was already merged, local branch deletion can fail because the branch is still attached to a worktree. The integrate command should classify this as progress toward hosted close rather than surfacing E_HANDOFF after the merge has succeeded. Keep true merge failures as handoff/errors.
+    - Out of scope: unrelated refactors not required for "Treat already-merged PR delete-branch failures as integration progress".
+  Plan: |-
+    Plan:
+    1. Add a narrow classifier for gh merge stderr/stdout that reports the PR is already merged, even when --delete-branch fails on a local worktree-attached branch.
+    2. Return protected-base merge status=merged for that classifier so cmdIntegrate records the normal hosted-close handoff instead of a generic E_HANDOFF failure.
+    3. Cover the regression in integrate command tests and run targeted tests plus type/lint checks.
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-22T22:28:13.645Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified: gh already-merged delete-branch failures now classify as protected-base merge progress; regression test covers worktree-attached local branch deletion, targeted integrate tests pass, lint passes, and typecheck passes.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T22:25:51.183Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605222225-2B0DJD-already-merged-pr-delete-branch/.agentplane/tasks/202605222225-2B0DJD/blueprint/resolved-snapshot.json
+    - old_digest: 5a7117f0090ab9fe3ac8ce70de6fa4e138603ade61af6498dd22bdb199a86ccf
+    - current_digest: 5a7117f0090ab9fe3ac8ce70de6fa4e138603ade61af6498dd22bdb199a86ccf
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605222225-2B0DJD
+
+    ### 2026-05-22T22:28:37.130Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Evaluator check: already-merged gh output is treated as protected-base merge completion while unrelated gh failures still flow through the existing handoff path; targeted regression, lint, and typecheck passed.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T22:28:13.671Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605222225-2B0DJD-already-merged-pr-delete-branch/.agentplane/tasks/202605222225-2B0DJD/blueprint/resolved-snapshot.json
+    - old_digest: 5a7117f0090ab9fe3ac8ce70de6fa4e138603ade61af6498dd22bdb199a86ccf
+    - current_digest: 5a7117f0090ab9fe3ac8ce70de6fa4e138603ade61af6498dd22bdb199a86ccf
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605222225-2B0DJD
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Treat already-merged PR delete-branch failures as integration progress
+
+When branch_pr integrate drives gh pr merge with --delete-branch and GitHub reports the task PR was already merged, local branch deletion can fail because the branch is still attached to a worktree. The integrate command should classify this as progress toward hosted close rather than surfacing E_HANDOFF after the merge has succeeded. Keep true merge failures as handoff/errors.
+
+## Scope
+
+- In scope: When branch_pr integrate drives gh pr merge with --delete-branch and GitHub reports the task PR was already merged, local branch deletion can fail because the branch is still attached to a worktree. The integrate command should classify this as progress toward hosted close rather than surfacing E_HANDOFF after the merge has succeeded. Keep true merge failures as handoff/errors.
+- Out of scope: unrelated refactors not required for "Treat already-merged PR delete-branch failures as integration progress".
+
+## Plan
+
+Plan:
+1. Add a narrow classifier for gh merge stderr/stdout that reports the PR is already merged, even when --delete-branch fails on a local worktree-attached branch.
+2. Return protected-base merge status=merged for that classifier so cmdIntegrate records the normal hosted-close handoff instead of a generic E_HANDOFF failure.
+3. Cover the regression in integrate command tests and run targeted tests plus type/lint checks.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-22T22:28:13.645Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: gh already-merged delete-branch failures now classify as protected-base merge progress; regression test covers worktree-attached local branch deletion, targeted integrate tests pass, lint passes, and typecheck passes.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T22:25:51.183Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605222225-2B0DJD-already-merged-pr-delete-branch/.agentplane/tasks/202605222225-2B0DJD/blueprint/resolved-snapshot.json
+- old_digest: 5a7117f0090ab9fe3ac8ce70de6fa4e138603ade61af6498dd22bdb199a86ccf
+- current_digest: 5a7117f0090ab9fe3ac8ce70de6fa4e138603ade61af6498dd22bdb199a86ccf
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605222225-2B0DJD
+
+### 2026-05-22T22:28:37.130Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Evaluator check: already-merged gh output is treated as protected-base merge completion while unrelated gh failures still flow through the existing handoff path; targeted regression, lint, and typecheck passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T22:28:13.671Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605222225-2B0DJD-already-merged-pr-delete-branch/.agentplane/tasks/202605222225-2B0DJD/blueprint/resolved-snapshot.json
+- old_digest: 5a7117f0090ab9fe3ac8ce70de6fa4e138603ade61af6498dd22bdb199a86ccf
+- current_digest: 5a7117f0090ab9fe3ac8ce70de6fa4e138603ade61af6498dd22bdb199a86ccf
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605222225-2B0DJD
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605222225-2B0DJD/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605222225-2B0DJD/blueprint/resolved-snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605222225-2B0DJD",
+    "title": "Treat already-merged PR delete-branch failures as integration progress",
+    "description": "When branch_pr integrate drives gh pr merge with --delete-branch and GitHub reports the task PR was already merged, local branch deletion can fail because the branch is still attached to a worktree. The integrate command should classify this as progress toward hosted close rather than surfacing E_HANDOFF after the merge has succeeded. Keep true merge failures as handoff/errors.",
+    "tags": [
+      "code",
+      "github",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605222225-2B0DJD",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "5a7117f0090ab9fe3ac8ce70de6fa4e138603ade61af6498dd22bdb199a86ccf"
+  }
+}

--- a/.agentplane/tasks/202605222225-2B0DJD/pr/diffstat.txt
+++ b/.agentplane/tasks/202605222225-2B0DJD/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../src/commands/pr/integrate/cmd.test.ts          | 73 ++++++++++++++++++++++
+ .../pr/integrate/internal/github-pr-merge.ts       | 11 ++++
+ 2 files changed, 84 insertions(+)

--- a/.agentplane/tasks/202605222225-2B0DJD/pr/github-body.md
+++ b/.agentplane/tasks/202605222225-2B0DJD/pr/github-body.md
@@ -1,0 +1,41 @@
+Task: `202605222225-2B0DJD`
+Title: Treat already-merged PR delete-branch failures as integration progress
+Canonical task record: `.agentplane/tasks/202605222225-2B0DJD/README.md`
+
+## Summary
+
+Treat already-merged PR delete-branch failures as integration progress
+
+When branch_pr integrate drives gh pr merge with --delete-branch and GitHub reports the task PR was already merged, local branch deletion can fail because the branch is still attached to a worktree. The integrate command should classify this as progress toward hosted close rather than surfacing E_HANDOFF after the merge has succeeded. Keep true merge failures as handoff/errors.
+
+## Scope
+
+- In scope: When branch_pr integrate drives gh pr merge with --delete-branch and GitHub reports the task PR was already merged, local branch deletion can fail because the branch is still attached to a worktree. The integrate command should classify this as progress toward hosted close rather than surfacing E_HANDOFF after the merge has succeeded. Keep true merge failures as handoff/errors.
+- Out of scope: unrelated refactors not required for "Treat already-merged PR delete-branch failures as integration progress".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Evaluator check: already-merged gh output is treated as protected-base merge completion while
+unrelated gh failures still flow through the existing handoff path; targeted regression, lint, and
+typecheck passed.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-22T22:28:13.725Z
+- Branch: task/202605222225-2B0DJD/already-merged-pr-delete-branch
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/commands/pr/integrate/cmd.test.ts          | 73 ++++++++++++++++++++++
+ .../pr/integrate/internal/github-pr-merge.ts       | 11 ++++
+ 2 files changed, 84 insertions(+)
+```
+
+</details>

--- a/.agentplane/tasks/202605222225-2B0DJD/pr/github-title.txt
+++ b/.agentplane/tasks/202605222225-2B0DJD/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 2B0DJD task: Treat already-merged PR delete-branch failures as integration progress [202605222225-2B0DJD]

--- a/.agentplane/tasks/202605222225-2B0DJD/pr/meta.json
+++ b/.agentplane/tasks/202605222225-2B0DJD/pr/meta.json
@@ -1,0 +1,17 @@
+{
+  "base": "main",
+  "branch": "task/202605222225-2B0DJD/already-merged-pr-delete-branch",
+  "created_at": "2026-05-22T22:28:13.725Z",
+  "diffstat_sha256": "sha256:5652f134335f6dd418e2045821b1d52f67ef7e11b69bc7bcf772164f5a1c55eb",
+  "last_verified_at": "2026-05-22T22:28:37.130Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "pr_number": 4042,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4042",
+  "schema_version": 1,
+  "status": "OPEN",
+  "task_id": "202605222225-2B0DJD",
+  "updated_at": "2026-05-22T22:29:12.162Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605222225-2B0DJD/pr/review.md
+++ b/.agentplane/tasks/202605222225-2B0DJD/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-05-22T22:28:13.725Z
+
+## Task
+
+- Task: `202605222225-2B0DJD`
+- Title: Treat already-merged PR delete-branch failures as integration progress
+- Status: DOING
+- Branch: `task/202605222225-2B0DJD/already-merged-pr-delete-branch`
+- Canonical task record: `.agentplane/tasks/202605222225-2B0DJD/README.md`
+
+## Verification
+
+- State: ok
+- Note: Evaluator check: already-merged gh output is treated as protected-base merge completion while unrelated gh failures still flow through the existing handoff path; targeted regression, lint, and typecheck passed.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-22T22:28:13.725Z
+- Branch: task/202605222225-2B0DJD/already-merged-pr-delete-branch
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/commands/pr/integrate/cmd.test.ts          | 73 ++++++++++++++++++++++
+ .../pr/integrate/internal/github-pr-merge.ts       | 11 ++++
+ 2 files changed, 84 insertions(+)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/pr/integrate/cmd.test.ts
+++ b/packages/agentplane/src/commands/pr/integrate/cmd.test.ts
@@ -516,6 +516,79 @@ describe("pr/integrate/cmd", () => {
     expect(mocks.finalizeIntegrate).not.toHaveBeenCalled();
   });
 
+  it("treats already-merged gh delete-branch failures as protected-base merge progress", async () => {
+    mocks.execFileAsync.mockImplementation((_cmd: string, args: string[]) => {
+      if (args.includes("--version") || args.includes("status")) {
+        return Promise.resolve({ stdout: "", stderr: "" });
+      }
+      if (args.includes("--auto")) {
+        return Promise.reject(new Error("auto merge unavailable"));
+      }
+      return Promise.reject(
+        new Error(
+          "! Pull request example/repo#338 was already merged\nfailed to delete local branch task/T-1: branch is used by worktree",
+        ),
+      );
+    });
+    mocks.prepareIntegrate.mockResolvedValue({
+      ctx: {
+        config: { paths: { workflow_dir: ".agentplane/tasks" } },
+        git: {},
+        taskBackend: {},
+        resolvedProject: { gitRoot: "/repo" },
+      },
+      resolved: { gitRoot: "/repo" },
+      loadedConfig: {
+        workflow_mode: "branch_pr",
+        paths: {
+          worktrees_dir: ".agentplane/worktrees",
+          workflow_dir: ".agentplane/tasks",
+        },
+        commit: { generic_tokens: [] },
+      },
+      task: { id: "T-1", title: "Task", tags: [], verify: [], status: "DOING" },
+      prDir: "/repo/.agentplane/tasks/T-1/pr",
+      metaPath: "/repo/.agentplane/tasks/T-1/pr/meta.json",
+      diffstatPath: "/repo/.agentplane/tasks/T-1/pr/diffstat.txt",
+      verifyLogPath: "/repo/.agentplane/tasks/T-1/pr/verify.log",
+      metaSource: {
+        base: "main",
+        branch: "task/T-1",
+        head_sha: "head-sha",
+        pr_number: 338,
+        pr_url: "https://github.com/example/repo/pull/338",
+      },
+      branch: "task/T-1",
+      base: "main",
+      verifyLogText: "",
+      branchHeadSha: "head-sha",
+      changedPaths: [],
+      verifyCommands: [],
+      alreadyVerifiedSha: null,
+      shouldRunVerify: false,
+      protectedBaseRequiresPrMerge: true,
+    });
+    const { cmdIntegrate } = await import("./cmd.js");
+
+    const caught = await cmdIntegrate({
+      cwd: "/repo",
+      taskId: "T-1",
+      mergeStrategy: "squash",
+      runVerify: false,
+      dryRun: false,
+      quiet: false,
+    }).catch((err: unknown) => err);
+
+    expect(caught).toMatchObject({ code: "E_HANDOFF" });
+    expect((caught as { context?: { reason_code?: unknown } }).context?.reason_code).toBe(
+      "protected_base_github_merge_completed",
+    );
+    expect(String((caught as Error).message)).toContain("GitHub PR was already merged");
+    expect(String((caught as Error).message)).not.toContain("Unable to drive");
+    expect(mocks.buildTaskHandoffArtifact).toHaveBeenCalled();
+    expect(mocks.finalizeIntegrate).not.toHaveBeenCalled();
+  });
+
   it("records a first-class protected-base handoff route when GitHub merge cannot be attempted", async () => {
     mocks.prepareIntegrate.mockResolvedValue({
       ctx: {

--- a/packages/agentplane/src/commands/pr/integrate/internal/github-pr-merge.ts
+++ b/packages/agentplane/src/commands/pr/integrate/internal/github-pr-merge.ts
@@ -41,6 +41,11 @@ function summarizeGithubFailure(err: unknown): string {
   return text || "unknown failure";
 }
 
+function isAlreadyMergedGithubPrFailure(err: unknown): boolean {
+  const text = summarizeGithubFailure(err).toLowerCase();
+  return /\bpull request\b/.test(text) && /\balready merged\b/.test(text);
+}
+
 function getGithubToken(): GithubToken | null {
   if (
     typeof process.env.GH_TOKEN === "string" &&
@@ -112,6 +117,12 @@ async function runGhCliMerge(opts: {
         detail: `GitHub PR merged with gh --merge: ${opts.prTarget}`,
       };
     } catch (directErr) {
+      if (isAlreadyMergedGithubPrFailure(directErr)) {
+        return {
+          status: "merged",
+          detail: `GitHub PR was already merged with gh --merge: ${opts.prTarget}`,
+        };
+      }
       throw new Error(
         `gh auto=${summarizeGithubFailure(autoErr)}; gh direct=${summarizeGithubFailure(directErr)}`,
       );


### PR DESCRIPTION
Task: `202605222225-2B0DJD`
Title: Treat already-merged PR delete-branch failures as integration progress
Canonical task record: `.agentplane/tasks/202605222225-2B0DJD/README.md`

## Summary

Treat already-merged PR delete-branch failures as integration progress

When branch_pr integrate drives gh pr merge with --delete-branch and GitHub reports the task PR was already merged, local branch deletion can fail because the branch is still attached to a worktree. The integrate command should classify this as progress toward hosted close rather than surfacing E_HANDOFF after the merge has succeeded. Keep true merge failures as handoff/errors.

## Scope

- In scope: When branch_pr integrate drives gh pr merge with --delete-branch and GitHub reports the task PR was already merged, local branch deletion can fail because the branch is still attached to a worktree. The integrate command should classify this as progress toward hosted close rather than surfacing E_HANDOFF after the merge has succeeded. Keep true merge failures as handoff/errors.
- Out of scope: unrelated refactors not required for "Treat already-merged PR delete-branch failures as integration progress".

## Verification

- State: ok
- Note:

```text
Evaluator check: already-merged gh output is treated as protected-base merge completion while
unrelated gh failures still flow through the existing handoff path; targeted regression, lint, and
typecheck passed.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-22T22:28:13.725Z
- Branch: task/202605222225-2B0DJD/already-merged-pr-delete-branch
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/commands/pr/integrate/cmd.test.ts          | 73 ++++++++++++++++++++++
 .../pr/integrate/internal/github-pr-merge.ts       | 11 ++++
 2 files changed, 84 insertions(+)
```

</details>
