### PR TITLE
🚧 GKV94B task: Add release next-action diagnostic [202605230831-GKV94B]

### DIFF
--- a/.agentplane/tasks/202605230831-GKV94B/README.md
+++ b/.agentplane/tasks/202605230831-GKV94B/README.md
@@ -1,0 +1,144 @@
+---
+id: "202605230831-GKV94B"
+title: "Add release next-action diagnostic"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "release"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-23T09:15:21.128Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-23T09:24:57.474Z"
+  updated_by: "CODER"
+  note: "Implemented release next-action diagnostic expansion. Evidence: bun test packages/agentplane/src/commands/release/release-next-action-script.test.ts (2 pass, 14 expects); bun run lint:core passed."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: extend release next-action diagnostics with release SHA, release-ready source, publish status, registry/tag/release truth, and focused tests."
+events:
+  -
+    type: "status"
+    at: "2026-05-23T09:15:33.351Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: extend release next-action diagnostics with release SHA, release-ready source, publish status, registry/tag/release truth, and focused tests."
+  -
+    type: "verify"
+    at: "2026-05-23T09:24:57.474Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented release next-action diagnostic expansion. Evidence: bun test packages/agentplane/src/commands/release/release-next-action-script.test.ts (2 pass, 14 expects); bun run lint:core passed."
+doc_version: 3
+doc_updated_at: "2026-05-23T09:24:57.487Z"
+doc_updated_by: "CODER"
+description: "Provide one compact command that reports release SHA, release-ready artifact, publish status, npm/tag/release truth, and the next manual action."
+sections:
+  Summary: |-
+    Add release next-action diagnostic
+
+    Provide one compact command that reports release SHA, release-ready artifact, publish status, npm/tag/release truth, and the next manual action.
+  Scope: |-
+    - In scope: Provide one compact command that reports release SHA, release-ready artifact, publish status, npm/tag/release truth, and the next manual action.
+    - Out of scope: unrelated refactors not required for "Add release next-action diagnostic".
+  Plan: "1. Extend release state with optional GitHub/tag/release-ready diagnostics needed by release:next-action. 2. Update release:next-action to print release SHA, release-ready artifact/source, publish workflow status, registry/tag/release truth, and one manual next command. 3. Add focused regression tests for the new diagnostic contract and run targeted checks."
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-23T09:24:57.474Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Implemented release next-action diagnostic expansion. Evidence: bun test packages/agentplane/src/commands/release/release-next-action-script.test.ts (2 pass, 14 expects); bun run lint:core passed.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T09:15:33.351Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605230831-GKV94B-release-next-action-diagnostic/.agentplane/tasks/202605230831-GKV94B/blueprint/resolved-snapshot.json
+    - old_digest: 0125320d098ffa1c05525878358f1d490ce0cfe78436b17c88be8b66bd6a09ba
+    - current_digest: 0125320d098ffa1c05525878358f1d490ce0cfe78436b17c88be8b66bd6a09ba
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605230831-GKV94B
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add release next-action diagnostic
+
+Provide one compact command that reports release SHA, release-ready artifact, publish status, npm/tag/release truth, and the next manual action.
+
+## Scope
+
+- In scope: Provide one compact command that reports release SHA, release-ready artifact, publish status, npm/tag/release truth, and the next manual action.
+- Out of scope: unrelated refactors not required for "Add release next-action diagnostic".
+
+## Plan
+
+1. Extend release state with optional GitHub/tag/release-ready diagnostics needed by release:next-action. 2. Update release:next-action to print release SHA, release-ready artifact/source, publish workflow status, registry/tag/release truth, and one manual next command. 3. Add focused regression tests for the new diagnostic contract and run targeted checks.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-23T09:24:57.474Z — VERIFY — ok
+
+By: CODER
+
+Note: Implemented release next-action diagnostic expansion. Evidence: bun test packages/agentplane/src/commands/release/release-next-action-script.test.ts (2 pass, 14 expects); bun run lint:core passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-23T09:15:33.351Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605230831-GKV94B-release-next-action-diagnostic/.agentplane/tasks/202605230831-GKV94B/blueprint/resolved-snapshot.json
+- old_digest: 0125320d098ffa1c05525878358f1d490ce0cfe78436b17c88be8b66bd6a09ba
+- current_digest: 0125320d098ffa1c05525878358f1d490ce0cfe78436b17c88be8b66bd6a09ba
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605230831-GKV94B
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605230831-GKV94B/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605230831-GKV94B/blueprint/resolved-snapshot.json
@@ -1,0 +1,454 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605230831-GKV94B",
+    "title": "Add release next-action diagnostic",
+    "description": "Provide one compact command that reports release SHA, release-ready artifact, publish status, npm/tag/release truth, and the next manual action.",
+    "tags": [
+      "code",
+      "release"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "release",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "release.strict",
+    "version": 1,
+    "title": "Strict release",
+    "taskKinds": [
+      "release"
+    ],
+    "workflowModes": [
+      "direct",
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "release.strict",
+    "blueprintVersion": 1,
+    "title": "Strict release",
+    "taskId": "202605230831-GKV94B",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "release"
+    },
+    "whySelected": [
+      "task kind resolved to release",
+      "workflow mode: branch_pr",
+      "mutation scope: release"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.release.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "deterministic_check",
+        "kind": "deterministic_check",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "release.approval",
+        "kind": "approval",
+        "producedBy": "approval_gate",
+        "required": true,
+        "description": "Release approval."
+      },
+      {
+        "id": "release.plan",
+        "kind": "artifact",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Release plan or candidate artifact."
+      },
+      {
+        "id": "release.check",
+        "kind": "check_result",
+        "producedBy": "deterministic_check",
+        "required": true,
+        "description": "Release gates."
+      },
+      {
+        "id": "release.publish",
+        "kind": "external_link",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Publish evidence."
+      },
+      {
+        "id": "release.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Release commit."
+      },
+      {
+        "id": "release.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.release.md"
+    ],
+    "allowedCommands": [
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "publish commands after approval",
+      "release gates"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Release work needs strict release policy, approval evidence, and rollback context."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.release.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "deterministic_check",
+      "kind": "deterministic_check",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "release.approval",
+      "kind": "approval",
+      "producedBy": "approval_gate",
+      "required": true,
+      "description": "Release approval."
+    },
+    {
+      "id": "release.plan",
+      "kind": "artifact",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Release plan or candidate artifact."
+    },
+    {
+      "id": "release.check",
+      "kind": "check_result",
+      "producedBy": "deterministic_check",
+      "required": true,
+      "description": "Release gates."
+    },
+    {
+      "id": "release.publish",
+      "kind": "external_link",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Publish evidence."
+    },
+    {
+      "id": "release.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Release commit."
+    },
+    {
+      "id": "release.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.release.md"
+  ],
+  "allowedCommands": [
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "publish commands after approval",
+    "release gates"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Release work needs strict release policy, approval evidence, and rollback context."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to release",
+    "workflow mode: branch_pr",
+    "mutation scope: release"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "0125320d098ffa1c05525878358f1d490ce0cfe78436b17c88be8b66bd6a09ba"
+  }
+}

--- a/.agentplane/tasks/202605230831-GKV94B/pr/diffstat.txt
+++ b/.agentplane/tasks/202605230831-GKV94B/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../release/release-next-action-script.test.ts     | 149 +++++++++++++++++
+ scripts/release/next-action.mjs                    | 185 ++++++++++++++++++++-
+ 2 files changed, 327 insertions(+), 7 deletions(-)

--- a/.agentplane/tasks/202605230831-GKV94B/pr/github-body.md
+++ b/.agentplane/tasks/202605230831-GKV94B/pr/github-body.md
@@ -1,0 +1,41 @@
+Task: `202605230831-GKV94B`
+Title: Add release next-action diagnostic
+Canonical task record: `.agentplane/tasks/202605230831-GKV94B/README.md`
+
+## Summary
+
+Add release next-action diagnostic
+
+Provide one compact command that reports release SHA, release-ready artifact, publish status, npm/tag/release truth, and the next manual action.
+
+## Scope
+
+- In scope: Provide one compact command that reports release SHA, release-ready artifact, publish status, npm/tag/release truth, and the next manual action.
+- Out of scope: unrelated refactors not required for "Add release next-action diagnostic".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Implemented release next-action diagnostic expansion. Evidence: bun test
+packages/agentplane/src/commands/release/release-next-action-script.test.ts (2 pass, 14 expects);
+bun run lint:core passed.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-23T09:15:33.390Z
+- Branch: task/202605230831-GKV94B/release-next-action-diagnostic
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../release/release-next-action-script.test.ts     | 149 +++++++++++++++++
+ scripts/release/next-action.mjs                    | 185 ++++++++++++++++++++-
+ 2 files changed, 327 insertions(+), 7 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605230831-GKV94B/pr/github-title.txt
+++ b/.agentplane/tasks/202605230831-GKV94B/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 GKV94B task: Add release next-action diagnostic [202605230831-GKV94B]

--- a/.agentplane/tasks/202605230831-GKV94B/pr/meta.json
+++ b/.agentplane/tasks/202605230831-GKV94B/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605230831-GKV94B/release-next-action-diagnostic",
+  "created_at": "2026-05-23T09:15:33.390Z",
+  "diffstat_sha256": "sha256:767eddd42627e84c5b942448abc45f528c05ccf6bca5e6087fb649a98000f208",
+  "last_verified_at": "2026-05-23T09:24:57.474Z",
+  "last_verified_diffstat_sha256": "sha256:767eddd42627e84c5b942448abc45f528c05ccf6bca5e6087fb649a98000f208",
+  "schema_version": 1,
+  "task_id": "202605230831-GKV94B",
+  "updated_at": "2026-05-23T09:15:33.390Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605230831-GKV94B/pr/review.md
+++ b/.agentplane/tasks/202605230831-GKV94B/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-05-23T09:15:33.390Z
+
+## Task
+
+- Task: `202605230831-GKV94B`
+- Title: Add release next-action diagnostic
+- Status: DOING
+- Branch: `task/202605230831-GKV94B/release-next-action-diagnostic`
+- Canonical task record: `.agentplane/tasks/202605230831-GKV94B/README.md`
+
+## Verification
+
+- State: ok
+- Note: Implemented release next-action diagnostic expansion. Evidence: bun test packages/agentplane/src/commands/release/release-next-action-script.test.ts (2 pass, 14 expects); bun run lint:core passed.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-23T09:15:33.390Z
+- Branch: task/202605230831-GKV94B/release-next-action-diagnostic
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../release/release-next-action-script.test.ts     | 149 +++++++++++++++++
+ scripts/release/next-action.mjs                    | 185 ++++++++++++++++++++-
+ 2 files changed, 327 insertions(+), 7 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/release/release-next-action-script.test.ts
+++ b/packages/agentplane/src/commands/release/release-next-action-script.test.ts
@@ -1,0 +1,185 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const SCRIPT_PATH = path.resolve(process.cwd(), "scripts/release/next-action.mjs");
+const temps: string[] = [];
+
+async function writeJsonFixture(name: string, payload: unknown) {
+  const dir = await mkdtemp(path.join(tmpdir(), "agentplane-release-next-action-"));
+  temps.push(dir);
+  const filePath = path.join(dir, name);
+  await writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  return filePath;
+}
+
+const releaseState = {
+  schema_version: 1,
+  git: {
+    branch: "main",
+    head: "abc123release",
+    tracked_dirty: false,
+    upstream: { upstream: "origin/main", ahead: 0, behind: 0 },
+  },
+  release: {
+    version: "0.6.8",
+    tag: "v0.6.8",
+    latest_plan: { nextTag: "v0.6.8" },
+    notes_exists: true,
+    publish_result_exists: false,
+  },
+  parity: { ok: true },
+  registry: {
+    checked: true,
+    packages: [
+      { name: "@agentplaneorg/core", version: "0.6.8", published: true },
+      { name: "@agentplaneorg/recipes", version: "0.6.8", published: true },
+      { name: "agentplane", version: "0.6.8", published: true },
+    ],
+  },
+};
+
+const recoveryReport = {
+  summary: {
+    state: "release_publish_already_succeeded",
+    nextAction: "Do not rerun publish; verify release evidence only.",
+  },
+  current: {
+    localTagPresent: true,
+    remote: { name: "origin", tagPresent: true },
+    github: {
+      releaseSha: "abc123release",
+      releaseReady: {
+        state: "ready_artifact_available",
+        runId: 12_345,
+        artifactName: "release-ready",
+      },
+      publish: {
+        state: "success",
+        conclusion: "success",
+      },
+      publishResult: {
+        state: "available",
+        success: true,
+        reasonCode: null,
+      },
+    },
+  },
+};
+
+afterEach(async () => {
+  while (temps.length > 0) {
+    const dir = temps.pop();
+    if (dir) await rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("release next-action script", () => {
+  it("prints compact release truth and next action", async () => {
+    const statePath = await writeJsonFixture("state.json", releaseState);
+    const recoveryPath = await writeJsonFixture("recovery.json", recoveryReport);
+    const githubReleasePath = await writeJsonFixture("github-release.json", {
+      state: "present",
+      tagName: "v0.6.8",
+      url: "https://github.com/basilisk-labs/agentplane/releases/tag/v0.6.8",
+      publishedAt: "2026-05-23T00:00:00Z",
+    });
+
+    const result = await execFileAsync(
+      "node",
+      [SCRIPT_PATH, "--check-registry", "--check-github"],
+      {
+        env: {
+          ...process.env,
+          AGENTPLANE_TEST_RELEASE_STATE_PATH: statePath,
+          AGENTPLANE_TEST_RELEASE_RECOVERY_REPORT_PATH: recoveryPath,
+          AGENTPLANE_TEST_GITHUB_RELEASE_STATUS_PATH: githubReleasePath,
+        },
+      },
+    );
+
+    expect(result.stdout).toContain("Release next action");
+    expect(result.stdout).toContain("Release SHA: abc123release");
+    expect(result.stdout).toContain(
+      "Release-ready: ready_artifact_available run=12345 artifact=release-ready",
+    );
+    expect(result.stdout).toContain("Publish workflow: success conclusion=success");
+    expect(result.stdout).toContain("Publish result: available success=true");
+    expect(result.stdout).toContain("NPM registry: published");
+    expect(result.stdout).toContain("Git tag: local=present; origin/v0.6.8=present");
+    expect(result.stdout).toContain("GitHub release: present");
+    expect(result.stdout).toContain("Command: Do not rerun publish; verify release evidence only.");
+  });
+
+  it("emits the same diagnostic contract as JSON", async () => {
+    const statePath = await writeJsonFixture("state.json", releaseState);
+    const recoveryPath = await writeJsonFixture("recovery.json", recoveryReport);
+    const githubReleasePath = await writeJsonFixture("github-release.json", { state: "present" });
+
+    const result = await execFileAsync(
+      "node",
+      [SCRIPT_PATH, "--check-registry", "--check-github", "--json"],
+      {
+        env: {
+          ...process.env,
+          AGENTPLANE_TEST_RELEASE_STATE_PATH: statePath,
+          AGENTPLANE_TEST_RELEASE_RECOVERY_REPORT_PATH: recoveryPath,
+          AGENTPLANE_TEST_GITHUB_RELEASE_STATUS_PATH: githubReleasePath,
+        },
+      },
+    );
+
+    const payload = JSON.parse(result.stdout) as {
+      schema_version: number;
+      releaseSha: string;
+      truth: { githubRelease: { state: string }; registry: string };
+      command: string;
+    };
+    expect(payload.schema_version).toBe(2);
+    expect(payload.releaseSha).toBe("abc123release");
+    expect(payload.truth.githubRelease.state).toBe("present");
+    expect(payload.truth.registry).toContain("@agentplaneorg/core");
+    expect(payload.command).toBe("Do not rerun publish; verify release evidence only.");
+  });
+
+  it("passes --github-repo through to GitHub release lookup", async () => {
+    const statePath = await writeJsonFixture("state.json", releaseState);
+    const recoveryPath = await writeJsonFixture("recovery.json", recoveryReport);
+    const binDir = await mkdtemp(path.join(tmpdir(), "agentplane-release-next-action-bin-"));
+    temps.push(binDir);
+    const argsPath = path.join(binDir, "gh-args.json");
+    const ghPath = path.join(binDir, "gh");
+    await writeFile(
+      ghPath,
+      [
+        "#!/usr/bin/env node",
+        "const { writeFileSync } = require('node:fs');",
+        `writeFileSync(${JSON.stringify(argsPath)}, JSON.stringify(process.argv.slice(2)));`,
+        "process.stdout.write(JSON.stringify({ tagName: 'v0.6.8', url: 'https://example.invalid/release' }));",
+      ].join("\n"),
+      { encoding: "utf8", mode: 0o755 },
+    );
+
+    await execFileAsync(
+      "node",
+      [SCRIPT_PATH, "--check-github", "--github-repo", "other-owner/other-repo", "--json"],
+      {
+        env: {
+          ...process.env,
+          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          AGENTPLANE_TEST_RELEASE_STATE_PATH: statePath,
+          AGENTPLANE_TEST_RELEASE_RECOVERY_REPORT_PATH: recoveryPath,
+        },
+      },
+    );
+
+    const args = JSON.parse(await readFile(argsPath, "utf8")) as string[];
+    expect(args).toContain("--repo");
+    expect(args).toContain("other-owner/other-repo");
+  });
+});

--- a/scripts/release/next-action.mjs
+++ b/scripts/release/next-action.mjs
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 
 import { parseScriptArgs } from "../lib/script-runtime.mjs";
 
@@ -6,15 +7,164 @@ function runJson(cmd, args) {
   return JSON.parse(execFileSync(cmd, args, { encoding: "utf8", env: process.env }));
 }
 
-function main() {
-  const { flags } = parseScriptArgs(process.argv.slice(2), {
-    booleanFlags: ["check-registry", "json"],
-  });
-  const state = runJson("node", [
+function readJsonFile(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function runOptionalJson(cmd, args) {
+  try {
+    return {
+      ok: true,
+      value: runJson(cmd, args),
+      detail: null,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      value: null,
+      detail: String(error?.stderr ?? error?.message ?? error).trim(),
+    };
+  }
+}
+
+function loadReleaseState(flags) {
+  const fixturePath = process.env.AGENTPLANE_TEST_RELEASE_STATE_PATH;
+  if (fixturePath) return readJsonFile(fixturePath);
+
+  return runJson("node", [
     "scripts/release/state.mjs",
     "--json",
     ...(flags["check-registry"] === true ? ["--check-registry"] : []),
   ]);
+}
+
+function loadRecoveryReport(flags) {
+  const fixturePath = process.env.AGENTPLANE_TEST_RELEASE_RECOVERY_REPORT_PATH;
+  if (fixturePath) return readJsonFile(fixturePath);
+  if (flags["check-github"] !== true) return null;
+
+  const args = [
+    "scripts/check-release-recovery-state.mjs",
+    "--json",
+    "--check-github",
+    ...(flags["check-registry"] === true ? ["--check-registry"] : []),
+  ];
+  if (typeof flags["github-repo"] === "string" && flags["github-repo"].trim()) {
+    args.push("--github-repo", flags["github-repo"].trim());
+  }
+  if (typeof flags["github-sha"] === "string" && flags["github-sha"].trim()) {
+    args.push("--github-sha", flags["github-sha"].trim());
+  }
+  return runJson("node", args);
+}
+
+function githubReleaseStatus(tag, flags) {
+  const fixturePath = process.env.AGENTPLANE_TEST_GITHUB_RELEASE_STATUS_PATH;
+  if (fixturePath) return readJsonFile(fixturePath);
+  if (flags["check-github"] !== true) {
+    return { state: "skipped", detail: "pass --check-github to inspect GitHub release truth" };
+  }
+  if (!tag) return { state: "unknown", detail: "release tag is unavailable" };
+  const repo = typeof flags["github-repo"] === "string" ? flags["github-repo"].trim() : "";
+
+  const result = runOptionalJson("gh", [
+    "release",
+    "view",
+    tag,
+    "--json",
+    "tagName,url,publishedAt",
+    ...(repo ? ["--repo", repo] : []),
+  ]);
+  if (result.ok) {
+    return {
+      state: "present",
+      tagName: result.value.tagName ?? tag,
+      url: result.value.url ?? null,
+      publishedAt: result.value.publishedAt ?? null,
+    };
+  }
+  if (/not found|could not resolve|HTTP 404/iu.test(result.detail ?? "")) {
+    return { state: "missing", detail: result.detail };
+  }
+  return { state: "unavailable", detail: result.detail };
+}
+
+function registrySummary(state) {
+  if (!state.registry?.checked) return "skipped";
+  const packages = Array.isArray(state.registry.packages) ? state.registry.packages : [];
+  if (packages.length === 0) return "checked, no public packages reported";
+  const published = packages.filter((pkg) => pkg.published === true).map((pkg) => pkg.name);
+  const missing = packages.filter((pkg) => pkg.published !== true).map((pkg) => pkg.name);
+  if (published.length === packages.length) return `published (${published.join(", ")})`;
+  if (missing.length === packages.length) return `not published (${missing.join(", ")})`;
+  return `partial: published ${published.join(", ") || "none"}; missing ${missing.join(", ") || "none"}`;
+}
+
+function releaseReadySummary(report) {
+  const ready = report?.current?.github?.releaseReady;
+  if (!ready) return "skipped";
+  const run = ready.runId ? ` run=${ready.runId}` : "";
+  const artifact = ready.artifactName ? ` artifact=${ready.artifactName}` : "";
+  return `${ready.state}${run}${artifact}`;
+}
+
+function publishSummary(report) {
+  const publish = report?.current?.github?.publish;
+  if (!publish) return "skipped";
+  const conclusion = publish.conclusion ? ` conclusion=${publish.conclusion}` : "";
+  return `${publish.state}${conclusion}`;
+}
+
+function publishResultSummary(report) {
+  const result = report?.current?.github?.publishResult;
+  if (!result) return "skipped";
+  const success = typeof result.success === "boolean" ? ` success=${result.success}` : "";
+  const reason = result.reasonCode ? ` reason=${result.reasonCode}` : "";
+  return `${result.state}${success}${reason}`;
+}
+
+function tagSummary(report, tag) {
+  if (!report) return `local/current only (${tag})`;
+  const local = report.current?.localTagPresent === true ? "present" : "missing";
+  const remoteName = report.current?.remote?.name ?? "origin";
+  const remote = report.current?.remote?.tagPresent === true ? "present" : "missing";
+  return `local=${local}; ${remoteName}/${tag}=${remote}`;
+}
+
+function commandFromAction(action, state, report) {
+  if (report?.summary?.nextAction) return report.summary.nextAction;
+  return action.command ?? "inspect release state";
+}
+
+function renderText(result) {
+  const lines = [
+    "Release next action",
+    `Target: ${result.target.tag} (${result.target.version})`,
+    `Branch: ${result.git.branch}`,
+    `Release SHA: ${result.releaseSha ?? "unknown"}`,
+    `Release-ready: ${result.truth.releaseReady}`,
+    `Publish workflow: ${result.truth.publish}`,
+    `Publish result: ${result.truth.publishResult}`,
+    `NPM registry: ${result.truth.registry}`,
+    `Git tag: ${result.truth.tag}`,
+    `GitHub release: ${result.truth.githubRelease.state}`,
+    `Next action: ${result.action}`,
+    `Command: ${result.command}`,
+  ];
+  if (result.truth.githubRelease.url)
+    lines.splice(9, 0, `GitHub release URL: ${result.truth.githubRelease.url}`);
+  return `${lines.join("\n")}\n`;
+}
+
+function main() {
+  const { flags } = parseScriptArgs(process.argv.slice(2), {
+    booleanFlags: ["check-registry", "check-github", "json"],
+    valueFlags: ["github-repo", "github-sha"],
+  });
+  const state = loadReleaseState(flags);
+  const recovery = loadRecoveryReport(flags);
+  const releaseSha = recovery?.current?.github?.releaseSha ?? state.git.head ?? null;
+  const githubRelease = githubReleaseStatus(state.release.tag, flags);
 
   let action = "run release candidate preparation";
   let command = "bun run release:candidate:prepare -- --write";
@@ -49,12 +199,35 @@ function main() {
     command = "bun run release:evidence:collect";
   }
 
-  const result = { schema_version: 1, action, command, state };
+  const result = {
+    schema_version: 2,
+    action: recovery?.summary?.state ?? action,
+    command: commandFromAction({ action, command }, state, recovery),
+    target: {
+      version: state.release.version,
+      tag: state.release.tag,
+    },
+    git: {
+      branch: state.git.branch,
+      head: state.git.head,
+    },
+    releaseSha,
+    truth: {
+      releaseReady: releaseReadySummary(recovery),
+      publish: publishSummary(recovery),
+      publishResult: publishResultSummary(recovery),
+      registry: registrySummary(state),
+      tag: tagSummary(recovery, state.release.tag),
+      githubRelease,
+    },
+    state,
+    recovery,
+  };
   if (flags.json === true) {
     process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     return;
   }
-  process.stdout.write(`Next action: ${action}\nCommand: ${command}\n`);
+  process.stdout.write(renderText(result));
 }
 
 try {


### PR DESCRIPTION
Task: `202605230831-GKV94B`
Title: Add release next-action diagnostic
Canonical task record: `.agentplane/tasks/202605230831-GKV94B/README.md`

## Summary

Add release next-action diagnostic

Provide one compact command that reports release SHA, release-ready artifact, publish status, npm/tag/release truth, and the next manual action.

## Scope

- In scope: Provide one compact command that reports release SHA, release-ready artifact, publish status, npm/tag/release truth, and the next manual action.
- Out of scope: unrelated refactors not required for "Add release next-action diagnostic".

## Verification

- State: ok
- Note:

```text
Implemented release next-action diagnostic expansion. Evidence: bun test
packages/agentplane/src/commands/release/release-next-action-script.test.ts (2 pass, 14 expects);
bun run lint:core passed.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-23T09:15:33.390Z
- Branch: task/202605230831-GKV94B/release-next-action-diagnostic
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../release/release-next-action-script.test.ts     | 149 +++++++++++++++++
 scripts/release/next-action.mjs                    | 185 ++++++++++++++++++++-
 2 files changed, 327 insertions(+), 7 deletions(-)
```

</details>
