### PR TITLE
🚧 28Z5H1 task: Reduce redundancy in AgentPlane code [202605251818-28Z5H1]

### DIFF
--- a/.agentplane/tasks/202605251818-28Z5H1/README.md
+++ b/.agentplane/tasks/202605251818-28Z5H1/README.md
@@ -4,7 +4,7 @@ title: "Reduce redundancy in AgentPlane code"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 7
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -31,6 +31,22 @@ verification:
     Command: bun run typecheck. Result: pass. Evidence: tsc -b completed with exit 0. Scope: TypeScript project references.
     Command: bun run format:changed. Result: pass. Evidence: all matched files use Prettier code style. Scope: changed file formatting.
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-25T18:43:19.070Z"
+  updated_by: "EVALUATOR"
+  note: "Low-risk redundancy refactor completed in branch_pr worktree. Local verification passed, clone metrics improved, knip baseline stayed unchanged, and PR #4145 hosted checks are stable-green on head 65cd7a0eb."
+  evaluated_sha: "5d1d48cf601e7ffce686af439159562a8ea8d977"
+  blueprint_digest: "9fd821cb546f4b86fe783224e49ba7bec93f2ab63b182badd824738f2f3803da"
+  evidence_refs:
+    - ".agentplane/tasks/202605251818-28Z5H1/README.md"
+    - ".agentplane/tasks/202605251818-28Z5H1/quality/20260525-184319070-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605251818-28Z5H1/quality/20260525-184319070-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605251818-28Z5H1/quality/20260525-184319070-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605251818-28Z5H1/blueprint/resolved-snapshot.json"
+    - "https://github.com/basilisk-labs/agentplane/pull/4145"
+  findings:
+    - "No blocking findings. Residual risk is limited to unchanged existing knip baseline debt and intentionally deferred broader command-catalog/test-fixture decomposition."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202605251818-28Z5H1/README.md
+++ b/.agentplane/tasks/202605251818-28Z5H1/README.md
@@ -4,7 +4,7 @@ title: "Reduce redundancy in AgentPlane code"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -18,10 +18,18 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-25T18:34:50.305Z"
+  updated_by: "CODER"
+  note: |-
+    Command: bun run arch:deps. Result: pass. Evidence: no dependency violations found across 1335 modules and 3423 dependencies. Scope: package import graph and circular dependency guard.
+    Command: bun run clone:report. Result: pass. Evidence: clone metrics improved from 1.12% to 0.98%, clones 94 to 89, duplicated lines 1595 to 1403. Scope: touched source and script clone clusters.
+    Command: bun run knip:report and bun run knip:check. Result: pass. Evidence: report preserved existing baseline shape; baseline OK files=1/1 exports=207/207 types=358/358 total=566/566. Scope: unused files/exports/types.
+    Command: bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/cli/prompts.test.ts. Result: pass. Evidence: 1 file, 12 tests passed. Scope: prompt canonical function behavior after alias removal.
+    Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.route-decision.test.ts packages/agentplane/src/cli/run-cli.core.route-decision.batch.test.ts. Result: pass. Evidence: 2 files, 11 tests passed. Scope: route/task brief source confidence behavior.
+    Command: bun run release:homebrew:check && bun run release:scoop:check && bun run release:setup-action:check. Result: pass. Evidence: all render checks reached skipped_missing_credentials gate. Scope: release distribution render helper extraction.
+    Command: bun run typecheck. Result: pass. Evidence: tsc -b completed with exit 0. Scope: TypeScript project references.
+    Command: bun run format:changed. Result: pass. Evidence: all matched files use Prettier code style. Scope: changed file formatting.
   attempts: 0
 commit: null
 comments:
@@ -36,8 +44,22 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: Implement approved low-risk redundancy reductions in the dedicated branch_pr worktree, preserving public CLI behavior and using the declared architecture, clone, knip, focused test, and typecheck verification contract."
+  -
+    type: "verify"
+    at: "2026-05-25T18:34:50.305Z"
+    author: "CODER"
+    state: "ok"
+    note: |-
+      Command: bun run arch:deps. Result: pass. Evidence: no dependency violations found across 1335 modules and 3423 dependencies. Scope: package import graph and circular dependency guard.
+      Command: bun run clone:report. Result: pass. Evidence: clone metrics improved from 1.12% to 0.98%, clones 94 to 89, duplicated lines 1595 to 1403. Scope: touched source and script clone clusters.
+      Command: bun run knip:report and bun run knip:check. Result: pass. Evidence: report preserved existing baseline shape; baseline OK files=1/1 exports=207/207 types=358/358 total=566/566. Scope: unused files/exports/types.
+      Command: bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/cli/prompts.test.ts. Result: pass. Evidence: 1 file, 12 tests passed. Scope: prompt canonical function behavior after alias removal.
+      Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.route-decision.test.ts packages/agentplane/src/cli/run-cli.core.route-decision.batch.test.ts. Result: pass. Evidence: 2 files, 11 tests passed. Scope: route/task brief source confidence behavior.
+      Command: bun run release:homebrew:check && bun run release:scoop:check && bun run release:setup-action:check. Result: pass. Evidence: all render checks reached skipped_missing_credentials gate. Scope: release distribution render helper extraction.
+      Command: bun run typecheck. Result: pass. Evidence: tsc -b completed with exit 0. Scope: TypeScript project references.
+      Command: bun run format:changed. Result: pass. Evidence: all matched files use Prettier code style. Scope: changed file formatting.
 doc_version: 3
-doc_updated_at: "2026-05-25T18:20:35.052Z"
+doc_updated_at: "2026-05-25T18:34:50.364Z"
 doc_updated_by: "CODER"
 description: "Refactor low-risk repeated code surfaces identified by the redundancy audit: prompt aliases, duplicated task domain constants, shared route source confidence, and closely related helper duplication where verification remains bounded."
 sections:
@@ -65,6 +87,25 @@ sections:
     5. Run: bun run typecheck. Expect TypeScript project references pass.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-25T18:34:50.305Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Command: bun run arch:deps. Result: pass. Evidence: no dependency violations found across 1335 modules and 3423 dependencies. Scope: package import graph and circular dependency guard.\nCommand: bun run clone:report. Result: pass. Evidence: clone metrics improved from 1.12% to 0.98%, clones 94 to 89, duplicated lines 1595 to 1403. Scope: touched source and script clone clusters.\nCommand: bun run knip:report and bun run knip:check. Result: pass. Evidence: report preserved existing baseline shape; baseline OK files=1/1 exports=207/207 types=358/358 total=566/566. Scope: unused files/exports/types.\nCommand: bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/cli/prompts.test.ts. Result: pass. Evidence: 1 file, 12 tests passed. Scope: prompt canonical function behavior after alias removal.\nCommand: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.route-decision.test.ts packages/agentplane/src/cli/run-cli.core.route-decision.batch.test.ts. Result: pass. Evidence: 2 files, 11 tests passed. Scope: route/task brief source confidence behavior.\nCommand: bun run release:homebrew:check && bun run release:scoop:check && bun run release:setup-action:check. Result: pass. Evidence: all render checks reached skipped_missing_credentials gate. Scope: release distribution render helper extraction.\nCommand: bun run typecheck. Result: pass. Evidence: tsc -b completed with exit 0. Scope: TypeScript project references.\nCommand: bun run format:changed. Result: pass. Evidence: all matched files use Prettier code style. Scope: changed file formatting.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-25T18:20:35.052Z, excerpt_hash=sha256:dd4bb74e0f9d94118dfeadc34f756017ac7ae699f7b7e108ab8b042a6492eb31
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605251818-28Z5H1-reduce-redundancy-in-agentplane-code/.agentplane/tasks/202605251818-28Z5H1/blueprint/resolved-snapshot.json
+    - old_digest: 9fd821cb546f4b86fe783224e49ba7bec93f2ab63b182badd824738f2f3803da
+    - current_digest: 9fd821cb546f4b86fe783224e49ba7bec93f2ab63b182badd824738f2f3803da
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605251818-28Z5H1
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: "Revert the implementation commit on the task branch. If a shared helper introduces behavior drift, revert only that helper extraction and keep independent low-risk deletions that passed targeted tests."
   Findings: ""
@@ -103,6 +144,25 @@ Atomic sequence:
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-25T18:34:50.305Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: bun run arch:deps. Result: pass. Evidence: no dependency violations found across 1335 modules and 3423 dependencies. Scope: package import graph and circular dependency guard.\nCommand: bun run clone:report. Result: pass. Evidence: clone metrics improved from 1.12% to 0.98%, clones 94 to 89, duplicated lines 1595 to 1403. Scope: touched source and script clone clusters.\nCommand: bun run knip:report and bun run knip:check. Result: pass. Evidence: report preserved existing baseline shape; baseline OK files=1/1 exports=207/207 types=358/358 total=566/566. Scope: unused files/exports/types.\nCommand: bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/cli/prompts.test.ts. Result: pass. Evidence: 1 file, 12 tests passed. Scope: prompt canonical function behavior after alias removal.\nCommand: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.route-decision.test.ts packages/agentplane/src/cli/run-cli.core.route-decision.batch.test.ts. Result: pass. Evidence: 2 files, 11 tests passed. Scope: route/task brief source confidence behavior.\nCommand: bun run release:homebrew:check && bun run release:scoop:check && bun run release:setup-action:check. Result: pass. Evidence: all render checks reached skipped_missing_credentials gate. Scope: release distribution render helper extraction.\nCommand: bun run typecheck. Result: pass. Evidence: tsc -b completed with exit 0. Scope: TypeScript project references.\nCommand: bun run format:changed. Result: pass. Evidence: all matched files use Prettier code style. Scope: changed file formatting.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-25T18:20:35.052Z, excerpt_hash=sha256:dd4bb74e0f9d94118dfeadc34f756017ac7ae699f7b7e108ab8b042a6492eb31
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605251818-28Z5H1-reduce-redundancy-in-agentplane-code/.agentplane/tasks/202605251818-28Z5H1/blueprint/resolved-snapshot.json
+- old_digest: 9fd821cb546f4b86fe783224e49ba7bec93f2ab63b182badd824738f2f3803da
+- current_digest: 9fd821cb546f4b86fe783224e49ba7bec93f2ab63b182badd824738f2f3803da
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605251818-28Z5H1
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605251818-28Z5H1/README.md
+++ b/.agentplane/tasks/202605251818-28Z5H1/README.md
@@ -1,0 +1,112 @@
+---
+id: "202605251818-28Z5H1"
+title: "Reduce redundancy in AgentPlane code"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-25T18:19:41.278Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Implement approved low-risk redundancy reductions in the dedicated branch_pr worktree, preserving public CLI behavior and using the declared architecture, clone, knip, focused test, and typecheck verification contract."
+events:
+  -
+    type: "status"
+    at: "2026-05-25T18:20:35.052Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Implement approved low-risk redundancy reductions in the dedicated branch_pr worktree, preserving public CLI behavior and using the declared architecture, clone, knip, focused test, and typecheck verification contract."
+doc_version: 3
+doc_updated_at: "2026-05-25T18:20:35.052Z"
+doc_updated_by: "CODER"
+description: "Refactor low-risk repeated code surfaces identified by the redundancy audit: prompt aliases, duplicated task domain constants, shared route source confidence, and closely related helper duplication where verification remains bounded."
+sections:
+  Summary: |-
+    Reduce redundancy in AgentPlane code
+
+    Refactor low-risk repeated code surfaces identified by the redundancy audit: prompt aliases, duplicated task domain constants, shared route source confidence, and closely related helper duplication where verification remains bounded.
+  Scope: |-
+    - In scope: Refactor low-risk repeated code surfaces identified by the redundancy audit: prompt aliases, duplicated task domain constants, shared route source confidence, and closely related helper duplication where verification remains bounded.
+    - Out of scope: unrelated refactors not required for "Reduce redundancy in AgentPlane code".
+  Plan: |-
+    Atomic sequence:
+    1. Establish baseline with existing architecture, clone, knip, and hotspot reports.
+    2. Remove or replace prompt alias exports only if internal usage proves they are not public API critical.
+    3. Centralize repeated task domain value sets used by task creation, backend record normalization, blueprint task input, and hooks task context.
+    4. Extract common route/remote source-confidence construction and reuse it from task status/next-action and task brief.
+    5. Reduce confirmed local clone clusters in release/check helpers only when the helper extraction stays narrow and covered by existing check scripts.
+    6. Leave speculative public/barrel export deletions as classified findings unless current evidence proves safe removal.
+    7. Run required checks and record verification evidence.
+  Verify Steps: |-
+    1. Run: bun run arch:deps. Expect no dependency violations or circular imports.
+    2. Run: bun run knip:report. Expect no new high-confidence dead-code findings introduced by the refactor; classify remaining public/barrel findings if unchanged.
+    3. Run: bun run clone:report. Expect clone percentage not to increase and target clone clusters reduced where touched.
+    4. Run focused Vitest coverage for touched command/backend/route modules. Expect all targeted tests pass.
+    5. Run: bun run typecheck. Expect TypeScript project references pass.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: "Revert the implementation commit on the task branch. If a shared helper introduces behavior drift, revert only that helper extraction and keep independent low-risk deletions that passed targeted tests."
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Reduce redundancy in AgentPlane code
+
+Refactor low-risk repeated code surfaces identified by the redundancy audit: prompt aliases, duplicated task domain constants, shared route source confidence, and closely related helper duplication where verification remains bounded.
+
+## Scope
+
+- In scope: Refactor low-risk repeated code surfaces identified by the redundancy audit: prompt aliases, duplicated task domain constants, shared route source confidence, and closely related helper duplication where verification remains bounded.
+- Out of scope: unrelated refactors not required for "Reduce redundancy in AgentPlane code".
+
+## Plan
+
+Atomic sequence:
+1. Establish baseline with existing architecture, clone, knip, and hotspot reports.
+2. Remove or replace prompt alias exports only if internal usage proves they are not public API critical.
+3. Centralize repeated task domain value sets used by task creation, backend record normalization, blueprint task input, and hooks task context.
+4. Extract common route/remote source-confidence construction and reuse it from task status/next-action and task brief.
+5. Reduce confirmed local clone clusters in release/check helpers only when the helper extraction stays narrow and covered by existing check scripts.
+6. Leave speculative public/barrel export deletions as classified findings unless current evidence proves safe removal.
+7. Run required checks and record verification evidence.
+
+## Verify Steps
+
+1. Run: bun run arch:deps. Expect no dependency violations or circular imports.
+2. Run: bun run knip:report. Expect no new high-confidence dead-code findings introduced by the refactor; classify remaining public/barrel findings if unchanged.
+3. Run: bun run clone:report. Expect clone percentage not to increase and target clone clusters reduced where touched.
+4. Run focused Vitest coverage for touched command/backend/route modules. Expect all targeted tests pass.
+5. Run: bun run typecheck. Expect TypeScript project references pass.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+Revert the implementation commit on the task branch. If a shared helper introduces behavior drift, revert only that helper extraction and keep independent low-risk deletions that passed targeted tests.
+
+## Findings

--- a/.agentplane/tasks/202605251818-28Z5H1/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605251818-28Z5H1/blueprint/resolved-snapshot.json
@@ -1,0 +1,571 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605251818-28Z5H1",
+    "title": "Reduce redundancy in AgentPlane code",
+    "description": "Refactor low-risk repeated code surfaces identified by the redundancy audit: prompt aliases, duplicated task domain constants, shared route source confidence, and closely related helper duplication where verification remains bounded.",
+    "tags": [
+      "code",
+      "refactor"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605251818-28Z5H1",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "9fd821cb546f4b86fe783224e49ba7bec93f2ab63b182badd824738f2f3803da"
+  }
+}

--- a/.agentplane/tasks/202605251818-28Z5H1/pr/diffstat.txt
+++ b/.agentplane/tasks/202605251818-28Z5H1/pr/diffstat.txt
@@ -1,0 +1,16 @@
+ .../backends/task-backend/shared/domain-values.ts  | 44 ++++++++++
+ .../src/backends/task-backend/shared/record.ts     | 48 ++---------
+ packages/agentplane/src/cli/prompts.test.ts        | 50 +++++------
+ packages/agentplane/src/cli/prompts.ts             |  4 -
+ .../src/commands/blueprint/task-input.ts           | 47 ++--------
+ .../agentplane/src/commands/hooks/task-context.ts  | 38 ++-------
+ .../src/commands/shared/route-decision.ts          | 69 ++-------------
+ .../src/commands/shared/source-confidence.ts       | 99 ++++++++++++++++++++++
+ .../commands/task/agent-work-context-contract.ts   |  1 +
+ .../agentplane/src/commands/task/brief.command.ts  | 58 ++-----------
+ packages/agentplane/src/commands/task/new.ts       | 48 ++---------
+ scripts/generate/render-homebrew-formula.mjs       | 45 ++--------
+ scripts/generate/render-scoop-manifest.mjs         | 45 ++--------
+ .../generate/render-setup-agentplane-action.mjs    | 45 ++--------
+ scripts/lib/release-distribution-render.mjs        | 39 +++++++++
+ 15 files changed, 268 insertions(+), 412 deletions(-)

--- a/.agentplane/tasks/202605251818-28Z5H1/pr/github-body.md
+++ b/.agentplane/tasks/202605251818-28Z5H1/pr/github-body.md
@@ -1,0 +1,48 @@
+Task: `202605251818-28Z5H1`
+Title: Reduce redundancy in AgentPlane code
+Canonical task record: `.agentplane/tasks/202605251818-28Z5H1/README.md`
+
+## Summary
+
+Reduce redundancy in AgentPlane code
+
+Refactor low-risk repeated code surfaces identified by the redundancy audit: prompt aliases, duplicated task domain constants, shared route source confidence, and closely related helper duplication where verification remains bounded.
+
+## Scope
+
+- In scope: Refactor low-risk repeated code surfaces identified by the redundancy audit: prompt aliases, duplicated task domain constants, shared route source confidence, and closely related helper duplication where verification remains bounded.
+- Out of scope: unrelated refactors not required for "Reduce redundancy in AgentPlane code".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-25T18:20:35.354Z
+- Branch: task/202605251818-28Z5H1/reduce-redundancy-in-agentplane-code
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../backends/task-backend/shared/domain-values.ts  | 44 ++++++++++
+ .../src/backends/task-backend/shared/record.ts     | 48 ++---------
+ packages/agentplane/src/cli/prompts.test.ts        | 50 +++++------
+ packages/agentplane/src/cli/prompts.ts             |  4 -
+ .../src/commands/blueprint/task-input.ts           | 47 ++--------
+ .../agentplane/src/commands/hooks/task-context.ts  | 38 ++-------
+ .../src/commands/shared/route-decision.ts          | 69 ++-------------
+ .../src/commands/shared/source-confidence.ts       | 99 ++++++++++++++++++++++
+ .../commands/task/agent-work-context-contract.ts   |  1 +
+ .../agentplane/src/commands/task/brief.command.ts  | 58 ++-----------
+ packages/agentplane/src/commands/task/new.ts       | 48 ++---------
+ scripts/generate/render-homebrew-formula.mjs       | 45 ++--------
+ scripts/generate/render-scoop-manifest.mjs         | 45 ++--------
+ .../generate/render-setup-agentplane-action.mjs    | 45 ++--------
+ scripts/lib/release-distribution-render.mjs        | 39 +++++++++
+ 15 files changed, 268 insertions(+), 412 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605251818-28Z5H1/pr/github-body.md
+++ b/.agentplane/tasks/202605251818-28Z5H1/pr/github-body.md
@@ -15,8 +15,20 @@ Refactor low-risk repeated code surfaces identified by the redundancy audit: pro
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```bash
+bun run arch:deps. Result: pass. Evidence: no dependency violations found across 1335 modules and \
+  3423 dependencies. Scope: package import graph and circular dependency guard.
+```
+Command: bun run clone:report. Result: pass. Evidence: clone metrics improved from 1.12% to 0.98%, clones 94 to 89, duplicated lines 1595 to 1403. Scope: touched source and script clone clusters.
+Command: bun run knip:report and bun run knip:check. Result: pass. Evidence: report preserved existing baseline shape; baseline OK files=1/1 exports=207/207 types=358/358 total=566/566. Scope: unused files/exports/types.
+Command: bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/cli/prompts.test.ts. Result: pass. Evidence: 1 file, 12 tests passed. Scope: prompt canonical function behavior after alias removal.
+Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.route-decision.test.ts packages/agentplane/src/cli/run-cli.core.route-decision.batch.test.ts. Result: pass. Evidence: 2 files, 11 tests passed. Scope: route/task brief source confidence behavior.
+Command: bun run release:homebrew:check && bun run release:scoop:check && bun run release:setup-action:check. Result: pass. Evidence: all render checks reached skipped_missing_credentials gate. Scope: release distribution render helper extraction.
+Command: bun run typecheck. Result: pass. Evidence: tsc -b completed with exit 0. Scope: TypeScript project references.
+Command: bun run format:changed. Result: pass. Evidence: all matched files use Prettier code style. Scope: changed file formatting.
 - Canonical workflow state lives in the task README.
 
 <details>

--- a/.agentplane/tasks/202605251818-28Z5H1/pr/github-title.txt
+++ b/.agentplane/tasks/202605251818-28Z5H1/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 28Z5H1 task: Reduce redundancy in AgentPlane code [202605251818-28Z5H1]

--- a/.agentplane/tasks/202605251818-28Z5H1/pr/meta.json
+++ b/.agentplane/tasks/202605251818-28Z5H1/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202605251818-28Z5H1/reduce-redundancy-in-agentplane-code",
+  "created_at": "2026-05-25T18:20:35.354Z",
+  "diffstat_sha256": "sha256:c7a522d3b44c6e179049ef600764a9043fac5f5b2be16dcde4004f0a854051dd",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202605251818-28Z5H1",
+  "updated_at": "2026-05-25T18:20:35.354Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605251818-28Z5H1/pr/meta.json
+++ b/.agentplane/tasks/202605251818-28Z5H1/pr/meta.json
@@ -3,11 +3,12 @@
   "branch": "task/202605251818-28Z5H1/reduce-redundancy-in-agentplane-code",
   "created_at": "2026-05-25T18:20:35.354Z",
   "diffstat_sha256": "sha256:c7a522d3b44c6e179049ef600764a9043fac5f5b2be16dcde4004f0a854051dd",
-  "last_verified_at": null,
+  "last_verified_at": "2026-05-25T18:34:50.305Z",
+  "last_verified_diffstat_sha256": "sha256:c7a522d3b44c6e179049ef600764a9043fac5f5b2be16dcde4004f0a854051dd",
   "schema_version": 1,
   "task_id": "202605251818-28Z5H1",
   "updated_at": "2026-05-25T18:20:35.354Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605251818-28Z5H1/pr/review.md
+++ b/.agentplane/tasks/202605251818-28Z5H1/pr/review.md
@@ -12,8 +12,15 @@ Created: 2026-05-25T18:20:35.354Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Command: bun run arch:deps. Result: pass. Evidence: no dependency violations found across 1335 modules and 3423 dependencies. Scope: package import graph and circular dependency guard.
+Command: bun run clone:report. Result: pass. Evidence: clone metrics improved from 1.12% to 0.98%, clones 94 to 89, duplicated lines 1595 to 1403. Scope: touched source and script clone clusters.
+Command: bun run knip:report and bun run knip:check. Result: pass. Evidence: report preserved existing baseline shape; baseline OK files=1/1 exports=207/207 types=358/358 total=566/566. Scope: unused files/exports/types.
+Command: bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/cli/prompts.test.ts. Result: pass. Evidence: 1 file, 12 tests passed. Scope: prompt canonical function behavior after alias removal.
+Command: bunx vitest --config vitest.workspace.ts run --project cli-core packages/agentplane/src/cli/run-cli.core.route-decision.test.ts packages/agentplane/src/cli/run-cli.core.route-decision.batch.test.ts. Result: pass. Evidence: 2 files, 11 tests passed. Scope: route/task brief source confidence behavior.
+Command: bun run release:homebrew:check && bun run release:scoop:check && bun run release:setup-action:check. Result: pass. Evidence: all render checks reached skipped_missing_credentials gate. Scope: release distribution render helper extraction.
+Command: bun run typecheck. Result: pass. Evidence: tsc -b completed with exit 0. Scope: TypeScript project references.
+Command: bun run format:changed. Result: pass. Evidence: all matched files use Prettier code style. Scope: changed file formatting.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes

--- a/.agentplane/tasks/202605251818-28Z5H1/pr/review.md
+++ b/.agentplane/tasks/202605251818-28Z5H1/pr/review.md
@@ -1,0 +1,51 @@
+# PR Review
+
+Created: 2026-05-25T18:20:35.354Z
+
+## Task
+
+- Task: `202605251818-28Z5H1`
+- Title: Reduce redundancy in AgentPlane code
+- Status: DOING
+- Branch: `task/202605251818-28Z5H1/reduce-redundancy-in-agentplane-code`
+- Canonical task record: `.agentplane/tasks/202605251818-28Z5H1/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-25T18:20:35.354Z
+- Branch: task/202605251818-28Z5H1/reduce-redundancy-in-agentplane-code
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../backends/task-backend/shared/domain-values.ts  | 44 ++++++++++
+ .../src/backends/task-backend/shared/record.ts     | 48 ++---------
+ packages/agentplane/src/cli/prompts.test.ts        | 50 +++++------
+ packages/agentplane/src/cli/prompts.ts             |  4 -
+ .../src/commands/blueprint/task-input.ts           | 47 ++--------
+ .../agentplane/src/commands/hooks/task-context.ts  | 38 ++-------
+ .../src/commands/shared/route-decision.ts          | 69 ++-------------
+ .../src/commands/shared/source-confidence.ts       | 99 ++++++++++++++++++++++
+ .../commands/task/agent-work-context-contract.ts   |  1 +
+ .../agentplane/src/commands/task/brief.command.ts  | 58 ++-----------
+ packages/agentplane/src/commands/task/new.ts       | 48 ++---------
+ scripts/generate/render-homebrew-formula.mjs       | 45 ++--------
+ scripts/generate/render-scoop-manifest.mjs         | 45 ++--------
+ .../generate/render-setup-agentplane-action.mjs    | 45 ++--------
+ scripts/lib/release-distribution-render.mjs        | 39 +++++++++
+ 15 files changed, 268 insertions(+), 412 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605251818-28Z5H1/quality/20260525-184319070-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605251818-28Z5H1/quality/20260525-184319070-recovery-context/evaluator-opinion.md
@@ -1,0 +1,19 @@
+# EVALUATOR opinion: pass
+
+Low-risk redundancy refactor completed in branch_pr worktree. Local verification passed, clone metrics improved, knip baseline stayed unchanged, and PR #4145 hosted checks are stable-green on head 65cd7a0eb.
+
+## Findings
+- No blocking findings. Residual risk is limited to unchanged existing knip baseline debt and intentionally deferred broader command-catalog/test-fixture decomposition.
+
+## Evidence
+- .agentplane/tasks/202605251818-28Z5H1/README.md
+- https://github.com/basilisk-labs/agentplane/pull/4145
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202605251818-28Z5H1/quality/20260525-184319070-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605251818-28Z5H1/quality/20260525-184319070-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605251818-28Z5H1
+- task_readme: .agentplane/tasks/202605251818-28Z5H1/README.md
+- report_path: .agentplane/tasks/202605251818-28Z5H1/quality/20260525-184319070-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605251818-28Z5H1/quality/20260525-184319070-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605251818-28Z5H1/quality/20260525-184319070-recovery-context/quality-report.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "task_id": "202605251818-28Z5H1",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-25T18:43:19.070Z",
+  "verdict": "pass",
+  "summary": "Low-risk redundancy refactor completed in branch_pr worktree. Local verification passed, clone metrics improved, knip baseline stayed unchanged, and PR #4145 hosted checks are stable-green on head 65cd7a0eb.",
+  "evaluated_sha": "5d1d48cf601e7ffce686af439159562a8ea8d977",
+  "blueprint_digest": "9fd821cb546f4b86fe783224e49ba7bec93f2ab63b182badd824738f2f3803da",
+  "findings": [
+    "No blocking findings. Residual risk is limited to unchanged existing knip baseline debt and intentionally deferred broader command-catalog/test-fixture decomposition."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605251818-28Z5H1/README.md",
+    "https://github.com/basilisk-labs/agentplane/pull/4145"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/backends/task-backend/shared/domain-values.ts
+++ b/packages/agentplane/src/backends/task-backend/shared/domain-values.ts
@@ -1,0 +1,44 @@
+export const TASK_KIND_VALUES = new Set([
+  "analysis",
+  "content",
+  "docs",
+  "code",
+  "release",
+  "ops",
+  "context",
+]);
+
+export const MUTATION_SCOPE_VALUES = new Set([
+  "none",
+  "docs",
+  "code",
+  "release",
+  "ops",
+  "context",
+  "unknown",
+]);
+
+export const RISK_FLAG_VALUES = new Set([
+  "network",
+  "credentials",
+  "deploy",
+  "publish",
+  "merge",
+  "security",
+  "external_system",
+]);
+
+export const BLUEPRINT_REQUEST_VALUES = new Set([
+  "analysis.light",
+  "content.light",
+  "docs.change",
+  "code.direct",
+  "code.branch_pr",
+  "performance.benchmark",
+  "quality.regression",
+  "context.assimilation",
+  "context.maximum_assimilation",
+  "post_run.improvement_review",
+  "release.strict",
+  "ops.approval",
+]);

--- a/packages/agentplane/src/backends/task-backend/shared/record.ts
+++ b/packages/agentplane/src/backends/task-backend/shared/record.ts
@@ -20,48 +20,12 @@ import {
 } from "./normalize.js";
 import { toStringArray } from "./strings.js";
 import type { TaskData } from "./types.js";
-
-const TASK_KIND_VALUES = new Set([
-  "analysis",
-  "content",
-  "docs",
-  "code",
-  "release",
-  "ops",
-  "context",
-]);
-const MUTATION_SCOPE_VALUES = new Set([
-  "none",
-  "docs",
-  "code",
-  "release",
-  "ops",
-  "context",
-  "unknown",
-]);
-const RISK_FLAG_VALUES = new Set([
-  "network",
-  "credentials",
-  "deploy",
-  "publish",
-  "merge",
-  "security",
-  "external_system",
-]);
-const BLUEPRINT_REQUEST_VALUES = new Set([
-  "analysis.light",
-  "content.light",
-  "docs.change",
-  "code.direct",
-  "code.branch_pr",
-  "performance.benchmark",
-  "quality.regression",
-  "context.assimilation",
-  "context.maximum_assimilation",
-  "post_run.improvement_review",
-  "release.strict",
-  "ops.approval",
-]);
+import {
+  BLUEPRINT_REQUEST_VALUES,
+  MUTATION_SCOPE_VALUES,
+  RISK_FLAG_VALUES,
+  TASK_KIND_VALUES,
+} from "./domain-values.js";
 
 function normalizeRevision(value: unknown): number | undefined {
   return Number.isInteger(value) && Number(value) > 0 ? Number(value) : undefined;

--- a/packages/agentplane/src/cli/prompts.test.ts
+++ b/packages/agentplane/src/cli/prompts.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { captureStdIO } from "@agentplane/testkit";
-import { promptChoice, promptInput, promptYesNo } from "./prompts.js";
+import { confirmPrompt, selectPrompt, textPrompt } from "./prompts.js";
 
 const mocks = vi.hoisted(() => {
   const state = { nextAnswer: "" };
@@ -99,64 +99,64 @@ describe("cli/prompts", () => {
     }
   });
 
-  it("promptChoice returns default on empty input", async () => {
+  it("selectPrompt returns default on empty input", async () => {
     mocks.state.nextAnswer = "   ";
 
-    await expect(promptChoice("Pick", ["a", "b"], "a")).resolves.toBe("a");
+    await expect(selectPrompt("Pick", ["a", "b"], "a")).resolves.toBe("a");
     expect(mocks.createInterfaceMock).toHaveBeenCalledOnce();
     expect(mocks.closeMock).toHaveBeenCalledOnce();
   });
 
-  it("promptChoice returns selected value when valid", async () => {
+  it("selectPrompt returns selected value when valid", async () => {
     mocks.state.nextAnswer = "b";
 
-    await expect(promptChoice("Pick", ["a", "b"], "a")).resolves.toBe("b");
+    await expect(selectPrompt("Pick", ["a", "b"], "a")).resolves.toBe("b");
   });
 
-  it("promptChoice warns and returns default on invalid choice", async () => {
+  it("selectPrompt warns and returns default on invalid choice", async () => {
     mocks.state.nextAnswer = "nope";
     const io = captureStdIO();
 
-    await expect(promptChoice("Pick", ["a", "b"], "a")).resolves.toBe("a");
+    await expect(selectPrompt("Pick", ["a", "b"], "a")).resolves.toBe("a");
     io.restore();
 
     expect(io.stdout).toContain("Invalid choice; using default a");
   });
 
-  it("promptYesNo uses default when input is empty", async () => {
+  it("confirmPrompt uses default when input is empty", async () => {
     mocks.state.nextAnswer = "";
 
-    await expect(promptYesNo("Continue", true)).resolves.toBe(true);
-    await expect(promptYesNo("Continue", false)).resolves.toBe(false);
+    await expect(confirmPrompt("Continue", true)).resolves.toBe(true);
+    await expect(confirmPrompt("Continue", false)).resolves.toBe(false);
   });
 
-  it("promptYesNo parses affirmative and negative inputs", async () => {
+  it("confirmPrompt parses affirmative and negative inputs", async () => {
     mocks.state.nextAnswer = "yes";
-    await expect(promptYesNo("Continue", false)).resolves.toBe(true);
+    await expect(confirmPrompt("Continue", false)).resolves.toBe(true);
 
     mocks.state.nextAnswer = "no";
-    await expect(promptYesNo("Continue", true)).resolves.toBe(false);
+    await expect(confirmPrompt("Continue", true)).resolves.toBe(false);
   });
 
-  it("promptYesNo falls back to default for invalid input", async () => {
+  it("confirmPrompt falls back to default for invalid input", async () => {
     mocks.state.nextAnswer = "definitely";
-    await expect(promptYesNo("Continue", true)).resolves.toBe(true);
+    await expect(confirmPrompt("Continue", true)).resolves.toBe(true);
 
     mocks.state.nextAnswer = "definitely";
-    await expect(promptYesNo("Continue", false)).resolves.toBe(false);
+    await expect(confirmPrompt("Continue", false)).resolves.toBe(false);
   });
 
-  it("promptInput trims input", async () => {
+  it("textPrompt trims input", async () => {
     mocks.state.nextAnswer = "  hello ";
 
-    await expect(promptInput("Name: ")).resolves.toBe("hello");
+    await expect(textPrompt("Name: ")).resolves.toBe("hello");
   });
 
   it("uses clack select in TTY mode", async () => {
     setTty(true);
     mocks.selectMock.mockResolvedValue("b");
 
-    await expect(promptChoice("Pick", ["a", "b"], "a")).resolves.toBe("b");
+    await expect(selectPrompt("Pick", ["a", "b"], "a")).resolves.toBe("b");
     expect(mocks.selectMock).toHaveBeenCalledWith({
       message: "Pick",
       options: [
@@ -172,7 +172,7 @@ describe("cli/prompts", () => {
     setTty(true);
     mocks.confirmMock.mockResolvedValue(false);
 
-    await expect(promptYesNo("Continue", true)).resolves.toBe(false);
+    await expect(confirmPrompt("Continue", true)).resolves.toBe(false);
     expect(mocks.confirmMock).toHaveBeenCalledWith({
       message: "Continue",
       initialValue: true,
@@ -184,7 +184,7 @@ describe("cli/prompts", () => {
     setTty(true);
     mocks.textMock.mockResolvedValue("  hello ");
 
-    await expect(promptInput("Name")).resolves.toBe("hello");
+    await expect(textPrompt("Name")).resolves.toBe("hello");
     expect(mocks.textMock).toHaveBeenCalledWith({ message: "Name" });
     expect(mocks.createInterfaceMock).not.toHaveBeenCalled();
   });
@@ -194,7 +194,7 @@ describe("cli/prompts", () => {
     process.env.AGENTPLANE_PROMPTS = "plain";
     mocks.state.nextAnswer = "b";
 
-    await expect(promptChoice("Pick", ["a", "b"], "a")).resolves.toBe("b");
+    await expect(selectPrompt("Pick", ["a", "b"], "a")).resolves.toBe("b");
     expect(mocks.selectMock).not.toHaveBeenCalled();
     expect(mocks.createInterfaceMock).toHaveBeenCalledOnce();
   });
@@ -205,9 +205,9 @@ describe("cli/prompts", () => {
     mocks.confirmMock.mockResolvedValue(mocks.cancelSymbol);
     mocks.textMock.mockResolvedValue(mocks.cancelSymbol);
 
-    await expect(promptChoice("Pick", ["a", "b"], "a")).resolves.toBe("a");
-    await expect(promptYesNo("Continue", true)).resolves.toBe(true);
-    await expect(promptInput("Name")).resolves.toBe("");
+    await expect(selectPrompt("Pick", ["a", "b"], "a")).resolves.toBe("a");
+    await expect(confirmPrompt("Continue", true)).resolves.toBe(true);
+    await expect(textPrompt("Name")).resolves.toBe("");
     expect(mocks.cancelMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/agentplane/src/cli/prompts.ts
+++ b/packages/agentplane/src/cli/prompts.ts
@@ -92,7 +92,3 @@ export async function textPrompt(prompt: string): Promise<string> {
   rl.close();
   return answer.trim();
 }
-
-export const promptChoice = selectPrompt;
-export const promptYesNo = confirmPrompt;
-export const promptInput = textPrompt;

--- a/packages/agentplane/src/commands/blueprint/task-input.ts
+++ b/packages/agentplane/src/commands/blueprint/task-input.ts
@@ -9,51 +9,16 @@ import type {
   TaskKind,
   WorkflowMode,
 } from "../../blueprints/model.js";
+import {
+  BLUEPRINT_REQUEST_VALUES,
+  MUTATION_SCOPE_VALUES,
+  RISK_FLAG_VALUES,
+  TASK_KIND_VALUES,
+} from "../../backends/task-backend/shared/domain-values.js";
 
 const CODE_TAGS = ["code", "backend", "frontend", "cli"] as const;
 const DOCS_TAGS = ["docs", "documentation", "roadmap"] as const;
 const OPS_TAGS = ["ops", "deploy", "config"] as const;
-const TASK_KIND_VALUES = new Set([
-  "analysis",
-  "content",
-  "docs",
-  "code",
-  "release",
-  "ops",
-  "context",
-]);
-const MUTATION_SCOPE_VALUES = new Set([
-  "none",
-  "docs",
-  "code",
-  "release",
-  "ops",
-  "context",
-  "unknown",
-]);
-const RISK_FLAG_VALUES = new Set([
-  "network",
-  "credentials",
-  "deploy",
-  "publish",
-  "merge",
-  "security",
-  "external_system",
-]);
-const BLUEPRINT_REQUEST_VALUES = new Set([
-  "analysis.light",
-  "content.light",
-  "docs.change",
-  "code.direct",
-  "code.branch_pr",
-  "performance.benchmark",
-  "quality.regression",
-  "context.assimilation",
-  "context.maximum_assimilation",
-  "post_run.improvement_review",
-  "release.strict",
-  "ops.approval",
-]);
 
 function hasAny(tags: Set<string>, candidates: readonly string[]): boolean {
   return candidates.some((candidate) => tags.has(candidate));

--- a/packages/agentplane/src/commands/hooks/task-context.ts
+++ b/packages/agentplane/src/commands/hooks/task-context.ts
@@ -4,40 +4,12 @@ import { parseTaskReadme } from "@agentplaneorg/core/tasks";
 import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 
+import {
+  BLUEPRINT_REQUEST_VALUES,
+  MUTATION_SCOPE_VALUES,
+  TASK_KIND_VALUES,
+} from "../../backends/task-backend/shared/domain-values.js";
 import { gitCurrentBranch } from "../shared/git-ops.js";
-
-const TASK_KIND_VALUES = new Set([
-  "analysis",
-  "content",
-  "docs",
-  "code",
-  "release",
-  "ops",
-  "context",
-]);
-const MUTATION_SCOPE_VALUES = new Set([
-  "none",
-  "docs",
-  "code",
-  "release",
-  "ops",
-  "context",
-  "unknown",
-]);
-const BLUEPRINT_REQUEST_VALUES = new Set([
-  "analysis.light",
-  "content.light",
-  "docs.change",
-  "code.direct",
-  "code.branch_pr",
-  "performance.benchmark",
-  "quality.regression",
-  "context.assimilation",
-  "context.maximum_assimilation",
-  "post_run.improvement_review",
-  "release.strict",
-  "ops.approval",
-]);
 
 function stringValue<T extends string>(value: unknown, allowed: Set<string>): T | undefined {
   return typeof value === "string" && allowed.has(value) ? (value as T) : undefined;

--- a/packages/agentplane/src/commands/shared/route-decision.ts
+++ b/packages/agentplane/src/commands/shared/route-decision.ts
@@ -11,6 +11,10 @@ import {
 import { workStartCommand } from "./work-start-command.js";
 
 import { loadBackendTask, loadCommandContext, type CommandContext } from "./task-backend.js";
+import {
+  buildRouteSourceConfidenceBase,
+  type SourceConfidence as RouteSourceConfidence,
+} from "./source-confidence.js";
 
 type RouteBlocker = {
   code: string;
@@ -24,13 +28,6 @@ type RouteRepairStep = {
   command: string | null;
   summary: string;
   mutates: boolean;
-};
-
-type RouteSourceConfidence = {
-  source: string;
-  freshness: string;
-  confidence: string;
-  note?: string;
 };
 
 type RouteAmbiguity = {
@@ -455,60 +452,10 @@ function buildRouteSourceConfidence(opts: {
   remoteEnabled: boolean;
   remoteResolved: boolean;
 }): TaskRouteDecision["sourceConfidence"] {
-  const routeFreshness = opts.remoteResolved ? "remote_live" : "computed_local";
-  const routeConfidence = opts.remoteResolved ? "medium" : opts.remoteEnabled ? "medium" : "high";
-  const routeNote = opts.remoteResolved
-    ? "route includes provider-derived PR/check state"
-    : opts.remoteEnabled
-      ? "remote lookup was requested but no provider state was available"
-      : "route excludes hosted PR/check/review lookups";
-  const remoteFreshness = opts.remoteResolved ? "remote_live" : "remote_skipped";
-  const remoteConfidence = opts.remoteResolved ? "medium" : opts.remoteEnabled ? "low" : "skipped";
-  const remoteNote = opts.remoteResolved
-    ? "remote provider state fetched"
-    : opts.remoteEnabled
-      ? "remote lookup was requested but route resolution fell back to local data"
-      : "remote lookup skipped by default";
-  return {
-    task: {
-      source: "task_backend",
-      freshness: "live_local",
-      confidence: "high",
-    },
-    workflow: {
-      source: "local_git",
-      freshness: "live_local",
-      confidence: "high",
-    },
-    route: {
-      source: "local_git",
-      freshness: routeFreshness,
-      confidence: routeConfidence,
-      note: routeNote,
-    },
-    next_action: {
-      source: "local_git",
-      freshness: routeFreshness,
-      confidence: routeConfidence,
-    },
-    blockers: {
-      source: "local_git",
-      freshness: routeFreshness,
-      confidence: routeConfidence,
-    },
-    batch_ownership: {
-      source: "pr_artifact",
-      freshness: "live_local",
-      confidence: "medium",
-      note: "derived from local branch_pr PR metadata",
-    },
-    remote: {
-      source: "remote_provider",
-      freshness: remoteFreshness,
-      confidence: remoteConfidence,
-      note: remoteNote,
-    },
-  };
+  return buildRouteSourceConfidenceBase({
+    ...opts,
+    batchOwnershipSource: "pr_artifact",
+  });
 }
 
 export async function buildTaskRouteDecision(opts: {

--- a/packages/agentplane/src/commands/shared/source-confidence.ts
+++ b/packages/agentplane/src/commands/shared/source-confidence.ts
@@ -1,0 +1,99 @@
+type SourceConfidenceSource =
+  | "static"
+  | "task_backend"
+  | "local_git"
+  | "pr_artifact"
+  | "task_doc"
+  | "blueprint_resolver"
+  | "snapshot_digest"
+  | "remote_provider";
+
+type SourceConfidenceFreshness =
+  | "static"
+  | "live_local"
+  | "computed_local"
+  | "cached_artifact"
+  | "remote_live"
+  | "remote_skipped";
+
+type SourceConfidenceLevel = "high" | "medium" | "low" | "skipped";
+
+export type SourceConfidence = {
+  source: SourceConfidenceSource;
+  freshness: SourceConfidenceFreshness;
+  confidence: SourceConfidenceLevel;
+  note?: string;
+};
+
+export function buildRouteSourceConfidenceBase<
+  TBatchSource extends "local_git" | "pr_artifact",
+>(opts: {
+  batchOwnershipSource: TBatchSource;
+  batchOwnershipNote?: string;
+  remoteEnabled: boolean;
+  remoteResolved: boolean;
+}): {
+  task: SourceConfidence;
+  workflow: SourceConfidence;
+  route: SourceConfidence;
+  next_action: SourceConfidence;
+  blockers: SourceConfidence;
+  batch_ownership: SourceConfidence & { source: TBatchSource };
+  remote: SourceConfidence;
+} {
+  const routeFreshness = opts.remoteResolved ? "remote_live" : "computed_local";
+  const routeConfidence = opts.remoteResolved ? "medium" : opts.remoteEnabled ? "medium" : "high";
+  const routeNote = opts.remoteResolved
+    ? "route includes provider-derived PR/check state"
+    : opts.remoteEnabled
+      ? "remote lookup was requested but no provider state was available"
+      : "route excludes hosted PR/check/review lookups";
+  const remoteFreshness = opts.remoteResolved ? "remote_live" : "remote_skipped";
+  const remoteConfidence = opts.remoteResolved ? "medium" : opts.remoteEnabled ? "low" : "skipped";
+  const remoteNote = opts.remoteResolved
+    ? "remote provider state fetched"
+    : opts.remoteEnabled
+      ? "remote lookup was requested but route resolution fell back to local data"
+      : "remote lookup skipped by default";
+
+  return {
+    task: {
+      source: "task_backend",
+      freshness: "live_local",
+      confidence: "high",
+    },
+    workflow: {
+      source: "local_git",
+      freshness: "live_local",
+      confidence: "high",
+    },
+    route: {
+      source: "local_git",
+      freshness: routeFreshness,
+      confidence: routeConfidence,
+      note: routeNote,
+    },
+    next_action: {
+      source: "local_git",
+      freshness: routeFreshness,
+      confidence: routeConfidence,
+    },
+    blockers: {
+      source: "local_git",
+      freshness: routeFreshness,
+      confidence: routeConfidence,
+    },
+    batch_ownership: {
+      source: opts.batchOwnershipSource,
+      freshness: "live_local",
+      confidence: "medium",
+      note: opts.batchOwnershipNote ?? "derived from local branch_pr PR metadata",
+    },
+    remote: {
+      source: "remote_provider",
+      freshness: remoteFreshness,
+      confidence: remoteConfidence,
+      note: remoteNote,
+    },
+  };
+}

--- a/packages/agentplane/src/commands/task/agent-work-context-contract.ts
+++ b/packages/agentplane/src/commands/task/agent-work-context-contract.ts
@@ -5,6 +5,7 @@ type AgentWorkContextSourceKind =
   | "static"
   | "task_backend"
   | "local_git"
+  | "pr_artifact"
   | "task_doc"
   | "blueprint_resolver"
   | "snapshot_digest"

--- a/packages/agentplane/src/commands/task/brief.command.ts
+++ b/packages/agentplane/src/commands/task/brief.command.ts
@@ -2,6 +2,7 @@ import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
 import { createCliEmitter, infoMessage } from "../../cli/output.js";
 import { checkTaskBlueprintSnapshotDrift } from "../blueprint/snapshot-artifact.js";
 import { buildTaskRouteDecision } from "../shared/route-decision.js";
+import { buildRouteSourceConfidenceBase } from "../shared/source-confidence.js";
 import { loadTaskFromContext, type CommandContext } from "../shared/task-backend.js";
 
 import {
@@ -156,20 +157,11 @@ function buildSourceConfidence(opts: {
   snapshotState: string;
   verifyStepsQuality: TaskBrief["verify_steps"]["quality"];
 }): TaskBrief["source_confidence"] {
-  const routeFreshness = opts.remoteResolved ? "remote_live" : "computed_local";
-  const routeConfidence = opts.remoteResolved ? "medium" : opts.remoteEnabled ? "medium" : "high";
-  const routeNote = opts.remoteResolved
-    ? "route includes provider-derived PR/check state"
-    : opts.remoteEnabled
-      ? "remote lookup was requested but no provider state was available"
-      : "route excludes hosted PR/check/review lookups";
-  const remoteFreshness = opts.remoteResolved ? "remote_live" : "remote_skipped";
-  const remoteConfidence = opts.remoteResolved ? "medium" : opts.remoteEnabled ? "low" : "skipped";
-  const remoteNote = opts.remoteResolved
-    ? "remote provider state fetched"
-    : opts.remoteEnabled
-      ? "remote lookup was requested but route resolution fell back to local data"
-      : "remote lookup skipped by default";
+  const routeSourceConfidence = buildRouteSourceConfidenceBase({
+    batchOwnershipSource: "local_git",
+    remoteEnabled: opts.remoteEnabled,
+    remoteResolved: opts.remoteResolved,
+  });
   const snapshotConfidence =
     opts.snapshotState === "current" ? "high" : opts.snapshotState === "invalid" ? "low" : "medium";
   const snapshotFreshness = opts.snapshotState === "missing" ? "computed_local" : "cached_artifact";
@@ -197,38 +189,7 @@ function buildSourceConfidence(opts: {
       freshness: "static",
       confidence: "high",
     },
-    task: {
-      source: "task_backend",
-      freshness: "live_local",
-      confidence: "high",
-    },
-    workflow: {
-      source: "local_git",
-      freshness: "live_local",
-      confidence: "high",
-    },
-    route: {
-      source: "local_git",
-      freshness: routeFreshness,
-      confidence: routeConfidence,
-      note: routeNote,
-    },
-    next_action: {
-      source: "local_git",
-      freshness: routeFreshness,
-      confidence: routeConfidence,
-    },
-    blockers: {
-      source: "local_git",
-      freshness: routeFreshness,
-      confidence: routeConfidence,
-    },
-    batch_ownership: {
-      source: "local_git",
-      freshness: "live_local",
-      confidence: "medium",
-      note: "derived from local branch_pr PR metadata",
-    },
+    ...routeSourceConfidence,
     verify_steps: {
       source: "task_doc",
       freshness: "live_local",
@@ -263,10 +224,7 @@ function buildSourceConfidence(opts: {
       confidence: opts.blueprintError ? "low" : "high",
     },
     remote: {
-      source: "remote_provider",
-      freshness: remoteFreshness,
-      confidence: remoteConfidence,
-      note: remoteNote,
+      ...routeSourceConfidence.remote,
     },
   };
 }

--- a/packages/agentplane/src/commands/task/new.ts
+++ b/packages/agentplane/src/commands/task/new.ts
@@ -13,6 +13,12 @@ import { CliError } from "../../shared/errors.js";
 import { loadCommandContext, type CommandContext } from "../shared/task-backend.js";
 import type { TaskData } from "../../backends/task-backend/shared/types.js";
 import {
+  BLUEPRINT_REQUEST_VALUES,
+  MUTATION_SCOPE_VALUES,
+  RISK_FLAG_VALUES,
+  TASK_KIND_VALUES,
+} from "../../backends/task-backend/shared/domain-values.js";
+import {
   ensureTaskDependsOnGraphIsAcyclic,
   nowIso,
   requiresVerifyStepsByPrimary,
@@ -45,48 +51,6 @@ export type TaskNewParsed = {
   showBlueprint: boolean;
   allowDuplicate: boolean;
 };
-
-const TASK_KIND_VALUES = new Set([
-  "analysis",
-  "content",
-  "docs",
-  "code",
-  "release",
-  "ops",
-  "context",
-]);
-const MUTATION_SCOPE_VALUES = new Set([
-  "none",
-  "docs",
-  "code",
-  "release",
-  "ops",
-  "context",
-  "unknown",
-]);
-const RISK_FLAG_VALUES = new Set([
-  "network",
-  "credentials",
-  "deploy",
-  "publish",
-  "merge",
-  "security",
-  "external_system",
-]);
-const BLUEPRINT_REQUEST_VALUES = new Set([
-  "analysis.light",
-  "content.light",
-  "docs.change",
-  "code.direct",
-  "code.branch_pr",
-  "performance.benchmark",
-  "quality.regression",
-  "context.assimilation",
-  "context.maximum_assimilation",
-  "post_run.improvement_review",
-  "release.strict",
-  "ops.approval",
-]);
 
 const TASK_NEW_DUPLICATE_THRESHOLD = 0.75;
 const TASK_NEW_DUPLICATE_STOPWORDS = new Set([

--- a/scripts/generate/render-homebrew-formula.mjs
+++ b/scripts/generate/render-homebrew-formula.mjs
@@ -1,9 +1,14 @@
-import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import {
+  findPlatformAsset,
+  readJson,
+  requireString,
+  runDistributionGenerator,
+} from "../lib/release-distribution-render.mjs";
 import { defineScript, parseScriptArgs, runScriptMain } from "../lib/script-runtime.mjs";
 
 const DEFAULT_MANIFEST_PATH = ".agentplane/.release/publish/distribution/release-distribution.json";
@@ -36,29 +41,6 @@ function parseArgs(argv, repoRoot) {
     check: Boolean(flags.check),
     json: Boolean(flags.json),
     help: Boolean(flags.help),
-  };
-}
-
-async function readJson(filePath) {
-  return JSON.parse(await readFile(filePath, "utf8"));
-}
-
-function requireString(value, label) {
-  const text = typeof value === "string" ? value.trim() : "";
-  if (!text) throw new Error(`Missing ${label}`);
-  return text;
-}
-
-function findPlatformAsset(manifest, platform, arch) {
-  const asset = (manifest.bunAssets ?? manifest.platformAssets ?? []).find(
-    (entry) =>
-      entry?.kind === "bun_executable" && entry?.platform === platform && entry?.arch === arch,
-  );
-  if (!asset) throw new Error(`Missing Bun platform asset: ${platform}-${arch}`);
-  return {
-    url: requireString(asset.url, `${platform}-${arch} Bun URL`),
-    sha256: requireString(asset.sha256, `${platform}-${arch} Bun sha256`),
-    name: requireString(asset.name, `${platform}-${arch} Bun asset name`),
   };
 }
 
@@ -100,19 +82,6 @@ function renderFormula(manifest) {
   end
 end
 `;
-}
-
-function runDistributionGenerator(repoRoot, outDir) {
-  execFileSync(
-    "node",
-    ["scripts/generate-release-distribution.mjs", "--out", outDir, "--standalone-check-mode"],
-    {
-      cwd: repoRoot,
-      stdio: "ignore",
-      env: process.env,
-    },
-  );
-  return path.join(outDir, "release-distribution.json");
 }
 
 async function renderHomebrew(repoRoot, args) {

--- a/scripts/generate/render-scoop-manifest.mjs
+++ b/scripts/generate/render-scoop-manifest.mjs
@@ -1,9 +1,14 @@
-import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import {
+  findPlatformAsset,
+  readJson,
+  requireString,
+  runDistributionGenerator,
+} from "../lib/release-distribution-render.mjs";
 import { defineScript, parseScriptArgs, runScriptMain } from "../lib/script-runtime.mjs";
 
 const DEFAULT_MANIFEST_PATH = ".agentplane/.release/publish/distribution/release-distribution.json";
@@ -39,29 +44,6 @@ function parseArgs(argv, repoRoot) {
   };
 }
 
-async function readJson(filePath) {
-  return JSON.parse(await readFile(filePath, "utf8"));
-}
-
-function requireString(value, label) {
-  const text = typeof value === "string" ? value.trim() : "";
-  if (!text) throw new Error(`Missing ${label}`);
-  return text;
-}
-
-function findPlatformAsset(manifest, platform, arch) {
-  const asset = (manifest.bunAssets ?? manifest.platformAssets ?? []).find(
-    (entry) =>
-      entry?.kind === "bun_executable" && entry?.platform === platform && entry?.arch === arch,
-  );
-  if (!asset) throw new Error(`Missing Bun platform asset: ${platform}-${arch}`);
-  return {
-    url: requireString(asset.url, `${platform}-${arch} Bun URL`),
-    sha256: requireString(asset.sha256, `${platform}-${arch} Bun sha256`),
-    name: requireString(asset.name, `${platform}-${arch} Bun asset name`),
-  };
-}
-
 function renderScoopManifest(manifest) {
   const version = requireString(manifest.version, "release version");
   const win32X64 = findPlatformAsset(manifest, "win32", "x64");
@@ -89,19 +71,6 @@ function renderScoopManifest(manifest) {
     },
     bin: [[String.raw`bin\agentplane.exe`, "agentplane"]],
   };
-}
-
-function runDistributionGenerator(repoRoot, outDir) {
-  execFileSync(
-    "node",
-    ["scripts/generate-release-distribution.mjs", "--out", outDir, "--standalone-check-mode"],
-    {
-      cwd: repoRoot,
-      stdio: "ignore",
-      env: process.env,
-    },
-  );
-  return path.join(outDir, "release-distribution.json");
 }
 
 async function renderScoop(repoRoot, args) {

--- a/scripts/generate/render-setup-agentplane-action.mjs
+++ b/scripts/generate/render-setup-agentplane-action.mjs
@@ -1,9 +1,14 @@
-import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import {
+  findPlatformAsset,
+  readJson,
+  requireString,
+  runDistributionGenerator,
+} from "../lib/release-distribution-render.mjs";
 import { defineScript, parseScriptArgs, runScriptMain } from "../lib/script-runtime.mjs";
 
 const DEFAULT_MANIFEST_PATH = ".agentplane/.release/publish/distribution/release-distribution.json";
@@ -36,29 +41,6 @@ function parseArgs(argv, repoRoot) {
     check: Boolean(flags.check),
     json: Boolean(flags.json),
     help: Boolean(flags.help),
-  };
-}
-
-async function readJson(filePath) {
-  return JSON.parse(await readFile(filePath, "utf8"));
-}
-
-function requireString(value, label) {
-  const text = typeof value === "string" ? value.trim() : "";
-  if (!text) throw new Error(`Missing ${label}`);
-  return text;
-}
-
-function findPlatformAsset(manifest, platform, arch) {
-  const asset = (manifest.bunAssets ?? manifest.platformAssets ?? []).find(
-    (entry) =>
-      entry?.kind === "bun_executable" && entry?.platform === platform && entry?.arch === arch,
-  );
-  if (!asset) throw new Error(`Missing Bun platform asset: ${platform}-${arch}`);
-  return {
-    url: requireString(asset.url, `${platform}-${arch} Bun URL`),
-    sha256: requireString(asset.sha256, `${platform}-${arch} Bun sha256`),
-    name: requireString(asset.name, `${platform}-${arch} Bun asset name`),
   };
 }
 
@@ -175,19 +157,6 @@ This composite action installs AgentPlane from the official Bun single-file exec
 
 \`\`\`bash\nagentplane --version\n\`\`\`
 `;
-}
-
-function runDistributionGenerator(repoRoot, outDir) {
-  execFileSync(
-    "node",
-    ["scripts/generate-release-distribution.mjs", "--out", outDir, "--standalone-check-mode"],
-    {
-      cwd: repoRoot,
-      stdio: "ignore",
-      env: process.env,
-    },
-  );
-  return path.join(outDir, "release-distribution.json");
 }
 
 async function renderSetupAction(repoRoot, args) {

--- a/scripts/lib/release-distribution-render.mjs
+++ b/scripts/lib/release-distribution-render.mjs
@@ -1,0 +1,39 @@
+import { execFileSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+export async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+export function requireString(value, label) {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) throw new Error(`Missing ${label}`);
+  return text;
+}
+
+export function findPlatformAsset(manifest, platform, arch) {
+  const asset = (manifest.bunAssets ?? manifest.platformAssets ?? []).find(
+    (entry) =>
+      entry?.kind === "bun_executable" && entry?.platform === platform && entry?.arch === arch,
+  );
+  if (!asset) throw new Error(`Missing Bun platform asset: ${platform}-${arch}`);
+  return {
+    url: requireString(asset.url, `${platform}-${arch} Bun URL`),
+    sha256: requireString(asset.sha256, `${platform}-${arch} Bun sha256`),
+    name: requireString(asset.name, `${platform}-${arch} Bun asset name`),
+  };
+}
+
+export function runDistributionGenerator(repoRoot, outDir) {
+  execFileSync(
+    "node",
+    ["scripts/generate-release-distribution.mjs", "--out", outDir, "--standalone-check-mode"],
+    {
+      cwd: repoRoot,
+      stdio: "ignore",
+      env: process.env,
+    },
+  );
+  return path.join(outDir, "release-distribution.json");
+}


### PR DESCRIPTION
Task: `202605251818-28Z5H1`
Title: Reduce redundancy in AgentPlane code
Canonical task record: `.agentplane/tasks/202605251818-28Z5H1/README.md`

## Summary

Reduce redundancy in AgentPlane code

Refactor low-risk repeated code surfaces identified by the redundancy audit: prompt aliases, duplicated task domain constants, shared route source confidence, and closely related helper duplication where verification remains bounded.

## Scope

- In scope: Refactor low-risk repeated code surfaces identified by the redundancy audit: prompt aliases, duplicated task domain constants, shared route source confidence, and closely related helper duplication where verification remains bounded.
- Out of scope: unrelated refactors not required for "Reduce redundancy in AgentPlane code".

## Verification

- State: pending
- Note: Not recorded yet.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-25T18:20:35.354Z
- Branch: task/202605251818-28Z5H1/reduce-redundancy-in-agentplane-code
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../backends/task-backend/shared/domain-values.ts  | 44 ++++++++++
 .../src/backends/task-backend/shared/record.ts     | 48 ++---------
 packages/agentplane/src/cli/prompts.test.ts        | 50 +++++------
 packages/agentplane/src/cli/prompts.ts             |  4 -
 .../src/commands/blueprint/task-input.ts           | 47 ++--------
 .../agentplane/src/commands/hooks/task-context.ts  | 38 ++-------
 .../src/commands/shared/route-decision.ts          | 69 ++-------------
 .../src/commands/shared/source-confidence.ts       | 99 ++++++++++++++++++++++
 .../commands/task/agent-work-context-contract.ts   |  1 +
 .../agentplane/src/commands/task/brief.command.ts  | 58 ++-----------
 packages/agentplane/src/commands/task/new.ts       | 48 ++---------
 scripts/generate/render-homebrew-formula.mjs       | 45 ++--------
 scripts/generate/render-scoop-manifest.mjs         | 45 ++--------
 .../generate/render-setup-agentplane-action.mjs    | 45 ++--------
 scripts/lib/release-distribution-render.mjs        | 39 +++++++++
 15 files changed, 268 insertions(+), 412 deletions(-)
```

</details>
