### PR TITLE
🚧 H3V7RB task: Remove unused pr flow status exported types [202605230004-H3V7RB]

### DIFF
--- a/.agentplane/tasks/202605230004-H3V7RB/README.md
+++ b/.agentplane/tasks/202605230004-H3V7RB/README.md
@@ -1,0 +1,218 @@
+---
+id: "202605230004-H3V7RB"
+title: "Remove unused pr flow status exported types"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "workflow"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-23T00:04:17.674Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-23T00:07:04.967Z"
+  updated_by: "EVALUATOR"
+  note: "Evaluator pass: scope is limited to removing unused exported helper types, and verification evidence covers the knip failure plus focused behavior and style checks."
+  attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-23T00:07:04.967Z"
+  updated_by: "EVALUATOR"
+  note: "Evaluator pass: scope is limited to removing unused exported helper types, and verification evidence covers the knip failure plus focused behavior and style checks."
+  evaluated_sha: "9524d8b72be120d36e9b8e7b80afb6ee1c9ec289"
+  blueprint_digest: "3c187eedd26b33779268267f19be5811d83e10f9b0f4d62cd223190130c950ee"
+  evidence_refs:
+    - ".agentplane/tasks/202605230004-H3V7RB/README.md"
+    - "/Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605230004-H3V7RB-pr-flow-status-knip-cleanup/.agentplane/tasks/202605230004-H3V7RB/blueprint/resolved-snapshot.json"
+  findings:
+    - "Reviewed diff: only four helper status aliases in packages/agentplane/src/commands/pr/flow-status.ts changed from exported to module-local. PrFlowStatusReport remains exported and report shape is unchanged. Recorded CODER evidence includes knip baseline pass, focused pr-flow status test pass, lint pass, and format pass."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: removing the unused pr flow status exported helper type surface that verify-static/knip reports after the lifecycle status work."
+events:
+  -
+    type: "status"
+    at: "2026-05-23T00:04:30.009Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: removing the unused pr flow status exported helper type surface that verify-static/knip reports after the lifecycle status work."
+  -
+    type: "verify"
+    at: "2026-05-23T00:06:36.588Z"
+    author: "CODER"
+    state: "ok"
+    note: "Removed unused pr flow status helper type exports without runtime changes."
+  -
+    type: "verify"
+    at: "2026-05-23T00:07:04.967Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Evaluator pass: scope is limited to removing unused exported helper types, and verification evidence covers the knip failure plus focused behavior and style checks."
+doc_version: 3
+doc_updated_at: "2026-05-23T00:07:04.995Z"
+doc_updated_by: "CODER"
+description: "Knip baseline flags exported status-report types from the hosted lifecycle report as unused. Make those helper types internal so verify-static passes without widening the public type surface."
+sections:
+  Summary: |-
+    Remove unused pr flow status exported types
+
+    Knip baseline flags exported status-report types from the hosted lifecycle report as unused. Make those helper types internal so verify-static passes without widening the public type surface.
+  Scope: |-
+    - In scope: Knip baseline flags exported status-report types from the hosted lifecycle report as unused. Make those helper types internal so verify-static passes without widening the public type surface.
+    - Out of scope: unrelated refactors not required for "Remove unused pr flow status exported types".
+  Plan: |-
+    1. Inspect pr flow status helper type exports flagged by knip.
+    2. Make the unused status-report helper types module-internal without changing runtime behavior.
+    3. Verify with knip baseline guard, focused pr flow status test, lint, and format check.
+    4. Publish as a one-commit branch_pr task, merge it, then rebase QRQFM9 onto the fixed main.
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-23T00:06:36.588Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Removed unused pr flow status helper type exports without runtime changes.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T00:04:30.009Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605230004-H3V7RB-pr-flow-status-knip-cleanup/.agentplane/tasks/202605230004-H3V7RB/blueprint/resolved-snapshot.json
+    - old_digest: 3c187eedd26b33779268267f19be5811d83e10f9b0f4d62cd223190130c950ee
+    - current_digest: 3c187eedd26b33779268267f19be5811d83e10f9b0f4d62cd223190130c950ee
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605230004-H3V7RB
+
+    ### 2026-05-23T00:07:04.967Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Evaluator pass: scope is limited to removing unused exported helper types, and verification evidence covers the knip failure plus focused behavior and style checks.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T00:06:36.616Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    Reviewed diff: only four helper status aliases in packages/agentplane/src/commands/pr/flow-status.ts changed from exported to module-local. PrFlowStatusReport remains exported and report shape is unchanged. Recorded CODER evidence includes knip baseline pass, focused pr-flow status test pass, lint pass, and format pass.
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605230004-H3V7RB-pr-flow-status-knip-cleanup/.agentplane/tasks/202605230004-H3V7RB/blueprint/resolved-snapshot.json
+    - old_digest: 3c187eedd26b33779268267f19be5811d83e10f9b0f4d62cd223190130c950ee
+    - current_digest: 3c187eedd26b33779268267f19be5811d83e10f9b0f4d62cd223190130c950ee
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605230004-H3V7RB
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Commands: bun run knip:check => pass (baseline OK, total=564/564); bunx vitest run packages/agentplane/src/cli/run-cli.core.pr-flow.status.test.ts => pass (1 file, 2 tests); bun run lint:core -- packages/agentplane/src/commands/pr/flow-status.ts => pass (eslint exit 0); bun run format:check -- packages/agentplane/src/commands/pr/flow-status.ts => pass (Prettier OK).
+      Impact: verify-static knip baseline no longer reports the pr flow status helper types as new unused exported types.
+      Resolution: Changed the four helper status aliases from exported types to module-local types; runtime report shape is unchanged.
+id_source: "generated"
+---
+## Summary
+
+Remove unused pr flow status exported types
+
+Knip baseline flags exported status-report types from the hosted lifecycle report as unused. Make those helper types internal so verify-static passes without widening the public type surface.
+
+## Scope
+
+- In scope: Knip baseline flags exported status-report types from the hosted lifecycle report as unused. Make those helper types internal so verify-static passes without widening the public type surface.
+- Out of scope: unrelated refactors not required for "Remove unused pr flow status exported types".
+
+## Plan
+
+1. Inspect pr flow status helper type exports flagged by knip.
+2. Make the unused status-report helper types module-internal without changing runtime behavior.
+3. Verify with knip baseline guard, focused pr flow status test, lint, and format check.
+4. Publish as a one-commit branch_pr task, merge it, then rebase QRQFM9 onto the fixed main.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-23T00:06:36.588Z — VERIFY — ok
+
+By: CODER
+
+Note: Removed unused pr flow status helper type exports without runtime changes.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T00:04:30.009Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605230004-H3V7RB-pr-flow-status-knip-cleanup/.agentplane/tasks/202605230004-H3V7RB/blueprint/resolved-snapshot.json
+- old_digest: 3c187eedd26b33779268267f19be5811d83e10f9b0f4d62cd223190130c950ee
+- current_digest: 3c187eedd26b33779268267f19be5811d83e10f9b0f4d62cd223190130c950ee
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605230004-H3V7RB
+
+### 2026-05-23T00:07:04.967Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Evaluator pass: scope is limited to removing unused exported helper types, and verification evidence covers the knip failure plus focused behavior and style checks.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T00:06:36.616Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+Reviewed diff: only four helper status aliases in packages/agentplane/src/commands/pr/flow-status.ts changed from exported to module-local. PrFlowStatusReport remains exported and report shape is unchanged. Recorded CODER evidence includes knip baseline pass, focused pr-flow status test pass, lint pass, and format pass.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605230004-H3V7RB-pr-flow-status-knip-cleanup/.agentplane/tasks/202605230004-H3V7RB/blueprint/resolved-snapshot.json
+- old_digest: 3c187eedd26b33779268267f19be5811d83e10f9b0f4d62cd223190130c950ee
+- current_digest: 3c187eedd26b33779268267f19be5811d83e10f9b0f4d62cd223190130c950ee
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605230004-H3V7RB
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Commands: bun run knip:check => pass (baseline OK, total=564/564); bunx vitest run packages/agentplane/src/cli/run-cli.core.pr-flow.status.test.ts => pass (1 file, 2 tests); bun run lint:core -- packages/agentplane/src/commands/pr/flow-status.ts => pass (eslint exit 0); bun run format:check -- packages/agentplane/src/commands/pr/flow-status.ts => pass (Prettier OK).
+  Impact: verify-static knip baseline no longer reports the pr flow status helper types as new unused exported types.
+  Resolution: Changed the four helper status aliases from exported types to module-local types; runtime report shape is unchanged.

--- a/.agentplane/tasks/202605230004-H3V7RB/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605230004-H3V7RB/blueprint/resolved-snapshot.json
@@ -1,0 +1,597 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605230004-H3V7RB",
+    "title": "Remove unused pr flow status exported types",
+    "description": "Knip baseline flags exported status-report types from the hosted lifecycle report as unused. Make those helper types internal so verify-static passes without widening the public type surface.",
+    "tags": [
+      "code",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "quality.regression",
+    "version": 1,
+    "title": "Quality regression",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "quality.regression",
+    "blueprintVersion": 1,
+    "title": "Quality regression",
+    "taskId": "202605230004-H3V7RB",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to quality.regression",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest",
+          "artifact"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "check_result"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "weak_links"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "regression.original_failure",
+        "kind": "artifact",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Original failure log or check output."
+      },
+      {
+        "id": "regression.reproduction",
+        "kind": "check_result",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Local reproduction or explicit non-reproduction result."
+      },
+      {
+        "id": "regression.focused_check",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Focused regression check."
+      },
+      {
+        "id": "regression.matrix_or_scope",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Affected test/check matrix or bounded scope."
+      },
+      {
+        "id": "regression.full_gate",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Full relevant gate or hosted check evidence."
+      },
+      {
+        "id": "regression.flake_classification",
+        "kind": "weak_links",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Flake classification or residual risk."
+      },
+      {
+        "id": "regression.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "regression.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "affected matrix or full relevant gate",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "failure reproduction command",
+      "focused regression check",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest",
+        "artifact"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "check_result"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "weak_links"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "regression.original_failure",
+      "kind": "artifact",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Original failure log or check output."
+    },
+    {
+      "id": "regression.reproduction",
+      "kind": "check_result",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Local reproduction or explicit non-reproduction result."
+    },
+    {
+      "id": "regression.focused_check",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Focused regression check."
+    },
+    {
+      "id": "regression.matrix_or_scope",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Affected test/check matrix or bounded scope."
+    },
+    {
+      "id": "regression.full_gate",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Full relevant gate or hosted check evidence."
+    },
+    {
+      "id": "regression.flake_classification",
+      "kind": "weak_links",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Flake classification or residual risk."
+    },
+    {
+      "id": "regression.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "regression.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "affected matrix or full relevant gate",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "failure reproduction command",
+    "focused regression check",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to quality.regression",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "3c187eedd26b33779268267f19be5811d83e10f9b0f4d62cd223190130c950ee"
+  }
+}

--- a/.agentplane/tasks/202605230004-H3V7RB/pr/diffstat.txt
+++ b/.agentplane/tasks/202605230004-H3V7RB/pr/diffstat.txt
@@ -1,0 +1,2 @@
+ packages/agentplane/src/commands/pr/flow-status.ts | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)

--- a/.agentplane/tasks/202605230004-H3V7RB/pr/github-body.md
+++ b/.agentplane/tasks/202605230004-H3V7RB/pr/github-body.md
@@ -1,0 +1,39 @@
+Task: `202605230004-H3V7RB`
+Title: Remove unused pr flow status exported types
+Canonical task record: `.agentplane/tasks/202605230004-H3V7RB/README.md`
+
+## Summary
+
+Remove unused pr flow status exported types
+
+Knip baseline flags exported status-report types from the hosted lifecycle report as unused. Make those helper types internal so verify-static passes without widening the public type surface.
+
+## Scope
+
+- In scope: Knip baseline flags exported status-report types from the hosted lifecycle report as unused. Make those helper types internal so verify-static passes without widening the public type surface.
+- Out of scope: unrelated refactors not required for "Remove unused pr flow status exported types".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Evaluator pass: scope is limited to removing unused exported helper types, and verification evidence
+covers the knip failure plus focused behavior and style checks.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-23T00:04:30.082Z
+- Branch: task/202605230004-H3V7RB/pr-flow-status-knip-cleanup
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ packages/agentplane/src/commands/pr/flow-status.ts | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605230004-H3V7RB/pr/github-title.txt
+++ b/.agentplane/tasks/202605230004-H3V7RB/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 H3V7RB task: Remove unused pr flow status exported types [202605230004-H3V7RB]

--- a/.agentplane/tasks/202605230004-H3V7RB/pr/meta.json
+++ b/.agentplane/tasks/202605230004-H3V7RB/pr/meta.json
@@ -1,0 +1,17 @@
+{
+  "base": "main",
+  "branch": "task/202605230004-H3V7RB/pr-flow-status-knip-cleanup",
+  "created_at": "2026-05-23T00:04:30.082Z",
+  "diffstat_sha256": "sha256:017395c2d8d7b7b3c73cf76a4732df3b8069edd282177ddf26f38c50b4902ffe",
+  "last_verified_at": "2026-05-23T00:07:04.967Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "pr_number": 4053,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4053",
+  "schema_version": 1,
+  "status": "OPEN",
+  "task_id": "202605230004-H3V7RB",
+  "updated_at": "2026-05-23T00:07:48.479Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605230004-H3V7RB/pr/review.md
+++ b/.agentplane/tasks/202605230004-H3V7RB/pr/review.md
@@ -1,0 +1,37 @@
+# PR Review
+
+Created: 2026-05-23T00:04:30.082Z
+
+## Task
+
+- Task: `202605230004-H3V7RB`
+- Title: Remove unused pr flow status exported types
+- Status: DOING
+- Branch: `task/202605230004-H3V7RB/pr-flow-status-knip-cleanup`
+- Canonical task record: `.agentplane/tasks/202605230004-H3V7RB/README.md`
+
+## Verification
+
+- State: ok
+- Note: Evaluator pass: scope is limited to removing unused exported helper types, and verification evidence covers the knip failure plus focused behavior and style checks.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-23T00:04:30.082Z
+- Branch: task/202605230004-H3V7RB/pr-flow-status-knip-cleanup
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ packages/agentplane/src/commands/pr/flow-status.ts | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/pr/flow-status.ts
+++ b/packages/agentplane/src/commands/pr/flow-status.ts
@@ -71,15 +71,15 @@ export type PrFlowStatusReport = {
   nextAction: string;
 };
 
-export type HostedChecksStatus =
+type HostedChecksStatus =
   | { checked: true; total: number; pending: number; failing: number; passing: number }
   | { checked: false; reason: string };
 
-export type ReviewThreadsStatus =
+type ReviewThreadsStatus =
   | { checked: true; unresolved: number }
   | { checked: false; reason: string };
 
-export type QueueStatus =
+type QueueStatus =
   | { present: false }
   | {
       present: true;
@@ -88,7 +88,7 @@ export type QueueStatus =
       updatedAt: string | null;
     };
 
-export type HandoffStatus =
+type HandoffStatus =
   | { present: false }
   | {
       present: true;


### PR DESCRIPTION
Task: `202605230004-H3V7RB`
Title: Remove unused pr flow status exported types
Canonical task record: `.agentplane/tasks/202605230004-H3V7RB/README.md`

## Summary

Remove unused pr flow status exported types

Knip baseline flags exported status-report types from the hosted lifecycle report as unused. Make those helper types internal so verify-static passes without widening the public type surface.

## Scope

- In scope: Knip baseline flags exported status-report types from the hosted lifecycle report as unused. Make those helper types internal so verify-static passes without widening the public type surface.
- Out of scope: unrelated refactors not required for "Remove unused pr flow status exported types".

## Verification

- State: ok
- Note:

```text
Evaluator pass: scope is limited to removing unused exported helper types, and verification evidence
covers the knip failure plus focused behavior and style checks.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-23T00:04:30.082Z
- Branch: task/202605230004-H3V7RB/pr-flow-status-knip-cleanup
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 packages/agentplane/src/commands/pr/flow-status.ts | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)
```

</details>
