### PR TITLE
🚧 2A32BY task: Blueprint catalog parser decomposition [202605282346-2A32BY]

### DIFF
--- a/.agentplane/tasks/202605282346-2A32BY/README.md
+++ b/.agentplane/tasks/202605282346-2A32BY/README.md
@@ -4,7 +4,7 @@ title: "Blueprint catalog parser decomposition"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 4
+revision: 5
 origin:
   system: "manual"
 depends_on: []
@@ -19,10 +19,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-28T23:51:11.658Z"
+  updated_by: "CODER"
+  note: "Verified blueprint catalog parser decomposition. Commands passed: focused blueprint catalog vitest (2 files, 25 tests), bun run typecheck, bun run arch:deps, bun run lint:core, bun run format:changed, hotspot report check. Runtime hotspot warnings decreased from 33 to 32; catalog.ts is 307 lines."
   attempts: 0
 commit: null
 comments:
@@ -37,8 +37,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: Decompose blueprint catalog type and parser helpers in the task worktree while preserving catalog load, manifest, and install behavior under focused tests."
+  -
+    type: "verify"
+    at: "2026-05-28T23:51:11.658Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified blueprint catalog parser decomposition. Commands passed: focused blueprint catalog vitest (2 files, 25 tests), bun run typecheck, bun run arch:deps, bun run lint:core, bun run format:changed, hotspot report check. Runtime hotspot warnings decreased from 33 to 32; catalog.ts is 307 lines."
 doc_version: 3
-doc_updated_at: "2026-05-28T23:46:36.811Z"
+doc_updated_at: "2026-05-28T23:51:11.683Z"
 doc_updated_by: "CODER"
 description: "Decompose packages/agentplane/src/commands/blueprints/catalog.ts by extracting catalog/manifest types and parsers while preserving catalog load/install behavior."
 sections:
@@ -69,6 +75,25 @@ sections:
     3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-28T23:51:11.658Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified blueprint catalog parser decomposition. Commands passed: focused blueprint catalog vitest (2 files, 25 tests), bun run typecheck, bun run arch:deps, bun run lint:core, bun run format:changed, hotspot report check. Runtime hotspot warnings decreased from 33 to 32; catalog.ts is 307 lines.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-28T23:46:36.811Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605282346-2A32BY-blueprint-catalog-parser-decomposition/.agentplane/tasks/202605282346-2A32BY/blueprint/resolved-snapshot.json
+    - old_digest: 3b12bbe014e5126d1468c03d871ec24e9b1d9b66df5ecaae8512a69fcd74b384
+    - current_digest: 3b12bbe014e5126d1468c03d871ec24e9b1d9b66df5ecaae8512a69fcd74b384
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605282346-2A32BY
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -112,6 +137,25 @@ PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLA
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-28T23:51:11.658Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified blueprint catalog parser decomposition. Commands passed: focused blueprint catalog vitest (2 files, 25 tests), bun run typecheck, bun run arch:deps, bun run lint:core, bun run format:changed, hotspot report check. Runtime hotspot warnings decreased from 33 to 32; catalog.ts is 307 lines.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-28T23:46:36.811Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605282346-2A32BY-blueprint-catalog-parser-decomposition/.agentplane/tasks/202605282346-2A32BY/blueprint/resolved-snapshot.json
+- old_digest: 3b12bbe014e5126d1468c03d871ec24e9b1d9b66df5ecaae8512a69fcd74b384
+- current_digest: 3b12bbe014e5126d1468c03d871ec24e9b1d9b66df5ecaae8512a69fcd74b384
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605282346-2A32BY
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605282346-2A32BY/README.md
+++ b/.agentplane/tasks/202605282346-2A32BY/README.md
@@ -1,0 +1,122 @@
+---
+id: "202605282346-2A32BY"
+title: "Blueprint catalog parser decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "hotspot"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-28T23:46:15.803Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Decompose blueprint catalog type and parser helpers in the task worktree while preserving catalog load, manifest, and install behavior under focused tests."
+events:
+  -
+    type: "status"
+    at: "2026-05-28T23:46:36.811Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Decompose blueprint catalog type and parser helpers in the task worktree while preserving catalog load, manifest, and install behavior under focused tests."
+doc_version: 3
+doc_updated_at: "2026-05-28T23:46:36.811Z"
+doc_updated_by: "CODER"
+description: "Decompose packages/agentplane/src/commands/blueprints/catalog.ts by extracting catalog/manifest types and parsers while preserving catalog load/install behavior."
+sections:
+  Summary: |-
+    Blueprint catalog parser decomposition
+
+    Decompose packages/agentplane/src/commands/blueprints/catalog.ts by extracting catalog/manifest types and parsers while preserving catalog load/install behavior.
+  Scope: |-
+    - In scope: Decompose packages/agentplane/src/commands/blueprints/catalog.ts by extracting catalog/manifest types and parsers while preserving catalog load/install behavior.
+    - Out of scope: unrelated refactors not required for "Blueprint catalog parser decomposition".
+  Plan: |-
+    Plan:
+    1. Start branch_pr worktree for CODER.
+    2. Extract catalog/manifest type definitions and parser helpers from blueprints/catalog.ts into a focused module.
+    3. Preserve public exports used by blueprints.command.ts and catalog-cache.ts.
+    4. Verify with blueprint catalog tests, typecheck, arch dependency check, lint, format, and hotspot threshold report.
+    5. Open PR, wait for hosted checks, merge to main, close lifecycle, and clean merged worktree.
+
+    Acceptance:
+    - catalog load/info/install behavior remains compatible.
+    - catalog.ts drops below the runtime hotspot warning threshold.
+    - hotspot runtime warning count decreases from 33 to 32.
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Blueprint catalog parser decomposition
+
+Decompose packages/agentplane/src/commands/blueprints/catalog.ts by extracting catalog/manifest types and parsers while preserving catalog load/install behavior.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/commands/blueprints/catalog.ts by extracting catalog/manifest types and parsers while preserving catalog load/install behavior.
+- Out of scope: unrelated refactors not required for "Blueprint catalog parser decomposition".
+
+## Plan
+
+Plan:
+1. Start branch_pr worktree for CODER.
+2. Extract catalog/manifest type definitions and parser helpers from blueprints/catalog.ts into a focused module.
+3. Preserve public exports used by blueprints.command.ts and catalog-cache.ts.
+4. Verify with blueprint catalog tests, typecheck, arch dependency check, lint, format, and hotspot threshold report.
+5. Open PR, wait for hosted checks, merge to main, close lifecycle, and clean merged worktree.
+
+Acceptance:
+- catalog load/info/install behavior remains compatible.
+- catalog.ts drops below the runtime hotspot warning threshold.
+- hotspot runtime warning count decreases from 33 to 32.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605282346-2A32BY/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605282346-2A32BY/blueprint/resolved-snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605282346-2A32BY",
+    "title": "Blueprint catalog parser decomposition",
+    "description": "Decompose packages/agentplane/src/commands/blueprints/catalog.ts by extracting catalog/manifest types and parsers while preserving catalog load/install behavior.",
+    "tags": [
+      "code",
+      "hotspot",
+      "refactor"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605282346-2A32BY",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "3b12bbe014e5126d1468c03d871ec24e9b1d9b66df5ecaae8512a69fcd74b384"
+  }
+}

--- a/.agentplane/tasks/202605282346-2A32BY/pr/diffstat.txt
+++ b/.agentplane/tasks/202605282346-2A32BY/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../src/commands/blueprints/catalog-model.ts       | 278 ++++++++++++++++++++
+ .../agentplane/src/commands/blueprints/catalog.ts  | 291 ++-------------------
+ 2 files changed, 293 insertions(+), 276 deletions(-)

--- a/.agentplane/tasks/202605282346-2A32BY/pr/diffstat.txt
+++ b/.agentplane/tasks/202605282346-2A32BY/pr/diffstat.txt
@@ -1,3 +1,5 @@
  .../src/commands/blueprints/catalog-model.ts       | 278 ++++++++++++++++++++
  .../agentplane/src/commands/blueprints/catalog.ts  | 291 ++-------------------
- 2 files changed, 293 insertions(+), 276 deletions(-)
+ .../commands/guard/impl/close-message-render.ts    |   2 +-
+ .../src/context/harvest-tasks-builders.ts          |   2 +-
+ 4 files changed, 295 insertions(+), 278 deletions(-)

--- a/.agentplane/tasks/202605282346-2A32BY/pr/github-body.md
+++ b/.agentplane/tasks/202605282346-2A32BY/pr/github-body.md
@@ -15,8 +15,15 @@ Decompose packages/agentplane/src/commands/blueprints/catalog.ts by extracting c
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Verified blueprint catalog parser decomposition. Commands passed: focused blueprint catalog vitest
+(2 files, 25 tests), bun run typecheck, bun run arch:deps, bun run lint:core, bun run
+format:changed, hotspot report check. Runtime hotspot warnings decreased from 33 to 32; catalog.ts
+is 307 lines.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
@@ -27,7 +34,9 @@ Decompose packages/agentplane/src/commands/blueprints/catalog.ts by extracting c
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/commands/blueprints/catalog-model.ts       | 278 ++++++++++++++++++++
+ .../agentplane/src/commands/blueprints/catalog.ts  | 291 ++-------------------
+ 2 files changed, 293 insertions(+), 276 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605282346-2A32BY/pr/github-body.md
+++ b/.agentplane/tasks/202605282346-2A32BY/pr/github-body.md
@@ -36,7 +36,9 @@ is 307 lines.
 ```text
  .../src/commands/blueprints/catalog-model.ts       | 278 ++++++++++++++++++++
  .../agentplane/src/commands/blueprints/catalog.ts  | 291 ++-------------------
- 2 files changed, 293 insertions(+), 276 deletions(-)
+ .../commands/guard/impl/close-message-render.ts    |   2 +-
+ .../src/context/harvest-tasks-builders.ts          |   2 +-
+ 4 files changed, 295 insertions(+), 278 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605282346-2A32BY/pr/github-body.md
+++ b/.agentplane/tasks/202605282346-2A32BY/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605282346-2A32BY`
+Title: Blueprint catalog parser decomposition
+Canonical task record: `.agentplane/tasks/202605282346-2A32BY/README.md`
+
+## Summary
+
+Blueprint catalog parser decomposition
+
+Decompose packages/agentplane/src/commands/blueprints/catalog.ts by extracting catalog/manifest types and parsers while preserving catalog load/install behavior.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/commands/blueprints/catalog.ts by extracting catalog/manifest types and parsers while preserving catalog load/install behavior.
+- Out of scope: unrelated refactors not required for "Blueprint catalog parser decomposition".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-28T23:46:36.926Z
+- Branch: task/202605282346-2A32BY/blueprint-catalog-parser-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605282346-2A32BY/pr/github-title.txt
+++ b/.agentplane/tasks/202605282346-2A32BY/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 2A32BY task: Blueprint catalog parser decomposition [202605282346-2A32BY]

--- a/.agentplane/tasks/202605282346-2A32BY/pr/meta.json
+++ b/.agentplane/tasks/202605282346-2A32BY/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605282346-2A32BY/blueprint-catalog-parser-decomposition",
   "created_at": "2026-05-28T23:46:36.926Z",
-  "diffstat_sha256": "sha256:124abdf7b07b83d6a51a3ca92c0de911c5076f18a4e44a9e55813b6eac214ad5",
+  "diffstat_sha256": "sha256:91fe6bfb018bd2201039e9a0f8e99419f0793c30361bdd9b09b93ebdbb2613ff",
   "last_verified_at": "2026-05-28T23:51:11.658Z",
   "last_verified_diffstat_sha256": "sha256:124abdf7b07b83d6a51a3ca92c0de911c5076f18a4e44a9e55813b6eac214ad5",
   "schema_version": 1,

--- a/.agentplane/tasks/202605282346-2A32BY/pr/meta.json
+++ b/.agentplane/tasks/202605282346-2A32BY/pr/meta.json
@@ -2,12 +2,13 @@
   "base": "main",
   "branch": "task/202605282346-2A32BY/blueprint-catalog-parser-decomposition",
   "created_at": "2026-05-28T23:46:36.926Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:124abdf7b07b83d6a51a3ca92c0de911c5076f18a4e44a9e55813b6eac214ad5",
+  "last_verified_at": "2026-05-28T23:51:11.658Z",
+  "last_verified_diffstat_sha256": "sha256:124abdf7b07b83d6a51a3ca92c0de911c5076f18a4e44a9e55813b6eac214ad5",
   "schema_version": 1,
   "task_id": "202605282346-2A32BY",
   "updated_at": "2026-05-28T23:46:36.926Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605282346-2A32BY/pr/meta.json
+++ b/.agentplane/tasks/202605282346-2A32BY/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202605282346-2A32BY/blueprint-catalog-parser-decomposition",
+  "created_at": "2026-05-28T23:46:36.926Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202605282346-2A32BY",
+  "updated_at": "2026-05-28T23:46:36.926Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605282346-2A32BY/pr/review.md
+++ b/.agentplane/tasks/202605282346-2A32BY/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-05-28T23:46:36.926Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified blueprint catalog parser decomposition. Commands passed: focused blueprint catalog vitest (2 files, 25 tests), bun run typecheck, bun run arch:deps, bun run lint:core, bun run format:changed, hotspot report check. Runtime hotspot warnings decreased from 33 to 32; catalog.ts is 307 lines.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -29,7 +29,9 @@ Created: 2026-05-28T23:46:36.926Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/commands/blueprints/catalog-model.ts       | 278 ++++++++++++++++++++
+ .../agentplane/src/commands/blueprints/catalog.ts  | 291 ++-------------------
+ 2 files changed, 293 insertions(+), 276 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605282346-2A32BY/pr/review.md
+++ b/.agentplane/tasks/202605282346-2A32BY/pr/review.md
@@ -31,7 +31,9 @@ Created: 2026-05-28T23:46:36.926Z
 ```text
  .../src/commands/blueprints/catalog-model.ts       | 278 ++++++++++++++++++++
  .../agentplane/src/commands/blueprints/catalog.ts  | 291 ++-------------------
- 2 files changed, 293 insertions(+), 276 deletions(-)
+ .../commands/guard/impl/close-message-render.ts    |   2 +-
+ .../src/context/harvest-tasks-builders.ts          |   2 +-
+ 4 files changed, 295 insertions(+), 278 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605282346-2A32BY/pr/review.md
+++ b/.agentplane/tasks/202605282346-2A32BY/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-28T23:46:36.926Z
+
+## Task
+
+- Task: `202605282346-2A32BY`
+- Title: Blueprint catalog parser decomposition
+- Status: DOING
+- Branch: `task/202605282346-2A32BY/blueprint-catalog-parser-decomposition`
+- Canonical task record: `.agentplane/tasks/202605282346-2A32BY/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-28T23:46:36.926Z
+- Branch: task/202605282346-2A32BY/blueprint-catalog-parser-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/blueprints/catalog-model.ts
+++ b/packages/agentplane/src/commands/blueprints/catalog-model.ts
@@ -80,7 +80,7 @@ export type InstalledBlueprint = {
   recommendedAllowedIds: string[];
 };
 
-export function parseCatalogEntry(raw: unknown, field: string): CatalogEntry {
+function parseCatalogEntry(raw: unknown, field: string): CatalogEntry {
   if (!isRecord(raw)) throw new ValidationError({ message: `${field} entry must be an object.` });
   const id = typeof raw.id === "string" ? raw.id.trim() : "";
   const entryPath = typeof raw.path === "string" ? raw.path.trim() : undefined;

--- a/packages/agentplane/src/commands/blueprints/catalog-model.ts
+++ b/packages/agentplane/src/commands/blueprints/catalog-model.ts
@@ -1,0 +1,278 @@
+import { ValidationError } from "../../shared/errors.js";
+import { isRecord } from "../../shared/guards.js";
+
+export type CatalogKind = "blueprint" | "pack";
+
+export type CatalogEntry = {
+  id: string;
+  path?: string;
+  name?: string;
+  summary?: string;
+  version?: string;
+  tags?: string[];
+  activation?: {
+    recommended_allowed_ids?: string[];
+  };
+  versions?: {
+    version: string;
+    url: string;
+    sha256: string;
+    min_agentplane_version?: string;
+    tags?: string[];
+  }[];
+  blueprints?: {
+    id: string;
+    version?: string;
+    required?: boolean;
+  }[];
+};
+
+export type BlueprintCatalogIndex = {
+  schema_version: 1;
+  catalog_id: string;
+  name: string;
+  description?: string;
+  blueprints: CatalogEntry[];
+  packs: CatalogEntry[];
+};
+
+export type BlueprintCatalogSource = {
+  schema_version: 1;
+  source: string;
+};
+
+export type CatalogBlueprintManifest = {
+  schema_version: 1;
+  id: string;
+  version: string;
+  name: string;
+  summary: string;
+  definition: {
+    id: string;
+    path: string;
+  };
+  activation?: {
+    recommended_allowed_ids?: string[];
+  };
+};
+
+export type CatalogPackManifest = {
+  schema_version: 1;
+  id: string;
+  version: string;
+  name: string;
+  summary: string;
+  blueprints: {
+    id: string;
+    version?: string;
+    required?: boolean;
+  }[];
+  activation?: {
+    recommended_allowed_ids?: string[];
+  };
+};
+
+export type InstalledBlueprint = {
+  catalogId: string;
+  blueprintId: string;
+  projectPath: string;
+  cachePath: string;
+  recommendedAllowedIds: string[];
+};
+
+export function parseCatalogEntry(raw: unknown, field: string): CatalogEntry {
+  if (!isRecord(raw)) throw new ValidationError({ message: `${field} entry must be an object.` });
+  const id = typeof raw.id === "string" ? raw.id.trim() : "";
+  const entryPath = typeof raw.path === "string" ? raw.path.trim() : undefined;
+  const versions = Array.isArray(raw.versions)
+    ? raw.versions.map((version) => {
+        if (!isRecord(version)) {
+          throw new ValidationError({ message: `${field} versions entries must be objects.` });
+        }
+        const versionId = typeof version.version === "string" ? version.version.trim() : "";
+        const url = typeof version.url === "string" ? version.url.trim() : "";
+        const sha256 = typeof version.sha256 === "string" ? version.sha256.trim() : "";
+        if (!versionId || !url || !sha256) {
+          throw new ValidationError({
+            message: `${field} versions entries must contain version, url, and sha256.`,
+          });
+        }
+        return {
+          version: versionId,
+          url,
+          sha256,
+          min_agentplane_version:
+            typeof version.min_agentplane_version === "string"
+              ? version.min_agentplane_version
+              : undefined,
+          tags: Array.isArray(version.tags)
+            ? version.tags.filter((tag): tag is string => typeof tag === "string")
+            : undefined,
+        };
+      })
+    : undefined;
+  const blueprints = Array.isArray(raw.blueprints)
+    ? raw.blueprints.map((entry) => {
+        if (!isRecord(entry) || typeof entry.id !== "string" || !entry.id.trim()) {
+          throw new ValidationError({ message: `${field} blueprint entries must contain id.` });
+        }
+        return {
+          id: entry.id.trim(),
+          version: typeof entry.version === "string" ? entry.version.trim() : undefined,
+          required: entry.required === true,
+        };
+      })
+    : undefined;
+  if (!id || (!entryPath && !versions && !blueprints)) {
+    throw new ValidationError({
+      message: `${field} entry must contain id plus path, versions, or blueprints.`,
+    });
+  }
+  return {
+    id,
+    path: entryPath,
+    name: typeof raw.name === "string" ? raw.name : undefined,
+    summary: typeof raw.summary === "string" ? raw.summary : undefined,
+    version: typeof raw.version === "string" ? raw.version : undefined,
+    tags: Array.isArray(raw.tags)
+      ? raw.tags.filter((tag): tag is string => typeof tag === "string")
+      : undefined,
+    activation: isRecord(raw.activation)
+      ? {
+          recommended_allowed_ids: Array.isArray(raw.activation.recommended_allowed_ids)
+            ? raw.activation.recommended_allowed_ids.filter(
+                (allowedId): allowedId is string => typeof allowedId === "string",
+              )
+            : undefined,
+        }
+      : undefined,
+    versions,
+    blueprints,
+  };
+}
+
+export function parseCatalogIndex(raw: unknown): BlueprintCatalogIndex {
+  if (!isRecord(raw)) {
+    throw new ValidationError({ message: "Blueprint catalog index must be an object." });
+  }
+  if (raw.schema_version !== 1) {
+    throw new ValidationError({ message: "Blueprint catalog index schema_version must be 1." });
+  }
+  const catalogId = typeof raw.catalog_id === "string" ? raw.catalog_id.trim() : "";
+  const name = typeof raw.name === "string" ? raw.name.trim() : "";
+  if (!catalogId || !name) {
+    throw new ValidationError({
+      message: "Blueprint catalog index must contain catalog_id and name.",
+    });
+  }
+  if (!Array.isArray(raw.blueprints)) {
+    throw new ValidationError({ message: "Blueprint catalog index blueprints must be an array." });
+  }
+  if (!Array.isArray(raw.packs)) {
+    throw new ValidationError({ message: "Blueprint catalog index packs must be an array." });
+  }
+  return {
+    schema_version: 1,
+    catalog_id: catalogId,
+    name,
+    description: typeof raw.description === "string" ? raw.description : undefined,
+    blueprints: raw.blueprints.map((entry) => parseCatalogEntry(entry, "blueprints")),
+    packs: raw.packs.map((entry) => parseCatalogEntry(entry, "packs")),
+  };
+}
+
+export function parseCatalogSource(raw: unknown): BlueprintCatalogSource {
+  if (!isRecord(raw) || raw.schema_version !== 1 || typeof raw.source !== "string") {
+    throw new ValidationError({ message: "Blueprint catalog cache source is invalid." });
+  }
+  return { schema_version: 1, source: raw.source };
+}
+
+export function assertSafeCatalogPathSegment(value: string, label: string): void {
+  if (
+    !value ||
+    value === "." ||
+    value === ".." ||
+    value.includes("..") ||
+    value.includes("/") ||
+    value.includes("\\")
+  ) {
+    throw new ValidationError({
+      message: `${label} must be a safe path segment.`,
+      context: { value },
+    });
+  }
+}
+
+export function parseBlueprintManifest(raw: unknown): CatalogBlueprintManifest {
+  if (!isRecord(raw) || raw.schema_version !== 1) {
+    throw new ValidationError({ message: "Catalog blueprint manifest schema_version must be 1." });
+  }
+  const definition = isRecord(raw.definition) ? raw.definition : {};
+  const manifest = {
+    schema_version: 1,
+    id: typeof raw.id === "string" ? raw.id.trim() : "",
+    version: typeof raw.version === "string" ? raw.version.trim() : "",
+    name: typeof raw.name === "string" ? raw.name.trim() : "",
+    summary: typeof raw.summary === "string" ? raw.summary.trim() : "",
+    definition: {
+      id: typeof definition.id === "string" ? definition.id.trim() : "",
+      path: typeof definition.path === "string" ? definition.path.trim() : "",
+    },
+    activation: isRecord(raw.activation)
+      ? {
+          recommended_allowed_ids: Array.isArray(raw.activation.recommended_allowed_ids)
+            ? raw.activation.recommended_allowed_ids.filter(
+                (id): id is string => typeof id === "string",
+              )
+            : undefined,
+        }
+      : undefined,
+  } satisfies CatalogBlueprintManifest;
+  if (!manifest.id || !manifest.version || !manifest.definition.id || !manifest.definition.path) {
+    throw new ValidationError({
+      message:
+        "Catalog blueprint manifest must contain id, version, definition.id, and definition.path.",
+    });
+  }
+  return manifest;
+}
+
+export function parsePackManifest(raw: unknown): CatalogPackManifest {
+  if (!isRecord(raw) || raw.schema_version !== 1) {
+    throw new ValidationError({ message: "Blueprint pack manifest schema_version must be 1." });
+  }
+  if (!Array.isArray(raw.blueprints)) {
+    throw new ValidationError({ message: "Blueprint pack manifest blueprints must be an array." });
+  }
+  const pack: CatalogPackManifest = {
+    schema_version: 1,
+    id: typeof raw.id === "string" ? raw.id.trim() : "",
+    version: typeof raw.version === "string" ? raw.version.trim() : "",
+    name: typeof raw.name === "string" ? raw.name.trim() : "",
+    summary: typeof raw.summary === "string" ? raw.summary.trim() : "",
+    blueprints: raw.blueprints.map((entry) => {
+      if (!isRecord(entry) || typeof entry.id !== "string" || !entry.id.trim()) {
+        throw new ValidationError({ message: "Blueprint pack entries must contain id." });
+      }
+      return {
+        id: entry.id.trim(),
+        version: typeof entry.version === "string" ? entry.version.trim() : undefined,
+        required: entry.required === true,
+      };
+    }),
+    activation: isRecord(raw.activation)
+      ? {
+          recommended_allowed_ids: Array.isArray(raw.activation.recommended_allowed_ids)
+            ? raw.activation.recommended_allowed_ids.filter(
+                (id): id is string => typeof id === "string",
+              )
+            : undefined,
+        }
+      : undefined,
+  };
+  if (!pack.id || !pack.version) {
+    throw new ValidationError({ message: "Blueprint pack manifest must contain id and version." });
+  }
+  return pack;
+}

--- a/packages/agentplane/src/commands/blueprints/catalog.ts
+++ b/packages/agentplane/src/commands/blueprints/catalog.ts
@@ -11,85 +11,21 @@ import { isRecord } from "../../shared/guards.js";
 import { writeJsonStableIfChanged } from "../../shared/write-if-changed.js";
 import { getVersion } from "../../meta/version.js";
 import { cacheBlueprintPackage, pickLatestVersion, resolvePackageRoot } from "./catalog-cache.js";
+import {
+  assertSafeCatalogPathSegment,
+  parseBlueprintManifest,
+  parseCatalogIndex,
+  parseCatalogSource,
+  parsePackManifest,
+  type BlueprintCatalogIndex,
+  type CatalogBlueprintManifest,
+  type CatalogEntry,
+  type CatalogKind,
+  type CatalogPackManifest,
+  type InstalledBlueprint,
+} from "./catalog-model.js";
 
-export type CatalogKind = "blueprint" | "pack";
-
-export type CatalogEntry = {
-  id: string;
-  path?: string;
-  name?: string;
-  summary?: string;
-  version?: string;
-  tags?: string[];
-  activation?: {
-    recommended_allowed_ids?: string[];
-  };
-  versions?: {
-    version: string;
-    url: string;
-    sha256: string;
-    min_agentplane_version?: string;
-    tags?: string[];
-  }[];
-  blueprints?: {
-    id: string;
-    version?: string;
-    required?: boolean;
-  }[];
-};
-
-type BlueprintCatalogIndex = {
-  schema_version: 1;
-  catalog_id: string;
-  name: string;
-  description?: string;
-  blueprints: CatalogEntry[];
-  packs: CatalogEntry[];
-};
-
-type BlueprintCatalogSource = {
-  schema_version: 1;
-  source: string;
-};
-
-export type CatalogBlueprintManifest = {
-  schema_version: 1;
-  id: string;
-  version: string;
-  name: string;
-  summary: string;
-  definition: {
-    id: string;
-    path: string;
-  };
-  activation?: {
-    recommended_allowed_ids?: string[];
-  };
-};
-
-type CatalogPackManifest = {
-  schema_version: 1;
-  id: string;
-  version: string;
-  name: string;
-  summary: string;
-  blueprints: {
-    id: string;
-    version?: string;
-    required?: boolean;
-  }[];
-  activation?: {
-    recommended_allowed_ids?: string[];
-  };
-};
-
-type InstalledBlueprint = {
-  catalogId: string;
-  blueprintId: string;
-  projectPath: string;
-  cachePath: string;
-  recommendedAllowedIds: string[];
-};
+export type { CatalogBlueprintManifest, CatalogEntry, CatalogKind } from "./catalog-model.js";
 
 function agentplaneHome(): string {
   const configuredHome = process.env.AGENTPLANE_HOME?.trim();
@@ -144,130 +80,6 @@ function resolveCatalogEntrySource(indexSource: string, relativePath: string): s
 async function readText(source: string): Promise<string> {
   if (isHttpUrl(source)) return await fetchText(source);
   return await readFile(source, "utf8");
-}
-
-function parseCatalogEntry(raw: unknown, field: string): CatalogEntry {
-  if (!isRecord(raw)) throw new ValidationError({ message: `${field} entry must be an object.` });
-  const id = typeof raw.id === "string" ? raw.id.trim() : "";
-  const entryPath = typeof raw.path === "string" ? raw.path.trim() : undefined;
-  const versions = Array.isArray(raw.versions)
-    ? raw.versions.map((version) => {
-        if (!isRecord(version)) {
-          throw new ValidationError({ message: `${field} versions entries must be objects.` });
-        }
-        const versionId = typeof version.version === "string" ? version.version.trim() : "";
-        const url = typeof version.url === "string" ? version.url.trim() : "";
-        const sha256 = typeof version.sha256 === "string" ? version.sha256.trim() : "";
-        if (!versionId || !url || !sha256) {
-          throw new ValidationError({
-            message: `${field} versions entries must contain version, url, and sha256.`,
-          });
-        }
-        return {
-          version: versionId,
-          url,
-          sha256,
-          min_agentplane_version:
-            typeof version.min_agentplane_version === "string"
-              ? version.min_agentplane_version
-              : undefined,
-          tags: Array.isArray(version.tags)
-            ? version.tags.filter((tag): tag is string => typeof tag === "string")
-            : undefined,
-        };
-      })
-    : undefined;
-  const blueprints = Array.isArray(raw.blueprints)
-    ? raw.blueprints.map((entry) => {
-        if (!isRecord(entry) || typeof entry.id !== "string" || !entry.id.trim()) {
-          throw new ValidationError({ message: `${field} blueprint entries must contain id.` });
-        }
-        return {
-          id: entry.id.trim(),
-          version: typeof entry.version === "string" ? entry.version.trim() : undefined,
-          required: entry.required === true,
-        };
-      })
-    : undefined;
-  if (!id || (!entryPath && !versions && !blueprints)) {
-    throw new ValidationError({
-      message: `${field} entry must contain id plus path, versions, or blueprints.`,
-    });
-  }
-  return {
-    id,
-    path: entryPath,
-    name: typeof raw.name === "string" ? raw.name : undefined,
-    summary: typeof raw.summary === "string" ? raw.summary : undefined,
-    version: typeof raw.version === "string" ? raw.version : undefined,
-    tags: Array.isArray(raw.tags)
-      ? raw.tags.filter((tag): tag is string => typeof tag === "string")
-      : undefined,
-    activation: isRecord(raw.activation)
-      ? {
-          recommended_allowed_ids: Array.isArray(raw.activation.recommended_allowed_ids)
-            ? raw.activation.recommended_allowed_ids.filter(
-                (allowedId): allowedId is string => typeof allowedId === "string",
-              )
-            : undefined,
-        }
-      : undefined,
-    versions,
-    blueprints,
-  };
-}
-
-function parseCatalogIndex(raw: unknown): BlueprintCatalogIndex {
-  if (!isRecord(raw)) {
-    throw new ValidationError({ message: "Blueprint catalog index must be an object." });
-  }
-  if (raw.schema_version !== 1) {
-    throw new ValidationError({ message: "Blueprint catalog index schema_version must be 1." });
-  }
-  const catalogId = typeof raw.catalog_id === "string" ? raw.catalog_id.trim() : "";
-  const name = typeof raw.name === "string" ? raw.name.trim() : "";
-  if (!catalogId || !name) {
-    throw new ValidationError({
-      message: "Blueprint catalog index must contain catalog_id and name.",
-    });
-  }
-  if (!Array.isArray(raw.blueprints)) {
-    throw new ValidationError({ message: "Blueprint catalog index blueprints must be an array." });
-  }
-  if (!Array.isArray(raw.packs)) {
-    throw new ValidationError({ message: "Blueprint catalog index packs must be an array." });
-  }
-  return {
-    schema_version: 1,
-    catalog_id: catalogId,
-    name,
-    description: typeof raw.description === "string" ? raw.description : undefined,
-    blueprints: raw.blueprints.map((entry) => parseCatalogEntry(entry, "blueprints")),
-    packs: raw.packs.map((entry) => parseCatalogEntry(entry, "packs")),
-  };
-}
-
-function parseCatalogSource(raw: unknown): BlueprintCatalogSource {
-  if (!isRecord(raw) || raw.schema_version !== 1 || typeof raw.source !== "string") {
-    throw new ValidationError({ message: "Blueprint catalog cache source is invalid." });
-  }
-  return { schema_version: 1, source: raw.source };
-}
-
-function assertSafeCatalogPathSegment(value: string, label: string): void {
-  if (
-    !value ||
-    value === "." ||
-    value === ".." ||
-    value.includes("..") ||
-    value.includes("/") ||
-    value.includes("\\")
-  ) {
-    throw new ValidationError({
-      message: `${label} must be a safe path segment.`,
-      context: { value },
-    });
-  }
 }
 
 async function loadCachedCatalog(): Promise<{ index: BlueprintCatalogIndex; source: string }> {
@@ -347,79 +159,6 @@ export function findEntry(
   if (blueprint) return { kind: "blueprint", entry: blueprint };
   if (pack) return { kind: "pack", entry: pack };
   throw new ValidationError({ message: `Unknown blueprint catalog id: ${id}` });
-}
-
-function parseBlueprintManifest(raw: unknown): CatalogBlueprintManifest {
-  if (!isRecord(raw) || raw.schema_version !== 1) {
-    throw new ValidationError({ message: "Catalog blueprint manifest schema_version must be 1." });
-  }
-  const definition = isRecord(raw.definition) ? raw.definition : {};
-  const manifest = {
-    schema_version: 1,
-    id: typeof raw.id === "string" ? raw.id.trim() : "",
-    version: typeof raw.version === "string" ? raw.version.trim() : "",
-    name: typeof raw.name === "string" ? raw.name.trim() : "",
-    summary: typeof raw.summary === "string" ? raw.summary.trim() : "",
-    definition: {
-      id: typeof definition.id === "string" ? definition.id.trim() : "",
-      path: typeof definition.path === "string" ? definition.path.trim() : "",
-    },
-    activation: isRecord(raw.activation)
-      ? {
-          recommended_allowed_ids: Array.isArray(raw.activation.recommended_allowed_ids)
-            ? raw.activation.recommended_allowed_ids.filter(
-                (id): id is string => typeof id === "string",
-              )
-            : undefined,
-        }
-      : undefined,
-  } satisfies CatalogBlueprintManifest;
-  if (!manifest.id || !manifest.version || !manifest.definition.id || !manifest.definition.path) {
-    throw new ValidationError({
-      message:
-        "Catalog blueprint manifest must contain id, version, definition.id, and definition.path.",
-    });
-  }
-  return manifest;
-}
-
-function parsePackManifest(raw: unknown): CatalogPackManifest {
-  if (!isRecord(raw) || raw.schema_version !== 1) {
-    throw new ValidationError({ message: "Blueprint pack manifest schema_version must be 1." });
-  }
-  if (!Array.isArray(raw.blueprints)) {
-    throw new ValidationError({ message: "Blueprint pack manifest blueprints must be an array." });
-  }
-  const pack: CatalogPackManifest = {
-    schema_version: 1,
-    id: typeof raw.id === "string" ? raw.id.trim() : "",
-    version: typeof raw.version === "string" ? raw.version.trim() : "",
-    name: typeof raw.name === "string" ? raw.name.trim() : "",
-    summary: typeof raw.summary === "string" ? raw.summary.trim() : "",
-    blueprints: raw.blueprints.map((entry) => {
-      if (!isRecord(entry) || typeof entry.id !== "string" || !entry.id.trim()) {
-        throw new ValidationError({ message: "Blueprint pack entries must contain id." });
-      }
-      return {
-        id: entry.id.trim(),
-        version: typeof entry.version === "string" ? entry.version.trim() : undefined,
-        required: entry.required === true,
-      };
-    }),
-    activation: isRecord(raw.activation)
-      ? {
-          recommended_allowed_ids: Array.isArray(raw.activation.recommended_allowed_ids)
-            ? raw.activation.recommended_allowed_ids.filter(
-                (id): id is string => typeof id === "string",
-              )
-            : undefined,
-        }
-      : undefined,
-  };
-  if (!pack.id || !pack.version) {
-    throw new ValidationError({ message: "Blueprint pack manifest must contain id and version." });
-  }
-  return pack;
 }
 
 export async function loadBlueprintManifest(opts: {

--- a/packages/agentplane/src/commands/guard/impl/close-message-render.ts
+++ b/packages/agentplane/src/commands/guard/impl/close-message-render.ts
@@ -9,7 +9,7 @@ export type NumstatEntry = {
   churn: number;
 };
 
-export function uniqInOrder(values: string[]): string[] {
+function uniqInOrder(values: string[]): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
   for (const v of values) {

--- a/packages/agentplane/src/context/harvest-tasks-builders.ts
+++ b/packages/agentplane/src/context/harvest-tasks-builders.ts
@@ -238,7 +238,7 @@ function buildReport(opts: {
   };
 }
 
-export function reportPathForWiki(wikiPath: string): string {
+function reportPathForWiki(wikiPath: string): string {
   return `.agentplane/context/derived/reports/task-harvest-${stableHash(wikiPath)}.json`;
 }
 


### PR DESCRIPTION
Task: `202605282346-2A32BY`
Title: Blueprint catalog parser decomposition
Canonical task record: `.agentplane/tasks/202605282346-2A32BY/README.md`

## Summary

Blueprint catalog parser decomposition

Decompose packages/agentplane/src/commands/blueprints/catalog.ts by extracting catalog/manifest types and parsers while preserving catalog load/install behavior.

## Scope

- In scope: Decompose packages/agentplane/src/commands/blueprints/catalog.ts by extracting catalog/manifest types and parsers while preserving catalog load/install behavior.
- Out of scope: unrelated refactors not required for "Blueprint catalog parser decomposition".

## Verification

- State: ok
- Note:

```text
Verified blueprint catalog parser decomposition. Commands passed: focused blueprint catalog vitest
(2 files, 25 tests), bun run typecheck, bun run arch:deps, bun run lint:core, bun run
format:changed, hotspot report check. Runtime hotspot warnings decreased from 33 to 32; catalog.ts
is 307 lines.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-28T23:46:36.926Z
- Branch: task/202605282346-2A32BY/blueprint-catalog-parser-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/commands/blueprints/catalog-model.ts       | 278 ++++++++++++++++++++
 .../agentplane/src/commands/blueprints/catalog.ts  | 291 ++-------------------
 2 files changed, 293 insertions(+), 276 deletions(-)
```

</details>
