### PR TITLE
🚧 VX8QQ2 task: Decouple prompt assembly from optional local context [202605281714-VX8QQ2]

### DIFF
--- a/.agentplane/tasks/202605281714-VX8QQ2/README.md
+++ b/.agentplane/tasks/202605281714-VX8QQ2/README.md
@@ -1,0 +1,152 @@
+---
+id: "202605281714-VX8QQ2"
+title: "Decouple prompt assembly from optional local context"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-28T17:15:06.168Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-28T17:20:11.658Z"
+  updated_by: "CODER"
+  note: "Focused prompt/context tests, docs freshness checks, typecheck, format check, diff check, routing policy, and doctor passed. Local context is now documented as optional and independent from runner prompt assembly; context init default remains maximum-assimilation."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: decouple runner prompt assembly from the optional local context workspace and align context init defaults with maximum-assimilation docs/tests."
+events:
+  -
+    type: "status"
+    at: "2026-05-28T17:15:16.931Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: decouple runner prompt assembly from the optional local context workspace and align context init defaults with maximum-assimilation docs/tests."
+  -
+    type: "verify"
+    at: "2026-05-28T17:20:11.658Z"
+    author: "CODER"
+    state: "ok"
+    note: "Focused prompt/context tests, docs freshness checks, typecheck, format check, diff check, routing policy, and doctor passed. Local context is now documented as optional and independent from runner prompt assembly; context init default remains maximum-assimilation."
+doc_version: 3
+doc_updated_at: "2026-05-28T17:20:11.674Z"
+doc_updated_by: "CODER"
+description: "Clarify and enforce that runner prompt assembly is independent from the optional local context workspace, and keep context init defaulting to maximum-assimilation across docs/tests."
+sections:
+  Summary: |-
+    Decouple prompt assembly from optional local context
+
+    Clarify and enforce that runner prompt assembly is independent from the optional local context workspace, and keep context init defaulting to maximum-assimilation across docs/tests.
+  Scope: |-
+    - In scope: Clarify and enforce that runner prompt assembly is independent from the optional local context workspace, and keep context init defaulting to maximum-assimilation across docs/tests.
+    - Out of scope: unrelated refactors not required for "Decouple prompt assembly from optional local context".
+  Plan: |-
+    1. Inspect runner prompt assembly and local context initialization surfaces.
+    2. Add focused tests documenting that runner prompt collection works without a local context workspace.
+    3. Clarify docs/bootstrap wording so prompt assembly and the optional local context layer are distinct.
+    4. Keep context init default as maximum-assimilation across CLI reference and context docs.
+    5. Run focused prompt/context tests plus docs/policy checks; record any pre-existing checkout blockers separately.
+  Verify Steps: |-
+    1. Inspect runner prompt assembly tests and docs to confirm local context is described as optional and independent from prompt/bootstrap surfaces.
+    2. Run focused prompt/context tests: `bun test packages/agentplane/src/runner/context/base-prompts.test.ts packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/cli/run-cli.core.context-init.test.ts`.
+    3. Run docs/runtime checks: `bun run docs:cli:check`, `bun run docs:bootstrap:check`, `bun run typecheck`, `bun run format:check`, `git diff --check`, `node .agentplane/policy/check-routing.mjs`, and `node packages/agentplane/bin/agentplane.js doctor`.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-28T17:20:11.658Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Focused prompt/context tests, docs freshness checks, typecheck, format check, diff check, routing policy, and doctor passed. Local context is now documented as optional and independent from runner prompt assembly; context init default remains maximum-assimilation.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-28T17:15:16.931Z, excerpt_hash=sha256:30605a674e2f325acf140ec5a9bbf4b4ec3f4e69166261ade7c3dc3afe1dbcd9
+
+    Details:
+
+    Commands: bun test packages/agentplane/src/runner/context/base-prompts.test.ts packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/cli/run-cli.core.context-init.test.ts; bun run docs:cli:check; bun run docs:bootstrap:check; bun run typecheck; bun run format:check; git diff --check; node .agentplane/policy/check-routing.mjs; node packages/agentplane/bin/agentplane.js doctor. Result: pass. Evidence: 37 tests passed, docs up to date, typecheck OK, Prettier OK, routing OK, doctor OK.
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605281714-VX8QQ2-prompt-context-decoupling/.agentplane/tasks/202605281714-VX8QQ2/blueprint/resolved-snapshot.json
+    - old_digest: f3860be40725fc676cb75dfd5ecc4306d8f892865f106faf102459fbf3515fd1
+    - current_digest: f3860be40725fc676cb75dfd5ecc4306d8f892865f106faf102459fbf3515fd1
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605281714-VX8QQ2
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Decouple prompt assembly from optional local context
+
+Clarify and enforce that runner prompt assembly is independent from the optional local context workspace, and keep context init defaulting to maximum-assimilation across docs/tests.
+
+## Scope
+
+- In scope: Clarify and enforce that runner prompt assembly is independent from the optional local context workspace, and keep context init defaulting to maximum-assimilation across docs/tests.
+- Out of scope: unrelated refactors not required for "Decouple prompt assembly from optional local context".
+
+## Plan
+
+1. Inspect runner prompt assembly and local context initialization surfaces.
+2. Add focused tests documenting that runner prompt collection works without a local context workspace.
+3. Clarify docs/bootstrap wording so prompt assembly and the optional local context layer are distinct.
+4. Keep context init default as maximum-assimilation across CLI reference and context docs.
+5. Run focused prompt/context tests plus docs/policy checks; record any pre-existing checkout blockers separately.
+
+## Verify Steps
+
+1. Inspect runner prompt assembly tests and docs to confirm local context is described as optional and independent from prompt/bootstrap surfaces.
+2. Run focused prompt/context tests: `bun test packages/agentplane/src/runner/context/base-prompts.test.ts packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/cli/run-cli.core.context-init.test.ts`.
+3. Run docs/runtime checks: `bun run docs:cli:check`, `bun run docs:bootstrap:check`, `bun run typecheck`, `bun run format:check`, `git diff --check`, `node .agentplane/policy/check-routing.mjs`, and `node packages/agentplane/bin/agentplane.js doctor`.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-28T17:20:11.658Z — VERIFY — ok
+
+By: CODER
+
+Note: Focused prompt/context tests, docs freshness checks, typecheck, format check, diff check, routing policy, and doctor passed. Local context is now documented as optional and independent from runner prompt assembly; context init default remains maximum-assimilation.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-28T17:15:16.931Z, excerpt_hash=sha256:30605a674e2f325acf140ec5a9bbf4b4ec3f4e69166261ade7c3dc3afe1dbcd9
+
+Details:
+
+Commands: bun test packages/agentplane/src/runner/context/base-prompts.test.ts packages/agentplane/src/commands/context/release-readiness.test.ts packages/agentplane/src/cli/run-cli.core.context-init.test.ts; bun run docs:cli:check; bun run docs:bootstrap:check; bun run typecheck; bun run format:check; git diff --check; node .agentplane/policy/check-routing.mjs; node packages/agentplane/bin/agentplane.js doctor. Result: pass. Evidence: 37 tests passed, docs up to date, typecheck OK, Prettier OK, routing OK, doctor OK.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605281714-VX8QQ2-prompt-context-decoupling/.agentplane/tasks/202605281714-VX8QQ2/blueprint/resolved-snapshot.json
+- old_digest: f3860be40725fc676cb75dfd5ecc4306d8f892865f106faf102459fbf3515fd1
+- current_digest: f3860be40725fc676cb75dfd5ecc4306d8f892865f106faf102459fbf3515fd1
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605281714-VX8QQ2
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605281714-VX8QQ2/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605281714-VX8QQ2/blueprint/resolved-snapshot.json
@@ -1,0 +1,570 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605281714-VX8QQ2",
+    "title": "Decouple prompt assembly from optional local context",
+    "description": "Clarify and enforce that runner prompt assembly is independent from the optional local context workspace, and keep context init defaulting to maximum-assimilation across docs/tests.",
+    "tags": [
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605281714-VX8QQ2",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "f3860be40725fc676cb75dfd5ecc4306d8f892865f106faf102459fbf3515fd1"
+  }
+}

--- a/.agentplane/tasks/202605281714-VX8QQ2/pr/diffstat.txt
+++ b/.agentplane/tasks/202605281714-VX8QQ2/pr/diffstat.txt
@@ -1,0 +1,13 @@
+ docs/context/index.mdx                             |  9 ++++++---
+ docs/context/modes.mdx                             | 23 +++++++++++++++++-----
+ docs/context/quickstart.mdx                        |  7 ++++++-
+ .../documentation-information-architecture.mdx     |  4 +++-
+ docs/user/commands.mdx                             |  7 ++++---
+ docs/user/local-context.mdx                        | 20 ++++++++++---------
+ docs/user/overview.mdx                             |  6 +++++-
+ docs/user/setup.mdx                                |  7 ++++++-
+ docs/user/website-ia.mdx                           |  5 ++++-
+ .../src/commands/context/context.command.ts        |  4 ++--
+ packages/agentplane/src/commands/context/init.ts   |  3 ++-
+ .../src/runner/context/base-prompts.test.ts        | 20 +++++++++++++++++++
+ 12 files changed, 87 insertions(+), 28 deletions(-)

--- a/.agentplane/tasks/202605281714-VX8QQ2/pr/github-body.md
+++ b/.agentplane/tasks/202605281714-VX8QQ2/pr/github-body.md
@@ -1,0 +1,51 @@
+Task: `202605281714-VX8QQ2`
+Title: Decouple prompt assembly from optional local context
+Canonical task record: `.agentplane/tasks/202605281714-VX8QQ2/README.md`
+
+## Summary
+
+Decouple prompt assembly from optional local context
+
+Clarify and enforce that runner prompt assembly is independent from the optional local context workspace, and keep context init defaulting to maximum-assimilation across docs/tests.
+
+## Scope
+
+- In scope: Clarify and enforce that runner prompt assembly is independent from the optional local context workspace, and keep context init defaulting to maximum-assimilation across docs/tests.
+- Out of scope: unrelated refactors not required for "Decouple prompt assembly from optional local context".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Focused prompt/context tests, docs freshness checks, typecheck, format check, diff check, routing
+policy, and doctor passed. Local context is now documented as optional and independent from runner
+prompt assembly; context init default remains maximum-assimilation.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-28T17:15:16.988Z
+- Branch: task/202605281714-VX8QQ2/prompt-context-decoupling
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ docs/context/index.mdx                             |  9 ++++++---
+ docs/context/modes.mdx                             | 23 +++++++++++++++++-----
+ docs/context/quickstart.mdx                        |  7 ++++++-
+ .../documentation-information-architecture.mdx     |  4 +++-
+ docs/user/commands.mdx                             |  7 ++++---
+ docs/user/local-context.mdx                        | 20 ++++++++++---------
+ docs/user/overview.mdx                             |  6 +++++-
+ docs/user/setup.mdx                                |  7 ++++++-
+ docs/user/website-ia.mdx                           |  5 ++++-
+ .../src/commands/context/context.command.ts        |  4 ++--
+ packages/agentplane/src/commands/context/init.ts   |  3 ++-
+ .../src/runner/context/base-prompts.test.ts        | 20 +++++++++++++++++++
+ 12 files changed, 87 insertions(+), 28 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605281714-VX8QQ2/pr/github-title.txt
+++ b/.agentplane/tasks/202605281714-VX8QQ2/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 VX8QQ2 task: Decouple prompt assembly from optional local context [202605281714-VX8QQ2]

--- a/.agentplane/tasks/202605281714-VX8QQ2/pr/meta.json
+++ b/.agentplane/tasks/202605281714-VX8QQ2/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605281714-VX8QQ2/prompt-context-decoupling",
+  "created_at": "2026-05-28T17:15:16.988Z",
+  "diffstat_sha256": "sha256:6e24fcac960f75dfc10f504865c479a72b8ac5c2f7b934484b68856c1ba76b70",
+  "last_verified_at": "2026-05-28T17:20:11.658Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202605281714-VX8QQ2",
+  "updated_at": "2026-05-28T17:15:16.988Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605281714-VX8QQ2/pr/review.md
+++ b/.agentplane/tasks/202605281714-VX8QQ2/pr/review.md
@@ -1,0 +1,48 @@
+# PR Review
+
+Created: 2026-05-28T17:15:16.988Z
+
+## Task
+
+- Task: `202605281714-VX8QQ2`
+- Title: Decouple prompt assembly from optional local context
+- Status: DOING
+- Branch: `task/202605281714-VX8QQ2/prompt-context-decoupling`
+- Canonical task record: `.agentplane/tasks/202605281714-VX8QQ2/README.md`
+
+## Verification
+
+- State: ok
+- Note: Focused prompt/context tests, docs freshness checks, typecheck, format check, diff check, routing policy, and doctor passed. Local context is now documented as optional and independent from runner prompt assembly; context init default remains maximum-assimilation.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-28T17:15:16.988Z
+- Branch: task/202605281714-VX8QQ2/prompt-context-decoupling
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ docs/context/index.mdx                             |  9 ++++++---
+ docs/context/modes.mdx                             | 23 +++++++++++++++++-----
+ docs/context/quickstart.mdx                        |  7 ++++++-
+ .../documentation-information-architecture.mdx     |  4 +++-
+ docs/user/commands.mdx                             |  7 ++++---
+ docs/user/local-context.mdx                        | 20 ++++++++++---------
+ docs/user/overview.mdx                             |  6 +++++-
+ docs/user/setup.mdx                                |  7 ++++++-
+ docs/user/website-ia.mdx                           |  5 ++++-
+ .../src/commands/context/context.command.ts        |  4 ++--
+ packages/agentplane/src/commands/context/init.ts   |  3 ++-
+ .../src/runner/context/base-prompts.test.ts        | 20 +++++++++++++++++++
+ 12 files changed, 87 insertions(+), 28 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/docs/context/index.mdx
+++ b/docs/context/index.mdx
@@ -5,9 +5,12 @@ description: "Use Agentplane context to give humans and agents durable project k
 
 # Context
 
-Agentplane context is repo-owned project knowledge for humans and agents. It keeps conventions,
-source notes, wiki pages, facts, graph relationships, and task-derived knowledge close to the code
-so later agent runs can search and reuse it.
+Agentplane context is an optional repo-owned project knowledge layer for humans and agents. It keeps
+conventions, source notes, wiki pages, facts, graph relationships, and task-derived knowledge close
+to the code so later agent runs can search and reuse it.
+
+Agentplane prompt assembly and runner bootstrap are separate surfaces. A normal task run can assemble
+policy, owner profile, recipe, skill, route, and task context without `agentplane context init`.
 
 ## Start here
 

--- a/docs/context/modes.mdx
+++ b/docs/context/modes.mdx
@@ -19,17 +19,30 @@ knowledge.
 | Coverage reports, glossary discipline, and raw-deletion resilience                         | `maximum-assimilation` |
 | A project knowledge base that should be useful even when raw sources are later unavailable | `maximum-assimilation` |
 
-## Adaptive
+## Default
 
-`adaptive` is the default.
+`maximum-assimilation` is the default for `agentplane context init`.
 
 ```bash
 agentplane context init
 ```
 
-Use it for most software repositories. It creates a stable context contract and lets the wiki
-structure grow from actual sources. Agents should keep the smallest useful structure, cite sources,
-and avoid duplicating concepts.
+Use the default when the context layer should become durable project memory. It creates the same
+editable context workspace as smaller profiles, but asks future context-ingestion work to preserve
+source meaning through wiki pages, facts, graph rows, glossary entries, provenance, and coverage.
+
+## Adaptive
+
+Choose `adaptive` explicitly when review cost matters more than exhaustive assimilation.
+
+```bash
+agentplane context init --profile adaptive
+```
+
+Use it for ordinary software repositories that only need reusable conventions and a small wiki that
+grows as work happens. It creates a stable context contract and lets the wiki structure grow from
+actual sources. Agents should keep the smallest useful structure, cite sources, and avoid duplicating
+concepts.
 
 Adaptive mode is best when:
 

--- a/docs/context/quickstart.mdx
+++ b/docs/context/quickstart.mdx
@@ -5,7 +5,9 @@ description: "Initialize Agentplane context, add a source, search it, and hand i
 
 # Context quickstart
 
-This path creates a small, reviewable context layer for a repository.
+This path creates an optional, reviewable context layer for a repository. Normal Agentplane prompt
+assembly, task routing, and runner bootstrap do not require this layer; initialize it only when the
+repository needs durable project knowledge.
 
 ## Initialize context
 
@@ -17,6 +19,9 @@ agentplane context check
 `context init` creates the editable context workspace and the root wiki contract. In an empty
 directory it can bootstrap an Agentplane project first. In a non-empty directory that is not already
 an Agentplane project, run `agentplane init` explicitly before context setup.
+
+When `--profile` is omitted, `context init` uses `maximum-assimilation`. Pass `--profile adaptive`
+for a smaller wiki that grows opportunistically.
 
 ## Add the first source
 

--- a/docs/developer/documentation-information-architecture.mdx
+++ b/docs/developer/documentation-information-architecture.mdx
@@ -62,12 +62,14 @@ or developer paths as if they were active guidance.
 The public docs entrypoints should mirror the default product journey:
 
 ```text
-install -> init -> context init -> hand off to an agent -> review task evidence
+install -> init -> hand off to an agent -> review task evidence
 ```
 
 Humans install and initialize Agentplane. Coding agents operate the lifecycle. Reviewers inspect the
 evidence in Git. Manual CLI operation after initialization is an advanced path for operators,
 maintainers, recovery, and debugging.
+Local context setup is an optional branch for repositories that need durable project knowledge; it is
+not part of prompt assembly or the required handoff path.
 
 1. **Start**: repository entry, setup, agent handoff, prerequisites, bootstrap.
 2. **Use with agents**: one agent-agnostic harness guide for coding agents, CI, and review modes around Agentplane.

--- a/docs/user/commands.mdx
+++ b/docs/user/commands.mdx
@@ -17,9 +17,10 @@ agentplane --version
 `agentplane --help` and `agentplane help` show the normal installed-project surface by default.
 The first screen is intentionally biased toward commands an agent needs for project work: startup,
 task lifecycle, branch/PR workflow, backend sync, recipes, diagnostics, and setup.
-For context management, `agentplane` keeps the human task-factory surface visible: `context init`,
-`context learn files`, `context learn changes`, `context learn tasks`, `context search`,
-`context show`, and `context check`.
+For optional local context management, `agentplane` keeps the human task-factory surface visible:
+`context init`, `context learn files`, `context learn changes`, `context learn tasks`,
+`context search`, `context show`, and `context check`. Runner prompt assembly does not require this
+local context layer.
 
 Advanced recovery and maintenance commands stay available through direct help or the full registry:
 

--- a/docs/user/local-context.mdx
+++ b/docs/user/local-context.mdx
@@ -112,22 +112,24 @@ project first and then creates the context workspace. In a non-empty directory t
 Agentplane project, run `agentplane init` explicitly before `agentplane context init` so the project
 gateway, workflow, backend, and conflict handling stay visible.
 
-The default init profile is `adaptive`: one stable llm-wiki contract with project-specific page
-structure. Init does not pre-create the internal wiki folders; first ingest creates the starter
-structure only when there is source material to assimilate. Agents should generate the wiki hierarchy
-from evidence, but keep page frontmatter, source refs, modalities, claims, graph refs, conflicts, and
-visibility metadata stable enough for future publication proposals and context-pack synchronization.
+The default init profile is `maximum-assimilation`: a stricter context contract for preserving
+significant source meaning as durable project memory. Init does not pre-create internal wiki folders;
+first ingest creates structure only when there is source material to assimilate. Agents should
+generate the wiki hierarchy from evidence, but keep page frontmatter, source refs, modalities,
+claims, graph refs, conflicts, and visibility metadata stable enough for future publication
+proposals and context-pack synchronization.
 
 `context show` resolves whole files, markdown sections, and line ranges. Markdown section refs use
 stable slugs such as `#section=publish-gate`; line refs use `#lines=12-24` or `#line=12`.
 
 ### Maximum-assimilation profile
 
-Use `agentplane context init --profile maximum-assimilation` when the maintained wiki and derived
-artifacts should become the complete semantic memory, not just a navigable synthesis over raw files.
-In this mode, the next context ingestion tasks request the `context.maximum_assimilation` blueprint.
+Use `agentplane context init` or `agentplane context init --profile maximum-assimilation` when the
+maintained wiki and derived artifacts should become the complete semantic memory, not just a
+navigable synthesis over raw files. In this mode, the next context ingestion tasks request the
+`context.maximum_assimilation` blueprint.
 
-The contract is stricter than the default adaptive profile:
+The contract is stricter than the adaptive profile:
 
 - Preserve all significant source meaning in wiki, fact, graph, glossary, provenance,
   and coverage artifacts. If `context/raw/**` is deleted later, the maintained context should still

--- a/docs/user/overview.mdx
+++ b/docs/user/overview.mdx
@@ -28,8 +28,12 @@ task -> plan -> approve -> implement -> verify -> finish
 The default path is:
 
 ```text
-install -> init -> context init -> hand off to an agent -> review task evidence
+install -> init -> hand off to an agent -> review task evidence
 ```
+
+Run `context init` only when the repository needs durable local knowledge. It is independent from
+the prompt assembly path that gives agents policy, owner profile, route, recipe, skill, and task
+context.
 
 Manual CLI usage beyond setup, recovery, and review is an advanced operator path. User guides should
 teach the harness boundary first; the command reference holds the exhaustive flags.

--- a/docs/user/setup.mdx
+++ b/docs/user/setup.mdx
@@ -121,7 +121,8 @@ export steps.
 ## Enable local context
 
 Use local context when agents need reusable project knowledge, source-backed facts, or task-scoped
-research material.
+research material. This layer is optional: normal prompt assembly and task execution work after
+`agentplane init` without `agentplane context init`.
 
 ```bash
 agentplane context init
@@ -132,6 +133,10 @@ agentplane context search "first task"
 In an empty standalone directory, `agentplane context init` also performs the initial Agentplane
 bootstrap before writing context files. For non-empty uninitialized projects, run `agentplane init`
 first so conflicts and gateway/workflow choices stay explicit.
+
+When no profile is provided, context initialization uses `maximum-assimilation`. Use
+`agentplane context init --profile adaptive` when the repository only needs a smaller, opportunistic
+wiki.
 
 For a task that needs context ingestion:
 

--- a/docs/user/website-ia.mdx
+++ b/docs/user/website-ia.mdx
@@ -65,8 +65,11 @@ navigation.
 The first-time path should show the default operating model before advanced command details:
 
 ```text
-install -> init -> context init -> hand off to an agent -> review task evidence
+install -> init -> hand off to an agent -> review task evidence
 ```
+
+Show `context init` as an optional local-knowledge branch from setup, not as a prerequisite for
+agent handoff or prompt assembly.
 
 Manual CLI usage beyond setup and recovery is an advanced operator path. Framework internals stay in
 the direct-link maintainer docs and are not part of the public user path.

--- a/packages/agentplane/src/commands/context/context.command.ts
+++ b/packages/agentplane/src/commands/context/context.command.ts
@@ -254,8 +254,8 @@ async function resolveContextInitParsed(
       [
         "Context init mode:",
         "minimal = smallest workspace scaffold",
-        "adaptive = default llm-wiki workspace for normal project context",
-        "maximum-assimilation = stricter mode for preserving significant source meaning",
+        "adaptive = smaller llm-wiki workspace for normal project context",
+        "maximum-assimilation = default mode for preserving significant source meaning",
       ].join("\n"),
     ) + "\n",
   );

--- a/packages/agentplane/src/commands/context/init.ts
+++ b/packages/agentplane/src/commands/context/init.ts
@@ -465,7 +465,8 @@ Profile: ${profile}
 
 Use this directory as the human-readable context surface.
 
-AgentPlane local context uses one adaptive llm-wiki contract:
+AgentPlane local context is optional and independent from runner prompt assembly. When enabled, it
+uses one llm-wiki contract:
 
 - \`context/raw/**\` keeps source material.
 - \`context/wiki/**\` keeps readable synthesis pages with AgentPlane frontmatter.

--- a/packages/agentplane/src/runner/context/base-prompts.test.ts
+++ b/packages/agentplane/src/runner/context/base-prompts.test.ts
@@ -142,6 +142,26 @@ describe("collectRunnerBasePrompts", () => {
     expect(prompts[2]?.resolution?.winner.layer).toBe("builtin");
   });
 
+  it("assembles runner prompts without an initialized local context workspace", async () => {
+    const root = await makeTempRepo();
+    await mkdir(path.join(root, ".agentplane"), { recursive: true });
+    await writeFile(path.join(root, "AGENTS.md"), "# Repo Policy\n\nNo local context layer.\n");
+
+    const prompts = await collectRunnerBasePrompts({
+      git_root: root,
+      owner_id: "CODER",
+    });
+
+    expect(prompts.map((prompt) => prompt.id)).toEqual([
+      "base.framework_runner",
+      "base.policy_gateway",
+      "base.owner_profile",
+    ]);
+    expect(prompts.find((prompt) => prompt.id === "base.policy_gateway")?.content).toContain(
+      "No local context layer",
+    );
+  });
+
   it("reuses static bundled framework prompt assembly across repeated collections", async () => {
     const root = await makeTempRepo();
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -205,8 +205,12 @@ task -> plan -> approve -> implement -> verify -> finish
 The default path is:
 
 ```text
-install -> init -> context init -> hand off to an agent -> review task evidence
+install -> init -> hand off to an agent -> review task evidence
 ```
+
+Run `context init` only when the repository needs durable local knowledge. It is independent from
+the prompt assembly path that gives agents policy, owner profile, route, recipe, skill, and task
+context.
 
 Manual CLI usage beyond setup, recovery, and review is an advanced operator path. User guides should
 teach the harness boundary first; the command reference holds the exhaustive flags.
@@ -424,7 +428,8 @@ export steps.
 ## Enable local context
 
 Use local context when agents need reusable project knowledge, source-backed facts, or task-scoped
-research material.
+research material. This layer is optional: normal prompt assembly and task execution work after
+`agentplane init` without `agentplane context init`.
 
 ```bash
 agentplane context init
@@ -435,6 +440,10 @@ agentplane context search "first task"
 In an empty standalone directory, `agentplane context init` also performs the initial Agentplane
 bootstrap before writing context files. For non-empty uninitialized projects, run `agentplane init`
 first so conflicts and gateway/workflow choices stay explicit.
+
+When no profile is provided, context initialization uses `maximum-assimilation`. Use
+`agentplane context init --profile adaptive` when the repository only needs a smaller, opportunistic
+wiki.
 
 For a task that needs context ingestion:
 
@@ -1018,9 +1027,10 @@ agentplane --version
 `agentplane --help` and `agentplane help` show the normal installed-project surface by default.
 The first screen is intentionally biased toward commands an agent needs for project work: startup,
 task lifecycle, branch/PR workflow, backend sync, recipes, diagnostics, and setup.
-For context management, `agentplane` keeps the human task-factory surface visible: `context init`,
-`context learn files`, `context learn changes`, `context learn tasks`, `context search`,
-`context show`, and `context check`.
+For optional local context management, `agentplane` keeps the human task-factory surface visible:
+`context init`, `context learn files`, `context learn changes`, `context learn tasks`,
+`context search`, `context show`, and `context check`. Runner prompt assembly does not require this
+local context layer.
 
 Advanced recovery and maintenance commands stay available through direct help or the full registry:
 
@@ -1127,8 +1137,21 @@ agentplane task doc set <task-id> --section Summary --text "..."
 agentplane task doc set <task-id> --full-doc --file ./task-readme.md
 ```
 
-Execution is owned by agents working in the repository through Codex, an IDE, or another
-human-assisted workflow. The runner command family is not part of the current public CLI surface.
+Execution is usually owned by agents working in the repository through Codex, an IDE, or another
+human-assisted workflow. For repositories that opt into the local runner path, `agentplane task run
+<task-id>` prepares AgentPlane runner artifacts and executes the configured adapter; with the default
+Codex adapter the prompt begins with `/goal ...` before the runner bundle contract.
+
+Runner observability commands are part of the same public surface:
+
+```bash
+agentplane task run status <task-id> --json
+agentplane task run inspect <task-id>
+agentplane task run logs <task-id> --stream events --follow
+```
+
+Use them from the parent/orchestrator context to monitor child runners without taking over their
+lifecycle authority.
 
 ## Advanced task projections
 


### PR DESCRIPTION
Task: `202605281714-VX8QQ2`
Title: Decouple prompt assembly from optional local context
Canonical task record: `.agentplane/tasks/202605281714-VX8QQ2/README.md`

## Summary

Decouple prompt assembly from optional local context

Clarify and enforce that runner prompt assembly is independent from the optional local context workspace, and keep context init defaulting to maximum-assimilation across docs/tests.

## Scope

- In scope: Clarify and enforce that runner prompt assembly is independent from the optional local context workspace, and keep context init defaulting to maximum-assimilation across docs/tests.
- Out of scope: unrelated refactors not required for "Decouple prompt assembly from optional local context".

## Verification

- State: ok
- Note:

```text
Focused prompt/context tests, docs freshness checks, typecheck, format check, diff check, routing
policy, and doctor passed. Local context is now documented as optional and independent from runner
prompt assembly; context init default remains maximum-assimilation.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-28T17:15:16.988Z
- Branch: task/202605281714-VX8QQ2/prompt-context-decoupling
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 docs/context/index.mdx                             |  9 ++++++---
 docs/context/modes.mdx                             | 23 +++++++++++++++++-----
 docs/context/quickstart.mdx                        |  7 ++++++-
 .../documentation-information-architecture.mdx     |  4 +++-
 docs/user/commands.mdx                             |  7 ++++---
 docs/user/local-context.mdx                        | 20 ++++++++++---------
 docs/user/overview.mdx                             |  6 +++++-
 docs/user/setup.mdx                                |  7 ++++++-
 docs/user/website-ia.mdx                           |  5 ++++-
 .../src/commands/context/context.command.ts        |  4 ++--
 packages/agentplane/src/commands/context/init.ts   |  3 ++-
 .../src/runner/context/base-prompts.test.ts        | 20 +++++++++++++++++++
 12 files changed, 87 insertions(+), 28 deletions(-)
```

</details>
