### PR TITLE
🚧 F705MZ task: Route hook runtime changes to targeted local CI [202605260807-F705MZ]

### DIFF
--- a/.agentplane/tasks/202605260807-F705MZ/README.md
+++ b/.agentplane/tasks/202605260807-F705MZ/README.md
@@ -1,0 +1,203 @@
+---
+id: "202605260807-F705MZ"
+title: "Route hook runtime changes to targeted local CI"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "hooks"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-26T08:07:32.472Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-26T08:12:52.094Z"
+  updated_by: "CODER"
+  note: "Hook runtime local CI routing now resolves to targeted hooks route; targeted selector, lint, format, and hooks suites pass."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: update local CI hook bucket routing and selector coverage so hook runtime changes avoid full-fast release suites."
+events:
+  -
+    type: "status"
+    at: "2026-05-26T08:08:07.870Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: update local CI hook bucket routing and selector coverage so hook runtime changes avoid full-fast release suites."
+  -
+    type: "verify"
+    at: "2026-05-26T08:12:52.094Z"
+    author: "CODER"
+    state: "ok"
+    note: "Hook runtime local CI routing now resolves to targeted hooks route; targeted selector, lint, format, and hooks suites pass."
+doc_version: 3
+doc_updated_at: "2026-05-26T08:12:52.155Z"
+doc_updated_by: "CODER"
+description: "Make local CI classify packages/agentplane/src/commands/hooks changes as hooks bucket so pre-push does not fall back to full-fast release suites for hook-only work."
+sections:
+  Summary: |-
+    Route hook runtime changes to targeted local CI
+
+    Make local CI classify packages/agentplane/src/commands/hooks changes as hooks bucket so pre-push does not fall back to full-fast release suites for hook-only work.
+  Scope: |-
+    - In scope: Make local CI classify packages/agentplane/src/commands/hooks changes as hooks bucket so pre-push does not fall back to full-fast release suites for hook-only work.
+    - Out of scope: unrelated refactors not required for "Route hook runtime changes to targeted local CI".
+  Plan: |-
+    1. Add packages/agentplane/src/commands/hooks to the hooks bucket in scripts/lib/local-ci-selection.mjs.
+    2. Add/adjust selector coverage in packages/agentplane/src/cli/local-ci-selection.test.ts so hook runtime + hook test changes resolve to targeted hooks, not full-fast.
+    3. Verify with selector explain, targeted unit tests, format/lint relevant to touched files, and hosted PR checks.
+    4. Open PR and merge to main after hosted green.
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-26T08:12:52.094Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Hook runtime local CI routing now resolves to targeted hooks route; targeted selector, lint, format, and hooks suites pass.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-26T08:08:07.870Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    Command: AGENTPLANE_FAST_CHANGED_FILES="packages/agentplane/src/commands/hooks/run.pre-commit.ts
+    packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts" node scripts/checks/run-local-ci.mjs --mode fast --explain
+    Result: pass
+    Evidence: selector targeted (hooks), execution route targeted-fast, includes run-cli.core.hooks.pre-commit.test.ts.
+    Scope: local CI routing for hook runtime changes.
+
+    Command: bun test packages/agentplane/src/cli/local-ci-selection.test.ts
+    Result: pass
+    Evidence: 55 pass, 0 fail.
+    Scope: selector regression coverage.
+
+    Command: bunx eslint scripts/lib/local-ci-selection.mjs scripts/lib/test-route-registry.mjs packages/agentplane/src/cli/local-ci-selection.test.ts
+    Result: pass
+    Evidence: exit 0.
+    Scope: touched JS/TS lint.
+
+    Command: bunx vitest run <hooks targeted test files> --pool=threads --testTimeout 60000 --hookTimeout 60000
+    Result: pass
+    Evidence: 8 files, 114 tests passed.
+    Scope: targeted hooks route tests.
+
+    Command: bun run format:check
+    Result: pass
+    Evidence: All matched files use Prettier code style.
+    Scope: repository formatting check.
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605260807-F705MZ-hook-runtime-ci-routing/.agentplane/tasks/202605260807-F705MZ/blueprint/resolved-snapshot.json
+    - old_digest: 414b65fa916f3044ce010fc407718c9ac453bc8f8b916584c2a34949a9343b63
+    - current_digest: 414b65fa916f3044ce010fc407718c9ac453bc8f8b916584c2a34949a9343b63
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605260807-F705MZ
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Route hook runtime changes to targeted local CI
+
+Make local CI classify packages/agentplane/src/commands/hooks changes as hooks bucket so pre-push does not fall back to full-fast release suites for hook-only work.
+
+## Scope
+
+- In scope: Make local CI classify packages/agentplane/src/commands/hooks changes as hooks bucket so pre-push does not fall back to full-fast release suites for hook-only work.
+- Out of scope: unrelated refactors not required for "Route hook runtime changes to targeted local CI".
+
+## Plan
+
+1. Add packages/agentplane/src/commands/hooks to the hooks bucket in scripts/lib/local-ci-selection.mjs.
+2. Add/adjust selector coverage in packages/agentplane/src/cli/local-ci-selection.test.ts so hook runtime + hook test changes resolve to targeted hooks, not full-fast.
+3. Verify with selector explain, targeted unit tests, format/lint relevant to touched files, and hosted PR checks.
+4. Open PR and merge to main after hosted green.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-26T08:12:52.094Z — VERIFY — ok
+
+By: CODER
+
+Note: Hook runtime local CI routing now resolves to targeted hooks route; targeted selector, lint, format, and hooks suites pass.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-26T08:08:07.870Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+Command: AGENTPLANE_FAST_CHANGED_FILES="packages/agentplane/src/commands/hooks/run.pre-commit.ts
+packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts" node scripts/checks/run-local-ci.mjs --mode fast --explain
+Result: pass
+Evidence: selector targeted (hooks), execution route targeted-fast, includes run-cli.core.hooks.pre-commit.test.ts.
+Scope: local CI routing for hook runtime changes.
+
+Command: bun test packages/agentplane/src/cli/local-ci-selection.test.ts
+Result: pass
+Evidence: 55 pass, 0 fail.
+Scope: selector regression coverage.
+
+Command: bunx eslint scripts/lib/local-ci-selection.mjs scripts/lib/test-route-registry.mjs packages/agentplane/src/cli/local-ci-selection.test.ts
+Result: pass
+Evidence: exit 0.
+Scope: touched JS/TS lint.
+
+Command: bunx vitest run <hooks targeted test files> --pool=threads --testTimeout 60000 --hookTimeout 60000
+Result: pass
+Evidence: 8 files, 114 tests passed.
+Scope: targeted hooks route tests.
+
+Command: bun run format:check
+Result: pass
+Evidence: All matched files use Prettier code style.
+Scope: repository formatting check.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605260807-F705MZ-hook-runtime-ci-routing/.agentplane/tasks/202605260807-F705MZ/blueprint/resolved-snapshot.json
+- old_digest: 414b65fa916f3044ce010fc407718c9ac453bc8f8b916584c2a34949a9343b63
+- current_digest: 414b65fa916f3044ce010fc407718c9ac453bc8f8b916584c2a34949a9343b63
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605260807-F705MZ
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605260807-F705MZ/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605260807-F705MZ/blueprint/resolved-snapshot.json
@@ -1,0 +1,571 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605260807-F705MZ",
+    "title": "Route hook runtime changes to targeted local CI",
+    "description": "Make local CI classify packages/agentplane/src/commands/hooks changes as hooks bucket so pre-push does not fall back to full-fast release suites for hook-only work.",
+    "tags": [
+      "code",
+      "hooks"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605260807-F705MZ",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "414b65fa916f3044ce010fc407718c9ac453bc8f8b916584c2a34949a9343b63"
+  }
+}

--- a/.agentplane/tasks/202605260807-F705MZ/pr/diffstat.txt
+++ b/.agentplane/tasks/202605260807-F705MZ/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ packages/agentplane/src/cli/local-ci-selection.test.ts | 13 +++++++++++++
+ scripts/lib/local-ci-selection.mjs                     |  1 +
+ scripts/lib/test-route-registry.mjs                    |  1 +
+ 3 files changed, 15 insertions(+)

--- a/.agentplane/tasks/202605260807-F705MZ/pr/github-body.md
+++ b/.agentplane/tasks/202605260807-F705MZ/pr/github-body.md
@@ -1,0 +1,38 @@
+Task: `202605260807-F705MZ`
+Title: Route hook runtime changes to targeted local CI
+Canonical task record: `.agentplane/tasks/202605260807-F705MZ/README.md`
+
+## Summary
+
+Route hook runtime changes to targeted local CI
+
+Make local CI classify packages/agentplane/src/commands/hooks changes as hooks bucket so pre-push does not fall back to full-fast release suites for hook-only work.
+
+## Scope
+
+- In scope: Make local CI classify packages/agentplane/src/commands/hooks changes as hooks bucket so pre-push does not fall back to full-fast release suites for hook-only work.
+- Out of scope: unrelated refactors not required for "Route hook runtime changes to targeted local CI".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Hook runtime local CI routing now resolves to targeted hooks route; targeted selector, lint, format,
+and hooks suites pass.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-26T08:08:08.069Z
+- Branch: task/202605260807-F705MZ/hook-runtime-ci-routing
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605260807-F705MZ/pr/github-body.md
+++ b/.agentplane/tasks/202605260807-F705MZ/pr/github-body.md
@@ -32,7 +32,10 @@ and hooks suites pass.
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ packages/agentplane/src/cli/local-ci-selection.test.ts | 13 +++++++++++++
+ scripts/lib/local-ci-selection.mjs                     |  1 +
+ scripts/lib/test-route-registry.mjs                    |  1 +
+ 3 files changed, 15 insertions(+)
 ```
 
 </details>

--- a/.agentplane/tasks/202605260807-F705MZ/pr/github-title.txt
+++ b/.agentplane/tasks/202605260807-F705MZ/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 F705MZ task: Route hook runtime changes to targeted local CI [202605260807-F705MZ]

--- a/.agentplane/tasks/202605260807-F705MZ/pr/meta.json
+++ b/.agentplane/tasks/202605260807-F705MZ/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605260807-F705MZ/hook-runtime-ci-routing",
+  "created_at": "2026-05-26T08:08:08.069Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": "2026-05-26T08:12:52.094Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202605260807-F705MZ",
+  "updated_at": "2026-05-26T08:08:08.069Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605260807-F705MZ/pr/meta.json
+++ b/.agentplane/tasks/202605260807-F705MZ/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605260807-F705MZ/hook-runtime-ci-routing",
   "created_at": "2026-05-26T08:08:08.069Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "diffstat_sha256": "sha256:ad86a9a136b651904cd8d448f9c3f7373a881f6cd71f66aa165d29c65afaf9d2",
   "last_verified_at": "2026-05-26T08:12:52.094Z",
   "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "schema_version": 1,

--- a/.agentplane/tasks/202605260807-F705MZ/pr/review.md
+++ b/.agentplane/tasks/202605260807-F705MZ/pr/review.md
@@ -29,7 +29,10 @@ Created: 2026-05-26T08:08:08.069Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ packages/agentplane/src/cli/local-ci-selection.test.ts | 13 +++++++++++++
+ scripts/lib/local-ci-selection.mjs                     |  1 +
+ scripts/lib/test-route-registry.mjs                    |  1 +
+ 3 files changed, 15 insertions(+)
 ```
 
 </details>

--- a/.agentplane/tasks/202605260807-F705MZ/pr/review.md
+++ b/.agentplane/tasks/202605260807-F705MZ/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-26T08:08:08.069Z
+
+## Task
+
+- Task: `202605260807-F705MZ`
+- Title: Route hook runtime changes to targeted local CI
+- Status: DOING
+- Branch: `task/202605260807-F705MZ/hook-runtime-ci-routing`
+- Canonical task record: `.agentplane/tasks/202605260807-F705MZ/README.md`
+
+## Verification
+
+- State: ok
+- Note: Hook runtime local CI routing now resolves to targeted hooks route; targeted selector, lint, format, and hooks suites pass.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-26T08:08:08.069Z
+- Branch: task/202605260807-F705MZ/hook-runtime-ci-routing
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/cli/local-ci-selection.test.ts
+++ b/packages/agentplane/src/cli/local-ci-selection.test.ts
@@ -255,6 +255,19 @@ describe("local CI fast selection", () => {
     );
   });
 
+  it("routes hook runtime changes to the hooks bucket", () => {
+    const plan = selectFastCiPlan([
+      "packages/agentplane/src/commands/hooks/run.pre-commit.ts",
+      "packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts",
+    ]);
+    expect(plan.kind).toBe("targeted");
+    expect(plan.bucket).toBe("hooks");
+    expect(plan.reason).toBe("hook_and_ci_routing_paths_only");
+    expect(plan.testFiles).toContain(
+      "packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts",
+    );
+  });
+
   it("routes local CI route registry maintenance to the hooks bucket", () => {
     const plan = selectFastCiPlan([
       "scripts/lib/local-ci-selection.mjs",

--- a/scripts/lib/local-ci-selection.mjs
+++ b/scripts/lib/local-ci-selection.mjs
@@ -71,6 +71,7 @@ const HOOKS_BUCKET_PATTERNS = [
   /^scripts\/lib\/pre-push-scope\.mjs$/,
   /^scripts\/lib\/test-route-registry\.mjs$/,
   /^lefthook\.yml$/,
+  /^packages\/agentplane\/src\/commands\/hooks(?:\/|\.|$)/,
   /^packages\/agentplane\/src\/cli\/local-ci-selection\.test\.ts$/,
   /^packages\/agentplane\/src\/cli\/run-cli\.core\.hooks(?:\..+)?\.test\.ts$/,
   /^packages\/agentplane\/src\/cli\/pre-commit-staged-files\.test\.ts$/,

--- a/scripts/lib/test-route-registry.mjs
+++ b/scripts/lib/test-route-registry.mjs
@@ -459,6 +459,7 @@ const HOOKS_TEST_FILES = [
   "packages/agentplane/src/cli/local-ci-selection.test.ts",
   "packages/agentplane/src/cli/run-cli.core.hooks.hook-run.test.ts",
   "packages/agentplane/src/cli/run-cli.core.hooks.install.test.ts",
+  "packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts",
   "packages/agentplane/src/cli/run-cli.core.hooks.runtime-shim.test.ts",
   "packages/agentplane/src/cli/run-cli.core.hooks.uninstall.test.ts",
   "packages/agentplane/src/cli/pre-commit-staged-files.test.ts",


### PR DESCRIPTION
Task: `202605260807-F705MZ`
Title: Route hook runtime changes to targeted local CI
Canonical task record: `.agentplane/tasks/202605260807-F705MZ/README.md`

## Summary

Route hook runtime changes to targeted local CI

Make local CI classify packages/agentplane/src/commands/hooks changes as hooks bucket so pre-push does not fall back to full-fast release suites for hook-only work.

## Scope

- In scope: Make local CI classify packages/agentplane/src/commands/hooks changes as hooks bucket so pre-push does not fall back to full-fast release suites for hook-only work.
- Out of scope: unrelated refactors not required for "Route hook runtime changes to targeted local CI".

## Verification

- State: ok
- Note:

```text
Hook runtime local CI routing now resolves to targeted hooks route; targeted selector, lint, format,
and hooks suites pass.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-26T08:08:08.069Z
- Branch: task/202605260807-F705MZ/hook-runtime-ci-routing
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
No changes detected.
```

</details>
