### PR TITLE
🚧 1K3J53 task: Strengthen task route oracle [202605271737-1K3J53]

### DIFF
--- a/.agentplane/tasks/202605271737-1K3J53/README.md
+++ b/.agentplane/tasks/202605271737-1K3J53/README.md
@@ -1,0 +1,236 @@
+---
+id: "202605271737-1K3J53"
+title: "Strengthen task route oracle"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 8
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "workflow"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-27T17:38:11.077Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-27T17:59:20.793Z"
+  updated_by: "CODER"
+  note: "Refactored route oracle into a separate module after hosted hotspot failure."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implementing the approved route oracle improvement in the dedicated branch_pr worktree, scoped to CLI route output and focused tests."
+events:
+  -
+    type: "status"
+    at: "2026-05-27T17:39:04.733Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implementing the approved route oracle improvement in the dedicated branch_pr worktree, scoped to CLI route output and focused tests."
+  -
+    type: "verify"
+    at: "2026-05-27T17:50:55.146Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented route oracle packet and verified focused route-decision behavior."
+  -
+    type: "verify"
+    at: "2026-05-27T17:59:20.793Z"
+    author: "CODER"
+    state: "ok"
+    note: "Refactored route oracle into a separate module after hosted hotspot failure."
+doc_version: 3
+doc_updated_at: "2026-05-27T17:59:20.841Z"
+doc_updated_by: "CODER"
+description: "Enhance the CLI route oracle so one command reports the current phase, authoritative checkout, blocker, and next concrete command for agent execution."
+sections:
+  Summary: |-
+    Strengthen task route oracle
+
+    Enhance the CLI route oracle so one command reports the current phase, authoritative checkout, blocker, and next concrete command for agent execution.
+  Scope: |-
+    - In scope: Enhance the CLI route oracle so one command reports the current phase, authoritative checkout, blocker, and next concrete command for agent execution.
+    - Out of scope: unrelated refactors not required for "Strengthen task route oracle".
+  Plan: "Implement a stronger task route oracle without adding AGENTS.md instructions. Scope: inspect current task next-action/status route implementation; add a compact route-oracle packet that reports phase, authoritative checkout, blocker, and next concrete command; preserve existing text output compatibility where practical; add focused tests; run task verify-show, focused tests, typecheck or targeted project check as appropriate, policy routing, and doctor."
+  Verify Steps: |-
+    1. Command: bun test packages/agentplane/src/cli/run-cli.core.route-decision.test.ts. Expected: route-decision command coverage passes, including route_oracle JSON and phase plus authoritative_checkout text output.
+    2. Command: bun run typecheck. Expected: TypeScript project references build cleanly after shared route decision type changes.
+    3. Command: bun run framework:dev:bootstrap. Expected: repo-local CLI build snapshot is current and runtime explain succeeds.
+    4. Command: node .agentplane/policy/check-routing.mjs. Expected: policy routing constraints still pass.
+    5. Command: ap task next-action 202605271737-1K3J53 --explain and ap task next-action 202605271737-1K3J53 --json. Expected: one command reports phase, authoritative checkout, primary blocker or null blocker, and next command.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-27T17:50:55.146Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Implemented route oracle packet and verified focused route-decision behavior.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-27T17:49:07.127Z, excerpt_hash=sha256:b6a477cdcea0248d67fbe7b4c29cdf593057154fa2f738c9fa771a6a8ebcec8a
+
+    Details:
+
+    Command: bun test packages/agentplane/src/cli/run-cli.core.route-decision.test.ts. Result: pass. Evidence: 9 pass, 0 fail, 108 expect calls. Scope: route-decision next-action/status/brief output.
+
+    Command: bun run typecheck. Result: pass. Evidence: tsc -b completed with exit 0. Scope: TypeScript project references.
+
+    Command: bun run framework:dev:bootstrap. Result: pass. Evidence: Framework dev runtime is ready; repo-local runtime 0.6.10 matches expectation. Scope: rebuilt CLI snapshot.
+
+    Command: node .agentplane/policy/check-routing.mjs. Result: pass. Evidence: policy routing OK. Scope: policy routing.
+
+    Command: ap doctor. Result: pass. Evidence: doctor (OK), errors=0 warnings=0. Scope: workspace/runtime route health.
+
+    Command: ap task next-action 202605271737-1K3J53 --explain and --json. Result: pass. Evidence: phase=verify_or_pr_update, authoritativeCheckout=task_worktree, blocker=null, nextCommand=agentplane pr update 202605271737-1K3J53. Scope: live oracle output.
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605271737-1K3J53-strengthen-task-route-oracle/.agentplane/tasks/202605271737-1K3J53/blueprint/resolved-snapshot.json
+    - old_digest: b8b091d55f60e3de3d8b767e00da151179c94ed96afebcc650ca245a8c723b61
+    - current_digest: b8b091d55f60e3de3d8b767e00da151179c94ed96afebcc650ca245a8c723b61
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605271737-1K3J53
+
+    ### 2026-05-27T17:59:20.793Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Refactored route oracle into a separate module after hosted hotspot failure.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-27T17:50:55.277Z, excerpt_hash=sha256:b6a477cdcea0248d67fbe7b4c29cdf593057154fa2f738c9fa771a6a8ebcec8a
+
+    Details:
+
+    Command: bun run hotspots:check. Result: pass. Evidence: Hotspot threshold check passed; route-decision.ts is 553 lines, below the 600-line hard threshold. Scope: hosted verify-contract blocker.
+
+    Command: bun test packages/agentplane/src/cli/run-cli.core.route-decision.test.ts. Result: pass. Evidence: 9 pass, 0 fail, 108 expect calls. Scope: route oracle behavior after extraction.
+
+    Command: bun run typecheck. Result: pass. Evidence: tsc -b completed with exit 0. Scope: route-oracle module extraction.
+
+    Command: bun run framework:dev:bootstrap. Result: pass. Evidence: Framework dev runtime is ready; repo-local runtime 0.6.10 matches expectation. Scope: rebuilt CLI snapshot.
+
+    Command: node .agentplane/policy/check-routing.mjs. Result: pass. Evidence: policy routing OK. Scope: policy routing.
+
+    Command: ap doctor. Result: pass. Evidence: doctor (OK), errors=0 warnings=0. Scope: workspace/runtime route health.
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605271737-1K3J53-strengthen-task-route-oracle/.agentplane/tasks/202605271737-1K3J53/blueprint/resolved-snapshot.json
+    - old_digest: b8b091d55f60e3de3d8b767e00da151179c94ed96afebcc650ca245a8c723b61
+    - current_digest: b8b091d55f60e3de3d8b767e00da151179c94ed96afebcc650ca245a8c723b61
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605271737-1K3J53
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Strengthen task route oracle
+
+Enhance the CLI route oracle so one command reports the current phase, authoritative checkout, blocker, and next concrete command for agent execution.
+
+## Scope
+
+- In scope: Enhance the CLI route oracle so one command reports the current phase, authoritative checkout, blocker, and next concrete command for agent execution.
+- Out of scope: unrelated refactors not required for "Strengthen task route oracle".
+
+## Plan
+
+Implement a stronger task route oracle without adding AGENTS.md instructions. Scope: inspect current task next-action/status route implementation; add a compact route-oracle packet that reports phase, authoritative checkout, blocker, and next concrete command; preserve existing text output compatibility where practical; add focused tests; run task verify-show, focused tests, typecheck or targeted project check as appropriate, policy routing, and doctor.
+
+## Verify Steps
+
+1. Command: bun test packages/agentplane/src/cli/run-cli.core.route-decision.test.ts. Expected: route-decision command coverage passes, including route_oracle JSON and phase plus authoritative_checkout text output.
+2. Command: bun run typecheck. Expected: TypeScript project references build cleanly after shared route decision type changes.
+3. Command: bun run framework:dev:bootstrap. Expected: repo-local CLI build snapshot is current and runtime explain succeeds.
+4. Command: node .agentplane/policy/check-routing.mjs. Expected: policy routing constraints still pass.
+5. Command: ap task next-action 202605271737-1K3J53 --explain and ap task next-action 202605271737-1K3J53 --json. Expected: one command reports phase, authoritative checkout, primary blocker or null blocker, and next command.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-27T17:50:55.146Z — VERIFY — ok
+
+By: CODER
+
+Note: Implemented route oracle packet and verified focused route-decision behavior.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-27T17:49:07.127Z, excerpt_hash=sha256:b6a477cdcea0248d67fbe7b4c29cdf593057154fa2f738c9fa771a6a8ebcec8a
+
+Details:
+
+Command: bun test packages/agentplane/src/cli/run-cli.core.route-decision.test.ts. Result: pass. Evidence: 9 pass, 0 fail, 108 expect calls. Scope: route-decision next-action/status/brief output.
+
+Command: bun run typecheck. Result: pass. Evidence: tsc -b completed with exit 0. Scope: TypeScript project references.
+
+Command: bun run framework:dev:bootstrap. Result: pass. Evidence: Framework dev runtime is ready; repo-local runtime 0.6.10 matches expectation. Scope: rebuilt CLI snapshot.
+
+Command: node .agentplane/policy/check-routing.mjs. Result: pass. Evidence: policy routing OK. Scope: policy routing.
+
+Command: ap doctor. Result: pass. Evidence: doctor (OK), errors=0 warnings=0. Scope: workspace/runtime route health.
+
+Command: ap task next-action 202605271737-1K3J53 --explain and --json. Result: pass. Evidence: phase=verify_or_pr_update, authoritativeCheckout=task_worktree, blocker=null, nextCommand=agentplane pr update 202605271737-1K3J53. Scope: live oracle output.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605271737-1K3J53-strengthen-task-route-oracle/.agentplane/tasks/202605271737-1K3J53/blueprint/resolved-snapshot.json
+- old_digest: b8b091d55f60e3de3d8b767e00da151179c94ed96afebcc650ca245a8c723b61
+- current_digest: b8b091d55f60e3de3d8b767e00da151179c94ed96afebcc650ca245a8c723b61
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605271737-1K3J53
+
+### 2026-05-27T17:59:20.793Z — VERIFY — ok
+
+By: CODER
+
+Note: Refactored route oracle into a separate module after hosted hotspot failure.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-27T17:50:55.277Z, excerpt_hash=sha256:b6a477cdcea0248d67fbe7b4c29cdf593057154fa2f738c9fa771a6a8ebcec8a
+
+Details:
+
+Command: bun run hotspots:check. Result: pass. Evidence: Hotspot threshold check passed; route-decision.ts is 553 lines, below the 600-line hard threshold. Scope: hosted verify-contract blocker.
+
+Command: bun test packages/agentplane/src/cli/run-cli.core.route-decision.test.ts. Result: pass. Evidence: 9 pass, 0 fail, 108 expect calls. Scope: route oracle behavior after extraction.
+
+Command: bun run typecheck. Result: pass. Evidence: tsc -b completed with exit 0. Scope: route-oracle module extraction.
+
+Command: bun run framework:dev:bootstrap. Result: pass. Evidence: Framework dev runtime is ready; repo-local runtime 0.6.10 matches expectation. Scope: rebuilt CLI snapshot.
+
+Command: node .agentplane/policy/check-routing.mjs. Result: pass. Evidence: policy routing OK. Scope: policy routing.
+
+Command: ap doctor. Result: pass. Evidence: doctor (OK), errors=0 warnings=0. Scope: workspace/runtime route health.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605271737-1K3J53-strengthen-task-route-oracle/.agentplane/tasks/202605271737-1K3J53/blueprint/resolved-snapshot.json
+- old_digest: b8b091d55f60e3de3d8b767e00da151179c94ed96afebcc650ca245a8c723b61
+- current_digest: b8b091d55f60e3de3d8b767e00da151179c94ed96afebcc650ca245a8c723b61
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605271737-1K3J53
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605271737-1K3J53/README.md
+++ b/.agentplane/tasks/202605271737-1K3J53/README.md
@@ -4,7 +4,7 @@ title: "Strengthen task route oracle"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 9
+revision: 10
 origin:
   system: "manual"
 depends_on: []
@@ -25,20 +25,20 @@ verification:
   attempts: 0
 quality_review:
   state: "pass"
-  updated_at: "2026-05-27T18:30:03.800Z"
+  updated_at: "2026-05-27T18:51:46.217Z"
   updated_by: "EVALUATOR"
-  note: "Route oracle now reports phase, authoritative checkout, blocker, and next command across next-action/status/brief surfaces."
-  evaluated_sha: "0a80638e2d4ff7fc5119782cfecd0a6abb3da3f3"
+  note: "Route oracle now reports phase, authoritative checkout, blocker, and next command, with approval/done phases taking precedence over included batch delegation."
+  evaluated_sha: "3635ae69ed4cea3ba464cab7bb148851cbac20ea"
   blueprint_digest: "b8b091d55f60e3de3d8b767e00da151179c94ed96afebcc650ca245a8c723b61"
   evidence_refs:
     - ".agentplane/tasks/202605271737-1K3J53/README.md"
-    - ".agentplane/tasks/202605271737-1K3J53/quality/20260527-183003800-recovery-context/quality-report.json"
-    - ".agentplane/tasks/202605271737-1K3J53/quality/20260527-183003800-recovery-context/evaluator-prompt.md"
-    - ".agentplane/tasks/202605271737-1K3J53/quality/20260527-183003800-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605271737-1K3J53/quality/20260527-185146217-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605271737-1K3J53/quality/20260527-185146217-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605271737-1K3J53/quality/20260527-185146217-recovery-context/evaluator-opinion.md"
     - ".agentplane/tasks/202605271737-1K3J53/blueprint/resolved-snapshot.json"
-    - "PR #4169 checks: PR verification, test-windows, verify-contract, verify-unit, verify-static, verify-workflow, verify-coverage, verify-cli-critical, docs, CodeQL all passed"
+    - "bun test packages/agentplane/src/cli/run-cli.core.route-decision.batch.test.ts; bun test --timeout 20000 packages/agentplane/src/cli/run-cli.core.route-decision.test.ts; bun run typecheck; bun run hotspots:check; bun run format:check"
   findings:
-    - "Focused route-decision tests, typecheck, routing policy, doctor, hotspots, format check, and hosted PR checks passed; local pre-push full-fast timed out in broad Vitest after required focused gates had passed."
+    - "Addressed PR review thread by moving done and approve_plan handling ahead of included batch delegation; added regression coverage for approved included delegation and unapproved included plan approval."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202605271737-1K3J53/README.md
+++ b/.agentplane/tasks/202605271737-1K3J53/README.md
@@ -4,7 +4,7 @@ title: "Strengthen task route oracle"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 8
+revision: 9
 origin:
   system: "manual"
 depends_on: []
@@ -23,6 +23,22 @@ verification:
   updated_by: "CODER"
   note: "Refactored route oracle into a separate module after hosted hotspot failure."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-27T18:30:03.800Z"
+  updated_by: "EVALUATOR"
+  note: "Route oracle now reports phase, authoritative checkout, blocker, and next command across next-action/status/brief surfaces."
+  evaluated_sha: "0a80638e2d4ff7fc5119782cfecd0a6abb3da3f3"
+  blueprint_digest: "b8b091d55f60e3de3d8b767e00da151179c94ed96afebcc650ca245a8c723b61"
+  evidence_refs:
+    - ".agentplane/tasks/202605271737-1K3J53/README.md"
+    - ".agentplane/tasks/202605271737-1K3J53/quality/20260527-183003800-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605271737-1K3J53/quality/20260527-183003800-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605271737-1K3J53/quality/20260527-183003800-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605271737-1K3J53/blueprint/resolved-snapshot.json"
+    - "PR #4169 checks: PR verification, test-windows, verify-contract, verify-unit, verify-static, verify-workflow, verify-coverage, verify-cli-critical, docs, CodeQL all passed"
+  findings:
+    - "Focused route-decision tests, typecheck, routing policy, doctor, hotspots, format check, and hosted PR checks passed; local pre-push full-fast timed out in broad Vitest after required focused gates had passed."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202605271737-1K3J53/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605271737-1K3J53/blueprint/resolved-snapshot.json
@@ -1,0 +1,571 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605271737-1K3J53",
+    "title": "Strengthen task route oracle",
+    "description": "Enhance the CLI route oracle so one command reports the current phase, authoritative checkout, blocker, and next concrete command for agent execution.",
+    "tags": [
+      "code",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605271737-1K3J53",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "b8b091d55f60e3de3d8b767e00da151179c94ed96afebcc650ca245a8c723b61"
+  }
+}

--- a/.agentplane/tasks/202605271737-1K3J53/pr/diffstat.txt
+++ b/.agentplane/tasks/202605271737-1K3J53/pr/diffstat.txt
@@ -1,0 +1,7 @@
+ .../src/cli/run-cli.core.route-decision.test.ts    |  31 ++++-
+ .../src/commands/shared/route-decision.ts          |  19 ++-
+ .../agentplane/src/commands/shared/route-oracle.ts | 150 +++++++++++++++++++++
+ .../agentplane/src/commands/task/brief.command.ts  |   6 +
+ .../src/commands/task/next-action.command.ts       |  11 +-
+ .../agentplane/src/commands/task/status.command.ts |   4 +-
+ 6 files changed, 213 insertions(+), 8 deletions(-)

--- a/.agentplane/tasks/202605271737-1K3J53/pr/github-body.md
+++ b/.agentplane/tasks/202605271737-1K3J53/pr/github-body.md
@@ -1,0 +1,39 @@
+Task: `202605271737-1K3J53`
+Title: Strengthen task route oracle
+Canonical task record: `.agentplane/tasks/202605271737-1K3J53/README.md`
+
+## Summary
+
+Strengthen task route oracle
+
+Enhance the CLI route oracle so one command reports the current phase, authoritative checkout, blocker, and next concrete command for agent execution.
+
+## Scope
+
+- In scope: Enhance the CLI route oracle so one command reports the current phase, authoritative checkout, blocker, and next concrete command for agent execution.
+- Out of scope: unrelated refactors not required for "Strengthen task route oracle".
+
+## Verification
+
+- State: ok
+- Note: Refactored route oracle into a separate module after hosted hotspot failure.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-27T17:39:04.987Z
+- Branch: task/202605271737-1K3J53/strengthen-task-route-oracle
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/cli/run-cli.core.route-decision.test.ts    |  31 ++++-
+ .../src/commands/shared/route-decision.ts          |  19 ++-
+ .../agentplane/src/commands/shared/route-oracle.ts | 150 +++++++++++++++++++++
+ .../agentplane/src/commands/task/brief.command.ts  |   6 +
+ .../src/commands/task/next-action.command.ts       |  11 +-
+ .../agentplane/src/commands/task/status.command.ts |   4 +-
+ 6 files changed, 213 insertions(+), 8 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605271737-1K3J53/pr/github-title.txt
+++ b/.agentplane/tasks/202605271737-1K3J53/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 1K3J53 task: Strengthen task route oracle [202605271737-1K3J53]

--- a/.agentplane/tasks/202605271737-1K3J53/pr/meta.json
+++ b/.agentplane/tasks/202605271737-1K3J53/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605271737-1K3J53/strengthen-task-route-oracle",
+  "created_at": "2026-05-27T17:39:04.987Z",
+  "diffstat_sha256": "sha256:1e93c6c1d58634b7afece6aa68cbc15f6d02c5a4d1c0a89f35b61a3c447cfbd3",
+  "last_verified_at": "2026-05-27T17:59:20.793Z",
+  "last_verified_diffstat_sha256": "sha256:2e5feeb9ce4af439131b52a5ec9845f292b287cea590d09a52f507dda8932b8e",
+  "schema_version": 1,
+  "task_id": "202605271737-1K3J53",
+  "updated_at": "2026-05-27T17:39:04.987Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605271737-1K3J53/pr/review.md
+++ b/.agentplane/tasks/202605271737-1K3J53/pr/review.md
@@ -1,0 +1,42 @@
+# PR Review
+
+Created: 2026-05-27T17:39:04.987Z
+
+## Task
+
+- Task: `202605271737-1K3J53`
+- Title: Strengthen task route oracle
+- Status: DOING
+- Branch: `task/202605271737-1K3J53/strengthen-task-route-oracle`
+- Canonical task record: `.agentplane/tasks/202605271737-1K3J53/README.md`
+
+## Verification
+
+- State: ok
+- Note: Refactored route oracle into a separate module after hosted hotspot failure.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-27T17:39:04.987Z
+- Branch: task/202605271737-1K3J53/strengthen-task-route-oracle
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/cli/run-cli.core.route-decision.test.ts    |  31 ++++-
+ .../src/commands/shared/route-decision.ts          |  19 ++-
+ .../agentplane/src/commands/shared/route-oracle.ts | 150 +++++++++++++++++++++
+ .../agentplane/src/commands/task/brief.command.ts  |   6 +
+ .../src/commands/task/next-action.command.ts       |  11 +-
+ .../agentplane/src/commands/task/status.command.ts |   4 +-
+ 6 files changed, 213 insertions(+), 8 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605271737-1K3J53/quality/20260527-183003800-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605271737-1K3J53/quality/20260527-183003800-recovery-context/evaluator-opinion.md
@@ -1,0 +1,19 @@
+# EVALUATOR opinion: pass
+
+Route oracle now reports phase, authoritative checkout, blocker, and next command across next-action/status/brief surfaces.
+
+## Findings
+- Focused route-decision tests, typecheck, routing policy, doctor, hotspots, format check, and hosted PR checks passed; local pre-push full-fast timed out in broad Vitest after required focused gates had passed.
+
+## Evidence
+- .agentplane/tasks/202605271737-1K3J53/README.md
+- PR #4169 checks: PR verification, test-windows, verify-contract, verify-unit, verify-static, verify-workflow, verify-coverage, verify-cli-critical, docs, CodeQL all passed
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- Base checkout may still have stale task metadata before the task branch is integrated; the task worktree route oracle is the authoritative source for this branch state.
+
+## Residual Risks
+- Integration queue may require re-running hosted close after merge because protected-base closeout is controlled by GitHub policy.

--- a/.agentplane/tasks/202605271737-1K3J53/quality/20260527-183003800-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605271737-1K3J53/quality/20260527-183003800-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605271737-1K3J53
+- task_readme: .agentplane/tasks/202605271737-1K3J53/README.md
+- report_path: .agentplane/tasks/202605271737-1K3J53/quality/20260527-183003800-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605271737-1K3J53/quality/20260527-183003800-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605271737-1K3J53/quality/20260527-183003800-recovery-context/quality-report.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "task_id": "202605271737-1K3J53",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-27T18:30:03.800Z",
+  "verdict": "pass",
+  "summary": "Route oracle now reports phase, authoritative checkout, blocker, and next command across next-action/status/brief surfaces.",
+  "evaluated_sha": "0a80638e2d4ff7fc5119782cfecd0a6abb3da3f3",
+  "blueprint_digest": "b8b091d55f60e3de3d8b767e00da151179c94ed96afebcc650ca245a8c723b61",
+  "findings": [
+    "Focused route-decision tests, typecheck, routing policy, doctor, hotspots, format check, and hosted PR checks passed; local pre-push full-fast timed out in broad Vitest after required focused gates had passed."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605271737-1K3J53/README.md",
+    "PR #4169 checks: PR verification, test-windows, verify-contract, verify-unit, verify-static, verify-workflow, verify-coverage, verify-cli-critical, docs, CodeQL all passed"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [
+    "Base checkout may still have stale task metadata before the task branch is integrated; the task worktree route oracle is the authoritative source for this branch state."
+  ],
+  "residual_risks": [
+    "Integration queue may require re-running hosted close after merge because protected-base closeout is controlled by GitHub policy."
+  ]
+}

--- a/.agentplane/tasks/202605271737-1K3J53/quality/20260527-185146217-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605271737-1K3J53/quality/20260527-185146217-recovery-context/evaluator-opinion.md
@@ -1,0 +1,19 @@
+# EVALUATOR opinion: pass
+
+Route oracle now reports phase, authoritative checkout, blocker, and next command, with approval/done phases taking precedence over included batch delegation.
+
+## Findings
+- Addressed PR review thread by moving done and approve_plan handling ahead of included batch delegation; added regression coverage for approved included delegation and unapproved included plan approval.
+
+## Evidence
+- .agentplane/tasks/202605271737-1K3J53/README.md
+- bun test packages/agentplane/src/cli/run-cli.core.route-decision.batch.test.ts; bun test --timeout 20000 packages/agentplane/src/cli/run-cli.core.route-decision.test.ts; bun run typecheck; bun run hotspots:check; bun run format:check
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- Broad local pre-push full-fast remains too long for this machine; protected PR hosted checks remain the merge source of truth.

--- a/.agentplane/tasks/202605271737-1K3J53/quality/20260527-185146217-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605271737-1K3J53/quality/20260527-185146217-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605271737-1K3J53
+- task_readme: .agentplane/tasks/202605271737-1K3J53/README.md
+- report_path: .agentplane/tasks/202605271737-1K3J53/quality/20260527-185146217-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605271737-1K3J53/quality/20260527-185146217-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605271737-1K3J53/quality/20260527-185146217-recovery-context/quality-report.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "task_id": "202605271737-1K3J53",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-27T18:51:46.217Z",
+  "verdict": "pass",
+  "summary": "Route oracle now reports phase, authoritative checkout, blocker, and next command, with approval/done phases taking precedence over included batch delegation.",
+  "evaluated_sha": "3635ae69ed4cea3ba464cab7bb148851cbac20ea",
+  "blueprint_digest": "b8b091d55f60e3de3d8b767e00da151179c94ed96afebcc650ca245a8c723b61",
+  "findings": [
+    "Addressed PR review thread by moving done and approve_plan handling ahead of included batch delegation; added regression coverage for approved included delegation and unapproved included plan approval."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605271737-1K3J53/README.md",
+    "bun test packages/agentplane/src/cli/run-cli.core.route-decision.batch.test.ts; bun test --timeout 20000 packages/agentplane/src/cli/run-cli.core.route-decision.test.ts; bun run typecheck; bun run hotspots:check; bun run format:check"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": [
+    "Broad local pre-push full-fast remains too long for this machine; protected PR hosted checks remain the merge source of truth."
+  ]
+}

--- a/packages/agentplane/src/cli/run-cli.core.route-decision.batch.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.route-decision.batch.test.ts
@@ -215,6 +215,67 @@ describe("runCli route decision batch ownership", () => {
     }
   });
 
+  it("reports included batch delegation in the route oracle after plan approval", async () => {
+    const root = await mkGitRepoRootWithBranch("main");
+    const config = defaultConfig();
+    config.workflow_mode = "branch_pr";
+    await writeConfig(root, config);
+    await runCliSilent(["branch", "base", "set", "main", "--root", root]);
+
+    const primaryTaskId = await createTask(root);
+    const includedTaskId = await createTask(root);
+    await approveTasks(root, [primaryTaskId, includedTaskId], "Exercise batch oracle routing.");
+    const branch = `task/${primaryTaskId}/batch-owner`;
+    await writeBatchMeta({ root, primaryTaskId, includedTaskId, branch, status: "OPEN" });
+
+    const nextIo = captureStdIO();
+    try {
+      const code = await runCli(["task", "next-action", includedTaskId, "--json", "--root", root]);
+      expect(code).toBe(0);
+      const parsed = JSON.parse(nextIo.stdout) as {
+        next_action: { code: string };
+        route_oracle: { phase: string; authoritativeCheckout: string };
+      };
+      expect(parsed.next_action.code).toBe("verify_included_task");
+      expect(parsed.route_oracle).toMatchObject({
+        phase: "batch_delegate",
+        authoritativeCheckout: "primary_task_worktree",
+      });
+    } finally {
+      nextIo.restore();
+    }
+  });
+
+  it("keeps plan approval ahead of included batch delegation in the route oracle", async () => {
+    const root = await mkGitRepoRootWithBranch("main");
+    const config = defaultConfig();
+    config.workflow_mode = "branch_pr";
+    await writeConfig(root, config);
+    await runCliSilent(["branch", "base", "set", "main", "--root", root]);
+
+    const primaryTaskId = await createTask(root);
+    const includedTaskId = await createTask(root);
+    const branch = `task/${primaryTaskId}/batch-owner`;
+    await writeBatchMeta({ root, primaryTaskId, includedTaskId, branch, status: "OPEN" });
+
+    const nextIo = captureStdIO();
+    try {
+      const code = await runCli(["task", "next-action", includedTaskId, "--json", "--root", root]);
+      expect(code).toBe(0);
+      const parsed = JSON.parse(nextIo.stdout) as {
+        next_action: { code: string; command: string };
+        route_oracle: { phase: string; authoritativeCheckout: string };
+      };
+      expect(parsed.next_action.code).toBe("approve_plan");
+      expect(parsed.route_oracle).toMatchObject({
+        phase: "needs_plan_approval",
+        authoritativeCheckout: "base_checkout",
+      });
+    } finally {
+      nextIo.restore();
+    }
+  });
+
   it("does not let stale batch PR artifacts override direct-mode routing", async () => {
     const root = await mkGitRepoRootWithBranch("main");
     const config = defaultConfig();

--- a/packages/agentplane/src/cli/run-cli.core.route-decision.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.route-decision.test.ts
@@ -73,6 +73,8 @@ describe("runCli route decision commands", () => {
       const code = await runCli(["task", "status", taskId, "--route", "--root", root]);
       expect(code).toBe(0);
       expect(statusIo.stdout).toContain(`task:                        ${taskId} TODO`);
+      expect(statusIo.stdout).toContain("phase:                       worktree_needed");
+      expect(statusIo.stdout).toContain("authoritative_checkout:      base_checkout");
       expect(statusIo.stdout).toContain("next_code:                   start_or_recover_worktree");
       expect(statusIo.stdout).toContain("blocker:                     missing_pr_branch");
     } finally {
@@ -84,12 +86,24 @@ describe("runCli route decision commands", () => {
       const code = await runCli(["task", "next-action", taskId, "--json", "--root", root]);
       expect(code).toBe(0);
       const parsed = JSON.parse(nextIo.stdout) as {
+        route_oracle: {
+          phase: string;
+          authoritativeCheckout: string;
+          blocker: { code: string } | null;
+          nextCommand: string;
+        };
         next_action: { code: string; command: string };
       };
+      expect(parsed.route_oracle).toMatchObject({
+        phase: "worktree_needed",
+        authoritativeCheckout: "base_checkout",
+        blocker: { code: "missing_pr_branch" },
+      });
       expect(parsed.next_action.code).toBe("start_or_recover_worktree");
       expect(parsed.next_action.command).toBe(
         `agentplane work start ${taskId} --agent CODER --slug route-decision-task --worktree`,
       );
+      expect(parsed.route_oracle.nextCommand).toBe(parsed.next_action.command);
     } finally {
       nextIo.restore();
     }
@@ -174,6 +188,8 @@ describe("runCli route decision commands", () => {
         const code = await runCli(["task", "brief", taskId, "--root", root]);
         expect(code).toBe(0);
         expect(textIo.stdout).toContain(`task brief: ${taskId}`);
+        expect(textIo.stdout).toContain("phase:");
+        expect(textIo.stdout).toContain("authoritative_checkout:");
         expect(textIo.stdout).toContain("next_code:");
         expect(textIo.stdout).toContain("confidence:");
         expect(textIo.stdout).toContain("verify_steps:");
@@ -241,7 +257,12 @@ describe("runCli route decision commands", () => {
         const parsed = JSON.parse(jsonIo.stdout) as {
           contract: { kind: string; version: number };
           task: { id: string };
-          route: { workflow_mode: string; next_action_code: string };
+          route: {
+            workflow_mode: string;
+            phase: string;
+            authoritative_checkout: string;
+            next_action_code: string;
+          };
           next_action: { code: string; command: string };
           verify_steps: { text: string; filled: boolean; quality: string };
           blueprint: { blueprint_id?: string; required_evidence?: string[] };
@@ -259,6 +280,8 @@ describe("runCli route decision commands", () => {
         });
         expect(parsed.task.id).toBe(taskId);
         expect(parsed.route.workflow_mode).toBe("branch_pr");
+        expect(parsed.route.phase).toBe("verify_or_pr_update");
+        expect(parsed.route.authoritative_checkout).toBe("task_worktree");
         expect(parsed.route.next_action_code).toBe("verify_or_update_pr");
         expect(parsed.next_action.code).toBe("verify_or_update_pr");
         expect(parsed.next_action.command).toBe(`agentplane pr update ${taskId}`);
@@ -743,10 +766,16 @@ describe("runCli route decision commands", () => {
         ]);
         expect(code).toBe(0);
         const parsed = JSON.parse(nextIo.stdout) as {
+          route_oracle: { phase: string; authoritativeCheckout: string; blocker: { code: string } };
           next_action: { code: string; command: string };
           blockers: { code: string }[];
         };
         expect(parsed.blockers.map((blocker) => blocker.code)).toContain("pr_meta_stale");
+        expect(parsed.route_oracle).toMatchObject({
+          phase: "pr_artifacts_stale",
+          authoritativeCheckout: "task_worktree",
+          blocker: { code: "pr_meta_stale" },
+        });
         expect(parsed.next_action.code).toBe("update_pr_artifacts");
         expect(parsed.next_action.command).toBe(`agentplane pr update ${taskId}`);
       } finally {

--- a/packages/agentplane/src/commands/shared/route-decision.ts
+++ b/packages/agentplane/src/commands/shared/route-decision.ts
@@ -8,6 +8,7 @@ import {
   type RouteBatchOwnership,
   type RouteBatchNextAction,
 } from "./route-batch-ownership.js";
+import { deriveRouteOracle, type RouteBlocker, type RouteOracle } from "./route-oracle.js";
 import { workStartCommand } from "./work-start-command.js";
 
 import { loadBackendTask, loadCommandContext, type CommandContext } from "./task-backend.js";
@@ -15,11 +16,6 @@ import {
   buildRouteSourceConfidenceBase,
   type SourceConfidence as RouteSourceConfidence,
 } from "./source-confidence.js";
-
-type RouteBlocker = {
-  code: string;
-  summary: string;
-};
 
 type RouteNextAction = RouteBatchNextAction;
 
@@ -69,6 +65,7 @@ type TaskRouteDecision = {
   blockers: RouteBlocker[];
   ambiguities: RouteAmbiguity[];
   nextAction: RouteNextAction;
+  oracle: RouteOracle;
   repairPlan: RouteRepairStep[];
   sourceConfidence: Record<string, RouteSourceConfidence>;
 };
@@ -514,6 +511,13 @@ export async function buildTaskRouteDecision(opts: {
     blockers,
     batchOwnership,
   });
+  const oracle = deriveRouteOracle({
+    task,
+    workflowMode: ctx.config.workflow_mode,
+    nextAction,
+    blockers,
+    batchOwnership,
+  });
   const partial = {
     task: taskSummary(task),
     workflowMode: ctx.config.workflow_mode,
@@ -530,6 +534,7 @@ export async function buildTaskRouteDecision(opts: {
     prFlow,
     blockers,
     nextAction,
+    oracle,
   };
   const withAmbiguities = { ...partial, ambiguities: deriveAmbiguities({ decision: partial }) };
   return {

--- a/packages/agentplane/src/commands/shared/route-oracle.ts
+++ b/packages/agentplane/src/commands/shared/route-oracle.ts
@@ -41,15 +41,6 @@ export function deriveRouteOracle(opts: {
       summary: opts.nextAction.summary,
     };
   }
-  if (opts.batchOwnership.role === "included") {
-    return {
-      phase: "batch_delegate",
-      authoritativeCheckout: "primary_task_worktree",
-      blocker,
-      nextCommand: opts.nextAction.command,
-      summary: opts.nextAction.summary,
-    };
-  }
   if (opts.task.status === "DONE") {
     return {
       phase: "done_pending_cleanup",
@@ -63,6 +54,15 @@ export function deriveRouteOracle(opts: {
     return {
       phase: "needs_plan_approval",
       authoritativeCheckout: "base_checkout",
+      blocker,
+      nextCommand: opts.nextAction.command,
+      summary: opts.nextAction.summary,
+    };
+  }
+  if (opts.batchOwnership.role === "included") {
+    return {
+      phase: "batch_delegate",
+      authoritativeCheckout: "primary_task_worktree",
       blocker,
       nextCommand: opts.nextAction.command,
       summary: opts.nextAction.summary,

--- a/packages/agentplane/src/commands/shared/route-oracle.ts
+++ b/packages/agentplane/src/commands/shared/route-oracle.ts
@@ -1,0 +1,150 @@
+import type { TaskData } from "../../backends/task-backend.js";
+import type { RouteBatchOwnership, RouteBatchNextAction } from "./route-batch-ownership.js";
+
+export type RouteBlocker = {
+  code: string;
+  summary: string;
+};
+
+export type RouteOracle = {
+  phase: string;
+  authoritativeCheckout:
+    | "base_checkout"
+    | "task_worktree"
+    | "current_checkout"
+    | "primary_task_worktree"
+    | "provider";
+  blocker: RouteBlocker | null;
+  nextCommand: string | null;
+  summary: string;
+};
+
+function primaryBlocker(blockers: readonly RouteBlocker[]): RouteBlocker | null {
+  return blockers[0] ? { ...blockers[0] } : null;
+}
+
+export function deriveRouteOracle(opts: {
+  task: TaskData;
+  workflowMode: string;
+  nextAction: RouteBatchNextAction;
+  blockers: readonly RouteBlocker[];
+  batchOwnership: RouteBatchOwnership;
+}): RouteOracle {
+  const code = opts.nextAction.code;
+  const blocker = primaryBlocker(opts.blockers);
+  if (opts.workflowMode !== "branch_pr") {
+    return {
+      phase: opts.task.status === "DONE" ? "done" : "direct_execution",
+      authoritativeCheckout: "current_checkout",
+      blocker,
+      nextCommand: opts.nextAction.command,
+      summary: opts.nextAction.summary,
+    };
+  }
+  if (opts.batchOwnership.role === "included") {
+    return {
+      phase: "batch_delegate",
+      authoritativeCheckout: "primary_task_worktree",
+      blocker,
+      nextCommand: opts.nextAction.command,
+      summary: opts.nextAction.summary,
+    };
+  }
+  if (opts.task.status === "DONE") {
+    return {
+      phase: "done_pending_cleanup",
+      authoritativeCheckout: "base_checkout",
+      blocker,
+      nextCommand: opts.nextAction.command,
+      summary: opts.nextAction.summary,
+    };
+  }
+  if (code === "approve_plan") {
+    return {
+      phase: "needs_plan_approval",
+      authoritativeCheckout: "base_checkout",
+      blocker,
+      nextCommand: opts.nextAction.command,
+      summary: opts.nextAction.summary,
+    };
+  }
+  if (code === "start_or_recover_worktree") {
+    return {
+      phase: "worktree_needed",
+      authoritativeCheckout: "base_checkout",
+      blocker,
+      nextCommand: opts.nextAction.command,
+      summary: opts.nextAction.summary,
+    };
+  }
+  if (code === "wait_runner") {
+    return {
+      phase: "runner_wait",
+      authoritativeCheckout: "task_worktree",
+      blocker,
+      nextCommand: opts.nextAction.command,
+      summary: opts.nextAction.summary,
+    };
+  }
+  if (code === "open_pr") {
+    return {
+      phase: "pr_needed",
+      authoritativeCheckout: "task_worktree",
+      blocker,
+      nextCommand: opts.nextAction.command,
+      summary: opts.nextAction.summary,
+    };
+  }
+  if (code === "update_pr_artifacts" || code === "verify_or_update_pr") {
+    return {
+      phase: code === "update_pr_artifacts" ? "pr_artifacts_stale" : "verify_or_pr_update",
+      authoritativeCheckout: "task_worktree",
+      blocker,
+      nextCommand: opts.nextAction.command,
+      summary: opts.nextAction.summary,
+    };
+  }
+  if (code === "wait_hosted_checks") {
+    return {
+      phase: "pr_open_integration_lane",
+      authoritativeCheckout: "base_checkout",
+      blocker,
+      nextCommand: opts.nextAction.command,
+      summary: opts.nextAction.summary,
+    };
+  }
+  if (code === "open_close_tail") {
+    return {
+      phase: "close_tail_needed",
+      authoritativeCheckout: "base_checkout",
+      blocker,
+      nextCommand: opts.nextAction.command,
+      summary: opts.nextAction.summary,
+    };
+  }
+  if (code === "merge_close_tail") {
+    return {
+      phase: "close_tail_provider_lane",
+      authoritativeCheckout: "provider",
+      blocker,
+      nextCommand: opts.nextAction.command,
+      summary: opts.nextAction.summary,
+    };
+  }
+  if (code === "cleanup") {
+    return {
+      phase: "done_pending_cleanup",
+      authoritativeCheckout: "base_checkout",
+      blocker,
+      nextCommand: opts.nextAction.command,
+      summary: opts.nextAction.summary,
+    };
+  }
+  return {
+    phase: code,
+    authoritativeCheckout: "current_checkout",
+    blocker,
+    nextCommand: opts.nextAction.command,
+    summary: opts.nextAction.summary,
+  };
+}

--- a/packages/agentplane/src/commands/task/brief.command.ts
+++ b/packages/agentplane/src/commands/task/brief.command.ts
@@ -21,6 +21,8 @@ export type TaskBriefParsed = {
 
 type TaskBriefRoute = {
   workflow_mode: string;
+  phase: string;
+  authoritative_checkout: string;
   checkout_role: string;
   branch: string | null;
   base_branch: string | null;
@@ -322,6 +324,8 @@ async function buildTaskBrief(opts: {
     },
     route: {
       workflow_mode: route.workflowMode,
+      phase: route.oracle.phase,
+      authoritative_checkout: route.oracle.authoritativeCheckout,
       checkout_role: route.workspace.checkoutRole,
       branch: route.workspace.branch,
       base_branch: route.workspace.baseBranch,
@@ -393,6 +397,8 @@ export function makeRunTaskBriefHandler(getCtx: (cmd: string) => Promise<Command
         { label: "title", value: brief.task.title },
         { label: "owner", value: brief.task.owner },
         { label: "workflow", value: brief.workflow.mode },
+        { label: "phase", value: brief.route.phase },
+        { label: "authoritative_checkout", value: brief.route.authoritative_checkout },
         { label: "checkout_role", value: brief.workflow.checkout_role },
         { label: "branch", value: brief.workflow.branch ?? "unknown" },
         { label: "base_branch", value: brief.workflow.base_branch ?? "unknown" },

--- a/packages/agentplane/src/commands/task/next-action.command.ts
+++ b/packages/agentplane/src/commands/task/next-action.command.ts
@@ -58,6 +58,7 @@ export function makeRunTaskNextActionHandler(getCtx: (cmd: string) => Promise<Co
     if (parsed.json) {
       output.json({
         task: decision.task,
+        route_oracle: decision.oracle,
         next_action: decision.nextAction,
         blockers: decision.blockers,
         source_confidence: {
@@ -71,10 +72,18 @@ export function makeRunTaskNextActionHandler(getCtx: (cmd: string) => Promise<Co
     }
     output.report(
       [
+        { label: "phase", value: decision.oracle.phase },
+        { label: "authoritative_checkout", value: decision.oracle.authoritativeCheckout },
         { label: "code", value: decision.nextAction.code },
         { label: "summary", value: decision.nextAction.summary },
         { label: "requires_approval", value: decision.nextAction.requiresApproval },
-        { label: "command", value: decision.nextAction.command ?? "none" },
+        { label: "next_command", value: decision.oracle.nextCommand ?? "none" },
+        {
+          label: "primary_blocker",
+          value: decision.oracle.blocker
+            ? `${decision.oracle.blocker.code}: ${decision.oracle.blocker.summary}`
+            : "none",
+        },
         ...(parsed.explain
           ? [
               { label: "workflow", value: decision.workflowMode },

--- a/packages/agentplane/src/commands/task/status.command.ts
+++ b/packages/agentplane/src/commands/task/status.command.ts
@@ -78,11 +78,13 @@ export function makeRunTaskStatusHandler(getCtx: (cmd: string) => Promise<Comman
     ];
     if (parsed.route) {
       entries.push(
+        { label: "phase", value: decision.oracle.phase },
+        { label: "authoritative_checkout", value: decision.oracle.authoritativeCheckout },
         { label: "branch", value: decision.workspace.branch ?? "unknown" },
         { label: "checkout_role", value: decision.workspace.checkoutRole },
         { label: "pr_branch", value: decision.workspace.prBranch ?? "missing" },
         { label: "next_code", value: decision.nextAction.code },
-        { label: "next", value: decision.nextAction.command ?? decision.nextAction.summary },
+        { label: "next", value: decision.oracle.nextCommand ?? decision.oracle.summary },
         {
           label: "effective_mutation_approval",
           value: String(decision.approval.effectiveMutationApprovalRequired),


### PR DESCRIPTION
Task: `202605271737-1K3J53`
Title: Strengthen task route oracle
Canonical task record: `.agentplane/tasks/202605271737-1K3J53/README.md`

## Summary

Strengthen task route oracle

Enhance the CLI route oracle so one command reports the current phase, authoritative checkout, blocker, and next concrete command for agent execution.

## Scope

- In scope: Enhance the CLI route oracle so one command reports the current phase, authoritative checkout, blocker, and next concrete command for agent execution.
- Out of scope: unrelated refactors not required for "Strengthen task route oracle".

## Verification

- State: ok
- Note: Implemented route oracle packet and verified focused route-decision behavior.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-27T17:39:04.987Z
- Branch: task/202605271737-1K3J53/strengthen-task-route-oracle
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/cli/run-cli.core.route-decision.test.ts    |  31 ++++-
 .../src/commands/shared/route-decision.ts          | 152 +++++++++++++++++++++
 .../agentplane/src/commands/task/brief.command.ts  |   6 +
 .../src/commands/task/next-action.command.ts       |  11 +-
 .../agentplane/src/commands/task/status.command.ts |   4 +-
 5 files changed, 201 insertions(+), 3 deletions(-)
```

</details>
