### PR TITLE
🚧 N9FJB1 task: Fix upgrade markdown fragment leak [202605250929-N9FJB1]

### DIFF
--- a/.agentplane/tasks/202605250929-N9FJB1/README.md
+++ b/.agentplane/tasks/202605250929-N9FJB1/README.md
@@ -1,0 +1,157 @@
+---
+id: "202605250929-N9FJB1"
+title: "Fix upgrade markdown fragment leak"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 8
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "upgrade"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-25T09:29:59.126Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-25T09:41:52.329Z"
+  updated_by: "CODER"
+  note: "Command: bun test packages/agentplane/src/cli/run-cli.core.upgrade.test.ts -t 'upgrade renders managed markdown assets before writing installed policy files'. Result: pass. Evidence: 1 pass, 0 fail; regression confirms installed dod.code.md has no ap:fragment markers. Scope: targeted upgrade markdown rendering regression. Command: bun test packages/agentplane/src/cli/run-cli.core.upgrade.test.ts. Result: pass. Evidence: 14 pass, 0 fail, 113 expect calls. Scope: existing upgrade CLI behavior. Command: bun test packages/agentplane/src/commands/upgrade.merge.test.ts. Result: pass. Evidence: 9 pass, 0 fail, 42 expect calls. Scope: upgrade planner merge semantics. Command: node .agentplane/policy/check-routing.mjs. Result: pass. Evidence: policy routing OK. Scope: policy routing constraints. Command: ap agents. Result: pass after framework bootstrap. Evidence: listed installed agent profiles. Scope: upgrade policy minimum verification."
+  attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-25T09:42:37.191Z"
+  updated_by: "EVALUATOR"
+  note: "Upgrade planner now renders managed markdown assets before writing installed policy files; regression and upgrade planner tests pass."
+  evaluated_sha: "caa43500b61c746fd315b3e0e1fdc62fb287db29"
+  blueprint_digest: "39605e3ceb9e21858000a94f4a7885acb1aa921d5b3278f8b7fece299303d241"
+  evidence_refs:
+    - ".agentplane/tasks/202605250929-N9FJB1/README.md"
+    - ".agentplane/tasks/202605250929-N9FJB1/quality/20260525-094237191-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605250929-N9FJB1/quality/20260525-094237191-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605250929-N9FJB1/quality/20260525-094237191-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605250929-N9FJB1/blueprint/resolved-snapshot.json"
+    - "packages/agentplane/src/cli/run-cli.core.upgrade.test.ts"
+    - "packages/agentplane/src/commands/upgrade/plan.ts"
+  findings:
+    - "No remaining fragment-marker leak found in covered upgrade path."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Implement upgrade markdown rendering regression fix for managed policy files, preserving existing branch_pr task scope and targeted verification."
+events:
+  -
+    type: "status"
+    at: "2026-05-25T09:30:16.672Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Implement upgrade markdown rendering regression fix for managed policy files, preserving existing branch_pr task scope and targeted verification."
+  -
+    type: "verify"
+    at: "2026-05-25T09:41:52.329Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: bun test packages/agentplane/src/cli/run-cli.core.upgrade.test.ts -t 'upgrade renders managed markdown assets before writing installed policy files'. Result: pass. Evidence: 1 pass, 0 fail; regression confirms installed dod.code.md has no ap:fragment markers. Scope: targeted upgrade markdown rendering regression. Command: bun test packages/agentplane/src/cli/run-cli.core.upgrade.test.ts. Result: pass. Evidence: 14 pass, 0 fail, 113 expect calls. Scope: existing upgrade CLI behavior. Command: bun test packages/agentplane/src/commands/upgrade.merge.test.ts. Result: pass. Evidence: 9 pass, 0 fail, 42 expect calls. Scope: upgrade planner merge semantics. Command: node .agentplane/policy/check-routing.mjs. Result: pass. Evidence: policy routing OK. Scope: policy routing constraints. Command: ap agents. Result: pass after framework bootstrap. Evidence: listed installed agent profiles. Scope: upgrade policy minimum verification."
+doc_version: 3
+doc_updated_at: "2026-05-25T09:41:52.347Z"
+doc_updated_by: "CODER"
+description: "Prevent agentplane upgrade from writing raw ap:fragment markers into installed managed markdown policy files in user repositories."
+sections:
+  Summary: |-
+    Fix upgrade markdown fragment leak
+
+    Prevent agentplane upgrade from writing raw ap:fragment markers into installed managed markdown policy files in user repositories.
+  Scope: |-
+    - In scope: Prevent agentplane upgrade from writing raw ap:fragment markers into installed managed markdown policy files in user repositories.
+    - Out of scope: unrelated refactors not required for "Fix upgrade markdown fragment leak".
+  Plan: "1. Add a regression test proving upgrade output for installed managed markdown policy files does not contain ap:fragment markers. 2. Update upgrade planning so incoming markdown assets are rendered to installed form before diffing/writing, while preserving special incidents merge behavior. 3. Run targeted upgrade tests plus routing checks and record verification."
+  Verify Steps: |-
+    1. Run `bun test packages/agentplane/src/cli/run-cli.core.upgrade.test.ts -t "upgrade renders managed markdown assets before writing installed policy files"`. Expected: regression passes and installed `.agentplane/policy/dod.code.md` contains no `ap:fragment` markers after upgrade.
+    2. Run `bun test packages/agentplane/src/cli/run-cli.core.upgrade.test.ts`. Expected: existing upgrade behavior remains green.
+    3. Run `node .agentplane/policy/check-routing.mjs`. Expected: policy routing constraints still pass.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-25T09:41:52.329Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Command: bun test packages/agentplane/src/cli/run-cli.core.upgrade.test.ts -t 'upgrade renders managed markdown assets before writing installed policy files'. Result: pass. Evidence: 1 pass, 0 fail; regression confirms installed dod.code.md has no ap:fragment markers. Scope: targeted upgrade markdown rendering regression. Command: bun test packages/agentplane/src/cli/run-cli.core.upgrade.test.ts. Result: pass. Evidence: 14 pass, 0 fail, 113 expect calls. Scope: existing upgrade CLI behavior. Command: bun test packages/agentplane/src/commands/upgrade.merge.test.ts. Result: pass. Evidence: 9 pass, 0 fail, 42 expect calls. Scope: upgrade planner merge semantics. Command: node .agentplane/policy/check-routing.mjs. Result: pass. Evidence: policy routing OK. Scope: policy routing constraints. Command: ap agents. Result: pass after framework bootstrap. Evidence: listed installed agent profiles. Scope: upgrade policy minimum verification.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-25T09:33:46.929Z, excerpt_hash=sha256:5105266045b51033fd3e894b6299eda9428667650e991ac882edc7056a875067
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605250929-N9FJB1-upgrade-fragment-render/.agentplane/tasks/202605250929-N9FJB1/blueprint/resolved-snapshot.json
+    - old_digest: 39605e3ceb9e21858000a94f4a7885acb1aa921d5b3278f8b7fece299303d241
+    - current_digest: 39605e3ceb9e21858000a94f4a7885acb1aa921d5b3278f8b7fece299303d241
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605250929-N9FJB1
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Fix upgrade markdown fragment leak
+
+Prevent agentplane upgrade from writing raw ap:fragment markers into installed managed markdown policy files in user repositories.
+
+## Scope
+
+- In scope: Prevent agentplane upgrade from writing raw ap:fragment markers into installed managed markdown policy files in user repositories.
+- Out of scope: unrelated refactors not required for "Fix upgrade markdown fragment leak".
+
+## Plan
+
+1. Add a regression test proving upgrade output for installed managed markdown policy files does not contain ap:fragment markers. 2. Update upgrade planning so incoming markdown assets are rendered to installed form before diffing/writing, while preserving special incidents merge behavior. 3. Run targeted upgrade tests plus routing checks and record verification.
+
+## Verify Steps
+
+1. Run `bun test packages/agentplane/src/cli/run-cli.core.upgrade.test.ts -t "upgrade renders managed markdown assets before writing installed policy files"`. Expected: regression passes and installed `.agentplane/policy/dod.code.md` contains no `ap:fragment` markers after upgrade.
+2. Run `bun test packages/agentplane/src/cli/run-cli.core.upgrade.test.ts`. Expected: existing upgrade behavior remains green.
+3. Run `node .agentplane/policy/check-routing.mjs`. Expected: policy routing constraints still pass.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-25T09:41:52.329Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: bun test packages/agentplane/src/cli/run-cli.core.upgrade.test.ts -t 'upgrade renders managed markdown assets before writing installed policy files'. Result: pass. Evidence: 1 pass, 0 fail; regression confirms installed dod.code.md has no ap:fragment markers. Scope: targeted upgrade markdown rendering regression. Command: bun test packages/agentplane/src/cli/run-cli.core.upgrade.test.ts. Result: pass. Evidence: 14 pass, 0 fail, 113 expect calls. Scope: existing upgrade CLI behavior. Command: bun test packages/agentplane/src/commands/upgrade.merge.test.ts. Result: pass. Evidence: 9 pass, 0 fail, 42 expect calls. Scope: upgrade planner merge semantics. Command: node .agentplane/policy/check-routing.mjs. Result: pass. Evidence: policy routing OK. Scope: policy routing constraints. Command: ap agents. Result: pass after framework bootstrap. Evidence: listed installed agent profiles. Scope: upgrade policy minimum verification.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-25T09:33:46.929Z, excerpt_hash=sha256:5105266045b51033fd3e894b6299eda9428667650e991ac882edc7056a875067
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605250929-N9FJB1-upgrade-fragment-render/.agentplane/tasks/202605250929-N9FJB1/blueprint/resolved-snapshot.json
+- old_digest: 39605e3ceb9e21858000a94f4a7885acb1aa921d5b3278f8b7fece299303d241
+- current_digest: 39605e3ceb9e21858000a94f4a7885acb1aa921d5b3278f8b7fece299303d241
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605250929-N9FJB1
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605250929-N9FJB1/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605250929-N9FJB1/blueprint/resolved-snapshot.json
@@ -1,0 +1,571 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605250929-N9FJB1",
+    "title": "Fix upgrade markdown fragment leak",
+    "description": "Prevent agentplane upgrade from writing raw ap:fragment markers into installed managed markdown policy files in user repositories.",
+    "tags": [
+      "code",
+      "upgrade"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605250929-N9FJB1",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "39605e3ceb9e21858000a94f4a7885acb1aa921d5b3278f8b7fece299303d241"
+  }
+}

--- a/.agentplane/tasks/202605250929-N9FJB1/pr/diffstat.txt
+++ b/.agentplane/tasks/202605250929-N9FJB1/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../src/cli/run-cli.core.upgrade.test.ts           | 42 ++++++++++++++++++++++
+ packages/agentplane/src/commands/upgrade/plan.ts   | 24 +++++++++++++
+ 2 files changed, 66 insertions(+)

--- a/.agentplane/tasks/202605250929-N9FJB1/pr/github-body.md
+++ b/.agentplane/tasks/202605250929-N9FJB1/pr/github-body.md
@@ -1,0 +1,49 @@
+Task: `202605250929-N9FJB1`
+Title: Fix upgrade markdown fragment leak
+Canonical task record: `.agentplane/tasks/202605250929-N9FJB1/README.md`
+
+## Summary
+
+Fix upgrade markdown fragment leak
+
+Prevent agentplane upgrade from writing raw ap:fragment markers into installed managed markdown policy files in user repositories.
+
+## Scope
+
+- In scope: Prevent agentplane upgrade from writing raw ap:fragment markers into installed managed markdown policy files in user repositories.
+- Out of scope: unrelated refactors not required for "Fix upgrade markdown fragment leak".
+
+## Verification
+
+- State: ok
+- Note:
+
+```bash
+bun test packages/agentplane/src/cli/run-cli.core.upgrade.test.ts -t 'upgrade renders managed \
+  markdown assets before writing installed policy files'. Result: pass. Evidence: 1 pass, 0 fail; \
+  regression confirms installed dod.code.md has no ap:fragment markers. Scope: targeted upgrade \
+  markdown rendering regression. Command: bun test \
+  packages/agentplane/src/cli/run-cli.core.upgrade.test.ts. Result: pass. Evidence: 14 pass, 0 fail, \
+  113 expect calls. Scope: existing upgrade CLI behavior. Command: bun test \
+  packages/agentplane/src/commands/upgrade.merge.test.ts. Result: pass. Evidence: 9 pass, 0 fail, 42 \
+  expect calls. Scope: upgrade planner merge semantics. Command: node \
+  .agentplane/policy/check-routing.mjs. Result: pass. Evidence: policy routing OK. Scope: policy \
+  routing constraints. Command: ap agents. Result: pass after framework bootstrap. Evidence: listed \
+  installed agent profiles. Scope: upgrade policy minimum verification.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-25T09:30:16.719Z
+- Branch: task/202605250929-N9FJB1/upgrade-fragment-render
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/cli/run-cli.core.upgrade.test.ts           | 42 ++++++++++++++++++++++
+ packages/agentplane/src/commands/upgrade/plan.ts   | 24 +++++++++++++
+ 2 files changed, 66 insertions(+)
+```
+
+</details>

--- a/.agentplane/tasks/202605250929-N9FJB1/pr/github-title.txt
+++ b/.agentplane/tasks/202605250929-N9FJB1/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 N9FJB1 task: Fix upgrade markdown fragment leak [202605250929-N9FJB1]

--- a/.agentplane/tasks/202605250929-N9FJB1/pr/meta.json
+++ b/.agentplane/tasks/202605250929-N9FJB1/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605250929-N9FJB1/upgrade-fragment-render",
+  "created_at": "2026-05-25T09:30:16.719Z",
+  "diffstat_sha256": "sha256:3a653d7c96461dce507865774dd74e353fca90f7f76d065a1c48a6c6b85a902e",
+  "last_verified_at": "2026-05-25T09:41:52.329Z",
+  "last_verified_diffstat_sha256": "sha256:3a653d7c96461dce507865774dd74e353fca90f7f76d065a1c48a6c6b85a902e",
+  "schema_version": 1,
+  "task_id": "202605250929-N9FJB1",
+  "updated_at": "2026-05-25T09:30:16.719Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605250929-N9FJB1/pr/review.md
+++ b/.agentplane/tasks/202605250929-N9FJB1/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-05-25T09:30:16.719Z
+
+## Task
+
+- Task: `202605250929-N9FJB1`
+- Title: Fix upgrade markdown fragment leak
+- Status: DOING
+- Branch: `task/202605250929-N9FJB1/upgrade-fragment-render`
+- Canonical task record: `.agentplane/tasks/202605250929-N9FJB1/README.md`
+
+## Verification
+
+- State: ok
+- Note: Command: bun test packages/agentplane/src/cli/run-cli.core.upgrade.test.ts -t 'upgrade renders managed markdown assets before writing installed policy files'. Result: pass. Evidence: 1 pass, 0 fail; regression confirms installed dod.code.md has no ap:fragment markers. Scope: targeted upgrade markdown rendering regression. Command: bun test packages/agentplane/src/cli/run-cli.core.upgrade.test.ts. Result: pass. Evidence: 14 pass, 0 fail, 113 expect calls. Scope: existing upgrade CLI behavior. Command: bun test packages/agentplane/src/commands/upgrade.merge.test.ts. Result: pass. Evidence: 9 pass, 0 fail, 42 expect calls. Scope: upgrade planner merge semantics. Command: node .agentplane/policy/check-routing.mjs. Result: pass. Evidence: policy routing OK. Scope: policy routing constraints. Command: ap agents. Result: pass after framework bootstrap. Evidence: listed installed agent profiles. Scope: upgrade policy minimum verification.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-25T09:30:16.719Z
+- Branch: task/202605250929-N9FJB1/upgrade-fragment-render
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/cli/run-cli.core.upgrade.test.ts           | 42 ++++++++++++++++++++++
+ packages/agentplane/src/commands/upgrade/plan.ts   | 24 +++++++++++++
+ 2 files changed, 66 insertions(+)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605250929-N9FJB1/quality/20260525-094237191-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605250929-N9FJB1/quality/20260525-094237191-recovery-context/evaluator-opinion.md
@@ -1,0 +1,20 @@
+# EVALUATOR opinion: pass
+
+Upgrade planner now renders managed markdown assets before writing installed policy files; regression and upgrade planner tests pass.
+
+## Findings
+- No remaining fragment-marker leak found in covered upgrade path.
+
+## Evidence
+- .agentplane/tasks/202605250929-N9FJB1/README.md
+- packages/agentplane/src/cli/run-cli.core.upgrade.test.ts
+- packages/agentplane/src/commands/upgrade/plan.ts
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- Remote release bundle path not separately smoke-tested, but it uses the same planManagedUpgrade rendering path.

--- a/.agentplane/tasks/202605250929-N9FJB1/quality/20260525-094237191-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605250929-N9FJB1/quality/20260525-094237191-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605250929-N9FJB1
+- task_readme: .agentplane/tasks/202605250929-N9FJB1/README.md
+- report_path: .agentplane/tasks/202605250929-N9FJB1/quality/20260525-094237191-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605250929-N9FJB1/quality/20260525-094237191-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605250929-N9FJB1/quality/20260525-094237191-recovery-context/quality-report.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "task_id": "202605250929-N9FJB1",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-25T09:42:37.191Z",
+  "verdict": "pass",
+  "summary": "Upgrade planner now renders managed markdown assets before writing installed policy files; regression and upgrade planner tests pass.",
+  "evaluated_sha": "caa43500b61c746fd315b3e0e1fdc62fb287db29",
+  "blueprint_digest": "39605e3ceb9e21858000a94f4a7885acb1aa921d5b3278f8b7fece299303d241",
+  "findings": [
+    "No remaining fragment-marker leak found in covered upgrade path."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605250929-N9FJB1/README.md",
+    "packages/agentplane/src/cli/run-cli.core.upgrade.test.ts",
+    "packages/agentplane/src/commands/upgrade/plan.ts"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": [
+    "Remote release bundle path not separately smoke-tested, but it uses the same planManagedUpgrade rendering path."
+  ]
+}

--- a/packages/agentplane/src/cli/run-cli.core.upgrade.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.upgrade.test.ts
@@ -110,6 +110,48 @@ describe("runCli", () => {
     expect(subject).toContain("upgrade: apply framework");
   });
 
+  it("upgrade renders managed markdown assets before writing installed policy files", async () => {
+    const root = await mkGitRepoRoot();
+    await writeDefaultConfig(root);
+    await writeFile(path.join(root, "AGENTS.md"), "legacy agents", "utf8");
+    await mkdir(path.join(root, ".agentplane", "policy"), { recursive: true });
+    await writeFile(path.join(root, ".agentplane", "policy", "dod.code.md"), "legacy policy\n");
+
+    const { bundlePath, checksumPath } = await createUpgradeBundle({
+      "policy/dod.code.md": [
+        '<!-- ap:fragment id="policy.dod.code.body.dod.code" slot="body" mutability="replaceable" -->',
+        "",
+        "# DoD: code",
+        "",
+        "Rendered policy body.",
+        "<!-- /ap:fragment -->",
+      ].join("\n"),
+    });
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli([
+        "upgrade",
+        "--bundle",
+        bundlePath,
+        "--checksum",
+        checksumPath,
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(0);
+    } finally {
+      io.restore();
+    }
+
+    const policyText = await readFile(
+      path.join(root, ".agentplane", "policy", "dod.code.md"),
+      "utf8",
+    );
+    expect(policyText).toContain("Rendered policy body.");
+    expect(policyText).not.toContain("ap:fragment");
+  });
+
   it(
     "upgrade includes runtime .gitignore cache lines in the upgrade commit",
     { timeout: WORKFLOW_RUNTIME_ARTIFACTS_TIMEOUT_MS },

--- a/packages/agentplane/src/commands/upgrade/plan.ts
+++ b/packages/agentplane/src/commands/upgrade/plan.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import { fileExists, getPathKind } from "../../cli/fs-utils.js";
 import { exitCodeForError } from "../../cli/exit-codes.js";
 import { CliError } from "../../shared/errors.js";
+import { renderMarkdownPromptTemplate } from "../../agents/agents-template.js";
+import { renderPolicyGatewayTemplateText } from "../../shared/policy-gateway.js";
 
 import {
   INCIDENTS_POLICY_PATH,
@@ -46,6 +48,21 @@ async function resolvePolicyGatewayRel(gitRoot: string): Promise<"AGENTS.md" | "
   if (await fileExists(path.join(gitRoot, "AGENTS.md"))) return "AGENTS.md";
   if (await fileExists(path.join(gitRoot, "CLAUDE.md"))) return "CLAUDE.md";
   return "AGENTS.md";
+}
+
+function renderIncomingMarkdownAsset(opts: {
+  rel: string;
+  sourceRel: string;
+  data: Buffer;
+}): Buffer {
+  let source = opts.data.toString("utf8");
+  if (opts.rel === "AGENTS.md" || opts.rel === "CLAUDE.md") {
+    source = renderPolicyGatewayTemplateText(source, opts.rel);
+  }
+  const rendered = renderMarkdownPromptTemplate(source, {
+    source_ref: `upgrade:${opts.sourceRel}`,
+  });
+  return Buffer.from(rendered.contents, "utf8");
 }
 
 export async function planManagedUpgrade(opts: {
@@ -125,6 +142,13 @@ export async function planManagedUpgrade(opts: {
     if (!incomingData) {
       if (entry.required) missingRequired.push(rel);
       continue;
+    }
+    if (entry.type === "markdown") {
+      incomingData = renderIncomingMarkdownAsset({
+        rel,
+        sourceRel: sourceCandidates[0] ?? sourceRelRaw,
+        data: incomingData,
+      });
     }
 
     let existingBuf: Buffer | null = null;


### PR DESCRIPTION
Task: `202605250929-N9FJB1`
Title: Fix upgrade markdown fragment leak
Canonical task record: `.agentplane/tasks/202605250929-N9FJB1/README.md`

## Summary

Fix upgrade markdown fragment leak

Prevent agentplane upgrade from writing raw ap:fragment markers into installed managed markdown policy files in user repositories.

## Scope

- In scope: Prevent agentplane upgrade from writing raw ap:fragment markers into installed managed markdown policy files in user repositories.
- Out of scope: unrelated refactors not required for "Fix upgrade markdown fragment leak".

## Verification

- State: ok
- Note:

```bash
bun test packages/agentplane/src/cli/run-cli.core.upgrade.test.ts -t 'upgrade renders managed \
  markdown assets before writing installed policy files'. Result: pass. Evidence: 1 pass, 0 fail; \
  regression confirms installed dod.code.md has no ap:fragment markers. Scope: targeted upgrade \
  markdown rendering regression. Command: bun test \
  packages/agentplane/src/cli/run-cli.core.upgrade.test.ts. Result: pass. Evidence: 14 pass, 0 fail, \
  113 expect calls. Scope: existing upgrade CLI behavior. Command: bun test \
  packages/agentplane/src/commands/upgrade.merge.test.ts. Result: pass. Evidence: 9 pass, 0 fail, 42 \
  expect calls. Scope: upgrade planner merge semantics. Command: node \
  .agentplane/policy/check-routing.mjs. Result: pass. Evidence: policy routing OK. Scope: policy \
  routing constraints. Command: ap agents. Result: pass after framework bootstrap. Evidence: listed \
  installed agent profiles. Scope: upgrade policy minimum verification.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-25T09:30:16.719Z
- Branch: task/202605250929-N9FJB1/upgrade-fragment-render
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/cli/run-cli.core.upgrade.test.ts           | 42 ++++++++++++++++++++++
 packages/agentplane/src/commands/upgrade/plan.ts   | 24 +++++++++++++
 2 files changed, 66 insertions(+)
```

</details>
