### PR TITLE
🚧 GQ43NN task: Handle context verify-task non-context skip [202605281326-GQ43NN]

### DIFF
--- a/.agentplane/tasks/202605281326-GQ43NN/README.md
+++ b/.agentplane/tasks/202605281326-GQ43NN/README.md
@@ -4,7 +4,7 @@ title: "Handle context verify-task non-context skip"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -22,6 +22,23 @@ verification:
   updated_by: "CODER"
   note: "Verified explicit non-applicable skip for non-context context verify-task."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-28T13:34:28.145Z"
+  updated_by: "EVALUATOR"
+  note: "context verify-task now reports non-context task-new work as an explicit non-applicable skip while preserving validation failures for malformed context tasks."
+  evaluated_sha: "0ba3f34dbe2815342a0cf962b723d62b6ba3c5b5"
+  blueprint_digest: "4b510f2c38efac6bf3c2410dfb06e06745700fd819b93c264606e6eaff1a0fff"
+  evidence_refs:
+    - ".agentplane/tasks/202605281326-GQ43NN/README.md"
+    - ".agentplane/tasks/202605281326-GQ43NN/quality/20260528-133428145-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605281326-GQ43NN/quality/20260528-133428145-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605281326-GQ43NN/quality/20260528-133428145-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605281326-GQ43NN/blueprint/resolved-snapshot.json"
+    - "packages/agentplane/src/commands/context/verify-task.maximum-assimilation.unit.test.ts"
+    - "packages/agentplane/src/context/verify-task.ts"
+  findings:
+    - "Focused regression and context verification tests passed; policy routing and doctor passed; current ordinary code task produces skipped_not_applicable instead of hidden success."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202605281326-GQ43NN/README.md
+++ b/.agentplane/tasks/202605281326-GQ43NN/README.md
@@ -1,0 +1,168 @@
+---
+id: "202605281326-GQ43NN"
+title: "Handle context verify-task non-context skip"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-28T13:26:30.757Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-28T13:32:51.911Z"
+  updated_by: "CODER"
+  note: "Verified explicit non-applicable skip for non-context context verify-task."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement explicit context verify-task non-applicable skip handling for ordinary non-context tasks, add regression coverage, and verify with targeted tests plus policy/doctor gates."
+events:
+  -
+    type: "status"
+    at: "2026-05-28T13:27:17.242Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement explicit context verify-task non-applicable skip handling for ordinary non-context tasks, add regression coverage, and verify with targeted tests plus policy/doctor gates."
+  -
+    type: "verify"
+    at: "2026-05-28T13:32:51.911Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified explicit non-applicable skip for non-context context verify-task."
+doc_version: 3
+doc_updated_at: "2026-05-28T13:32:52.005Z"
+doc_updated_by: "CODER"
+description: "Fix context verify-task handling so tasks created through ordinary task new that are not task_kind=context are reported as an explicit non-applicable skip when appropriate, and cover the behavior with focused tests."
+sections:
+  Summary: |-
+    Handle context verify-task non-context skip
+
+    Fix context verify-task handling so tasks created through ordinary task new that are not task_kind=context are reported as an explicit non-applicable skip when appropriate, and cover the behavior with focused tests.
+  Scope: |-
+    - In scope: Fix context verify-task handling so tasks created through ordinary task new that are not task_kind=context are reported as an explicit non-applicable skip when appropriate, and cover the behavior with focused tests.
+    - Out of scope: unrelated refactors not required for "Handle context verify-task non-context skip".
+  Plan: |-
+    1. Inspect context verify-task command behavior for non-context tasks and existing context verification tests.
+    2. Implement explicit non-applicable skip handling for tasks that are not task_kind=context so policy/doctor evidence can record a skip without presenting hidden success.
+    3. Add focused regression coverage for ordinary task new / code task behavior and keep existing context-task failure behavior intact.
+    4. Run targeted tests plus policy routing, doctor, and task verify-show; record any explicit skips in task verification.
+  Verify Steps: |-
+    1. Run focused regression tests for context verify-task non-context behavior. Expected: non-context tasks produce an explicit non-applicable skip result, while malformed context tasks still fail validation.
+    2. Run the relevant context verify-task/maximum-assimilation test subset. Expected: existing context-task validation remains green.
+    3. Run policy/runtime gates: node .agentplane/policy/check-routing.mjs and ap doctor. Expected: both pass.
+    4. Run ap task verify-show 202605281326-GQ43NN. Expected: declared task verification contract is visible and satisfied or any skip is recorded explicitly.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-28T13:32:51.911Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified explicit non-applicable skip for non-context context verify-task.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-28T13:27:17.242Z, excerpt_hash=sha256:f0cd55d010af445f6dc464218f66275631a1dffcec19f5bfff824d3f06c1b2a0
+
+    Details:
+
+    Command: bunx vitest run packages/agentplane/src/commands/context/verify-task.maximum-assimilation.unit.test.ts. Result: pass. Evidence: 1 file, 3 tests passed; ordinary task-new task reports skipped_not_applicable and malformed context task still fails validation. Scope: regression for context verify-task applicability.
+    Command: bunx vitest run packages/agentplane/src/commands/context/verify-task.maximum-assimilation.test.ts packages/agentplane/src/commands/context/release-readiness.test.ts. Result: pass. Evidence: 2 files, 23 tests passed. Scope: existing context-task and maximum-assimilation behavior.
+    Command: node .agentplane/policy/check-routing.mjs. Result: pass. Evidence: policy routing OK. Scope: policy graph/routing budgets.
+    Command: ap doctor. Result: pass. Evidence: doctor OK; errors=0 warnings=0. Scope: runtime and workflow health.
+    Command: ap task verify-show 202605281326-GQ43NN. Result: pass. Evidence: Verify Steps and blueprint evidence displayed; snapshot current. Scope: task verification contract.
+    Command: bunx prettier --check packages/agentplane/src/context/verify-task.ts packages/agentplane/src/commands/context/verify-task.maximum-assimilation.unit.test.ts. Result: pass. Evidence: all matched files use Prettier style. Scope: touched files formatting.
+    Command: bunx eslint packages/agentplane/src/context/verify-task.ts packages/agentplane/src/commands/context/verify-task.maximum-assimilation.unit.test.ts. Result: pass. Evidence: ESLint exited 0. Scope: touched files lint.
+    Command: git diff --check. Result: pass. Evidence: no whitespace errors. Scope: final diff hygiene.
+    Command: ap context verify-task 202605281326-GQ43NN. Result: pass as explicit skip. Evidence: skipped_not_applicable (task_kind=unknown; expected context). Scope: current ordinary task-new code task is not a context assimilation task.
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605281326-GQ43NN-handle-context-verify-task-non-context-skip/.agentplane/tasks/202605281326-GQ43NN/blueprint/resolved-snapshot.json
+    - old_digest: 4b510f2c38efac6bf3c2410dfb06e06745700fd819b93c264606e6eaff1a0fff
+    - current_digest: 4b510f2c38efac6bf3c2410dfb06e06745700fd819b93c264606e6eaff1a0fff
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605281326-GQ43NN
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Handle context verify-task non-context skip
+
+Fix context verify-task handling so tasks created through ordinary task new that are not task_kind=context are reported as an explicit non-applicable skip when appropriate, and cover the behavior with focused tests.
+
+## Scope
+
+- In scope: Fix context verify-task handling so tasks created through ordinary task new that are not task_kind=context are reported as an explicit non-applicable skip when appropriate, and cover the behavior with focused tests.
+- Out of scope: unrelated refactors not required for "Handle context verify-task non-context skip".
+
+## Plan
+
+1. Inspect context verify-task command behavior for non-context tasks and existing context verification tests.
+2. Implement explicit non-applicable skip handling for tasks that are not task_kind=context so policy/doctor evidence can record a skip without presenting hidden success.
+3. Add focused regression coverage for ordinary task new / code task behavior and keep existing context-task failure behavior intact.
+4. Run targeted tests plus policy routing, doctor, and task verify-show; record any explicit skips in task verification.
+
+## Verify Steps
+
+1. Run focused regression tests for context verify-task non-context behavior. Expected: non-context tasks produce an explicit non-applicable skip result, while malformed context tasks still fail validation.
+2. Run the relevant context verify-task/maximum-assimilation test subset. Expected: existing context-task validation remains green.
+3. Run policy/runtime gates: node .agentplane/policy/check-routing.mjs and ap doctor. Expected: both pass.
+4. Run ap task verify-show 202605281326-GQ43NN. Expected: declared task verification contract is visible and satisfied or any skip is recorded explicitly.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-28T13:32:51.911Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified explicit non-applicable skip for non-context context verify-task.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-28T13:27:17.242Z, excerpt_hash=sha256:f0cd55d010af445f6dc464218f66275631a1dffcec19f5bfff824d3f06c1b2a0
+
+Details:
+
+Command: bunx vitest run packages/agentplane/src/commands/context/verify-task.maximum-assimilation.unit.test.ts. Result: pass. Evidence: 1 file, 3 tests passed; ordinary task-new task reports skipped_not_applicable and malformed context task still fails validation. Scope: regression for context verify-task applicability.
+Command: bunx vitest run packages/agentplane/src/commands/context/verify-task.maximum-assimilation.test.ts packages/agentplane/src/commands/context/release-readiness.test.ts. Result: pass. Evidence: 2 files, 23 tests passed. Scope: existing context-task and maximum-assimilation behavior.
+Command: node .agentplane/policy/check-routing.mjs. Result: pass. Evidence: policy routing OK. Scope: policy graph/routing budgets.
+Command: ap doctor. Result: pass. Evidence: doctor OK; errors=0 warnings=0. Scope: runtime and workflow health.
+Command: ap task verify-show 202605281326-GQ43NN. Result: pass. Evidence: Verify Steps and blueprint evidence displayed; snapshot current. Scope: task verification contract.
+Command: bunx prettier --check packages/agentplane/src/context/verify-task.ts packages/agentplane/src/commands/context/verify-task.maximum-assimilation.unit.test.ts. Result: pass. Evidence: all matched files use Prettier style. Scope: touched files formatting.
+Command: bunx eslint packages/agentplane/src/context/verify-task.ts packages/agentplane/src/commands/context/verify-task.maximum-assimilation.unit.test.ts. Result: pass. Evidence: ESLint exited 0. Scope: touched files lint.
+Command: git diff --check. Result: pass. Evidence: no whitespace errors. Scope: final diff hygiene.
+Command: ap context verify-task 202605281326-GQ43NN. Result: pass as explicit skip. Evidence: skipped_not_applicable (task_kind=unknown; expected context). Scope: current ordinary task-new code task is not a context assimilation task.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605281326-GQ43NN-handle-context-verify-task-non-context-skip/.agentplane/tasks/202605281326-GQ43NN/blueprint/resolved-snapshot.json
+- old_digest: 4b510f2c38efac6bf3c2410dfb06e06745700fd819b93c264606e6eaff1a0fff
+- current_digest: 4b510f2c38efac6bf3c2410dfb06e06745700fd819b93c264606e6eaff1a0fff
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605281326-GQ43NN
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605281326-GQ43NN/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605281326-GQ43NN/blueprint/resolved-snapshot.json
@@ -1,0 +1,570 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605281326-GQ43NN",
+    "title": "Handle context verify-task non-context skip",
+    "description": "Fix context verify-task handling so tasks created through ordinary task new that are not task_kind=context are reported as an explicit non-applicable skip when appropriate, and cover the behavior with focused tests.",
+    "tags": [
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605281326-GQ43NN",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "4b510f2c38efac6bf3c2410dfb06e06745700fd819b93c264606e6eaff1a0fff"
+  }
+}

--- a/.agentplane/tasks/202605281326-GQ43NN/pr/diffstat.txt
+++ b/.agentplane/tasks/202605281326-GQ43NN/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../verify-task.maximum-assimilation.unit.test.ts  | 62 ++++++++++++++++++++++
+ packages/agentplane/src/context/verify-task.ts     |  9 ++--
+ 2 files changed, 66 insertions(+), 5 deletions(-)

--- a/.agentplane/tasks/202605281326-GQ43NN/pr/github-body.md
+++ b/.agentplane/tasks/202605281326-GQ43NN/pr/github-body.md
@@ -27,7 +27,9 @@ Fix context verify-task handling so tasks created through ordinary task new that
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../verify-task.maximum-assimilation.unit.test.ts  | 62 ++++++++++++++++++++++
+ packages/agentplane/src/context/verify-task.ts     |  9 ++--
+ 2 files changed, 66 insertions(+), 5 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605281326-GQ43NN/pr/github-body.md
+++ b/.agentplane/tasks/202605281326-GQ43NN/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605281326-GQ43NN`
+Title: Handle context verify-task non-context skip
+Canonical task record: `.agentplane/tasks/202605281326-GQ43NN/README.md`
+
+## Summary
+
+Handle context verify-task non-context skip
+
+Fix context verify-task handling so tasks created through ordinary task new that are not task_kind=context are reported as an explicit non-applicable skip when appropriate, and cover the behavior with focused tests.
+
+## Scope
+
+- In scope: Fix context verify-task handling so tasks created through ordinary task new that are not task_kind=context are reported as an explicit non-applicable skip when appropriate, and cover the behavior with focused tests.
+- Out of scope: unrelated refactors not required for "Handle context verify-task non-context skip".
+
+## Verification
+
+- State: ok
+- Note: Verified explicit non-applicable skip for non-context context verify-task.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-28T13:27:17.393Z
+- Branch: task/202605281326-GQ43NN/handle-context-verify-task-non-context-skip
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605281326-GQ43NN/pr/github-title.txt
+++ b/.agentplane/tasks/202605281326-GQ43NN/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 GQ43NN task: Handle context verify-task non-context skip [202605281326-GQ43NN]

--- a/.agentplane/tasks/202605281326-GQ43NN/pr/meta.json
+++ b/.agentplane/tasks/202605281326-GQ43NN/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605281326-GQ43NN/handle-context-verify-task-non-context-skip",
+  "created_at": "2026-05-28T13:27:17.393Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": "2026-05-28T13:32:51.911Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202605281326-GQ43NN",
+  "updated_at": "2026-05-28T13:27:17.393Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605281326-GQ43NN/pr/meta.json
+++ b/.agentplane/tasks/202605281326-GQ43NN/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605281326-GQ43NN/handle-context-verify-task-non-context-skip",
   "created_at": "2026-05-28T13:27:17.393Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "diffstat_sha256": "sha256:578212f948ae10f5d2ee35efe7f6ee8e8a40579a4e4fcb4b5f79c2828a7a572c",
   "last_verified_at": "2026-05-28T13:32:51.911Z",
   "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "schema_version": 1,

--- a/.agentplane/tasks/202605281326-GQ43NN/pr/review.md
+++ b/.agentplane/tasks/202605281326-GQ43NN/pr/review.md
@@ -29,7 +29,9 @@ Created: 2026-05-28T13:27:17.393Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../verify-task.maximum-assimilation.unit.test.ts  | 62 ++++++++++++++++++++++
+ packages/agentplane/src/context/verify-task.ts     |  9 ++--
+ 2 files changed, 66 insertions(+), 5 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605281326-GQ43NN/pr/review.md
+++ b/.agentplane/tasks/202605281326-GQ43NN/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-28T13:27:17.393Z
+
+## Task
+
+- Task: `202605281326-GQ43NN`
+- Title: Handle context verify-task non-context skip
+- Status: DOING
+- Branch: `task/202605281326-GQ43NN/handle-context-verify-task-non-context-skip`
+- Canonical task record: `.agentplane/tasks/202605281326-GQ43NN/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified explicit non-applicable skip for non-context context verify-task.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-28T13:27:17.393Z
+- Branch: task/202605281326-GQ43NN/handle-context-verify-task-non-context-skip
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605281326-GQ43NN/quality/20260528-133428145-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605281326-GQ43NN/quality/20260528-133428145-recovery-context/evaluator-opinion.md
@@ -1,0 +1,20 @@
+# EVALUATOR opinion: pass
+
+context verify-task now reports non-context task-new work as an explicit non-applicable skip while preserving validation failures for malformed context tasks.
+
+## Findings
+- Focused regression and context verification tests passed; policy routing and doctor passed; current ordinary code task produces skipped_not_applicable instead of hidden success.
+
+## Evidence
+- .agentplane/tasks/202605281326-GQ43NN/README.md
+- packages/agentplane/src/commands/context/verify-task.maximum-assimilation.unit.test.ts
+- packages/agentplane/src/context/verify-task.ts
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202605281326-GQ43NN/quality/20260528-133428145-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605281326-GQ43NN/quality/20260528-133428145-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605281326-GQ43NN
+- task_readme: .agentplane/tasks/202605281326-GQ43NN/README.md
+- report_path: .agentplane/tasks/202605281326-GQ43NN/quality/20260528-133428145-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605281326-GQ43NN/quality/20260528-133428145-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605281326-GQ43NN/quality/20260528-133428145-recovery-context/quality-report.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "task_id": "202605281326-GQ43NN",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-28T13:34:28.145Z",
+  "verdict": "pass",
+  "summary": "context verify-task now reports non-context task-new work as an explicit non-applicable skip while preserving validation failures for malformed context tasks.",
+  "evaluated_sha": "0ba3f34dbe2815342a0cf962b723d62b6ba3c5b5",
+  "blueprint_digest": "4b510f2c38efac6bf3c2410dfb06e06745700fd819b93c264606e6eaff1a0fff",
+  "findings": [
+    "Focused regression and context verification tests passed; policy routing and doctor passed; current ordinary code task produces skipped_not_applicable instead of hidden success."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605281326-GQ43NN/README.md",
+    "packages/agentplane/src/commands/context/verify-task.maximum-assimilation.unit.test.ts",
+    "packages/agentplane/src/context/verify-task.ts"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/commands/context/verify-task.maximum-assimilation.unit.test.ts
+++ b/packages/agentplane/src/commands/context/verify-task.maximum-assimilation.unit.test.ts
@@ -29,6 +29,68 @@ async function write(root: string, rel: string, text: string): Promise<void> {
 }
 
 describe("maximum-assimilation task verification", () => {
+  it("reports ordinary task-new tasks as an explicit non-applicable skip", async () => {
+    const root = await tempRoot();
+    const task = {
+      id: "202605281326-CODE01",
+      status: "DOING",
+      owner: "CODER",
+      mutation_scope: "code",
+      blueprint_request: "code.branch_pr",
+      runner: { evidence: { changed_paths: ["packages/agentplane/src/context/verify-task.ts"] } },
+    };
+    const ctx = {
+      resolvedProject: { gitRoot: root },
+      config: { paths: { workflow_dir: ".agentplane/tasks" } },
+      taskBackend: { getTask: () => Promise.resolve(task) },
+      backendId: "local",
+      backendConfigPath: path.join(root, ".agentplane/backends/local/backend.json"),
+      memo: {},
+    } as unknown as CommandContext;
+    const out = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await expect(
+      cmdContextVerifyTask({
+        ctx,
+        cwd: root,
+        parsed: { taskId: task.id },
+      }),
+    ).resolves.toBe(0);
+
+    expect(out.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      "context verify-task 202605281326-CODE01: skipped_not_applicable (task_kind=unknown; expected context)",
+    );
+  });
+
+  it("still rejects context tasks with invalid mutation scope", async () => {
+    const root = await tempRoot();
+    const task = {
+      id: "202605281326-CTXBAD",
+      status: "DOING",
+      owner: "CURATOR",
+      task_kind: "context",
+      mutation_scope: "code",
+      blueprint_request: "context.assimilation",
+      extensions: { "agentplane.context": {} },
+    };
+    const ctx = {
+      resolvedProject: { gitRoot: root },
+      config: { paths: { workflow_dir: ".agentplane/tasks" } },
+      taskBackend: { getTask: () => Promise.resolve(task) },
+      backendId: "local",
+      backendConfigPath: path.join(root, ".agentplane/backends/local/backend.json"),
+      memo: {},
+    } as unknown as CommandContext;
+
+    await expect(
+      cmdContextVerifyTask({
+        ctx,
+        cwd: root,
+        parsed: { taskId: task.id },
+      }),
+    ).rejects.toThrow(/invalid mutation scope/u);
+  });
+
   it("rejects glossary files without navigable canonical entries", async () => {
     const root = await tempRoot();
     await write(

--- a/packages/agentplane/src/context/verify-task.ts
+++ b/packages/agentplane/src/context/verify-task.ts
@@ -458,11 +458,10 @@ export async function cmdContextVerifyTask(opts: {
     });
   }
   if (task.task_kind !== "context") {
-    throw new CliError({
-      exitCode: 3,
-      code: "E_VALIDATION",
-      message: `Task ${opts.parsed.taskId} is not a context task (found ${task.task_kind ?? "unknown"})`,
-    });
+    process.stdout.write(
+      `context verify-task ${opts.parsed.taskId}: skipped_not_applicable (task_kind=${task.task_kind ?? "unknown"}; expected context)\n`,
+    );
+    return 0;
   }
   if (task.mutation_scope !== "context") {
     throw new CliError({


### PR DESCRIPTION
Task: `202605281326-GQ43NN`
Title: Handle context verify-task non-context skip
Canonical task record: `.agentplane/tasks/202605281326-GQ43NN/README.md`

## Summary

Handle context verify-task non-context skip

Fix context verify-task handling so tasks created through ordinary task new that are not task_kind=context are reported as an explicit non-applicable skip when appropriate, and cover the behavior with focused tests.

## Scope

- In scope: Fix context verify-task handling so tasks created through ordinary task new that are not task_kind=context are reported as an explicit non-applicable skip when appropriate, and cover the behavior with focused tests.
- Out of scope: unrelated refactors not required for "Handle context verify-task non-context skip".

## Verification

- State: ok
- Note: Verified explicit non-applicable skip for non-context context verify-task.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-28T13:27:17.393Z
- Branch: task/202605281326-GQ43NN/handle-context-verify-task-non-context-skip
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../verify-task.maximum-assimilation.unit.test.ts  | 62 ++++++++++++++++++++++
 packages/agentplane/src/context/verify-task.ts     |  9 ++--
 2 files changed, 66 insertions(+), 5 deletions(-)
```

</details>
