### PR TITLE
🚧 RZVQJ9 task: Narrow pr flow status local CI route [202605222339-RZVQJ9]

### DIFF
--- a/.agentplane/tasks/202605222339-RZVQJ9/README.md
+++ b/.agentplane/tasks/202605222339-RZVQJ9/README.md
@@ -1,0 +1,210 @@
+---
+id: "202605222339-RZVQJ9"
+title: "Narrow pr flow status local CI route"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "performance"
+  - "workflow"
+verify:
+  - "bunx vitest run packages/agentplane/src/cli/local-ci-selection.test.ts"
+  - "node scripts/checks/run-local-ci.mjs --mode fast with changed files for flow-status paths reports targeted pr-flow-status"
+  - "bun run lint:core -- scripts/lib/local-ci-selection.mjs packages/agentplane/src/cli/local-ci-selection.test.ts"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-22T23:40:00.343Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-22T23:44:31.177Z"
+  updated_by: "EVALUATOR"
+  note: "Evaluator check: route is narrow, ordered before broader cli-core/pr catch-alls, preserves task artifact neutrality, and smoke output confirms targeted pr-flow-status selection."
+  attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-22T23:44:31.177Z"
+  updated_by: "EVALUATOR"
+  note: "Evaluator check: route is narrow, ordered before broader cli-core/pr catch-alls, preserves task artifact neutrality, and smoke output confirms targeted pr-flow-status selection."
+  evaluated_sha: "16c70acd9a8bba86961657c5a13db1e04d5e2098"
+  blueprint_digest: "1ba13f231a86fc2f92004c16db267594835fb3f93b647feb1e4830ceb1b82147"
+  evidence_refs:
+    - ".agentplane/tasks/202605222339-RZVQJ9/README.md"
+    - "/Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605222339-RZVQJ9-pr-flow-status-ci-route/.agentplane/tasks/202605222339-RZVQJ9/blueprint/resolved-snapshot.json"
+  findings: []
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: narrowing local CI routing for pr flow status changes."
+events:
+  -
+    type: "status"
+    at: "2026-05-22T23:40:42.881Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: narrowing local CI routing for pr flow status changes."
+  -
+    type: "verify"
+    at: "2026-05-22T23:44:22.570Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: local CI selection now routes pr flow status implementation/test changes to targeted pr-flow-status bucket; selector unit test passes and run-local-ci smoke reports targeted (pr-flow-status) with only run-cli.core.pr-flow.status.test.ts in the unit phase."
+  -
+    type: "verify"
+    at: "2026-05-22T23:44:31.177Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Evaluator check: route is narrow, ordered before broader cli-core/pr catch-alls, preserves task artifact neutrality, and smoke output confirms targeted pr-flow-status selection."
+doc_version: 3
+doc_updated_at: "2026-05-22T23:44:31.205Z"
+doc_updated_by: "CODER"
+description: "Pre-push currently routes pr flow status changes through the broad pr test bucket, causing long or stalled pushes. Add a narrower local CI route for pr flow status files so small status-report changes run the focused status test and standard static checks."
+sections:
+  Summary: |-
+    Narrow pr flow status local CI route
+
+    Pre-push currently routes pr flow status changes through the broad pr test bucket, causing long or stalled pushes. Add a narrower local CI route for pr flow status files so small status-report changes run the focused status test and standard static checks.
+  Scope: |-
+    - In scope: Pre-push currently routes pr flow status changes through the broad pr test bucket, causing long or stalled pushes. Add a narrower local CI route for pr flow status files so small status-report changes run the focused status test and standard static checks.
+    - Out of scope: unrelated refactors not required for "Narrow pr flow status local CI route".
+  Plan: "Add a focused local CI mapping for pr flow status changes: identify current selector path classification, route flow-status implementation/test files to the narrow status test instead of the broad pr bucket, and verify with selector unit tests plus targeted local CI output."
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-22T23:44:22.570Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified: local CI selection now routes pr flow status implementation/test changes to targeted pr-flow-status bucket; selector unit test passes and run-local-ci smoke reports targeted (pr-flow-status) with only run-cli.core.pr-flow.status.test.ts in the unit phase.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T23:40:42.881Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605222339-RZVQJ9-pr-flow-status-ci-route/.agentplane/tasks/202605222339-RZVQJ9/blueprint/resolved-snapshot.json
+    - old_digest: 1ba13f231a86fc2f92004c16db267594835fb3f93b647feb1e4830ceb1b82147
+    - current_digest: 1ba13f231a86fc2f92004c16db267594835fb3f93b647feb1e4830ceb1b82147
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605222339-RZVQJ9
+
+    ### 2026-05-22T23:44:31.177Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Evaluator check: route is narrow, ordered before broader cli-core/pr catch-alls, preserves task artifact neutrality, and smoke output confirms targeted pr-flow-status selection.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T23:44:22.597Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605222339-RZVQJ9-pr-flow-status-ci-route/.agentplane/tasks/202605222339-RZVQJ9/blueprint/resolved-snapshot.json
+    - old_digest: 1ba13f231a86fc2f92004c16db267594835fb3f93b647feb1e4830ceb1b82147
+    - current_digest: 1ba13f231a86fc2f92004c16db267594835fb3f93b647feb1e4830ceb1b82147
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605222339-RZVQJ9
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Pre-push for small pr flow status changes previously selected broad targeted:pr and ran the full pr-flow split suite.
+      Impact: Small status-report fixes stalled or took several minutes despite touching one command and one focused split test.
+      Resolution: Added a pr-flow-status bucket ahead of cli-core/pr catch-all patterns and covered task-artifact-neutral routing in local-ci-selection.test.ts.
+id_source: "generated"
+---
+## Summary
+
+Narrow pr flow status local CI route
+
+Pre-push currently routes pr flow status changes through the broad pr test bucket, causing long or stalled pushes. Add a narrower local CI route for pr flow status files so small status-report changes run the focused status test and standard static checks.
+
+## Scope
+
+- In scope: Pre-push currently routes pr flow status changes through the broad pr test bucket, causing long or stalled pushes. Add a narrower local CI route for pr flow status files so small status-report changes run the focused status test and standard static checks.
+- Out of scope: unrelated refactors not required for "Narrow pr flow status local CI route".
+
+## Plan
+
+Add a focused local CI mapping for pr flow status changes: identify current selector path classification, route flow-status implementation/test files to the narrow status test instead of the broad pr bucket, and verify with selector unit tests plus targeted local CI output.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-22T23:44:22.570Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: local CI selection now routes pr flow status implementation/test changes to targeted pr-flow-status bucket; selector unit test passes and run-local-ci smoke reports targeted (pr-flow-status) with only run-cli.core.pr-flow.status.test.ts in the unit phase.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T23:40:42.881Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605222339-RZVQJ9-pr-flow-status-ci-route/.agentplane/tasks/202605222339-RZVQJ9/blueprint/resolved-snapshot.json
+- old_digest: 1ba13f231a86fc2f92004c16db267594835fb3f93b647feb1e4830ceb1b82147
+- current_digest: 1ba13f231a86fc2f92004c16db267594835fb3f93b647feb1e4830ceb1b82147
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605222339-RZVQJ9
+
+### 2026-05-22T23:44:31.177Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Evaluator check: route is narrow, ordered before broader cli-core/pr catch-alls, preserves task artifact neutrality, and smoke output confirms targeted pr-flow-status selection.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-22T23:44:22.597Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605222339-RZVQJ9-pr-flow-status-ci-route/.agentplane/tasks/202605222339-RZVQJ9/blueprint/resolved-snapshot.json
+- old_digest: 1ba13f231a86fc2f92004c16db267594835fb3f93b647feb1e4830ceb1b82147
+- current_digest: 1ba13f231a86fc2f92004c16db267594835fb3f93b647feb1e4830ceb1b82147
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605222339-RZVQJ9
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Pre-push for small pr flow status changes previously selected broad targeted:pr and ran the full pr-flow split suite.
+  Impact: Small status-report fixes stalled or took several minutes despite touching one command and one focused split test.
+  Resolution: Added a pr-flow-status bucket ahead of cli-core/pr catch-all patterns and covered task-artifact-neutral routing in local-ci-selection.test.ts.

--- a/.agentplane/tasks/202605222339-RZVQJ9/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605222339-RZVQJ9/blueprint/resolved-snapshot.json
@@ -1,0 +1,594 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605222339-RZVQJ9",
+    "title": "Narrow pr flow status local CI route",
+    "description": "Pre-push currently routes pr flow status changes through the broad pr test bucket, causing long or stalled pushes. Add a narrower local CI route for pr flow status files so small status-report changes run the focused status test and standard static checks.",
+    "tags": [
+      "code",
+      "performance",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "performance.benchmark",
+    "version": 1,
+    "title": "Performance benchmark",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "performance.benchmark",
+    "blueprintVersion": 1,
+    "title": "Performance benchmark",
+    "taskId": "202605222339-RZVQJ9",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to performance.benchmark",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "artifact"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "final_output"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "benchmark.baseline",
+        "kind": "artifact",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Baseline measurement artifact."
+      },
+      {
+        "id": "benchmark.method",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Benchmark method, environment, and warm/cold mode."
+      },
+      {
+        "id": "benchmark.runs",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Run count and raw measurement results."
+      },
+      {
+        "id": "benchmark.threshold",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Accepted threshold or noise tolerance."
+      },
+      {
+        "id": "benchmark.comparison",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Before/after comparison result."
+      },
+      {
+        "id": "benchmark.verdict",
+        "kind": "final_output",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Faster, slower, unchanged, or noisy verdict."
+      },
+      {
+        "id": "benchmark.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "benchmark.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "benchmark baseline command",
+      "benchmark comparison command",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Benchmark work needs normal branch_pr code policy plus room for baseline and comparison artifacts."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "artifact"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "final_output"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "benchmark.baseline",
+      "kind": "artifact",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Baseline measurement artifact."
+    },
+    {
+      "id": "benchmark.method",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Benchmark method, environment, and warm/cold mode."
+    },
+    {
+      "id": "benchmark.runs",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Run count and raw measurement results."
+    },
+    {
+      "id": "benchmark.threshold",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Accepted threshold or noise tolerance."
+    },
+    {
+      "id": "benchmark.comparison",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Before/after comparison result."
+    },
+    {
+      "id": "benchmark.verdict",
+      "kind": "final_output",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Faster, slower, unchanged, or noisy verdict."
+    },
+    {
+      "id": "benchmark.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "benchmark.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "benchmark baseline command",
+    "benchmark comparison command",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Benchmark work needs normal branch_pr code policy plus room for baseline and comparison artifacts."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to performance.benchmark",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "1ba13f231a86fc2f92004c16db267594835fb3f93b647feb1e4830ceb1b82147"
+  }
+}

--- a/.agentplane/tasks/202605222339-RZVQJ9/pr/diffstat.txt
+++ b/.agentplane/tasks/202605222339-RZVQJ9/pr/diffstat.txt
@@ -1,0 +1,5 @@
+ .../agentplane/src/cli/local-ci-selection.test.ts  | 20 ++++++++++++++++++
+ scripts/lib/local-ci-selection.d.ts                |  1 +
+ scripts/lib/local-ci-selection.mjs                 | 24 ++++++++++++++++++++++
+ scripts/lib/test-route-registry.mjs                |  5 +++++
+ 4 files changed, 50 insertions(+)

--- a/.agentplane/tasks/202605222339-RZVQJ9/pr/github-body.md
+++ b/.agentplane/tasks/202605222339-RZVQJ9/pr/github-body.md
@@ -1,0 +1,42 @@
+Task: `202605222339-RZVQJ9`
+Title: Narrow pr flow status local CI route
+Canonical task record: `.agentplane/tasks/202605222339-RZVQJ9/README.md`
+
+## Summary
+
+Narrow pr flow status local CI route
+
+Pre-push currently routes pr flow status changes through the broad pr test bucket, causing long or stalled pushes. Add a narrower local CI route for pr flow status files so small status-report changes run the focused status test and standard static checks.
+
+## Scope
+
+- In scope: Pre-push currently routes pr flow status changes through the broad pr test bucket, causing long or stalled pushes. Add a narrower local CI route for pr flow status files so small status-report changes run the focused status test and standard static checks.
+- Out of scope: unrelated refactors not required for "Narrow pr flow status local CI route".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Evaluator check: route is narrow, ordered before broader cli-core/pr catch-alls, preserves task
+artifact neutrality, and smoke output confirms targeted pr-flow-status selection.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-22T23:40:42.951Z
+- Branch: task/202605222339-RZVQJ9/pr-flow-status-ci-route
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../agentplane/src/cli/local-ci-selection.test.ts  | 20 ++++++++++++++++++
+ scripts/lib/local-ci-selection.d.ts                |  1 +
+ scripts/lib/local-ci-selection.mjs                 | 24 ++++++++++++++++++++++
+ scripts/lib/test-route-registry.mjs                |  5 +++++
+ 4 files changed, 50 insertions(+)
+```
+
+</details>

--- a/.agentplane/tasks/202605222339-RZVQJ9/pr/github-title.txt
+++ b/.agentplane/tasks/202605222339-RZVQJ9/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 RZVQJ9 task: Narrow pr flow status local CI route [202605222339-RZVQJ9]

--- a/.agentplane/tasks/202605222339-RZVQJ9/pr/meta.json
+++ b/.agentplane/tasks/202605222339-RZVQJ9/pr/meta.json
@@ -1,0 +1,17 @@
+{
+  "base": "main",
+  "branch": "task/202605222339-RZVQJ9/pr-flow-status-ci-route",
+  "created_at": "2026-05-22T23:40:42.951Z",
+  "diffstat_sha256": "sha256:97cd9037b3dfb4dd98b07cc51eb31bede90aa82d783bd44c7c30e091c72d3965",
+  "last_verified_at": "2026-05-22T23:44:31.177Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "pr_number": 4050,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4050",
+  "schema_version": 1,
+  "status": "OPEN",
+  "task_id": "202605222339-RZVQJ9",
+  "updated_at": "2026-05-22T23:44:57.151Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605222339-RZVQJ9/pr/review.md
+++ b/.agentplane/tasks/202605222339-RZVQJ9/pr/review.md
@@ -1,0 +1,40 @@
+# PR Review
+
+Created: 2026-05-22T23:40:42.951Z
+
+## Task
+
+- Task: `202605222339-RZVQJ9`
+- Title: Narrow pr flow status local CI route
+- Status: DOING
+- Branch: `task/202605222339-RZVQJ9/pr-flow-status-ci-route`
+- Canonical task record: `.agentplane/tasks/202605222339-RZVQJ9/README.md`
+
+## Verification
+
+- State: ok
+- Note: Evaluator check: route is narrow, ordered before broader cli-core/pr catch-alls, preserves task artifact neutrality, and smoke output confirms targeted pr-flow-status selection.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-22T23:40:42.951Z
+- Branch: task/202605222339-RZVQJ9/pr-flow-status-ci-route
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../agentplane/src/cli/local-ci-selection.test.ts  | 20 ++++++++++++++++++
+ scripts/lib/local-ci-selection.d.ts                |  1 +
+ scripts/lib/local-ci-selection.mjs                 | 24 ++++++++++++++++++++++
+ scripts/lib/test-route-registry.mjs                |  5 +++++
+ 4 files changed, 50 insertions(+)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/cli/local-ci-selection.test.ts
+++ b/packages/agentplane/src/cli/local-ci-selection.test.ts
@@ -27,6 +27,7 @@ type FastCiPlan =
         | "release"
         | "upgrade"
         | "guard"
+        | "pr-flow-status"
         | "mixed";
       buckets?: string[];
       reason: string;
@@ -350,6 +351,25 @@ describe("local CI fast selection", () => {
     expect(plan.testFiles).toContain(
       "packages/agentplane/src/cli/run-cli.core.pr-flow.integrate-failures.test.ts",
     );
+  });
+
+  it("routes PR flow status paths to the narrow status bucket", () => {
+    const plan = selectFastCiPlan([
+      ".agentplane/tasks/202605222339-RZVQJ9/README.md",
+      ".agentplane/tasks/202605222339-RZVQJ9/pr/meta.json",
+      "packages/agentplane/src/commands/pr/flow-status.ts",
+      "packages/agentplane/src/cli/run-cli.core.pr-flow.status.test.ts",
+    ]);
+    expect(plan.kind).toBe("targeted");
+    expect(plan.bucket).toBe("pr-flow-status");
+    expect(plan.reason).toBe("pr_flow_status_paths_only");
+    expect(plan.lintTargets).toEqual([
+      "packages/agentplane/src/commands/pr/flow-status.ts",
+      "packages/agentplane/src/cli/run-cli.core.pr-flow.status.test.ts",
+    ]);
+    expect(plan.testFiles).toEqual([
+      "packages/agentplane/src/cli/run-cli.core.pr-flow.status.test.ts",
+    ]);
   });
 
   it("routes PR integrate command paths to a narrow integrate bucket", () => {

--- a/scripts/lib/local-ci-selection.d.ts
+++ b/scripts/lib/local-ci-selection.d.ts
@@ -21,6 +21,7 @@ export type FastCiPlan =
         | "cli-core"
         | "cli-runtime"
         | "pr"
+        | "pr-flow-status"
         | "pr-integrate"
         | "release"
         | "upgrade"

--- a/scripts/lib/local-ci-selection.mjs
+++ b/scripts/lib/local-ci-selection.mjs
@@ -10,6 +10,7 @@ const {
   guard: GUARD_TEST_FILES,
   hooks: HOOKS_TEST_FILES,
   pr: PR_TEST_FILES,
+  "pr-flow-status": PR_FLOW_STATUS_TEST_FILES,
   "pr-integrate": PR_INTEGRATE_TEST_FILES,
   release: RELEASE_TEST_FILES,
   task: TASK_TEST_FILES,
@@ -103,6 +104,10 @@ const CLI_CORE_BUCKET_PATTERNS = [
 const PR_BUCKET_PATTERNS = [
   /^packages\/agentplane\/src\/commands\/pr(?:\/|\.|$)/,
   /^packages\/agentplane\/src\/cli\/run-cli\.core\.pr-flow(?:\..+)?\.test\.ts$/,
+];
+const PR_FLOW_STATUS_BUCKET_PATTERNS = [
+  /^packages\/agentplane\/src\/commands\/pr\/flow-status\.ts$/,
+  /^packages\/agentplane\/src\/cli\/run-cli\.core\.pr-flow\.status\.test\.ts$/,
 ];
 const PR_INTEGRATE_BUCKET_PATTERNS = [
   /^packages\/agentplane\/src\/commands\/pr\/integrate(?:\/|\.|$)/,
@@ -210,6 +215,13 @@ const TARGET_BUCKET_DEFINITIONS = [
     reason: "cli_help_and_spec_paths_only",
     patterns: CLI_HELP_BUCKET_PATTERNS,
     testFiles: CLI_HELP_TEST_FILES,
+    vitestPool: "threads",
+  },
+  {
+    bucket: "pr-flow-status",
+    reason: "pr_flow_status_paths_only",
+    patterns: PR_FLOW_STATUS_BUCKET_PATTERNS,
+    testFiles: PR_FLOW_STATUS_TEST_FILES,
     vitestPool: "threads",
   },
   {
@@ -408,6 +420,18 @@ export function selectFastCiPlan(changedFiles) {
       files,
       lintTargets: effectiveFiles,
       testFiles: CLI_HELP_TEST_FILES,
+      vitestPool: "threads",
+    };
+  }
+
+  if (everyPathMatches(effectiveFiles, PR_FLOW_STATUS_BUCKET_PATTERNS)) {
+    return {
+      kind: "targeted",
+      bucket: "pr-flow-status",
+      reason: "pr_flow_status_paths_only",
+      files,
+      lintTargets: effectiveFiles,
+      testFiles: PR_FLOW_STATUS_TEST_FILES,
       vitestPool: "threads",
     };
   }

--- a/scripts/lib/test-route-registry.mjs
+++ b/scripts/lib/test-route-registry.mjs
@@ -508,6 +508,10 @@ const PR_TEST_FILES = [
   ...discoverTestFiles(["packages/agentplane/src/cli"], PR_FLOW_DISCOVERY_PATTERNS),
 ];
 
+const PR_FLOW_STATUS_TEST_FILES = [
+  "packages/agentplane/src/cli/run-cli.core.pr-flow.status.test.ts",
+];
+
 const PR_INTEGRATE_TEST_FILES = discoverTestFiles(
   ["packages/agentplane/src/commands/pr/integrate"],
   PR_INTEGRATE_DISCOVERY_PATTERNS,
@@ -572,6 +576,7 @@ export const LOCAL_CI_TARGET_TEST_FILES = {
   guard: GUARD_TEST_FILES,
   hooks: HOOKS_TEST_FILES,
   pr: PR_TEST_FILES,
+  "pr-flow-status": PR_FLOW_STATUS_TEST_FILES,
   "pr-integrate": PR_INTEGRATE_TEST_FILES,
   release: RELEASE_TEST_FILES,
   task: TASK_TEST_FILES,


### PR DESCRIPTION
Task: `202605222339-RZVQJ9`
Title: Narrow pr flow status local CI route
Canonical task record: `.agentplane/tasks/202605222339-RZVQJ9/README.md`

## Summary

Narrow pr flow status local CI route

Pre-push currently routes pr flow status changes through the broad pr test bucket, causing long or stalled pushes. Add a narrower local CI route for pr flow status files so small status-report changes run the focused status test and standard static checks.

## Scope

- In scope: Pre-push currently routes pr flow status changes through the broad pr test bucket, causing long or stalled pushes. Add a narrower local CI route for pr flow status files so small status-report changes run the focused status test and standard static checks.
- Out of scope: unrelated refactors not required for "Narrow pr flow status local CI route".

## Verification

- State: ok
- Note:

```text
Evaluator check: route is narrow, ordered before broader cli-core/pr catch-alls, preserves task
artifact neutrality, and smoke output confirms targeted pr-flow-status selection.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-22T23:40:42.951Z
- Branch: task/202605222339-RZVQJ9/pr-flow-status-ci-route
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../agentplane/src/cli/local-ci-selection.test.ts  | 20 ++++++++++++++++++
 scripts/lib/local-ci-selection.d.ts                |  1 +
 scripts/lib/local-ci-selection.mjs                 | 24 ++++++++++++++++++++++
 scripts/lib/test-route-registry.mjs                |  5 +++++
 4 files changed, 50 insertions(+)
```

</details>
