### PR TITLE
🚧 8SA692 task: Add combined hosted lifecycle status report [202605221726-8SA692]

### DIFF
--- a/.agentplane/tasks/202605221726-8SA692/README.md
+++ b/.agentplane/tasks/202605221726-8SA692/README.md
@@ -1,10 +1,10 @@
 ---
 id: "202605221726-8SA692"
 title: "Add combined hosted lifecycle status report"
-status: "TODO"
+status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 4
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -23,17 +23,50 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-22T23:15:08.379Z"
+  updated_by: "EVALUATOR"
+  note: "Evaluator check: combined report extends the existing branch_pr flow surface without adding a second lifecycle truth; unavailable GitHub/provider state degrades into explicit unchecked reasons and local queue/handoff evidence remains visible."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-22T23:15:08.379Z"
+  updated_by: "EVALUATOR"
+  note: "Evaluator check: combined report extends the existing branch_pr flow surface without adding a second lifecycle truth; unavailable GitHub/provider state degrades into explicit unchecked reasons and local queue/handoff evidence remains visible."
+  evaluated_sha: "fa202aa7f8123a8ce3fcba03affed3f37ae8a53e"
+  blueprint_digest: "d25e505733877eb7200a4fb76923472a539c38ba67e83aff07a561bdfe5a0bef"
+  evidence_refs:
+    - ".agentplane/tasks/202605221726-8SA692/README.md"
+    - "/Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221726-8SA692-hosted-lifecycle-status-report/.agentplane/tasks/202605221726-8SA692/blueprint/resolved-snapshot.json"
+  findings: []
 commit: null
-comments: []
-events: []
+comments:
+  -
+    author: "CODER"
+    body: "Start: adding combined hosted lifecycle status report for branch_pr tasks."
+events:
+  -
+    type: "status"
+    at: "2026-05-22T23:11:41.641Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: adding combined hosted lifecycle status report for branch_pr tasks."
+  -
+    type: "verify"
+    at: "2026-05-22T23:15:03.751Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: pr flow status now combines lifecycle, remote PR, hosted checks, review threads, integration queue, handoff, close-tail, and next action; mocked output test covers degraded GitHub PR-number state plus queue/handoff, lint/typecheck/docs CLI checks passed."
+  -
+    type: "verify"
+    at: "2026-05-22T23:15:08.379Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Evaluator check: combined report extends the existing branch_pr flow surface without adding a second lifecycle truth; unavailable GitHub/provider state degrades into explicit unchecked reasons and local queue/handoff evidence remains visible."
 doc_version: 3
-doc_updated_at: "2026-05-22T17:27:52.436Z"
-doc_updated_by: "PLANNER"
+doc_updated_at: "2026-05-22T23:15:08.407Z"
+doc_updated_by: "CODER"
 description: "Expose local AgentPlane lifecycle, queue/handoff state, GitHub PR state, hosted checks, review threads, and close-tail state in one command for branch_pr tasks."
 sections:
   Summary: |-
@@ -50,6 +83,44 @@ sections:
     3. Confirm command degrades clearly when GitHub auth or network is unavailable.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-22T23:15:03.751Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified: pr flow status now combines lifecycle, remote PR, hosted checks, review threads, integration queue, handoff, close-tail, and next action; mocked output test covers degraded GitHub PR-number state plus queue/handoff, lint/typecheck/docs CLI checks passed.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T23:11:41.641Z, excerpt_hash=sha256:4ba29801faaa6b9b348da08e907a63ba8554ed7ae1c42136a0766f152bf6b6e9
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221726-8SA692-hosted-lifecycle-status-report/.agentplane/tasks/202605221726-8SA692/blueprint/resolved-snapshot.json
+    - old_digest: d25e505733877eb7200a4fb76923472a539c38ba67e83aff07a561bdfe5a0bef
+    - current_digest: d25e505733877eb7200a4fb76923472a539c38ba67e83aff07a561bdfe5a0bef
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605221726-8SA692
+
+    ### 2026-05-22T23:15:08.379Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Evaluator check: combined report extends the existing branch_pr flow surface without adding a second lifecycle truth; unavailable GitHub/provider state degrades into explicit unchecked reasons and local queue/handoff evidence remains visible.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T23:15:03.778Z, excerpt_hash=sha256:4ba29801faaa6b9b348da08e907a63ba8554ed7ae1c42136a0766f152bf6b6e9
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221726-8SA692-hosted-lifecycle-status-report/.agentplane/tasks/202605221726-8SA692/blueprint/resolved-snapshot.json
+    - old_digest: d25e505733877eb7200a4fb76923472a539c38ba67e83aff07a561bdfe5a0bef
+    - current_digest: d25e505733877eb7200a4fb76923472a539c38ba67e83aff07a561bdfe5a0bef
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605221726-8SA692
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -81,6 +152,44 @@ Add a combined hosted lifecycle status surface that keeps ap as lifecycle truth 
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-22T23:15:03.751Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: pr flow status now combines lifecycle, remote PR, hosted checks, review threads, integration queue, handoff, close-tail, and next action; mocked output test covers degraded GitHub PR-number state plus queue/handoff, lint/typecheck/docs CLI checks passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T23:11:41.641Z, excerpt_hash=sha256:4ba29801faaa6b9b348da08e907a63ba8554ed7ae1c42136a0766f152bf6b6e9
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221726-8SA692-hosted-lifecycle-status-report/.agentplane/tasks/202605221726-8SA692/blueprint/resolved-snapshot.json
+- old_digest: d25e505733877eb7200a4fb76923472a539c38ba67e83aff07a561bdfe5a0bef
+- current_digest: d25e505733877eb7200a4fb76923472a539c38ba67e83aff07a561bdfe5a0bef
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605221726-8SA692
+
+### 2026-05-22T23:15:08.379Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Evaluator check: combined report extends the existing branch_pr flow surface without adding a second lifecycle truth; unavailable GitHub/provider state degrades into explicit unchecked reasons and local queue/handoff evidence remains visible.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T23:15:03.778Z, excerpt_hash=sha256:4ba29801faaa6b9b348da08e907a63ba8554ed7ae1c42136a0766f152bf6b6e9
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221726-8SA692-hosted-lifecycle-status-report/.agentplane/tasks/202605221726-8SA692/blueprint/resolved-snapshot.json
+- old_digest: d25e505733877eb7200a4fb76923472a539c38ba67e83aff07a561bdfe5a0bef
+- current_digest: d25e505733877eb7200a4fb76923472a539c38ba67e83aff07a561bdfe5a0bef
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605221726-8SA692
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605221726-8SA692/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605221726-8SA692/blueprint/resolved-snapshot.json
@@ -1,0 +1,573 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605221726-8SA692",
+    "title": "Add combined hosted lifecycle status report",
+    "description": "Expose local AgentPlane lifecycle, queue/handoff state, GitHub PR state, hosted checks, review threads, and close-tail state in one command for branch_pr tasks.",
+    "tags": [
+      "cli",
+      "code",
+      "github",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605221726-8SA692",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "d25e505733877eb7200a4fb76923472a539c38ba67e83aff07a561bdfe5a0bef"
+  }
+}

--- a/.agentplane/tasks/202605221726-8SA692/pr/diffstat.txt
+++ b/.agentplane/tasks/202605221726-8SA692/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../src/cli/run-cli.core.pr-flow.status.test.ts    |  57 ++++++++
+ packages/agentplane/src/commands/pr/flow-status.ts | 162 +++++++++++++++++++++
+ 2 files changed, 219 insertions(+)

--- a/.agentplane/tasks/202605221726-8SA692/pr/github-body.md
+++ b/.agentplane/tasks/202605221726-8SA692/pr/github-body.md
@@ -1,0 +1,41 @@
+Task: `202605221726-8SA692`
+Title: Add combined hosted lifecycle status report
+Canonical task record: `.agentplane/tasks/202605221726-8SA692/README.md`
+
+## Summary
+
+Add combined hosted lifecycle status report
+
+Expose local AgentPlane lifecycle, queue/handoff state, GitHub PR state, hosted checks, review threads, and close-tail state in one command for branch_pr tasks.
+
+## Scope
+
+- In scope: Expose local AgentPlane lifecycle, queue/handoff state, GitHub PR state, hosted checks, review threads, and close-tail state in one command for branch_pr tasks.
+- Out of scope: unrelated refactors not required for "Add combined hosted lifecycle status report".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Evaluator check: combined report extends the existing branch_pr flow surface without adding a second
+lifecycle truth; unavailable GitHub/provider state degrades into explicit unchecked reasons and
+local queue/handoff evidence remains visible.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-22T23:15:03.831Z
+- Branch: task/202605221726-8SA692/hosted-lifecycle-status-report
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/cli/run-cli.core.pr-flow.status.test.ts    |  57 ++++++++
+ packages/agentplane/src/commands/pr/flow-status.ts | 162 +++++++++++++++++++++
+ 2 files changed, 219 insertions(+)
+```
+
+</details>

--- a/.agentplane/tasks/202605221726-8SA692/pr/github-title.txt
+++ b/.agentplane/tasks/202605221726-8SA692/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 8SA692 task: Add combined hosted lifecycle status report [202605221726-8SA692]

--- a/.agentplane/tasks/202605221726-8SA692/pr/meta.json
+++ b/.agentplane/tasks/202605221726-8SA692/pr/meta.json
@@ -1,0 +1,17 @@
+{
+  "base": "main",
+  "branch": "task/202605221726-8SA692/hosted-lifecycle-status-report",
+  "created_at": "2026-05-22T23:15:03.831Z",
+  "diffstat_sha256": "sha256:2c50072ecf94cc99adc71b05afbcbc83d3b518cbcbdb37ff9f082d6adb29cae0",
+  "last_verified_at": "2026-05-22T23:15:08.379Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "pr_number": 4048,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4048",
+  "schema_version": 1,
+  "status": "OPEN",
+  "task_id": "202605221726-8SA692",
+  "updated_at": "2026-05-22T23:15:33.387Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605221726-8SA692/pr/review.md
+++ b/.agentplane/tasks/202605221726-8SA692/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-05-22T23:15:03.831Z
+
+## Task
+
+- Task: `202605221726-8SA692`
+- Title: Add combined hosted lifecycle status report
+- Status: DOING
+- Branch: `task/202605221726-8SA692/hosted-lifecycle-status-report`
+- Canonical task record: `.agentplane/tasks/202605221726-8SA692/README.md`
+
+## Verification
+
+- State: ok
+- Note: Evaluator check: combined report extends the existing branch_pr flow surface without adding a second lifecycle truth; unavailable GitHub/provider state degrades into explicit unchecked reasons and local queue/handoff evidence remains visible.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-22T23:15:03.831Z
+- Branch: task/202605221726-8SA692/hosted-lifecycle-status-report
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/cli/run-cli.core.pr-flow.status.test.ts    |  57 ++++++++
+ packages/agentplane/src/commands/pr/flow-status.ts | 162 +++++++++++++++++++++
+ 2 files changed, 219 insertions(+)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/cli/run-cli.core.pr-flow.status.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.pr-flow.status.test.ts
@@ -11,12 +11,50 @@ import {
   runCliSilent,
   writeConfig,
 } from "@agentplane/testkit/cli-core-pr-flow";
+import { execFileAsync } from "@agentplaneorg/core/process";
+import { chmod, mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 function expectLabeledValue(output: string, label: string, expected: string): void {
   const line = output.split(/\r?\n/u).find((line) => line.trimStart().startsWith(`${label}:`));
   const separator = line?.indexOf(":") ?? -1;
   expect(separator >= 0 ? line?.slice(separator + 1).trim() : undefined).toBe(expected);
+}
+
+async function installFakeGh(root: string, opts: { checksExitCode: number }) {
+  const fakeBin = path.join(root, "fake-bin");
+  await mkdir(fakeBin, { recursive: true });
+  const scriptPath = path.join(fakeBin, "fake-gh.mjs");
+  const ghPath = path.join(fakeBin, process.platform === "win32" ? "gh.cmd" : "gh");
+  await writeFile(
+    scriptPath,
+    [
+      "const args = process.argv.slice(2);",
+      'if (args[0] === "pr" && args[1] === "checks") {',
+      "  console.log(JSON.stringify([",
+      '    { name: "unit", state: "SUCCESS" },',
+      '    { name: "lint", state: "PENDING" },',
+      '    { name: "static", state: "SKIPPING" }',
+      "  ]));",
+      `  process.exit(${opts.checksExitCode});`,
+      "}",
+      'if (args[0] === "api" && args[1] === "graphql") {',
+      "  console.log(JSON.stringify({ data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } }));",
+      "  process.exit(0);",
+      "}",
+      "console.error(`unexpected gh args: ${JSON.stringify(args)}`);",
+      "process.exit(91);",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  if (process.platform === "win32") {
+    await writeFile(ghPath, '@echo off\r\nnode "%~dp0\\fake-gh.mjs" %*\r\n', "utf8");
+  } else {
+    await writeFile(ghPath, '#!/bin/sh\nnode "$(dirname "$0")/fake-gh.mjs" "$@"\n', "utf8");
+    await chmod(ghPath, 0o755);
+  }
+  return fakeBin;
 }
 
 describe("runCli pr flow status", () => {
@@ -71,6 +109,46 @@ describe("runCli pr flow status", () => {
     const metaPath = path.join(root, ".agentplane", "tasks", taskId, "pr", "meta.json");
     const meta = JSON.parse(await readFile(metaPath, "utf8")) as { branch?: string };
     expect(meta.branch).toBe(branch);
+    await mkdir(path.join(root, ".agentplane", "cache"), { recursive: true });
+    await writeFile(
+      path.join(root, ".agentplane", "cache", "integration-queue.json"),
+      `${JSON.stringify({
+        schema_version: 1,
+        entries: [
+          {
+            task_id: taskId,
+            branch,
+            base: "main",
+            head_sha: "head",
+            base_sha: "base",
+            changed_paths: ["file.txt"],
+            pr_number: null,
+            pr_url: null,
+            priority: 0,
+            status: "handoff",
+            enqueued_at: "2026-01-01T00:00:00.000Z",
+            updated_at: "2026-01-01T00:01:00.000Z",
+            reason: "protected base handoff recorded",
+          },
+        ],
+      })}\n`,
+      "utf8",
+    );
+    const handoffDir = path.join(root, ".agentplane", "tasks", taskId, "handoff");
+    await mkdir(handoffDir, { recursive: true });
+    await writeFile(
+      path.join(handoffDir, "latest.json"),
+      `${JSON.stringify({
+        schema_version: 1,
+        task_id: taskId,
+        created_at: "2026-01-01T00:00:00.000Z",
+        from_role: "INTEGRATOR",
+        reason: "branch_pr integration is waiting for hosted close",
+        route: { kind: "protected_base_integrate", status: "awaiting_github_merge" },
+        next_actions: ["git pull --ff-only"],
+      })}\n`,
+      "utf8",
+    );
 
     const io = captureStdIO();
     try {
@@ -80,9 +158,99 @@ describe("runCli pr flow status", () => {
       expectLabeledValue(io.stdout, "task", `${taskId} TODO`);
       expectLabeledValue(io.stdout, "branch", branch);
       expectLabeledValue(io.stdout, "remote_pr", "github: not_found (source=metadata)");
+      expectLabeledValue(
+        io.stdout,
+        "hosted_checks",
+        "unchecked: GitHub PR number is not recorded in PR metadata",
+      );
+      expectLabeledValue(
+        io.stdout,
+        "review_threads",
+        "unchecked: GitHub PR number is not recorded in PR metadata",
+      );
+      expectLabeledValue(io.stdout, "queue", "handoff: protected base handoff recorded");
+      expectLabeledValue(
+        io.stdout,
+        "handoff",
+        "awaiting_github_merge: branch_pr integration is waiting for hosted close",
+      );
       expectLabeledValue(io.stdout, "next", `agentplane pr open ${taskId} --author <ROLE>`);
     } finally {
       io.restore();
+    }
+  });
+
+  it("reports hosted check counts when gh returns pending status with exit code 8", async () => {
+    const root = await mkGitRepoRootWithBranch("main");
+    const config = defaultConfig();
+    config.workflow_mode = "branch_pr";
+    await writeConfig(root, config);
+    await runCliSilent(["branch", "base", "set", "main", "--root", root]);
+    await execFileAsync("git", ["remote", "add", "origin", "git@github.com:example/repo.git"], {
+      cwd: root,
+    });
+
+    let taskId = "";
+    const taskIo = captureStdIO();
+    try {
+      const code = await runCli([
+        "task",
+        "new",
+        "--title",
+        "Inspect hosted checks",
+        "--description",
+        "PR flow status should summarize pending hosted checks.",
+        "--priority",
+        "med",
+        "--owner",
+        "CODER",
+        "--tag",
+        "workflow",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(0);
+      taskId = taskIo.stdout.trim();
+    } finally {
+      taskIo.restore();
+    }
+
+    const branch = `task/${taskId}/flow-status`;
+    expect(
+      await runCliSilent([
+        "pr",
+        "open",
+        taskId,
+        "--author",
+        "CODER",
+        "--branch",
+        branch,
+        "--sync-only",
+        "--root",
+        root,
+      ]),
+    ).toBe(0);
+
+    const metaPath = path.join(root, ".agentplane", "tasks", taskId, "pr", "meta.json");
+    const meta = JSON.parse(await readFile(metaPath, "utf8")) as Record<string, unknown>;
+    await writeFile(
+      metaPath,
+      `${JSON.stringify({ ...meta, pr_number: 123, pr_url: "https://github.com/example/repo/pull/123", status: "OPEN" })}\n`,
+      "utf8",
+    );
+
+    const fakeBin = await installFakeGh(root, { checksExitCode: 8 });
+    const oldPath = process.env.PATH;
+    process.env.PATH = `${fakeBin}${path.delimiter}${oldPath ?? ""}`;
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["pr", "flow", "status", taskId, "--root", root]);
+      expect(code).toBe(0);
+      expectLabeledValue(io.stdout, "hosted_checks", "total=3 passing=2 pending=1 failing=0");
+      expectLabeledValue(io.stdout, "review_threads", "unresolved=0");
+    } finally {
+      io.restore();
+      process.env.PATH = oldPath;
     }
   });
 });

--- a/packages/agentplane/src/commands/pr/flow-status.ts
+++ b/packages/agentplane/src/commands/pr/flow-status.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 
 import { gitRevParse, taskCloseBranchName } from "@agentplaneorg/core/git";
+import { runProcess } from "@agentplaneorg/core/process";
 
 import { createCliEmitter } from "../../cli/output.js";
 import { mapBackendError } from "../../cli/error-map.js";
@@ -13,11 +14,18 @@ import {
 } from "../shared/task-backend.js";
 import { taskCloseAlreadyRecordedOnBase } from "../task/close-tail-state.js";
 import { parsePrMeta, type PrMeta } from "../shared/pr-meta.js";
+import { readTaskHandoffLatest, resolveTaskHandoffPaths } from "../shared/task-handoff.js";
+import { normalizeGhTransportError } from "../shared/gh-transport.js";
+import { readIntegrationQueue, type IntegrationQueueEntry } from "../pr/integrate/queue-state.js";
+import { checkGithubUnresolvedReviewThreads } from "./internal/github-review-threads.js";
+import { ghEnv } from "./internal/gh-api.js";
 
 import { resolvePrPaths } from "./internal/pr-paths.js";
 import { tryLookupExistingGithubPrByBranch } from "./internal/sync-github.js";
 
 type ProviderName = "github";
+
+type GhPrCheckRow = { state?: string | null };
 
 export type RemotePrStatus =
   | { provider: ProviderName; state: "not_found"; source: "lookup" | "metadata" }
@@ -56,8 +64,69 @@ export type PrFlowStatusReport = {
   };
   pr: RemotePrStatus;
   closeTail: CloseTailStatus;
+  hostedChecks: HostedChecksStatus;
+  reviewThreads: ReviewThreadsStatus;
+  queue: QueueStatus;
+  handoff: HandoffStatus;
   nextAction: string;
 };
+
+export type HostedChecksStatus =
+  | { checked: true; total: number; pending: number; failing: number; passing: number }
+  | { checked: false; reason: string };
+
+export type ReviewThreadsStatus =
+  | { checked: true; unresolved: number }
+  | { checked: false; reason: string };
+
+export type QueueStatus =
+  | { present: false }
+  | {
+      present: true;
+      status: IntegrationQueueEntry["status"];
+      reason: string | null;
+      updatedAt: string | null;
+    };
+
+export type HandoffStatus =
+  | { present: false }
+  | {
+      present: true;
+      reason: string;
+      routeStatus: string | null;
+      nextActions: string[];
+    };
+
+function parseGhPrChecks(stdout: string): GhPrCheckRow[] {
+  const rows = JSON.parse(stdout) as GhPrCheckRow[];
+  return Array.isArray(rows) ? rows : [];
+}
+
+function isPendingGhCheckState(state: string): boolean {
+  return ["PENDING", "QUEUED", "IN_PROGRESS", "WAITING", "REQUESTED", "EXPECTED"].includes(state);
+}
+
+function isFailingGhCheckState(state: string): boolean {
+  return ["FAIL", "FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED"].includes(state);
+}
+
+function summarizeHostedChecks(
+  checks: GhPrCheckRow[],
+): Extract<HostedChecksStatus, { checked: true }> {
+  const pending = checks.filter((check) =>
+    isPendingGhCheckState((check.state ?? "").toUpperCase()),
+  ).length;
+  const failing = checks.filter((check) =>
+    isFailingGhCheckState((check.state ?? "").toUpperCase()),
+  ).length;
+  return {
+    checked: true,
+    total: checks.length,
+    pending,
+    failing,
+    passing: Math.max(0, checks.length - pending - failing),
+  };
+}
 
 function shortSha(value: string | null | undefined): string | null {
   const trimmed = value?.trim() ?? "";
@@ -100,6 +169,78 @@ function remoteStatusFromMeta(meta: PrMeta | null): RemotePrStatus {
     };
   }
   return { provider: "github", state: "not_found", source: "metadata" };
+}
+
+async function resolveHostedChecksStatus(opts: {
+  gitRoot: string;
+  prNumber: number | null;
+}): Promise<HostedChecksStatus> {
+  if (opts.prNumber === null || opts.prNumber <= 0) {
+    return { checked: false, reason: "GitHub PR number is not recorded in PR metadata" };
+  }
+  try {
+    const result = await runProcess({
+      command: "gh",
+      args: ["pr", "checks", String(opts.prNumber), "--json", "name,state"],
+      cwd: opts.gitRoot,
+      env: ghEnv(),
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+      reject: false,
+    });
+    if (result.exitCode === 0 || result.exitCode === 8) {
+      return summarizeHostedChecks(parseGhPrChecks(String(result.stdout)));
+    }
+    return { checked: false, reason: normalizeGhTransportError(result.stderr || result.stdout) };
+  } catch (err) {
+    const code = (err as { code?: string } | null)?.code;
+    return {
+      checked: false,
+      reason: code === "ENOENT" ? "gh CLI is unavailable" : normalizeGhTransportError(err),
+    };
+  }
+}
+
+async function resolveReviewThreadsStatus(opts: {
+  gitRoot: string;
+  prNumber: number | null;
+}): Promise<ReviewThreadsStatus> {
+  const result = await checkGithubUnresolvedReviewThreads(opts);
+  if (!result.checked) return { checked: false, reason: result.reason };
+  return { checked: true, unresolved: result.unresolved.length };
+}
+
+async function resolveQueueStatus(opts: { gitRoot: string; taskId: string }): Promise<QueueStatus> {
+  const queue = await readIntegrationQueue(opts.gitRoot);
+  const entry = queue.entries.find((candidate) => candidate.task_id === opts.taskId);
+  if (!entry) return { present: false };
+  return {
+    present: true,
+    status: entry.status,
+    reason: entry.reason ?? null,
+    updatedAt: entry.updated_at ?? null,
+  };
+}
+
+async function resolveHandoffStatus(opts: {
+  gitRoot: string;
+  workflowDir: string;
+  taskId: string;
+}): Promise<HandoffStatus> {
+  const handoff = await readTaskHandoffLatest(
+    resolveTaskHandoffPaths({
+      git_root: opts.gitRoot,
+      workflow_dir: opts.workflowDir,
+      task_id: opts.taskId,
+    }),
+  );
+  if (!handoff) return { present: false };
+  return {
+    present: true,
+    reason: handoff.reason,
+    routeStatus: handoff.route?.status ?? null,
+    nextActions: handoff.next_actions ?? [],
+  };
 }
 
 function remoteStatusFromObserved(
@@ -239,6 +380,17 @@ export async function resolvePrFlowStatus(opts: {
     baseBranch,
     remotePr: pr,
   });
+  const prNumber = pr.state === "not_found" ? null : pr.prNumber;
+  const [hostedChecks, reviewThreads, queue, handoff] = await Promise.all([
+    resolveHostedChecksStatus({ gitRoot: resolved.gitRoot, prNumber }),
+    resolveReviewThreadsStatus({ gitRoot: resolved.gitRoot, prNumber }),
+    resolveQueueStatus({ gitRoot: resolved.gitRoot, taskId: task.id }),
+    resolveHandoffStatus({
+      gitRoot: resolved.gitRoot,
+      workflowDir: config.paths.workflow_dir,
+      taskId: task.id,
+    }),
+  ]);
   const report: PrFlowStatusReport = {
     task: {
       id: task.id,
@@ -252,10 +404,34 @@ export async function resolvePrFlowStatus(opts: {
     },
     pr,
     closeTail,
+    hostedChecks,
+    reviewThreads,
+    queue,
+    handoff,
     nextAction: "",
   };
   report.nextAction = deriveNextAction(report);
   return report;
+}
+
+function renderHostedChecksLine(status: HostedChecksStatus): string {
+  if (!status.checked) return `unchecked: ${status.reason}`;
+  return `total=${status.total} passing=${status.passing} pending=${status.pending} failing=${status.failing}`;
+}
+
+function renderReviewThreadsLine(status: ReviewThreadsStatus): string {
+  if (!status.checked) return `unchecked: ${status.reason}`;
+  return `unresolved=${status.unresolved}`;
+}
+
+function renderQueueLine(status: QueueStatus): string {
+  if (!status.present) return "not_queued";
+  return `${status.status}${status.reason ? `: ${status.reason}` : ""}`;
+}
+
+function renderHandoffLine(status: HandoffStatus): string {
+  if (!status.present) return "none";
+  return `${status.routeStatus ?? "recorded"}: ${status.reason}`;
 }
 
 function renderPrLine(pr: RemotePrStatus): string {
@@ -298,6 +474,10 @@ export async function cmdPrFlowStatus(opts: {
         { label: "branch_head", value: shortSha(report.branch.headSha) ?? "unknown" },
         { label: "meta_head", value: shortSha(report.branch.metaHeadSha) ?? "unknown" },
         { label: "remote_pr", value: renderPrLine(report.pr) },
+        { label: "hosted_checks", value: renderHostedChecksLine(report.hostedChecks) },
+        { label: "review_threads", value: renderReviewThreadsLine(report.reviewThreads) },
+        { label: "queue", value: renderQueueLine(report.queue) },
+        { label: "handoff", value: renderHandoffLine(report.handoff) },
         { label: "close_tail", value: renderCloseTailLine(report.closeTail) },
         { label: "next", value: report.nextAction },
       ],


### PR DESCRIPTION
Task: `202605221726-8SA692`
Title: Add combined hosted lifecycle status report
Canonical task record: `.agentplane/tasks/202605221726-8SA692/README.md`

## Summary

Add combined hosted lifecycle status report

Expose local AgentPlane lifecycle, queue/handoff state, GitHub PR state, hosted checks, review threads, and close-tail state in one command for branch_pr tasks.

## Scope

- In scope: Expose local AgentPlane lifecycle, queue/handoff state, GitHub PR state, hosted checks, review threads, and close-tail state in one command for branch_pr tasks.
- Out of scope: unrelated refactors not required for "Add combined hosted lifecycle status report".

## Verification

- State: ok
- Note:

```text
Evaluator check: combined report extends the existing branch_pr flow surface without adding a second
lifecycle truth; unavailable GitHub/provider state degrades into explicit unchecked reasons and
local queue/handoff evidence remains visible.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-22T23:15:03.831Z
- Branch: task/202605221726-8SA692/hosted-lifecycle-status-report
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/cli/run-cli.core.pr-flow.status.test.ts    |  57 ++++++++
 packages/agentplane/src/commands/pr/flow-status.ts | 162 +++++++++++++++++++++
 2 files changed, 219 insertions(+)
```

</details>
