### PR TITLE
🚧 H5JAWT task: Block unstaged generated task artifacts in pre-commit [202605260641-H5JAWT]

### DIFF
--- a/.agentplane/tasks/202605260641-H5JAWT/README.md
+++ b/.agentplane/tasks/202605260641-H5JAWT/README.md
@@ -4,7 +4,7 @@ title: "Block unstaged generated task artifacts in pre-commit"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -24,6 +24,26 @@ verification:
   updated_by: "CODER"
   note: "Command: bun run test:precommit. Result: pass, 17 files and 145 tests passed. Scope: pre-commit hook/runtime regression suite, including generated task artifact guard and commit wrapper allow-tasks behavior. Command: node .agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Scope: AgentPlane routing policy."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-26T06:48:51.605Z"
+  updated_by: "EVALUATOR"
+  note: "Pre-commit now blocks unstaged generated active task artifacts while preserving the agentplane commit --allow-tasks path."
+  evaluated_sha: "217cee043ccf1ada34247200da4d290f4c7b934b"
+  blueprint_digest: "b114644e8a655cea0db073d39a69e41b909b75e4829f35abf503028b2f025148"
+  evidence_refs:
+    - ".agentplane/tasks/202605260641-H5JAWT/README.md"
+    - ".agentplane/tasks/202605260641-H5JAWT/quality/20260526-064851605-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605260641-H5JAWT/quality/20260526-064851605-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605260641-H5JAWT/quality/20260526-064851605-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605260641-H5JAWT/blueprint/resolved-snapshot.json"
+    - "packages/agentplane/src/commands/hooks/run.pre-commit.ts"
+    - "packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts"
+    - "bun run test:precommit"
+    - "node .agentplane/policy/check-routing.mjs"
+  findings:
+    - "Generated blueprint and evaluator artifacts are detected from git changed paths and rejected when absent from the index."
+    - "Focused hook and commit-wrapper tests cover raw pre-commit blocking, staged artifact acceptance, and allow-tasks auto-staging."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202605260641-H5JAWT/README.md
+++ b/.agentplane/tasks/202605260641-H5JAWT/README.md
@@ -1,0 +1,148 @@
+---
+id: "202605260641-H5JAWT"
+title: "Block unstaged generated task artifacts in pre-commit"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "git"
+  - "hooks"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-26T06:41:37.034Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-26T06:48:10.945Z"
+  updated_by: "CODER"
+  note: "Command: bun run test:precommit. Result: pass, 17 files and 145 tests passed. Scope: pre-commit hook/runtime regression suite, including generated task artifact guard and commit wrapper allow-tasks behavior. Command: node .agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Scope: AgentPlane routing policy."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Implement pre-commit protection so generated active task artifacts cannot be left untracked or unstaged during task commits."
+events:
+  -
+    type: "status"
+    at: "2026-05-26T06:41:51.119Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Implement pre-commit protection so generated active task artifacts cannot be left untracked or unstaged during task commits."
+  -
+    type: "verify"
+    at: "2026-05-26T06:48:10.945Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: bun run test:precommit. Result: pass, 17 files and 145 tests passed. Scope: pre-commit hook/runtime regression suite, including generated task artifact guard and commit wrapper allow-tasks behavior. Command: node .agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Scope: AgentPlane routing policy."
+doc_version: 3
+doc_updated_at: "2026-05-26T06:48:10.960Z"
+doc_updated_by: "CODER"
+description: "Add a pre-commit guard that prevents commits when generated active task artifacts such as blueprint snapshots or evaluator quality reports remain untracked or unstaged."
+sections:
+  Summary: |-
+    Block unstaged generated task artifacts in pre-commit
+
+    Add a pre-commit guard that prevents commits when generated active task artifacts such as blueprint snapshots or evaluator quality reports remain untracked or unstaged.
+  Scope: |-
+    - In scope: Add a pre-commit guard that prevents commits when generated active task artifacts such as blueprint snapshots or evaluator quality reports remain untracked or unstaged.
+    - Out of scope: unrelated refactors not required for "Block unstaged generated task artifacts in pre-commit".
+  Plan: |-
+    1. Inspect existing pre-commit/commit guard flow and task artifact path helpers.
+    2. Add a focused pre-commit check for generated active task artifacts left untracked or unstaged.
+    3. Cover raw git commit blocking and agentplane commit --allow-tasks compatibility with tests.
+    4. Run targeted tests plus routing validation.
+  Verify Steps: |-
+    1. Run `bun test packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts packages/agentplane/src/cli/run-cli.core.guard.commit-wrapper.refresh.test.ts`. Expected: raw pre-commit blocks unstaged generated task artifacts and the `agentplane commit --allow-tasks` path still stages task artifacts.
+    2. Run `node .agentplane/policy/check-routing.mjs`. Expected: policy routing remains valid.
+    3. Run `ap task verify-show 202605260641-H5JAWT`. Expected: blueprint evidence is current and task verification contract is readable.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-26T06:48:10.945Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Command: bun run test:precommit. Result: pass, 17 files and 145 tests passed. Scope: pre-commit hook/runtime regression suite, including generated task artifact guard and commit wrapper allow-tasks behavior. Command: node .agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Scope: AgentPlane routing policy.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-26T06:41:51.119Z, excerpt_hash=sha256:b28d50d1ba5d703b099532b39eed03469608dee56eab15b9b6cb8710da2e647c
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605260641-H5JAWT-generated-artifact-precommit/.agentplane/tasks/202605260641-H5JAWT/blueprint/resolved-snapshot.json
+    - old_digest: b114644e8a655cea0db073d39a69e41b909b75e4829f35abf503028b2f025148
+    - current_digest: b114644e8a655cea0db073d39a69e41b909b75e4829f35abf503028b2f025148
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605260641-H5JAWT
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Block unstaged generated task artifacts in pre-commit
+
+Add a pre-commit guard that prevents commits when generated active task artifacts such as blueprint snapshots or evaluator quality reports remain untracked or unstaged.
+
+## Scope
+
+- In scope: Add a pre-commit guard that prevents commits when generated active task artifacts such as blueprint snapshots or evaluator quality reports remain untracked or unstaged.
+- Out of scope: unrelated refactors not required for "Block unstaged generated task artifacts in pre-commit".
+
+## Plan
+
+1. Inspect existing pre-commit/commit guard flow and task artifact path helpers.
+2. Add a focused pre-commit check for generated active task artifacts left untracked or unstaged.
+3. Cover raw git commit blocking and agentplane commit --allow-tasks compatibility with tests.
+4. Run targeted tests plus routing validation.
+
+## Verify Steps
+
+1. Run `bun test packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts packages/agentplane/src/cli/run-cli.core.guard.commit-wrapper.refresh.test.ts`. Expected: raw pre-commit blocks unstaged generated task artifacts and the `agentplane commit --allow-tasks` path still stages task artifacts.
+2. Run `node .agentplane/policy/check-routing.mjs`. Expected: policy routing remains valid.
+3. Run `ap task verify-show 202605260641-H5JAWT`. Expected: blueprint evidence is current and task verification contract is readable.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-26T06:48:10.945Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: bun run test:precommit. Result: pass, 17 files and 145 tests passed. Scope: pre-commit hook/runtime regression suite, including generated task artifact guard and commit wrapper allow-tasks behavior. Command: node .agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Scope: AgentPlane routing policy.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-26T06:41:51.119Z, excerpt_hash=sha256:b28d50d1ba5d703b099532b39eed03469608dee56eab15b9b6cb8710da2e647c
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605260641-H5JAWT-generated-artifact-precommit/.agentplane/tasks/202605260641-H5JAWT/blueprint/resolved-snapshot.json
+- old_digest: b114644e8a655cea0db073d39a69e41b909b75e4829f35abf503028b2f025148
+- current_digest: b114644e8a655cea0db073d39a69e41b909b75e4829f35abf503028b2f025148
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605260641-H5JAWT
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605260641-H5JAWT/README.md
+++ b/.agentplane/tasks/202605260641-H5JAWT/README.md
@@ -4,7 +4,7 @@ title: "Block unstaged generated task artifacts in pre-commit"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -26,24 +26,26 @@ verification:
   attempts: 0
 quality_review:
   state: "pass"
-  updated_at: "2026-05-26T06:48:51.605Z"
+  updated_at: "2026-05-26T06:56:24.130Z"
   updated_by: "EVALUATOR"
-  note: "Pre-commit now blocks unstaged generated active task artifacts while preserving the agentplane commit --allow-tasks path."
-  evaluated_sha: "217cee043ccf1ada34247200da4d290f4c7b934b"
+  note: "Final review after formatting and lint fixes: pre-commit generated-artifact guard is covered and local verification is green."
+  evaluated_sha: "8c80eadcb5a5c115c26f1386dd9dffca2b50e805"
   blueprint_digest: "b114644e8a655cea0db073d39a69e41b909b75e4829f35abf503028b2f025148"
   evidence_refs:
     - ".agentplane/tasks/202605260641-H5JAWT/README.md"
-    - ".agentplane/tasks/202605260641-H5JAWT/quality/20260526-064851605-recovery-context/quality-report.json"
-    - ".agentplane/tasks/202605260641-H5JAWT/quality/20260526-064851605-recovery-context/evaluator-prompt.md"
-    - ".agentplane/tasks/202605260641-H5JAWT/quality/20260526-064851605-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605260641-H5JAWT/quality/20260526-065624130-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605260641-H5JAWT/quality/20260526-065624130-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605260641-H5JAWT/quality/20260526-065624130-recovery-context/evaluator-opinion.md"
     - ".agentplane/tasks/202605260641-H5JAWT/blueprint/resolved-snapshot.json"
     - "packages/agentplane/src/commands/hooks/run.pre-commit.ts"
     - "packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts"
+    - "bun run format:check"
+    - "bun run lint:core"
     - "bun run test:precommit"
     - "node .agentplane/policy/check-routing.mjs"
   findings:
-    - "Generated blueprint and evaluator artifacts are detected from git changed paths and rejected when absent from the index."
-    - "Focused hook and commit-wrapper tests cover raw pre-commit blocking, staged artifact acceptance, and allow-tasks auto-staging."
+    - "The guard blocks generated active task artifacts when they are changed but absent from the index, and reports exact files plus the agentplane commit --allow-tasks remediation."
+    - "Local checks now include format:check, lint:core, and the precommit test suite after the hosted CI failures were addressed."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202605260641-H5JAWT/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605260641-H5JAWT/blueprint/resolved-snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605260641-H5JAWT",
+    "title": "Block unstaged generated task artifacts in pre-commit",
+    "description": "Add a pre-commit guard that prevents commits when generated active task artifacts such as blueprint snapshots or evaluator quality reports remain untracked or unstaged.",
+    "tags": [
+      "code",
+      "git",
+      "hooks"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605260641-H5JAWT",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "b114644e8a655cea0db073d39a69e41b909b75e4829f35abf503028b2f025148"
+  }
+}

--- a/.agentplane/tasks/202605260641-H5JAWT/pr/diffstat.txt
+++ b/.agentplane/tasks/202605260641-H5JAWT/pr/diffstat.txt
@@ -1,3 +1,3 @@
- .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 82 ++++++++++++++++++++
- .../src/commands/hooks/run.pre-commit.ts           | 87 +++++++++++++++++++++-
- 2 files changed, 167 insertions(+), 2 deletions(-)
+ .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 78 +++++++++++++++++++
+ .../src/commands/hooks/run.pre-commit.ts           | 90 +++++++++++++++++++++-
+ 2 files changed, 166 insertions(+), 2 deletions(-)

--- a/.agentplane/tasks/202605260641-H5JAWT/pr/diffstat.txt
+++ b/.agentplane/tasks/202605260641-H5JAWT/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 82 ++++++++++++++++++++
+ .../src/commands/hooks/run.pre-commit.ts           | 87 +++++++++++++++++++++-
+ 2 files changed, 167 insertions(+), 2 deletions(-)

--- a/.agentplane/tasks/202605260641-H5JAWT/pr/diffstat.txt
+++ b/.agentplane/tasks/202605260641-H5JAWT/pr/diffstat.txt
@@ -1,3 +1,3 @@
- .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 78 +++++++++++++++++++
- .../src/commands/hooks/run.pre-commit.ts           | 90 +++++++++++++++++++++-
- 2 files changed, 166 insertions(+), 2 deletions(-)
+ .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 139 +++++++++++++++++++++
+ .../src/commands/hooks/run.pre-commit.ts           |  89 ++++++++++++-
+ 2 files changed, 226 insertions(+), 2 deletions(-)

--- a/.agentplane/tasks/202605260641-H5JAWT/pr/github-body.md
+++ b/.agentplane/tasks/202605260641-H5JAWT/pr/github-body.md
@@ -34,9 +34,9 @@ bun run test:precommit. Result: pass, 17 files and 145 tests passed. Scope: pre-
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
- .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 82 ++++++++++++++++++++
- .../src/commands/hooks/run.pre-commit.ts           | 87 +++++++++++++++++++++-
- 2 files changed, 167 insertions(+), 2 deletions(-)
+ .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 78 +++++++++++++++++++
+ .../src/commands/hooks/run.pre-commit.ts           | 90 +++++++++++++++++++++-
+ 2 files changed, 166 insertions(+), 2 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605260641-H5JAWT/pr/github-body.md
+++ b/.agentplane/tasks/202605260641-H5JAWT/pr/github-body.md
@@ -1,0 +1,42 @@
+Task: `202605260641-H5JAWT`
+Title: Block unstaged generated task artifacts in pre-commit
+Canonical task record: `.agentplane/tasks/202605260641-H5JAWT/README.md`
+
+## Summary
+
+Block unstaged generated task artifacts in pre-commit
+
+Add a pre-commit guard that prevents commits when generated active task artifacts such as blueprint snapshots or evaluator quality reports remain untracked or unstaged.
+
+## Scope
+
+- In scope: Add a pre-commit guard that prevents commits when generated active task artifacts such as blueprint snapshots or evaluator quality reports remain untracked or unstaged.
+- Out of scope: unrelated refactors not required for "Block unstaged generated task artifacts in pre-commit".
+
+## Verification
+
+- State: ok
+- Note:
+
+```bash
+bun run test:precommit. Result: pass, 17 files and 145 tests passed. Scope: pre-commit hook/runtime \
+  regression suite, including generated task artifact guard and commit wrapper allow-tasks behavior. \
+  Command: node .agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Scope: \
+  AgentPlane routing policy.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-26T06:41:51.179Z
+- Branch: task/202605260641-H5JAWT/generated-artifact-precommit
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 82 ++++++++++++++++++++
+ .../src/commands/hooks/run.pre-commit.ts           | 87 +++++++++++++++++++++-
+ 2 files changed, 167 insertions(+), 2 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605260641-H5JAWT/pr/github-body.md
+++ b/.agentplane/tasks/202605260641-H5JAWT/pr/github-body.md
@@ -34,9 +34,9 @@ bun run test:precommit. Result: pass, 17 files and 145 tests passed. Scope: pre-
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
- .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 78 +++++++++++++++++++
- .../src/commands/hooks/run.pre-commit.ts           | 90 +++++++++++++++++++++-
- 2 files changed, 166 insertions(+), 2 deletions(-)
+ .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 139 +++++++++++++++++++++
+ .../src/commands/hooks/run.pre-commit.ts           |  89 ++++++++++++-
+ 2 files changed, 226 insertions(+), 2 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605260641-H5JAWT/pr/github-title.txt
+++ b/.agentplane/tasks/202605260641-H5JAWT/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 H5JAWT task: Block unstaged generated task artifacts in pre-commit [202605260641-H5JAWT]

--- a/.agentplane/tasks/202605260641-H5JAWT/pr/meta.json
+++ b/.agentplane/tasks/202605260641-H5JAWT/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605260641-H5JAWT/generated-artifact-precommit",
+  "created_at": "2026-05-26T06:41:51.179Z",
+  "diffstat_sha256": "sha256:e1660851a78f626ea3170d8c8f3f8dcb77b75ca3b598bb62fe10a1ba92ecd098",
+  "last_verified_at": "2026-05-26T06:48:10.945Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202605260641-H5JAWT",
+  "updated_at": "2026-05-26T06:41:51.179Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605260641-H5JAWT/pr/meta.json
+++ b/.agentplane/tasks/202605260641-H5JAWT/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605260641-H5JAWT/generated-artifact-precommit",
   "created_at": "2026-05-26T06:41:51.179Z",
-  "diffstat_sha256": "sha256:aadd34bf7feb9a1e861bf4f756f0a12f579a3274d2dafd7da8902be4d7ab262e",
+  "diffstat_sha256": "sha256:06037bad19ff2a5f15201c5be31483a4a9b62968a53171a8d05b4d36ffd96882",
   "last_verified_at": "2026-05-26T06:48:10.945Z",
   "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "schema_version": 1,

--- a/.agentplane/tasks/202605260641-H5JAWT/pr/meta.json
+++ b/.agentplane/tasks/202605260641-H5JAWT/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605260641-H5JAWT/generated-artifact-precommit",
   "created_at": "2026-05-26T06:41:51.179Z",
-  "diffstat_sha256": "sha256:e1660851a78f626ea3170d8c8f3f8dcb77b75ca3b598bb62fe10a1ba92ecd098",
+  "diffstat_sha256": "sha256:aadd34bf7feb9a1e861bf4f756f0a12f579a3274d2dafd7da8902be4d7ab262e",
   "last_verified_at": "2026-05-26T06:48:10.945Z",
   "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "schema_version": 1,

--- a/.agentplane/tasks/202605260641-H5JAWT/pr/review.md
+++ b/.agentplane/tasks/202605260641-H5JAWT/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-05-26T06:41:51.179Z
+
+## Task
+
+- Task: `202605260641-H5JAWT`
+- Title: Block unstaged generated task artifacts in pre-commit
+- Status: DOING
+- Branch: `task/202605260641-H5JAWT/generated-artifact-precommit`
+- Canonical task record: `.agentplane/tasks/202605260641-H5JAWT/README.md`
+
+## Verification
+
+- State: ok
+- Note: Command: bun run test:precommit. Result: pass, 17 files and 145 tests passed. Scope: pre-commit hook/runtime regression suite, including generated task artifact guard and commit wrapper allow-tasks behavior. Command: node .agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Scope: AgentPlane routing policy.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-26T06:41:51.179Z
+- Branch: task/202605260641-H5JAWT/generated-artifact-precommit
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 82 ++++++++++++++++++++
+ .../src/commands/hooks/run.pre-commit.ts           | 87 +++++++++++++++++++++-
+ 2 files changed, 167 insertions(+), 2 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605260641-H5JAWT/pr/review.md
+++ b/.agentplane/tasks/202605260641-H5JAWT/pr/review.md
@@ -29,9 +29,9 @@ Created: 2026-05-26T06:41:51.179Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
- .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 78 +++++++++++++++++++
- .../src/commands/hooks/run.pre-commit.ts           | 90 +++++++++++++++++++++-
- 2 files changed, 166 insertions(+), 2 deletions(-)
+ .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 139 +++++++++++++++++++++
+ .../src/commands/hooks/run.pre-commit.ts           |  89 ++++++++++++-
+ 2 files changed, 226 insertions(+), 2 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605260641-H5JAWT/pr/review.md
+++ b/.agentplane/tasks/202605260641-H5JAWT/pr/review.md
@@ -29,9 +29,9 @@ Created: 2026-05-26T06:41:51.179Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
- .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 82 ++++++++++++++++++++
- .../src/commands/hooks/run.pre-commit.ts           | 87 +++++++++++++++++++++-
- 2 files changed, 167 insertions(+), 2 deletions(-)
+ .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 78 +++++++++++++++++++
+ .../src/commands/hooks/run.pre-commit.ts           | 90 +++++++++++++++++++++-
+ 2 files changed, 166 insertions(+), 2 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605260641-H5JAWT/quality/20260526-064851605-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605260641-H5JAWT/quality/20260526-064851605-recovery-context/evaluator-opinion.md
@@ -1,0 +1,23 @@
+# EVALUATOR opinion: pass
+
+Pre-commit now blocks unstaged generated active task artifacts while preserving the agentplane commit --allow-tasks path.
+
+## Findings
+- Generated blueprint and evaluator artifacts are detected from git changed paths and rejected when absent from the index.
+- Focused hook and commit-wrapper tests cover raw pre-commit blocking, staged artifact acceptance, and allow-tasks auto-staging.
+
+## Evidence
+- .agentplane/tasks/202605260641-H5JAWT/README.md
+- packages/agentplane/src/commands/hooks/run.pre-commit.ts
+- packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts
+- bun run test:precommit
+- node .agentplane/policy/check-routing.mjs
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202605260641-H5JAWT/quality/20260526-064851605-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605260641-H5JAWT/quality/20260526-064851605-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605260641-H5JAWT
+- task_readme: .agentplane/tasks/202605260641-H5JAWT/README.md
+- report_path: .agentplane/tasks/202605260641-H5JAWT/quality/20260526-064851605-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605260641-H5JAWT/quality/20260526-064851605-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605260641-H5JAWT/quality/20260526-064851605-recovery-context/quality-report.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "task_id": "202605260641-H5JAWT",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-26T06:48:51.605Z",
+  "verdict": "pass",
+  "summary": "Pre-commit now blocks unstaged generated active task artifacts while preserving the agentplane commit --allow-tasks path.",
+  "evaluated_sha": "217cee043ccf1ada34247200da4d290f4c7b934b",
+  "blueprint_digest": "b114644e8a655cea0db073d39a69e41b909b75e4829f35abf503028b2f025148",
+  "findings": [
+    "Generated blueprint and evaluator artifacts are detected from git changed paths and rejected when absent from the index.",
+    "Focused hook and commit-wrapper tests cover raw pre-commit blocking, staged artifact acceptance, and allow-tasks auto-staging."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605260641-H5JAWT/README.md",
+    "packages/agentplane/src/commands/hooks/run.pre-commit.ts",
+    "packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts",
+    "bun run test:precommit",
+    "node .agentplane/policy/check-routing.mjs"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/.agentplane/tasks/202605260641-H5JAWT/quality/20260526-065624130-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605260641-H5JAWT/quality/20260526-065624130-recovery-context/evaluator-opinion.md
@@ -1,0 +1,25 @@
+# EVALUATOR opinion: pass
+
+Final review after formatting and lint fixes: pre-commit generated-artifact guard is covered and local verification is green.
+
+## Findings
+- The guard blocks generated active task artifacts when they are changed but absent from the index, and reports exact files plus the agentplane commit --allow-tasks remediation.
+- Local checks now include format:check, lint:core, and the precommit test suite after the hosted CI failures were addressed.
+
+## Evidence
+- .agentplane/tasks/202605260641-H5JAWT/README.md
+- packages/agentplane/src/commands/hooks/run.pre-commit.ts
+- packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts
+- bun run format:check
+- bun run lint:core
+- bun run test:precommit
+- node .agentplane/policy/check-routing.mjs
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202605260641-H5JAWT/quality/20260526-065624130-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605260641-H5JAWT/quality/20260526-065624130-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605260641-H5JAWT
+- task_readme: .agentplane/tasks/202605260641-H5JAWT/README.md
+- report_path: .agentplane/tasks/202605260641-H5JAWT/quality/20260526-065624130-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605260641-H5JAWT/quality/20260526-065624130-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605260641-H5JAWT/quality/20260526-065624130-recovery-context/quality-report.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "task_id": "202605260641-H5JAWT",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-26T06:56:24.130Z",
+  "verdict": "pass",
+  "summary": "Final review after formatting and lint fixes: pre-commit generated-artifact guard is covered and local verification is green.",
+  "evaluated_sha": "8c80eadcb5a5c115c26f1386dd9dffca2b50e805",
+  "blueprint_digest": "b114644e8a655cea0db073d39a69e41b909b75e4829f35abf503028b2f025148",
+  "findings": [
+    "The guard blocks generated active task artifacts when they are changed but absent from the index, and reports exact files plus the agentplane commit --allow-tasks remediation.",
+    "Local checks now include format:check, lint:core, and the precommit test suite after the hosted CI failures were addressed."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605260641-H5JAWT/README.md",
+    "packages/agentplane/src/commands/hooks/run.pre-commit.ts",
+    "packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts",
+    "bun run format:check",
+    "bun run lint:core",
+    "bun run test:precommit",
+    "node .agentplane/policy/check-routing.mjs"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts
@@ -118,12 +118,8 @@ describe("runCli hooks pre-commit guards", () => {
       const code = await runCli(["hooks", "run", "pre-commit", "--root", root]);
       expect(code).toBe(5);
       expect(io.stderr).toContain("Generated task artifacts are not staged.");
-      expect(io.stderr).toContain(
-        `.agentplane/tasks/${taskId}/quality/run/quality-report.json`,
-      );
-      expect(io.stderr).toContain(
-        `.agentplane/tasks/${taskId}/quality/run/evaluator-opinion.md`,
-      );
+      expect(io.stderr).toContain(`.agentplane/tasks/${taskId}/quality/run/quality-report.json`);
+      expect(io.stderr).toContain(`.agentplane/tasks/${taskId}/quality/run/evaluator-opinion.md`);
       expect(io.stderr).toContain("agentplane commit <task-id>");
     } finally {
       io.restore();

--- a/packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts
@@ -49,7 +49,9 @@ describe("runCli hooks pre-commit guards", () => {
     await execFileAsync("git", ["add", "src/app.ts"], { cwd: root });
 
     const prev = process.env.AGENTPLANE_TASK_ID;
+    const prevAllowTasks = process.env.AGENTPLANE_ALLOW_TASKS;
     delete process.env.AGENTPLANE_TASK_ID;
+    process.env.AGENTPLANE_ALLOW_TASKS = "1";
 
     const io = captureStdIO();
     try {
@@ -59,6 +61,7 @@ describe("runCli hooks pre-commit guards", () => {
     } finally {
       io.restore();
       restoreEnv("AGENTPLANE_TASK_ID", prev);
+      restoreEnv("AGENTPLANE_ALLOW_TASKS", prevAllowTasks);
     }
   });
 
@@ -72,7 +75,9 @@ describe("runCli hooks pre-commit guards", () => {
     await execFileAsync("git", ["add", "src/app.ts"], { cwd: root });
 
     const prev = process.env.AGENTPLANE_TASK_ID;
+    const prevAllowTasks = process.env.AGENTPLANE_ALLOW_TASKS;
     delete process.env.AGENTPLANE_TASK_ID;
+    process.env.AGENTPLANE_ALLOW_TASKS = "1";
 
     const io = captureStdIO();
     try {
@@ -81,6 +86,83 @@ describe("runCli hooks pre-commit guards", () => {
     } finally {
       io.restore();
       restoreEnv("AGENTPLANE_TASK_ID", prev);
+      restoreEnv("AGENTPLANE_ALLOW_TASKS", prevAllowTasks);
+    }
+  });
+
+  it("hooks run pre-commit blocks generated active task artifacts that are not staged", async () => {
+    const taskId = "202601010101-ABCDEF";
+    const root = await mkGitRepoRootWithBranch(`task/${taskId}/hook-scope`);
+    await writeDefaultConfig(root);
+    await mkdir(`${root}/src`, { recursive: true });
+    await mkdir(`${root}/.agentplane/tasks/${taskId}/quality/run`, { recursive: true });
+    await writeFile(`${root}/src/app.ts`, "export const value = 1;\n", "utf8");
+    await writeFile(
+      `${root}/.agentplane/tasks/${taskId}/quality/run/quality-report.json`,
+      "{}\n",
+      "utf8",
+    );
+    await writeFile(
+      `${root}/.agentplane/tasks/${taskId}/quality/run/evaluator-opinion.md`,
+      "# Opinion\n",
+      "utf8",
+    );
+    const execFileAsync = promisify(execFile);
+    await execFileAsync("git", ["add", "src/app.ts"], { cwd: root });
+
+    const prev = process.env.AGENTPLANE_TASK_ID;
+    delete process.env.AGENTPLANE_TASK_ID;
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["hooks", "run", "pre-commit", "--root", root]);
+      expect(code).toBe(5);
+      expect(io.stderr).toContain("Generated task artifacts are not staged.");
+      expect(io.stderr).toContain(
+        `.agentplane/tasks/${taskId}/quality/run/quality-report.json`,
+      );
+      expect(io.stderr).toContain(
+        `.agentplane/tasks/${taskId}/quality/run/evaluator-opinion.md`,
+      );
+      expect(io.stderr).toContain("agentplane commit <task-id>");
+    } finally {
+      io.restore();
+      restoreEnv("AGENTPLANE_TASK_ID", prev);
+    }
+  });
+
+  it("hooks run pre-commit allows generated active task artifacts when they are staged", async () => {
+    const taskId = "202601010101-ABCDEF";
+    const root = await mkGitRepoRootWithBranch(`task/${taskId}/hook-scope`);
+    await writeDefaultConfig(root);
+    await mkdir(`${root}/src`, { recursive: true });
+    await mkdir(`${root}/.agentplane/tasks/${taskId}/blueprint`, { recursive: true });
+    await writeFile(`${root}/src/app.ts`, "export const value = 1;\n", "utf8");
+    await writeFile(
+      `${root}/.agentplane/tasks/${taskId}/blueprint/resolved-snapshot.json`,
+      "{}\n",
+      "utf8",
+    );
+    const execFileAsync = promisify(execFile);
+    await execFileAsync(
+      "git",
+      ["add", "src/app.ts", `.agentplane/tasks/${taskId}/blueprint/resolved-snapshot.json`],
+      { cwd: root },
+    );
+
+    const prev = process.env.AGENTPLANE_TASK_ID;
+    const prevAllowTasks = process.env.AGENTPLANE_ALLOW_TASKS;
+    delete process.env.AGENTPLANE_TASK_ID;
+    process.env.AGENTPLANE_ALLOW_TASKS = "1";
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["hooks", "run", "pre-commit", "--root", root]);
+      expect(code).toBe(0);
+    } finally {
+      io.restore();
+      restoreEnv("AGENTPLANE_TASK_ID", prev);
+      restoreEnv("AGENTPLANE_ALLOW_TASKS", prevAllowTasks);
     }
   });
 

--- a/packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts
@@ -127,6 +127,67 @@ describe("runCli hooks pre-commit guards", () => {
     }
   });
 
+  it("hooks run pre-commit blocks partially staged generated active task artifacts", async () => {
+    const taskId = "202601010101-ABCDEF";
+    const root = await mkGitRepoRootWithBranch(`task/${taskId}/hook-scope`);
+    await writeDefaultConfig(root);
+    await mkdir(`${root}/src`, { recursive: true });
+    await mkdir(`${root}/.agentplane/tasks/${taskId}/quality/run`, { recursive: true });
+    const reportPath = `.agentplane/tasks/${taskId}/quality/run/quality-report.json`;
+    await writeFile(`${root}/src/app.ts`, "export const value = 1;\n", "utf8");
+    await writeFile(`${root}/${reportPath}`, '{"status":"staged"}\n', "utf8");
+    const execFileAsync = promisify(execFile);
+    await execFileAsync("git", ["add", "src/app.ts", reportPath], { cwd: root });
+    await writeFile(`${root}/${reportPath}`, '{"status":"unstaged"}\n', "utf8");
+
+    const prev = process.env.AGENTPLANE_TASK_ID;
+    delete process.env.AGENTPLANE_TASK_ID;
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["hooks", "run", "pre-commit", "--root", root]);
+      expect(code).toBe(5);
+      expect(io.stderr).toContain("Generated task artifacts are not staged.");
+      expect(io.stderr).toContain(reportPath);
+    } finally {
+      io.restore();
+      restoreEnv("AGENTPLANE_TASK_ID", prev);
+    }
+  });
+
+  it("hooks run pre-commit does not infer active task context from unstaged task artifacts", async () => {
+    const taskId = "202601010101-ABCDEF";
+    const root = await mkGitRepoRootWithBranch("main");
+    await writeDefaultConfig(root);
+    await mkdir(`${root}/src`, { recursive: true });
+    await mkdir(`${root}/.agentplane/tasks/${taskId}/quality/run`, { recursive: true });
+    await writeFile(`${root}/src/app.ts`, "export const value = 1;\n", "utf8");
+    await writeFile(
+      `${root}/.agentplane/tasks/${taskId}/quality/run/quality-report.json`,
+      "{}\n",
+      "utf8",
+    );
+    const execFileAsync = promisify(execFile);
+    await execFileAsync("git", ["add", "src/app.ts"], { cwd: root });
+
+    const prev = process.env.AGENTPLANE_TASK_ID;
+    const prevAllowTasks = process.env.AGENTPLANE_ALLOW_TASKS;
+    delete process.env.AGENTPLANE_TASK_ID;
+    process.env.AGENTPLANE_ALLOW_TASKS = "1";
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["hooks", "run", "pre-commit", "--root", root]);
+      expect(code).toBe(5);
+      expect(io.stderr).toContain("Mutating staged paths require an active AgentPlane task");
+      expect(io.stderr).not.toContain("Generated task artifacts are not staged.");
+    } finally {
+      io.restore();
+      restoreEnv("AGENTPLANE_TASK_ID", prev);
+      restoreEnv("AGENTPLANE_ALLOW_TASKS", prevAllowTasks);
+    }
+  });
+
   it("hooks run pre-commit allows generated active task artifacts when they are staged", async () => {
     const taskId = "202601010101-ABCDEF";
     const root = await mkGitRepoRootWithBranch(`task/${taskId}/hook-scope`);

--- a/packages/agentplane/src/commands/hooks/run.pre-commit.ts
+++ b/packages/agentplane/src/commands/hooks/run.pre-commit.ts
@@ -3,6 +3,7 @@ import { resolveProject } from "@agentplaneorg/core/project";
 import { resolveBaseBranch, GitContext } from "@agentplaneorg/core/git";
 
 import { evaluatePolicy } from "../../policy/evaluate.js";
+import { CliError } from "../../shared/errors.js";
 import { throwIfPolicyDenied } from "../shared/policy-deny.js";
 import type { HooksRunOptions } from "./run.js";
 import {
@@ -12,12 +13,86 @@ import {
   readTaskIntent,
 } from "./task-context.js";
 
+function normalizeGitPath(value: string): string {
+  return value.replaceAll("\\", "/").replaceAll(/\/+/g, "/").replaceAll(/^\/+|\/+$/g, "");
+}
+
+function taskPathPrefix(workflowDir: string, taskId: string): string {
+  return `${normalizeGitPath(workflowDir)}/${taskId}/`;
+}
+
+function taskIdFromTaskPath(filePath: string, workflowDir: string): string {
+  const normalized = normalizeGitPath(filePath);
+  const prefix = `${normalizeGitPath(workflowDir)}/`;
+  if (!normalized.startsWith(prefix)) return "";
+  return normalized.slice(prefix.length).split("/")[0] ?? "";
+}
+
+function isGeneratedTaskArtifact(filePath: string, workflowDir: string, taskId: string): boolean {
+  const normalized = normalizeGitPath(filePath);
+  const prefix = taskPathPrefix(workflowDir, taskId);
+  if (!normalized.startsWith(prefix)) return false;
+  const relative = normalized.slice(prefix.length);
+  if (relative === "blueprint/resolved-snapshot.json") return true;
+  if (!relative.startsWith("quality/")) return false;
+  return (
+    relative.endsWith("/quality-report.json") ||
+    relative.endsWith("/evaluator-prompt.md") ||
+    relative.endsWith("/evaluator-opinion.md")
+  );
+}
+
+function inferSingleTaskIdFromPaths(paths: string[], workflowDir: string): string {
+  const taskIds = [
+    ...new Set(
+      paths
+        .map((filePath) => taskIdFromTaskPath(filePath, workflowDir))
+        .filter((taskId) => taskId.length > 0),
+    ),
+  ];
+  return taskIds.length === 1 ? (taskIds[0] ?? "") : "";
+}
+
+function assertGeneratedTaskArtifactsStaged(opts: {
+  changed: string[];
+  staged: string[];
+  workflowDir: string;
+  taskId: string;
+}): void {
+  if (!opts.taskId) return;
+  const staged = new Set(opts.staged.map(normalizeGitPath));
+  const missing = opts.changed
+    .map(normalizeGitPath)
+    .filter((filePath) => isGeneratedTaskArtifact(filePath, opts.workflowDir, opts.taskId))
+    .filter((filePath) => !staged.has(filePath))
+    .toSorted((a, b) => a.localeCompare(b));
+  if (missing.length === 0) return;
+
+  throw new CliError({
+    exitCode: 5,
+    code: "E_GIT",
+    message: [
+      "Generated task artifacts are not staged.",
+      `task=${opts.taskId}`,
+      "Stage these files or use `agentplane commit <task-id> -m \"...\" --allow-tasks`:",
+      ...missing.map((filePath) => `- ${filePath}`),
+    ].join("\n"),
+    context: {
+      task_id: opts.taskId,
+      unstaged_generated_task_artifacts: missing,
+      remediation:
+        "Stage generated task artifacts before committing, or use agentplane commit with --allow-tasks so the active task subtree is staged automatically.",
+    },
+  });
+}
+
 export async function runPreCommitHook(opts: HooksRunOptions): Promise<number> {
   const resolved = await resolveProject({
     cwd: opts.cwd,
     rootOverride: opts.rootOverride ?? null,
   });
-  const staged = await new GitContext({ gitRoot: resolved.gitRoot }).statusStagedPaths();
+  const git = new GitContext({ gitRoot: resolved.gitRoot });
+  const staged = await git.statusStagedPaths();
   if (staged.length === 0) return 0;
 
   const loaded = await loadConfig(resolved.agentplaneDir);
@@ -31,13 +106,21 @@ export async function runPreCommitHook(opts: HooksRunOptions): Promise<number> {
       })
     : null;
   const currentBranch = await currentBranchOrUndefined(resolved.gitRoot);
+  const changed = await git.statusChangedPaths();
   const taskId =
     (process.env.AGENTPLANE_TASK_ID ?? "").trim() ||
     inferTaskIdFromBranch(
       currentBranch,
       loaded.config.branch.task_prefix,
       loaded.config.branch.task_close_prefix,
-    );
+    ) ||
+    inferSingleTaskIdFromPaths([...staged, ...changed], loaded.config.paths.workflow_dir);
+  assertGeneratedTaskArtifactsStaged({
+    changed,
+    staged,
+    workflowDir: loaded.config.paths.workflow_dir,
+    taskId,
+  });
   const taskIntent = taskId
     ? await readTaskIntent({
         gitRoot: resolved.gitRoot,

--- a/packages/agentplane/src/commands/hooks/run.pre-commit.ts
+++ b/packages/agentplane/src/commands/hooks/run.pre-commit.ts
@@ -57,17 +57,14 @@ function inferSingleTaskIdFromPaths(paths: string[], workflowDir: string): strin
 }
 
 function assertGeneratedTaskArtifactsStaged(opts: {
-  changed: string[];
-  staged: string[];
+  unstaged: string[];
   workflowDir: string;
   taskId: string;
 }): void {
   if (!opts.taskId) return;
-  const staged = new Set(opts.staged.map((filePath) => normalizeGitPath(filePath)));
-  const missing = opts.changed
+  const missing = opts.unstaged
     .map((filePath) => normalizeGitPath(filePath))
     .filter((filePath) => isGeneratedTaskArtifact(filePath, opts.workflowDir, opts.taskId))
-    .filter((filePath) => !staged.has(filePath))
     .toSorted((a, b) => a.localeCompare(b));
   if (missing.length === 0) return;
 
@@ -109,7 +106,10 @@ export async function runPreCommitHook(opts: HooksRunOptions): Promise<number> {
       })
     : null;
   const currentBranch = await currentBranchOrUndefined(resolved.gitRoot);
-  const changed = await git.statusChangedPaths();
+  const [unstagedTracked, untracked] = await Promise.all([
+    git.statusUnstagedTrackedPaths(),
+    git.statusUntrackedPaths(),
+  ]);
   const taskId =
     (process.env.AGENTPLANE_TASK_ID ?? "").trim() ||
     inferTaskIdFromBranch(
@@ -117,10 +117,9 @@ export async function runPreCommitHook(opts: HooksRunOptions): Promise<number> {
       loaded.config.branch.task_prefix,
       loaded.config.branch.task_close_prefix,
     ) ||
-    inferSingleTaskIdFromPaths([...staged, ...changed], loaded.config.paths.workflow_dir);
+    inferSingleTaskIdFromPaths(staged, loaded.config.paths.workflow_dir);
   assertGeneratedTaskArtifactsStaged({
-    changed,
-    staged,
+    unstaged: [...unstagedTracked, ...untracked],
     workflowDir: loaded.config.paths.workflow_dir,
     taskId,
   });

--- a/packages/agentplane/src/commands/hooks/run.pre-commit.ts
+++ b/packages/agentplane/src/commands/hooks/run.pre-commit.ts
@@ -14,7 +14,10 @@ import {
 } from "./task-context.js";
 
 function normalizeGitPath(value: string): string {
-  return value.replaceAll("\\", "/").replaceAll(/\/+/g, "/").replaceAll(/^\/+|\/+$/g, "");
+  return value
+    .replaceAll("\\", "/")
+    .replaceAll(/\/+/g, "/")
+    .replaceAll(/^\/+|\/+$/g, "");
 }
 
 function taskPathPrefix(workflowDir: string, taskId: string): string {
@@ -60,9 +63,9 @@ function assertGeneratedTaskArtifactsStaged(opts: {
   taskId: string;
 }): void {
   if (!opts.taskId) return;
-  const staged = new Set(opts.staged.map(normalizeGitPath));
+  const staged = new Set(opts.staged.map((filePath) => normalizeGitPath(filePath)));
   const missing = opts.changed
-    .map(normalizeGitPath)
+    .map((filePath) => normalizeGitPath(filePath))
     .filter((filePath) => isGeneratedTaskArtifact(filePath, opts.workflowDir, opts.taskId))
     .filter((filePath) => !staged.has(filePath))
     .toSorted((a, b) => a.localeCompare(b));
@@ -74,7 +77,7 @@ function assertGeneratedTaskArtifactsStaged(opts: {
     message: [
       "Generated task artifacts are not staged.",
       `task=${opts.taskId}`,
-      "Stage these files or use `agentplane commit <task-id> -m \"...\" --allow-tasks`:",
+      'Stage these files or use `agentplane commit <task-id> -m "..." --allow-tasks`:',
       ...missing.map((filePath) => `- ${filePath}`),
     ].join("\n"),
     context: {


### PR DESCRIPTION
Task: `202605260641-H5JAWT`
Title: Block unstaged generated task artifacts in pre-commit
Canonical task record: `.agentplane/tasks/202605260641-H5JAWT/README.md`

## Summary

Block unstaged generated task artifacts in pre-commit

Add a pre-commit guard that prevents commits when generated active task artifacts such as blueprint snapshots or evaluator quality reports remain untracked or unstaged.

## Scope

- In scope: Add a pre-commit guard that prevents commits when generated active task artifacts such as blueprint snapshots or evaluator quality reports remain untracked or unstaged.
- Out of scope: unrelated refactors not required for "Block unstaged generated task artifacts in pre-commit".

## Verification

- State: ok
- Note:

```bash
bun run test:precommit. Result: pass, 17 files and 145 tests passed. Scope: pre-commit hook/runtime \
  regression suite, including generated task artifact guard and commit wrapper allow-tasks behavior. \
  Command: node .agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Scope: \
  AgentPlane routing policy.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-26T06:41:51.179Z
- Branch: task/202605260641-H5JAWT/generated-artifact-precommit
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 82 ++++++++++++++++++++
 .../src/commands/hooks/run.pre-commit.ts           | 87 +++++++++++++++++++++-
 2 files changed, 167 insertions(+), 2 deletions(-)
```

</details>
