### PR TITLE
🚧 DXR7ZX task: Context init builder decomposition [202605282234-DXR7ZX]

### DIFF
--- a/.agentplane/tasks/202605282234-DXR7ZX/README.md
+++ b/.agentplane/tasks/202605282234-DXR7ZX/README.md
@@ -4,7 +4,7 @@ title: "Context init builder decomposition"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -24,6 +24,30 @@ verification:
   updated_by: "CODER"
   note: "Context init was decomposed into command orchestration, bootstrap/git helpers, and content builders. Verified with focused context CLI tests, typecheck, arch deps, lint, format, and hotspot threshold check (runtime warnings 39 -> 38)."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-28T22:42:50.512Z"
+  updated_by: "EVALUATOR"
+  note: "Context init builder decomposition completed without behavior changes."
+  evaluated_sha: "0f3c098c28ff587e4eb9080963c05f75e08f58c6"
+  blueprint_digest: "ac2130312a9c9df8994ec714ec7c87b2f489c88307bfaca5bfc69cdca2fa590a"
+  evidence_refs:
+    - ".agentplane/tasks/202605282234-DXR7ZX/README.md"
+    - ".agentplane/tasks/202605282234-DXR7ZX/quality/20260528-224250512-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605282234-DXR7ZX/quality/20260528-224250512-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605282234-DXR7ZX/quality/20260528-224250512-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605282234-DXR7ZX/blueprint/resolved-snapshot.json"
+    - "packages/agentplane/src/commands/context/init.ts"
+    - "packages/agentplane/src/commands/context/context-init-bootstrap.ts"
+    - "packages/agentplane/src/commands/context/context-init-builders.ts"
+    - "bunx vitest run packages/agentplane/src/cli/run-cli.core.context-init.test.ts packages/agentplane/src/commands/context/release-readiness.test.ts --config vitest.workspace.ts"
+    - "bun run typecheck"
+    - "bun run arch:deps"
+    - "bun run lint:core"
+    - "bun run format:changed"
+    - "node scripts/checks/hotspot-report.mjs --check --warning-lines 400 --oversized-lines 600 --test-warning-lines 1000 --oversized-test-lines 1300"
+  findings:
+    - "packages/agentplane/src/commands/context/init.ts now focuses on command orchestration and workspace file writes at 284 lines; bootstrap/git helpers moved to context-init-bootstrap.ts, and generated content builders moved to context-init-builders.ts. Hotspot warning count decreased from 39 to 38."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202605282234-DXR7ZX/README.md
+++ b/.agentplane/tasks/202605282234-DXR7ZX/README.md
@@ -1,0 +1,152 @@
+---
+id: "202605282234-DXR7ZX"
+title: "Context init builder decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "context"
+  - "hotspot"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-28T22:34:37.140Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-28T22:42:34.688Z"
+  updated_by: "CODER"
+  note: "Context init was decomposed into command orchestration, bootstrap/git helpers, and content builders. Verified with focused context CLI tests, typecheck, arch deps, lint, format, and hotspot threshold check (runtime warnings 39 -> 38)."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: decompose context init builders from command orchestration while preserving context init behavior and verifying hotspot warning reduction."
+events:
+  -
+    type: "status"
+    at: "2026-05-28T22:34:52.690Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: decompose context init builders from command orchestration while preserving context init behavior and verifying hotspot warning reduction."
+  -
+    type: "verify"
+    at: "2026-05-28T22:42:34.688Z"
+    author: "CODER"
+    state: "ok"
+    note: "Context init was decomposed into command orchestration, bootstrap/git helpers, and content builders. Verified with focused context CLI tests, typecheck, arch deps, lint, format, and hotspot threshold check (runtime warnings 39 -> 38)."
+doc_version: 3
+doc_updated_at: "2026-05-28T22:42:34.712Z"
+doc_updated_by: "CODER"
+description: "Decompose packages/agentplane/src/commands/context/init.ts by extracting context init content builders and small file-read helpers into focused modules, preserving context init behavior and reducing hotspot warning count."
+sections:
+  Summary: |-
+    Context init builder decomposition
+
+    Decompose packages/agentplane/src/commands/context/init.ts by extracting context init content builders and small file-read helpers into focused modules, preserving context init behavior and reducing hotspot warning count.
+  Scope: |-
+    - In scope: Decompose packages/agentplane/src/commands/context/init.ts by extracting context init content builders and small file-read helpers into focused modules, preserving context init behavior and reducing hotspot warning count.
+    - Out of scope: unrelated refactors not required for "Context init builder decomposition".
+  Plan: |-
+    1. Start the branch_pr task worktree from canonical main.
+    2. Keep context init CLI behavior stable while extracting content builders and simple file-read helpers from packages/agentplane/src/commands/context/init.ts into focused modules.
+    3. Verify with focused context init tests, typecheck, arch dependency check, lint, format, and hotspot threshold check; expected runtime hotspot warning count decreases from 39 to 38.
+    4. Record verification/evaluator evidence, open PR, wait for hosted checks and review threads, then merge and close the task.
+  Verify Steps: |-
+    PLANNER fallback scaffold for "Context init builder decomposition". Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the requested outcome for "Context init builder decomposition". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-28T22:42:34.688Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Context init was decomposed into command orchestration, bootstrap/git helpers, and content builders. Verified with focused context CLI tests, typecheck, arch deps, lint, format, and hotspot threshold check (runtime warnings 39 -> 38).
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-28T22:34:52.690Z, excerpt_hash=sha256:6268127a7714fcdcf25b06b41e00b0b08f7ab62508aee058e5c630f9807581af
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605282234-DXR7ZX-context-init-builder-decomposition/.agentplane/tasks/202605282234-DXR7ZX/blueprint/resolved-snapshot.json
+    - old_digest: ac2130312a9c9df8994ec714ec7c87b2f489c88307bfaca5bfc69cdca2fa590a
+    - current_digest: ac2130312a9c9df8994ec714ec7c87b2f489c88307bfaca5bfc69cdca2fa590a
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605282234-DXR7ZX
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Context init builder decomposition
+
+Decompose packages/agentplane/src/commands/context/init.ts by extracting context init content builders and small file-read helpers into focused modules, preserving context init behavior and reducing hotspot warning count.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/commands/context/init.ts by extracting context init content builders and small file-read helpers into focused modules, preserving context init behavior and reducing hotspot warning count.
+- Out of scope: unrelated refactors not required for "Context init builder decomposition".
+
+## Plan
+
+1. Start the branch_pr task worktree from canonical main.
+2. Keep context init CLI behavior stable while extracting content builders and simple file-read helpers from packages/agentplane/src/commands/context/init.ts into focused modules.
+3. Verify with focused context init tests, typecheck, arch dependency check, lint, format, and hotspot threshold check; expected runtime hotspot warning count decreases from 39 to 38.
+4. Record verification/evaluator evidence, open PR, wait for hosted checks and review threads, then merge and close the task.
+
+## Verify Steps
+
+PLANNER fallback scaffold for "Context init builder decomposition". Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the requested outcome for "Context init builder decomposition". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-28T22:42:34.688Z — VERIFY — ok
+
+By: CODER
+
+Note: Context init was decomposed into command orchestration, bootstrap/git helpers, and content builders. Verified with focused context CLI tests, typecheck, arch deps, lint, format, and hotspot threshold check (runtime warnings 39 -> 38).
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-28T22:34:52.690Z, excerpt_hash=sha256:6268127a7714fcdcf25b06b41e00b0b08f7ab62508aee058e5c630f9807581af
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605282234-DXR7ZX-context-init-builder-decomposition/.agentplane/tasks/202605282234-DXR7ZX/blueprint/resolved-snapshot.json
+- old_digest: ac2130312a9c9df8994ec714ec7c87b2f489c88307bfaca5bfc69cdca2fa590a
+- current_digest: ac2130312a9c9df8994ec714ec7c87b2f489c88307bfaca5bfc69cdca2fa590a
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605282234-DXR7ZX
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605282234-DXR7ZX/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605282234-DXR7ZX/blueprint/resolved-snapshot.json
@@ -1,0 +1,362 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605282234-DXR7ZX",
+    "title": "Context init builder decomposition",
+    "description": "Decompose packages/agentplane/src/commands/context/init.ts by extracting context init content builders and small file-read helpers into focused modules, preserving context init behavior and reducing hotspot warning count.",
+    "tags": [
+      "context",
+      "hotspot",
+      "refactor"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "none",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "analysis.light",
+    "version": 1,
+    "title": "Lightweight analysis",
+    "taskKinds": [
+      "analysis"
+    ],
+    "workflowModes": []
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "analysis.light",
+    "blueprintVersion": 1,
+    "title": "Lightweight analysis",
+    "taskId": "202605282234-DXR7ZX",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "none"
+    },
+    "whySelected": [
+      "task kind resolved to analysis",
+      "workflow mode: branch_pr",
+      "mutation scope: none"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "context_manifest",
+          "sources"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "weak_links",
+          "final_output"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "analysis.sources",
+        "kind": "sources",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Sources used for analysis."
+      },
+      {
+        "id": "analysis.assumptions",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Assumptions and constraints."
+      },
+      {
+        "id": "analysis.weak_links",
+        "kind": "weak_links",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Weak links or uncertainty."
+      },
+      {
+        "id": "analysis.final",
+        "kind": "final_output",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Final answer or report."
+      },
+      {
+        "id": "analysis.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      }
+    ],
+    "policyModules": [],
+    "allowedCommands": [],
+    "contextBudget": {
+      "maxPolicyModules": 0,
+      "maxPromptBlocks": 6,
+      "rationale": "Lightweight analysis should load sources and task context without policy modules."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "context_manifest",
+        "sources"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "weak_links",
+        "final_output"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "analysis.sources",
+      "kind": "sources",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Sources used for analysis."
+    },
+    {
+      "id": "analysis.assumptions",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Assumptions and constraints."
+    },
+    {
+      "id": "analysis.weak_links",
+      "kind": "weak_links",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Weak links or uncertainty."
+    },
+    {
+      "id": "analysis.final",
+      "kind": "final_output",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Final answer or report."
+    },
+    {
+      "id": "analysis.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    }
+  ],
+  "policyModules": [],
+  "allowedCommands": [],
+  "contextBudget": {
+    "maxPolicyModules": 0,
+    "maxPromptBlocks": 6,
+    "rationale": "Lightweight analysis should load sources and task context without policy modules."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to analysis",
+    "workflow mode: branch_pr",
+    "mutation scope: none"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "ac2130312a9c9df8994ec714ec7c87b2f489c88307bfaca5bfc69cdca2fa590a"
+  }
+}

--- a/.agentplane/tasks/202605282234-DXR7ZX/pr/diffstat.txt
+++ b/.agentplane/tasks/202605282234-DXR7ZX/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ .../src/commands/context/context-init-bootstrap.ts | 200 ++++++++++++
+ .../src/commands/context/context-init-builders.ts  | 131 ++++++++
+ packages/agentplane/src/commands/context/init.ts   | 340 +--------------------
+ 3 files changed, 347 insertions(+), 324 deletions(-)

--- a/.agentplane/tasks/202605282234-DXR7ZX/pr/github-body.md
+++ b/.agentplane/tasks/202605282234-DXR7ZX/pr/github-body.md
@@ -33,7 +33,10 @@ check (runtime warnings 39 -> 38).
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/commands/context/context-init-bootstrap.ts | 200 ++++++++++++
+ .../src/commands/context/context-init-builders.ts  | 131 ++++++++
+ packages/agentplane/src/commands/context/init.ts   | 340 +--------------------
+ 3 files changed, 347 insertions(+), 324 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605282234-DXR7ZX/pr/github-body.md
+++ b/.agentplane/tasks/202605282234-DXR7ZX/pr/github-body.md
@@ -1,0 +1,39 @@
+Task: `202605282234-DXR7ZX`
+Title: Context init builder decomposition
+Canonical task record: `.agentplane/tasks/202605282234-DXR7ZX/README.md`
+
+## Summary
+
+Context init builder decomposition
+
+Decompose packages/agentplane/src/commands/context/init.ts by extracting context init content builders and small file-read helpers into focused modules, preserving context init behavior and reducing hotspot warning count.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/commands/context/init.ts by extracting context init content builders and small file-read helpers into focused modules, preserving context init behavior and reducing hotspot warning count.
+- Out of scope: unrelated refactors not required for "Context init builder decomposition".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Context init was decomposed into command orchestration, bootstrap/git helpers, and content builders.
+Verified with focused context CLI tests, typecheck, arch deps, lint, format, and hotspot threshold
+check (runtime warnings 39 -> 38).
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-28T22:34:52.803Z
+- Branch: task/202605282234-DXR7ZX/context-init-builder-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605282234-DXR7ZX/pr/github-title.txt
+++ b/.agentplane/tasks/202605282234-DXR7ZX/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 DXR7ZX task: Context init builder decomposition [202605282234-DXR7ZX]

--- a/.agentplane/tasks/202605282234-DXR7ZX/pr/meta.json
+++ b/.agentplane/tasks/202605282234-DXR7ZX/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605282234-DXR7ZX/context-init-builder-decomposition",
+  "created_at": "2026-05-28T22:34:52.803Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": "2026-05-28T22:42:34.688Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202605282234-DXR7ZX",
+  "updated_at": "2026-05-28T22:34:52.803Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605282234-DXR7ZX/pr/meta.json
+++ b/.agentplane/tasks/202605282234-DXR7ZX/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605282234-DXR7ZX/context-init-builder-decomposition",
   "created_at": "2026-05-28T22:34:52.803Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "diffstat_sha256": "sha256:0aaa5e180903e9161b8f7ba73a0dea53f7cb568eb073e9c90277116874f4a711",
   "last_verified_at": "2026-05-28T22:42:34.688Z",
   "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "schema_version": 1,

--- a/.agentplane/tasks/202605282234-DXR7ZX/pr/review.md
+++ b/.agentplane/tasks/202605282234-DXR7ZX/pr/review.md
@@ -29,7 +29,10 @@ Created: 2026-05-28T22:34:52.803Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/commands/context/context-init-bootstrap.ts | 200 ++++++++++++
+ .../src/commands/context/context-init-builders.ts  | 131 ++++++++
+ packages/agentplane/src/commands/context/init.ts   | 340 +--------------------
+ 3 files changed, 347 insertions(+), 324 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605282234-DXR7ZX/pr/review.md
+++ b/.agentplane/tasks/202605282234-DXR7ZX/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-28T22:34:52.803Z
+
+## Task
+
+- Task: `202605282234-DXR7ZX`
+- Title: Context init builder decomposition
+- Status: DOING
+- Branch: `task/202605282234-DXR7ZX/context-init-builder-decomposition`
+- Canonical task record: `.agentplane/tasks/202605282234-DXR7ZX/README.md`
+
+## Verification
+
+- State: ok
+- Note: Context init was decomposed into command orchestration, bootstrap/git helpers, and content builders. Verified with focused context CLI tests, typecheck, arch deps, lint, format, and hotspot threshold check (runtime warnings 39 -> 38).
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-28T22:34:52.803Z
+- Branch: task/202605282234-DXR7ZX/context-init-builder-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605282234-DXR7ZX/quality/20260528-224250512-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605282234-DXR7ZX/quality/20260528-224250512-recovery-context/evaluator-opinion.md
@@ -1,0 +1,27 @@
+# EVALUATOR opinion: pass
+
+Context init builder decomposition completed without behavior changes.
+
+## Findings
+- packages/agentplane/src/commands/context/init.ts now focuses on command orchestration and workspace file writes at 284 lines; bootstrap/git helpers moved to context-init-bootstrap.ts, and generated content builders moved to context-init-builders.ts. Hotspot warning count decreased from 39 to 38.
+
+## Evidence
+- .agentplane/tasks/202605282234-DXR7ZX/README.md
+- packages/agentplane/src/commands/context/init.ts
+- packages/agentplane/src/commands/context/context-init-bootstrap.ts
+- packages/agentplane/src/commands/context/context-init-builders.ts
+- bunx vitest run packages/agentplane/src/cli/run-cli.core.context-init.test.ts packages/agentplane/src/commands/context/release-readiness.test.ts --config vitest.workspace.ts
+- bun run typecheck
+- bun run arch:deps
+- bun run lint:core
+- bun run format:changed
+- node scripts/checks/hotspot-report.mjs --check --warning-lines 400 --oversized-lines 600 --test-warning-lines 1000 --oversized-test-lines 1300
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- Remaining context hotspots such as context/wiki.ts and context harvest/ingest modules are intentionally outside this bounded init split and should be handled as separate tasks.

--- a/.agentplane/tasks/202605282234-DXR7ZX/quality/20260528-224250512-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605282234-DXR7ZX/quality/20260528-224250512-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605282234-DXR7ZX
+- task_readme: .agentplane/tasks/202605282234-DXR7ZX/README.md
+- report_path: .agentplane/tasks/202605282234-DXR7ZX/quality/20260528-224250512-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605282234-DXR7ZX/quality/20260528-224250512-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605282234-DXR7ZX/quality/20260528-224250512-recovery-context/quality-report.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "task_id": "202605282234-DXR7ZX",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-28T22:42:50.512Z",
+  "verdict": "pass",
+  "summary": "Context init builder decomposition completed without behavior changes.",
+  "evaluated_sha": "0f3c098c28ff587e4eb9080963c05f75e08f58c6",
+  "blueprint_digest": "ac2130312a9c9df8994ec714ec7c87b2f489c88307bfaca5bfc69cdca2fa590a",
+  "findings": [
+    "packages/agentplane/src/commands/context/init.ts now focuses on command orchestration and workspace file writes at 284 lines; bootstrap/git helpers moved to context-init-bootstrap.ts, and generated content builders moved to context-init-builders.ts. Hotspot warning count decreased from 39 to 38."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605282234-DXR7ZX/README.md",
+    "packages/agentplane/src/commands/context/init.ts",
+    "packages/agentplane/src/commands/context/context-init-bootstrap.ts",
+    "packages/agentplane/src/commands/context/context-init-builders.ts",
+    "bunx vitest run packages/agentplane/src/cli/run-cli.core.context-init.test.ts packages/agentplane/src/commands/context/release-readiness.test.ts --config vitest.workspace.ts",
+    "bun run typecheck",
+    "bun run arch:deps",
+    "bun run lint:core",
+    "bun run format:changed",
+    "node scripts/checks/hotspot-report.mjs --check --warning-lines 400 --oversized-lines 600 --test-warning-lines 1000 --oversized-test-lines 1300"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": [
+    "Remaining context hotspots such as context/wiki.ts and context harvest/ingest modules are intentionally outside this bounded init split and should be handled as separate tasks."
+  ]
+}

--- a/packages/agentplane/src/commands/context/context-init-bootstrap.ts
+++ b/packages/agentplane/src/commands/context/context-init-bootstrap.ts
@@ -1,0 +1,200 @@
+import { execFile } from "node:child_process";
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { gitAddPaths, gitCommit, gitEnv, gitStagedPaths } from "@agentplaneorg/core/git";
+
+import { exitCodeForError } from "../../cli/exit-codes.js";
+import { infoMessage } from "../../cli/output.js";
+import { detectParentGitRoot } from "../../cli/run-cli/commands/init/git.js";
+import type { InitParsed } from "../../cli/run-cli/commands/init/model.js";
+import { cmdInit } from "../../cli/run-cli/commands/init/orchestrate.js";
+import type { CommandSpec } from "../../cli/spec/spec.js";
+import { CliError } from "../../shared/errors.js";
+import { loadCommandContext, type CommandContext } from "../shared/task-backend.js";
+
+const execFileAsync = promisify(execFile);
+const CONTEXT_BOOTSTRAP_TASK_ID = "202601010101-CTX1NT";
+const SAFE_EMPTY_PLACEHOLDERS = new Set([".DS_Store"]);
+
+const contextBootstrapInitSpec: CommandSpec<InitParsed> = {
+  id: ["init"],
+  group: "Setup",
+  summary: "Initialize agentplane project files before context bootstrap.",
+  parse: () => ({ yes: true }),
+};
+
+export async function loadOrBootstrapCommandContext(opts: {
+  cwd: string;
+  rootOverride?: string | null;
+}): Promise<{ ctx: CommandContext; bootstrapped: boolean }> {
+  const root = path.resolve(opts.rootOverride ?? opts.cwd);
+  const target = await inspectBootstrapTarget(root);
+  if (target?.canBootstrap) {
+    return { ctx: await bootstrapEmptyProjectForContextInit(root), bootstrapped: true };
+  }
+
+  try {
+    return {
+      ctx: await loadCommandContext({ cwd: opts.cwd, rootOverride: opts.rootOverride ?? null }),
+      bootstrapped: false,
+    };
+  } catch (err) {
+    if (target && !target.hasAgentplaneDir && isMissingProjectError(err)) {
+      throw new CliError({
+        exitCode: exitCodeForError("E_USAGE"),
+        code: "E_USAGE",
+        message:
+          "context init can bootstrap AgentPlane only in an empty directory. " +
+          "Run agentplane init explicitly before context init for non-empty directories.",
+      });
+    }
+    throw err;
+  }
+}
+
+export async function assertContextBootstrapIndexClean(root: string): Promise<void> {
+  const baseGitEnv = gitEnv();
+  if (!(await isInsideGitWorkTree(root, baseGitEnv))) return;
+  const stagedBefore = await gitStagedPaths(root);
+  if (stagedBefore.length === 0) return;
+  throw new CliError({
+    exitCode: exitCodeForError("E_GIT"),
+    code: "E_GIT",
+    message:
+      "Git index has staged changes; commit or unstage them before running agentplane context init.",
+  });
+}
+
+export async function commitContextBootstrapIfChanged(
+  root: string,
+  paths: string[],
+): Promise<boolean> {
+  const baseGitEnv = gitEnv();
+  if (!(await isInsideGitWorkTree(root, baseGitEnv))) return false;
+  const dedupedPaths = [...new Set(paths)].filter((entry) => entry.length > 0);
+  const committablePaths = await filterGitIgnoredPaths(root, dedupedPaths, baseGitEnv);
+  if (committablePaths.length === 0) return false;
+  await gitAddPaths(root, committablePaths);
+  const staged = await gitStagedPaths(root);
+  if (staged.length === 0) return false;
+  const env = {
+    ...baseGitEnv,
+    AGENTPLANE_ALLOW_POLICY: "1",
+    AGENTPLANE_TASK_ID: CONTEXT_BOOTSTRAP_TASK_ID,
+  };
+  await gitCommit(
+    root,
+    [
+      "✅ CTX1NT task: initialize AgentPlane context",
+      "",
+      "Context-Bootstrap: true",
+      `Context-Bootstrap-Task: ${CONTEXT_BOOTSTRAP_TASK_ID}`,
+    ].join("\n"),
+    { env },
+  );
+  return true;
+}
+
+async function isInsideGitWorkTree(root: string, env: NodeJS.ProcessEnv): Promise<boolean> {
+  try {
+    const result = await execFileAsync("git", ["rev-parse", "--is-inside-work-tree"], {
+      cwd: root,
+      env,
+    });
+    return result.stdout.trim() === "true";
+  } catch {
+    return false;
+  }
+}
+
+async function filterGitIgnoredPaths(
+  root: string,
+  paths: string[],
+  env: NodeJS.ProcessEnv,
+): Promise<string[]> {
+  const kept: string[] = [];
+  for (const relative of paths) {
+    if (await isGitIgnoredPath(root, relative, env)) continue;
+    kept.push(relative);
+  }
+  return kept;
+}
+
+async function isGitIgnoredPath(
+  root: string,
+  relative: string,
+  env: NodeJS.ProcessEnv,
+): Promise<boolean> {
+  try {
+    await execFileAsync("git", ["check-ignore", "--quiet", "--", relative], { cwd: root, env });
+    return true;
+  } catch (err) {
+    const code = (err as { code?: number | string } | null)?.code;
+    if (code === 1) return false;
+    throw err;
+  }
+}
+
+type BootstrapTarget = {
+  canBootstrap: boolean;
+  hasAgentplaneDir: boolean;
+};
+
+async function inspectBootstrapTarget(root: string): Promise<BootstrapTarget | null> {
+  const entries = await readBootstrapTargetEntries(root);
+  if (!entries) return null;
+  const meaningfulEntries = entries.filter((entry) => !SAFE_EMPTY_PLACEHOLDERS.has(entry));
+  const canBootstrap =
+    meaningfulEntries.length === 0 ||
+    (meaningfulEntries.length === 1 && meaningfulEntries[0] === ".git");
+
+  return {
+    canBootstrap,
+    hasAgentplaneDir: meaningfulEntries.includes(".agentplane"),
+  };
+}
+
+async function bootstrapEmptyProjectForContextInit(root: string): Promise<CommandContext> {
+  const parentGitRoot = await detectParentGitRoot(root);
+  if (parentGitRoot) {
+    throw new CliError({
+      exitCode: exitCodeForError("E_USAGE"),
+      code: "E_USAGE",
+      message:
+        "context init can bootstrap AgentPlane only in a standalone empty directory. " +
+        `Target ${root} is inside parent Git repository ${parentGitRoot}. ` +
+        "Run agentplane init explicitly from the intended nested project root, then run agentplane context init.",
+    });
+  }
+
+  process.stdout.write(
+    infoMessage("agentplane project not found; bootstrapping empty directory") + "\n",
+  );
+  await cmdInit({
+    cwd: root,
+    rootOverride: root,
+    outputMode: "text",
+    flags: { yes: true },
+    spec: contextBootstrapInitSpec,
+  });
+  return await loadCommandContext({ cwd: root, rootOverride: root });
+}
+
+async function readBootstrapTargetEntries(root: string): Promise<string[] | null> {
+  try {
+    return await readdir(root);
+  } catch {
+    return null;
+  }
+}
+
+function isMissingProjectError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    message.startsWith("Not a git repository") ||
+    message.includes("ENOENT") ||
+    message.includes(".agentplane")
+  );
+}

--- a/packages/agentplane/src/commands/context/context-init-builders.ts
+++ b/packages/agentplane/src/commands/context/context-init-builders.ts
@@ -1,0 +1,131 @@
+import type { ContextInitParsed } from "./context.spec.js";
+import { wikiFrontmatter } from "./init-wiki.js";
+
+export function buildContextReadme(profile: ContextInitParsed["profile"]): string {
+  const maximumAssimilation =
+    profile === "maximum-assimilation"
+      ? `
+Maximum-assimilation mode adds a stricter wiki maintenance contract:
+
+- Preserve all significant source meaning in wiki, facts, graph, glossary, and coverage
+  artifacts so maintained context remains useful even if \`context/raw/**\` is later removed.
+- Keep original source identity in a source registry with \`source_id\`, original path,
+  \`sha256:\` hash, content type, line count, ingest time, and availability state.
+- Use line-addressed source refs as provenance pointers, not retained content; missing raw refs may be non-dereferenceable while wiki/fact/graph artifacts stay self-contained.
+- Extract entities, aliases, relations, decisions, requirements, risks, workflows, and conflicts
+  before writing narrative articles.
+- Choose the wiki structure from source content; do not create the default
+  concepts/entities/decisions/modules/contradictions/reports scaffold unless source analysis
+  justifies it. Record the topology decision before creating page families.
+- Create or maintain the canonical glossary as root file \`context/wiki/glossary.md\`; keep it as navigation/aliases over wiki pages and graph entities, then use canonical terms in prose.
+- Create Obsidian page properties automatically for wiki pages: \`aliases\`, \`tags\`, and
+  \`cssclasses\` stay alongside AgentPlane frontmatter for better vault rendering.
+- Use Obsidian-compatible links whose target case exactly matches a canonical page path, title, or
+  alias; prefer \`[[canonical-page|Display Label]]\` when file path and display title differ.
+- Cite raw sources in prose with numeric notes like \`[1]\`; keep the raw-data Markdown links in a
+  trailing \`## Sources\` section.
+- Treat coverage gaps, unresolved entity identity, sensitive-source leakage risk, and missing line refs
+  as blockers or explicit approval-required findings.
+- Require EVALUATOR review of topology, granularity, wikilinks, coverage, glossary safety,
+  raw-deletion resilience, and private leakage risk before finish.
+`
+      : "";
+  return `# Context workspace
+
+Profile: ${profile}
+
+Use this directory as the human-readable context surface.
+
+AgentPlane local context is optional and independent from runner prompt assembly. When enabled, it
+uses one llm-wiki contract:
+
+- \`context/raw/**\` keeps source material.
+- \`context/wiki/**\` keeps readable synthesis pages with AgentPlane frontmatter.
+- \`.agentplane/context/derived/**\` keeps reproducible claims, graph rows, provenance, and reports.
+- \`.agentplane/context/service/**\` keeps local caches only.
+
+Agents should create wiki pages when a topic is reusable for future tasks, but keep atomic claims in
+derived machine artifacts. \`context init\` creates only \`context/raw/.gitkeep\`,
+\`context/wiki/AGENTS.md\`, and \`context/wiki/index.md\`; users own any hierarchy below
+\`context/raw/**\`. Source references should preserve user-created raw paths where possible.
+${maximumAssimilation}
+`;
+}
+
+export function buildWikiAgentsMarkdown(profile: ContextInitParsed["profile"]): string {
+  const maximumAssimilation =
+    profile === "maximum-assimilation"
+      ? `
+## Maximum assimilation mode
+
+- Use the \`context.maximum_assimilation\` blueprint for new context assimilation tasks.
+- Goal: after assimilation, the maintained wiki and derived artifacts preserve all significant
+  source meaning without relying on raw files for semantic recall.
+- Keep original hashes in the source-set lock and cite source content with concrete line refs such as
+  \`context/raw/<user-path>/note.md#lines=12-24\`; treat those refs as audit provenance, not as the
+  stored meaning.
+- First pass: build or update canonical entities, glossary aliases, relation candidates, conflicts, and coverage notes.
+- Glossary output: create or update \`context/wiki/glossary.md\` as the root glossary file; do not scatter canonical glossary state across reports or page-local notes.
+- Topology pass: choose wiki structure from source content; do not mechanically create
+  \`concepts/\`, \`entities/\`, \`decisions/\`, \`modules/\`, \`contradictions/\`, or \`reports/\`.
+- Record a topology decision before page-family creation. It must classify the source shape (book/corpus, codebase, task history, product docs, research notes, ops logs, or another named shape), name canonical page families, justify page-vs-heading granularity, map source-local terms to canonical labels or aliases, and keep ambiguous identities as open questions.
+- Second pass: synthesize granular wiki articles from that graph/glossary layer; use canonical terms from \`context/wiki/glossary.md\` and preserve source-local wording as aliases.
+- Create separate pages for reusable entities, concepts, decisions, requirements, risks, workflows,
+  and modules; use stable headings for smaller objects inside broader pages.
+- Ensure each wiki page has Obsidian properties \`aliases\`, \`tags\`, and \`cssclasses\` in YAML
+  frontmatter in addition to the \`agentplane_context\` manifest.
+- Use Obsidian-compatible wikilinks whose target case exactly matches a canonical page path, title,
+  or alias; add a display alias or heading anchor only when display wording differs.
+- Cite raw sources in prose with numeric notes like \`[1]\`; keep Markdown raw-data links in a
+  trailing \`## Sources\` section rather than scattering long source URLs through prose.
+- Record extraction coverage: covered source spans, intentionally omitted boilerplate, redacted
+  spans, unresolved conflicts, and open questions.
+- Record EVALUATOR review for topology, granularity, wikilinks, line refs, glossary safety,
+  coverage gaps, raw-deletion resilience, and private leakage risk before finish.
+- If a raw source is missing later, keep its source registry entry with availability state
+  \`missing\`; the wiki, facts, graph, glossary, and coverage artifacts must still carry the
+  assimilated meaning.
+- Do not copy secrets into public wiki pages. Redact sensitive source spans before publication.
+`
+      : "";
+  return `${wikiFrontmatter("wiki.agents", "Context wiki agent notes", "policy")}
+
+# Context wiki agent notes
+
+Profile: ${profile}
+
+- Treat \`context/wiki/**\` as durable, source-backed project knowledge with stable AgentPlane frontmatter.
+- Treat \`.agentplane/context/agentplane.context.yaml\` as the machine-readable context contract and \`.agentplane/context/policies/wiki.rules.md\` as the human-readable wiki policy.
+- Analyze the base project, existing docs, task history, and raw sources before choosing a wiki structure.
+- Choose the smallest wiki hierarchy that fits this project; do not force a universal concepts/entities/decisions/modules layout.
+- Keep this initialized wiki minimal until first ingest; project-specific folders should appear from source-backed assimilation, not from empty scaffolding.
+- Preserve modality, source refs, cross-links, glossary aliases, and graph alignment when updating pages.
+- Write synthesized wiki prose in English by default; preserve source-language terms only for quotes, titles, proper names, aliases, paths, and code identifiers.
+- Prefer updating existing canonical pages over creating duplicates; describe small objects under stable headings when that is clearer.
+- Use \`agentplane context wiki new\`, \`agentplane context wiki lint\`, \`agentplane context wiki explain\`, \`agentplane context wiki link\`, and \`agentplane context wiki index\`.
+- When claims conflict, keep both claims, create a conflict candidate, and ask for review before promotion or overwrite.
+- Keep raw inputs in \`context/raw/**\`; preserve the user-created hierarchy when citing sources.
+- Add source references for factual claims and run \`agentplane context verify-task <task-id>\` before closing context assimilation work.
+${maximumAssimilation}
+
+## Sources
+
+- no-source: generated policy notes from \`agentplane context init\`; add source references before promotion.
+`;
+}
+
+export function buildCapabilitiesReadme(profile: ContextInitParsed["profile"]): string {
+  return `# Context capabilities\n\nProfile: ${profile}\n\nReusable artefacts for prompts, playbooks, templates, checklists and rubrics.\n`;
+}
+
+export function buildPolicyMarkdown(name: string): string {
+  return `# ${name}\n\n- Keep raw sources in \`context/raw\`.\n- Keep durable machine artifacts under \`.agentplane/context/derived\`.\n- Keep service caches under \`.agentplane/context/service\`.\n`;
+}
+
+export function buildRedactionRulesYaml(): string {
+  return `mode: explicit\nallowlist: []\ndenylist: []\n`;
+}
+
+export function buildSyncRulesYaml(): string {
+  return `mode: manual\nallow_external: false\n`;
+}

--- a/packages/agentplane/src/commands/context/init.ts
+++ b/packages/agentplane/src/commands/context/init.ts
@@ -1,22 +1,26 @@
 /* eslint-disable @typescript-eslint/no-unused-vars, unicorn/no-array-sort */
-import { execFile } from "node:child_process";
-import { readdir, readFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { promisify } from "node:util";
-
-import { gitAddPaths, gitCommit, gitEnv, gitStagedPaths } from "@agentplaneorg/core/git";
 
 import { infoMessage } from "../../cli/output.js";
-import { exitCodeForError } from "../../cli/exit-codes.js";
-import { cmdInit } from "../../cli/run-cli/commands/init/orchestrate.js";
-import { detectParentGitRoot } from "../../cli/run-cli/commands/init/git.js";
-import type { InitParsed } from "../../cli/run-cli/commands/init/model.js";
-import type { CommandSpec } from "../../cli/spec/spec.js";
 import { CliError } from "../../shared/errors.js";
-import { writeJsonStableIfChanged, writeTextIfChanged } from "../../shared/write-if-changed.js";
-import { loadCommandContext, type CommandContext } from "../shared/task-backend.js";
+import { writeTextIfChanged } from "../../shared/write-if-changed.js";
+import type { CommandContext } from "../shared/task-backend.js";
 
 import type { ContextInitParsed } from "./context.spec.js";
+import {
+  assertContextBootstrapIndexClean,
+  commitContextBootstrapIfChanged,
+  loadOrBootstrapCommandContext,
+} from "./context-init-bootstrap.js";
+import {
+  buildCapabilitiesReadme,
+  buildContextReadme,
+  buildPolicyMarkdown,
+  buildRedactionRulesYaml,
+  buildSyncRulesYaml,
+  buildWikiAgentsMarkdown,
+} from "./context-init-builders.js";
 import {
   assertProfileSwitchIsExplicit,
   POLICY_FILES,
@@ -31,9 +35,6 @@ import { starterWikiPageFiles, wikiFrontmatter } from "./init-wiki.js";
 import { buildWikiPolicyMarkdown } from "./init-wiki-policy.js";
 import { cmdContextReindex } from "./reindex.js";
 
-const execFileAsync = promisify(execFile);
-const CONTEXT_BOOTSTRAP_TASK_ID = "202601010101-CTX1NT";
-
 const DEFAULT_GITIGNORE_ENTRIES = [
   ".agentplane/cache.sqlite",
   ".agentplane/cache.sqlite-wal",
@@ -43,15 +44,6 @@ const DEFAULT_GITIGNORE_ENTRIES = [
   ".agentplane/context/service/embeddings/",
   ".agentplane/context/service/remotes/",
 ];
-
-const SAFE_EMPTY_PLACEHOLDERS = new Set([".DS_Store"]);
-
-const contextBootstrapInitSpec: CommandSpec<InitParsed> = {
-  id: ["init"],
-  group: "Setup",
-  summary: "Initialize agentplane project files before context bootstrap.",
-  parse: () => ({ yes: true }),
-};
 
 type InitReport = {
   created: string[];
@@ -115,177 +107,6 @@ export async function cmdContextInit(opts: {
       message: `context init failed: ${(err as Error).message}`,
     });
   }
-}
-
-async function loadOrBootstrapCommandContext(opts: {
-  cwd: string;
-  rootOverride?: string | null;
-}): Promise<{ ctx: CommandContext; bootstrapped: boolean }> {
-  const root = path.resolve(opts.rootOverride ?? opts.cwd);
-  const target = await inspectBootstrapTarget(root);
-  if (target?.canBootstrap) {
-    return { ctx: await bootstrapEmptyProjectForContextInit(root), bootstrapped: true };
-  }
-
-  try {
-    return {
-      ctx: await loadCommandContext({ cwd: opts.cwd, rootOverride: opts.rootOverride ?? null }),
-      bootstrapped: false,
-    };
-  } catch (err) {
-    if (target && !target.hasAgentplaneDir && isMissingProjectError(err)) {
-      throw new CliError({
-        exitCode: exitCodeForError("E_USAGE"),
-        code: "E_USAGE",
-        message:
-          "context init can bootstrap AgentPlane only in an empty directory. " +
-          "Run agentplane init explicitly before context init for non-empty directories.",
-      });
-    }
-    throw err;
-  }
-}
-
-async function assertContextBootstrapIndexClean(root: string): Promise<void> {
-  const baseGitEnv = gitEnv();
-  if (!(await isInsideGitWorkTree(root, baseGitEnv))) return;
-  const stagedBefore = await gitStagedPaths(root);
-  if (stagedBefore.length === 0) return;
-  throw new CliError({
-    exitCode: exitCodeForError("E_GIT"),
-    code: "E_GIT",
-    message:
-      "Git index has staged changes; commit or unstage them before running agentplane context init.",
-  });
-}
-
-async function commitContextBootstrapIfChanged(root: string, paths: string[]): Promise<boolean> {
-  const baseGitEnv = gitEnv();
-  if (!(await isInsideGitWorkTree(root, baseGitEnv))) return false;
-  const dedupedPaths = [...new Set(paths)].filter((entry) => entry.length > 0);
-  const committablePaths = await filterGitIgnoredPaths(root, dedupedPaths, baseGitEnv);
-  if (committablePaths.length === 0) return false;
-  await gitAddPaths(root, committablePaths);
-  const staged = await gitStagedPaths(root);
-  if (staged.length === 0) return false;
-  const env = {
-    ...baseGitEnv,
-    AGENTPLANE_ALLOW_POLICY: "1",
-    AGENTPLANE_TASK_ID: CONTEXT_BOOTSTRAP_TASK_ID,
-  };
-  await gitCommit(
-    root,
-    [
-      "✅ CTX1NT task: initialize AgentPlane context",
-      "",
-      "Context-Bootstrap: true",
-      `Context-Bootstrap-Task: ${CONTEXT_BOOTSTRAP_TASK_ID}`,
-    ].join("\n"),
-    { env },
-  );
-  return true;
-}
-
-async function isInsideGitWorkTree(root: string, env: NodeJS.ProcessEnv): Promise<boolean> {
-  try {
-    const result = await execFileAsync("git", ["rev-parse", "--is-inside-work-tree"], {
-      cwd: root,
-      env,
-    });
-    return result.stdout.trim() === "true";
-  } catch {
-    return false;
-  }
-}
-
-async function filterGitIgnoredPaths(
-  root: string,
-  paths: string[],
-  env: NodeJS.ProcessEnv,
-): Promise<string[]> {
-  const kept: string[] = [];
-  for (const relative of paths) {
-    if (await isGitIgnoredPath(root, relative, env)) continue;
-    kept.push(relative);
-  }
-  return kept;
-}
-
-async function isGitIgnoredPath(
-  root: string,
-  relative: string,
-  env: NodeJS.ProcessEnv,
-): Promise<boolean> {
-  try {
-    await execFileAsync("git", ["check-ignore", "--quiet", "--", relative], { cwd: root, env });
-    return true;
-  } catch (err) {
-    const code = (err as { code?: number | string } | null)?.code;
-    if (code === 1) return false;
-    throw err;
-  }
-}
-
-type BootstrapTarget = {
-  canBootstrap: boolean;
-  hasAgentplaneDir: boolean;
-};
-
-async function inspectBootstrapTarget(root: string): Promise<BootstrapTarget | null> {
-  const entries = await readBootstrapTargetEntries(root);
-  if (!entries) return null;
-  const meaningfulEntries = entries.filter((entry) => !SAFE_EMPTY_PLACEHOLDERS.has(entry));
-  const canBootstrap =
-    meaningfulEntries.length === 0 ||
-    (meaningfulEntries.length === 1 && meaningfulEntries[0] === ".git");
-
-  return {
-    canBootstrap,
-    hasAgentplaneDir: meaningfulEntries.includes(".agentplane"),
-  };
-}
-
-async function bootstrapEmptyProjectForContextInit(root: string): Promise<CommandContext> {
-  const parentGitRoot = await detectParentGitRoot(root);
-  if (parentGitRoot) {
-    throw new CliError({
-      exitCode: exitCodeForError("E_USAGE"),
-      code: "E_USAGE",
-      message:
-        "context init can bootstrap AgentPlane only in a standalone empty directory. " +
-        `Target ${root} is inside parent Git repository ${parentGitRoot}. ` +
-        "Run agentplane init explicitly from the intended nested project root, then run agentplane context init.",
-    });
-  }
-
-  process.stdout.write(
-    infoMessage("agentplane project not found; bootstrapping empty directory") + "\n",
-  );
-  await cmdInit({
-    cwd: root,
-    rootOverride: root,
-    outputMode: "text",
-    flags: { yes: true },
-    spec: contextBootstrapInitSpec,
-  });
-  return await loadCommandContext({ cwd: root, rootOverride: root });
-}
-
-async function readBootstrapTargetEntries(root: string): Promise<string[] | null> {
-  try {
-    return await readdir(root);
-  } catch {
-    return null;
-  }
-}
-
-function isMissingProjectError(err: unknown): boolean {
-  const message = err instanceof Error ? err.message : String(err);
-  return (
-    message.startsWith("Not a git repository") ||
-    message.includes("ENOENT") ||
-    message.includes(".agentplane")
-  );
 }
 
 async function createContextWorkspace(
@@ -428,135 +249,6 @@ async function ensureContextGitignore(root: string, parsed: ContextInitParsed): 
   if (currentText.trimEnd() === nextText.trimEnd()) return false;
   await writeTextIfChanged(gitignorePath, nextText);
   return true;
-}
-
-function buildContextReadme(profile: ContextInitParsed["profile"]): string {
-  const maximumAssimilation =
-    profile === "maximum-assimilation"
-      ? `
-Maximum-assimilation mode adds a stricter wiki maintenance contract:
-
-- Preserve all significant source meaning in wiki, facts, graph, glossary, and coverage
-  artifacts so maintained context remains useful even if \`context/raw/**\` is later removed.
-- Keep original source identity in a source registry with \`source_id\`, original path,
-  \`sha256:\` hash, content type, line count, ingest time, and availability state.
-- Use line-addressed source refs as provenance pointers, not retained content; missing raw refs may be non-dereferenceable while wiki/fact/graph artifacts stay self-contained.
-- Extract entities, aliases, relations, decisions, requirements, risks, workflows, and conflicts
-  before writing narrative articles.
-- Choose the wiki structure from source content; do not create the default
-  concepts/entities/decisions/modules/contradictions/reports scaffold unless source analysis
-  justifies it. Record the topology decision before creating page families.
-- Create or maintain the canonical glossary as root file \`context/wiki/glossary.md\`; keep it as navigation/aliases over wiki pages and graph entities, then use canonical terms in prose.
-- Create Obsidian page properties automatically for wiki pages: \`aliases\`, \`tags\`, and
-  \`cssclasses\` stay alongside AgentPlane frontmatter for better vault rendering.
-- Use Obsidian-compatible links whose target case exactly matches a canonical page path, title, or
-  alias; prefer \`[[canonical-page|Display Label]]\` when file path and display title differ.
-- Cite raw sources in prose with numeric notes like \`[1]\`; keep the raw-data Markdown links in a
-  trailing \`## Sources\` section.
-- Treat coverage gaps, unresolved entity identity, sensitive-source leakage risk, and missing line refs
-  as blockers or explicit approval-required findings.
-- Require EVALUATOR review of topology, granularity, wikilinks, coverage, glossary safety,
-  raw-deletion resilience, and private leakage risk before finish.
-`
-      : "";
-  return `# Context workspace
-
-Profile: ${profile}
-
-Use this directory as the human-readable context surface.
-
-AgentPlane local context is optional and independent from runner prompt assembly. When enabled, it
-uses one llm-wiki contract:
-
-- \`context/raw/**\` keeps source material.
-- \`context/wiki/**\` keeps readable synthesis pages with AgentPlane frontmatter.
-- \`.agentplane/context/derived/**\` keeps reproducible claims, graph rows, provenance, and reports.
-- \`.agentplane/context/service/**\` keeps local caches only.
-
-Agents should create wiki pages when a topic is reusable for future tasks, but keep atomic claims in
-derived machine artifacts. \`context init\` creates only \`context/raw/.gitkeep\`,
-\`context/wiki/AGENTS.md\`, and \`context/wiki/index.md\`; users own any hierarchy below
-\`context/raw/**\`. Source references should preserve user-created raw paths where possible.
-${maximumAssimilation}
-`;
-}
-
-function buildWikiAgentsMarkdown(profile: ContextInitParsed["profile"]): string {
-  const maximumAssimilation =
-    profile === "maximum-assimilation"
-      ? `
-## Maximum assimilation mode
-
-- Use the \`context.maximum_assimilation\` blueprint for new context assimilation tasks.
-- Goal: after assimilation, the maintained wiki and derived artifacts preserve all significant
-  source meaning without relying on raw files for semantic recall.
-- Keep original hashes in the source-set lock and cite source content with concrete line refs such as
-  \`context/raw/<user-path>/note.md#lines=12-24\`; treat those refs as audit provenance, not as the
-  stored meaning.
-- First pass: build or update canonical entities, glossary aliases, relation candidates, conflicts, and coverage notes.
-- Glossary output: create or update \`context/wiki/glossary.md\` as the root glossary file; do not scatter canonical glossary state across reports or page-local notes.
-- Topology pass: choose wiki structure from source content; do not mechanically create
-  \`concepts/\`, \`entities/\`, \`decisions/\`, \`modules/\`, \`contradictions/\`, or \`reports/\`.
-- Record a topology decision before page-family creation. It must classify the source shape (book/corpus, codebase, task history, product docs, research notes, ops logs, or another named shape), name canonical page families, justify page-vs-heading granularity, map source-local terms to canonical labels or aliases, and keep ambiguous identities as open questions.
-- Second pass: synthesize granular wiki articles from that graph/glossary layer; use canonical terms from \`context/wiki/glossary.md\` and preserve source-local wording as aliases.
-- Create separate pages for reusable entities, concepts, decisions, requirements, risks, workflows,
-  and modules; use stable headings for smaller objects inside broader pages.
-- Ensure each wiki page has Obsidian properties \`aliases\`, \`tags\`, and \`cssclasses\` in YAML
-  frontmatter in addition to the \`agentplane_context\` manifest.
-- Use Obsidian-compatible wikilinks whose target case exactly matches a canonical page path, title,
-  or alias; add a display alias or heading anchor only when display wording differs.
-- Cite raw sources in prose with numeric notes like \`[1]\`; keep Markdown raw-data links in a
-  trailing \`## Sources\` section rather than scattering long source URLs through prose.
-- Record extraction coverage: covered source spans, intentionally omitted boilerplate, redacted
-  spans, unresolved conflicts, and open questions.
-- Record EVALUATOR review for topology, granularity, wikilinks, line refs, glossary safety,
-  coverage gaps, raw-deletion resilience, and private leakage risk before finish.
-- If a raw source is missing later, keep its source registry entry with availability state
-  \`missing\`; the wiki, facts, graph, glossary, and coverage artifacts must still carry the
-  assimilated meaning.
-- Do not copy secrets into public wiki pages. Redact sensitive source spans before publication.
-`
-      : "";
-  return `${wikiFrontmatter("wiki.agents", "Context wiki agent notes", "policy")}
-
-# Context wiki agent notes
-
-Profile: ${profile}
-
-- Treat \`context/wiki/**\` as durable, source-backed project knowledge with stable AgentPlane frontmatter.
-- Treat \`.agentplane/context/agentplane.context.yaml\` as the machine-readable context contract and \`.agentplane/context/policies/wiki.rules.md\` as the human-readable wiki policy.
-- Analyze the base project, existing docs, task history, and raw sources before choosing a wiki structure.
-- Choose the smallest wiki hierarchy that fits this project; do not force a universal concepts/entities/decisions/modules layout.
-- Keep this initialized wiki minimal until first ingest; project-specific folders should appear from source-backed assimilation, not from empty scaffolding.
-- Preserve modality, source refs, cross-links, glossary aliases, and graph alignment when updating pages.
-- Write synthesized wiki prose in English by default; preserve source-language terms only for quotes, titles, proper names, aliases, paths, and code identifiers.
-- Prefer updating existing canonical pages over creating duplicates; describe small objects under stable headings when that is clearer.
-- Use \`agentplane context wiki new\`, \`agentplane context wiki lint\`, \`agentplane context wiki explain\`, \`agentplane context wiki link\`, and \`agentplane context wiki index\`.
-- When claims conflict, keep both claims, create a conflict candidate, and ask for review before promotion or overwrite.
-- Keep raw inputs in \`context/raw/**\`; preserve the user-created hierarchy when citing sources.
-- Add source references for factual claims and run \`agentplane context verify-task <task-id>\` before closing context assimilation work.
-${maximumAssimilation}
-
-## Sources
-
-- no-source: generated policy notes from \`agentplane context init\`; add source references before promotion.
-`;
-}
-
-function buildCapabilitiesReadme(profile: ContextInitParsed["profile"]): string {
-  return `# Context capabilities\n\nProfile: ${profile}\n\nReusable artefacts for prompts, playbooks, templates, checklists and rubrics.\n`;
-}
-
-function buildPolicyMarkdown(name: string): string {
-  return `# ${name}\n\n- Keep raw sources in \`context/raw\`.\n- Keep durable machine artifacts under \`.agentplane/context/derived\`.\n- Keep service caches under \`.agentplane/context/service\`.\n`;
-}
-
-function buildRedactionRulesYaml(): string {
-  return `mode: explicit\nallowlist: []\ndenylist: []\n`;
-}
-
-function buildSyncRulesYaml(): string {
-  return `mode: manual\nallow_external: false\n`;
 }
 
 async function readExisting(filePath: string): Promise<string | null> {


### PR DESCRIPTION
Task: `202605282234-DXR7ZX`
Title: Context init builder decomposition
Canonical task record: `.agentplane/tasks/202605282234-DXR7ZX/README.md`

## Summary

Context init builder decomposition

Decompose packages/agentplane/src/commands/context/init.ts by extracting context init content builders and small file-read helpers into focused modules, preserving context init behavior and reducing hotspot warning count.

## Scope

- In scope: Decompose packages/agentplane/src/commands/context/init.ts by extracting context init content builders and small file-read helpers into focused modules, preserving context init behavior and reducing hotspot warning count.
- Out of scope: unrelated refactors not required for "Context init builder decomposition".

## Verification

- State: ok
- Note:

```text
Context init was decomposed into command orchestration, bootstrap/git helpers, and content builders.
Verified with focused context CLI tests, typecheck, arch deps, lint, format, and hotspot threshold
check (runtime warnings 39 -> 38).
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-28T22:34:52.803Z
- Branch: task/202605282234-DXR7ZX/context-init-builder-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/commands/context/context-init-bootstrap.ts | 200 ++++++++++++
 .../src/commands/context/context-init-builders.ts  | 131 ++++++++
 packages/agentplane/src/commands/context/init.ts   | 340 +--------------------
 3 files changed, 347 insertions(+), 324 deletions(-)
```

</details>
