### PR TITLE
🚧 SN168C task: Refresh CLI help snapshot for active work commands [202605230524-SN168C]

### DIFF
--- a/.agentplane/tasks/202605230524-SN168C/README.md
+++ b/.agentplane/tasks/202605230524-SN168C/README.md
@@ -1,0 +1,198 @@
+---
+id: "202605230524-SN168C"
+title: "Refresh CLI help snapshot for active work commands"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "tests"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-23T05:25:04.637Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-23T05:40:54.342Z"
+  updated_by: "EVALUATOR"
+  note: "Hosted PR #4075 checks passed: CodeQL, docs, PR verification, Release-ready manifest, test-windows, verify-cli-critical, verify-contract, verify-coverage, verify-static, verify-unit, verify-workflow."
+  attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-23T05:40:54.342Z"
+  updated_by: "EVALUATOR"
+  note: "Hosted PR #4075 checks passed: CodeQL, docs, PR verification, Release-ready manifest, test-windows, verify-cli-critical, verify-contract, verify-coverage, verify-static, verify-unit, verify-workflow."
+  evaluated_sha: "59e32b3f72f881b35969176c87cf33a8c3f54075"
+  blueprint_digest: "b837e48f4c23dff48a2d2e0282a24e51a18024467cdf85d8dd726088f74905c1"
+  evidence_refs:
+    - ".agentplane/tasks/202605230524-SN168C/README.md"
+    - "/Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605230524-SN168C-refresh-help-snapshot/.agentplane/tasks/202605230524-SN168C/blueprint/resolved-snapshot.json"
+  findings: []
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: refresh stale CLI help snapshot found by release prepublish heavy."
+events:
+  -
+    type: "status"
+    at: "2026-05-23T05:25:16.069Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: refresh stale CLI help snapshot found by release prepublish heavy."
+  -
+    type: "verify"
+    at: "2026-05-23T05:36:09.269Z"
+    author: "CODER"
+    state: "ok"
+    note: "Local verification passed: updated CLI help snapshot with vitest -u; bunx vitest run packages/agentplane/src/cli/run-cli.core.help-snap.test.ts; bun run format:check for touched files. Pre-push fast route also passed through broad fast checks and all fast unit tests before the push session was interrupted."
+  -
+    type: "verify"
+    at: "2026-05-23T05:40:54.342Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "Hosted PR #4075 checks passed: CodeQL, docs, PR verification, Release-ready manifest, test-windows, verify-cli-critical, verify-contract, verify-coverage, verify-static, verify-unit, verify-workflow."
+doc_version: 3
+doc_updated_at: "2026-05-23T05:40:54.370Z"
+doc_updated_by: "CODER"
+description: "Update stale CLI help snapshot coverage after active work and task brief commands changed the registered help output. This unblocks release prepublish heavy validation for v0.6.7."
+sections:
+  Summary: |-
+    Refresh CLI help snapshot for active work commands
+
+    Update stale CLI help snapshot coverage after active work and task brief commands changed the registered help output. This unblocks release prepublish heavy validation for v0.6.7.
+  Scope: |-
+    - In scope: Update stale CLI help snapshot coverage after active work and task brief commands changed the registered help output. This unblocks release prepublish heavy validation for v0.6.7.
+    - Out of scope: unrelated refactors not required for "Refresh CLI help snapshot for active work commands".
+  Plan: "Update the CLI help snapshot so release-ci-base matches the current command registry output for task active, task brief, task list, and flow repair. Verify with the failing help snapshot test and release prepublish heavy route as part of the resumed release."
+  Verify Steps: |-
+    PLANNER fallback scaffold for "Refresh CLI help snapshot for active work commands". Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the requested outcome for "Refresh CLI help snapshot for active work commands". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-23T05:36:09.269Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Local verification passed: updated CLI help snapshot with vitest -u; bunx vitest run packages/agentplane/src/cli/run-cli.core.help-snap.test.ts; bun run format:check for touched files. Pre-push fast route also passed through broad fast checks and all fast unit tests before the push session was interrupted.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T05:25:16.069Z, excerpt_hash=sha256:87af881501d072176fb39d4211c7b735719f35672bb11af64cabb2e55f9808ec
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605230524-SN168C-refresh-help-snapshot/.agentplane/tasks/202605230524-SN168C/blueprint/resolved-snapshot.json
+    - old_digest: b837e48f4c23dff48a2d2e0282a24e51a18024467cdf85d8dd726088f74905c1
+    - current_digest: b837e48f4c23dff48a2d2e0282a24e51a18024467cdf85d8dd726088f74905c1
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605230524-SN168C
+
+    ### 2026-05-23T05:40:54.342Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: Hosted PR #4075 checks passed: CodeQL, docs, PR verification, Release-ready manifest, test-windows, verify-cli-critical, verify-contract, verify-coverage, verify-static, verify-unit, verify-workflow.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T05:36:09.295Z, excerpt_hash=sha256:87af881501d072176fb39d4211c7b735719f35672bb11af64cabb2e55f9808ec
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605230524-SN168C-refresh-help-snapshot/.agentplane/tasks/202605230524-SN168C/blueprint/resolved-snapshot.json
+    - old_digest: b837e48f4c23dff48a2d2e0282a24e51a18024467cdf85d8dd726088f74905c1
+    - current_digest: b837e48f4c23dff48a2d2e0282a24e51a18024467cdf85d8dd726088f74905c1
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605230524-SN168C
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Refresh CLI help snapshot for active work commands
+
+Update stale CLI help snapshot coverage after active work and task brief commands changed the registered help output. This unblocks release prepublish heavy validation for v0.6.7.
+
+## Scope
+
+- In scope: Update stale CLI help snapshot coverage after active work and task brief commands changed the registered help output. This unblocks release prepublish heavy validation for v0.6.7.
+- Out of scope: unrelated refactors not required for "Refresh CLI help snapshot for active work commands".
+
+## Plan
+
+Update the CLI help snapshot so release-ci-base matches the current command registry output for task active, task brief, task list, and flow repair. Verify with the failing help snapshot test and release prepublish heavy route as part of the resumed release.
+
+## Verify Steps
+
+PLANNER fallback scaffold for "Refresh CLI help snapshot for active work commands". Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the requested outcome for "Refresh CLI help snapshot for active work commands". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-23T05:36:09.269Z — VERIFY — ok
+
+By: CODER
+
+Note: Local verification passed: updated CLI help snapshot with vitest -u; bunx vitest run packages/agentplane/src/cli/run-cli.core.help-snap.test.ts; bun run format:check for touched files. Pre-push fast route also passed through broad fast checks and all fast unit tests before the push session was interrupted.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T05:25:16.069Z, excerpt_hash=sha256:87af881501d072176fb39d4211c7b735719f35672bb11af64cabb2e55f9808ec
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605230524-SN168C-refresh-help-snapshot/.agentplane/tasks/202605230524-SN168C/blueprint/resolved-snapshot.json
+- old_digest: b837e48f4c23dff48a2d2e0282a24e51a18024467cdf85d8dd726088f74905c1
+- current_digest: b837e48f4c23dff48a2d2e0282a24e51a18024467cdf85d8dd726088f74905c1
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605230524-SN168C
+
+### 2026-05-23T05:40:54.342Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: Hosted PR #4075 checks passed: CodeQL, docs, PR verification, Release-ready manifest, test-windows, verify-cli-critical, verify-contract, verify-coverage, verify-static, verify-unit, verify-workflow.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T05:36:09.295Z, excerpt_hash=sha256:87af881501d072176fb39d4211c7b735719f35672bb11af64cabb2e55f9808ec
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605230524-SN168C-refresh-help-snapshot/.agentplane/tasks/202605230524-SN168C/blueprint/resolved-snapshot.json
+- old_digest: b837e48f4c23dff48a2d2e0282a24e51a18024467cdf85d8dd726088f74905c1
+- current_digest: b837e48f4c23dff48a2d2e0282a24e51a18024467cdf85d8dd726088f74905c1
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605230524-SN168C
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605230524-SN168C/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605230524-SN168C/blueprint/resolved-snapshot.json
@@ -1,0 +1,360 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605230524-SN168C",
+    "title": "Refresh CLI help snapshot for active work commands",
+    "description": "Update stale CLI help snapshot coverage after active work and task brief commands changed the registered help output. This unblocks release prepublish heavy validation for v0.6.7.",
+    "tags": [
+      "tests"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "none",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "analysis.light",
+    "version": 1,
+    "title": "Lightweight analysis",
+    "taskKinds": [
+      "analysis"
+    ],
+    "workflowModes": []
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "analysis.light",
+    "blueprintVersion": 1,
+    "title": "Lightweight analysis",
+    "taskId": "202605230524-SN168C",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "none"
+    },
+    "whySelected": [
+      "task kind resolved to analysis",
+      "workflow mode: branch_pr",
+      "mutation scope: none"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "context_manifest",
+          "sources"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "weak_links",
+          "final_output"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "analysis.sources",
+        "kind": "sources",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Sources used for analysis."
+      },
+      {
+        "id": "analysis.assumptions",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Assumptions and constraints."
+      },
+      {
+        "id": "analysis.weak_links",
+        "kind": "weak_links",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Weak links or uncertainty."
+      },
+      {
+        "id": "analysis.final",
+        "kind": "final_output",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Final answer or report."
+      },
+      {
+        "id": "analysis.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      }
+    ],
+    "policyModules": [],
+    "allowedCommands": [],
+    "contextBudget": {
+      "maxPolicyModules": 0,
+      "maxPromptBlocks": 6,
+      "rationale": "Lightweight analysis should load sources and task context without policy modules."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "context_manifest",
+        "sources"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "weak_links",
+        "final_output"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "analysis.sources",
+      "kind": "sources",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Sources used for analysis."
+    },
+    {
+      "id": "analysis.assumptions",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Assumptions and constraints."
+    },
+    {
+      "id": "analysis.weak_links",
+      "kind": "weak_links",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Weak links or uncertainty."
+    },
+    {
+      "id": "analysis.final",
+      "kind": "final_output",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Final answer or report."
+    },
+    {
+      "id": "analysis.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    }
+  ],
+  "policyModules": [],
+  "allowedCommands": [],
+  "contextBudget": {
+    "maxPolicyModules": 0,
+    "maxPromptBlocks": 6,
+    "rationale": "Lightweight analysis should load sources and task context without policy modules."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to analysis",
+    "workflow mode: branch_pr",
+    "mutation scope: none"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "b837e48f4c23dff48a2d2e0282a24e51a18024467cdf85d8dd726088f74905c1"
+  }
+}

--- a/.agentplane/tasks/202605230524-SN168C/pr/diffstat.txt
+++ b/.agentplane/tasks/202605230524-SN168C/pr/diffstat.txt
@@ -1,0 +1,2 @@
+ .../src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap       | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)

--- a/.agentplane/tasks/202605230524-SN168C/pr/github-body.md
+++ b/.agentplane/tasks/202605230524-SN168C/pr/github-body.md
@@ -1,0 +1,39 @@
+Task: `202605230524-SN168C`
+Title: Refresh CLI help snapshot for active work commands
+Canonical task record: `.agentplane/tasks/202605230524-SN168C/README.md`
+
+## Summary
+
+Refresh CLI help snapshot for active work commands
+
+Update stale CLI help snapshot coverage after active work and task brief commands changed the registered help output. This unblocks release prepublish heavy validation for v0.6.7.
+
+## Scope
+
+- In scope: Update stale CLI help snapshot coverage after active work and task brief commands changed the registered help output. This unblocks release prepublish heavy validation for v0.6.7.
+- Out of scope: unrelated refactors not required for "Refresh CLI help snapshot for active work commands".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Hosted PR #4075 checks passed: CodeQL, docs, PR verification, Release-ready manifest, test-windows,
+verify-cli-critical, verify-contract, verify-coverage, verify-static, verify-unit, verify-workflow.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-23T05:25:16.141Z
+- Branch: task/202605230524-SN168C/refresh-help-snapshot
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap       | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605230524-SN168C/pr/github-title.txt
+++ b/.agentplane/tasks/202605230524-SN168C/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 SN168C task: Refresh CLI help snapshot for active work commands [202605230524-SN168C]

--- a/.agentplane/tasks/202605230524-SN168C/pr/meta.json
+++ b/.agentplane/tasks/202605230524-SN168C/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605230524-SN168C/refresh-help-snapshot",
+  "created_at": "2026-05-23T05:25:16.141Z",
+  "diffstat_sha256": "sha256:6f16b6bd9f6ff3941dfa76a0e26a1c6a3270e540c7eb66c6b2a809b5a90d10cf",
+  "last_verified_at": "2026-05-23T05:40:54.342Z",
+  "last_verified_diffstat_sha256": "sha256:6f16b6bd9f6ff3941dfa76a0e26a1c6a3270e540c7eb66c6b2a809b5a90d10cf",
+  "schema_version": 1,
+  "task_id": "202605230524-SN168C",
+  "updated_at": "2026-05-23T05:25:16.141Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605230524-SN168C/pr/review.md
+++ b/.agentplane/tasks/202605230524-SN168C/pr/review.md
@@ -1,0 +1,37 @@
+# PR Review
+
+Created: 2026-05-23T05:25:16.141Z
+
+## Task
+
+- Task: `202605230524-SN168C`
+- Title: Refresh CLI help snapshot for active work commands
+- Status: DOING
+- Branch: `task/202605230524-SN168C/refresh-help-snapshot`
+- Canonical task record: `.agentplane/tasks/202605230524-SN168C/README.md`
+
+## Verification
+
+- State: ok
+- Note: Hosted PR #4075 checks passed: CodeQL, docs, PR verification, Release-ready manifest, test-windows, verify-cli-critical, verify-contract, verify-coverage, verify-static, verify-unit, verify-workflow.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-23T05:25:16.141Z
+- Branch: task/202605230524-SN168C/refresh-help-snapshot
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap       | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap
+++ b/packages/agentplane/src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap
@@ -15,13 +15,15 @@ Commands:
   Task:
     ready  Report dependency readiness details for a task.
     task  Task lifecycle and task-store commands.
+    task active  Select active agent work with next actions, blockers, dependency readiness, and freshness.
     task begin  Create, plan, approve, and start or route a task through the normal lifecycle.
+    task brief  Print an agent-ready task brief without remote lookups by default.
     task comment  Append a comment to a task.
     task complete  Record OK verification and finish a direct task, or print the branch_pr close route.
     task doc  Task doc commands (show/set).
     task doc set  Update a task README section.
     task doc show  Print task README content (entire doc or one section).
-    task list  List tasks with compact resolved blueprint route hints.
+    task list  List active tasks with compact resolved blueprint route hints.
     task new  Create a new task (prints the generated task id).
     task next  List ready tasks (default status=TODO) with optional filters.
     task next-action  Print the single safest next command for a task route.
@@ -177,7 +179,7 @@ Commands:
     evidence verify  Verify a task evidence bundle manifest and referenced file hashes.
   Workflow:
     flow  Inspect and repair high-level task workflow routes.
-    flow repair  Print a dry-run repair plan for task workflow drift.
+    flow repair  Print or apply safe repair steps for task workflow drift.
   Framework Dev:
     codex  Codex integration commands.
     codex plugin  Install and inspect bundled Codex plugin integrations.


### PR DESCRIPTION
Task: `202605230524-SN168C`
Title: Refresh CLI help snapshot for active work commands
Canonical task record: `.agentplane/tasks/202605230524-SN168C/README.md`

## Summary

Refresh CLI help snapshot for active work commands

Update stale CLI help snapshot coverage after active work and task brief commands changed the registered help output. This unblocks release prepublish heavy validation for v0.6.7.

## Scope

- In scope: Update stale CLI help snapshot coverage after active work and task brief commands changed the registered help output. This unblocks release prepublish heavy validation for v0.6.7.
- Out of scope: unrelated refactors not required for "Refresh CLI help snapshot for active work commands".

## Verification

- State: pending
- Note: Not recorded yet.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-23T05:25:16.141Z
- Branch: task/202605230524-SN168C/refresh-help-snapshot
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/cli/__snapshots__/run-cli.core.help-snap.test.ts.snap       | 6 ++++--
 1 file changed, 4 insertions(+), 2 deletions(-)
```

</details>
