### PR TITLE
🚧 V6VTG8 task: Narrow pre-push PR-flow test selection for small integrate changes [202605222245-V6VTG8]

### DIFF
--- a/.agentplane/tasks/202605222245-V6VTG8/README.md
+++ b/.agentplane/tasks/202605222245-V6VTG8/README.md
@@ -1,0 +1,207 @@
+---
+id: "202605222245-V6VTG8"
+title: "Narrow pre-push PR-flow test selection for small integrate changes"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "performance"
+  - "workflow"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-22T22:46:12.328Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-22T22:48:36.375Z"
+  updated_by: "EVALUATOR"
+  note: "Evaluator check: pre-push routing is narrowed by path-specific PR integrate bucket while generic PR paths still keep the existing pr bucket; regression coverage asserts pr-flow suites are excluded for integrate internals."
+  attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-22T22:48:36.375Z"
+  updated_by: "EVALUATOR"
+  note: "Evaluator check: pre-push routing is narrowed by path-specific PR integrate bucket while generic PR paths still keep the existing pr bucket; regression coverage asserts pr-flow suites are excluded for integrate internals."
+  evaluated_sha: "cb5e1611bfac8dc26796761f3ba48b2988cf80aa"
+  blueprint_digest: "8cceb46aad272efd793c6c2cc69c711c27a3f4851d54633ceaa6d195cab8fba1"
+  evidence_refs:
+    - ".agentplane/tasks/202605222245-V6VTG8/README.md"
+    - "/Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605222245-V6VTG8-narrow-pr-integrate-ci-selection/.agentplane/tasks/202605222245-V6VTG8/blueprint/resolved-snapshot.json"
+  findings: []
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: narrowing pre-push local CI selection for small PR integrate command changes."
+events:
+  -
+    type: "status"
+    at: "2026-05-22T22:46:13.412Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: narrowing pre-push local CI selection for small PR integrate command changes."
+  -
+    type: "verify"
+    at: "2026-05-22T22:48:31.347Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: observed PR integrate changed-file set now selects targeted pr-integrate bucket instead of broad pr-flow suites; selector test passes, selected integrate unit suite passes, lint passes, typecheck passes, and local CI explain shows the narrowed route."
+  -
+    type: "verify"
+    at: "2026-05-22T22:48:36.375Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Evaluator check: pre-push routing is narrowed by path-specific PR integrate bucket while generic PR paths still keep the existing pr bucket; regression coverage asserts pr-flow suites are excluded for integrate internals."
+doc_version: 3
+doc_updated_at: "2026-05-22T22:48:36.403Z"
+doc_updated_by: "CODER"
+description: "A small protected-base integrate transport change triggered the pre-push fast CI targeted pr selector to run the broad pr-flow Vitest bucket and hang for more than ten minutes. Tighten changed-file routing so focused integrate internals and cmd tests do not fan out to unrelated PR lifecycle suites, or add a bounded timeout/reporting guard for that selector."
+sections:
+  Summary: |-
+    Narrow pre-push PR-flow test selection for small integrate changes
+
+    A small protected-base integrate transport change triggered the pre-push fast CI targeted pr selector to run the broad pr-flow Vitest bucket and hang for more than ten minutes. Tighten changed-file routing so focused integrate internals and cmd tests do not fan out to unrelated PR lifecycle suites, or add a bounded timeout/reporting guard for that selector.
+  Scope: |-
+    - In scope: A small protected-base integrate transport change triggered the pre-push fast CI targeted pr selector to run the broad pr-flow Vitest bucket and hang for more than ten minutes. Tighten changed-file routing so focused integrate internals and cmd tests do not fan out to unrelated PR lifecycle suites, or add a bounded timeout/reporting guard for that selector.
+    - Out of scope: unrelated refactors not required for "Narrow pre-push PR-flow test selection for small integrate changes".
+  Plan: |-
+    Plan:
+    1. Add a narrow local-CI bucket for packages/agentplane/src/commands/pr/integrate/** so command-level integrate changes run command tests instead of every CLI pr-flow suite.
+    2. Keep existing broad pr bucket for generic PR command paths and CLI pr-flow tests.
+    3. Add selector tests for integrate internals and mixed task artifacts, then run selector tests plus local CI explain for the observed changed-file set.
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-22T22:48:31.347Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified: observed PR integrate changed-file set now selects targeted pr-integrate bucket instead of broad pr-flow suites; selector test passes, selected integrate unit suite passes, lint passes, typecheck passes, and local CI explain shows the narrowed route.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T22:46:13.412Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605222245-V6VTG8-narrow-pr-integrate-ci-selection/.agentplane/tasks/202605222245-V6VTG8/blueprint/resolved-snapshot.json
+    - old_digest: 8cceb46aad272efd793c6c2cc69c711c27a3f4851d54633ceaa6d195cab8fba1
+    - current_digest: 8cceb46aad272efd793c6c2cc69c711c27a3f4851d54633ceaa6d195cab8fba1
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605222245-V6VTG8
+
+    ### 2026-05-22T22:48:36.375Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Evaluator check: pre-push routing is narrowed by path-specific PR integrate bucket while generic PR paths still keep the existing pr bucket; regression coverage asserts pr-flow suites are excluded for integrate internals.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T22:48:31.373Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605222245-V6VTG8-narrow-pr-integrate-ci-selection/.agentplane/tasks/202605222245-V6VTG8/blueprint/resolved-snapshot.json
+    - old_digest: 8cceb46aad272efd793c6c2cc69c711c27a3f4851d54633ceaa6d195cab8fba1
+    - current_digest: 8cceb46aad272efd793c6c2cc69c711c27a3f4851d54633ceaa6d195cab8fba1
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605222245-V6VTG8
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Narrow pre-push PR-flow test selection for small integrate changes
+
+A small protected-base integrate transport change triggered the pre-push fast CI targeted pr selector to run the broad pr-flow Vitest bucket and hang for more than ten minutes. Tighten changed-file routing so focused integrate internals and cmd tests do not fan out to unrelated PR lifecycle suites, or add a bounded timeout/reporting guard for that selector.
+
+## Scope
+
+- In scope: A small protected-base integrate transport change triggered the pre-push fast CI targeted pr selector to run the broad pr-flow Vitest bucket and hang for more than ten minutes. Tighten changed-file routing so focused integrate internals and cmd tests do not fan out to unrelated PR lifecycle suites, or add a bounded timeout/reporting guard for that selector.
+- Out of scope: unrelated refactors not required for "Narrow pre-push PR-flow test selection for small integrate changes".
+
+## Plan
+
+Plan:
+1. Add a narrow local-CI bucket for packages/agentplane/src/commands/pr/integrate/** so command-level integrate changes run command tests instead of every CLI pr-flow suite.
+2. Keep existing broad pr bucket for generic PR command paths and CLI pr-flow tests.
+3. Add selector tests for integrate internals and mixed task artifacts, then run selector tests plus local CI explain for the observed changed-file set.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-22T22:48:31.347Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: observed PR integrate changed-file set now selects targeted pr-integrate bucket instead of broad pr-flow suites; selector test passes, selected integrate unit suite passes, lint passes, typecheck passes, and local CI explain shows the narrowed route.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T22:46:13.412Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605222245-V6VTG8-narrow-pr-integrate-ci-selection/.agentplane/tasks/202605222245-V6VTG8/blueprint/resolved-snapshot.json
+- old_digest: 8cceb46aad272efd793c6c2cc69c711c27a3f4851d54633ceaa6d195cab8fba1
+- current_digest: 8cceb46aad272efd793c6c2cc69c711c27a3f4851d54633ceaa6d195cab8fba1
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605222245-V6VTG8
+
+### 2026-05-22T22:48:36.375Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Evaluator check: pre-push routing is narrowed by path-specific PR integrate bucket while generic PR paths still keep the existing pr bucket; regression coverage asserts pr-flow suites are excluded for integrate internals.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T22:48:31.373Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605222245-V6VTG8-narrow-pr-integrate-ci-selection/.agentplane/tasks/202605222245-V6VTG8/blueprint/resolved-snapshot.json
+- old_digest: 8cceb46aad272efd793c6c2cc69c711c27a3f4851d54633ceaa6d195cab8fba1
+- current_digest: 8cceb46aad272efd793c6c2cc69c711c27a3f4851d54633ceaa6d195cab8fba1
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605222245-V6VTG8
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605222245-V6VTG8/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605222245-V6VTG8/blueprint/resolved-snapshot.json
@@ -1,0 +1,594 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605222245-V6VTG8",
+    "title": "Narrow pre-push PR-flow test selection for small integrate changes",
+    "description": "A small protected-base integrate transport change triggered the pre-push fast CI targeted pr selector to run the broad pr-flow Vitest bucket and hang for more than ten minutes. Tighten changed-file routing so focused integrate internals and cmd tests do not fan out to unrelated PR lifecycle suites, or add a bounded timeout/reporting guard for that selector.",
+    "tags": [
+      "code",
+      "performance",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "performance.benchmark",
+    "version": 1,
+    "title": "Performance benchmark",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "performance.benchmark",
+    "blueprintVersion": 1,
+    "title": "Performance benchmark",
+    "taskId": "202605222245-V6VTG8",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to performance.benchmark",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "artifact"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "final_output"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "benchmark.baseline",
+        "kind": "artifact",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Baseline measurement artifact."
+      },
+      {
+        "id": "benchmark.method",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Benchmark method, environment, and warm/cold mode."
+      },
+      {
+        "id": "benchmark.runs",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Run count and raw measurement results."
+      },
+      {
+        "id": "benchmark.threshold",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Accepted threshold or noise tolerance."
+      },
+      {
+        "id": "benchmark.comparison",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Before/after comparison result."
+      },
+      {
+        "id": "benchmark.verdict",
+        "kind": "final_output",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Faster, slower, unchanged, or noisy verdict."
+      },
+      {
+        "id": "benchmark.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "benchmark.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "benchmark baseline command",
+      "benchmark comparison command",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Benchmark work needs normal branch_pr code policy plus room for baseline and comparison artifacts."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "artifact"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "final_output"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "benchmark.baseline",
+      "kind": "artifact",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Baseline measurement artifact."
+    },
+    {
+      "id": "benchmark.method",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Benchmark method, environment, and warm/cold mode."
+    },
+    {
+      "id": "benchmark.runs",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Run count and raw measurement results."
+    },
+    {
+      "id": "benchmark.threshold",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Accepted threshold or noise tolerance."
+    },
+    {
+      "id": "benchmark.comparison",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Before/after comparison result."
+    },
+    {
+      "id": "benchmark.verdict",
+      "kind": "final_output",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Faster, slower, unchanged, or noisy verdict."
+    },
+    {
+      "id": "benchmark.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "benchmark.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "benchmark baseline command",
+    "benchmark comparison command",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Benchmark work needs normal branch_pr code policy plus room for baseline and comparison artifacts."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to performance.benchmark",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "8cceb46aad272efd793c6c2cc69c711c27a3f4851d54633ceaa6d195cab8fba1"
+  }
+}

--- a/.agentplane/tasks/202605222245-V6VTG8/pr/diffstat.txt
+++ b/.agentplane/tasks/202605222245-V6VTG8/pr/diffstat.txt
@@ -1,0 +1,5 @@
+ .../agentplane/src/cli/local-ci-selection.test.ts  | 23 ++++++++++++++++++++++
+ scripts/lib/local-ci-selection.d.ts                |  2 ++
+ scripts/lib/local-ci-selection.mjs                 | 23 ++++++++++++++++++++++
+ scripts/lib/test-route-registry.mjs                | 10 ++++++++++
+ 4 files changed, 58 insertions(+)

--- a/.agentplane/tasks/202605222245-V6VTG8/pr/github-body.md
+++ b/.agentplane/tasks/202605222245-V6VTG8/pr/github-body.md
@@ -1,0 +1,43 @@
+Task: `202605222245-V6VTG8`
+Title: Narrow pre-push PR-flow test selection for small integrate changes
+Canonical task record: `.agentplane/tasks/202605222245-V6VTG8/README.md`
+
+## Summary
+
+Narrow pre-push PR-flow test selection for small integrate changes
+
+A small protected-base integrate transport change triggered the pre-push fast CI targeted pr selector to run the broad pr-flow Vitest bucket and hang for more than ten minutes. Tighten changed-file routing so focused integrate internals and cmd tests do not fan out to unrelated PR lifecycle suites, or add a bounded timeout/reporting guard for that selector.
+
+## Scope
+
+- In scope: A small protected-base integrate transport change triggered the pre-push fast CI targeted pr selector to run the broad pr-flow Vitest bucket and hang for more than ten minutes. Tighten changed-file routing so focused integrate internals and cmd tests do not fan out to unrelated PR lifecycle suites, or add a bounded timeout/reporting guard for that selector.
+- Out of scope: unrelated refactors not required for "Narrow pre-push PR-flow test selection for small integrate changes".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Evaluator check: pre-push routing is narrowed by path-specific PR integrate bucket while generic PR
+paths still keep the existing pr bucket; regression coverage asserts pr-flow suites are excluded for
+integrate internals.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-22T22:48:31.426Z
+- Branch: task/202605222245-V6VTG8/narrow-pr-integrate-ci-selection
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../agentplane/src/cli/local-ci-selection.test.ts  | 23 ++++++++++++++++++++++
+ scripts/lib/local-ci-selection.d.ts                |  2 ++
+ scripts/lib/local-ci-selection.mjs                 | 23 ++++++++++++++++++++++
+ scripts/lib/test-route-registry.mjs                | 10 ++++++++++
+ 4 files changed, 58 insertions(+)
+```
+
+</details>

--- a/.agentplane/tasks/202605222245-V6VTG8/pr/github-title.txt
+++ b/.agentplane/tasks/202605222245-V6VTG8/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 V6VTG8 task: Narrow pre-push PR-flow test selection for small integrate changes [202605222245-V6VTG8]

--- a/.agentplane/tasks/202605222245-V6VTG8/pr/meta.json
+++ b/.agentplane/tasks/202605222245-V6VTG8/pr/meta.json
@@ -1,0 +1,17 @@
+{
+  "base": "main",
+  "branch": "task/202605222245-V6VTG8/narrow-pr-integrate-ci-selection",
+  "created_at": "2026-05-22T22:48:31.426Z",
+  "diffstat_sha256": "sha256:baee0e36e03d40f5e78464b75640726c9d11bfa9723f737559088032eb4e36f6",
+  "last_verified_at": "2026-05-22T22:48:36.375Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "pr_number": 4044,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4044",
+  "schema_version": 1,
+  "status": "OPEN",
+  "task_id": "202605222245-V6VTG8",
+  "updated_at": "2026-05-22T22:49:06.148Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605222245-V6VTG8/pr/review.md
+++ b/.agentplane/tasks/202605222245-V6VTG8/pr/review.md
@@ -1,0 +1,40 @@
+# PR Review
+
+Created: 2026-05-22T22:48:31.426Z
+
+## Task
+
+- Task: `202605222245-V6VTG8`
+- Title: Narrow pre-push PR-flow test selection for small integrate changes
+- Status: DOING
+- Branch: `task/202605222245-V6VTG8/narrow-pr-integrate-ci-selection`
+- Canonical task record: `.agentplane/tasks/202605222245-V6VTG8/README.md`
+
+## Verification
+
+- State: ok
+- Note: Evaluator check: pre-push routing is narrowed by path-specific PR integrate bucket while generic PR paths still keep the existing pr bucket; regression coverage asserts pr-flow suites are excluded for integrate internals.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-22T22:48:31.426Z
+- Branch: task/202605222245-V6VTG8/narrow-pr-integrate-ci-selection
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../agentplane/src/cli/local-ci-selection.test.ts  | 23 ++++++++++++++++++++++
+ scripts/lib/local-ci-selection.d.ts                |  2 ++
+ scripts/lib/local-ci-selection.mjs                 | 23 ++++++++++++++++++++++
+ scripts/lib/test-route-registry.mjs                | 10 ++++++++++
+ 4 files changed, 58 insertions(+)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/cli/local-ci-selection.test.ts
+++ b/packages/agentplane/src/cli/local-ci-selection.test.ts
@@ -339,6 +339,29 @@ describe("local CI fast selection", () => {
     );
   });
 
+  it("routes PR integrate command paths to a narrow integrate bucket", () => {
+    const plan = selectFastCiPlan([
+      ".agentplane/tasks/202605222225-2B0DJD/README.md",
+      ".agentplane/tasks/202605222225-2B0DJD/pr/meta.json",
+      "packages/agentplane/src/commands/pr/integrate/cmd.test.ts",
+      "packages/agentplane/src/commands/pr/integrate/internal/github-pr-merge.ts",
+    ]);
+    expect(plan.kind).toBe("targeted");
+    expect(plan.bucket).toBe("pr-integrate");
+    expect(plan.reason).toBe("pr_integrate_paths_only");
+    expect(plan.lintTargets).toEqual([
+      "packages/agentplane/src/commands/pr/integrate/cmd.test.ts",
+      "packages/agentplane/src/commands/pr/integrate/internal/github-pr-merge.ts",
+    ]);
+    expect(plan.testFiles).toContain("packages/agentplane/src/commands/pr/integrate/cmd.test.ts");
+    expect(plan.testFiles).toContain(
+      "packages/agentplane/src/commands/pr/integrate/internal/merge.test.ts",
+    );
+    expect(plan.testFiles).not.toContain(
+      "packages/agentplane/src/cli/run-cli.core.pr-flow.pr-validation.test.ts",
+    );
+  });
+
   it("ignores task artifacts when routing PR bucket changes", () => {
     const plan = selectFastCiPlan([
       ".agentplane/tasks/202604130750-E2J835/README.md",

--- a/scripts/lib/local-ci-selection.d.ts
+++ b/scripts/lib/local-ci-selection.d.ts
@@ -20,6 +20,8 @@ export type FastCiPlan =
         | "cli-help"
         | "cli-core"
         | "cli-runtime"
+        | "pr"
+        | "pr-integrate"
         | "release"
         | "upgrade"
         | "guard"

--- a/scripts/lib/local-ci-selection.mjs
+++ b/scripts/lib/local-ci-selection.mjs
@@ -10,6 +10,7 @@ const {
   guard: GUARD_TEST_FILES,
   hooks: HOOKS_TEST_FILES,
   pr: PR_TEST_FILES,
+  "pr-integrate": PR_INTEGRATE_TEST_FILES,
   release: RELEASE_TEST_FILES,
   task: TASK_TEST_FILES,
   upgrade: UPGRADE_TEST_FILES,
@@ -100,6 +101,9 @@ const CLI_CORE_BUCKET_PATTERNS = [
 const PR_BUCKET_PATTERNS = [
   /^packages\/agentplane\/src\/commands\/pr(?:\/|\.|$)/,
   /^packages\/agentplane\/src\/cli\/run-cli\.core\.pr-flow(?:\..+)?\.test\.ts$/,
+];
+const PR_INTEGRATE_BUCKET_PATTERNS = [
+  /^packages\/agentplane\/src\/commands\/pr\/integrate(?:\/|\.|$)/,
 ];
 
 const CLI_RUNTIME_BUCKET_PATTERNS = [
@@ -211,6 +215,13 @@ const TARGET_BUCKET_DEFINITIONS = [
     reason: "cli_core_execution_paths_only",
     patterns: CLI_CORE_BUCKET_PATTERNS,
     testFiles: CLI_CORE_TEST_FILES,
+    vitestPool: "threads",
+  },
+  {
+    bucket: "pr-integrate",
+    reason: "pr_integrate_paths_only",
+    patterns: PR_INTEGRATE_BUCKET_PATTERNS,
+    testFiles: PR_INTEGRATE_TEST_FILES,
     vitestPool: "threads",
   },
   {
@@ -407,6 +418,18 @@ export function selectFastCiPlan(changedFiles) {
       files,
       lintTargets: effectiveFiles,
       testFiles: CLI_CORE_TEST_FILES,
+      vitestPool: "threads",
+    };
+  }
+
+  if (everyPathMatches(effectiveFiles, PR_INTEGRATE_BUCKET_PATTERNS)) {
+    return {
+      kind: "targeted",
+      bucket: "pr-integrate",
+      reason: "pr_integrate_paths_only",
+      files,
+      lintTargets: effectiveFiles,
+      testFiles: PR_INTEGRATE_TEST_FILES,
       vitestPool: "threads",
     };
   }

--- a/scripts/lib/test-route-registry.mjs
+++ b/scripts/lib/test-route-registry.mjs
@@ -474,6 +474,10 @@ const PR_FLOW_DISCOVERY_PATTERNS = [
   /^packages\/agentplane\/src\/cli\/run-cli\.core\.pr-flow(?:\..+)?\.test\.ts$/,
 ];
 
+const PR_INTEGRATE_DISCOVERY_PATTERNS = [
+  /^packages\/agentplane\/src\/commands\/pr\/integrate(?:\/|\.|$).+\.test\.ts$/,
+];
+
 const GUARD_DISCOVERY_PATTERNS = [
   /^packages\/agentplane\/src\/commands\/guard\/.+\.test\.ts$/,
   /^packages\/agentplane\/src\/cli\/run-cli\.core\.guard(?:\..+)?\.test\.ts$/,
@@ -503,6 +507,11 @@ const PR_TEST_FILES = [
   "packages/agentplane/src/commands/pr/input-validation.test.ts",
   ...discoverTestFiles(["packages/agentplane/src/cli"], PR_FLOW_DISCOVERY_PATTERNS),
 ];
+
+const PR_INTEGRATE_TEST_FILES = discoverTestFiles(
+  ["packages/agentplane/src/commands/pr/integrate"],
+  PR_INTEGRATE_DISCOVERY_PATTERNS,
+);
 
 const CLI_RUNTIME_TEST_FILES = [
   "packages/agentplane/src/cli/runtime-context.test.ts",
@@ -563,6 +572,7 @@ export const LOCAL_CI_TARGET_TEST_FILES = {
   guard: GUARD_TEST_FILES,
   hooks: HOOKS_TEST_FILES,
   pr: PR_TEST_FILES,
+  "pr-integrate": PR_INTEGRATE_TEST_FILES,
   release: RELEASE_TEST_FILES,
   task: TASK_TEST_FILES,
   upgrade: UPGRADE_TEST_FILES,


### PR DESCRIPTION
Task: `202605222245-V6VTG8`
Title: Narrow pre-push PR-flow test selection for small integrate changes
Canonical task record: `.agentplane/tasks/202605222245-V6VTG8/README.md`

## Summary

Narrow pre-push PR-flow test selection for small integrate changes

A small protected-base integrate transport change triggered the pre-push fast CI targeted pr selector to run the broad pr-flow Vitest bucket and hang for more than ten minutes. Tighten changed-file routing so focused integrate internals and cmd tests do not fan out to unrelated PR lifecycle suites, or add a bounded timeout/reporting guard for that selector.

## Scope

- In scope: A small protected-base integrate transport change triggered the pre-push fast CI targeted pr selector to run the broad pr-flow Vitest bucket and hang for more than ten minutes. Tighten changed-file routing so focused integrate internals and cmd tests do not fan out to unrelated PR lifecycle suites, or add a bounded timeout/reporting guard for that selector.
- Out of scope: unrelated refactors not required for "Narrow pre-push PR-flow test selection for small integrate changes".

## Verification

- State: ok
- Note:

```text
Evaluator check: pre-push routing is narrowed by path-specific PR integrate bucket while generic PR
paths still keep the existing pr bucket; regression coverage asserts pr-flow suites are excluded for
integrate internals.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-22T22:48:31.426Z
- Branch: task/202605222245-V6VTG8/narrow-pr-integrate-ci-selection
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../agentplane/src/cli/local-ci-selection.test.ts  | 23 ++++++++++++++++++++++
 scripts/lib/local-ci-selection.d.ts                |  2 ++
 scripts/lib/local-ci-selection.mjs                 | 23 ++++++++++++++++++++++
 scripts/lib/test-route-registry.mjs                | 10 ++++++++++
 4 files changed, 58 insertions(+)
```

</details>
