### PR TITLE
🚧 8W56N1 task: Add source confidence labels to agent route output [202605221745-8W56N1]

### DIFF
--- a/.agentplane/tasks/202605221745-8W56N1/README.md
+++ b/.agentplane/tasks/202605221745-8W56N1/README.md
@@ -1,10 +1,10 @@
 ---
 id: "202605221745-8W56N1"
 title: "Add source confidence labels to agent route output"
-status: "TODO"
+status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 3
+revision: 6
 origin:
   system: "manual"
 depends_on:
@@ -27,17 +27,50 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-23T03:02:26.078Z"
+  updated_by: "EVALUATOR"
+  note: "Evaluator pass: JSON route outputs expose source_confidence for route, next_action, blockers, and remote; default status/next-action commands are local-only; explicit --remote path is covered by tests and smoke."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-23T03:02:26.078Z"
+  updated_by: "EVALUATOR"
+  note: "Evaluator pass: JSON route outputs expose source_confidence for route, next_action, blockers, and remote; default status/next-action commands are local-only; explicit --remote path is covered by tests and smoke."
+  evaluated_sha: "ecdd8be371c870e65b27326a14b94a0810ba9744"
+  blueprint_digest: "bdc62efdf3f8fad4fc1dfbd130775a4006f534725fdabce7a128a7b54d4181c4"
+  evidence_refs:
+    - ".agentplane/tasks/202605221745-8W56N1/README.md"
+    - "/Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221745-8W56N1-source-confidence-labels/.agentplane/tasks/202605221745-8W56N1/blueprint/resolved-snapshot.json"
+  findings: []
 commit: null
-comments: []
-events: []
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement source confidence labels for agent route output with local/default and explicit remote evidence coverage."
+events:
+  -
+    type: "status"
+    at: "2026-05-23T02:56:35.957Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement source confidence labels for agent route output with local/default and explicit remote evidence coverage."
+  -
+    type: "verify"
+    at: "2026-05-23T03:02:13.364Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented route source confidence labels for task status --route --json and task next-action --json; remote lookup is skipped by default and requires --remote; text output remains compact."
+  -
+    type: "verify"
+    at: "2026-05-23T03:02:26.078Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Evaluator pass: JSON route outputs expose source_confidence for route, next_action, blockers, and remote; default status/next-action commands are local-only; explicit --remote path is covered by tests and smoke."
 doc_version: 3
-doc_updated_at: "2026-05-22T17:45:11.478Z"
-doc_updated_by: "PLANNER"
+doc_updated_at: "2026-05-23T03:02:26.107Z"
+doc_updated_by: "CODER"
 description: "Label route, PR, close-tail, task, and verification fields by source and freshness so agents can tell local, cached, stale, and remote-checked context apart before mutating state."
 sections:
   Summary: |-
@@ -58,11 +91,56 @@ sections:
     5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-23T03:02:13.364Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Implemented route source confidence labels for task status --route --json and task next-action --json; remote lookup is skipped by default and requires --remote; text output remains compact.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T02:56:35.957Z, excerpt_hash=sha256:34112a79d377c3daeb4c006810f840b65acefb56e8a85bde31ba9c1ea9a7616c
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221745-8W56N1-source-confidence-labels/.agentplane/tasks/202605221745-8W56N1/blueprint/resolved-snapshot.json
+    - old_digest: bdc62efdf3f8fad4fc1dfbd130775a4006f534725fdabce7a128a7b54d4181c4
+    - current_digest: bdc62efdf3f8fad4fc1dfbd130775a4006f534725fdabce7a128a7b54d4181c4
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605221745-8W56N1
+
+    ### 2026-05-23T03:02:26.078Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Evaluator pass: JSON route outputs expose source_confidence for route, next_action, blockers, and remote; default status/next-action commands are local-only; explicit --remote path is covered by tests and smoke.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T03:02:13.390Z, excerpt_hash=sha256:34112a79d377c3daeb4c006810f840b65acefb56e8a85bde31ba9c1ea9a7616c
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221745-8W56N1-source-confidence-labels/.agentplane/tasks/202605221745-8W56N1/blueprint/resolved-snapshot.json
+    - old_digest: bdc62efdf3f8fad4fc1dfbd130775a4006f534725fdabce7a128a7b54d4181c4
+    - current_digest: bdc62efdf3f8fad4fc1dfbd130775a4006f534725fdabce7a128a7b54d4181c4
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605221745-8W56N1
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
     - Re-run required checks to confirm rollback safety.
-  Findings: ""
+  Findings: |-
+    - Observation: Local smoke: status/next-action JSON report route computed_local high confidence and remote_skipped skipped; --remote downgrades route to medium and remote to low when provider state is unavailable.
+      Impact: Agents can distinguish local/computed route data from explicit remote/provider state without triggering default remote calls.
+      Resolution: Use --remote only when hosted PR/check/review truth is required.
+
+    - Observation: Route-decision suite passed 8 tests, typecheck passed, CLI docs check passed, lint/format passed, bootstrap passed, knip and task-scope checks passed.
+      Impact: Route output now carries source/freshness/confidence labels without increasing text output noise.
+      Resolution: Proceed to PR publication and hosted checks.
 id_source: "generated"
 ---
 ## Summary
@@ -93,6 +171,44 @@ PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLA
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-23T03:02:13.364Z — VERIFY — ok
+
+By: CODER
+
+Note: Implemented route source confidence labels for task status --route --json and task next-action --json; remote lookup is skipped by default and requires --remote; text output remains compact.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T02:56:35.957Z, excerpt_hash=sha256:34112a79d377c3daeb4c006810f840b65acefb56e8a85bde31ba9c1ea9a7616c
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221745-8W56N1-source-confidence-labels/.agentplane/tasks/202605221745-8W56N1/blueprint/resolved-snapshot.json
+- old_digest: bdc62efdf3f8fad4fc1dfbd130775a4006f534725fdabce7a128a7b54d4181c4
+- current_digest: bdc62efdf3f8fad4fc1dfbd130775a4006f534725fdabce7a128a7b54d4181c4
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605221745-8W56N1
+
+### 2026-05-23T03:02:26.078Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Evaluator pass: JSON route outputs expose source_confidence for route, next_action, blockers, and remote; default status/next-action commands are local-only; explicit --remote path is covered by tests and smoke.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T03:02:13.390Z, excerpt_hash=sha256:34112a79d377c3daeb4c006810f840b65acefb56e8a85bde31ba9c1ea9a7616c
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605221745-8W56N1-source-confidence-labels/.agentplane/tasks/202605221745-8W56N1/blueprint/resolved-snapshot.json
+- old_digest: bdc62efdf3f8fad4fc1dfbd130775a4006f534725fdabce7a128a7b54d4181c4
+- current_digest: bdc62efdf3f8fad4fc1dfbd130775a4006f534725fdabce7a128a7b54d4181c4
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605221745-8W56N1
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -101,3 +217,11 @@ PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLA
 - Re-run required checks to confirm rollback safety.
 
 ## Findings
+
+- Observation: Local smoke: status/next-action JSON report route computed_local high confidence and remote_skipped skipped; --remote downgrades route to medium and remote to low when provider state is unavailable.
+  Impact: Agents can distinguish local/computed route data from explicit remote/provider state without triggering default remote calls.
+  Resolution: Use --remote only when hosted PR/check/review truth is required.
+
+- Observation: Route-decision suite passed 8 tests, typecheck passed, CLI docs check passed, lint/format passed, bootstrap passed, knip and task-scope checks passed.
+  Impact: Route output now carries source/freshness/confidence labels without increasing text output noise.
+  Resolution: Proceed to PR publication and hosted checks.

--- a/.agentplane/tasks/202605221745-8W56N1/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605221745-8W56N1/blueprint/resolved-snapshot.json
@@ -1,0 +1,580 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605221745-8W56N1",
+    "title": "Add source confidence labels to agent route output",
+    "description": "Label route, PR, close-tail, task, and verification fields by source and freshness so agents can tell local, cached, stale, and remote-checked context apart before mutating state.",
+    "tags": [
+      "cli",
+      "code",
+      "github",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605221745-8W56N1",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane verify <task-id> --ok|--rework --by EVALUATOR"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane verify <task-id> --ok|--rework --by EVALUATOR",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "bdc62efdf3f8fad4fc1dfbd130775a4006f534725fdabce7a128a7b54d4181c4"
+  }
+}

--- a/.agentplane/tasks/202605221745-8W56N1/pr/diffstat.txt
+++ b/.agentplane/tasks/202605221745-8W56N1/pr/diffstat.txt
@@ -1,0 +1,6 @@
+ docs/user/cli-reference.generated.mdx              |  2 +
+ .../src/cli/run-cli.core.route-decision.test.ts    | 87 +++++++++++++++++++++-
+ .../src/commands/shared/route-decision.ts          | 87 +++++++++++++++++++++-
+ .../src/commands/task/next-action.command.ts       | 15 ++++
+ .../agentplane/src/commands/task/status.command.ts | 16 +++-
+ 5 files changed, 201 insertions(+), 6 deletions(-)

--- a/.agentplane/tasks/202605221745-8W56N1/pr/github-body.md
+++ b/.agentplane/tasks/202605221745-8W56N1/pr/github-body.md
@@ -1,0 +1,44 @@
+Task: `202605221745-8W56N1`
+Title: Add source confidence labels to agent route output
+Canonical task record: `.agentplane/tasks/202605221745-8W56N1/README.md`
+
+## Summary
+
+Add source confidence labels to agent route output
+
+Label route, PR, close-tail, task, and verification fields by source and freshness so agents can tell local, cached, stale, and remote-checked context apart before mutating state.
+
+## Scope
+
+- In scope: Label route, PR, close-tail, task, and verification fields by source and freshness so agents can tell local, cached, stale, and remote-checked context apart before mutating state.
+- Out of scope: unrelated refactors not required for "Add source confidence labels to agent route output".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Evaluator pass: JSON route outputs expose source_confidence for route, next_action, blockers, and
+remote; default status/next-action commands are local-only; explicit --remote path is covered by
+tests and smoke.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-23T02:56:36.034Z
+- Branch: task/202605221745-8W56N1/source-confidence-labels
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ docs/user/cli-reference.generated.mdx              |  2 +
+ .../src/cli/run-cli.core.route-decision.test.ts    | 87 +++++++++++++++++++++-
+ .../src/commands/shared/route-decision.ts          | 87 +++++++++++++++++++++-
+ .../src/commands/task/next-action.command.ts       | 15 ++++
+ .../agentplane/src/commands/task/status.command.ts | 16 +++-
+ 5 files changed, 201 insertions(+), 6 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605221745-8W56N1/pr/github-title.txt
+++ b/.agentplane/tasks/202605221745-8W56N1/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 8W56N1 task: Add source confidence labels to agent route output [202605221745-8W56N1]

--- a/.agentplane/tasks/202605221745-8W56N1/pr/meta.json
+++ b/.agentplane/tasks/202605221745-8W56N1/pr/meta.json
@@ -1,0 +1,17 @@
+{
+  "base": "main",
+  "branch": "task/202605221745-8W56N1/source-confidence-labels",
+  "created_at": "2026-05-23T02:56:36.034Z",
+  "diffstat_sha256": "sha256:19dfb396ecc17e419c7876f88708cc4a20e7a9dc4d5891b5ae8c3f96e191f698",
+  "last_verified_at": "2026-05-23T03:02:26.078Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "pr_number": 4066,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4066",
+  "schema_version": 1,
+  "status": "OPEN",
+  "task_id": "202605221745-8W56N1",
+  "updated_at": "2026-05-23T03:03:23.863Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605221745-8W56N1/pr/review.md
+++ b/.agentplane/tasks/202605221745-8W56N1/pr/review.md
@@ -1,0 +1,41 @@
+# PR Review
+
+Created: 2026-05-23T02:56:36.034Z
+
+## Task
+
+- Task: `202605221745-8W56N1`
+- Title: Add source confidence labels to agent route output
+- Status: DOING
+- Branch: `task/202605221745-8W56N1/source-confidence-labels`
+- Canonical task record: `.agentplane/tasks/202605221745-8W56N1/README.md`
+
+## Verification
+
+- State: ok
+- Note: Evaluator pass: JSON route outputs expose source_confidence for route, next_action, blockers, and remote; default status/next-action commands are local-only; explicit --remote path is covered by tests and smoke.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-23T02:56:36.034Z
+- Branch: task/202605221745-8W56N1/source-confidence-labels
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ docs/user/cli-reference.generated.mdx              |  2 +
+ .../src/cli/run-cli.core.route-decision.test.ts    | 87 +++++++++++++++++++++-
+ .../src/commands/shared/route-decision.ts          | 87 +++++++++++++++++++++-
+ .../src/commands/task/next-action.command.ts       | 15 ++++
+ .../agentplane/src/commands/task/status.command.ts | 16 +++-
+ 5 files changed, 201 insertions(+), 6 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -704,6 +704,7 @@ agentplane task next-action <task-id> [options]
 Options:
 
 - `--explain`: Include route context, approval policy, blockers, and ambiguity resolution hints. (default=false)
+- `--remote`: Include hosted PR/check/review state using configured remote tools. (default=false)
 - `--json`: Emit JSON. (default=false)
 
 Examples:
@@ -858,6 +859,7 @@ agentplane task status <task-id> [options]
 Options:
 
 - `--route`: Include route blockers, next action, and repair-plan hints. (default=false)
+- `--remote`: Include hosted PR/check/review state using configured remote tools. (default=false)
 - `--json`: Emit JSON. (default=false)
 
 Examples:

--- a/packages/agentplane/src/cli/run-cli.core.route-decision.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.route-decision.test.ts
@@ -181,6 +181,52 @@ describe("runCli route decision commands", () => {
 
       await expect(readFile(marker, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
 
+      const statusJsonIo = captureStdIO();
+      try {
+        const code = await runCli(["task", "status", taskId, "--route", "--json", "--root", root]);
+        expect(code).toBe(0);
+        const parsed = JSON.parse(statusJsonIo.stdout) as {
+          source_confidence: Record<
+            string,
+            { source: string; freshness: string; confidence: string; note?: string }
+          >;
+        };
+        expect(parsed.source_confidence.route).toMatchObject({
+          freshness: "computed_local",
+          confidence: "high",
+        });
+        expect(parsed.source_confidence.remote).toMatchObject({
+          freshness: "remote_skipped",
+          confidence: "skipped",
+        });
+      } finally {
+        statusJsonIo.restore();
+      }
+
+      const nextJsonIo = captureStdIO();
+      try {
+        const code = await runCli(["task", "next-action", taskId, "--json", "--root", root]);
+        expect(code).toBe(0);
+        const parsed = JSON.parse(nextJsonIo.stdout) as {
+          source_confidence: Record<
+            string,
+            { source: string; freshness: string; confidence: string; note?: string }
+          >;
+        };
+        expect(parsed.source_confidence.next_action).toMatchObject({
+          freshness: "computed_local",
+          confidence: "high",
+        });
+        expect(parsed.source_confidence.remote).toMatchObject({
+          freshness: "remote_skipped",
+          confidence: "skipped",
+        });
+      } finally {
+        nextJsonIo.restore();
+      }
+
+      await expect(readFile(marker, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+
       const jsonIo = captureStdIO();
       try {
         const code = await runCli(["task", "brief", taskId, "--json", "--root", root]);
@@ -260,6 +306,135 @@ describe("runCli route decision commands", () => {
         expect(parsed.source_confidence.remote.note).toContain("fell back to local data");
       } finally {
         remoteIo.restore();
+      }
+
+      const remoteStatusIo = captureStdIO();
+      try {
+        const code = await runCli([
+          "task",
+          "status",
+          taskId,
+          "--route",
+          "--json",
+          "--remote",
+          "--root",
+          root,
+        ]);
+        expect(code).toBe(0);
+        const parsed = JSON.parse(remoteStatusIo.stdout) as {
+          source_confidence: Record<
+            string,
+            { source: string; freshness: string; confidence: string; note?: string }
+          >;
+        };
+        expect(parsed.source_confidence.route).toMatchObject({
+          freshness: "computed_local",
+          confidence: "medium",
+        });
+        expect(parsed.source_confidence.remote).toMatchObject({
+          freshness: "remote_skipped",
+          confidence: "low",
+        });
+      } finally {
+        remoteStatusIo.restore();
+      }
+    } finally {
+      process.env.PATH = previousPath;
+    }
+  });
+
+  it("marks close-tail provider lookup as remote evidence", async () => {
+    const root = await mkGitRepoRootWithBranch("main");
+    const config = defaultConfig();
+    config.workflow_mode = "branch_pr";
+    await writeConfig(root, config);
+    await runCliSilent(["branch", "base", "set", "main", "--root", root]);
+    await execFileAsync("git", ["remote", "add", "origin", "https://github.com/example/repo.git"], {
+      cwd: root,
+    });
+
+    const taskId = await createBranchPrTask(root);
+    const prDir = path.join(root, ".agentplane", "tasks", taskId, "pr");
+    await mkdir(prDir, { recursive: true });
+    await writeFile(
+      path.join(prDir, "meta.json"),
+      JSON.stringify(
+        {
+          schema_version: 1,
+          task_id: taskId,
+          branch: `task/${taskId}/route-confidence`,
+          base: "main",
+          created_at: "2026-05-23T00:00:00.000Z",
+          updated_at: "2026-05-23T00:00:00.000Z",
+          status: "MERGED",
+          pr_url: "https://github.com/example/repo/pull/123",
+          merge_commit: "abc123def456",
+          head_sha: "def456abc123",
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const fakeBin = path.join(root, "fake-bin");
+    await mkdir(fakeBin, { recursive: true });
+    const fakeGh = path.join(fakeBin, "gh");
+    await writeFile(fakeGh, "#!/bin/sh\nprintf '[]\\n'\n", "utf8");
+    await chmod(fakeGh, 0o755);
+
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${fakeBin}${path.delimiter}${previousPath ?? ""}`;
+    try {
+      const statusIo = captureStdIO();
+      try {
+        const code = await runCli([
+          "task",
+          "status",
+          taskId,
+          "--route",
+          "--json",
+          "--remote",
+          "--root",
+          root,
+        ]);
+        expect(code).toBe(0);
+        const parsed = JSON.parse(statusIo.stdout) as {
+          prFlow: { closeTail: { state: string; provider?: string } };
+          source_confidence: Record<
+            string,
+            { source: string; freshness: string; confidence: string; note?: string }
+          >;
+        };
+        expect(parsed.prFlow.closeTail).toMatchObject({
+          state: "not_found",
+          provider: "github",
+        });
+        expect(parsed.source_confidence.route).toMatchObject({
+          freshness: "remote_live",
+          confidence: "medium",
+        });
+        expect(parsed.source_confidence.remote).toMatchObject({
+          freshness: "remote_live",
+          confidence: "medium",
+        });
+      } finally {
+        statusIo.restore();
+      }
+
+      const briefIo = captureStdIO();
+      try {
+        const code = await runCli(["task", "brief", taskId, "--json", "--remote", "--root", root]);
+        expect(code).toBe(0);
+        const parsed = JSON.parse(briefIo.stdout) as {
+          source_confidence: Record<string, { freshness: string; confidence: string }>;
+        };
+        expect(parsed.source_confidence.remote).toMatchObject({
+          freshness: "remote_live",
+          confidence: "medium",
+        });
+      } finally {
+        briefIo.restore();
       }
     } finally {
       process.env.PATH = previousPath;
@@ -532,7 +707,15 @@ describe("runCli route decision commands", () => {
 
     const nextIo = captureStdIO();
     try {
-      const code = await runCli(["task", "next-action", taskId, "--json", "--root", root]);
+      const code = await runCli([
+        "task",
+        "next-action",
+        taskId,
+        "--json",
+        "--remote",
+        "--root",
+        root,
+      ]);
       expect(code).toBe(0);
       const parsed = JSON.parse(nextIo.stdout) as {
         next_action: { code: string; command: string };

--- a/packages/agentplane/src/commands/shared/route-decision.ts
+++ b/packages/agentplane/src/commands/shared/route-decision.ts
@@ -25,6 +25,13 @@ type RouteRepairStep = {
   mutates: boolean;
 };
 
+type RouteSourceConfidence = {
+  source: string;
+  freshness: string;
+  confidence: string;
+  note?: string;
+};
+
 type RouteAmbiguity = {
   code: string;
   summary: string;
@@ -64,6 +71,7 @@ type TaskRouteDecision = {
   ambiguities: RouteAmbiguity[];
   nextAction: RouteNextAction;
   repairPlan: RouteRepairStep[];
+  sourceConfidence: Record<string, RouteSourceConfidence>;
 };
 
 function isCliUsageOrIo(err: unknown): boolean {
@@ -290,7 +298,7 @@ function deriveApprovalContract(ctx: CommandContext): TaskRouteDecision["approva
 }
 
 function deriveAmbiguities(opts: {
-  decision: Omit<TaskRouteDecision, "ambiguities" | "repairPlan">;
+  decision: Omit<TaskRouteDecision, "ambiguities" | "repairPlan" | "sourceConfidence">;
 }): RouteAmbiguity[] {
   const ambiguities: RouteAmbiguity[] = [];
   const blockerCodes = new Set(opts.decision.blockers.map((blocker) => blocker.code));
@@ -327,7 +335,9 @@ function deriveAmbiguities(opts: {
   return ambiguities;
 }
 
-function deriveRepairPlan(decision: Omit<TaskRouteDecision, "repairPlan">): RouteRepairStep[] {
+function deriveRepairPlan(
+  decision: Omit<TaskRouteDecision, "repairPlan" | "sourceConfidence">,
+): RouteRepairStep[] {
   const steps: RouteRepairStep[] = [];
   const id = decision.task.id;
   for (const blocker of decision.blockers) {
@@ -420,6 +430,70 @@ function deriveRepairPlan(decision: Omit<TaskRouteDecision, "repairPlan">): Rout
   return steps;
 }
 
+function hasRemoteProviderEvidence(prFlow: PrFlowStatusReport | null): boolean {
+  if (!prFlow) return false;
+  return (
+    prFlow.pr.source === "lookup" ||
+    "provider" in prFlow.closeTail ||
+    prFlow.hostedChecks.checked ||
+    prFlow.reviewThreads.checked
+  );
+}
+
+function buildRouteSourceConfidence(opts: {
+  remoteEnabled: boolean;
+  remoteResolved: boolean;
+}): TaskRouteDecision["sourceConfidence"] {
+  const routeFreshness = opts.remoteResolved ? "remote_live" : "computed_local";
+  const routeConfidence = opts.remoteResolved ? "medium" : opts.remoteEnabled ? "medium" : "high";
+  const routeNote = opts.remoteResolved
+    ? "route includes provider-derived PR/check state"
+    : opts.remoteEnabled
+      ? "remote lookup was requested but no provider state was available"
+      : "route excludes hosted PR/check/review lookups";
+  const remoteFreshness = opts.remoteResolved ? "remote_live" : "remote_skipped";
+  const remoteConfidence = opts.remoteResolved ? "medium" : opts.remoteEnabled ? "low" : "skipped";
+  const remoteNote = opts.remoteResolved
+    ? "remote provider state fetched"
+    : opts.remoteEnabled
+      ? "remote lookup was requested but route resolution fell back to local data"
+      : "remote lookup skipped by default";
+  return {
+    task: {
+      source: "task_backend",
+      freshness: "live_local",
+      confidence: "high",
+    },
+    workflow: {
+      source: "local_git",
+      freshness: "live_local",
+      confidence: "high",
+    },
+    route: {
+      source: "local_git",
+      freshness: routeFreshness,
+      confidence: routeConfidence,
+      note: routeNote,
+    },
+    next_action: {
+      source: "local_git",
+      freshness: routeFreshness,
+      confidence: routeConfidence,
+    },
+    blockers: {
+      source: "local_git",
+      freshness: routeFreshness,
+      confidence: routeConfidence,
+    },
+    remote: {
+      source: "remote_provider",
+      freshness: remoteFreshness,
+      confidence: remoteConfidence,
+      note: remoteNote,
+    },
+  };
+}
+
 export async function buildTaskRouteDecision(opts: {
   ctx?: CommandContext;
   cwd: string;
@@ -443,7 +517,8 @@ export async function buildTaskRouteDecision(opts: {
     task_id: opts.taskId,
   });
   let prFlow: PrFlowStatusReport | null = null;
-  if (ctx.config.workflow_mode === "branch_pr" && opts.includeRemote !== false) {
+  const remoteEnabled = ctx.config.workflow_mode === "branch_pr" && opts.includeRemote !== false;
+  if (remoteEnabled) {
     try {
       prFlow = await resolvePrFlowStatus({
         ctx,
@@ -486,5 +561,12 @@ export async function buildTaskRouteDecision(opts: {
     nextAction,
   };
   const withAmbiguities = { ...partial, ambiguities: deriveAmbiguities({ decision: partial }) };
-  return { ...withAmbiguities, repairPlan: deriveRepairPlan(withAmbiguities) };
+  return {
+    ...withAmbiguities,
+    repairPlan: deriveRepairPlan(withAmbiguities),
+    sourceConfidence: buildRouteSourceConfidence({
+      remoteEnabled,
+      remoteResolved: hasRemoteProviderEvidence(prFlow),
+    }),
+  };
 }

--- a/packages/agentplane/src/commands/task/brief.command.ts
+++ b/packages/agentplane/src/commands/task/brief.command.ts
@@ -233,7 +233,10 @@ function hasRemoteProviderEvidence(
   const prFlow = route.prFlow;
   if (!prFlow) return false;
   return (
-    prFlow.pr.source === "lookup" || prFlow.hostedChecks.checked || prFlow.reviewThreads.checked
+    prFlow.pr.source === "lookup" ||
+    "provider" in prFlow.closeTail ||
+    prFlow.hostedChecks.checked ||
+    prFlow.reviewThreads.checked
   );
 }
 

--- a/packages/agentplane/src/commands/task/next-action.command.ts
+++ b/packages/agentplane/src/commands/task/next-action.command.ts
@@ -6,6 +6,7 @@ import { buildTaskRouteDecision } from "../shared/route-decision.js";
 export type TaskNextActionParsed = {
   taskId: string;
   explain: boolean;
+  remote: boolean;
   json: boolean;
 };
 
@@ -22,6 +23,12 @@ export const taskNextActionSpec: CommandSpec<TaskNextActionParsed> = {
       description:
         "Include route context, approval policy, blockers, and ambiguity resolution hints.",
     },
+    {
+      kind: "boolean",
+      name: "remote",
+      default: false,
+      description: "Include hosted PR/check/review state using configured remote tools.",
+    },
     { kind: "boolean", name: "json", default: false, description: "Emit JSON." },
   ],
   examples: [
@@ -33,6 +40,7 @@ export const taskNextActionSpec: CommandSpec<TaskNextActionParsed> = {
   parse: (raw) => ({
     taskId: String(raw.args["task-id"]),
     explain: raw.opts.explain === true,
+    remote: raw.opts.remote === true,
     json: raw.opts.json === true,
   }),
 };
@@ -42,6 +50,7 @@ export function makeRunTaskNextActionHandler(getCtx: (cmd: string) => Promise<Co
     const decision = await buildTaskRouteDecision({
       ctx: await getCtx("task next-action"),
       cwd: ctx.cwd,
+      includeRemote: parsed.remote,
       rootOverride: ctx.rootOverride ?? null,
       taskId: parsed.taskId,
     });
@@ -51,6 +60,12 @@ export function makeRunTaskNextActionHandler(getCtx: (cmd: string) => Promise<Co
         task: decision.task,
         next_action: decision.nextAction,
         blockers: decision.blockers,
+        source_confidence: {
+          next_action: decision.sourceConfidence.next_action,
+          blockers: decision.sourceConfidence.blockers,
+          route: decision.sourceConfidence.route,
+          remote: decision.sourceConfidence.remote,
+        },
       });
       return 0;
     }

--- a/packages/agentplane/src/commands/task/status.command.ts
+++ b/packages/agentplane/src/commands/task/status.command.ts
@@ -6,6 +6,7 @@ import { buildTaskRouteDecision } from "../shared/route-decision.js";
 export type TaskStatusParsed = {
   taskId: string;
   route: boolean;
+  remote: boolean;
   json: boolean;
 };
 
@@ -20,6 +21,12 @@ export const taskStatusSpec: CommandSpec<TaskStatusParsed> = {
       name: "route",
       default: false,
       description: "Include route blockers, next action, and repair-plan hints.",
+    },
+    {
+      kind: "boolean",
+      name: "remote",
+      default: false,
+      description: "Include hosted PR/check/review state using configured remote tools.",
     },
     { kind: "boolean", name: "json", default: false, description: "Emit JSON." },
   ],
@@ -36,6 +43,7 @@ export const taskStatusSpec: CommandSpec<TaskStatusParsed> = {
   parse: (raw) => ({
     taskId: String(raw.args["task-id"]),
     route: raw.opts.route === true,
+    remote: raw.opts.remote === true,
     json: raw.opts.json === true,
   }),
 };
@@ -46,12 +54,18 @@ export function makeRunTaskStatusHandler(getCtx: (cmd: string) => Promise<Comman
     const decision = await buildTaskRouteDecision({
       ctx: commandCtx,
       cwd: ctx.cwd,
+      includeRemote: parsed.remote,
       rootOverride: ctx.rootOverride ?? null,
       taskId: parsed.taskId,
     });
     const output = createCliEmitter();
     if (parsed.json) {
-      output.json(parsed.route ? decision : decision.task);
+      if (parsed.route) {
+        const { sourceConfidence, ...routeDecision } = decision;
+        output.json({ ...routeDecision, source_confidence: sourceConfidence });
+      } else {
+        output.json(decision.task);
+      }
       return 0;
     }
     const entries = [


### PR DESCRIPTION
Task: `202605221745-8W56N1`
Title: Add source confidence labels to agent route output
Canonical task record: `.agentplane/tasks/202605221745-8W56N1/README.md`

## Summary

Add source confidence labels to agent route output

Label route, PR, close-tail, task, and verification fields by source and freshness so agents can tell local, cached, stale, and remote-checked context apart before mutating state.

## Scope

- In scope: Label route, PR, close-tail, task, and verification fields by source and freshness so agents can tell local, cached, stale, and remote-checked context apart before mutating state.
- Out of scope: unrelated refactors not required for "Add source confidence labels to agent route output".

## Verification

- State: ok
- Note:

```text
Evaluator pass: JSON route outputs expose source_confidence for route, next_action, blockers, and
remote; default status/next-action commands are local-only; explicit --remote path is covered by
tests and smoke.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-23T02:56:36.034Z
- Branch: task/202605221745-8W56N1/source-confidence-labels
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 docs/user/cli-reference.generated.mdx              |  2 +
 .../src/cli/run-cli.core.route-decision.test.ts    | 87 +++++++++++++++++++++-
 .../src/commands/shared/route-decision.ts          | 87 +++++++++++++++++++++-
 .../src/commands/task/next-action.command.ts       | 15 ++++
 .../agentplane/src/commands/task/status.command.ts | 16 +++-
 5 files changed, 201 insertions(+), 6 deletions(-)
```

</details>
