### PR TITLE
🚧 GF25D1 task: Add agent task brief command [202605221744-GF25D1]

### DIFF
--- a/.agentplane/tasks/202605221744-GF25D1/README.md
+++ b/.agentplane/tasks/202605221744-GF25D1/README.md
@@ -1,10 +1,10 @@
 ---
 id: "202605221744-GF25D1"
 title: "Add agent task brief command"
-status: "TODO"
+status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 3
+revision: 6
 origin:
   system: "manual"
 depends_on:
@@ -27,17 +27,51 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-23T01:17:26.781Z"
+  updated_by: "EVALUATOR"
+  note: "Evaluator check: task brief satisfies approved local-first agent context scope. Evidence covers text and JSON output, no default gh lookup regression, generated CLI docs, typecheck, lint, format, and runtime bootstrap."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-23T01:17:26.781Z"
+  updated_by: "EVALUATOR"
+  note: "Evaluator check: task brief satisfies approved local-first agent context scope. Evidence covers text and JSON output, no default gh lookup regression, generated CLI docs, typecheck, lint, format, and runtime bootstrap."
+  evaluated_sha: "f0c34065e9497a1254ee57de2b91d88d7885dc24"
+  blueprint_digest: "c061dce418c548fb5171b42daa78994cc91cd9477bd70c6b467767e353ebc2b2"
+  evidence_refs:
+    - ".agentplane/tasks/202605221744-GF25D1/README.md"
+    - "/Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221744-GF25D1-agent-task-brief/.agentplane/tasks/202605221744-GF25D1/blueprint/resolved-snapshot.json"
+  findings:
+    - "Reviewed implementation and test evidence. The default task brief path passes includeRemote=false into route decision; existing route decision callers keep the previous remote-aware default. The regression test seeds PR metadata plus a fake gh binary and confirms default task brief does not invoke gh. JSON output includes task, workflow, next_action, blockers, verify_steps, blueprint, snapshot, stop_rules, and remote.enabled=false."
 commit: null
-comments: []
-events: []
+comments:
+  -
+    author: "CODER"
+    body: "Start: implementing the local-first task brief command with text and JSON output, reusing route, next-action, verify, and blueprint evidence surfaces."
+events:
+  -
+    type: "status"
+    at: "2026-05-23T01:10:06.943Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implementing the local-first task brief command with text and JSON output, reusing route, next-action, verify, and blueprint evidence surfaces."
+  -
+    type: "verify"
+    at: "2026-05-23T01:17:05.405Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented task brief with local-first text and JSON output. It includes route/checkout/next action, blockers, Verify Steps, blueprint evidence, snapshot evidence, stop rules, and an explicit --remote flag for hosted truth. Verification passed."
+  -
+    type: "verify"
+    at: "2026-05-23T01:17:26.781Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Evaluator check: task brief satisfies approved local-first agent context scope. Evidence covers text and JSON output, no default gh lookup regression, generated CLI docs, typecheck, lint, format, and runtime bootstrap."
 doc_version: 3
-doc_updated_at: "2026-05-22T17:44:14.273Z"
-doc_updated_by: "PLANNER"
+doc_updated_at: "2026-05-23T01:17:26.808Z"
+doc_updated_by: "CODER"
 description: "Add a compact task brief surface that merges route decision, checkout role, next action, blockers, Verify Steps, blueprint evidence, and stop rules into one agent-ready view."
 sections:
   Summary: |-
@@ -49,15 +83,87 @@ sections:
     - Out of scope: unrelated refactors not required for "Add agent task brief command".
   Plan: "Implement an agent-ready task brief command by reusing route-decision and Verify Steps/blueprint evidence surfaces. Keep default output compact and local-only; provide JSON output for agents and an explicit remote mode for hosted truth."
   Verify Steps: |-
-    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
-
-    1. Run `Run targeted CLI tests for task brief text and JSON output.`. Expected: it succeeds and confirms the requested outcome for this task.
-    2. Run `Confirm task brief includes route decision, Verify Steps, blueprint evidence, blockers, and next command for branch_pr tasks.`. Expected: it succeeds and confirms the requested outcome for this task.
-    3. Run `Confirm task brief avoids remote network lookups unless an explicit remote flag is used.`. Expected: it succeeds and confirms the requested outcome for this task.
-    4. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
-    5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+    1. Run `bunx vitest run packages/agentplane/src/cli/run-cli.core.route-decision.test.ts packages/agentplane/src/cli/run-cli.core.help-contract.test.ts`. Expected: task brief text/JSON coverage and command registration coverage pass.
+    2. Run `ap task brief 202605221744-GF25D1` and `ap task brief 202605221744-GF25D1 --json`. Expected: output includes route decision, Verify Steps, blueprint evidence, blockers, next command, and local-only remote note.
+    3. Run `bun run docs:cli:check`. Expected: generated CLI reference is fresh for `task brief`.
+    4. Run targeted lint and format checks for touched source/test files. Expected: no lint errors and formatting is unchanged.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-23T01:17:05.405Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Implemented task brief with local-first text and JSON output. It includes route/checkout/next action, blockers, Verify Steps, blueprint evidence, snapshot evidence, stop rules, and an explicit --remote flag for hosted truth. Verification passed.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T01:10:06.943Z, excerpt_hash=sha256:f851459322eebe1a8bb3ad0b93556d66f3eb8cfa009f5efc5a0b43e2ac46968a
+
+    Details:
+
+    Command: bunx vitest run packages/agentplane/src/cli/run-cli.core.route-decision.test.ts packages/agentplane/src/cli/run-cli.core.help-contract.test.ts
+    Result: pass
+    Evidence: 2 files, 21 tests passed; task brief text/JSON and command registration covered.
+    Scope: CLI behavior and command catalog.
+
+    Command: ap task brief 202605221744-GF25D1; ap task brief 202605221744-GF25D1 --json
+    Result: pass
+    Evidence: output includes route decision, Verify Steps, blueprint evidence, snapshot evidence, next command, blockers array, and remote lookup skipped note.
+    Scope: real task smoke.
+
+    Command: bun run docs:cli:check
+    Result: pass
+    Evidence: docs/user/cli-reference.generated.mdx is up to date.
+    Scope: generated CLI docs.
+
+    Command: bun run lint:core -- packages/agentplane/src/commands/task/brief.command.ts packages/agentplane/src/commands/shared/route-decision.ts packages/agentplane/src/cli/run-cli/command-catalog/task.ts packages/agentplane/src/cli/run-cli/command-loaders/task.ts packages/agentplane/src/commands/task/task.command.ts packages/agentplane/src/cli/run-cli.core.route-decision.test.ts
+    Result: pass
+    Evidence: no lint errors.
+    Scope: touched source/test files.
+
+    Command: bun run format:check -- packages/agentplane/src/commands/task/brief.command.ts packages/agentplane/src/commands/shared/route-decision.ts packages/agentplane/src/cli/run-cli/command-catalog/task.ts packages/agentplane/src/cli/run-cli/command-loaders/task.ts packages/agentplane/src/commands/task/task.command.ts packages/agentplane/src/cli/run-cli.core.route-decision.test.ts
+    Result: pass
+    Evidence: All matched files use Prettier code style.
+    Scope: touched source/test files.
+
+    Command: bun run typecheck
+    Result: pass
+    Evidence: tsc -b completed with exit 0.
+    Scope: TypeScript project references.
+
+    Command: bun run framework:dev:bootstrap
+    Result: pass
+    Evidence: repo-local runtime ready after rebuild.
+    Scope: runtime freshness for new CLI command.
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221744-GF25D1-agent-task-brief/.agentplane/tasks/202605221744-GF25D1/blueprint/resolved-snapshot.json
+    - old_digest: c061dce418c548fb5171b42daa78994cc91cd9477bd70c6b467767e353ebc2b2
+    - current_digest: c061dce418c548fb5171b42daa78994cc91cd9477bd70c6b467767e353ebc2b2
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605221744-GF25D1
+
+    ### 2026-05-23T01:17:26.781Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Evaluator check: task brief satisfies approved local-first agent context scope. Evidence covers text and JSON output, no default gh lookup regression, generated CLI docs, typecheck, lint, format, and runtime bootstrap.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T01:17:05.431Z, excerpt_hash=sha256:f851459322eebe1a8bb3ad0b93556d66f3eb8cfa009f5efc5a0b43e2ac46968a
+
+    Details:
+
+    Reviewed implementation and test evidence. The default task brief path passes includeRemote=false into route decision; existing route decision callers keep the previous remote-aware default. The regression test seeds PR metadata plus a fake gh binary and confirms default task brief does not invoke gh. JSON output includes task, workflow, next_action, blockers, verify_steps, blueprint, snapshot, stop_rules, and remote.enabled=false.
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221744-GF25D1-agent-task-brief/.agentplane/tasks/202605221744-GF25D1/blueprint/resolved-snapshot.json
+    - old_digest: c061dce418c548fb5171b42daa78994cc91cd9477bd70c6b467767e353ebc2b2
+    - current_digest: c061dce418c548fb5171b42daa78994cc91cd9477bd70c6b467767e353ebc2b2
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605221744-GF25D1
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -82,17 +188,89 @@ Implement an agent-ready task brief command by reusing route-decision and Verify
 
 ## Verify Steps
 
-PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
-
-1. Run `Run targeted CLI tests for task brief text and JSON output.`. Expected: it succeeds and confirms the requested outcome for this task.
-2. Run `Confirm task brief includes route decision, Verify Steps, blueprint evidence, blockers, and next command for branch_pr tasks.`. Expected: it succeeds and confirms the requested outcome for this task.
-3. Run `Confirm task brief avoids remote network lookups unless an explicit remote flag is used.`. Expected: it succeeds and confirms the requested outcome for this task.
-4. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
-5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+1. Run `bunx vitest run packages/agentplane/src/cli/run-cli.core.route-decision.test.ts packages/agentplane/src/cli/run-cli.core.help-contract.test.ts`. Expected: task brief text/JSON coverage and command registration coverage pass.
+2. Run `ap task brief 202605221744-GF25D1` and `ap task brief 202605221744-GF25D1 --json`. Expected: output includes route decision, Verify Steps, blueprint evidence, blockers, next command, and local-only remote note.
+3. Run `bun run docs:cli:check`. Expected: generated CLI reference is fresh for `task brief`.
+4. Run targeted lint and format checks for touched source/test files. Expected: no lint errors and formatting is unchanged.
 
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-23T01:17:05.405Z — VERIFY — ok
+
+By: CODER
+
+Note: Implemented task brief with local-first text and JSON output. It includes route/checkout/next action, blockers, Verify Steps, blueprint evidence, snapshot evidence, stop rules, and an explicit --remote flag for hosted truth. Verification passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T01:10:06.943Z, excerpt_hash=sha256:f851459322eebe1a8bb3ad0b93556d66f3eb8cfa009f5efc5a0b43e2ac46968a
+
+Details:
+
+Command: bunx vitest run packages/agentplane/src/cli/run-cli.core.route-decision.test.ts packages/agentplane/src/cli/run-cli.core.help-contract.test.ts
+Result: pass
+Evidence: 2 files, 21 tests passed; task brief text/JSON and command registration covered.
+Scope: CLI behavior and command catalog.
+
+Command: ap task brief 202605221744-GF25D1; ap task brief 202605221744-GF25D1 --json
+Result: pass
+Evidence: output includes route decision, Verify Steps, blueprint evidence, snapshot evidence, next command, blockers array, and remote lookup skipped note.
+Scope: real task smoke.
+
+Command: bun run docs:cli:check
+Result: pass
+Evidence: docs/user/cli-reference.generated.mdx is up to date.
+Scope: generated CLI docs.
+
+Command: bun run lint:core -- packages/agentplane/src/commands/task/brief.command.ts packages/agentplane/src/commands/shared/route-decision.ts packages/agentplane/src/cli/run-cli/command-catalog/task.ts packages/agentplane/src/cli/run-cli/command-loaders/task.ts packages/agentplane/src/commands/task/task.command.ts packages/agentplane/src/cli/run-cli.core.route-decision.test.ts
+Result: pass
+Evidence: no lint errors.
+Scope: touched source/test files.
+
+Command: bun run format:check -- packages/agentplane/src/commands/task/brief.command.ts packages/agentplane/src/commands/shared/route-decision.ts packages/agentplane/src/cli/run-cli/command-catalog/task.ts packages/agentplane/src/cli/run-cli/command-loaders/task.ts packages/agentplane/src/commands/task/task.command.ts packages/agentplane/src/cli/run-cli.core.route-decision.test.ts
+Result: pass
+Evidence: All matched files use Prettier code style.
+Scope: touched source/test files.
+
+Command: bun run typecheck
+Result: pass
+Evidence: tsc -b completed with exit 0.
+Scope: TypeScript project references.
+
+Command: bun run framework:dev:bootstrap
+Result: pass
+Evidence: repo-local runtime ready after rebuild.
+Scope: runtime freshness for new CLI command.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221744-GF25D1-agent-task-brief/.agentplane/tasks/202605221744-GF25D1/blueprint/resolved-snapshot.json
+- old_digest: c061dce418c548fb5171b42daa78994cc91cd9477bd70c6b467767e353ebc2b2
+- current_digest: c061dce418c548fb5171b42daa78994cc91cd9477bd70c6b467767e353ebc2b2
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605221744-GF25D1
+
+### 2026-05-23T01:17:26.781Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Evaluator check: task brief satisfies approved local-first agent context scope. Evidence covers text and JSON output, no default gh lookup regression, generated CLI docs, typecheck, lint, format, and runtime bootstrap.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T01:17:05.431Z, excerpt_hash=sha256:f851459322eebe1a8bb3ad0b93556d66f3eb8cfa009f5efc5a0b43e2ac46968a
+
+Details:
+
+Reviewed implementation and test evidence. The default task brief path passes includeRemote=false into route decision; existing route decision callers keep the previous remote-aware default. The regression test seeds PR metadata plus a fake gh binary and confirms default task brief does not invoke gh. JSON output includes task, workflow, next_action, blockers, verify_steps, blueprint, snapshot, stop_rules, and remote.enabled=false.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221744-GF25D1-agent-task-brief/.agentplane/tasks/202605221744-GF25D1/blueprint/resolved-snapshot.json
+- old_digest: c061dce418c548fb5171b42daa78994cc91cd9477bd70c6b467767e353ebc2b2
+- current_digest: c061dce418c548fb5171b42daa78994cc91cd9477bd70c6b467767e353ebc2b2
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605221744-GF25D1
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605221744-GF25D1/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605221744-GF25D1/blueprint/resolved-snapshot.json
@@ -1,0 +1,580 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605221744-GF25D1",
+    "title": "Add agent task brief command",
+    "description": "Add a compact task brief surface that merges route decision, checkout role, next action, blockers, Verify Steps, blueprint evidence, and stop rules into one agent-ready view.",
+    "tags": [
+      "cli",
+      "code",
+      "context",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605221744-GF25D1",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "c061dce418c548fb5171b42daa78994cc91cd9477bd70c6b467767e353ebc2b2"
+  }
+}

--- a/.agentplane/tasks/202605221744-GF25D1/pr/diffstat.txt
+++ b/.agentplane/tasks/202605221744-GF25D1/pr/diffstat.txt
@@ -1,0 +1,8 @@
+ docs/user/cli-reference.generated.mdx              |  36 ++++
+ .../src/cli/run-cli.core.route-decision.test.ts    |  96 ++++++++-
+ .../src/cli/run-cli/command-catalog/task.ts        |   3 +
+ .../src/cli/run-cli/command-loaders/task.ts        |   4 +
+ .../src/commands/shared/route-decision.ts          |   3 +-
+ .../agentplane/src/commands/task/brief.command.ts  | 224 +++++++++++++++++++++
+ .../agentplane/src/commands/task/task.command.ts   |   4 +
+ 7 files changed, 368 insertions(+), 2 deletions(-)

--- a/.agentplane/tasks/202605221744-GF25D1/pr/github-body.md
+++ b/.agentplane/tasks/202605221744-GF25D1/pr/github-body.md
@@ -1,0 +1,46 @@
+Task: `202605221744-GF25D1`
+Title: Add agent task brief command
+Canonical task record: `.agentplane/tasks/202605221744-GF25D1/README.md`
+
+## Summary
+
+Add agent task brief command
+
+Add a compact task brief surface that merges route decision, checkout role, next action, blockers, Verify Steps, blueprint evidence, and stop rules into one agent-ready view.
+
+## Scope
+
+- In scope: Add a compact task brief surface that merges route decision, checkout role, next action, blockers, Verify Steps, blueprint evidence, and stop rules into one agent-ready view.
+- Out of scope: unrelated refactors not required for "Add agent task brief command".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Evaluator check: task brief satisfies approved local-first agent context scope. Evidence covers text
+and JSON output, no default gh lookup regression, generated CLI docs, typecheck, lint, format, and
+runtime bootstrap.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-23T01:10:07.020Z
+- Branch: task/202605221744-GF25D1/agent-task-brief
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ docs/user/cli-reference.generated.mdx              |  36 ++++
+ .../src/cli/run-cli.core.route-decision.test.ts    |  96 ++++++++-
+ .../src/cli/run-cli/command-catalog/task.ts        |   3 +
+ .../src/cli/run-cli/command-loaders/task.ts        |   4 +
+ .../src/commands/shared/route-decision.ts          |   3 +-
+ .../agentplane/src/commands/task/brief.command.ts  | 224 +++++++++++++++++++++
+ .../agentplane/src/commands/task/task.command.ts   |   4 +
+ 7 files changed, 368 insertions(+), 2 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605221744-GF25D1/pr/github-title.txt
+++ b/.agentplane/tasks/202605221744-GF25D1/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 GF25D1 task: Add agent task brief command [202605221744-GF25D1]

--- a/.agentplane/tasks/202605221744-GF25D1/pr/meta.json
+++ b/.agentplane/tasks/202605221744-GF25D1/pr/meta.json
@@ -1,0 +1,17 @@
+{
+  "base": "main",
+  "branch": "task/202605221744-GF25D1/agent-task-brief",
+  "created_at": "2026-05-23T01:10:07.020Z",
+  "diffstat_sha256": "sha256:b39dc0b10f17b035ccd90ca008a9a2e0c05be25b58693db779e350f9021122b2",
+  "last_verified_at": "2026-05-23T01:17:26.781Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "pr_number": 4060,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4060",
+  "schema_version": 1,
+  "status": "OPEN",
+  "task_id": "202605221744-GF25D1",
+  "updated_at": "2026-05-23T01:17:53.644Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605221744-GF25D1/pr/review.md
+++ b/.agentplane/tasks/202605221744-GF25D1/pr/review.md
@@ -1,0 +1,43 @@
+# PR Review
+
+Created: 2026-05-23T01:10:07.020Z
+
+## Task
+
+- Task: `202605221744-GF25D1`
+- Title: Add agent task brief command
+- Status: DOING
+- Branch: `task/202605221744-GF25D1/agent-task-brief`
+- Canonical task record: `.agentplane/tasks/202605221744-GF25D1/README.md`
+
+## Verification
+
+- State: ok
+- Note: Evaluator check: task brief satisfies approved local-first agent context scope. Evidence covers text and JSON output, no default gh lookup regression, generated CLI docs, typecheck, lint, format, and runtime bootstrap.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-23T01:10:07.020Z
+- Branch: task/202605221744-GF25D1/agent-task-brief
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ docs/user/cli-reference.generated.mdx              |  36 ++++
+ .../src/cli/run-cli.core.route-decision.test.ts    |  96 ++++++++-
+ .../src/cli/run-cli/command-catalog/task.ts        |   3 +
+ .../src/cli/run-cli/command-loaders/task.ts        |   4 +
+ .../src/commands/shared/route-decision.ts          |   3 +-
+ .../agentplane/src/commands/task/brief.command.ts  | 224 +++++++++++++++++++++
+ .../agentplane/src/commands/task/task.command.ts   |   4 +
+ 7 files changed, 368 insertions(+), 2 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -14,6 +14,7 @@ This page is generated from the CLI command specs. Do not edit it by hand; edit 
 - Task
   - [ready](#ready)
   - [task begin](#task-begin)
+  - [task brief](#task-brief)
   - [task comment](#task-comment)
   - [task complete](#task-complete)
   - [task doc set](#task-doc-set)
@@ -365,6 +366,41 @@ agentplane task begin "Fix parser edge case" --tag code --verify "bun run test:f
 ```
 
 - Create the task, seed a minimal plan, approve it, then start or print the branch_pr worktree route.
+
+### task brief
+
+Print an agent-ready task brief without remote lookups by default.
+
+Usage:
+
+```text
+agentplane task brief <task-id> [options]
+```
+
+Options:
+
+- `--json`: Emit JSON. (default=false)
+- `--remote`: Include hosted PR/check/review state using configured remote tools. (default=false)
+
+Examples:
+
+```sh
+agentplane task brief 202602030608-F1Q8AB
+```
+
+- Get local route, Verify Steps, blueprint, blockers, and next command in one view.
+
+```sh
+agentplane task brief 202602030608-F1Q8AB --json
+```
+
+- Emit a machine-readable agent work context.
+
+```sh
+agentplane task brief 202602030608-F1Q8AB --remote
+```
+
+- Include hosted PR truth when remote access is explicitly intended.
 
 ### task comment
 

--- a/packages/agentplane/src/cli/run-cli.core.route-decision.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.route-decision.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 
@@ -110,6 +110,100 @@ describe("runCli route decision commands", () => {
       expect(repairIo.stdout).toContain(`agentplane work start ${taskId}`);
     } finally {
       repairIo.restore();
+    }
+  });
+
+  it("prints a local-first task brief with JSON output and no default gh lookup", async () => {
+    const root = await mkGitRepoRootWithBranch("main");
+    const config = defaultConfig();
+    config.workflow_mode = "branch_pr";
+    await writeConfig(root, config);
+    await runCliSilent(["branch", "base", "set", "main", "--root", root]);
+
+    const taskId = await createBranchPrTask(root);
+    await runCliSilent([
+      "task",
+      "plan",
+      "set",
+      taskId,
+      "--text",
+      "Exercise task brief command.",
+      "--updated-by",
+      "ORCHESTRATOR",
+      "--root",
+      root,
+    ]);
+    await runCliSilent(["task", "plan", "approve", taskId, "--by", "ORCHESTRATOR", "--root", root]);
+
+    const prDir = path.join(root, ".agentplane", "tasks", taskId, "pr");
+    await mkdir(prDir, { recursive: true });
+    await writeFile(
+      path.join(prDir, "meta.json"),
+      JSON.stringify(
+        {
+          task_id: taskId,
+          branch: `task/${taskId}/agent-task-brief`,
+          base: "main",
+          status: "OPEN",
+          pr_number: 123,
+          pr_url: "https://github.com/example/repo/pull/123",
+          head_sha: "abc123",
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const fakeBin = path.join(root, "fake-bin");
+    const marker = path.join(root, "gh-called");
+    await mkdir(fakeBin, { recursive: true });
+    const fakeGh = path.join(fakeBin, "gh");
+    await writeFile(fakeGh, `#!/bin/sh\ntouch "${marker}"\nexit 2\n`, "utf8");
+    await chmod(fakeGh, 0o755);
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${fakeBin}${path.delimiter}${previousPath ?? ""}`;
+    try {
+      const textIo = captureStdIO();
+      try {
+        const code = await runCli(["task", "brief", taskId, "--root", root]);
+        expect(code).toBe(0);
+        expect(textIo.stdout).toContain(`task brief: ${taskId}`);
+        expect(textIo.stdout).toContain("next_code:");
+        expect(textIo.stdout).toContain("verify_steps:");
+        expect(textIo.stdout).toContain("blueprint_id:");
+        expect(textIo.stdout).toContain("snapshot_safe_command:");
+        expect(textIo.stdout).toContain("remote lookup skipped");
+      } finally {
+        textIo.restore();
+      }
+
+      await expect(readFile(marker, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+
+      const jsonIo = captureStdIO();
+      try {
+        const code = await runCli(["task", "brief", taskId, "--json", "--root", root]);
+        expect(code).toBe(0);
+        const parsed = JSON.parse(jsonIo.stdout) as {
+          task: { id: string };
+          next_action: { code: string; command: string };
+          verify_steps: { text: string; filled: boolean };
+          blueprint: { blueprint_id?: string; required_evidence?: string[] };
+          remote: { enabled: boolean };
+        };
+        expect(parsed.task.id).toBe(taskId);
+        expect(parsed.next_action.code).toBe("verify_or_update_pr");
+        expect(parsed.next_action.command).toBe(`agentplane pr update ${taskId}`);
+        expect(parsed.verify_steps.text).toContain("PLANNER fallback scaffold");
+        expect(parsed.verify_steps.filled).toBe(true);
+        expect(parsed.blueprint.blueprint_id).toBe("code.branch_pr");
+        expect(parsed.blueprint.required_evidence).toContain("code_pr.paths");
+        expect(parsed.remote.enabled).toBe(false);
+      } finally {
+        jsonIo.restore();
+      }
+    } finally {
+      process.env.PATH = previousPath;
     }
   });
 

--- a/packages/agentplane/src/cli/run-cli/command-catalog/task.ts
+++ b/packages/agentplane/src/cli/run-cli/command-catalog/task.ts
@@ -28,6 +28,7 @@ import { taskMigrateDocSpec } from "../../../commands/task/migrate-doc.command.j
 import { taskMigrateSpec } from "../../../commands/task/migrate.command.js";
 import { taskNewSpec } from "../../../commands/task/new.spec.js";
 import { taskBeginSpec } from "../../../commands/task/begin.command.js";
+import { taskBriefSpec } from "../../../commands/task/brief.command.js";
 import { taskCompleteSpec } from "../../../commands/task/complete.command.js";
 import { taskNextSpec } from "../../../commands/task/next.spec.js";
 import {
@@ -81,6 +82,7 @@ import {
   loadTaskNextActionSpec,
   loadTaskNewSpec,
   loadTaskBeginSpec,
+  loadTaskBriefSpec,
   loadTaskCompleteSpec,
   loadTaskDeriveSpec,
   loadTaskEvidenceCheckSpec,
@@ -158,6 +160,7 @@ export const TASK_COMMANDS = [
     invocation: requireCanonicalCommandInvocation(["task", "new"]),
   }),
   declareCommand(taskBeginSpec, { load: loadTaskBeginSpec }),
+  declareCommand(taskBriefSpec, { load: loadTaskBriefSpec }),
   declareCommand(taskCompleteSpec, { load: loadTaskCompleteSpec }),
   declareCommand(taskDeriveSpec, {
     load: loadTaskDeriveSpec,

--- a/packages/agentplane/src/cli/run-cli/command-loaders/task.ts
+++ b/packages/agentplane/src/cli/run-cli/command-loaders/task.ts
@@ -65,6 +65,10 @@ export const loadTaskBeginSpec = (deps: RunDeps) =>
   import("../../../commands/task/begin.command.js").then((m) =>
     m.makeRunTaskBeginHandler(deps.getCtx),
   );
+export const loadTaskBriefSpec = (deps: RunDeps) =>
+  import("../../../commands/task/brief.command.js").then((m) =>
+    m.makeRunTaskBriefHandler(deps.getCtx),
+  );
 export const loadTaskCompleteSpec = (deps: RunDeps) =>
   import("../../../commands/task/complete.command.js").then((m) =>
     m.makeRunTaskCompleteHandler(deps.getCtx),

--- a/packages/agentplane/src/commands/shared/route-decision.ts
+++ b/packages/agentplane/src/commands/shared/route-decision.ts
@@ -423,6 +423,7 @@ function deriveRepairPlan(decision: Omit<TaskRouteDecision, "repairPlan">): Rout
 export async function buildTaskRouteDecision(opts: {
   ctx?: CommandContext;
   cwd: string;
+  includeRemote?: boolean;
   rootOverride?: string | null;
   taskId: string;
 }): Promise<TaskRouteDecision> {
@@ -442,7 +443,7 @@ export async function buildTaskRouteDecision(opts: {
     task_id: opts.taskId,
   });
   let prFlow: PrFlowStatusReport | null = null;
-  if (ctx.config.workflow_mode === "branch_pr") {
+  if (ctx.config.workflow_mode === "branch_pr" && opts.includeRemote !== false) {
     try {
       prFlow = await resolvePrFlowStatus({
         ctx,

--- a/packages/agentplane/src/commands/task/brief.command.ts
+++ b/packages/agentplane/src/commands/task/brief.command.ts
@@ -1,0 +1,224 @@
+import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
+import { createCliEmitter, infoMessage } from "../../cli/output.js";
+import { checkTaskBlueprintSnapshotDrift } from "../blueprint/snapshot-artifact.js";
+import { buildTaskRouteDecision } from "../shared/route-decision.js";
+import { loadTaskFromContext, type CommandContext } from "../shared/task-backend.js";
+
+import { resolveTaskBlueprintLifecycleSummary } from "./blueprint-summary.js";
+import { extractDocSection, isVerifyStepsFilled } from "./shared.js";
+
+export type TaskBriefParsed = {
+  taskId: string;
+  json: boolean;
+  remote: boolean;
+};
+
+type TaskBrief = {
+  task: {
+    id: string;
+    title: string;
+    status: string;
+    owner: string;
+    plan: string | null;
+    verification: string | null;
+  };
+  workflow: {
+    mode: string;
+    checkout_role: string;
+    branch: string | null;
+    base_branch: string | null;
+    pr_branch: string | null;
+  };
+  next_action: {
+    code: string;
+    summary: string;
+    command: string | null;
+    requires_approval: boolean;
+  };
+  blockers: { code: string; summary: string }[];
+  verify_steps: {
+    filled: boolean;
+    text: string;
+  };
+  blueprint: Awaited<ReturnType<typeof resolveTaskBlueprintLifecycleSummary>>;
+  snapshot: {
+    state: string;
+    path: string;
+    digest: string | null;
+    current_digest: string;
+    route_changed: boolean | null;
+    safe_command: string;
+  };
+  stop_rules: string[];
+  remote: {
+    enabled: boolean;
+    note: string;
+  };
+};
+
+export const taskBriefSpec: CommandSpec<TaskBriefParsed> = {
+  id: ["task", "brief"],
+  group: "Task",
+  summary: "Print an agent-ready task brief without remote lookups by default.",
+  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
+  options: [
+    { kind: "boolean", name: "json", default: false, description: "Emit JSON." },
+    {
+      kind: "boolean",
+      name: "remote",
+      default: false,
+      description: "Include hosted PR/check/review state using configured remote tools.",
+    },
+  ],
+  examples: [
+    {
+      cmd: "agentplane task brief 202602030608-F1Q8AB",
+      why: "Get local route, Verify Steps, blueprint, blockers, and next command in one view.",
+    },
+    {
+      cmd: "agentplane task brief 202602030608-F1Q8AB --json",
+      why: "Emit a machine-readable agent work context.",
+    },
+    {
+      cmd: "agentplane task brief 202602030608-F1Q8AB --remote",
+      why: "Include hosted PR truth when remote access is explicitly intended.",
+    },
+  ],
+  parse: (raw) => ({
+    taskId: String(raw.args["task-id"]),
+    json: raw.opts.json === true,
+    remote: raw.opts.remote === true,
+  }),
+};
+
+function splitNonEmptyLines(text: string): string[] {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+async function buildTaskBrief(opts: {
+  commandCtx: CommandContext;
+  cwd: string;
+  parsed: TaskBriefParsed;
+  rootOverride?: string | null;
+}): Promise<TaskBrief> {
+  const task = await loadTaskFromContext({ ctx: opts.commandCtx, taskId: opts.parsed.taskId });
+  const doc =
+    typeof task.doc === "string"
+      ? task.doc
+      : ((await opts.commandCtx.taskBackend.getTaskDoc?.(opts.parsed.taskId)) ?? "");
+  const verifySteps = (extractDocSection(doc, "Verify Steps") ?? "").trim();
+  const route = await buildTaskRouteDecision({
+    ctx: opts.commandCtx,
+    cwd: opts.cwd,
+    includeRemote: opts.parsed.remote,
+    rootOverride: opts.rootOverride ?? null,
+    taskId: opts.parsed.taskId,
+  });
+  const blueprint = await resolveTaskBlueprintLifecycleSummary({
+    task,
+    config: opts.commandCtx.config,
+    projectRoot: opts.commandCtx.resolvedProject.gitRoot,
+  });
+  const snapshot = await checkTaskBlueprintSnapshotDrift({ ctx: opts.commandCtx, task });
+
+  return {
+    task: {
+      id: task.id,
+      title: task.title,
+      status: task.status,
+      owner: task.owner,
+      plan: task.plan_approval?.state ?? null,
+      verification: task.verification?.state ?? null,
+    },
+    workflow: {
+      mode: route.workflowMode,
+      checkout_role: route.workspace.checkoutRole,
+      branch: route.workspace.branch,
+      base_branch: route.workspace.baseBranch,
+      pr_branch: route.workspace.prBranch,
+    },
+    next_action: {
+      code: route.nextAction.code,
+      summary: route.nextAction.summary,
+      command: route.nextAction.command,
+      requires_approval: route.nextAction.requiresApproval,
+    },
+    blockers: route.blockers.map((blocker) => ({ ...blocker })),
+    verify_steps: {
+      filled: isVerifyStepsFilled(verifySteps),
+      text: verifySteps,
+    },
+    blueprint,
+    snapshot: {
+      state: snapshot.state,
+      path: snapshot.path,
+      digest: snapshot.previous.digest,
+      current_digest: snapshot.current.digest,
+      route_changed: snapshot.routeChanged,
+      safe_command: snapshot.safeCommand,
+    },
+    stop_rules: blueprint.stop_reasons ?? [],
+    remote: {
+      enabled: opts.parsed.remote,
+      note: opts.parsed.remote
+        ? "remote lookup explicitly enabled"
+        : "remote lookup skipped; pass --remote for hosted PR/check/review truth",
+    },
+  };
+}
+
+export function makeRunTaskBriefHandler(getCtx: (cmd: string) => Promise<CommandContext>) {
+  return async (ctx: CommandCtx, parsed: TaskBriefParsed): Promise<number> => {
+    const commandCtx = await getCtx("task brief");
+    const brief = await buildTaskBrief({
+      commandCtx,
+      cwd: ctx.cwd,
+      parsed,
+      rootOverride: ctx.rootOverride ?? null,
+    });
+    const output = createCliEmitter();
+    if (parsed.json) {
+      output.json(brief);
+      return 0;
+    }
+    output.report(
+      [
+        { label: "task", value: `${brief.task.id} ${brief.task.status}` },
+        { label: "title", value: brief.task.title },
+        { label: "owner", value: brief.task.owner },
+        { label: "workflow", value: brief.workflow.mode },
+        { label: "checkout_role", value: brief.workflow.checkout_role },
+        { label: "branch", value: brief.workflow.branch ?? "unknown" },
+        { label: "base_branch", value: brief.workflow.base_branch ?? "unknown" },
+        { label: "pr_branch", value: brief.workflow.pr_branch ?? "missing" },
+        { label: "next_code", value: brief.next_action.code },
+        { label: "next", value: brief.next_action.command ?? brief.next_action.summary },
+        { label: "requires_approval", value: String(brief.next_action.requires_approval) },
+        { label: "remote", value: brief.remote.note },
+      ],
+      { header: infoMessage(`task brief: ${parsed.taskId}`) },
+    );
+    for (const blocker of brief.blockers) {
+      output.line(`blocker: ${blocker.code}: ${blocker.summary}`);
+    }
+    output.line("verify_steps:");
+    for (const line of splitNonEmptyLines(brief.verify_steps.text)) {
+      output.line(`  ${line}`);
+    }
+    output.report([
+      { label: "blueprint_id", value: brief.blueprint.blueprint_id ?? "unresolved" },
+      { label: "blueprint_route", value: brief.blueprint.route?.join(" -> ") ?? "none" },
+      {
+        label: "required_evidence",
+        value: brief.blueprint.required_evidence?.join(", ") ?? "none",
+      },
+      { label: "snapshot_state", value: brief.snapshot.state },
+      { label: "snapshot_safe_command", value: brief.snapshot.safe_command },
+      { label: "stop_rules", value: brief.stop_rules.join(", ") || "none" },
+    ]);
+    return 0;
+  };
+}

--- a/packages/agentplane/src/commands/task/task.command.ts
+++ b/packages/agentplane/src/commands/task/task.command.ts
@@ -69,6 +69,10 @@ export const taskSpec: CommandSpec<TaskGroupParsed> = {
       cmd: "agentplane task next-action <task-id>",
       why: "Print the single safest next command for the task route.",
     },
+    {
+      cmd: "agentplane task brief <task-id>",
+      why: "Print an agent-ready local task brief with route, Verify Steps, and blueprint evidence.",
+    },
   ],
   parse: (raw) => parseGroupCommand(raw),
 };


### PR DESCRIPTION
Task: `202605221744-GF25D1`
Title: Add agent task brief command
Canonical task record: `.agentplane/tasks/202605221744-GF25D1/README.md`

## Summary

Add agent task brief command

Add a compact task brief surface that merges route decision, checkout role, next action, blockers, Verify Steps, blueprint evidence, and stop rules into one agent-ready view.

## Scope

- In scope: Add a compact task brief surface that merges route decision, checkout role, next action, blockers, Verify Steps, blueprint evidence, and stop rules into one agent-ready view.
- Out of scope: unrelated refactors not required for "Add agent task brief command".

## Verification

- State: ok
- Note:

```text
Evaluator check: task brief satisfies approved local-first agent context scope. Evidence covers text
and JSON output, no default gh lookup regression, generated CLI docs, typecheck, lint, format, and
runtime bootstrap.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-23T01:10:07.020Z
- Branch: task/202605221744-GF25D1/agent-task-brief
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 docs/user/cli-reference.generated.mdx              |  36 ++++
 .../src/cli/run-cli.core.route-decision.test.ts    |  96 ++++++++-
 .../src/cli/run-cli/command-catalog/task.ts        |   3 +
 .../src/cli/run-cli/command-loaders/task.ts        |   4 +
 .../src/commands/shared/route-decision.ts          |   3 +-
 .../agentplane/src/commands/task/brief.command.ts  | 224 +++++++++++++++++++++
 .../agentplane/src/commands/task/task.command.ts   |   4 +
 7 files changed, 368 insertions(+), 2 deletions(-)
```

</details>
