### PR TITLE
🚧 M9JY3M task: Task run command decomposition [202605282136-M9JY3M]

### DIFF
--- a/.agentplane/tasks/202605282136-M9JY3M/README.md
+++ b/.agentplane/tasks/202605282136-M9JY3M/README.md
@@ -1,0 +1,170 @@
+---
+id: "202605282136-M9JY3M"
+title: "Task run command decomposition"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "hotspot"
+  - "refactor"
+  - "task-runner"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "bun run format:changed"
+  - "bun run lint:core"
+  - "bun run typecheck"
+  - "bunx vitest run packages/agentplane/src/cli/run-cli.core.task-run.test.ts packages/agentplane/src/runner/usecases/task-run-lifecycle.test.ts packages/agentplane/src/runner/usecases/scenario-materialize-task.test.ts --config vitest.workspace.ts"
+  - "node scripts/checks/hotspot-report.mjs --check --warning-lines 400 --oversized-lines 600 --test-warning-lines 1000 --oversized-test-lines 1300"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-28T21:36:41.365Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-28T21:40:30.192Z"
+  updated_by: "CODER"
+  note: "Task run command decomposition verified locally."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: decompose task run command helpers while preserving runner lifecycle and output behavior."
+events:
+  -
+    type: "status"
+    at: "2026-05-28T21:36:56.439Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: decompose task run command helpers while preserving runner lifecycle and output behavior."
+  -
+    type: "verify"
+    at: "2026-05-28T21:40:30.192Z"
+    author: "CODER"
+    state: "ok"
+    note: "Task run command decomposition verified locally."
+doc_version: 3
+doc_updated_at: "2026-05-28T21:40:30.218Z"
+doc_updated_by: "CODER"
+description: "Decompose packages/agentplane/src/commands/task/run.command.ts into focused task-run CLI helper modules without changing runner lifecycle, status, inspect, logs, wait, or JSON/text output behavior. Reduce the command file below the hotspot warning threshold when safe."
+sections:
+  Summary: |-
+    Task run command decomposition
+
+    Decompose packages/agentplane/src/commands/task/run.command.ts into focused task-run CLI helper modules without changing runner lifecycle, status, inspect, logs, wait, or JSON/text output behavior. Reduce the command file below the hotspot warning threshold when safe.
+  Scope: |-
+    - In scope: Decompose packages/agentplane/src/commands/task/run.command.ts into focused task-run CLI helper modules without changing runner lifecycle, status, inspect, logs, wait, or JSON/text output behavior. Reduce the command file below the hotspot warning threshold when safe.
+    - Out of scope: unrelated refactors not required for "Task run command decomposition".
+  Plan: |-
+    1. Inspect task/run.command.ts and task-run runner usecases to identify behavior-preserving extraction boundaries for CLI specs, rendering, log loading, and handler orchestration.
+    2. Extract render/status/inspect/log helpers into focused sibling modules while keeping public task run command specs and handler exports stable.
+    3. Preserve runner lifecycle semantics, wait behavior, process liveness reporting, JSON/text output, and error handling.
+    4. Run focused task-run tests, typecheck, lint:core, format:changed, and hotspot-report check.
+    5. Publish PR artifacts, record verification/evaluator evidence, wait for hosted checks, and merge through the GitHub branch_pr route.
+  Verify Steps: |-
+    1. Run focused task-run behavior tests: bunx vitest run packages/agentplane/src/cli/run-cli.core.task-run.test.ts packages/agentplane/src/runner/usecases/task-run-lifecycle.test.ts packages/agentplane/src/runner/usecases/scenario-materialize-task.test.ts --config vitest.workspace.ts. Expected: all selected tests pass and cover task run CLI behavior, lifecycle transitions, and scenario materialization.
+    2. Run bun run typecheck. Expected: TypeScript project build passes without new type errors.
+    3. Run bun run lint:core. Expected: ESLint passes for core source.
+    4. Run bun run format:changed. Expected: changed files are formatted.
+    5. Run node scripts/checks/hotspot-report.mjs --check --warning-lines 400 --oversized-lines 600 --test-warning-lines 1000 --oversized-test-lines 1300. Expected: no oversized runtime/test errors; task/run.command.ts is reduced below 400 lines if extraction remains behavior-preserving, otherwise any residual warning is recorded with rationale.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-28T21:40:30.192Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Task run command decomposition verified locally.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-28T21:36:56.439Z, excerpt_hash=sha256:e60aaba55deb332118151eeba18b955864cc1b7c1292639b5a63aa422f42e5e1
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605282136-M9JY3M-task-run-command-decomposition/.agentplane/tasks/202605282136-M9JY3M/blueprint/resolved-snapshot.json
+    - old_digest: edeff3ec03f169e4ee95a77bbac0cd33f436ed9469364a1b55848e207cca6a33
+    - current_digest: edeff3ec03f169e4ee95a77bbac0cd33f436ed9469364a1b55848e207cca6a33
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605282136-M9JY3M
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Command: bunx vitest run packages/agentplane/src/cli/run-cli.core.task-run.test.ts packages/agentplane/src/runner/usecases/task-run-lifecycle.test.ts packages/agentplane/src/runner/usecases/scenario-materialize-task.test.ts --config vitest.workspace.ts; Result: pass; Evidence: 3 files, 11 tests passed. Command: bun run typecheck; Result: pass; Evidence: tsc -b completed. Command: bun run lint:core; Result: pass; Evidence: ESLint completed. Command: bun run format:changed; Result: pass; Evidence: all matched files use Prettier. Command: node scripts/checks/hotspot-report.mjs --check --warning-lines 400 --oversized-lines 600 --test-warning-lines 1000 --oversized-test-lines 1300; Result: pass; Evidence: runtime hotspot warnings reduced 43 to 42 and task/run.command.ts is 389 lines.
+      Impact: task/run.command.ts now keeps specs and command handlers while task-run payload rendering, log loading, and integer parsing live in focused helper modules.
+      Resolution: Proceed to PR, evaluator review, and hosted checks.
+id_source: "generated"
+---
+## Summary
+
+Task run command decomposition
+
+Decompose packages/agentplane/src/commands/task/run.command.ts into focused task-run CLI helper modules without changing runner lifecycle, status, inspect, logs, wait, or JSON/text output behavior. Reduce the command file below the hotspot warning threshold when safe.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/commands/task/run.command.ts into focused task-run CLI helper modules without changing runner lifecycle, status, inspect, logs, wait, or JSON/text output behavior. Reduce the command file below the hotspot warning threshold when safe.
+- Out of scope: unrelated refactors not required for "Task run command decomposition".
+
+## Plan
+
+1. Inspect task/run.command.ts and task-run runner usecases to identify behavior-preserving extraction boundaries for CLI specs, rendering, log loading, and handler orchestration.
+2. Extract render/status/inspect/log helpers into focused sibling modules while keeping public task run command specs and handler exports stable.
+3. Preserve runner lifecycle semantics, wait behavior, process liveness reporting, JSON/text output, and error handling.
+4. Run focused task-run tests, typecheck, lint:core, format:changed, and hotspot-report check.
+5. Publish PR artifacts, record verification/evaluator evidence, wait for hosted checks, and merge through the GitHub branch_pr route.
+
+## Verify Steps
+
+1. Run focused task-run behavior tests: bunx vitest run packages/agentplane/src/cli/run-cli.core.task-run.test.ts packages/agentplane/src/runner/usecases/task-run-lifecycle.test.ts packages/agentplane/src/runner/usecases/scenario-materialize-task.test.ts --config vitest.workspace.ts. Expected: all selected tests pass and cover task run CLI behavior, lifecycle transitions, and scenario materialization.
+2. Run bun run typecheck. Expected: TypeScript project build passes without new type errors.
+3. Run bun run lint:core. Expected: ESLint passes for core source.
+4. Run bun run format:changed. Expected: changed files are formatted.
+5. Run node scripts/checks/hotspot-report.mjs --check --warning-lines 400 --oversized-lines 600 --test-warning-lines 1000 --oversized-test-lines 1300. Expected: no oversized runtime/test errors; task/run.command.ts is reduced below 400 lines if extraction remains behavior-preserving, otherwise any residual warning is recorded with rationale.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-28T21:40:30.192Z — VERIFY — ok
+
+By: CODER
+
+Note: Task run command decomposition verified locally.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-28T21:36:56.439Z, excerpt_hash=sha256:e60aaba55deb332118151eeba18b955864cc1b7c1292639b5a63aa422f42e5e1
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605282136-M9JY3M-task-run-command-decomposition/.agentplane/tasks/202605282136-M9JY3M/blueprint/resolved-snapshot.json
+- old_digest: edeff3ec03f169e4ee95a77bbac0cd33f436ed9469364a1b55848e207cca6a33
+- current_digest: edeff3ec03f169e4ee95a77bbac0cd33f436ed9469364a1b55848e207cca6a33
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605282136-M9JY3M
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Command: bunx vitest run packages/agentplane/src/cli/run-cli.core.task-run.test.ts packages/agentplane/src/runner/usecases/task-run-lifecycle.test.ts packages/agentplane/src/runner/usecases/scenario-materialize-task.test.ts --config vitest.workspace.ts; Result: pass; Evidence: 3 files, 11 tests passed. Command: bun run typecheck; Result: pass; Evidence: tsc -b completed. Command: bun run lint:core; Result: pass; Evidence: ESLint completed. Command: bun run format:changed; Result: pass; Evidence: all matched files use Prettier. Command: node scripts/checks/hotspot-report.mjs --check --warning-lines 400 --oversized-lines 600 --test-warning-lines 1000 --oversized-test-lines 1300; Result: pass; Evidence: runtime hotspot warnings reduced 43 to 42 and task/run.command.ts is 389 lines.
+  Impact: task/run.command.ts now keeps specs and command handlers while task-run payload rendering, log loading, and integer parsing live in focused helper modules.
+  Resolution: Proceed to PR, evaluator review, and hosted checks.

--- a/.agentplane/tasks/202605282136-M9JY3M/README.md
+++ b/.agentplane/tasks/202605282136-M9JY3M/README.md
@@ -4,7 +4,7 @@ title: "Task run command decomposition"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -33,6 +33,24 @@ verification:
   updated_by: "CODER"
   note: "Task run command decomposition verified locally."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-28T21:40:51.687Z"
+  updated_by: "EVALUATOR"
+  note: "Task run command decomposition preserves runner CLI behavior while reducing task/run.command.ts below the hotspot threshold."
+  evaluated_sha: "efabaea85dab384a44002a3350aa7298857dd583"
+  blueprint_digest: "edeff3ec03f169e4ee95a77bbac0cd33f436ed9469364a1b55848e207cca6a33"
+  evidence_refs:
+    - ".agentplane/tasks/202605282136-M9JY3M/README.md"
+    - ".agentplane/tasks/202605282136-M9JY3M/quality/20260528-214051687-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605282136-M9JY3M/quality/20260528-214051687-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605282136-M9JY3M/quality/20260528-214051687-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605282136-M9JY3M/blueprint/resolved-snapshot.json"
+    - "packages/agentplane/src/commands/task/run.command.ts"
+    - "packages/agentplane/src/commands/task/run-render.ts"
+    - "packages/agentplane/src/commands/task/run-parse.ts"
+  findings:
+    - "Extracted task-run payload rendering, log loading, and integer parsing into focused helper modules. Focused task-run tests passed, plus typecheck, lint, format, and hotspot check."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202605282136-M9JY3M/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605282136-M9JY3M/blueprint/resolved-snapshot.json
@@ -1,0 +1,580 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605282136-M9JY3M",
+    "title": "Task run command decomposition",
+    "description": "Decompose packages/agentplane/src/commands/task/run.command.ts into focused task-run CLI helper modules without changing runner lifecycle, status, inspect, logs, wait, or JSON/text output behavior. Reduce the command file below the hotspot warning threshold when safe.",
+    "tags": [
+      "code",
+      "hotspot",
+      "refactor",
+      "task-runner"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605282136-M9JY3M",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "edeff3ec03f169e4ee95a77bbac0cd33f436ed9469364a1b55848e207cca6a33"
+  }
+}

--- a/.agentplane/tasks/202605282136-M9JY3M/pr/diffstat.txt
+++ b/.agentplane/tasks/202605282136-M9JY3M/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ packages/agentplane/src/commands/task/run-parse.ts |  15 ++
+ .../agentplane/src/commands/task/run-render.ts     | 166 +++++++++++++++++++
+ .../agentplane/src/commands/task/run.command.ts    | 180 ++-------------------
+ 3 files changed, 196 insertions(+), 165 deletions(-)

--- a/.agentplane/tasks/202605282136-M9JY3M/pr/github-body.md
+++ b/.agentplane/tasks/202605282136-M9JY3M/pr/github-body.md
@@ -27,7 +27,10 @@ Decompose packages/agentplane/src/commands/task/run.command.ts into focused task
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ packages/agentplane/src/commands/task/run-parse.ts |  15 ++
+ .../agentplane/src/commands/task/run-render.ts     | 166 +++++++++++++++++++
+ .../agentplane/src/commands/task/run.command.ts    | 180 ++-------------------
+ 3 files changed, 196 insertions(+), 165 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605282136-M9JY3M/pr/github-body.md
+++ b/.agentplane/tasks/202605282136-M9JY3M/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605282136-M9JY3M`
+Title: Task run command decomposition
+Canonical task record: `.agentplane/tasks/202605282136-M9JY3M/README.md`
+
+## Summary
+
+Task run command decomposition
+
+Decompose packages/agentplane/src/commands/task/run.command.ts into focused task-run CLI helper modules without changing runner lifecycle, status, inspect, logs, wait, or JSON/text output behavior. Reduce the command file below the hotspot warning threshold when safe.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/commands/task/run.command.ts into focused task-run CLI helper modules without changing runner lifecycle, status, inspect, logs, wait, or JSON/text output behavior. Reduce the command file below the hotspot warning threshold when safe.
+- Out of scope: unrelated refactors not required for "Task run command decomposition".
+
+## Verification
+
+- State: ok
+- Note: Task run command decomposition verified locally.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-28T21:36:56.557Z
+- Branch: task/202605282136-M9JY3M/task-run-command-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605282136-M9JY3M/pr/github-title.txt
+++ b/.agentplane/tasks/202605282136-M9JY3M/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 M9JY3M task: Task run command decomposition [202605282136-M9JY3M]

--- a/.agentplane/tasks/202605282136-M9JY3M/pr/meta.json
+++ b/.agentplane/tasks/202605282136-M9JY3M/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605282136-M9JY3M/task-run-command-decomposition",
   "created_at": "2026-05-28T21:36:56.557Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "diffstat_sha256": "sha256:45197562487fee8577247f9ae60c8e9a66faffb2fe32329c7acf1e83ddea9593",
   "last_verified_at": "2026-05-28T21:40:30.192Z",
   "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "schema_version": 1,

--- a/.agentplane/tasks/202605282136-M9JY3M/pr/meta.json
+++ b/.agentplane/tasks/202605282136-M9JY3M/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605282136-M9JY3M/task-run-command-decomposition",
+  "created_at": "2026-05-28T21:36:56.557Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": "2026-05-28T21:40:30.192Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202605282136-M9JY3M",
+  "updated_at": "2026-05-28T21:36:56.557Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605282136-M9JY3M/pr/review.md
+++ b/.agentplane/tasks/202605282136-M9JY3M/pr/review.md
@@ -29,7 +29,10 @@ Created: 2026-05-28T21:36:56.557Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ packages/agentplane/src/commands/task/run-parse.ts |  15 ++
+ .../agentplane/src/commands/task/run-render.ts     | 166 +++++++++++++++++++
+ .../agentplane/src/commands/task/run.command.ts    | 180 ++-------------------
+ 3 files changed, 196 insertions(+), 165 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605282136-M9JY3M/pr/review.md
+++ b/.agentplane/tasks/202605282136-M9JY3M/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-28T21:36:56.557Z
+
+## Task
+
+- Task: `202605282136-M9JY3M`
+- Title: Task run command decomposition
+- Status: DOING
+- Branch: `task/202605282136-M9JY3M/task-run-command-decomposition`
+- Canonical task record: `.agentplane/tasks/202605282136-M9JY3M/README.md`
+
+## Verification
+
+- State: ok
+- Note: Task run command decomposition verified locally.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-28T21:36:56.557Z
+- Branch: task/202605282136-M9JY3M/task-run-command-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605282136-M9JY3M/quality/20260528-214051687-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605282136-M9JY3M/quality/20260528-214051687-recovery-context/evaluator-opinion.md
@@ -1,0 +1,21 @@
+# EVALUATOR opinion: pass
+
+Task run command decomposition preserves runner CLI behavior while reducing task/run.command.ts below the hotspot threshold.
+
+## Findings
+- Extracted task-run payload rendering, log loading, and integer parsing into focused helper modules. Focused task-run tests passed, plus typecheck, lint, format, and hotspot check.
+
+## Evidence
+- .agentplane/tasks/202605282136-M9JY3M/README.md
+- packages/agentplane/src/commands/task/run.command.ts
+- packages/agentplane/src/commands/task/run-render.ts
+- packages/agentplane/src/commands/task/run-parse.ts
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- Task-run behavior is covered by focused CLI/usecase tests; hosted CI is still required before merge.

--- a/.agentplane/tasks/202605282136-M9JY3M/quality/20260528-214051687-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605282136-M9JY3M/quality/20260528-214051687-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605282136-M9JY3M
+- task_readme: .agentplane/tasks/202605282136-M9JY3M/README.md
+- report_path: .agentplane/tasks/202605282136-M9JY3M/quality/20260528-214051687-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605282136-M9JY3M/quality/20260528-214051687-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605282136-M9JY3M/quality/20260528-214051687-recovery-context/quality-report.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "task_id": "202605282136-M9JY3M",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-28T21:40:51.687Z",
+  "verdict": "pass",
+  "summary": "Task run command decomposition preserves runner CLI behavior while reducing task/run.command.ts below the hotspot threshold.",
+  "evaluated_sha": "efabaea85dab384a44002a3350aa7298857dd583",
+  "blueprint_digest": "edeff3ec03f169e4ee95a77bbac0cd33f436ed9469364a1b55848e207cca6a33",
+  "findings": [
+    "Extracted task-run payload rendering, log loading, and integer parsing into focused helper modules. Focused task-run tests passed, plus typecheck, lint, format, and hotspot check."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605282136-M9JY3M/README.md",
+    "packages/agentplane/src/commands/task/run.command.ts",
+    "packages/agentplane/src/commands/task/run-render.ts",
+    "packages/agentplane/src/commands/task/run-parse.ts"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": [
+    "Task-run behavior is covered by focused CLI/usecase tests; hosted CI is still required before merge."
+  ]
+}

--- a/packages/agentplane/src/commands/task/run-parse.ts
+++ b/packages/agentplane/src/commands/task/run-parse.ts
@@ -1,0 +1,15 @@
+import { CliError } from "../../shared/errors.js";
+
+export function parsePositiveInteger(value: unknown, fallback: number, flag: string): number {
+  const raw = typeof value === "string" ? value.trim() : "";
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new CliError({
+      exitCode: 2,
+      code: "E_USAGE",
+      message: `Invalid ${flag}: ${String(value)} (expected a non-negative integer)`,
+    });
+  }
+  return parsed;
+}

--- a/packages/agentplane/src/commands/task/run-parse.ts
+++ b/packages/agentplane/src/commands/task/run-parse.ts
@@ -1,5 +1,13 @@
 import { CliError } from "../../shared/errors.js";
 
+export type TaskRunLogsParsed = {
+  taskId: string;
+  runId?: string;
+  stream: "events" | "trace" | "stderr";
+  follow: boolean;
+  tail: number;
+};
+
 export function parsePositiveInteger(value: unknown, fallback: number, flag: string): number {
   const raw = typeof value === "string" ? value.trim() : "";
   if (!raw) return fallback;

--- a/packages/agentplane/src/commands/task/run-render.ts
+++ b/packages/agentplane/src/commands/task/run-render.ts
@@ -1,0 +1,166 @@
+import { createCliEmitter, infoMessage } from "../../cli/output.js";
+import { RunnerRunRepository } from "../../runner/run-repository.js";
+import { readTraceArtifactText } from "../../runner/trace-artifacts.js";
+import type { LoadedTaskRunnerInspection } from "../../runner/usecases/task-run-inspect.js";
+import type { RunnerLifecycleStatus } from "../../runner/types.js";
+import { isProcessAlive } from "../../runner/process-supervision/signals.js";
+import { CliError } from "../../shared/errors.js";
+import type { TaskRunLogsParsed } from "./run.command.js";
+
+export function renderTaskRunPayload(opts: {
+  taskId: string;
+  mode: "dry_run" | "execute";
+  adapterId: string;
+  runId: string;
+  runDir: string;
+  bundlePath: string;
+  bootstrapPath: string;
+  resultPath: string;
+  status?: string;
+  exitCode?: number | null;
+  summary?: string;
+}) {
+  return {
+    task_id: opts.taskId,
+    mode: opts.mode,
+    adapter_id: opts.adapterId,
+    run_id: opts.runId,
+    run_dir: opts.runDir,
+    bundle_path: opts.bundlePath,
+    bootstrap_path: opts.bootstrapPath,
+    result_path: opts.resultPath,
+    ...(opts.status ? { status: opts.status } : {}),
+    ...(opts.exitCode === undefined ? {} : { exit_code: opts.exitCode }),
+    ...(opts.summary ? { summary: opts.summary } : {}),
+  };
+}
+
+export function isTerminalRunnerStatus(status: RunnerLifecycleStatus): boolean {
+  return status === "success" || status === "failed" || status === "cancelled";
+}
+
+export function tailText(text: string, lineCount: number): string {
+  if (lineCount === 0) return "";
+  const normalized = text.replaceAll("\r\n", "\n");
+  const lines = normalized.split("\n");
+  const trailingEmpty = lines.at(-1) === "" ? lines.slice(0, -1) : lines;
+  return trailingEmpty.slice(-lineCount).join("\n");
+}
+
+function runnerProcessAlive(inspection: LoadedTaskRunnerInspection): boolean | null {
+  const pid = inspection.state.supervision?.pid;
+  if (typeof pid !== "number") return null;
+  return isProcessAlive(pid);
+}
+
+export function renderRunnerStatusPayload(inspection: LoadedTaskRunnerInspection) {
+  const state = inspection.state;
+  const supervision = state.supervision ?? null;
+  return {
+    task_id: inspection.task_id,
+    run_id: inspection.run_id,
+    selection: inspection.selection,
+    status: state.status,
+    mode: state.mode,
+    adapter_id: state.adapter_id,
+    target: state.target,
+    created_at: state.created_at,
+    updated_at: state.updated_at,
+    started_at: supervision?.started_at ?? null,
+    heartbeat_at: supervision?.heartbeat_at ?? null,
+    ended_at: state.result?.ended_at ?? null,
+    pid: supervision?.pid ?? null,
+    pid_alive: runnerProcessAlive(inspection),
+    exit_code: state.result?.exit_code ?? null,
+    summary: state.result?.summary ?? null,
+    paths: {
+      run_dir: inspection.paths.run_dir,
+      state: inspection.paths.state_path,
+      events: inspection.paths.events_path,
+      trace: inspection.paths.trace_path,
+      stderr: inspection.paths.stderr_path,
+      result: inspection.paths.result_path,
+      bundle: inspection.paths.bundle_path,
+      bootstrap: inspection.paths.bootstrap_path,
+    },
+  };
+}
+
+export function renderRunnerInspectPayload(
+  inspection: LoadedTaskRunnerInspection,
+  eventCount: number,
+) {
+  return {
+    ...renderRunnerStatusPayload(inspection),
+    recent_events: inspection.events.slice(-eventCount),
+    result: inspection.state.result ?? null,
+    prepared_metadata: inspection.state.prepared_metadata ?? null,
+    policy_decision: inspection.state.policy_decision ?? null,
+  };
+}
+
+export async function loadRunnerLogText(
+  inspection: LoadedTaskRunnerInspection,
+  stream: TaskRunLogsParsed["stream"],
+): Promise<string> {
+  if (stream === "events") return inspection.events_text;
+  if (stream === "trace") {
+    const repository = new RunnerRunRepository(inspection.paths);
+    return await repository.readTraceTextRequired({
+      task_id: inspection.task_id,
+      run_id: inspection.run_id,
+    });
+  }
+  try {
+    return await readTraceArtifactText(inspection.paths.stderr_path);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | null)?.code;
+    if (code === "ENOENT") {
+      throw new CliError({
+        exitCode: 4,
+        code: "E_IO",
+        message:
+          `Runner artifact not found for ${inspection.task_id}:${inspection.run_id} ` +
+          `(stderr at ${inspection.paths.stderr_path} or ${inspection.paths.stderr_path}.gz)`,
+      });
+    }
+    throw err;
+  }
+}
+
+export function reportPreparedTaskRun(
+  payload: ReturnType<typeof renderTaskRunPayload>,
+  taskId: string,
+): void {
+  createCliEmitter().report(
+    [
+      { label: "task", value: payload.task_id },
+      { label: "mode", value: payload.mode },
+      { label: "adapter", value: payload.adapter_id },
+      { label: "run", value: payload.run_id },
+      { label: "bundle", value: payload.bundle_path },
+      { label: "bootstrap", value: payload.bootstrap_path },
+      { label: "result", value: payload.result_path },
+    ],
+    { header: infoMessage(`task run prepared: ${taskId}`) },
+  );
+}
+
+export function reportExecutedTaskRun(
+  payload: ReturnType<typeof renderTaskRunPayload>,
+  taskId: string,
+): void {
+  createCliEmitter().report(
+    [
+      { label: "task", value: payload.task_id },
+      { label: "mode", value: payload.mode },
+      { label: "adapter", value: payload.adapter_id },
+      { label: "run", value: payload.run_id },
+      { label: "status", value: payload.status ?? "unknown" },
+      { label: "exit_code", value: payload.exit_code ?? null },
+      { label: "summary", value: payload.summary ?? null },
+      { label: "result", value: payload.result_path },
+    ],
+    { header: infoMessage(`task run completed: ${taskId}`) },
+  );
+}

--- a/packages/agentplane/src/commands/task/run-render.ts
+++ b/packages/agentplane/src/commands/task/run-render.ts
@@ -5,7 +5,7 @@ import type { LoadedTaskRunnerInspection } from "../../runner/usecases/task-run-
 import type { RunnerLifecycleStatus } from "../../runner/types.js";
 import { isProcessAlive } from "../../runner/process-supervision/signals.js";
 import { CliError } from "../../shared/errors.js";
-import type { TaskRunLogsParsed } from "./run.command.js";
+import type { TaskRunLogsParsed } from "./run-parse.js";
 
 export function renderTaskRunPayload(opts: {
   taskId: string;

--- a/packages/agentplane/src/commands/task/run.command.ts
+++ b/packages/agentplane/src/commands/task/run.command.ts
@@ -6,7 +6,7 @@ import {
   prepareTaskRunnerExecution,
 } from "../../runner/usecases/task-run.js";
 import { loadTaskRunnerInspection } from "../../runner/usecases/task-run-inspect.js";
-import { parsePositiveInteger } from "./run-parse.js";
+import { type TaskRunLogsParsed, parsePositiveInteger } from "./run-parse.js";
 import {
   isTerminalRunnerStatus,
   loadRunnerLogText,
@@ -35,14 +35,6 @@ export type TaskRunInspectParsed = {
   runId?: string;
   json: boolean;
   events: number;
-};
-
-export type TaskRunLogsParsed = {
-  taskId: string;
-  runId?: string;
-  stream: "events" | "trace" | "stderr";
-  follow: boolean;
-  tail: number;
 };
 
 export const taskRunSpec: CommandSpec<TaskRunParsed> = {

--- a/packages/agentplane/src/commands/task/run.command.ts
+++ b/packages/agentplane/src/commands/task/run.command.ts
@@ -6,12 +6,17 @@ import {
   prepareTaskRunnerExecution,
 } from "../../runner/usecases/task-run.js";
 import { loadTaskRunnerInspection } from "../../runner/usecases/task-run-inspect.js";
-import { RunnerRunRepository } from "../../runner/run-repository.js";
-import { readTraceArtifactText } from "../../runner/trace-artifacts.js";
-import { isProcessAlive } from "../../runner/process-supervision/signals.js";
-import { CliError } from "../../shared/errors.js";
-import type { LoadedTaskRunnerInspection } from "../../runner/usecases/task-run-inspect.js";
-import type { RunnerLifecycleStatus } from "../../runner/types.js";
+import { parsePositiveInteger } from "./run-parse.js";
+import {
+  isTerminalRunnerStatus,
+  loadRunnerLogText,
+  renderRunnerInspectPayload,
+  renderRunnerStatusPayload,
+  renderTaskRunPayload,
+  reportExecutedTaskRun,
+  reportPreparedTaskRun,
+  tailText,
+} from "./run-render.js";
 
 export type TaskRunParsed = {
   taskId: string;
@@ -190,138 +195,6 @@ export const taskRunLogsSpec: CommandSpec<TaskRunLogsParsed> = {
   }),
 };
 
-function renderPayload(opts: {
-  taskId: string;
-  mode: "dry_run" | "execute";
-  adapterId: string;
-  runId: string;
-  runDir: string;
-  bundlePath: string;
-  bootstrapPath: string;
-  resultPath: string;
-  status?: string;
-  exitCode?: number | null;
-  summary?: string;
-}) {
-  return {
-    task_id: opts.taskId,
-    mode: opts.mode,
-    adapter_id: opts.adapterId,
-    run_id: opts.runId,
-    run_dir: opts.runDir,
-    bundle_path: opts.bundlePath,
-    bootstrap_path: opts.bootstrapPath,
-    result_path: opts.resultPath,
-    ...(opts.status ? { status: opts.status } : {}),
-    ...(opts.exitCode === undefined ? {} : { exit_code: opts.exitCode }),
-    ...(opts.summary ? { summary: opts.summary } : {}),
-  };
-}
-
-function parsePositiveInteger(value: unknown, fallback: number, flag: string): number {
-  const raw = typeof value === "string" ? value.trim() : "";
-  if (!raw) return fallback;
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isInteger(parsed) || parsed < 0) {
-    throw new CliError({
-      exitCode: 2,
-      code: "E_USAGE",
-      message: `Invalid ${flag}: ${String(value)} (expected a non-negative integer)`,
-    });
-  }
-  return parsed;
-}
-
-function isTerminalRunnerStatus(status: RunnerLifecycleStatus): boolean {
-  return status === "success" || status === "failed" || status === "cancelled";
-}
-
-function tailText(text: string, lineCount: number): string {
-  if (lineCount === 0) return "";
-  const normalized = text.replaceAll("\r\n", "\n");
-  const lines = normalized.split("\n");
-  const trailingEmpty = lines.at(-1) === "" ? lines.slice(0, -1) : lines;
-  return trailingEmpty.slice(-lineCount).join("\n");
-}
-
-function runnerProcessAlive(inspection: LoadedTaskRunnerInspection): boolean | null {
-  const pid = inspection.state.supervision?.pid;
-  if (typeof pid !== "number") return null;
-  return isProcessAlive(pid);
-}
-
-function renderRunnerStatusPayload(inspection: LoadedTaskRunnerInspection) {
-  const state = inspection.state;
-  const supervision = state.supervision ?? null;
-  return {
-    task_id: inspection.task_id,
-    run_id: inspection.run_id,
-    selection: inspection.selection,
-    status: state.status,
-    mode: state.mode,
-    adapter_id: state.adapter_id,
-    target: state.target,
-    created_at: state.created_at,
-    updated_at: state.updated_at,
-    started_at: supervision?.started_at ?? null,
-    heartbeat_at: supervision?.heartbeat_at ?? null,
-    ended_at: state.result?.ended_at ?? null,
-    pid: supervision?.pid ?? null,
-    pid_alive: runnerProcessAlive(inspection),
-    exit_code: state.result?.exit_code ?? null,
-    summary: state.result?.summary ?? null,
-    paths: {
-      run_dir: inspection.paths.run_dir,
-      state: inspection.paths.state_path,
-      events: inspection.paths.events_path,
-      trace: inspection.paths.trace_path,
-      stderr: inspection.paths.stderr_path,
-      result: inspection.paths.result_path,
-      bundle: inspection.paths.bundle_path,
-      bootstrap: inspection.paths.bootstrap_path,
-    },
-  };
-}
-
-function renderRunnerInspectPayload(inspection: LoadedTaskRunnerInspection, eventCount: number) {
-  return {
-    ...renderRunnerStatusPayload(inspection),
-    recent_events: inspection.events.slice(-eventCount),
-    result: inspection.state.result ?? null,
-    prepared_metadata: inspection.state.prepared_metadata ?? null,
-    policy_decision: inspection.state.policy_decision ?? null,
-  };
-}
-
-async function loadRunnerLogText(
-  inspection: LoadedTaskRunnerInspection,
-  stream: TaskRunLogsParsed["stream"],
-): Promise<string> {
-  if (stream === "events") return inspection.events_text;
-  if (stream === "trace") {
-    const repository = new RunnerRunRepository(inspection.paths);
-    return await repository.readTraceTextRequired({
-      task_id: inspection.task_id,
-      run_id: inspection.run_id,
-    });
-  }
-  try {
-    return await readTraceArtifactText(inspection.paths.stderr_path);
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException | null)?.code;
-    if (code === "ENOENT") {
-      throw new CliError({
-        exitCode: 4,
-        code: "E_IO",
-        message:
-          `Runner artifact not found for ${inspection.task_id}:${inspection.run_id} ` +
-          `(stderr at ${inspection.paths.stderr_path} or ${inspection.paths.stderr_path}.gz)`,
-      });
-    }
-    throw err;
-  }
-}
-
 async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -338,7 +211,7 @@ export function makeRunTaskRunHandler(getCtx: (cmd: string) => Promise<CommandCo
         task_id: parsed.taskId,
         mode: "dry_run",
       });
-      const payload = renderPayload({
+      const payload = renderTaskRunPayload({
         taskId: parsed.taskId,
         mode: "dry_run",
         adapterId: prepared.invocation.adapter_id,
@@ -351,18 +224,7 @@ export function makeRunTaskRunHandler(getCtx: (cmd: string) => Promise<CommandCo
       if (parsed.json) {
         output.json(payload);
       } else {
-        output.report(
-          [
-            { label: "task", value: payload.task_id },
-            { label: "mode", value: payload.mode },
-            { label: "adapter", value: payload.adapter_id },
-            { label: "run", value: payload.run_id },
-            { label: "bundle", value: payload.bundle_path },
-            { label: "bootstrap", value: payload.bootstrap_path },
-            { label: "result", value: payload.result_path },
-          ],
-          { header: infoMessage(`task run prepared: ${parsed.taskId}`) },
-        );
+        reportPreparedTaskRun(payload, parsed.taskId);
       }
       return 0;
     }
@@ -373,7 +235,7 @@ export function makeRunTaskRunHandler(getCtx: (cmd: string) => Promise<CommandCo
       rootOverride: ctx.rootOverride ?? null,
       task_id: parsed.taskId,
     });
-    const payload = renderPayload({
+    const payload = renderTaskRunPayload({
       taskId: parsed.taskId,
       mode: "execute",
       adapterId: executed.invocation.adapter_id,
@@ -389,19 +251,7 @@ export function makeRunTaskRunHandler(getCtx: (cmd: string) => Promise<CommandCo
     if (parsed.json) {
       output.json(payload);
     } else {
-      output.report(
-        [
-          { label: "task", value: payload.task_id },
-          { label: "mode", value: payload.mode },
-          { label: "adapter", value: payload.adapter_id },
-          { label: "run", value: payload.run_id },
-          { label: "status", value: payload.status ?? "unknown" },
-          { label: "exit_code", value: payload.exit_code ?? null },
-          { label: "summary", value: payload.summary ?? null },
-          { label: "result", value: payload.result_path },
-        ],
-        { header: infoMessage(`task run completed: ${parsed.taskId}`) },
-      );
+      reportExecutedTaskRun(payload, parsed.taskId);
     }
     return executed.result.status === "success" ? 0 : 1;
   };


### PR DESCRIPTION
Task: `202605282136-M9JY3M`
Title: Task run command decomposition
Canonical task record: `.agentplane/tasks/202605282136-M9JY3M/README.md`

## Summary

Task run command decomposition

Decompose packages/agentplane/src/commands/task/run.command.ts into focused task-run CLI helper modules without changing runner lifecycle, status, inspect, logs, wait, or JSON/text output behavior. Reduce the command file below the hotspot warning threshold when safe.

## Scope

- In scope: Decompose packages/agentplane/src/commands/task/run.command.ts into focused task-run CLI helper modules without changing runner lifecycle, status, inspect, logs, wait, or JSON/text output behavior. Reduce the command file below the hotspot warning threshold when safe.
- Out of scope: unrelated refactors not required for "Task run command decomposition".

## Verification

- State: ok
- Note: Task run command decomposition verified locally.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-28T21:36:56.557Z
- Branch: task/202605282136-M9JY3M/task-run-command-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 packages/agentplane/src/commands/task/run-parse.ts |  15 ++
 .../agentplane/src/commands/task/run-render.ts     | 166 +++++++++++++++++++
 .../agentplane/src/commands/task/run.command.ts    | 180 ++-------------------
 3 files changed, 196 insertions(+), 165 deletions(-)
```

</details>
