### PR TITLE
🚧 XJETF6 task: Task runner execution usecase decomposition [202605282000-XJETF6]

### DIFF
--- a/.agentplane/tasks/202605282000-XJETF6/README.md
+++ b/.agentplane/tasks/202605282000-XJETF6/README.md
@@ -4,7 +4,7 @@ title: "Task runner execution usecase decomposition"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -25,6 +25,23 @@ verification:
   updated_by: "CODER"
   note: "Task runner usecase decomposition verified: task-run.ts reduced from 566 to 388 lines, blueprint plan/snapshot helpers extracted, targeted runner blueprint/lifecycle tests passed, typecheck passed, lint:core passed, format:changed passed, hotspot threshold check passed."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-28T20:04:52.698Z"
+  updated_by: "EVALUATOR"
+  note: "Task runner usecase decomposed by extracting blueprint plan and snapshot helpers."
+  evaluated_sha: "83b2e005cace2239004f24590409dfce8a6c9ac1"
+  blueprint_digest: "000c32c7735bd834124cb44e81f34c1083fe2b6023c5efae60a4195bdc50a6c0"
+  evidence_refs:
+    - ".agentplane/tasks/202605282000-XJETF6/README.md"
+    - ".agentplane/tasks/202605282000-XJETF6/quality/20260528-200452698-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605282000-XJETF6/quality/20260528-200452698-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605282000-XJETF6/quality/20260528-200452698-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605282000-XJETF6/blueprint/resolved-snapshot.json"
+    - "packages/agentplane/src/runner/usecases/task-run.ts"
+    - "packages/agentplane/src/runner/usecases/task-run-blueprint-plan.ts"
+  findings:
+    - "Evidence: task-run.ts reduced from 566 to 388 lines; task-run-blueprint-plan.ts owns blueprint budget, context manifest, plan resolution, and snapshot writes; targeted runner tests, typecheck, lint:core, format:changed, and hotspot check passed."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202605282000-XJETF6/README.md
+++ b/.agentplane/tasks/202605282000-XJETF6/README.md
@@ -1,0 +1,155 @@
+---
+id: "202605282000-XJETF6"
+title: "Task runner execution usecase decomposition"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "agent-efficiency"
+  - "code"
+  - "refactor"
+  - "runner"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-28T20:00:57.674Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-28T20:04:39.875Z"
+  updated_by: "CODER"
+  note: "Task runner usecase decomposition verified: task-run.ts reduced from 566 to 388 lines, blueprint plan/snapshot helpers extracted, targeted runner blueprint/lifecycle tests passed, typecheck passed, lint:core passed, format:changed passed, hotspot threshold check passed."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: decompose task runner execution usecase in the dedicated branch_pr worktree, preserving runner lifecycle behavior and verifying with targeted runner checks."
+events:
+  -
+    type: "status"
+    at: "2026-05-28T20:01:14.258Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: decompose task runner execution usecase in the dedicated branch_pr worktree, preserving runner lifecycle behavior and verifying with targeted runner checks."
+  -
+    type: "verify"
+    at: "2026-05-28T20:04:39.875Z"
+    author: "CODER"
+    state: "ok"
+    note: "Task runner usecase decomposition verified: task-run.ts reduced from 566 to 388 lines, blueprint plan/snapshot helpers extracted, targeted runner blueprint/lifecycle tests passed, typecheck passed, lint:core passed, format:changed passed, hotspot threshold check passed."
+doc_version: 3
+doc_updated_at: "2026-05-28T20:04:39.901Z"
+doc_updated_by: "CODER"
+description: "Decompose packages/agentplane/src/runner/usecases/task-run.ts into focused runner execution modules without changing runner lifecycle behavior. Extract manifest/result construction and execution status mapping so agent-run evidence is easier to audit and future runner changes touch smaller files."
+sections:
+  Summary: |-
+    Task runner execution usecase decomposition
+
+    Decompose packages/agentplane/src/runner/usecases/task-run.ts into focused runner execution modules without changing runner lifecycle behavior. Extract manifest/result construction and execution status mapping so agent-run evidence is easier to audit and future runner changes touch smaller files.
+  Scope: |-
+    - In scope: Decompose packages/agentplane/src/runner/usecases/task-run.ts into focused runner execution modules without changing runner lifecycle behavior. Extract manifest/result construction and execution status mapping so agent-run evidence is easier to audit and future runner changes touch smaller files.
+    - Out of scope: unrelated refactors not required for "Task runner execution usecase decomposition".
+  Plan: |-
+    1. Inspect task-run.ts dependencies and runner tests to identify pure extraction boundaries.
+    2. Extract result/manifest/status helpers into focused runner modules without changing TaskRunResult shape.
+    3. Keep task-run.ts as the orchestration facade and reduce hotspot line count.
+    4. Run targeted runner tests plus typecheck, lint/format, and hotspot threshold check.
+    5. Open a branch_pr with evaluator evidence and hosted CI.
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-28T20:04:39.875Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Task runner usecase decomposition verified: task-run.ts reduced from 566 to 388 lines, blueprint plan/snapshot helpers extracted, targeted runner blueprint/lifecycle tests passed, typecheck passed, lint:core passed, format:changed passed, hotspot threshold check passed.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-28T20:01:14.258Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605282000-XJETF6-task-runner-execution-usecase-decomposition/.agentplane/tasks/202605282000-XJETF6/blueprint/resolved-snapshot.json
+    - old_digest: 000c32c7735bd834124cb44e81f34c1083fe2b6023c5efae60a4195bdc50a6c0
+    - current_digest: 000c32c7735bd834124cb44e81f34c1083fe2b6023c5efae60a4195bdc50a6c0
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605282000-XJETF6
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Task runner execution usecase decomposition
+
+Decompose packages/agentplane/src/runner/usecases/task-run.ts into focused runner execution modules without changing runner lifecycle behavior. Extract manifest/result construction and execution status mapping so agent-run evidence is easier to audit and future runner changes touch smaller files.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/runner/usecases/task-run.ts into focused runner execution modules without changing runner lifecycle behavior. Extract manifest/result construction and execution status mapping so agent-run evidence is easier to audit and future runner changes touch smaller files.
+- Out of scope: unrelated refactors not required for "Task runner execution usecase decomposition".
+
+## Plan
+
+1. Inspect task-run.ts dependencies and runner tests to identify pure extraction boundaries.
+2. Extract result/manifest/status helpers into focused runner modules without changing TaskRunResult shape.
+3. Keep task-run.ts as the orchestration facade and reduce hotspot line count.
+4. Run targeted runner tests plus typecheck, lint/format, and hotspot threshold check.
+5. Open a branch_pr with evaluator evidence and hosted CI.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-28T20:04:39.875Z — VERIFY — ok
+
+By: CODER
+
+Note: Task runner usecase decomposition verified: task-run.ts reduced from 566 to 388 lines, blueprint plan/snapshot helpers extracted, targeted runner blueprint/lifecycle tests passed, typecheck passed, lint:core passed, format:changed passed, hotspot threshold check passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-28T20:01:14.258Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605282000-XJETF6-task-runner-execution-usecase-decomposition/.agentplane/tasks/202605282000-XJETF6/blueprint/resolved-snapshot.json
+- old_digest: 000c32c7735bd834124cb44e81f34c1083fe2b6023c5efae60a4195bdc50a6c0
+- current_digest: 000c32c7735bd834124cb44e81f34c1083fe2b6023c5efae60a4195bdc50a6c0
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605282000-XJETF6
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605282000-XJETF6/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605282000-XJETF6/blueprint/resolved-snapshot.json
@@ -1,0 +1,573 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605282000-XJETF6",
+    "title": "Task runner execution usecase decomposition",
+    "description": "Decompose packages/agentplane/src/runner/usecases/task-run.ts into focused runner execution modules without changing runner lifecycle behavior. Extract manifest/result construction and execution status mapping so agent-run evidence is easier to audit and future runner changes touch smaller files.",
+    "tags": [
+      "agent-efficiency",
+      "code",
+      "refactor",
+      "runner"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605282000-XJETF6",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "000c32c7735bd834124cb44e81f34c1083fe2b6023c5efae60a4195bdc50a6c0"
+  }
+}

--- a/.agentplane/tasks/202605282000-XJETF6/pr/diffstat.txt
+++ b/.agentplane/tasks/202605282000-XJETF6/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../src/runner/usecases/task-run-blueprint-plan.ts | 189 ++++++++++++++++++++
+ .../agentplane/src/runner/usecases/task-run.ts     | 190 +--------------------
+ 2 files changed, 195 insertions(+), 184 deletions(-)

--- a/.agentplane/tasks/202605282000-XJETF6/pr/github-body.md
+++ b/.agentplane/tasks/202605282000-XJETF6/pr/github-body.md
@@ -1,0 +1,39 @@
+Task: `202605282000-XJETF6`
+Title: Task runner execution usecase decomposition
+Canonical task record: `.agentplane/tasks/202605282000-XJETF6/README.md`
+
+## Summary
+
+Task runner execution usecase decomposition
+
+Decompose packages/agentplane/src/runner/usecases/task-run.ts into focused runner execution modules without changing runner lifecycle behavior. Extract manifest/result construction and execution status mapping so agent-run evidence is easier to audit and future runner changes touch smaller files.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/runner/usecases/task-run.ts into focused runner execution modules without changing runner lifecycle behavior. Extract manifest/result construction and execution status mapping so agent-run evidence is easier to audit and future runner changes touch smaller files.
+- Out of scope: unrelated refactors not required for "Task runner execution usecase decomposition".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Task runner usecase decomposition verified: task-run.ts reduced from 566 to 388 lines, blueprint
+plan/snapshot helpers extracted, targeted runner blueprint/lifecycle tests passed, typecheck passed,
+lint:core passed, format:changed passed, hotspot threshold check passed.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-28T20:01:14.372Z
+- Branch: task/202605282000-XJETF6/task-runner-execution-usecase-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605282000-XJETF6/pr/github-body.md
+++ b/.agentplane/tasks/202605282000-XJETF6/pr/github-body.md
@@ -33,7 +33,9 @@ lint:core passed, format:changed passed, hotspot threshold check passed.
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/runner/usecases/task-run-blueprint-plan.ts | 189 ++++++++++++++++++++
+ .../agentplane/src/runner/usecases/task-run.ts     | 190 +--------------------
+ 2 files changed, 195 insertions(+), 184 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605282000-XJETF6/pr/github-title.txt
+++ b/.agentplane/tasks/202605282000-XJETF6/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 XJETF6 task: Task runner execution usecase decomposition [202605282000-XJETF6]

--- a/.agentplane/tasks/202605282000-XJETF6/pr/meta.json
+++ b/.agentplane/tasks/202605282000-XJETF6/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605282000-XJETF6/task-runner-execution-usecase-decomposition",
   "created_at": "2026-05-28T20:01:14.372Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "diffstat_sha256": "sha256:5a40dd37f4bb43cb84ee226d1761fb4ee4838844a9dfc742bf7659d577c02428",
   "last_verified_at": "2026-05-28T20:04:39.875Z",
   "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "schema_version": 1,

--- a/.agentplane/tasks/202605282000-XJETF6/pr/meta.json
+++ b/.agentplane/tasks/202605282000-XJETF6/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605282000-XJETF6/task-runner-execution-usecase-decomposition",
+  "created_at": "2026-05-28T20:01:14.372Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": "2026-05-28T20:04:39.875Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202605282000-XJETF6",
+  "updated_at": "2026-05-28T20:01:14.372Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605282000-XJETF6/pr/review.md
+++ b/.agentplane/tasks/202605282000-XJETF6/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-28T20:01:14.372Z
+
+## Task
+
+- Task: `202605282000-XJETF6`
+- Title: Task runner execution usecase decomposition
+- Status: DOING
+- Branch: `task/202605282000-XJETF6/task-runner-execution-usecase-decomposition`
+- Canonical task record: `.agentplane/tasks/202605282000-XJETF6/README.md`
+
+## Verification
+
+- State: ok
+- Note: Task runner usecase decomposition verified: task-run.ts reduced from 566 to 388 lines, blueprint plan/snapshot helpers extracted, targeted runner blueprint/lifecycle tests passed, typecheck passed, lint:core passed, format:changed passed, hotspot threshold check passed.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-28T20:01:14.372Z
+- Branch: task/202605282000-XJETF6/task-runner-execution-usecase-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605282000-XJETF6/pr/review.md
+++ b/.agentplane/tasks/202605282000-XJETF6/pr/review.md
@@ -29,7 +29,9 @@ Created: 2026-05-28T20:01:14.372Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/runner/usecases/task-run-blueprint-plan.ts | 189 ++++++++++++++++++++
+ .../agentplane/src/runner/usecases/task-run.ts     | 190 +--------------------
+ 2 files changed, 195 insertions(+), 184 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605282000-XJETF6/quality/20260528-200452698-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605282000-XJETF6/quality/20260528-200452698-recovery-context/evaluator-opinion.md
@@ -1,0 +1,20 @@
+# EVALUATOR opinion: pass
+
+Task runner usecase decomposed by extracting blueprint plan and snapshot helpers.
+
+## Findings
+- Evidence: task-run.ts reduced from 566 to 388 lines; task-run-blueprint-plan.ts owns blueprint budget, context manifest, plan resolution, and snapshot writes; targeted runner tests, typecheck, lint:core, format:changed, and hotspot check passed.
+
+## Evidence
+- .agentplane/tasks/202605282000-XJETF6/README.md
+- packages/agentplane/src/runner/usecases/task-run.ts
+- packages/agentplane/src/runner/usecases/task-run-blueprint-plan.ts
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202605282000-XJETF6/quality/20260528-200452698-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605282000-XJETF6/quality/20260528-200452698-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605282000-XJETF6
+- task_readme: .agentplane/tasks/202605282000-XJETF6/README.md
+- report_path: .agentplane/tasks/202605282000-XJETF6/quality/20260528-200452698-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605282000-XJETF6/quality/20260528-200452698-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605282000-XJETF6/quality/20260528-200452698-recovery-context/quality-report.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "task_id": "202605282000-XJETF6",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-28T20:04:52.698Z",
+  "verdict": "pass",
+  "summary": "Task runner usecase decomposed by extracting blueprint plan and snapshot helpers.",
+  "evaluated_sha": "83b2e005cace2239004f24590409dfce8a6c9ac1",
+  "blueprint_digest": "000c32c7735bd834124cb44e81f34c1083fe2b6023c5efae60a4195bdc50a6c0",
+  "findings": [
+    "Evidence: task-run.ts reduced from 566 to 388 lines; task-run-blueprint-plan.ts owns blueprint budget, context manifest, plan resolution, and snapshot writes; targeted runner tests, typecheck, lint:core, format:changed, and hotspot check passed."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605282000-XJETF6/README.md",
+    "packages/agentplane/src/runner/usecases/task-run.ts",
+    "packages/agentplane/src/runner/usecases/task-run-blueprint-plan.ts"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/runner/usecases/task-run-blueprint-plan.ts
+++ b/packages/agentplane/src/runner/usecases/task-run-blueprint-plan.ts
@@ -64,7 +64,7 @@ export function assertRunnerBlueprintPolicyModuleBudget(bundle: RunnerContextBun
   });
 }
 
-export function buildRunnerBlueprintContextManifest(opts: {
+function buildRunnerBlueprintContextManifest(opts: {
   basePrompts: readonly RunnerPromptBlock[];
   recipe?: RunnerRecipeContext;
   policyModules: readonly string[];

--- a/packages/agentplane/src/runner/usecases/task-run-blueprint-plan.ts
+++ b/packages/agentplane/src/runner/usecases/task-run-blueprint-plan.ts
@@ -1,0 +1,189 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { resolveRecipeBlueprintExtensions, type RecipeManifest } from "@agentplaneorg/recipes";
+
+import { exitCodeForError } from "../../cli/exit-codes.js";
+import { blueprintResolveInputFromTask } from "../../commands/blueprint/task-input.js";
+import type { CommandContext } from "../../commands/shared/task-backend.js";
+import {
+  buildBlueprintExecutionPlanArtifact,
+  buildBlueprintExecutionStateArtifact,
+  buildBlueprintPlanArtifact,
+  createTrustedProjectBlueprintRegistry,
+  inferBlueprintTaskKind,
+  recipeBlueprintExtensionsToHints,
+  resolveBlueprint,
+  type BlueprintContextManifestEntry,
+} from "../../blueprints/index.js";
+import { CliError } from "../../shared/errors.js";
+import type { RunnerContextBundle, RunnerPromptBlock, RunnerRecipeContext } from "../types.js";
+import type { assembleRunnerTaskContext } from "../context/task-context.js";
+
+function recipeManifestFromContext(recipe: RunnerRecipeContext | undefined): RecipeManifest | null {
+  if (!recipe?.manifest || typeof recipe.manifest !== "object") return null;
+  return recipe.manifest as RecipeManifest;
+}
+
+function isBlueprintPolicyModuleEntry(entry: {
+  kind: string;
+  source?: string;
+  id: string;
+}): boolean {
+  const source = entry.source ?? entry.id;
+  return entry.kind === "policy_module" && source.startsWith(".agentplane/policy/");
+}
+
+export function assertRunnerBlueprintPolicyModuleBudget(bundle: RunnerContextBundle): void {
+  const blueprint = bundle.blueprint;
+  if (!blueprint) return;
+  const maxPolicyModules = blueprint.contextBudget.maxPolicyModules;
+  const policyModules = blueprint.policyModules.filter((item) => item.trim().length > 0);
+  const policyManifestEntries = blueprint.contextManifest.filter((entry) =>
+    isBlueprintPolicyModuleEntry(entry),
+  );
+  const actualCount = Math.max(policyModules.length, policyManifestEntries.length);
+  if (actualCount <= maxPolicyModules) return;
+  throw new CliError({
+    exitCode: exitCodeForError("E_VALIDATION"),
+    code: "E_VALIDATION",
+    message: [
+      "Runner blueprint policy module budget exceeded.",
+      `blueprint=${blueprint.blueprintId}`,
+      `policy_modules=${policyModules.length}`,
+      `context_manifest_policy_modules=${policyManifestEntries.length}`,
+      `max_policy_modules=${maxPolicyModules}`,
+      "Fix: remove unrelated policy modules from the runner context or select a blueprint with a larger explicit budget.",
+    ].join("\n"),
+    context: {
+      blueprint_id: blueprint.blueprintId,
+      policy_modules: policyModules.length,
+      context_manifest_policy_modules: policyManifestEntries.length,
+      max_policy_modules: maxPolicyModules,
+    },
+  });
+}
+
+export function buildRunnerBlueprintContextManifest(opts: {
+  basePrompts: readonly RunnerPromptBlock[];
+  recipe?: RunnerRecipeContext;
+  policyModules: readonly string[];
+}): BlueprintContextManifestEntry[] {
+  const entries: BlueprintContextManifestEntry[] = opts.basePrompts.map((prompt) => ({
+    id: prompt.id,
+    kind: prompt.id.includes("policy") ? "policy_module" : "prompt",
+    reason: prompt.resolution
+      ? `Resolved from ${prompt.resolution.winner.source}.`
+      : "Loaded as part of the runner base prompt bundle.",
+    ...(prompt.source ? { source: prompt.source } : {}),
+  }));
+  for (const policyModule of opts.policyModules) {
+    if (entries.some((entry) => entry.source === policyModule || entry.id === policyModule)) {
+      continue;
+    }
+    entries.push({
+      id: policyModule,
+      kind: "policy_module",
+      reason: "Allowed by the resolved blueprint policy module budget.",
+      source: policyModule,
+    });
+  }
+  if (opts.recipe) {
+    entries.push({
+      id: opts.recipe.recipe_id,
+      kind: "recipe",
+      reason: "Selected recipe context attached to this runner invocation.",
+      ...(opts.recipe.recipe_dir ? { source: opts.recipe.recipe_dir } : {}),
+    });
+  }
+  return entries;
+}
+
+export function resolveRunnerBlueprintPlan(opts: {
+  taskEnvelope: Awaited<ReturnType<typeof assembleRunnerTaskContext>>;
+  config: CommandContext["config"];
+  projectRoot: string;
+  recipe?: RunnerRecipeContext;
+  basePrompts: readonly RunnerPromptBlock[];
+}): Promise<RunnerContextBundle["blueprint"]> {
+  const input = blueprintResolveInputFromTask({
+    task: opts.taskEnvelope.task.data,
+    config: opts.config,
+  });
+  const manifest = recipeManifestFromContext(opts.recipe);
+  if (manifest) {
+    const taskKind = inferBlueprintTaskKind(input);
+    const recipeExtensions = resolveRecipeBlueprintExtensions({
+      recipes: [{ manifest }],
+      runtime: {
+        task_kind: taskKind,
+        command: "task run",
+        tags: input.tags ? [...input.tags] : [],
+      },
+      includeIncompatible: true,
+    });
+    input.recipeHints = recipeBlueprintExtensionsToHints(recipeExtensions.accepted);
+  }
+  return createTrustedProjectBlueprintRegistry(opts.projectRoot)
+    .then((projectRegistry) => {
+      const resolved = resolveBlueprint({
+        input,
+        registry: projectRegistry.registry,
+        projectBlueprintIds: projectRegistry.projectBlueprintIds,
+      });
+      return buildBlueprintPlanArtifact({
+        resolved,
+        input,
+        workflowMode: input.workflowMode,
+        contextManifest: buildRunnerBlueprintContextManifest({
+          basePrompts: opts.basePrompts,
+          recipe: opts.recipe,
+          policyModules: resolved.blueprint.policyModules,
+        }),
+      });
+    })
+    .catch((err) => {
+      throw new CliError({
+        exitCode: exitCodeForError("E_VALIDATION"),
+        code: "E_VALIDATION",
+        message:
+          err instanceof Error
+            ? err.message
+            : `Invalid project-local blueprint trust registry: ${String(err)}`,
+      });
+    });
+}
+
+export async function writeTaskBlueprintSnapshot(bundle: RunnerContextBundle): Promise<void> {
+  if (bundle.target.kind !== "task" || !bundle.blueprint) return;
+  const snapshotPath = bundle.execution.artifact_paths.blueprint_plan_path;
+  const executionPlanPath = bundle.execution.artifact_paths.blueprint_execution_plan_path;
+  const executionStatePath = bundle.execution.artifact_paths.blueprint_execution_state_path;
+  await mkdir(path.dirname(snapshotPath), { recursive: true });
+  const executionPlan = buildBlueprintExecutionPlanArtifact({
+    plan: bundle.blueprint,
+    runId: bundle.execution.run_id,
+    generatedAt: bundle.execution.run_id,
+  });
+  await writeFile(snapshotPath, `${JSON.stringify(bundle.blueprint, null, 2)}\n`, "utf8");
+  await writeFile(executionPlanPath, `${JSON.stringify(executionPlan, null, 2)}\n`, "utf8");
+  await writeFile(
+    executionStatePath,
+    `${JSON.stringify(
+      buildBlueprintExecutionStateArtifact({
+        plan: bundle.blueprint,
+        executionPlan,
+        runId: bundle.execution.run_id,
+        at: bundle.execution.run_id,
+      }),
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+  await writeFile(
+    bundle.execution.artifact_paths.context_manifest_path,
+    `${JSON.stringify(bundle.blueprint.contextManifest, null, 2)}\n`,
+    "utf8",
+  );
+}

--- a/packages/agentplane/src/runner/usecases/task-run.ts
+++ b/packages/agentplane/src/runner/usecases/task-run.ts
@@ -1,24 +1,9 @@
-import { mkdir, writeFile } from "node:fs/promises";
-import path from "node:path";
-
 import { normalizeTaskStatus } from "@agentplaneorg/core/tasks";
-import { resolveRecipeBlueprintExtensions, type RecipeManifest } from "@agentplaneorg/recipes";
 
 import { exitCodeForError } from "../../cli/exit-codes.js";
 import { loadCommandContext, type CommandContext } from "../../commands/shared/task-backend.js";
-import { blueprintResolveInputFromTask } from "../../commands/blueprint/task-input.js";
 import { buildTaskRouteDecision } from "../../commands/shared/route-decision.js";
 import { CliError } from "../../shared/errors.js";
-import {
-  buildBlueprintPlanArtifact,
-  buildBlueprintExecutionPlanArtifact,
-  buildBlueprintExecutionStateArtifact,
-  createTrustedProjectBlueprintRegistry,
-  type BlueprintContextManifestEntry,
-  inferBlueprintTaskKind,
-  recipeBlueprintExtensionsToHints,
-  resolveBlueprint,
-} from "../../blueprints/index.js";
 import { resolveRunnerAdapterCapabilityRegistry } from "../../runtime/capabilities/index.js";
 import { consumeExecutionProfileBudget } from "../../runtime/execution-profile/index.js";
 import {
@@ -42,6 +27,12 @@ import { createRunnerRunId, resolveTaskRunnerPaths } from "../task-run-paths.js"
 import { normalizeRecipeArtifactPrefixes } from "../result-manifest-policy.js";
 import { renderTaskRunnerBootstrap } from "./task-run-bootstrap.js";
 export { renderTaskRunnerBootstrap } from "./task-run-bootstrap.js";
+export { assertRunnerBlueprintPolicyModuleBudget } from "./task-run-blueprint-plan.js";
+import {
+  assertRunnerBlueprintPolicyModuleBudget,
+  resolveRunnerBlueprintPlan,
+  writeTaskBlueprintSnapshot,
+} from "./task-run-blueprint-plan.js";
 import {
   RUNNER_API_VERSION,
   RUNNER_BUNDLE_SCHEMA_VERSION,
@@ -49,7 +40,6 @@ import {
   type RunnerExecutionContract,
   type RunnerInvocation,
   type RunnerRecipeContext,
-  type RunnerPromptBlock,
   type RunnerResult,
   type RunnerRunState,
   type RunnerTarget,
@@ -133,174 +123,6 @@ function assertRunnerPolicyCompatibility(bundle: RunnerContextBundle): void {
   if (profile.writes_artifacts_to && profile.writes_artifacts_to.length > 0) {
     normalizeRecipeArtifactPrefixes(profile.writes_artifacts_to);
   }
-}
-
-function isBlueprintPolicyModuleEntry(entry: {
-  kind: string;
-  source?: string;
-  id: string;
-}): boolean {
-  const source = entry.source ?? entry.id;
-  return entry.kind === "policy_module" && source.startsWith(".agentplane/policy/");
-}
-
-export function assertRunnerBlueprintPolicyModuleBudget(bundle: RunnerContextBundle): void {
-  const blueprint = bundle.blueprint;
-  if (!blueprint) return;
-  const maxPolicyModules = blueprint.contextBudget.maxPolicyModules;
-  const policyModules = blueprint.policyModules.filter((item) => item.trim().length > 0);
-  const policyManifestEntries = blueprint.contextManifest.filter((entry) =>
-    isBlueprintPolicyModuleEntry(entry),
-  );
-  const actualCount = Math.max(policyModules.length, policyManifestEntries.length);
-  if (actualCount <= maxPolicyModules) return;
-  throw new CliError({
-    exitCode: exitCodeForError("E_VALIDATION"),
-    code: "E_VALIDATION",
-    message: [
-      "Runner blueprint policy module budget exceeded.",
-      `blueprint=${blueprint.blueprintId}`,
-      `policy_modules=${policyModules.length}`,
-      `context_manifest_policy_modules=${policyManifestEntries.length}`,
-      `max_policy_modules=${maxPolicyModules}`,
-      "Fix: remove unrelated policy modules from the runner context or select a blueprint with a larger explicit budget.",
-    ].join("\n"),
-    context: {
-      blueprint_id: blueprint.blueprintId,
-      policy_modules: policyModules.length,
-      context_manifest_policy_modules: policyManifestEntries.length,
-      max_policy_modules: maxPolicyModules,
-    },
-  });
-}
-
-function recipeManifestFromContext(recipe: RunnerRecipeContext | undefined): RecipeManifest | null {
-  if (!recipe?.manifest || typeof recipe.manifest !== "object") return null;
-  return recipe.manifest as RecipeManifest;
-}
-
-function resolveRunnerBlueprintPlan(opts: {
-  taskEnvelope: Awaited<ReturnType<typeof assembleRunnerTaskContext>>;
-  config: CommandContext["config"];
-  projectRoot: string;
-  recipe?: RunnerRecipeContext;
-  basePrompts: readonly RunnerPromptBlock[];
-}): Promise<RunnerContextBundle["blueprint"]> {
-  const input = blueprintResolveInputFromTask({
-    task: opts.taskEnvelope.task.data,
-    config: opts.config,
-  });
-  const manifest = recipeManifestFromContext(opts.recipe);
-  if (manifest) {
-    const taskKind = inferBlueprintTaskKind(input);
-    const recipeExtensions = resolveRecipeBlueprintExtensions({
-      recipes: [{ manifest }],
-      runtime: {
-        task_kind: taskKind,
-        command: "task run",
-        tags: input.tags ? [...input.tags] : [],
-      },
-      includeIncompatible: true,
-    });
-    input.recipeHints = recipeBlueprintExtensionsToHints(recipeExtensions.accepted);
-  }
-  return createTrustedProjectBlueprintRegistry(opts.projectRoot)
-    .then((projectRegistry) => {
-      const resolved = resolveBlueprint({
-        input,
-        registry: projectRegistry.registry,
-        projectBlueprintIds: projectRegistry.projectBlueprintIds,
-      });
-      return buildBlueprintPlanArtifact({
-        resolved,
-        input,
-        workflowMode: input.workflowMode,
-        contextManifest: buildRunnerBlueprintContextManifest({
-          basePrompts: opts.basePrompts,
-          recipe: opts.recipe,
-          policyModules: resolved.blueprint.policyModules,
-        }),
-      });
-    })
-    .catch((err) => {
-      throw new CliError({
-        exitCode: exitCodeForError("E_VALIDATION"),
-        code: "E_VALIDATION",
-        message:
-          err instanceof Error
-            ? err.message
-            : `Invalid project-local blueprint trust registry: ${String(err)}`,
-      });
-    });
-}
-
-function buildRunnerBlueprintContextManifest(opts: {
-  basePrompts: readonly RunnerPromptBlock[];
-  recipe?: RunnerRecipeContext;
-  policyModules: readonly string[];
-}): BlueprintContextManifestEntry[] {
-  const entries: BlueprintContextManifestEntry[] = opts.basePrompts.map((prompt) => ({
-    id: prompt.id,
-    kind: prompt.id.includes("policy") ? "policy_module" : "prompt",
-    reason: prompt.resolution
-      ? `Resolved from ${prompt.resolution.winner.source}.`
-      : "Loaded as part of the runner base prompt bundle.",
-    ...(prompt.source ? { source: prompt.source } : {}),
-  }));
-  for (const policyModule of opts.policyModules) {
-    if (entries.some((entry) => entry.source === policyModule || entry.id === policyModule)) {
-      continue;
-    }
-    entries.push({
-      id: policyModule,
-      kind: "policy_module",
-      reason: "Allowed by the resolved blueprint policy module budget.",
-      source: policyModule,
-    });
-  }
-  if (opts.recipe) {
-    entries.push({
-      id: opts.recipe.recipe_id,
-      kind: "recipe",
-      reason: "Selected recipe context attached to this runner invocation.",
-      ...(opts.recipe.recipe_dir ? { source: opts.recipe.recipe_dir } : {}),
-    });
-  }
-  return entries;
-}
-
-async function writeTaskBlueprintSnapshot(bundle: RunnerContextBundle): Promise<void> {
-  if (bundle.target.kind !== "task" || !bundle.blueprint) return;
-  const snapshotPath = bundle.execution.artifact_paths.blueprint_plan_path;
-  const executionPlanPath = bundle.execution.artifact_paths.blueprint_execution_plan_path;
-  const executionStatePath = bundle.execution.artifact_paths.blueprint_execution_state_path;
-  await mkdir(path.dirname(snapshotPath), { recursive: true });
-  const executionPlan = buildBlueprintExecutionPlanArtifact({
-    plan: bundle.blueprint,
-    runId: bundle.execution.run_id,
-    generatedAt: bundle.execution.run_id,
-  });
-  await writeFile(snapshotPath, `${JSON.stringify(bundle.blueprint, null, 2)}\n`, "utf8");
-  await writeFile(executionPlanPath, `${JSON.stringify(executionPlan, null, 2)}\n`, "utf8");
-  await writeFile(
-    executionStatePath,
-    `${JSON.stringify(
-      buildBlueprintExecutionStateArtifact({
-        plan: bundle.blueprint,
-        executionPlan,
-        runId: bundle.execution.run_id,
-        at: bundle.execution.run_id,
-      }),
-      null,
-      2,
-    )}\n`,
-    "utf8",
-  );
-  await writeFile(
-    bundle.execution.artifact_paths.context_manifest_path,
-    `${JSON.stringify(bundle.blueprint.contextManifest, null, 2)}\n`,
-    "utf8",
-  );
 }
 
 async function writeRunnerRefusalArtifacts(opts: {


### PR DESCRIPTION
Task: `202605282000-XJETF6`
Title: Task runner execution usecase decomposition
Canonical task record: `.agentplane/tasks/202605282000-XJETF6/README.md`

## Summary

Task runner execution usecase decomposition

Decompose packages/agentplane/src/runner/usecases/task-run.ts into focused runner execution modules without changing runner lifecycle behavior. Extract manifest/result construction and execution status mapping so agent-run evidence is easier to audit and future runner changes touch smaller files.

## Scope

- In scope: Decompose packages/agentplane/src/runner/usecases/task-run.ts into focused runner execution modules without changing runner lifecycle behavior. Extract manifest/result construction and execution status mapping so agent-run evidence is easier to audit and future runner changes touch smaller files.
- Out of scope: unrelated refactors not required for "Task runner execution usecase decomposition".

## Verification

- State: ok
- Note:

```text
Task runner usecase decomposition verified: task-run.ts reduced from 566 to 388 lines, blueprint
plan/snapshot helpers extracted, targeted runner blueprint/lifecycle tests passed, typecheck passed,
lint:core passed, format:changed passed, hotspot threshold check passed.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-28T20:01:14.372Z
- Branch: task/202605282000-XJETF6/task-runner-execution-usecase-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/runner/usecases/task-run-blueprint-plan.ts | 189 ++++++++++++++++++++
 .../agentplane/src/runner/usecases/task-run.ts     | 190 +--------------------
 2 files changed, 195 insertions(+), 184 deletions(-)
```

</details>
