### PR TITLE
🚧 WXWH7T task: Harden publish evidence workflow token permissions [202605230831-WXWH7T]

### DIFF
--- a/.agentplane/tasks/202605230831-WXWH7T/README.md
+++ b/.agentplane/tasks/202605230831-WXWH7T/README.md
@@ -1,0 +1,191 @@
+---
+id: "202605230831-WXWH7T"
+title: "Harden publish evidence workflow token permissions"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 7
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "release"
+  - "workflow"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-23T08:37:36.954Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-23T08:52:42.427Z"
+  updated_by: "EVALUATOR"
+  note: "EVALUATOR quality gate passed. Evidence: PR #4084 hosted checks are green, including actionlint, PR verification, release-ready manifest, docs, CodeQL, and verify-routed. Local contract test passed: bun test packages/agentplane/src/commands/release/publish-workflow-contract.test.ts (9 pass)."
+  attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-23T08:52:42.427Z"
+  updated_by: "EVALUATOR"
+  note: "EVALUATOR quality gate passed. Evidence: PR #4084 hosted checks are green, including actionlint, PR verification, release-ready manifest, docs, CodeQL, and verify-routed. Local contract test passed: bun test packages/agentplane/src/commands/release/publish-workflow-contract.test.ts (9 pass)."
+  evaluated_sha: "31dc1f340db45321c09d466d5a89164ef496f934"
+  blueprint_digest: "9cfd395ebb6fd0a7a3793771cc010c29e31f31c6d2704430e482a24a9a839895"
+  evidence_refs:
+    - ".agentplane/tasks/202605230831-WXWH7T/README.md"
+    - "/Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605230831-WXWH7T-publish-evidence-token-hardening/.agentplane/tasks/202605230831-WXWH7T/blueprint/resolved-snapshot.json"
+  findings: []
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: harden publish workflow token permissions and post-publish release evidence handling so successful publication is not reported as failed by follow-up automation."
+events:
+  -
+    type: "status"
+    at: "2026-05-23T08:37:51.526Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: harden publish workflow token permissions and post-publish release evidence handling so successful publication is not reported as failed by follow-up automation."
+  -
+    type: "verify"
+    at: "2026-05-23T08:39:00.085Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: bun test packages/agentplane/src/commands/release/publish-workflow-contract.test.ts. Result: pass. Evidence: 9 pass, 0 fail, 197 expect calls. Scope: publish workflow permissions and release evidence follow-up contract."
+  -
+    type: "verify"
+    at: "2026-05-23T08:52:42.427Z"
+    author: "EVALUATOR"
+    state: "ok"
+    note: "EVALUATOR quality gate passed. Evidence: PR #4084 hosted checks are green, including actionlint, PR verification, release-ready manifest, docs, CodeQL, and verify-routed. Local contract test passed: bun test packages/agentplane/src/commands/release/publish-workflow-contract.test.ts (9 pass)."
+doc_version: 3
+doc_updated_at: "2026-05-23T08:52:42.442Z"
+doc_updated_by: "CODER"
+description: "Allow publish workflow to dispatch evidence CI and keep post-publish evidence automation from making a completed publish look failed."
+sections:
+  Summary: |-
+    Harden publish evidence workflow token permissions
+
+    Allow publish workflow to dispatch evidence CI and keep post-publish evidence automation from making a completed publish look failed.
+  Scope: |-
+    - In scope: Allow publish workflow to dispatch evidence CI and keep post-publish evidence automation from making a completed publish look failed.
+    - Out of scope: unrelated refactors not required for "Harden publish evidence workflow token permissions".
+  Plan: "Plan: update publish workflow permissions so GITHUB_TOKEN can dispatch Core CI for release evidence branches; make release evidence follow-up failures warnings after publish-result succeeds instead of turning a completed publish red; add/adjust workflow contract tests; document operator token requirements in final user instructions."
+  Verify Steps: "1. Run bun test packages/agentplane/src/commands/release/publish-workflow-contract.test.ts. Expected: publish workflow contract covers actions: write and best-effort release evidence follow-up handling."
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-23T08:39:00.085Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Command: bun test packages/agentplane/src/commands/release/publish-workflow-contract.test.ts. Result: pass. Evidence: 9 pass, 0 fail, 197 expect calls. Scope: publish workflow permissions and release evidence follow-up contract.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T08:38:58.412Z, excerpt_hash=sha256:dd7f5dcde3932dfae9cc37c7d232cbc48d8bf0cd7b99c71379e5af3784258f0f
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605230831-WXWH7T-publish-evidence-token-hardening/.agentplane/tasks/202605230831-WXWH7T/blueprint/resolved-snapshot.json
+    - old_digest: 9cfd395ebb6fd0a7a3793771cc010c29e31f31c6d2704430e482a24a9a839895
+    - current_digest: 9cfd395ebb6fd0a7a3793771cc010c29e31f31c6d2704430e482a24a9a839895
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605230831-WXWH7T
+
+    ### 2026-05-23T08:52:42.427Z — VERIFY — ok
+
+    By: EVALUATOR
+
+    Note: EVALUATOR quality gate passed. Evidence: PR #4084 hosted checks are green, including actionlint, PR verification, release-ready manifest, docs, CodeQL, and verify-routed. Local contract test passed: bun test packages/agentplane/src/commands/release/publish-workflow-contract.test.ts (9 pass).
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T08:39:00.101Z, excerpt_hash=sha256:dd7f5dcde3932dfae9cc37c7d232cbc48d8bf0cd7b99c71379e5af3784258f0f
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605230831-WXWH7T-publish-evidence-token-hardening/.agentplane/tasks/202605230831-WXWH7T/blueprint/resolved-snapshot.json
+    - old_digest: 9cfd395ebb6fd0a7a3793771cc010c29e31f31c6d2704430e482a24a9a839895
+    - current_digest: 9cfd395ebb6fd0a7a3793771cc010c29e31f31c6d2704430e482a24a9a839895
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605230831-WXWH7T
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Harden publish evidence workflow token permissions
+
+Allow publish workflow to dispatch evidence CI and keep post-publish evidence automation from making a completed publish look failed.
+
+## Scope
+
+- In scope: Allow publish workflow to dispatch evidence CI and keep post-publish evidence automation from making a completed publish look failed.
+- Out of scope: unrelated refactors not required for "Harden publish evidence workflow token permissions".
+
+## Plan
+
+Plan: update publish workflow permissions so GITHUB_TOKEN can dispatch Core CI for release evidence branches; make release evidence follow-up failures warnings after publish-result succeeds instead of turning a completed publish red; add/adjust workflow contract tests; document operator token requirements in final user instructions.
+
+## Verify Steps
+
+1. Run bun test packages/agentplane/src/commands/release/publish-workflow-contract.test.ts. Expected: publish workflow contract covers actions: write and best-effort release evidence follow-up handling.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-23T08:39:00.085Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: bun test packages/agentplane/src/commands/release/publish-workflow-contract.test.ts. Result: pass. Evidence: 9 pass, 0 fail, 197 expect calls. Scope: publish workflow permissions and release evidence follow-up contract.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T08:38:58.412Z, excerpt_hash=sha256:dd7f5dcde3932dfae9cc37c7d232cbc48d8bf0cd7b99c71379e5af3784258f0f
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605230831-WXWH7T-publish-evidence-token-hardening/.agentplane/tasks/202605230831-WXWH7T/blueprint/resolved-snapshot.json
+- old_digest: 9cfd395ebb6fd0a7a3793771cc010c29e31f31c6d2704430e482a24a9a839895
+- current_digest: 9cfd395ebb6fd0a7a3793771cc010c29e31f31c6d2704430e482a24a9a839895
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605230831-WXWH7T
+
+### 2026-05-23T08:52:42.427Z — VERIFY — ok
+
+By: EVALUATOR
+
+Note: EVALUATOR quality gate passed. Evidence: PR #4084 hosted checks are green, including actionlint, PR verification, release-ready manifest, docs, CodeQL, and verify-routed. Local contract test passed: bun test packages/agentplane/src/commands/release/publish-workflow-contract.test.ts (9 pass).
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T08:39:00.101Z, excerpt_hash=sha256:dd7f5dcde3932dfae9cc37c7d232cbc48d8bf0cd7b99c71379e5af3784258f0f
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605230831-WXWH7T-publish-evidence-token-hardening/.agentplane/tasks/202605230831-WXWH7T/blueprint/resolved-snapshot.json
+- old_digest: 9cfd395ebb6fd0a7a3793771cc010c29e31f31c6d2704430e482a24a9a839895
+- current_digest: 9cfd395ebb6fd0a7a3793771cc010c29e31f31c6d2704430e482a24a9a839895
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605230831-WXWH7T
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605230831-WXWH7T/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605230831-WXWH7T/blueprint/resolved-snapshot.json
@@ -1,0 +1,455 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605230831-WXWH7T",
+    "title": "Harden publish evidence workflow token permissions",
+    "description": "Allow publish workflow to dispatch evidence CI and keep post-publish evidence automation from making a completed publish look failed.",
+    "tags": [
+      "code",
+      "release",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "release",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "release.strict",
+    "version": 1,
+    "title": "Strict release",
+    "taskKinds": [
+      "release"
+    ],
+    "workflowModes": [
+      "direct",
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "release.strict",
+    "blueprintVersion": 1,
+    "title": "Strict release",
+    "taskId": "202605230831-WXWH7T",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "release"
+    },
+    "whySelected": [
+      "task kind resolved to release",
+      "workflow mode: branch_pr",
+      "mutation scope: release"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.release.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "deterministic_check",
+        "kind": "deterministic_check",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "release.approval",
+        "kind": "approval",
+        "producedBy": "approval_gate",
+        "required": true,
+        "description": "Release approval."
+      },
+      {
+        "id": "release.plan",
+        "kind": "artifact",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Release plan or candidate artifact."
+      },
+      {
+        "id": "release.check",
+        "kind": "check_result",
+        "producedBy": "deterministic_check",
+        "required": true,
+        "description": "Release gates."
+      },
+      {
+        "id": "release.publish",
+        "kind": "external_link",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Publish evidence."
+      },
+      {
+        "id": "release.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Release commit."
+      },
+      {
+        "id": "release.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.release.md"
+    ],
+    "allowedCommands": [
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "publish commands after approval",
+      "release gates"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Release work needs strict release policy, approval evidence, and rollback context."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.release.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "deterministic_check",
+      "kind": "deterministic_check",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "release.approval",
+      "kind": "approval",
+      "producedBy": "approval_gate",
+      "required": true,
+      "description": "Release approval."
+    },
+    {
+      "id": "release.plan",
+      "kind": "artifact",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Release plan or candidate artifact."
+    },
+    {
+      "id": "release.check",
+      "kind": "check_result",
+      "producedBy": "deterministic_check",
+      "required": true,
+      "description": "Release gates."
+    },
+    {
+      "id": "release.publish",
+      "kind": "external_link",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Publish evidence."
+    },
+    {
+      "id": "release.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Release commit."
+    },
+    {
+      "id": "release.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.release.md"
+  ],
+  "allowedCommands": [
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "publish commands after approval",
+    "release gates"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Release work needs strict release policy, approval evidence, and rollback context."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to release",
+    "workflow mode: branch_pr",
+    "mutation scope: release"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "9cfd395ebb6fd0a7a3793771cc010c29e31f31c6d2704430e482a24a9a839895"
+  }
+}

--- a/.agentplane/tasks/202605230831-WXWH7T/pr/diffstat.txt
+++ b/.agentplane/tasks/202605230831-WXWH7T/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .github/workflows/publish.yml                        | 16 +++++++++++-----
+ .../release/publish-workflow-contract.test.ts        | 20 +++++++++++++++++++-
+ 2 files changed, 30 insertions(+), 6 deletions(-)

--- a/.agentplane/tasks/202605230831-WXWH7T/pr/github-body.md
+++ b/.agentplane/tasks/202605230831-WXWH7T/pr/github-body.md
@@ -1,0 +1,41 @@
+Task: `202605230831-WXWH7T`
+Title: Harden publish evidence workflow token permissions
+Canonical task record: `.agentplane/tasks/202605230831-WXWH7T/README.md`
+
+## Summary
+
+Harden publish evidence workflow token permissions
+
+Allow publish workflow to dispatch evidence CI and keep post-publish evidence automation from making a completed publish look failed.
+
+## Scope
+
+- In scope: Allow publish workflow to dispatch evidence CI and keep post-publish evidence automation from making a completed publish look failed.
+- Out of scope: unrelated refactors not required for "Harden publish evidence workflow token permissions".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+EVALUATOR quality gate passed. Evidence: PR #4084 hosted checks are green, including actionlint, PR
+verification, release-ready manifest, docs, CodeQL, and verify-routed. Local contract test passed:
+bun test packages/agentplane/src/commands/release/publish-workflow-contract.test.ts (9 pass).
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-23T08:37:51.572Z
+- Branch: task/202605230831-WXWH7T/publish-evidence-token-hardening
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .github/workflows/publish.yml                        | 16 +++++++++++-----
+ .../release/publish-workflow-contract.test.ts        | 20 +++++++++++++++++++-
+ 2 files changed, 30 insertions(+), 6 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605230831-WXWH7T/pr/github-title.txt
+++ b/.agentplane/tasks/202605230831-WXWH7T/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 WXWH7T task: Harden publish evidence workflow token permissions [202605230831-WXWH7T]

--- a/.agentplane/tasks/202605230831-WXWH7T/pr/meta.json
+++ b/.agentplane/tasks/202605230831-WXWH7T/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605230831-WXWH7T/publish-evidence-token-hardening",
+  "created_at": "2026-05-23T08:37:51.572Z",
+  "diffstat_sha256": "sha256:6acbd42144fc85f99d0a5b137f5608b25658d7bf37c2b6e6e5b81ce451feb218",
+  "last_verified_at": "2026-05-23T08:52:42.427Z",
+  "last_verified_diffstat_sha256": "sha256:6acbd42144fc85f99d0a5b137f5608b25658d7bf37c2b6e6e5b81ce451feb218",
+  "schema_version": 1,
+  "task_id": "202605230831-WXWH7T",
+  "updated_at": "2026-05-23T08:37:51.572Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605230831-WXWH7T/pr/review.md
+++ b/.agentplane/tasks/202605230831-WXWH7T/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-05-23T08:37:51.572Z
+
+## Task
+
+- Task: `202605230831-WXWH7T`
+- Title: Harden publish evidence workflow token permissions
+- Status: DOING
+- Branch: `task/202605230831-WXWH7T/publish-evidence-token-hardening`
+- Canonical task record: `.agentplane/tasks/202605230831-WXWH7T/README.md`
+
+## Verification
+
+- State: ok
+- Note: EVALUATOR quality gate passed. Evidence: PR #4084 hosted checks are green, including actionlint, PR verification, release-ready manifest, docs, CodeQL, and verify-routed. Local contract test passed: bun test packages/agentplane/src/commands/release/publish-workflow-contract.test.ts (9 pass).
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-23T08:37:51.572Z
+- Branch: task/202605230831-WXWH7T/publish-evidence-token-hardening
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .github/workflows/publish.yml                        | 16 +++++++++++-----
+ .../release/publish-workflow-contract.test.ts        | 20 +++++++++++++++++++-
+ 2 files changed, 30 insertions(+), 6 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ on:
         default: "main"
 
 permissions:
-  actions: read
+  actions: write
   contents: write
   id-token: write
   packages: write
@@ -625,19 +625,19 @@ jobs:
       - name: Prepare release task evidence
         if: always()
         id: release_evidence
+        continue-on-error: true
         env:
           RELEASE_SHA: ${{ needs.detect.outputs.sha }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           mkdir -p .agentplane/.release/publish
-          if bun scripts/release-task-evidence.mjs prepare \
+          if ! bun scripts/release-task-evidence.mjs prepare \
             --release-sha "${RELEASE_SHA}" \
             --publish-result .agentplane/.release/publish/publish-result.json \
             --repo "${REPO}" > .agentplane/.release/publish/release-task-evidence.json; then
-            true
-          else
-            true
+            echo "::warning::release task evidence prepare failed; publish-result remains the authoritative publication outcome"
+            printf '%s\n' '{"actionable":false,"reason":"release task evidence prepare failed"}' > .agentplane/.release/publish/release-task-evidence.json
           fi
           node <<'EOF'
           const fs = require("node:fs");
@@ -672,6 +672,7 @@ jobs:
       - name: Check for existing release evidence PR
         if: steps.release_evidence.outputs.actionable == 'true'
         id: release_evidence_existing
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -694,6 +695,7 @@ jobs:
           steps.release_evidence_existing.outputs.pr_url == '' &&
           steps.release_evidence_existing.outputs.branch_exists != 'true'
         id: apply_release_evidence
+        continue-on-error: true
         env:
           REPO: ${{ github.repository }}
         run: |
@@ -721,11 +723,13 @@ jobs:
           echo "closure_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Push release evidence branch
         if: steps.apply_release_evidence.outputs.created_commit == 'true'
+        continue-on-error: true
         run: |
           set -euo pipefail
           git push --set-upstream origin "${{ steps.release_evidence.outputs.closure_branch }}"
       - name: Dispatch Core CI for release evidence branch
         if: steps.apply_release_evidence.outputs.created_commit == 'true'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -736,6 +740,7 @@ jobs:
           steps.release_evidence.outputs.actionable == 'true' &&
           steps.release_evidence_existing.outputs.pr_url == ''
         id: create_release_evidence_pr
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           PR_TITLE: ${{ steps.release_evidence.outputs.pr_title }}
@@ -768,6 +773,7 @@ jobs:
         if: |
           steps.release_evidence.outputs.actionable == 'true' &&
           (steps.release_evidence_existing.outputs.pr_url != '' || steps.create_release_evidence_pr.outputs.pr_url != '')
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/packages/agentplane/src/commands/release/publish-workflow-contract.test.ts
+++ b/packages/agentplane/src/commands/release/publish-workflow-contract.test.ts
@@ -137,8 +137,12 @@ describe("publish workflow contract", () => {
     );
     expect(workflow).toContain('--ghcr-outcome "${{ steps.publish_ghcr.outcome }}"');
     expect(workflow).toContain("if: always()");
+    expect(workflow).toContain("actions: write");
     expect(workflow).toContain("pull-requests: write");
     expect(workflow).toContain("Prepare release task evidence");
+    expect(workflow).toContain(
+      "::warning::release task evidence prepare failed; publish-result remains the authoritative publication outcome",
+    );
     expect(workflow).toContain("bun scripts/release-task-evidence.mjs prepare");
     expect(workflow).toContain(".agentplane/.release/publish/release-task-evidence.json");
     expect(workflow).toContain("Check for existing release evidence PR");
@@ -153,7 +157,11 @@ describe("publish workflow contract", () => {
       workflow.indexOf("Upload release-distribution artifact"),
     );
     for (const stepName of [
+      "Prepare release task evidence",
       "Check for existing release evidence PR",
+      "Apply release task evidence on a follow-up branch",
+      "Push release evidence branch",
+      "Dispatch Core CI for release evidence branch",
       "Open or recover release evidence PR",
       "Enable auto-merge for release evidence PR",
     ]) {
@@ -164,7 +172,17 @@ describe("publish workflow contract", () => {
         stepIndex,
         nextStepIndex === -1 ? workflow.length : nextStepIndex,
       );
-      expect(stepBlock).toContain("GH_TOKEN: ${{ github.token }}");
+      expect(stepBlock).toContain("continue-on-error: true");
+      if (
+        [
+          "Check for existing release evidence PR",
+          "Dispatch Core CI for release evidence branch",
+          "Open or recover release evidence PR",
+          "Enable auto-merge for release evidence PR",
+        ].includes(stepName)
+      ) {
+        expect(stepBlock).toContain("GH_TOKEN: ${{ github.token }}");
+      }
     }
   });
 


### PR DESCRIPTION
Task: `202605230831-WXWH7T`
Title: Harden publish evidence workflow token permissions
Canonical task record: `.agentplane/tasks/202605230831-WXWH7T/README.md`

## Summary

Harden publish evidence workflow token permissions

Allow publish workflow to dispatch evidence CI and keep post-publish evidence automation from making a completed publish look failed.

## Scope

- In scope: Allow publish workflow to dispatch evidence CI and keep post-publish evidence automation from making a completed publish look failed.
- Out of scope: unrelated refactors not required for "Harden publish evidence workflow token permissions".

## Verification

- State: ok
- Note:

```bash
bun test packages/agentplane/src/commands/release/publish-workflow-contract.test.ts. Result: pass. \
  Evidence: 9 pass, 0 fail, 197 expect calls. Scope: publish workflow permissions and release \
  evidence follow-up contract.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-23T08:37:51.572Z
- Branch: task/202605230831-WXWH7T/publish-evidence-token-hardening
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .github/workflows/publish.yml                        | 16 +++++++++++-----
 .../release/publish-workflow-contract.test.ts        | 20 +++++++++++++++++++-
 2 files changed, 30 insertions(+), 6 deletions(-)
```

</details>
