### PR TITLE
🚧 F1A522 task: Respect ignored tasks.json in hooks [202605281745-F1A522]

### DIFF
--- a/.agentplane/tasks/202605281745-F1A522/README.md
+++ b/.agentplane/tasks/202605281745-F1A522/README.md
@@ -1,0 +1,153 @@
+---
+id: "202605281745-F1A522"
+title: "Respect ignored tasks.json in hooks"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "github-issue"
+  - "hooks"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-28T17:45:41.148Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-28T17:52:34.201Z"
+  updated_by: "CODER"
+  note: "Verified issue #4188 hook behavior fix. Focused hook/protected-path tests passed; format:changed, typecheck, policy routing, and doctor passed."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement issue #4188 hook protection fix in the dedicated branch_pr worktree, keeping enforcement for tracked or explicitly staged protected files and adding focused regression coverage."
+events:
+  -
+    type: "status"
+    at: "2026-05-28T17:46:18.098Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement issue #4188 hook protection fix in the dedicated branch_pr worktree, keeping enforcement for tracked or explicitly staged protected files and adding focused regression coverage."
+  -
+    type: "verify"
+    at: "2026-05-28T17:52:34.201Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified issue #4188 hook behavior fix. Focused hook/protected-path tests passed; format:changed, typecheck, policy routing, and doctor passed."
+doc_version: 3
+doc_updated_at: "2026-05-28T17:52:34.252Z"
+doc_updated_by: "CODER"
+description: "Fix Git hook task-protection behavior from GitHub issue #4188 so ignored .agentplane/tasks.json does not require AGENTPLANE_ALLOW_TASKS unless tracked or explicitly staged."
+sections:
+  Summary: |-
+    Respect ignored tasks.json in hooks
+
+    Fix Git hook task-protection behavior from GitHub issue #4188 so ignored .agentplane/tasks.json does not require AGENTPLANE_ALLOW_TASKS unless tracked or explicitly staged.
+  Scope: |-
+    - In scope: Fix Git hook task-protection behavior from GitHub issue #4188 so ignored .agentplane/tasks.json does not require AGENTPLANE_ALLOW_TASKS unless tracked or explicitly staged.
+    - Out of scope: unrelated refactors not required for "Respect ignored tasks.json in hooks".
+  Plan: "Fix issue #4188 by narrowing hook task-protection enforcement to protected files that Git considers tracked or explicitly staged. Add a focused regression test covering ignored .agentplane/tasks.json plus a tracked/force-staged protection case. Verify with task Verify Steps, focused precommit hook tests, policy routing, and doctor."
+  Verify Steps: |-
+    1. Review the hook policy diff. Expected: `hook_pre_commit` allows active task subtree artifacts without treating ignored untracked `.agentplane/tasks.json` as staged state, while still blocking force-staged `.agentplane/tasks.json`.
+    2. Run `bun test packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts packages/agentplane/src/cli/run-cli.critical.protected-paths.test.ts packages/agentplane/src/policy/evaluate.test.ts`. Expected: all focused hook/protected-path policy tests pass.
+    3. Run `bun run format:changed`, `bun run typecheck`, `node .agentplane/policy/check-routing.mjs`, and `ap doctor`. Expected: formatting, typecheck, policy routing, and runtime health pass.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-28T17:52:34.201Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified issue #4188 hook behavior fix. Focused hook/protected-path tests passed; format:changed, typecheck, policy routing, and doctor passed.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-28T17:46:18.098Z, excerpt_hash=sha256:1dcec9bc602332260dbec126ccd200081d6e9cbf7a9a1d5b477429f46da16358
+
+    Details:
+
+    Command: bun test packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts packages/agentplane/src/cli/run-cli.critical.protected-paths.test.ts packages/agentplane/src/policy/evaluate.test.ts. Result: pass. Evidence: 30 pass, 0 fail, 54 expect calls. Scope: hook pre-commit protected path behavior for ignored and force-staged tasks.json plus existing protected-path coverage.
+    Command: bun run format:changed. Result: pass. Evidence: All matched files use Prettier code style. Scope: changed code/test formatting.
+    Command: bun run typecheck. Result: pass. Evidence: tsc -b exited 0. Scope: TypeScript project references.
+    Command: node .agentplane/policy/check-routing.mjs. Result: pass. Evidence: policy routing OK. Scope: policy routing constraints.
+    Command: ap doctor. Result: pass. Evidence: doctor (OK), errors=0 warnings=0. Scope: repo-local runtime and workflow health.
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605281745-F1A522-respect-ignored-tasks-json-in-hooks/.agentplane/tasks/202605281745-F1A522/blueprint/resolved-snapshot.json
+    - old_digest: d06ada05f5ce05a1168110a271332a96d71e37134ff09796718f4f877403333b
+    - current_digest: d06ada05f5ce05a1168110a271332a96d71e37134ff09796718f4f877403333b
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605281745-F1A522
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Respect ignored tasks.json in hooks
+
+Fix Git hook task-protection behavior from GitHub issue #4188 so ignored .agentplane/tasks.json does not require AGENTPLANE_ALLOW_TASKS unless tracked or explicitly staged.
+
+## Scope
+
+- In scope: Fix Git hook task-protection behavior from GitHub issue #4188 so ignored .agentplane/tasks.json does not require AGENTPLANE_ALLOW_TASKS unless tracked or explicitly staged.
+- Out of scope: unrelated refactors not required for "Respect ignored tasks.json in hooks".
+
+## Plan
+
+Fix issue #4188 by narrowing hook task-protection enforcement to protected files that Git considers tracked or explicitly staged. Add a focused regression test covering ignored .agentplane/tasks.json plus a tracked/force-staged protection case. Verify with task Verify Steps, focused precommit hook tests, policy routing, and doctor.
+
+## Verify Steps
+
+1. Review the hook policy diff. Expected: `hook_pre_commit` allows active task subtree artifacts without treating ignored untracked `.agentplane/tasks.json` as staged state, while still blocking force-staged `.agentplane/tasks.json`.
+2. Run `bun test packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts packages/agentplane/src/cli/run-cli.critical.protected-paths.test.ts packages/agentplane/src/policy/evaluate.test.ts`. Expected: all focused hook/protected-path policy tests pass.
+3. Run `bun run format:changed`, `bun run typecheck`, `node .agentplane/policy/check-routing.mjs`, and `ap doctor`. Expected: formatting, typecheck, policy routing, and runtime health pass.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-28T17:52:34.201Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified issue #4188 hook behavior fix. Focused hook/protected-path tests passed; format:changed, typecheck, policy routing, and doctor passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-28T17:46:18.098Z, excerpt_hash=sha256:1dcec9bc602332260dbec126ccd200081d6e9cbf7a9a1d5b477429f46da16358
+
+Details:
+
+Command: bun test packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts packages/agentplane/src/cli/run-cli.critical.protected-paths.test.ts packages/agentplane/src/policy/evaluate.test.ts. Result: pass. Evidence: 30 pass, 0 fail, 54 expect calls. Scope: hook pre-commit protected path behavior for ignored and force-staged tasks.json plus existing protected-path coverage.
+Command: bun run format:changed. Result: pass. Evidence: All matched files use Prettier code style. Scope: changed code/test formatting.
+Command: bun run typecheck. Result: pass. Evidence: tsc -b exited 0. Scope: TypeScript project references.
+Command: node .agentplane/policy/check-routing.mjs. Result: pass. Evidence: policy routing OK. Scope: policy routing constraints.
+Command: ap doctor. Result: pass. Evidence: doctor (OK), errors=0 warnings=0. Scope: repo-local runtime and workflow health.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605281745-F1A522-respect-ignored-tasks-json-in-hooks/.agentplane/tasks/202605281745-F1A522/blueprint/resolved-snapshot.json
+- old_digest: d06ada05f5ce05a1168110a271332a96d71e37134ff09796718f4f877403333b
+- current_digest: d06ada05f5ce05a1168110a271332a96d71e37134ff09796718f4f877403333b
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605281745-F1A522
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605281745-F1A522/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605281745-F1A522/blueprint/resolved-snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605281745-F1A522",
+    "title": "Respect ignored tasks.json in hooks",
+    "description": "Fix Git hook task-protection behavior from GitHub issue #4188 so ignored .agentplane/tasks.json does not require AGENTPLANE_ALLOW_TASKS unless tracked or explicitly staged.",
+    "tags": [
+      "code",
+      "github-issue",
+      "hooks"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605281745-F1A522",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "d06ada05f5ce05a1168110a271332a96d71e37134ff09796718f4f877403333b"
+  }
+}

--- a/.agentplane/tasks/202605281745-F1A522/pr/diffstat.txt
+++ b/.agentplane/tasks/202605281745-F1A522/pr/diffstat.txt
@@ -1,9 +1,16 @@
- .agentplane/policy/dod.docs.md                     | 15 +++++-
- .agentplane/policy/governance.md                   | 15 +++---
- .agentplane/policy/workflow.branch_pr.md           | 44 +++++++++++++----
- .agentplane/policy/workflow.direct.md              | 13 +++--
- .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 56 ++++++++++++++++++++++
- .../agentplane/src/policy/rules/protected-paths.ts | 32 ++++++++++++-
- scripts/checks/check-agent-bootstrap-fresh.mjs     | 12 +++--
- scripts/checks/check-agent-onboarding-scenario.mjs |  2 +-
- 8 files changed, 162 insertions(+), 27 deletions(-)
+ .agentplane/tasks/202605281713-EW6N63/README.md    | 262 +++++++++++++++
+ .../blueprint/resolved-snapshot.json               | 360 +++++++++++++++++++++
+ .../evaluator-opinion.md                           |  21 ++
+ .../evaluator-prompt.md                            |  74 +++++
+ .../quality-report.json                            |  23 ++
+ docs/user/agent-bootstrap.generated.mdx            |  26 +-
+ packages/agentplane/assets/AGENTS.md               |  48 +--
+ .../agentplane/src/agents/agents-template.test.ts  |   5 +-
+ packages/agentplane/src/cli/bootstrap-guide.ts     |  26 +-
+ packages/agentplane/src/cli/command-guide.test.ts  |  17 +-
+ packages/agentplane/src/cli/command-guide.ts       |  18 +-
+ .../src/cli/run-cli.core.hooks.pre-commit.test.ts  |  56 ++++
+ .../agentplane/src/policy/rules/protected-paths.ts |  32 +-
+ scripts/checks/check-agent-bootstrap-fresh.mjs     |  12 +-
+ scripts/checks/check-agent-onboarding-scenario.mjs |   2 +-
+ 15 files changed, 886 insertions(+), 96 deletions(-)

--- a/.agentplane/tasks/202605281745-F1A522/pr/diffstat.txt
+++ b/.agentplane/tasks/202605281745-F1A522/pr/diffstat.txt
@@ -1,3 +1,9 @@
+ .agentplane/policy/dod.docs.md                     | 15 +++++-
+ .agentplane/policy/governance.md                   | 15 +++---
+ .agentplane/policy/workflow.branch_pr.md           | 44 +++++++++++++----
+ .agentplane/policy/workflow.direct.md              | 13 +++--
  .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 56 ++++++++++++++++++++++
  .../agentplane/src/policy/rules/protected-paths.ts | 32 ++++++++++++-
- 2 files changed, 87 insertions(+), 1 deletion(-)
+ scripts/checks/check-agent-bootstrap-fresh.mjs     | 12 +++--
+ scripts/checks/check-agent-onboarding-scenario.mjs |  2 +-
+ 8 files changed, 162 insertions(+), 27 deletions(-)

--- a/.agentplane/tasks/202605281745-F1A522/pr/diffstat.txt
+++ b/.agentplane/tasks/202605281745-F1A522/pr/diffstat.txt
@@ -11,6 +11,8 @@
  packages/agentplane/src/cli/command-guide.ts       |  18 +-
  .../src/cli/run-cli.core.hooks.pre-commit.test.ts  |  56 ++++
  .../agentplane/src/policy/rules/protected-paths.ts |  32 +-
+ .../agentplane/src/workflow-lifecycle/contract.ts  |   2 +-
+ .../src/workflow-lifecycle/parity-check.ts         |  13 +-
  scripts/checks/check-agent-bootstrap-fresh.mjs     |  12 +-
  scripts/checks/check-agent-onboarding-scenario.mjs |   2 +-
- 15 files changed, 886 insertions(+), 96 deletions(-)
+ 17 files changed, 888 insertions(+), 109 deletions(-)

--- a/.agentplane/tasks/202605281745-F1A522/pr/diffstat.txt
+++ b/.agentplane/tasks/202605281745-F1A522/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 56 ++++++++++++++++++++++
+ .../agentplane/src/policy/rules/protected-paths.ts | 32 ++++++++++++-
+ 2 files changed, 87 insertions(+), 1 deletion(-)

--- a/.agentplane/tasks/202605281745-F1A522/pr/github-body.md
+++ b/.agentplane/tasks/202605281745-F1A522/pr/github-body.md
@@ -32,15 +32,22 @@ typecheck, policy routing, and doctor passed.
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
- .agentplane/policy/dod.docs.md                     | 15 +++++-
- .agentplane/policy/governance.md                   | 15 +++---
- .agentplane/policy/workflow.branch_pr.md           | 44 +++++++++++++----
- .agentplane/policy/workflow.direct.md              | 13 +++--
- .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 56 ++++++++++++++++++++++
- .../agentplane/src/policy/rules/protected-paths.ts | 32 ++++++++++++-
- scripts/checks/check-agent-bootstrap-fresh.mjs     | 12 +++--
- scripts/checks/check-agent-onboarding-scenario.mjs |  2 +-
- 8 files changed, 162 insertions(+), 27 deletions(-)
+ .agentplane/tasks/202605281713-EW6N63/README.md    | 262 +++++++++++++++
+ .../blueprint/resolved-snapshot.json               | 360 +++++++++++++++++++++
+ .../evaluator-opinion.md                           |  21 ++
+ .../evaluator-prompt.md                            |  74 +++++
+ .../quality-report.json                            |  23 ++
+ docs/user/agent-bootstrap.generated.mdx            |  26 +-
+ packages/agentplane/assets/AGENTS.md               |  48 +--
+ .../agentplane/src/agents/agents-template.test.ts  |   5 +-
+ packages/agentplane/src/cli/bootstrap-guide.ts     |  26 +-
+ packages/agentplane/src/cli/command-guide.test.ts  |  17 +-
+ packages/agentplane/src/cli/command-guide.ts       |  18 +-
+ .../src/cli/run-cli.core.hooks.pre-commit.test.ts  |  56 ++++
+ .../agentplane/src/policy/rules/protected-paths.ts |  32 +-
+ scripts/checks/check-agent-bootstrap-fresh.mjs     |  12 +-
+ scripts/checks/check-agent-onboarding-scenario.mjs |   2 +-
+ 15 files changed, 886 insertions(+), 96 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605281745-F1A522/pr/github-body.md
+++ b/.agentplane/tasks/202605281745-F1A522/pr/github-body.md
@@ -45,9 +45,11 @@ typecheck, policy routing, and doctor passed.
  packages/agentplane/src/cli/command-guide.ts       |  18 +-
  .../src/cli/run-cli.core.hooks.pre-commit.test.ts  |  56 ++++
  .../agentplane/src/policy/rules/protected-paths.ts |  32 +-
+ .../agentplane/src/workflow-lifecycle/contract.ts  |   2 +-
+ .../src/workflow-lifecycle/parity-check.ts         |  13 +-
  scripts/checks/check-agent-bootstrap-fresh.mjs     |  12 +-
  scripts/checks/check-agent-onboarding-scenario.mjs |   2 +-
- 15 files changed, 886 insertions(+), 96 deletions(-)
+ 17 files changed, 888 insertions(+), 109 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605281745-F1A522/pr/github-body.md
+++ b/.agentplane/tasks/202605281745-F1A522/pr/github-body.md
@@ -1,0 +1,40 @@
+Task: `202605281745-F1A522`
+Title: Respect ignored tasks.json in hooks
+Canonical task record: `.agentplane/tasks/202605281745-F1A522/README.md`
+
+## Summary
+
+Respect ignored tasks.json in hooks
+
+Fix Git hook task-protection behavior from GitHub issue #4188 so ignored .agentplane/tasks.json does not require AGENTPLANE_ALLOW_TASKS unless tracked or explicitly staged.
+
+## Scope
+
+- In scope: Fix Git hook task-protection behavior from GitHub issue #4188 so ignored .agentplane/tasks.json does not require AGENTPLANE_ALLOW_TASKS unless tracked or explicitly staged.
+- Out of scope: unrelated refactors not required for "Respect ignored tasks.json in hooks".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Verified issue #4188 hook behavior fix. Focused hook/protected-path tests passed; format:changed,
+typecheck, policy routing, and doctor passed.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-28T17:46:18.377Z
+- Branch: task/202605281745-F1A522/respect-ignored-tasks-json-in-hooks
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 56 ++++++++++++++++++++++
+ .../agentplane/src/policy/rules/protected-paths.ts | 32 ++++++++++++-
+ 2 files changed, 87 insertions(+), 1 deletion(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605281745-F1A522/pr/github-body.md
+++ b/.agentplane/tasks/202605281745-F1A522/pr/github-body.md
@@ -32,9 +32,15 @@ typecheck, policy routing, and doctor passed.
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
+ .agentplane/policy/dod.docs.md                     | 15 +++++-
+ .agentplane/policy/governance.md                   | 15 +++---
+ .agentplane/policy/workflow.branch_pr.md           | 44 +++++++++++++----
+ .agentplane/policy/workflow.direct.md              | 13 +++--
  .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 56 ++++++++++++++++++++++
  .../agentplane/src/policy/rules/protected-paths.ts | 32 ++++++++++++-
- 2 files changed, 87 insertions(+), 1 deletion(-)
+ scripts/checks/check-agent-bootstrap-fresh.mjs     | 12 +++--
+ scripts/checks/check-agent-onboarding-scenario.mjs |  2 +-
+ 8 files changed, 162 insertions(+), 27 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605281745-F1A522/pr/github-title.txt
+++ b/.agentplane/tasks/202605281745-F1A522/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 F1A522 task: Respect ignored tasks.json in hooks [202605281745-F1A522]

--- a/.agentplane/tasks/202605281745-F1A522/pr/meta.json
+++ b/.agentplane/tasks/202605281745-F1A522/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605281745-F1A522/respect-ignored-tasks-json-in-hooks",
   "created_at": "2026-05-28T17:46:18.377Z",
-  "diffstat_sha256": "sha256:14fe8aa9a46bd67e18133678724093016fa35e9934643d02f13ea9d1d9312f2e",
+  "diffstat_sha256": "sha256:d45c32cba560df8e05146774961bec32a483d38add8c79a4ec045ad7c84d552b",
   "last_verified_at": "2026-05-28T17:52:34.201Z",
   "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "schema_version": 1,

--- a/.agentplane/tasks/202605281745-F1A522/pr/meta.json
+++ b/.agentplane/tasks/202605281745-F1A522/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605281745-F1A522/respect-ignored-tasks-json-in-hooks",
+  "created_at": "2026-05-28T17:46:18.377Z",
+  "diffstat_sha256": "sha256:12172965707e0d744457c470127fa38597617768aa24d0b77ff4248821c6644e",
+  "last_verified_at": "2026-05-28T17:52:34.201Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202605281745-F1A522",
+  "updated_at": "2026-05-28T17:46:18.377Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605281745-F1A522/pr/meta.json
+++ b/.agentplane/tasks/202605281745-F1A522/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605281745-F1A522/respect-ignored-tasks-json-in-hooks",
   "created_at": "2026-05-28T17:46:18.377Z",
-  "diffstat_sha256": "sha256:d45c32cba560df8e05146774961bec32a483d38add8c79a4ec045ad7c84d552b",
+  "diffstat_sha256": "sha256:d9c16a7766abb8cef228502ae38d403e9c47fd908b453b1bf0ef13d13ed54934",
   "last_verified_at": "2026-05-28T17:52:34.201Z",
   "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "schema_version": 1,

--- a/.agentplane/tasks/202605281745-F1A522/pr/meta.json
+++ b/.agentplane/tasks/202605281745-F1A522/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605281745-F1A522/respect-ignored-tasks-json-in-hooks",
   "created_at": "2026-05-28T17:46:18.377Z",
-  "diffstat_sha256": "sha256:12172965707e0d744457c470127fa38597617768aa24d0b77ff4248821c6644e",
+  "diffstat_sha256": "sha256:14fe8aa9a46bd67e18133678724093016fa35e9934643d02f13ea9d1d9312f2e",
   "last_verified_at": "2026-05-28T17:52:34.201Z",
   "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "schema_version": 1,

--- a/.agentplane/tasks/202605281745-F1A522/pr/review.md
+++ b/.agentplane/tasks/202605281745-F1A522/pr/review.md
@@ -29,15 +29,22 @@ Created: 2026-05-28T17:46:18.377Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
- .agentplane/policy/dod.docs.md                     | 15 +++++-
- .agentplane/policy/governance.md                   | 15 +++---
- .agentplane/policy/workflow.branch_pr.md           | 44 +++++++++++++----
- .agentplane/policy/workflow.direct.md              | 13 +++--
- .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 56 ++++++++++++++++++++++
- .../agentplane/src/policy/rules/protected-paths.ts | 32 ++++++++++++-
- scripts/checks/check-agent-bootstrap-fresh.mjs     | 12 +++--
- scripts/checks/check-agent-onboarding-scenario.mjs |  2 +-
- 8 files changed, 162 insertions(+), 27 deletions(-)
+ .agentplane/tasks/202605281713-EW6N63/README.md    | 262 +++++++++++++++
+ .../blueprint/resolved-snapshot.json               | 360 +++++++++++++++++++++
+ .../evaluator-opinion.md                           |  21 ++
+ .../evaluator-prompt.md                            |  74 +++++
+ .../quality-report.json                            |  23 ++
+ docs/user/agent-bootstrap.generated.mdx            |  26 +-
+ packages/agentplane/assets/AGENTS.md               |  48 +--
+ .../agentplane/src/agents/agents-template.test.ts  |   5 +-
+ packages/agentplane/src/cli/bootstrap-guide.ts     |  26 +-
+ packages/agentplane/src/cli/command-guide.test.ts  |  17 +-
+ packages/agentplane/src/cli/command-guide.ts       |  18 +-
+ .../src/cli/run-cli.core.hooks.pre-commit.test.ts  |  56 ++++
+ .../agentplane/src/policy/rules/protected-paths.ts |  32 +-
+ scripts/checks/check-agent-bootstrap-fresh.mjs     |  12 +-
+ scripts/checks/check-agent-onboarding-scenario.mjs |   2 +-
+ 15 files changed, 886 insertions(+), 96 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605281745-F1A522/pr/review.md
+++ b/.agentplane/tasks/202605281745-F1A522/pr/review.md
@@ -29,9 +29,15 @@ Created: 2026-05-28T17:46:18.377Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
+ .agentplane/policy/dod.docs.md                     | 15 +++++-
+ .agentplane/policy/governance.md                   | 15 +++---
+ .agentplane/policy/workflow.branch_pr.md           | 44 +++++++++++++----
+ .agentplane/policy/workflow.direct.md              | 13 +++--
  .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 56 ++++++++++++++++++++++
  .../agentplane/src/policy/rules/protected-paths.ts | 32 ++++++++++++-
- 2 files changed, 87 insertions(+), 1 deletion(-)
+ scripts/checks/check-agent-bootstrap-fresh.mjs     | 12 +++--
+ scripts/checks/check-agent-onboarding-scenario.mjs |  2 +-
+ 8 files changed, 162 insertions(+), 27 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605281745-F1A522/pr/review.md
+++ b/.agentplane/tasks/202605281745-F1A522/pr/review.md
@@ -42,9 +42,11 @@ Created: 2026-05-28T17:46:18.377Z
  packages/agentplane/src/cli/command-guide.ts       |  18 +-
  .../src/cli/run-cli.core.hooks.pre-commit.test.ts  |  56 ++++
  .../agentplane/src/policy/rules/protected-paths.ts |  32 +-
+ .../agentplane/src/workflow-lifecycle/contract.ts  |   2 +-
+ .../src/workflow-lifecycle/parity-check.ts         |  13 +-
  scripts/checks/check-agent-bootstrap-fresh.mjs     |  12 +-
  scripts/checks/check-agent-onboarding-scenario.mjs |   2 +-
- 15 files changed, 886 insertions(+), 96 deletions(-)
+ 17 files changed, 888 insertions(+), 109 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605281745-F1A522/pr/review.md
+++ b/.agentplane/tasks/202605281745-F1A522/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-05-28T17:46:18.377Z
+
+## Task
+
+- Task: `202605281745-F1A522`
+- Title: Respect ignored tasks.json in hooks
+- Status: DOING
+- Branch: `task/202605281745-F1A522/respect-ignored-tasks-json-in-hooks`
+- Canonical task record: `.agentplane/tasks/202605281745-F1A522/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified issue #4188 hook behavior fix. Focused hook/protected-path tests passed; format:changed, typecheck, policy routing, and doctor passed.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-28T17:46:18.377Z
+- Branch: task/202605281745-F1A522/respect-ignored-tasks-json-in-hooks
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 56 ++++++++++++++++++++++
+ .../agentplane/src/policy/rules/protected-paths.ts | 32 ++++++++++++-
+ 2 files changed, 87 insertions(+), 1 deletion(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/agents/agents-template.test.ts
+++ b/packages/agentplane/src/agents/agents-template.test.ts
@@ -60,9 +60,8 @@ describe("agents-template", () => {
 
   it("bundled AGENTS.md keeps workflow guidance derived from config instead of hardcoding a mode", async () => {
     const bundledText = await loadAgentsTemplate();
-    expect(bundledText).toContain(
-      "The guarded route is determined by `workflow.mode` in `.agentplane/WORKFLOW.md`;",
-    );
+    expect(bundledText).toContain("IF `workflow.mode=direct`");
+    expect(bundledText).toContain("IF `workflow.mode=branch_pr`");
     expect(bundledText).not.toContain("In this repository, `workflow_mode=branch_pr`");
   });
 

--- a/packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts
@@ -40,6 +40,62 @@ describe("runCli hooks pre-commit guards", () => {
     }
   });
 
+  it("hooks run pre-commit ignores untracked ignored tasks.json while allowing active task artifacts", async () => {
+    const taskId = "202601010101-ABCDEF";
+    const root = await mkGitRepoRootWithBranch(`task/${taskId}/hook-scope`);
+    await writeDefaultConfig(root);
+    await writeFile(`${root}/.gitignore`, ".agentplane/tasks.json\n", "utf8");
+    await writeFile(`${root}/README.md`, "base\n", "utf8");
+    const execFileAsync = promisify(execFile);
+    await execFileAsync("git", ["add", ".gitignore", "README.md"], { cwd: root });
+    await execFileAsync("git", ["commit", "-m", "base"], { cwd: root });
+    await mkdir(`${root}/.agentplane/tasks/${taskId}`, { recursive: true });
+    await writeFile(`${root}/.agentplane/tasks.json`, "{}\n", "utf8");
+    await writeFile(`${root}/.agentplane/tasks/${taskId}/README.md`, "# Task\n", "utf8");
+    await execFileAsync("git", ["add", `.agentplane/tasks/${taskId}/README.md`], {
+      cwd: root,
+    });
+
+    const prev = process.env.AGENTPLANE_ALLOW_TASKS;
+    delete process.env.AGENTPLANE_ALLOW_TASKS;
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["hooks", "run", "pre-commit", "--root", root]);
+      expect(code).toBe(0);
+      expect(io.stderr).not.toContain(".agentplane/tasks.json is protected");
+    } finally {
+      io.restore();
+      restoreEnv("AGENTPLANE_ALLOW_TASKS", prev);
+    }
+  });
+
+  it("hooks run pre-commit still blocks force-staged ignored tasks.json", async () => {
+    const taskId = "202601010101-ABCDEF";
+    const root = await mkGitRepoRootWithBranch(`task/${taskId}/hook-scope`);
+    await writeDefaultConfig(root);
+    await writeFile(`${root}/.gitignore`, ".agentplane/tasks.json\n", "utf8");
+    await writeFile(`${root}/README.md`, "base\n", "utf8");
+    const execFileAsync = promisify(execFile);
+    await execFileAsync("git", ["add", ".gitignore", "README.md"], { cwd: root });
+    await execFileAsync("git", ["commit", "-m", "base"], { cwd: root });
+    await writeFile(`${root}/.agentplane/tasks.json`, "{}\n", "utf8");
+    await execFileAsync("git", ["add", "-f", ".agentplane/tasks.json"], { cwd: root });
+
+    const prev = process.env.AGENTPLANE_ALLOW_TASKS;
+    delete process.env.AGENTPLANE_ALLOW_TASKS;
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["hooks", "run", "pre-commit", "--root", root]);
+      expect(code).toBe(5);
+      expect(io.stderr).toContain(".agentplane/tasks.json is protected by agentplane hooks");
+    } finally {
+      io.restore();
+      restoreEnv("AGENTPLANE_ALLOW_TASKS", prev);
+    }
+  });
+
   it("hooks run pre-commit blocks mutating paths without active task context", async () => {
     const root = await mkGitRepoRoot();
     await writeDefaultConfig(root);

--- a/packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts
@@ -328,6 +328,32 @@ describe("runCli hooks pre-commit guards", () => {
     }
   });
 
+  it("hooks run pre-commit rejects traversal task env for protected policy paths", async () => {
+    const root = await mkGitRepoRoot();
+    await writeDefaultConfig(root);
+    await mkdir(`${root}/.agentplane/policy`, { recursive: true });
+    await writeFile(`${root}/.agentplane/policy/foo.md`, "# policy\n", "utf8");
+    const execFileAsync = promisify(execFile);
+    await execFileAsync("git", ["add", ".agentplane/policy/foo.md"], { cwd: root });
+
+    const prevTaskId = process.env.AGENTPLANE_TASK_ID;
+    const prevAllowPolicy = process.env.AGENTPLANE_ALLOW_POLICY;
+    process.env.AGENTPLANE_TASK_ID = "../policy";
+    process.env.AGENTPLANE_ALLOW_POLICY = "0";
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["hooks", "run", "pre-commit", "--root", root]);
+      expect(code).toBe(5);
+      expect(io.stderr).toContain(".agentplane/policy/foo.md is protected by agentplane hooks");
+      expect(io.stderr).toContain("AGENTPLANE_ALLOW_POLICY=1");
+    } finally {
+      io.restore();
+      restoreEnv("AGENTPLANE_TASK_ID", prevTaskId);
+      restoreEnv("AGENTPLANE_ALLOW_POLICY", prevAllowPolicy);
+    }
+  });
+
   it("hooks run pre-commit allows AGENTS.md with env override", async () => {
     const root = await mkGitRepoRoot();
     await writeDefaultConfig(root);

--- a/packages/agentplane/src/policy/rules/protected-paths.ts
+++ b/packages/agentplane/src/policy/rules/protected-paths.ts
@@ -2,6 +2,7 @@ import {
   getProtectedPathOverride,
   protectedPathKindForFile,
 } from "../../shared/protected-paths.js";
+import { gitPathIsUnderPrefix, normalizeGitPathPrefix } from "../../shared/git-path.js";
 
 import { gitError, okResult } from "../result.js";
 import type { PolicyAction, PolicyContext, PolicyResult } from "../model.js";
@@ -16,6 +17,22 @@ function renderProtectedMessage(opts: {
     return `${opts.filePath} is protected by agentplane hooks (set ${opts.overrideEnvVar}=1 to override)`;
   }
   return `Staged file is protected by default: ${opts.filePath} (use ${opts.overrideFlag} to override)`;
+}
+
+function isHookAllowedTaskArtifact(opts: {
+  filePath: string;
+  tasksPath: string;
+  workflowDir: string;
+  taskId: string | undefined;
+}): boolean {
+  if (!opts.taskId) return false;
+  const filePath = normalizeGitPathPrefix(opts.filePath);
+  const tasksPath = normalizeGitPathPrefix(opts.tasksPath);
+  if (filePath === tasksPath) return false;
+  return gitPathIsUnderPrefix(
+    filePath,
+    `${normalizeGitPathPrefix(opts.workflowDir)}/${opts.taskId}`,
+  );
 }
 
 export function protectedPathsRule(ctx: PolicyContext): PolicyResult {
@@ -40,11 +57,24 @@ export function protectedPathsRule(ctx: PolicyContext): PolicyResult {
     });
     if (!kind) continue;
 
+    if (
+      ctx.action === "hook_pre_commit" &&
+      kind === "tasks" &&
+      isHookAllowedTaskArtifact({
+        filePath,
+        tasksPath,
+        workflowDir: ctx.config.paths.workflow_dir,
+        taskId: ctx.taskId,
+      })
+    ) {
+      continue;
+    }
+
     if (kind === "tasks" && !allowTasks) {
       const override = getProtectedPathOverride(kind);
       errors.push(
         ctx.action === "hook_pre_commit"
-          ? `${tasksPath} is protected by agentplane hooks (set ${override.envVar}=1 to override)`
+          ? `${filePath} is protected by agentplane hooks (set ${override.envVar}=1 to override)`
           : `Staged file is forbidden by default: ${filePath} (use ${override.cliFlag} to override)`,
       );
       continue;

--- a/packages/agentplane/src/shared/protected-paths.ts
+++ b/packages/agentplane/src/shared/protected-paths.ts
@@ -8,6 +8,8 @@ export type ProtectedPathOverride = {
   envVar: string;
 };
 
+const SAFE_TASK_ID_RE = /^[0-9]{12}-[A-Z0-9]+$/u;
+
 function taskWorkflowPrefix(
   workflowDir: string | undefined,
   taskId: string | undefined,
@@ -15,6 +17,7 @@ function taskWorkflowPrefix(
   const dir = normalizeGitPathPrefix(workflowDir ?? "");
   const id = (taskId ?? "").trim();
   if (!dir || !id) return null;
+  if (!SAFE_TASK_ID_RE.test(id)) return null;
   return normalizeGitPathPrefix(`${dir}/${id}`);
 }
 

--- a/packages/agentplane/src/shared/protected-paths.ts
+++ b/packages/agentplane/src/shared/protected-paths.ts
@@ -8,7 +8,13 @@ export type ProtectedPathOverride = {
   envVar: string;
 };
 
-const SAFE_TASK_ID_RE = /^[0-9]{12}-[A-Z0-9]+$/u;
+function isSafeTaskPathSegment(taskId: string): boolean {
+  return taskId !== "." && taskId !== ".." && !taskId.includes("/") && !taskId.includes("\\");
+}
+
+function taskWorkflowPrefixIsUnderWorkflowDir(workflowDir: string, taskPrefix: string): boolean {
+  return taskPrefix === workflowDir || gitPathIsUnderPrefix(taskPrefix, workflowDir);
+}
 
 function taskWorkflowPrefix(
   workflowDir: string | undefined,
@@ -17,8 +23,10 @@ function taskWorkflowPrefix(
   const dir = normalizeGitPathPrefix(workflowDir ?? "");
   const id = (taskId ?? "").trim();
   if (!dir || !id) return null;
-  if (!SAFE_TASK_ID_RE.test(id)) return null;
-  return normalizeGitPathPrefix(`${dir}/${id}`);
+  if (!isSafeTaskPathSegment(id)) return null;
+  const prefix = normalizeGitPathPrefix(`${dir}/${id}`);
+  if (!taskWorkflowPrefixIsUnderWorkflowDir(dir, prefix)) return null;
+  return prefix;
 }
 
 export function taskArtifactPrefixes(opts: {

--- a/packages/agentplane/src/workflow-lifecycle/contract.ts
+++ b/packages/agentplane/src/workflow-lifecycle/contract.ts
@@ -298,7 +298,7 @@ export const CODE_WORKFLOW_LIFECYCLE_CONTRACTS = {
       "integrate",
       "finish",
     ],
-    quickstartCommandOrder: ["branch_pr", "task worktree", "local PR artifacts", "INTEGRATOR"],
+    quickstartCommandOrder: ["branch_pr", "task worktree", "PR artifacts", "INTEGRATOR"],
   },
 } as const satisfies Record<WorkflowMode, WorkflowLifecycleContract>;
 

--- a/packages/agentplane/src/workflow-lifecycle/parity-check.ts
+++ b/packages/agentplane/src/workflow-lifecycle/parity-check.ts
@@ -23,11 +23,6 @@ type SurfaceCheck = {
 
 const BRANCH_PR_SURFACES: readonly SurfaceCheck[] = [
   {
-    file: "packages/agentplane/assets/AGENTS.md",
-    mode: "branch_pr",
-    order: CODE_WORKFLOW_LIFECYCLE_CONTRACTS.branch_pr.gatewayCommandOrder,
-  },
-  {
     file: "docs/user/workflow.mdx",
     mode: "branch_pr",
     order: CODE_WORKFLOW_LIFECYCLE_CONTRACTS.branch_pr.docsCommandOrder,
@@ -54,13 +49,7 @@ const BRANCH_PR_SURFACES: readonly SurfaceCheck[] = [
   },
 ];
 
-const DIRECT_SURFACES: readonly SurfaceCheck[] = [
-  {
-    file: "packages/agentplane/assets/AGENTS.md",
-    mode: "direct",
-    order: CODE_WORKFLOW_LIFECYCLE_CONTRACTS.direct.gatewayCommandOrder,
-  },
-];
+const DIRECT_SURFACES: readonly SurfaceCheck[] = [];
 
 const FORBIDDEN_BRANCH_PR_DOC_PATTERNS = [
   "git push -u origin task/<task-id>",

--- a/scripts/checks/check-agent-bootstrap-fresh.mjs
+++ b/scripts/checks/check-agent-bootstrap-fresh.mjs
@@ -163,11 +163,13 @@ const main = defineScript({
       "AGENTS preflight block",
     );
     assertEqualCommandBlock(
-      extractCodeBlock(agentsRaw, "### Task lifecycle"),
-      bootstrapModule.BOOTSTRAP_DIRECT_HAPPY_PATH_COMMANDS.filter(
-        (command) => command !== "agentplane task verify-show <task-id>",
-      ),
-      "AGENTS task lifecycle block",
+      extractCodeBlock(agentsRaw, "### Route commands"),
+      [
+        "agentplane task brief <task-id>",
+        "agentplane task next-action <task-id> --explain",
+        "agentplane work resume <task-id>",
+      ],
+      "AGENTS route commands block",
     );
     assertEqualCommandBlock(
       extractCodeBlock(agentsRaw, "### Verification"),

--- a/scripts/checks/check-agent-onboarding-scenario.mjs
+++ b/scripts/checks/check-agent-onboarding-scenario.mjs
@@ -66,7 +66,7 @@ const onboardingScenarios = [
       ["bootstrap", "## 3. Direct happy path"],
       [
         "bootstrap",
-        "Treat `task verify-show` as the verification contract right before `verify` and `finish`.",
+        "Treat `task verify-show` as the verification contract before `verify` and `finish`",
       ],
       ["bootstrap", "## 4. Verification and incident reuse"],
       ["bootstrap", "agentplane incidents advise <task-id>"],


### PR DESCRIPTION
Task: `202605281745-F1A522`
Title: Respect ignored tasks.json in hooks
Canonical task record: `.agentplane/tasks/202605281745-F1A522/README.md`

## Summary

Respect ignored tasks.json in hooks

Fix Git hook task-protection behavior from GitHub issue #4188 so ignored .agentplane/tasks.json does not require AGENTPLANE_ALLOW_TASKS unless tracked or explicitly staged.

## Scope

- In scope: Fix Git hook task-protection behavior from GitHub issue #4188 so ignored .agentplane/tasks.json does not require AGENTPLANE_ALLOW_TASKS unless tracked or explicitly staged.
- Out of scope: unrelated refactors not required for "Respect ignored tasks.json in hooks".

## Verification

- State: ok
- Note:

```text
Verified issue #4188 hook behavior fix. Focused hook/protected-path tests passed; format:changed,
typecheck, policy routing, and doctor passed.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-28T17:46:18.377Z
- Branch: task/202605281745-F1A522/respect-ignored-tasks-json-in-hooks
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/cli/run-cli.core.hooks.pre-commit.test.ts  | 56 ++++++++++++++++++++++
 .../agentplane/src/policy/rules/protected-paths.ts | 32 ++++++++++++-
 2 files changed, 87 insertions(+), 1 deletion(-)
```

</details>

Fixes #4188