### PR TITLE
🚧 EJTNXA task: Evaluator command decomposition [202605282017-EJTNXA]

### DIFF
--- a/.agentplane/tasks/202605282017-EJTNXA/README.md
+++ b/.agentplane/tasks/202605282017-EJTNXA/README.md
@@ -4,7 +4,7 @@ title: "Evaluator command decomposition"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -25,6 +25,23 @@ verification:
   updated_by: "CODER"
   note: "Evaluator command decomposition verified: evaluator.command.ts reduced from 455 to 365 lines, quality artifact rendering/helpers extracted, evaluator run focused tests passed, typecheck passed, lint:core passed, format:changed passed, hotspot threshold check passed."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-28T20:21:40.187Z"
+  updated_by: "EVALUATOR"
+  note: "Evaluator command decomposed by extracting quality artifact helpers."
+  evaluated_sha: "9dd5da22fb6a910ed761563141f7164cc2b709ca"
+  blueprint_digest: "ab4abe2d89a62a67484ee6f40ff476601da6f3570e7a51e62c085636edc96e33"
+  evidence_refs:
+    - ".agentplane/tasks/202605282017-EJTNXA/README.md"
+    - ".agentplane/tasks/202605282017-EJTNXA/quality/20260528-202140187-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605282017-EJTNXA/quality/20260528-202140187-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605282017-EJTNXA/quality/20260528-202140187-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605282017-EJTNXA/blueprint/resolved-snapshot.json"
+    - "packages/agentplane/src/commands/evaluator/evaluator.command.ts"
+    - "packages/agentplane/src/commands/evaluator/evaluator-quality-artifacts.ts"
+  findings:
+    - "Evidence: evaluator.command.ts reduced from 455 to 365 lines; evaluator-quality-artifacts.ts owns report rendering/path helpers; focused evaluator tests, typecheck, lint:core, format:changed, and hotspot check passed."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202605282017-EJTNXA/README.md
+++ b/.agentplane/tasks/202605282017-EJTNXA/README.md
@@ -1,0 +1,155 @@
+---
+id: "202605282017-EJTNXA"
+title: "Evaluator command decomposition"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "agent-efficiency"
+  - "code"
+  - "evaluator"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-28T20:17:58.889Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-28T20:21:29.143Z"
+  updated_by: "CODER"
+  note: "Evaluator command decomposition verified: evaluator.command.ts reduced from 455 to 365 lines, quality artifact rendering/helpers extracted, evaluator run focused tests passed, typecheck passed, lint:core passed, format:changed passed, hotspot threshold check passed."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: decompose evaluator command internals in the dedicated branch_pr worktree while preserving evaluator run behavior, quality report artifacts, and task README updates."
+events:
+  -
+    type: "status"
+    at: "2026-05-28T20:18:18.748Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: decompose evaluator command internals in the dedicated branch_pr worktree while preserving evaluator run behavior, quality report artifacts, and task README updates."
+  -
+    type: "verify"
+    at: "2026-05-28T20:21:29.143Z"
+    author: "CODER"
+    state: "ok"
+    note: "Evaluator command decomposition verified: evaluator.command.ts reduced from 455 to 365 lines, quality artifact rendering/helpers extracted, evaluator run focused tests passed, typecheck passed, lint:core passed, format:changed passed, hotspot threshold check passed."
+doc_version: 3
+doc_updated_at: "2026-05-28T20:21:29.169Z"
+doc_updated_by: "CODER"
+description: "Decompose packages/agentplane/src/commands/evaluator/evaluator.command.ts into focused evaluator command modules without changing evaluator CLI behavior. Extract option parsing/report construction/persistence helpers so quality-review evidence remains easier for agents to inspect and future evaluator changes touch smaller files."
+sections:
+  Summary: |-
+    Evaluator command decomposition
+
+    Decompose packages/agentplane/src/commands/evaluator/evaluator.command.ts into focused evaluator command modules without changing evaluator CLI behavior. Extract option parsing/report construction/persistence helpers so quality-review evidence remains easier for agents to inspect and future evaluator changes touch smaller files.
+  Scope: |-
+    - In scope: Decompose packages/agentplane/src/commands/evaluator/evaluator.command.ts into focused evaluator command modules without changing evaluator CLI behavior. Extract option parsing/report construction/persistence helpers so quality-review evidence remains easier for agents to inspect and future evaluator changes touch smaller files.
+    - Out of scope: unrelated refactors not required for "Evaluator command decomposition".
+  Plan: |-
+    1. Inspect evaluator.command.ts and evaluator tests to identify extraction seams.
+    2. Extract pure evaluator report/quality artifact helpers without changing evaluator run CLI output or task README writes.
+    3. Keep evaluator.command.ts as the command facade and reduce hotspot line count below the warning threshold.
+    4. Run evaluator-focused tests plus typecheck, lint, format, and hotspot threshold check.
+    5. Open branch_pr, wait for hosted CI, merge to main, and close task lifecycle.
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-28T20:21:29.143Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Evaluator command decomposition verified: evaluator.command.ts reduced from 455 to 365 lines, quality artifact rendering/helpers extracted, evaluator run focused tests passed, typecheck passed, lint:core passed, format:changed passed, hotspot threshold check passed.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-28T20:18:18.748Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605282017-EJTNXA-evaluator-command-decomposition/.agentplane/tasks/202605282017-EJTNXA/blueprint/resolved-snapshot.json
+    - old_digest: ab4abe2d89a62a67484ee6f40ff476601da6f3570e7a51e62c085636edc96e33
+    - current_digest: ab4abe2d89a62a67484ee6f40ff476601da6f3570e7a51e62c085636edc96e33
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605282017-EJTNXA
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Evaluator command decomposition
+
+Decompose packages/agentplane/src/commands/evaluator/evaluator.command.ts into focused evaluator command modules without changing evaluator CLI behavior. Extract option parsing/report construction/persistence helpers so quality-review evidence remains easier for agents to inspect and future evaluator changes touch smaller files.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/commands/evaluator/evaluator.command.ts into focused evaluator command modules without changing evaluator CLI behavior. Extract option parsing/report construction/persistence helpers so quality-review evidence remains easier for agents to inspect and future evaluator changes touch smaller files.
+- Out of scope: unrelated refactors not required for "Evaluator command decomposition".
+
+## Plan
+
+1. Inspect evaluator.command.ts and evaluator tests to identify extraction seams.
+2. Extract pure evaluator report/quality artifact helpers without changing evaluator run CLI output or task README writes.
+3. Keep evaluator.command.ts as the command facade and reduce hotspot line count below the warning threshold.
+4. Run evaluator-focused tests plus typecheck, lint, format, and hotspot threshold check.
+5. Open branch_pr, wait for hosted CI, merge to main, and close task lifecycle.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-28T20:21:29.143Z — VERIFY — ok
+
+By: CODER
+
+Note: Evaluator command decomposition verified: evaluator.command.ts reduced from 455 to 365 lines, quality artifact rendering/helpers extracted, evaluator run focused tests passed, typecheck passed, lint:core passed, format:changed passed, hotspot threshold check passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-28T20:18:18.748Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605282017-EJTNXA-evaluator-command-decomposition/.agentplane/tasks/202605282017-EJTNXA/blueprint/resolved-snapshot.json
+- old_digest: ab4abe2d89a62a67484ee6f40ff476601da6f3570e7a51e62c085636edc96e33
+- current_digest: ab4abe2d89a62a67484ee6f40ff476601da6f3570e7a51e62c085636edc96e33
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605282017-EJTNXA
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605282017-EJTNXA/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605282017-EJTNXA/blueprint/resolved-snapshot.json
@@ -1,0 +1,573 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605282017-EJTNXA",
+    "title": "Evaluator command decomposition",
+    "description": "Decompose packages/agentplane/src/commands/evaluator/evaluator.command.ts into focused evaluator command modules without changing evaluator CLI behavior. Extract option parsing/report construction/persistence helpers so quality-review evidence remains easier for agents to inspect and future evaluator changes touch smaller files.",
+    "tags": [
+      "agent-efficiency",
+      "code",
+      "evaluator",
+      "refactor"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605282017-EJTNXA",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "ab4abe2d89a62a67484ee6f40ff476601da6f3570e7a51e62c085636edc96e33"
+  }
+}

--- a/.agentplane/tasks/202605282017-EJTNXA/pr/diffstat.txt
+++ b/.agentplane/tasks/202605282017-EJTNXA/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../evaluator/evaluator-quality-artifacts.ts       | 118 +++++++++++++++++++++
+ .../src/commands/evaluator/evaluator.command.ts    | 118 +++------------------
+ 2 files changed, 132 insertions(+), 104 deletions(-)

--- a/.agentplane/tasks/202605282017-EJTNXA/pr/github-body.md
+++ b/.agentplane/tasks/202605282017-EJTNXA/pr/github-body.md
@@ -1,0 +1,39 @@
+Task: `202605282017-EJTNXA`
+Title: Evaluator command decomposition
+Canonical task record: `.agentplane/tasks/202605282017-EJTNXA/README.md`
+
+## Summary
+
+Evaluator command decomposition
+
+Decompose packages/agentplane/src/commands/evaluator/evaluator.command.ts into focused evaluator command modules without changing evaluator CLI behavior. Extract option parsing/report construction/persistence helpers so quality-review evidence remains easier for agents to inspect and future evaluator changes touch smaller files.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/commands/evaluator/evaluator.command.ts into focused evaluator command modules without changing evaluator CLI behavior. Extract option parsing/report construction/persistence helpers so quality-review evidence remains easier for agents to inspect and future evaluator changes touch smaller files.
+- Out of scope: unrelated refactors not required for "Evaluator command decomposition".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Evaluator command decomposition verified: evaluator.command.ts reduced from 455 to 365 lines,
+quality artifact rendering/helpers extracted, evaluator run focused tests passed, typecheck passed,
+lint:core passed, format:changed passed, hotspot threshold check passed.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-28T20:18:18.862Z
+- Branch: task/202605282017-EJTNXA/evaluator-command-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605282017-EJTNXA/pr/github-body.md
+++ b/.agentplane/tasks/202605282017-EJTNXA/pr/github-body.md
@@ -33,7 +33,9 @@ lint:core passed, format:changed passed, hotspot threshold check passed.
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../evaluator/evaluator-quality-artifacts.ts       | 118 +++++++++++++++++++++
+ .../src/commands/evaluator/evaluator.command.ts    | 118 +++------------------
+ 2 files changed, 132 insertions(+), 104 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605282017-EJTNXA/pr/github-title.txt
+++ b/.agentplane/tasks/202605282017-EJTNXA/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 EJTNXA task: Evaluator command decomposition [202605282017-EJTNXA]

--- a/.agentplane/tasks/202605282017-EJTNXA/pr/meta.json
+++ b/.agentplane/tasks/202605282017-EJTNXA/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605282017-EJTNXA/evaluator-command-decomposition",
   "created_at": "2026-05-28T20:18:18.862Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "diffstat_sha256": "sha256:6adf8874ee6581df3887b7fbac598044f939e8d9ee10052e965511f1ea6bcb75",
   "last_verified_at": "2026-05-28T20:21:29.143Z",
   "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "schema_version": 1,

--- a/.agentplane/tasks/202605282017-EJTNXA/pr/meta.json
+++ b/.agentplane/tasks/202605282017-EJTNXA/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605282017-EJTNXA/evaluator-command-decomposition",
+  "created_at": "2026-05-28T20:18:18.862Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": "2026-05-28T20:21:29.143Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202605282017-EJTNXA",
+  "updated_at": "2026-05-28T20:18:18.862Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605282017-EJTNXA/pr/review.md
+++ b/.agentplane/tasks/202605282017-EJTNXA/pr/review.md
@@ -29,7 +29,9 @@ Created: 2026-05-28T20:18:18.862Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../evaluator/evaluator-quality-artifacts.ts       | 118 +++++++++++++++++++++
+ .../src/commands/evaluator/evaluator.command.ts    | 118 +++------------------
+ 2 files changed, 132 insertions(+), 104 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605282017-EJTNXA/pr/review.md
+++ b/.agentplane/tasks/202605282017-EJTNXA/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-28T20:18:18.862Z
+
+## Task
+
+- Task: `202605282017-EJTNXA`
+- Title: Evaluator command decomposition
+- Status: DOING
+- Branch: `task/202605282017-EJTNXA/evaluator-command-decomposition`
+- Canonical task record: `.agentplane/tasks/202605282017-EJTNXA/README.md`
+
+## Verification
+
+- State: ok
+- Note: Evaluator command decomposition verified: evaluator.command.ts reduced from 455 to 365 lines, quality artifact rendering/helpers extracted, evaluator run focused tests passed, typecheck passed, lint:core passed, format:changed passed, hotspot threshold check passed.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-28T20:18:18.862Z
+- Branch: task/202605282017-EJTNXA/evaluator-command-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605282017-EJTNXA/quality/20260528-202140187-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605282017-EJTNXA/quality/20260528-202140187-recovery-context/evaluator-opinion.md
@@ -1,0 +1,20 @@
+# EVALUATOR opinion: pass
+
+Evaluator command decomposed by extracting quality artifact helpers.
+
+## Findings
+- Evidence: evaluator.command.ts reduced from 455 to 365 lines; evaluator-quality-artifacts.ts owns report rendering/path helpers; focused evaluator tests, typecheck, lint:core, format:changed, and hotspot check passed.
+
+## Evidence
+- .agentplane/tasks/202605282017-EJTNXA/README.md
+- packages/agentplane/src/commands/evaluator/evaluator.command.ts
+- packages/agentplane/src/commands/evaluator/evaluator-quality-artifacts.ts
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202605282017-EJTNXA/quality/20260528-202140187-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605282017-EJTNXA/quality/20260528-202140187-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605282017-EJTNXA
+- task_readme: .agentplane/tasks/202605282017-EJTNXA/README.md
+- report_path: .agentplane/tasks/202605282017-EJTNXA/quality/20260528-202140187-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605282017-EJTNXA/quality/20260528-202140187-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605282017-EJTNXA/quality/20260528-202140187-recovery-context/quality-report.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "task_id": "202605282017-EJTNXA",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-28T20:21:40.187Z",
+  "verdict": "pass",
+  "summary": "Evaluator command decomposed by extracting quality artifact helpers.",
+  "evaluated_sha": "9dd5da22fb6a910ed761563141f7164cc2b709ca",
+  "blueprint_digest": "ab4abe2d89a62a67484ee6f40ff476601da6f3570e7a51e62c085636edc96e33",
+  "findings": [
+    "Evidence: evaluator.command.ts reduced from 455 to 365 lines; evaluator-quality-artifacts.ts owns report rendering/path helpers; focused evaluator tests, typecheck, lint:core, format:changed, and hotspot check passed."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605282017-EJTNXA/README.md",
+    "packages/agentplane/src/commands/evaluator/evaluator.command.ts",
+    "packages/agentplane/src/commands/evaluator/evaluator-quality-artifacts.ts"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/commands/evaluator/evaluator-quality-artifacts.ts
+++ b/packages/agentplane/src/commands/evaluator/evaluator-quality-artifacts.ts
@@ -1,0 +1,118 @@
+import path from "node:path";
+
+import type { EvaluatorModule } from "../../evaluators/catalog.js";
+import type { EvaluatorRunParsed } from "./evaluator.spec.js";
+
+export const QUALITY_REPORT_FILE = "quality-report.json";
+export const EVALUATOR_PROMPT_FILE = "evaluator-prompt.md";
+export const EVALUATOR_OPINION_FILE = "evaluator-opinion.md";
+
+export type EvaluatorQualityReport = {
+  schema_version: 1;
+  task_id: string;
+  evaluator_id: string;
+  evaluator_profile: string;
+  generated_at: string;
+  verdict: EvaluatorRunParsed["verdict"];
+  summary: string;
+  evaluated_sha: string | null;
+  blueprint_digest: string | null;
+  findings: string[];
+  evidence_refs: string[];
+  missing_tests: string[];
+  hidden_assumptions: string[];
+  residual_risks: string[];
+};
+
+export function safePathSegment(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9._-]+/g, "-")
+    .replaceAll(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+export function timestampPathSegment(at: string): string {
+  return at.replaceAll(/[-:.]/g, "").replace("T", "-").replace("Z", "");
+}
+
+export function relativeArtifactPath(gitRoot: string, absPath: string): string {
+  return path.relative(gitRoot, absPath).replaceAll("\\", "/");
+}
+
+export function pathsOutsideTaskArtifacts(
+  paths: string[],
+  workflowDir: string,
+  taskId: string,
+): string[] {
+  const normalizedWorkflowDir = workflowDir.replaceAll("\\", "/").replaceAll(/\/+$/g, "");
+  const taskPrefix = `${normalizedWorkflowDir}/${taskId}/`;
+  return paths.filter((changedPath) => {
+    const normalizedPath = changedPath.replaceAll("\\", "/");
+    return !normalizedPath.startsWith(taskPrefix);
+  });
+}
+
+export function renderEvaluatorPrompt(opts: {
+  evaluator: EvaluatorModule;
+  taskId: string;
+  taskReadmePath: string;
+  reportPath: string;
+}): string {
+  return [
+    "# AgentPlane EVALUATOR quality review",
+    "",
+    "Use the evaluator module below as binding review procedure.",
+    "Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.",
+    "Write the final structured review to the report path as JSON matching the requested report shape.",
+    "",
+    `- task_id: ${opts.taskId}`,
+    `- task_readme: ${opts.taskReadmePath}`,
+    `- report_path: ${opts.reportPath}`,
+    "",
+    "Required report fields:",
+    "- verdict: pass | rework | blocked | human_review",
+    "- summary: concise judgement",
+    "- findings: non-empty list for pass/rework/blocked",
+    "- evidence_refs: concrete files, checks, PRs, traces, or reports inspected",
+    "- missing_tests: tests or checks that should exist but do not",
+    "- hidden_assumptions: assumptions the implementation relies on",
+    "- residual_risks: known remaining risks",
+    "",
+    "## Evaluator module",
+    "",
+    opts.evaluator.content.trim(),
+    "",
+  ].join("\n");
+}
+
+export function renderOpinionMarkdown(report: EvaluatorQualityReport): string {
+  return [
+    `# EVALUATOR opinion: ${report.verdict}`,
+    "",
+    report.summary,
+    "",
+    "## Findings",
+    ...report.findings.map((finding) => `- ${finding}`),
+    "",
+    "## Evidence",
+    ...report.evidence_refs.map((ref) => `- ${ref}`),
+    "",
+    "## Missing Tests",
+    ...(report.missing_tests.length > 0
+      ? report.missing_tests.map((row) => `- ${row}`)
+      : ["- none recorded"]),
+    "",
+    "## Hidden Assumptions",
+    ...(report.hidden_assumptions.length > 0
+      ? report.hidden_assumptions.map((row) => `- ${row}`)
+      : ["- none recorded"]),
+    "",
+    "## Residual Risks",
+    ...(report.residual_risks.length > 0
+      ? report.residual_risks.map((row) => `- ${row}`)
+      : ["- none recorded"]),
+    "",
+  ].join("\n");
+}

--- a/packages/agentplane/src/commands/evaluator/evaluator.command.ts
+++ b/packages/agentplane/src/commands/evaluator/evaluator.command.ts
@@ -21,6 +21,18 @@ import {
   type EvaluatorRunParsed,
   type EvaluatorShowParsed,
 } from "./evaluator.spec.js";
+import {
+  EVALUATOR_OPINION_FILE,
+  EVALUATOR_PROMPT_FILE,
+  QUALITY_REPORT_FILE,
+  pathsOutsideTaskArtifacts,
+  relativeArtifactPath,
+  renderEvaluatorPrompt,
+  renderOpinionMarkdown,
+  safePathSegment,
+  timestampPathSegment,
+  type EvaluatorQualityReport,
+} from "./evaluator-quality-artifacts.js";
 
 export {
   evaluatorListSpec,
@@ -28,10 +40,6 @@ export {
   evaluatorShowSpec,
   evaluatorSpec,
 } from "./evaluator.spec.js";
-
-const QUALITY_REPORT_FILE = "quality-report.json";
-const EVALUATOR_PROMPT_FILE = "evaluator-prompt.md";
-const EVALUATOR_OPINION_FILE = "evaluator-opinion.md";
 
 export async function runEvaluatorGroup(_ctx: CommandCtx, p: GroupCommandParsed): Promise<number> {
   return throwGroupCommandUsage({
@@ -96,24 +104,6 @@ async function loadCatalogForCommand(ctx: CommandCtx, includeBuiltin: boolean) {
   return await loadEvaluatorCatalog({ projectRoot, includeBuiltin });
 }
 
-function safePathSegment(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replaceAll(/[^a-z0-9._-]+/g, "-")
-    .replaceAll(/^-+|-+$/g, "")
-    .slice(0, 80);
-}
-
-function pathsOutsideTaskArtifacts(paths: string[], workflowDir: string, taskId: string): string[] {
-  const normalizedWorkflowDir = workflowDir.replaceAll("\\", "/").replaceAll(/\/+$/g, "");
-  const taskPrefix = `${normalizedWorkflowDir}/${taskId}/`;
-  return paths.filter((changedPath) => {
-    const normalizedPath = changedPath.replaceAll("\\", "/");
-    return !normalizedPath.startsWith(taskPrefix);
-  });
-}
-
 async function resolveEvaluatedSha(opts: {
   gitRoot: string;
   workflowDir: string;
@@ -151,86 +141,6 @@ async function resolveEvaluatedSha(opts: {
 
   return current;
 }
-
-function renderEvaluatorPrompt(opts: {
-  evaluator: EvaluatorModule;
-  taskId: string;
-  taskReadmePath: string;
-  reportPath: string;
-}): string {
-  return [
-    "# AgentPlane EVALUATOR quality review",
-    "",
-    "Use the evaluator module below as binding review procedure.",
-    "Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.",
-    "Write the final structured review to the report path as JSON matching the requested report shape.",
-    "",
-    `- task_id: ${opts.taskId}`,
-    `- task_readme: ${opts.taskReadmePath}`,
-    `- report_path: ${opts.reportPath}`,
-    "",
-    "Required report fields:",
-    "- verdict: pass | rework | blocked | human_review",
-    "- summary: concise judgement",
-    "- findings: non-empty list for pass/rework/blocked",
-    "- evidence_refs: concrete files, checks, PRs, traces, or reports inspected",
-    "- missing_tests: tests or checks that should exist but do not",
-    "- hidden_assumptions: assumptions the implementation relies on",
-    "- residual_risks: known remaining risks",
-    "",
-    "## Evaluator module",
-    "",
-    opts.evaluator.content.trim(),
-    "",
-  ].join("\n");
-}
-
-function renderOpinionMarkdown(report: EvaluatorQualityReport): string {
-  return [
-    `# EVALUATOR opinion: ${report.verdict}`,
-    "",
-    report.summary,
-    "",
-    "## Findings",
-    ...report.findings.map((finding) => `- ${finding}`),
-    "",
-    "## Evidence",
-    ...report.evidence_refs.map((ref) => `- ${ref}`),
-    "",
-    "## Missing Tests",
-    ...(report.missing_tests.length > 0
-      ? report.missing_tests.map((row) => `- ${row}`)
-      : ["- none recorded"]),
-    "",
-    "## Hidden Assumptions",
-    ...(report.hidden_assumptions.length > 0
-      ? report.hidden_assumptions.map((row) => `- ${row}`)
-      : ["- none recorded"]),
-    "",
-    "## Residual Risks",
-    ...(report.residual_risks.length > 0
-      ? report.residual_risks.map((row) => `- ${row}`)
-      : ["- none recorded"]),
-    "",
-  ].join("\n");
-}
-
-type EvaluatorQualityReport = {
-  schema_version: 1;
-  task_id: string;
-  evaluator_id: string;
-  evaluator_profile: string;
-  generated_at: string;
-  verdict: EvaluatorRunParsed["verdict"];
-  summary: string;
-  evaluated_sha: string | null;
-  blueprint_digest: string | null;
-  findings: string[];
-  evidence_refs: string[];
-  missing_tests: string[];
-  hidden_assumptions: string[];
-  residual_risks: string[];
-};
 
 function assertRunnableReviewInput(parsed: EvaluatorRunParsed): void {
   if (!parsed.summary) {
@@ -345,7 +255,7 @@ export const runEvaluatorRun: CommandHandler<EvaluatorRunParsed> = async (ctx, p
     "README.md",
   );
   const at = new Date().toISOString();
-  const stamp = at.replaceAll(/[-:.]/g, "").replace("T", "-").replace("Z", "");
+  const stamp = timestampPathSegment(at);
   const reviewDir = path.join(
     gitRoot,
     command.config.paths.workflow_dir,
@@ -364,7 +274,7 @@ export const runEvaluatorRun: CommandHandler<EvaluatorRunParsed> = async (ctx, p
   const reportPath = path.join(reviewDir, QUALITY_REPORT_FILE);
   const promptPath = path.join(reviewDir, EVALUATOR_PROMPT_FILE);
   const opinionPath = path.join(reviewDir, EVALUATOR_OPINION_FILE);
-  const rel = (absPath: string) => path.relative(gitRoot, absPath).replaceAll("\\", "/");
+  const rel = (absPath: string) => relativeArtifactPath(gitRoot, absPath);
   const report: EvaluatorQualityReport = {
     schema_version: 1,
     task_id: p.taskId,


### PR DESCRIPTION
Task: `202605282017-EJTNXA`
Title: Evaluator command decomposition
Canonical task record: `.agentplane/tasks/202605282017-EJTNXA/README.md`

## Summary

Evaluator command decomposition

Decompose packages/agentplane/src/commands/evaluator/evaluator.command.ts into focused evaluator command modules without changing evaluator CLI behavior. Extract option parsing/report construction/persistence helpers so quality-review evidence remains easier for agents to inspect and future evaluator changes touch smaller files.

## Scope

- In scope: Decompose packages/agentplane/src/commands/evaluator/evaluator.command.ts into focused evaluator command modules without changing evaluator CLI behavior. Extract option parsing/report construction/persistence helpers so quality-review evidence remains easier for agents to inspect and future evaluator changes touch smaller files.
- Out of scope: unrelated refactors not required for "Evaluator command decomposition".

## Verification

- State: ok
- Note:

```text
Evaluator command decomposition verified: evaluator.command.ts reduced from 455 to 365 lines,
quality artifact rendering/helpers extracted, evaluator run focused tests passed, typecheck passed,
lint:core passed, format:changed passed, hotspot threshold check passed.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-28T20:18:18.862Z
- Branch: task/202605282017-EJTNXA/evaluator-command-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../evaluator/evaluator-quality-artifacts.ts       | 118 +++++++++++++++++++++
 .../src/commands/evaluator/evaluator.command.ts    | 118 +++------------------
 2 files changed, 132 insertions(+), 104 deletions(-)
```

</details>
