### PR TITLE
🚧 ZA0BEE task: Route decision module decomposition [202605281934-ZA0BEE]

### DIFF
--- a/.agentplane/tasks/202605281934-ZA0BEE/README.md
+++ b/.agentplane/tasks/202605281934-ZA0BEE/README.md
@@ -1,0 +1,155 @@
+---
+id: "202605281934-ZA0BEE"
+title: "Route decision module decomposition"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 7
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "agent-efficiency"
+  - "code"
+  - "refactor"
+  - "route-oracle"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-28T19:34:36.129Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-28T19:39:40.365Z"
+  updated_by: "CODER"
+  note: "Route decision decomposition verified: facade reduced to 335 lines, blockers/next-action/types extracted into focused modules, route-decision CLI tests passed, typecheck passed, hotspot threshold check passed, format:changed passed."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: decompose route decision internals from the dedicated branch_pr worktree while preserving the public route oracle output and verifying with targeted tests plus typecheck."
+events:
+  -
+    type: "status"
+    at: "2026-05-28T19:34:55.410Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: decompose route decision internals from the dedicated branch_pr worktree while preserving the public route oracle output and verifying with targeted tests plus typecheck."
+  -
+    type: "verify"
+    at: "2026-05-28T19:39:40.365Z"
+    author: "CODER"
+    state: "ok"
+    note: "Route decision decomposition verified: facade reduced to 335 lines, blockers/next-action/types extracted into focused modules, route-decision CLI tests passed, typecheck passed, hotspot threshold check passed, format:changed passed."
+doc_version: 3
+doc_updated_at: "2026-05-28T19:39:40.390Z"
+doc_updated_by: "CODER"
+description: "Decompose the route decision hotspot into focused, testable modules without changing route semantics. Keep the public command behavior stable while isolating pure route classification, hosted/PR state interpretation, blocker formatting, and next-command rendering so agents receive the same or better next-action guidance from smaller code units."
+sections:
+  Summary: |-
+    Route decision module decomposition
+
+    Decompose the route decision hotspot into focused, testable modules without changing route semantics. Keep the public command behavior stable while isolating pure route classification, hosted/PR state interpretation, blocker formatting, and next-command rendering so agents receive the same or better next-action guidance from smaller code units.
+  Scope: |-
+    - In scope: Decompose the route decision hotspot into focused, testable modules without changing route semantics. Keep the public command behavior stable while isolating pure route classification, hosted/PR state interpretation, blocker formatting, and next-command rendering so agents receive the same or better next-action guidance from smaller code units.
+    - Out of scope: unrelated refactors not required for "Route decision module decomposition".
+  Plan: |-
+    1. Split route decision into focused internal modules while preserving exported behavior.
+    2. Extract pure blocker/phase formatting and next-command rendering helpers with unit coverage.
+    3. Keep packages/agentplane/src/commands/shared/route-decision.ts as the compatibility facade and reduce its responsibility/line count.
+    4. Extend existing route decision tests or add narrow tests for unchanged next-action output.
+    5. Verify with targeted tests, hotspot report check, typecheck, and changed-file formatting.
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-28T19:39:40.365Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Route decision decomposition verified: facade reduced to 335 lines, blockers/next-action/types extracted into focused modules, route-decision CLI tests passed, typecheck passed, hotspot threshold check passed, format:changed passed.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-28T19:34:55.410Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605281934-ZA0BEE-route-decision-module-decomposition/.agentplane/tasks/202605281934-ZA0BEE/blueprint/resolved-snapshot.json
+    - old_digest: cba1b8dabedfca03e084b837fcea290fe2bd08ab57aa5c5f8c1f9ca106f5a9e5
+    - current_digest: cba1b8dabedfca03e084b837fcea290fe2bd08ab57aa5c5f8c1f9ca106f5a9e5
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605281934-ZA0BEE
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Route decision module decomposition
+
+Decompose the route decision hotspot into focused, testable modules without changing route semantics. Keep the public command behavior stable while isolating pure route classification, hosted/PR state interpretation, blocker formatting, and next-command rendering so agents receive the same or better next-action guidance from smaller code units.
+
+## Scope
+
+- In scope: Decompose the route decision hotspot into focused, testable modules without changing route semantics. Keep the public command behavior stable while isolating pure route classification, hosted/PR state interpretation, blocker formatting, and next-command rendering so agents receive the same or better next-action guidance from smaller code units.
+- Out of scope: unrelated refactors not required for "Route decision module decomposition".
+
+## Plan
+
+1. Split route decision into focused internal modules while preserving exported behavior.
+2. Extract pure blocker/phase formatting and next-command rendering helpers with unit coverage.
+3. Keep packages/agentplane/src/commands/shared/route-decision.ts as the compatibility facade and reduce its responsibility/line count.
+4. Extend existing route decision tests or add narrow tests for unchanged next-action output.
+5. Verify with targeted tests, hotspot report check, typecheck, and changed-file formatting.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-28T19:39:40.365Z — VERIFY — ok
+
+By: CODER
+
+Note: Route decision decomposition verified: facade reduced to 335 lines, blockers/next-action/types extracted into focused modules, route-decision CLI tests passed, typecheck passed, hotspot threshold check passed, format:changed passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-28T19:34:55.410Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605281934-ZA0BEE-route-decision-module-decomposition/.agentplane/tasks/202605281934-ZA0BEE/blueprint/resolved-snapshot.json
+- old_digest: cba1b8dabedfca03e084b837fcea290fe2bd08ab57aa5c5f8c1f9ca106f5a9e5
+- current_digest: cba1b8dabedfca03e084b837fcea290fe2bd08ab57aa5c5f8c1f9ca106f5a9e5
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605281934-ZA0BEE
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605281934-ZA0BEE/README.md
+++ b/.agentplane/tasks/202605281934-ZA0BEE/README.md
@@ -4,7 +4,7 @@ title: "Route decision module decomposition"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 7
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -25,6 +25,25 @@ verification:
   updated_by: "CODER"
   note: "Route decision decomposition verified: facade reduced to 335 lines, blockers/next-action/types extracted into focused modules, route-decision CLI tests passed, typecheck passed, hotspot threshold check passed, format:changed passed."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-28T19:40:03.838Z"
+  updated_by: "EVALUATOR"
+  note: "Route decision facade decomposed into focused modules with unchanged CLI route-decision behavior."
+  evaluated_sha: "68b96584c9a3aba4ca7823af4115b599558bfc62"
+  blueprint_digest: "cba1b8dabedfca03e084b837fcea290fe2bd08ab57aa5c5f8c1f9ca106f5a9e5"
+  evidence_refs:
+    - ".agentplane/tasks/202605281934-ZA0BEE/README.md"
+    - ".agentplane/tasks/202605281934-ZA0BEE/quality/20260528-194003838-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605281934-ZA0BEE/quality/20260528-194003838-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605281934-ZA0BEE/quality/20260528-194003838-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605281934-ZA0BEE/blueprint/resolved-snapshot.json"
+    - "packages/agentplane/src/commands/shared/route-decision.ts"
+    - "packages/agentplane/src/commands/shared/route-decision-blockers.ts"
+    - "packages/agentplane/src/commands/shared/route-decision-next-action.ts"
+    - "packages/agentplane/src/commands/shared/route-decision-types.ts"
+  findings:
+    - "Evidence: route-decision facade is 335 lines; extracted blockers, next-action, and shared types modules; vitest route-decision suites passed; typecheck, hotspot check, and format:changed passed."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202605281934-ZA0BEE/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605281934-ZA0BEE/blueprint/resolved-snapshot.json
@@ -1,0 +1,573 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605281934-ZA0BEE",
+    "title": "Route decision module decomposition",
+    "description": "Decompose the route decision hotspot into focused, testable modules without changing route semantics. Keep the public command behavior stable while isolating pure route classification, hosted/PR state interpretation, blocker formatting, and next-command rendering so agents receive the same or better next-action guidance from smaller code units.",
+    "tags": [
+      "agent-efficiency",
+      "code",
+      "refactor",
+      "route-oracle"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605281934-ZA0BEE",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "cba1b8dabedfca03e084b837fcea290fe2bd08ab57aa5c5f8c1f9ca106f5a9e5"
+  }
+}

--- a/.agentplane/tasks/202605281934-ZA0BEE/pr/diffstat.txt
+++ b/.agentplane/tasks/202605281934-ZA0BEE/pr/diffstat.txt
@@ -1,0 +1,5 @@
+ .../src/commands/shared/route-decision-blockers.ts |  93 +++++++
+ .../commands/shared/route-decision-next-action.ts  | 116 +++++++++
+ .../src/commands/shared/route-decision-types.ts    |  75 ++++++
+ .../src/commands/shared/route-decision.ts          | 280 +--------------------
+ 4 files changed, 292 insertions(+), 272 deletions(-)

--- a/.agentplane/tasks/202605281934-ZA0BEE/pr/github-body.md
+++ b/.agentplane/tasks/202605281934-ZA0BEE/pr/github-body.md
@@ -33,7 +33,11 @@ check passed, format:changed passed.
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/commands/shared/route-decision-blockers.ts |  93 +++++++
+ .../commands/shared/route-decision-next-action.ts  | 116 +++++++++
+ .../src/commands/shared/route-decision-types.ts    |  75 ++++++
+ .../src/commands/shared/route-decision.ts          | 280 +--------------------
+ 4 files changed, 292 insertions(+), 272 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605281934-ZA0BEE/pr/github-body.md
+++ b/.agentplane/tasks/202605281934-ZA0BEE/pr/github-body.md
@@ -1,0 +1,39 @@
+Task: `202605281934-ZA0BEE`
+Title: Route decision module decomposition
+Canonical task record: `.agentplane/tasks/202605281934-ZA0BEE/README.md`
+
+## Summary
+
+Route decision module decomposition
+
+Decompose the route decision hotspot into focused, testable modules without changing route semantics. Keep the public command behavior stable while isolating pure route classification, hosted/PR state interpretation, blocker formatting, and next-command rendering so agents receive the same or better next-action guidance from smaller code units.
+
+## Scope
+
+- In scope: Decompose the route decision hotspot into focused, testable modules without changing route semantics. Keep the public command behavior stable while isolating pure route classification, hosted/PR state interpretation, blocker formatting, and next-command rendering so agents receive the same or better next-action guidance from smaller code units.
+- Out of scope: unrelated refactors not required for "Route decision module decomposition".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Route decision decomposition verified: facade reduced to 335 lines, blockers/next-action/types
+extracted into focused modules, route-decision CLI tests passed, typecheck passed, hotspot threshold
+check passed, format:changed passed.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-28T19:34:55.525Z
+- Branch: task/202605281934-ZA0BEE/route-decision-module-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605281934-ZA0BEE/pr/github-title.txt
+++ b/.agentplane/tasks/202605281934-ZA0BEE/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 ZA0BEE task: Route decision module decomposition [202605281934-ZA0BEE]

--- a/.agentplane/tasks/202605281934-ZA0BEE/pr/meta.json
+++ b/.agentplane/tasks/202605281934-ZA0BEE/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605281934-ZA0BEE/route-decision-module-decomposition",
+  "created_at": "2026-05-28T19:34:55.525Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": "2026-05-28T19:39:40.365Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202605281934-ZA0BEE",
+  "updated_at": "2026-05-28T19:34:55.525Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605281934-ZA0BEE/pr/meta.json
+++ b/.agentplane/tasks/202605281934-ZA0BEE/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605281934-ZA0BEE/route-decision-module-decomposition",
   "created_at": "2026-05-28T19:34:55.525Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "diffstat_sha256": "sha256:f10ba4ddf1f4d8fb345c155969eebe2d9dd1ad8daa8920750f24cc14e3bec361",
   "last_verified_at": "2026-05-28T19:39:40.365Z",
   "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "schema_version": 1,

--- a/.agentplane/tasks/202605281934-ZA0BEE/pr/review.md
+++ b/.agentplane/tasks/202605281934-ZA0BEE/pr/review.md
@@ -29,7 +29,11 @@ Created: 2026-05-28T19:34:55.525Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/commands/shared/route-decision-blockers.ts |  93 +++++++
+ .../commands/shared/route-decision-next-action.ts  | 116 +++++++++
+ .../src/commands/shared/route-decision-types.ts    |  75 ++++++
+ .../src/commands/shared/route-decision.ts          | 280 +--------------------
+ 4 files changed, 292 insertions(+), 272 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605281934-ZA0BEE/pr/review.md
+++ b/.agentplane/tasks/202605281934-ZA0BEE/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-28T19:34:55.525Z
+
+## Task
+
+- Task: `202605281934-ZA0BEE`
+- Title: Route decision module decomposition
+- Status: DOING
+- Branch: `task/202605281934-ZA0BEE/route-decision-module-decomposition`
+- Canonical task record: `.agentplane/tasks/202605281934-ZA0BEE/README.md`
+
+## Verification
+
+- State: ok
+- Note: Route decision decomposition verified: facade reduced to 335 lines, blockers/next-action/types extracted into focused modules, route-decision CLI tests passed, typecheck passed, hotspot threshold check passed, format:changed passed.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-28T19:34:55.525Z
+- Branch: task/202605281934-ZA0BEE/route-decision-module-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605281934-ZA0BEE/quality/20260528-194003838-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605281934-ZA0BEE/quality/20260528-194003838-recovery-context/evaluator-opinion.md
@@ -1,0 +1,22 @@
+# EVALUATOR opinion: pass
+
+Route decision facade decomposed into focused modules with unchanged CLI route-decision behavior.
+
+## Findings
+- Evidence: route-decision facade is 335 lines; extracted blockers, next-action, and shared types modules; vitest route-decision suites passed; typecheck, hotspot check, and format:changed passed.
+
+## Evidence
+- .agentplane/tasks/202605281934-ZA0BEE/README.md
+- packages/agentplane/src/commands/shared/route-decision.ts
+- packages/agentplane/src/commands/shared/route-decision-blockers.ts
+- packages/agentplane/src/commands/shared/route-decision-next-action.ts
+- packages/agentplane/src/commands/shared/route-decision-types.ts
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202605281934-ZA0BEE/quality/20260528-194003838-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605281934-ZA0BEE/quality/20260528-194003838-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605281934-ZA0BEE
+- task_readme: .agentplane/tasks/202605281934-ZA0BEE/README.md
+- report_path: .agentplane/tasks/202605281934-ZA0BEE/quality/20260528-194003838-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605281934-ZA0BEE/quality/20260528-194003838-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605281934-ZA0BEE/quality/20260528-194003838-recovery-context/quality-report.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "task_id": "202605281934-ZA0BEE",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-28T19:40:03.838Z",
+  "verdict": "pass",
+  "summary": "Route decision facade decomposed into focused modules with unchanged CLI route-decision behavior.",
+  "evaluated_sha": "68b96584c9a3aba4ca7823af4115b599558bfc62",
+  "blueprint_digest": "cba1b8dabedfca03e084b837fcea290fe2bd08ab57aa5c5f8c1f9ca106f5a9e5",
+  "findings": [
+    "Evidence: route-decision facade is 335 lines; extracted blockers, next-action, and shared types modules; vitest route-decision suites passed; typecheck, hotspot check, and format:changed passed."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605281934-ZA0BEE/README.md",
+    "packages/agentplane/src/commands/shared/route-decision.ts",
+    "packages/agentplane/src/commands/shared/route-decision-blockers.ts",
+    "packages/agentplane/src/commands/shared/route-decision-next-action.ts",
+    "packages/agentplane/src/commands/shared/route-decision-types.ts"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/commands/shared/route-decision-blockers.ts
+++ b/packages/agentplane/src/commands/shared/route-decision-blockers.ts
@@ -1,0 +1,93 @@
+import type { TaskData } from "../../backends/task-backend.js";
+import type { PrFlowStatusReport } from "../pr/flow-status.js";
+import type { TaskResumeContext } from "../task/handoff.shared.js";
+import type { RouteBatchOwnership } from "./route-batch-ownership.js";
+import type { RouteBlocker } from "./route-oracle.js";
+import { isTaskLocalOnlyAdvance } from "./task-local-freshness.js";
+import type { CommandContext } from "./task-backend.js";
+
+function addBlocker(blockers: RouteBlocker[], code: string, summary: string): void {
+  if (blockers.some((blocker) => blocker.code === code)) return;
+  blockers.push({ code, summary });
+}
+
+async function isPrMetaOnlyTaskLocalAdvance(opts: {
+  ctx: CommandContext;
+  taskId: string;
+  prFlow: PrFlowStatusReport | null;
+}): Promise<boolean> {
+  const branchHeadSha = opts.prFlow?.branch.headSha ?? null;
+  const metaHeadSha = opts.prFlow?.branch.metaHeadSha ?? null;
+  if (!branchHeadSha || !metaHeadSha || branchHeadSha === metaHeadSha) return false;
+  return isTaskLocalOnlyAdvance({
+    gitRoot: opts.ctx.resolvedProject.gitRoot,
+    workflowDir: opts.ctx.config.paths.workflow_dir,
+    tasksPath: opts.ctx.config.paths.tasks_path,
+    taskId: opts.taskId,
+    fromRef: metaHeadSha,
+    toRef: branchHeadSha,
+  }).catch(() => false);
+}
+
+export async function deriveBlockers(opts: {
+  ctx: CommandContext;
+  task: TaskData;
+  resume: TaskResumeContext;
+  workflowMode: string;
+  prFlow: PrFlowStatusReport | null;
+  batchOwnership: RouteBatchOwnership;
+}): Promise<RouteBlocker[]> {
+  const blockers: RouteBlocker[] = [];
+  if (opts.task.status === "DONE") return blockers;
+  if (opts.task.plan_approval?.state !== "approved") {
+    addBlocker(blockers, "plan_not_approved", "task plan is not approved");
+  }
+  if (opts.workflowMode === "branch_pr") {
+    if (
+      opts.batchOwnership.role !== "included" &&
+      !opts.resume.pr_branch &&
+      !opts.prFlow?.branch.name
+    ) {
+      addBlocker(blockers, "missing_pr_branch", "branch_pr task has no recorded PR branch");
+    }
+    if (opts.resume.branch === opts.resume.base_branch) {
+      addBlocker(blockers, "on_base_checkout", "current checkout appears to be the base branch");
+    }
+    if (opts.prFlow?.pr.state === "not_found") {
+      addBlocker(blockers, "remote_pr_missing", "task branch is not linked to a remote PR");
+    }
+    if (opts.prFlow?.branch.name && !opts.prFlow.branch.headSha) {
+      addBlocker(
+        blockers,
+        "branch_head_missing",
+        "recorded task branch cannot be resolved locally",
+      );
+    }
+    if (
+      opts.prFlow?.branch.headSha &&
+      opts.prFlow.branch.metaHeadSha &&
+      opts.prFlow.branch.headSha !== opts.prFlow.branch.metaHeadSha &&
+      !(await isPrMetaOnlyTaskLocalAdvance({
+        ctx: opts.ctx,
+        taskId: opts.task.id,
+        prFlow: opts.prFlow,
+      }))
+    ) {
+      addBlocker(blockers, "pr_meta_stale", "PR metadata head differs from local branch head");
+    }
+    if (opts.prFlow?.closeTail.state === "open") {
+      addBlocker(blockers, "close_tail_open", "hosted close-tail PR is still open");
+    }
+    if (opts.prFlow?.closeTail.state === "not_found") {
+      addBlocker(
+        blockers,
+        "close_tail_missing",
+        "implementation PR is merged but close-tail is missing",
+      );
+    }
+  }
+  if (opts.resume.runner.next_action === "wait") {
+    addBlocker(blockers, "runner_alive", "latest runner still appears alive");
+  }
+  return blockers;
+}

--- a/packages/agentplane/src/commands/shared/route-decision-next-action.ts
+++ b/packages/agentplane/src/commands/shared/route-decision-next-action.ts
@@ -1,0 +1,116 @@
+import type { TaskData } from "../../backends/task-backend.js";
+import type { PrFlowStatusReport } from "../pr/flow-status.js";
+import type { TaskResumeContext } from "../task/handoff.shared.js";
+import type { RouteBatchOwnership } from "./route-batch-ownership.js";
+import type { RouteNextAction } from "./route-decision-types.js";
+import type { RouteBlocker } from "./route-oracle.js";
+import { workStartCommand } from "./work-start-command.js";
+
+export function deriveNextAction(opts: {
+  task: TaskData;
+  resume: TaskResumeContext;
+  workflowMode: string;
+  prFlow: PrFlowStatusReport | null;
+  blockers: readonly RouteBlocker[];
+  batchOwnership: RouteBatchOwnership;
+}): RouteNextAction {
+  const id = opts.task.id;
+  if (opts.task.status === "DONE") {
+    if (opts.workflowMode !== "branch_pr") {
+      return {
+        code: "done",
+        command: null,
+        summary: "task is already done; no branch cleanup is required in direct workflow",
+        requiresApproval: false,
+      };
+    }
+    return {
+      code: "cleanup",
+      command: "agentplane cleanup merged",
+      summary:
+        "task is already done; pull the base branch and clean merged task branches/worktrees",
+      requiresApproval: false,
+    };
+  }
+  if (opts.task.plan_approval?.state !== "approved") {
+    return {
+      code: "approve_plan",
+      command: `agentplane task plan approve ${id} --by ORCHESTRATOR`,
+      summary: "approve the task plan before owner-scoped execution",
+      requiresApproval: true,
+    };
+  }
+  if (opts.workflowMode !== "branch_pr") {
+    return {
+      code: opts.resume.runner.next_action ?? "continue_direct",
+      command: opts.resume.runner.next_command ?? `agentplane task verify-show ${id}`,
+      summary: "continue the direct-mode task from the current checkout",
+      requiresApproval: false,
+    };
+  }
+  if (opts.batchOwnership.role === "included") {
+    return opts.batchOwnership.nextOwnerAction;
+  }
+  if (opts.resume.runner.next_action === "wait") {
+    return {
+      code: "wait_runner",
+      command: null,
+      summary: "wait for the active runner or reclaim with explicit force if it is orphaned",
+      requiresApproval: false,
+    };
+  }
+  if (opts.blockers.some((blocker) => blocker.code === "missing_pr_branch")) {
+    return {
+      code: "start_or_recover_worktree",
+      command: workStartCommand(opts.task),
+      summary: "create or recover the dedicated branch_pr worktree before opening a PR",
+      requiresApproval: false,
+    };
+  }
+  if (opts.blockers.some((blocker) => blocker.code === "pr_meta_stale")) {
+    return {
+      code: "update_pr_artifacts",
+      command: `agentplane pr update ${id}`,
+      summary: "refresh stale PR metadata before hosted checks or integration",
+      requiresApproval: false,
+    };
+  }
+  if (opts.prFlow?.pr.state === "not_found") {
+    return {
+      code: "open_pr",
+      command: `agentplane pr open ${id} --author ${opts.task.owner}`,
+      summary: "publish/link the task PR",
+      requiresApproval: false,
+    };
+  }
+  if (opts.prFlow?.pr.state === "OPEN") {
+    return {
+      code: "wait_hosted_checks",
+      command: `agentplane integrate queue enqueue ${id} --branch ${opts.prFlow.branch.name ?? "<branch>"}`,
+      summary: "enqueue the verified branch after hosted checks are stable",
+      requiresApproval: false,
+    };
+  }
+  if (opts.prFlow?.closeTail.state === "open") {
+    return {
+      code: "merge_close_tail",
+      command: null,
+      summary: "wait for hosted checks and merge the close-tail PR through the provider",
+      requiresApproval: true,
+    };
+  }
+  if (opts.prFlow?.closeTail.state === "not_found") {
+    return {
+      code: "open_close_tail",
+      command: `agentplane task hosted-close-pr ${id}`,
+      summary: "open the hosted close-tail PR for the merged implementation PR",
+      requiresApproval: false,
+    };
+  }
+  return {
+    code: "verify_or_update_pr",
+    command: `agentplane pr update ${id}`,
+    summary: "refresh PR artifacts, verify, then queue integration",
+    requiresApproval: false,
+  };
+}

--- a/packages/agentplane/src/commands/shared/route-decision-types.ts
+++ b/packages/agentplane/src/commands/shared/route-decision-types.ts
@@ -1,6 +1,5 @@
 import type { TaskData } from "../../backends/task-backend.js";
 import type { PrFlowStatusReport } from "../pr/flow-status.js";
-import type { TaskResumeContext } from "../task/handoff.shared.js";
 import type { RouteBatchNextAction, RouteBatchOwnership } from "./route-batch-ownership.js";
 import type { RouteBlocker, RouteExecutionPacket, RouteOracle } from "./route-oracle.js";
 import type { SourceConfidence as RouteSourceConfidence } from "./source-confidence.js";

--- a/packages/agentplane/src/commands/shared/route-decision-types.ts
+++ b/packages/agentplane/src/commands/shared/route-decision-types.ts
@@ -1,0 +1,75 @@
+import type { TaskData } from "../../backends/task-backend.js";
+import type { PrFlowStatusReport } from "../pr/flow-status.js";
+import type { TaskResumeContext } from "../task/handoff.shared.js";
+import type { RouteBatchNextAction, RouteBatchOwnership } from "./route-batch-ownership.js";
+import type { RouteBlocker, RouteExecutionPacket, RouteOracle } from "./route-oracle.js";
+import type { SourceConfidence as RouteSourceConfidence } from "./source-confidence.js";
+
+export type RouteNextAction = RouteBatchNextAction;
+
+export type RouteRepairStep = {
+  code: string;
+  command: string | null;
+  summary: string;
+  mutates: boolean;
+};
+
+export type RouteAmbiguity = {
+  code: string;
+  summary: string;
+  resolution: string;
+};
+
+export type TaskRouteDecision = {
+  task: {
+    id: string;
+    title: string;
+    status: string;
+    owner: string;
+    planApproval: string | null;
+    verification: string | null;
+    commit: string | null;
+  };
+  workflowMode: string;
+  workspace: {
+    root: string;
+    branch: string | null;
+    baseBranch: string | null;
+    headSha: string | null;
+    prBranch: string | null;
+    checkoutRole: "base" | "task_worktree" | "unknown";
+    baseCheckoutPath: string | null;
+    taskWorktreePath: string | null;
+  };
+  approval: {
+    runtime: {
+      requirePlan: boolean;
+      requireNetwork: boolean;
+      requireVerify: boolean;
+    };
+    gatewayMutationApprovalRequired: boolean;
+    effectiveMutationApprovalRequired: boolean;
+  };
+  batchOwnership: RouteBatchOwnership;
+  prFlow: PrFlowStatusReport | null;
+  blockers: RouteBlocker[];
+  ambiguities: RouteAmbiguity[];
+  nextAction: RouteNextAction;
+  oracle: RouteOracle;
+  executionPacket: RouteExecutionPacket;
+  repairPlan: RouteRepairStep[];
+  sourceConfidence: Record<string, RouteSourceConfidence>;
+};
+
+export function taskSummary(task: TaskData): TaskRouteDecision["task"] {
+  const commit = task.commit as unknown;
+  return {
+    id: task.id,
+    title: task.title,
+    status: task.status,
+    owner: task.owner,
+    planApproval: task.plan_approval?.state ?? null,
+    verification: task.verification?.state ?? null,
+    commit: typeof commit === "string" && commit.trim() ? commit : null,
+  };
+}

--- a/packages/agentplane/src/commands/shared/route-decision.ts
+++ b/packages/agentplane/src/commands/shared/route-decision.ts
@@ -3,7 +3,7 @@ import { findWorktreeForBranch } from "@agentplaneorg/core/git";
 import { CliError } from "../../shared/errors.js";
 import { resolvePrFlowStatus, type PrFlowStatusReport } from "../pr/flow-status.js";
 import { buildTaskResumeContext, type TaskResumeContext } from "../task/handoff.shared.js";
-import { resolveBatchOwnership, type RouteBatchOwnership } from "./route-batch-ownership.js";
+import { resolveBatchOwnership } from "./route-batch-ownership.js";
 import { deriveBlockers } from "./route-decision-blockers.js";
 import { deriveNextAction } from "./route-decision-next-action.js";
 import {
@@ -12,18 +12,11 @@ import {
   type RouteRepairStep,
   type TaskRouteDecision,
 } from "./route-decision-types.js";
-import {
-  deriveRouteExecutionPacket,
-  deriveRouteOracle,
-  type RouteBlocker,
-} from "./route-oracle.js";
+import { deriveRouteExecutionPacket, deriveRouteOracle } from "./route-oracle.js";
 import { workStartCommand } from "./work-start-command.js";
 
 import { loadBackendTask, loadCommandContext, type CommandContext } from "./task-backend.js";
-import {
-  buildRouteSourceConfidenceBase,
-  type SourceConfidence as RouteSourceConfidence,
-} from "./source-confidence.js";
+import { buildRouteSourceConfidenceBase } from "./source-confidence.js";
 
 function isCliUsageOrIo(err: unknown): boolean {
   return err instanceof CliError && (err.code === "E_USAGE" || err.code === "E_IO");

--- a/packages/agentplane/src/commands/shared/route-decision.ts
+++ b/packages/agentplane/src/commands/shared/route-decision.ts
@@ -1,21 +1,21 @@
 import { findWorktreeForBranch } from "@agentplaneorg/core/git";
 
-import type { TaskData } from "../../backends/task-backend.js";
 import { CliError } from "../../shared/errors.js";
 import { resolvePrFlowStatus, type PrFlowStatusReport } from "../pr/flow-status.js";
-import { isTaskLocalOnlyAdvance } from "./task-local-freshness.js";
 import { buildTaskResumeContext, type TaskResumeContext } from "../task/handoff.shared.js";
+import { resolveBatchOwnership, type RouteBatchOwnership } from "./route-batch-ownership.js";
+import { deriveBlockers } from "./route-decision-blockers.js";
+import { deriveNextAction } from "./route-decision-next-action.js";
 import {
-  resolveBatchOwnership,
-  type RouteBatchOwnership,
-  type RouteBatchNextAction,
-} from "./route-batch-ownership.js";
+  taskSummary,
+  type RouteAmbiguity,
+  type RouteRepairStep,
+  type TaskRouteDecision,
+} from "./route-decision-types.js";
 import {
   deriveRouteExecutionPacket,
   deriveRouteOracle,
   type RouteBlocker,
-  type RouteExecutionPacket,
-  type RouteOracle,
 } from "./route-oracle.js";
 import { workStartCommand } from "./work-start-command.js";
 
@@ -25,272 +25,8 @@ import {
   type SourceConfidence as RouteSourceConfidence,
 } from "./source-confidence.js";
 
-type RouteNextAction = RouteBatchNextAction;
-
-type RouteRepairStep = {
-  code: string;
-  command: string | null;
-  summary: string;
-  mutates: boolean;
-};
-
-type RouteAmbiguity = {
-  code: string;
-  summary: string;
-  resolution: string;
-};
-
-type TaskRouteDecision = {
-  task: {
-    id: string;
-    title: string;
-    status: string;
-    owner: string;
-    planApproval: string | null;
-    verification: string | null;
-    commit: string | null;
-  };
-  workflowMode: string;
-  workspace: {
-    root: string;
-    branch: string | null;
-    baseBranch: string | null;
-    headSha: string | null;
-    prBranch: string | null;
-    checkoutRole: "base" | "task_worktree" | "unknown";
-    baseCheckoutPath: string | null;
-    taskWorktreePath: string | null;
-  };
-  approval: {
-    runtime: {
-      requirePlan: boolean;
-      requireNetwork: boolean;
-      requireVerify: boolean;
-    };
-    gatewayMutationApprovalRequired: boolean;
-    effectiveMutationApprovalRequired: boolean;
-  };
-  batchOwnership: RouteBatchOwnership;
-  prFlow: PrFlowStatusReport | null;
-  blockers: RouteBlocker[];
-  ambiguities: RouteAmbiguity[];
-  nextAction: RouteNextAction;
-  oracle: RouteOracle;
-  executionPacket: RouteExecutionPacket;
-  repairPlan: RouteRepairStep[];
-  sourceConfidence: Record<string, RouteSourceConfidence>;
-};
-
 function isCliUsageOrIo(err: unknown): boolean {
   return err instanceof CliError && (err.code === "E_USAGE" || err.code === "E_IO");
-}
-
-function taskSummary(task: TaskData): TaskRouteDecision["task"] {
-  const commit = task.commit as unknown;
-  return {
-    id: task.id,
-    title: task.title,
-    status: task.status,
-    owner: task.owner,
-    planApproval: task.plan_approval?.state ?? null,
-    verification: task.verification?.state ?? null,
-    commit: typeof commit === "string" && commit.trim() ? commit : null,
-  };
-}
-
-function addBlocker(blockers: RouteBlocker[], code: string, summary: string): void {
-  if (blockers.some((blocker) => blocker.code === code)) return;
-  blockers.push({ code, summary });
-}
-
-async function isPrMetaOnlyTaskLocalAdvance(opts: {
-  ctx: CommandContext;
-  taskId: string;
-  prFlow: PrFlowStatusReport | null;
-}): Promise<boolean> {
-  const branchHeadSha = opts.prFlow?.branch.headSha ?? null;
-  const metaHeadSha = opts.prFlow?.branch.metaHeadSha ?? null;
-  if (!branchHeadSha || !metaHeadSha || branchHeadSha === metaHeadSha) return false;
-  return isTaskLocalOnlyAdvance({
-    gitRoot: opts.ctx.resolvedProject.gitRoot,
-    workflowDir: opts.ctx.config.paths.workflow_dir,
-    tasksPath: opts.ctx.config.paths.tasks_path,
-    taskId: opts.taskId,
-    fromRef: metaHeadSha,
-    toRef: branchHeadSha,
-  }).catch(() => false);
-}
-
-async function deriveBlockers(opts: {
-  ctx: CommandContext;
-  task: TaskData;
-  resume: TaskResumeContext;
-  workflowMode: string;
-  prFlow: PrFlowStatusReport | null;
-  batchOwnership: RouteBatchOwnership;
-}): Promise<RouteBlocker[]> {
-  const blockers: RouteBlocker[] = [];
-  if (opts.task.status === "DONE") return blockers;
-  if (opts.task.plan_approval?.state !== "approved") {
-    addBlocker(blockers, "plan_not_approved", "task plan is not approved");
-  }
-  if (opts.workflowMode === "branch_pr") {
-    if (
-      opts.batchOwnership.role !== "included" &&
-      !opts.resume.pr_branch &&
-      !opts.prFlow?.branch.name
-    ) {
-      addBlocker(blockers, "missing_pr_branch", "branch_pr task has no recorded PR branch");
-    }
-    if (opts.resume.branch === opts.resume.base_branch) {
-      addBlocker(blockers, "on_base_checkout", "current checkout appears to be the base branch");
-    }
-    if (opts.prFlow?.pr.state === "not_found") {
-      addBlocker(blockers, "remote_pr_missing", "task branch is not linked to a remote PR");
-    }
-    if (opts.prFlow?.branch.name && !opts.prFlow.branch.headSha) {
-      addBlocker(
-        blockers,
-        "branch_head_missing",
-        "recorded task branch cannot be resolved locally",
-      );
-    }
-    if (
-      opts.prFlow?.branch.headSha &&
-      opts.prFlow.branch.metaHeadSha &&
-      opts.prFlow.branch.headSha !== opts.prFlow.branch.metaHeadSha &&
-      !(await isPrMetaOnlyTaskLocalAdvance({
-        ctx: opts.ctx,
-        taskId: opts.task.id,
-        prFlow: opts.prFlow,
-      }))
-    ) {
-      addBlocker(blockers, "pr_meta_stale", "PR metadata head differs from local branch head");
-    }
-    if (opts.prFlow?.closeTail.state === "open") {
-      addBlocker(blockers, "close_tail_open", "hosted close-tail PR is still open");
-    }
-    if (opts.prFlow?.closeTail.state === "not_found") {
-      addBlocker(
-        blockers,
-        "close_tail_missing",
-        "implementation PR is merged but close-tail is missing",
-      );
-    }
-  }
-  if (opts.resume.runner.next_action === "wait") {
-    addBlocker(blockers, "runner_alive", "latest runner still appears alive");
-  }
-  return blockers;
-}
-
-function deriveNextAction(opts: {
-  task: TaskData;
-  resume: TaskResumeContext;
-  workflowMode: string;
-  prFlow: PrFlowStatusReport | null;
-  blockers: readonly RouteBlocker[];
-  batchOwnership: RouteBatchOwnership;
-}): RouteNextAction {
-  const id = opts.task.id;
-  if (opts.task.status === "DONE") {
-    if (opts.workflowMode !== "branch_pr") {
-      return {
-        code: "done",
-        command: null,
-        summary: "task is already done; no branch cleanup is required in direct workflow",
-        requiresApproval: false,
-      };
-    }
-    return {
-      code: "cleanup",
-      command: "agentplane cleanup merged",
-      summary:
-        "task is already done; pull the base branch and clean merged task branches/worktrees",
-      requiresApproval: false,
-    };
-  }
-  if (opts.task.plan_approval?.state !== "approved") {
-    return {
-      code: "approve_plan",
-      command: `agentplane task plan approve ${id} --by ORCHESTRATOR`,
-      summary: "approve the task plan before owner-scoped execution",
-      requiresApproval: true,
-    };
-  }
-  if (opts.workflowMode !== "branch_pr") {
-    return {
-      code: opts.resume.runner.next_action ?? "continue_direct",
-      command: opts.resume.runner.next_command ?? `agentplane task verify-show ${id}`,
-      summary: "continue the direct-mode task from the current checkout",
-      requiresApproval: false,
-    };
-  }
-  if (opts.batchOwnership.role === "included") {
-    return opts.batchOwnership.nextOwnerAction;
-  }
-  if (opts.resume.runner.next_action === "wait") {
-    return {
-      code: "wait_runner",
-      command: null,
-      summary: "wait for the active runner or reclaim with explicit force if it is orphaned",
-      requiresApproval: false,
-    };
-  }
-  if (opts.blockers.some((blocker) => blocker.code === "missing_pr_branch")) {
-    return {
-      code: "start_or_recover_worktree",
-      command: workStartCommand(opts.task),
-      summary: "create or recover the dedicated branch_pr worktree before opening a PR",
-      requiresApproval: false,
-    };
-  }
-  if (opts.blockers.some((blocker) => blocker.code === "pr_meta_stale")) {
-    return {
-      code: "update_pr_artifacts",
-      command: `agentplane pr update ${id}`,
-      summary: "refresh stale PR metadata before hosted checks or integration",
-      requiresApproval: false,
-    };
-  }
-  if (opts.prFlow?.pr.state === "not_found") {
-    return {
-      code: "open_pr",
-      command: `agentplane pr open ${id} --author ${opts.task.owner}`,
-      summary: "publish/link the task PR",
-      requiresApproval: false,
-    };
-  }
-  if (opts.prFlow?.pr.state === "OPEN") {
-    return {
-      code: "wait_hosted_checks",
-      command: `agentplane integrate queue enqueue ${id} --branch ${opts.prFlow.branch.name ?? "<branch>"}`,
-      summary: "enqueue the verified branch after hosted checks are stable",
-      requiresApproval: false,
-    };
-  }
-  if (opts.prFlow?.closeTail.state === "open") {
-    return {
-      code: "merge_close_tail",
-      command: null,
-      summary: "wait for hosted checks and merge the close-tail PR through the provider",
-      requiresApproval: true,
-    };
-  }
-  if (opts.prFlow?.closeTail.state === "not_found") {
-    return {
-      code: "open_close_tail",
-      command: `agentplane task hosted-close-pr ${id}`,
-      summary: "open the hosted close-tail PR for the merged implementation PR",
-      requiresApproval: false,
-    };
-  }
-  return {
-    code: "verify_or_update_pr",
-    command: `agentplane pr update ${id}`,
-    summary: "refresh PR artifacts, verify, then queue integration",
-    requiresApproval: false,
-  };
 }
 
 function deriveCheckoutRole(


### PR DESCRIPTION
Task: `202605281934-ZA0BEE`
Title: Route decision module decomposition
Canonical task record: `.agentplane/tasks/202605281934-ZA0BEE/README.md`

## Summary

Route decision module decomposition

Decompose the route decision hotspot into focused, testable modules without changing route semantics. Keep the public command behavior stable while isolating pure route classification, hosted/PR state interpretation, blocker formatting, and next-command rendering so agents receive the same or better next-action guidance from smaller code units.

## Scope

- In scope: Decompose the route decision hotspot into focused, testable modules without changing route semantics. Keep the public command behavior stable while isolating pure route classification, hosted/PR state interpretation, blocker formatting, and next-command rendering so agents receive the same or better next-action guidance from smaller code units.
- Out of scope: unrelated refactors not required for "Route decision module decomposition".

## Verification

- State: ok
- Note:

```text
Route decision decomposition verified: facade reduced to 335 lines, blockers/next-action/types
extracted into focused modules, route-decision CLI tests passed, typecheck passed, hotspot threshold
check passed, format:changed passed.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-28T19:34:55.525Z
- Branch: task/202605281934-ZA0BEE/route-decision-module-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/commands/shared/route-decision-blockers.ts |  93 +++++++
 .../commands/shared/route-decision-next-action.ts  | 116 +++++++++
 .../src/commands/shared/route-decision-types.ts    |  75 ++++++
 .../src/commands/shared/route-decision.ts          | 280 +--------------------
 4 files changed, 292 insertions(+), 272 deletions(-)
```

</details>
