### PR TITLE
🚧 M9K6C0 task: Preflight report command decomposition [202605290043-M9K6C0]

### DIFF
--- a/.agentplane/tasks/202605290043-M9K6C0/README.md
+++ b/.agentplane/tasks/202605290043-M9K6C0/README.md
@@ -1,0 +1,122 @@
+---
+id: "202605290043-M9K6C0"
+title: "Preflight report command decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "hotspot"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-29T00:43:18.820Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Extract preflight report drift and message guard helpers while preserving buildPreflightReport output."
+events:
+  -
+    type: "status"
+    at: "2026-05-29T00:43:29.168Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Extract preflight report drift and message guard helpers while preserving buildPreflightReport output."
+doc_version: 3
+doc_updated_at: "2026-05-29T00:43:29.168Z"
+doc_updated_by: "CODER"
+description: "Decompose packages/agentplane/src/cli/run-cli/commands/core/preflight-report.ts into focused preflight report modules while preserving CLI behavior and reducing runtime hotspot warnings."
+sections:
+  Summary: |-
+    Preflight report command decomposition
+
+    Decompose packages/agentplane/src/cli/run-cli/commands/core/preflight-report.ts into focused preflight report modules while preserving CLI behavior and reducing runtime hotspot warnings.
+  Scope: |-
+    - In scope: Decompose packages/agentplane/src/cli/run-cli/commands/core/preflight-report.ts into focused preflight report modules while preserving CLI behavior and reducing runtime hotspot warnings.
+    - Out of scope: unrelated refactors not required for "Preflight report command decomposition".
+  Plan: |-
+    Plan:
+    1. Start branch_pr worktree for CODER.
+    2. Extract preflight report task artifact drift classification and changed PR title guard into focused helper modules.
+    3. Keep buildPreflightReport behavior and PreflightReport public type compatible.
+    4. Verify with preflight/core tests, typecheck, arch/knip/lint/format, and hotspot threshold report.
+    5. Open PR, wait for hosted checks, merge to main, close lifecycle, and clean worktree.
+
+    Acceptance:
+    - preflight report behavior remains compatible.
+    - preflight-report.ts drops below the 400-line hotspot warning threshold.
+    - runtime hotspot warning count decreases from 29 to 28 without adding new warning-sized runtime modules.
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Preflight report command decomposition
+
+Decompose packages/agentplane/src/cli/run-cli/commands/core/preflight-report.ts into focused preflight report modules while preserving CLI behavior and reducing runtime hotspot warnings.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/cli/run-cli/commands/core/preflight-report.ts into focused preflight report modules while preserving CLI behavior and reducing runtime hotspot warnings.
+- Out of scope: unrelated refactors not required for "Preflight report command decomposition".
+
+## Plan
+
+Plan:
+1. Start branch_pr worktree for CODER.
+2. Extract preflight report task artifact drift classification and changed PR title guard into focused helper modules.
+3. Keep buildPreflightReport behavior and PreflightReport public type compatible.
+4. Verify with preflight/core tests, typecheck, arch/knip/lint/format, and hotspot threshold report.
+5. Open PR, wait for hosted checks, merge to main, close lifecycle, and clean worktree.
+
+Acceptance:
+- preflight report behavior remains compatible.
+- preflight-report.ts drops below the 400-line hotspot warning threshold.
+- runtime hotspot warning count decreases from 29 to 28 without adding new warning-sized runtime modules.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605290043-M9K6C0/README.md
+++ b/.agentplane/tasks/202605290043-M9K6C0/README.md
@@ -4,7 +4,7 @@ title: "Preflight report command decomposition"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 4
+revision: 5
 origin:
   system: "manual"
 depends_on: []
@@ -19,10 +19,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-29T00:47:48.232Z"
+  updated_by: "CODER"
+  note: "Verified preflight report decomposition. Commands passed: focused preflight readiness test, bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, hotspot report check. Runtime hotspot warnings decreased from 29 to 28; preflight-report.ts is 332 lines."
   attempts: 0
 commit: null
 comments:
@@ -37,8 +37,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: Extract preflight report drift and message guard helpers while preserving buildPreflightReport output."
+  -
+    type: "verify"
+    at: "2026-05-29T00:47:48.232Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified preflight report decomposition. Commands passed: focused preflight readiness test, bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, hotspot report check. Runtime hotspot warnings decreased from 29 to 28; preflight-report.ts is 332 lines."
 doc_version: 3
-doc_updated_at: "2026-05-29T00:43:29.168Z"
+doc_updated_at: "2026-05-29T00:47:48.257Z"
 doc_updated_by: "CODER"
 description: "Decompose packages/agentplane/src/cli/run-cli/commands/core/preflight-report.ts into focused preflight report modules while preserving CLI behavior and reducing runtime hotspot warnings."
 sections:
@@ -69,6 +75,25 @@ sections:
     3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-29T00:47:48.232Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified preflight report decomposition. Commands passed: focused preflight readiness test, bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, hotspot report check. Runtime hotspot warnings decreased from 29 to 28; preflight-report.ts is 332 lines.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T00:43:29.168Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605290043-M9K6C0-preflight-report-decomposition/.agentplane/tasks/202605290043-M9K6C0/blueprint/resolved-snapshot.json
+    - old_digest: 3ecbec30b224f6f6f30dd6012db5a76def20aaec85ab14edd8c56c321f3d8b57
+    - current_digest: 3ecbec30b224f6f6f30dd6012db5a76def20aaec85ab14edd8c56c321f3d8b57
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605290043-M9K6C0
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -112,6 +137,25 @@ PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLA
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-29T00:47:48.232Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified preflight report decomposition. Commands passed: focused preflight readiness test, bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, hotspot report check. Runtime hotspot warnings decreased from 29 to 28; preflight-report.ts is 332 lines.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T00:43:29.168Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605290043-M9K6C0-preflight-report-decomposition/.agentplane/tasks/202605290043-M9K6C0/blueprint/resolved-snapshot.json
+- old_digest: 3ecbec30b224f6f6f30dd6012db5a76def20aaec85ab14edd8c56c321f3d8b57
+- current_digest: 3ecbec30b224f6f6f30dd6012db5a76def20aaec85ab14edd8c56c321f3d8b57
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605290043-M9K6C0
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605290043-M9K6C0/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605290043-M9K6C0/blueprint/resolved-snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605290043-M9K6C0",
+    "title": "Preflight report command decomposition",
+    "description": "Decompose packages/agentplane/src/cli/run-cli/commands/core/preflight-report.ts into focused preflight report modules while preserving CLI behavior and reducing runtime hotspot warnings.",
+    "tags": [
+      "code",
+      "hotspot",
+      "refactor"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605290043-M9K6C0",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "3ecbec30b224f6f6f30dd6012db5a76def20aaec85ab14edd8c56c321f3d8b57"
+  }
+}

--- a/.agentplane/tasks/202605290043-M9K6C0/pr/diffstat.txt
+++ b/.agentplane/tasks/202605290043-M9K6C0/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ .../commands/core/preflight-report-drift.ts        | 187 ++++++++++++++++
+ .../core/preflight-report-message-guard.ts         |  52 +++++
+ .../cli/run-cli/commands/core/preflight-report.ts  | 241 +--------------------
+ 3 files changed, 251 insertions(+), 229 deletions(-)

--- a/.agentplane/tasks/202605290043-M9K6C0/pr/github-body.md
+++ b/.agentplane/tasks/202605290043-M9K6C0/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605290043-M9K6C0`
+Title: Preflight report command decomposition
+Canonical task record: `.agentplane/tasks/202605290043-M9K6C0/README.md`
+
+## Summary
+
+Preflight report command decomposition
+
+Decompose packages/agentplane/src/cli/run-cli/commands/core/preflight-report.ts into focused preflight report modules while preserving CLI behavior and reducing runtime hotspot warnings.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/cli/run-cli/commands/core/preflight-report.ts into focused preflight report modules while preserving CLI behavior and reducing runtime hotspot warnings.
+- Out of scope: unrelated refactors not required for "Preflight report command decomposition".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T00:43:29.282Z
+- Branch: task/202605290043-M9K6C0/preflight-report-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605290043-M9K6C0/pr/github-body.md
+++ b/.agentplane/tasks/202605290043-M9K6C0/pr/github-body.md
@@ -15,8 +15,15 @@ Decompose packages/agentplane/src/cli/run-cli/commands/core/preflight-report.ts 
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Verified preflight report decomposition. Commands passed: focused preflight readiness test, bun run
+typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed,
+hotspot report check. Runtime hotspot warnings decreased from 29 to 28; preflight-report.ts is 332
+lines.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
@@ -27,7 +34,10 @@ Decompose packages/agentplane/src/cli/run-cli/commands/core/preflight-report.ts 
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../commands/core/preflight-report-drift.ts        | 187 ++++++++++++++++
+ .../core/preflight-report-message-guard.ts         |  52 +++++
+ .../cli/run-cli/commands/core/preflight-report.ts  | 241 +--------------------
+ 3 files changed, 251 insertions(+), 229 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605290043-M9K6C0/pr/github-title.txt
+++ b/.agentplane/tasks/202605290043-M9K6C0/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 M9K6C0 task: Preflight report command decomposition [202605290043-M9K6C0]

--- a/.agentplane/tasks/202605290043-M9K6C0/pr/meta.json
+++ b/.agentplane/tasks/202605290043-M9K6C0/pr/meta.json
@@ -2,12 +2,13 @@
   "base": "main",
   "branch": "task/202605290043-M9K6C0/preflight-report-decomposition",
   "created_at": "2026-05-29T00:43:29.282Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:ec6158e79f59dcf3b003034d241633ba5091962c4d340133861d19cfb1fe913b",
+  "last_verified_at": "2026-05-29T00:47:48.232Z",
+  "last_verified_diffstat_sha256": "sha256:ec6158e79f59dcf3b003034d241633ba5091962c4d340133861d19cfb1fe913b",
   "schema_version": 1,
   "task_id": "202605290043-M9K6C0",
   "updated_at": "2026-05-29T00:43:29.282Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605290043-M9K6C0/pr/meta.json
+++ b/.agentplane/tasks/202605290043-M9K6C0/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202605290043-M9K6C0/preflight-report-decomposition",
+  "created_at": "2026-05-29T00:43:29.282Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202605290043-M9K6C0",
+  "updated_at": "2026-05-29T00:43:29.282Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605290043-M9K6C0/pr/review.md
+++ b/.agentplane/tasks/202605290043-M9K6C0/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-05-29T00:43:29.282Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified preflight report decomposition. Commands passed: focused preflight readiness test, bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, hotspot report check. Runtime hotspot warnings decreased from 29 to 28; preflight-report.ts is 332 lines.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -29,7 +29,10 @@ Created: 2026-05-29T00:43:29.282Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../commands/core/preflight-report-drift.ts        | 187 ++++++++++++++++
+ .../core/preflight-report-message-guard.ts         |  52 +++++
+ .../cli/run-cli/commands/core/preflight-report.ts  | 241 +--------------------
+ 3 files changed, 251 insertions(+), 229 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605290043-M9K6C0/pr/review.md
+++ b/.agentplane/tasks/202605290043-M9K6C0/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-29T00:43:29.282Z
+
+## Task
+
+- Task: `202605290043-M9K6C0`
+- Title: Preflight report command decomposition
+- Status: DOING
+- Branch: `task/202605290043-M9K6C0/preflight-report-decomposition`
+- Canonical task record: `.agentplane/tasks/202605290043-M9K6C0/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T00:43:29.282Z
+- Branch: task/202605290043-M9K6C0/preflight-report-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/cli/run-cli/commands/core/preflight-report-drift.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/core/preflight-report-drift.ts
@@ -1,0 +1,187 @@
+import { normalizeTaskStatus, readTask, type TaskStatus } from "@agentplaneorg/core/tasks";
+
+type TaskArtifactKind = "task_readme" | "handoff" | "pr_artifact" | "blueprint" | "unknown";
+type TaskArtifactClassification =
+  | "active_parallel_task_artifact"
+  | "stale_done_handoff"
+  | "task_blueprint_evidence"
+  | "unknown_task_artifact";
+type TaskArtifactAction =
+  | "ignore_parallel_agent"
+  | "cleanup_candidate"
+  | "commit_with_task_evidence"
+  | "inspect";
+type TaskArtifactDriftItem = {
+  path: string;
+  task_id: string;
+  artifact_kind: TaskArtifactKind;
+  classification: TaskArtifactClassification;
+  action: TaskArtifactAction;
+  status: TaskStatus | "unknown";
+  reason: string;
+};
+export type TaskArtifactDrift = {
+  present: boolean;
+  task_ids: string[];
+  paths: string[];
+  actionable: boolean;
+  items: TaskArtifactDriftItem[];
+  counts: Record<TaskArtifactClassification, number>;
+};
+
+export function emptyTaskArtifactDrift(): TaskArtifactDrift {
+  return {
+    present: false,
+    task_ids: [],
+    paths: [],
+    actionable: false,
+    items: [],
+    counts: {
+      active_parallel_task_artifact: 0,
+      stale_done_handoff: 0,
+      task_blueprint_evidence: 0,
+      unknown_task_artifact: 0,
+    },
+  };
+}
+
+export function normalizeRepoPath(value: string): string {
+  return value.replaceAll("\\", "/");
+}
+
+function inferTaskArtifactKind(relativeTaskPath: string): TaskArtifactKind {
+  if (relativeTaskPath === "README.md") return "task_readme";
+  if (relativeTaskPath.startsWith("handoff/")) return "handoff";
+  if (relativeTaskPath.startsWith("pr/")) return "pr_artifact";
+  if (relativeTaskPath.startsWith("blueprint/")) return "blueprint";
+  return "unknown";
+}
+
+function isActiveParallelStatus(status: TaskStatus | "unknown"): boolean {
+  return status === "TODO" || status === "DOING" || status === "BLOCKED";
+}
+
+function classifyTaskArtifactDriftItem(opts: {
+  path: string;
+  taskId: string;
+  artifactKind: TaskArtifactKind;
+  status: TaskStatus | "unknown";
+}): TaskArtifactDriftItem {
+  if (isActiveParallelStatus(opts.status) && opts.artifactKind === "task_readme") {
+    return {
+      path: opts.path,
+      task_id: opts.taskId,
+      artifact_kind: opts.artifactKind,
+      classification: "active_parallel_task_artifact",
+      action: "ignore_parallel_agent",
+      status: opts.status,
+      reason: "README belongs to an active task and may be owned by another parallel agent",
+    };
+  }
+  if (opts.status === "DONE" && opts.artifactKind === "handoff") {
+    return {
+      path: opts.path,
+      task_id: opts.taskId,
+      artifact_kind: opts.artifactKind,
+      classification: "stale_done_handoff",
+      action: "cleanup_candidate",
+      status: opts.status,
+      reason: "handoff artifact belongs to a completed task and may be stale closure residue",
+    };
+  }
+  if (opts.artifactKind === "blueprint") {
+    return {
+      path: opts.path,
+      task_id: opts.taskId,
+      artifact_kind: opts.artifactKind,
+      classification: "task_blueprint_evidence",
+      action: "commit_with_task_evidence",
+      status: opts.status,
+      reason:
+        "blueprint artifact is task-local verification evidence and must travel with the task artifact commit",
+    };
+  }
+  return {
+    path: opts.path,
+    task_id: opts.taskId,
+    artifact_kind: opts.artifactKind,
+    classification: "unknown_task_artifact",
+    action: "inspect",
+    status: opts.status,
+    reason: "artifact ownership could not be classified from task status and path",
+  };
+}
+
+async function resolveTaskStatus(opts: {
+  gitRoot: string;
+  taskId: string;
+}): Promise<TaskStatus | "unknown"> {
+  try {
+    const task = await readTask({
+      cwd: opts.gitRoot,
+      rootOverride: opts.gitRoot,
+      taskId: opts.taskId,
+    });
+    return normalizeTaskStatus(task.frontmatter.status);
+  } catch {
+    return "unknown";
+  }
+}
+
+export async function detectTaskArtifactDrift(opts: {
+  gitRoot: string;
+  changedPaths: string[];
+  workflowDir: string;
+}): Promise<TaskArtifactDrift> {
+  const workflowDir = normalizeRepoPath(opts.workflowDir).replace(/\/+$/, "");
+  const prefix = `${workflowDir}/`;
+  const matched = opts.changedPaths
+    .map((value) => normalizeRepoPath(value))
+    .filter((value) => value.startsWith(prefix))
+    .toSorted((a, b) => a.localeCompare(b));
+  const taskIds = new Set<string>();
+  for (const matchedPath of matched) {
+    const relative = matchedPath.slice(prefix.length);
+    const [taskId] = relative.split("/", 1);
+    if (taskId && taskId !== "." && taskId !== "..") {
+      taskIds.add(taskId);
+    }
+  }
+  const taskStatusById = new Map<string, TaskStatus | "unknown">();
+  for (const taskId of taskIds) {
+    taskStatusById.set(taskId, await resolveTaskStatus({ gitRoot: opts.gitRoot, taskId }));
+  }
+  const items: TaskArtifactDriftItem[] = [];
+  for (const matchedPath of matched) {
+    const relative = matchedPath.slice(prefix.length);
+    const [taskId, ...artifactParts] = relative.split("/");
+    if (!taskId || taskId === "." || taskId === "..") continue;
+    const artifactKind = inferTaskArtifactKind(artifactParts.join("/"));
+    items.push(
+      classifyTaskArtifactDriftItem({
+        path: matchedPath,
+        taskId,
+        artifactKind,
+        status: taskStatusById.get(taskId) ?? "unknown",
+      }),
+    );
+  }
+  const counts: Record<TaskArtifactClassification, number> = {
+    active_parallel_task_artifact: 0,
+    stale_done_handoff: 0,
+    task_blueprint_evidence: 0,
+    unknown_task_artifact: 0,
+  };
+  for (const item of items) {
+    counts[item.classification] += 1;
+  }
+  const actionable = items.some((item) => item.action !== "ignore_parallel_agent");
+  return {
+    present: matched.length > 0,
+    task_ids: [...taskIds].toSorted((a, b) => a.localeCompare(b)),
+    paths: matched,
+    actionable,
+    items,
+    counts,
+  };
+}

--- a/packages/agentplane/src/cli/run-cli/commands/core/preflight-report-message-guard.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/core/preflight-report-message-guard.ts
@@ -1,0 +1,52 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { validateGithubPrTitleContents } from "../../../../commands/pr/internal/review-template.js";
+
+import { normalizeRepoPath } from "./preflight-report-drift.js";
+
+export type MessageFormatGuard = {
+  ok: boolean;
+  checked_paths: string[];
+  errors: string[];
+};
+
+export function emptyMessageFormatGuard(): MessageFormatGuard {
+  return {
+    ok: true,
+    checked_paths: [],
+    errors: [],
+  };
+}
+
+export async function validateChangedGithubTitleArtifacts(opts: {
+  gitRoot: string;
+  changedPaths: string[];
+  workflowDir: string;
+}): Promise<MessageFormatGuard> {
+  const workflowDir = normalizeRepoPath(opts.workflowDir).replace(/\/+$/, "");
+  const prefix = `${workflowDir}/`;
+  const suffix = "/pr/github-title.txt";
+  const checkedPaths = opts.changedPaths
+    .map((value) => normalizeRepoPath(value))
+    .filter((value) => value.startsWith(prefix) && value.endsWith(suffix))
+    .toSorted((a, b) => a.localeCompare(b));
+  const errors: string[] = [];
+  for (const relPath of checkedPaths) {
+    const relative = relPath.slice(prefix.length);
+    const taskId = relative.slice(0, -suffix.length);
+    if (!taskId || taskId.includes("/")) {
+      errors.push(`${relPath}: cannot infer task id from PR title artifact path`);
+      continue;
+    }
+    const title = await readFile(path.join(opts.gitRoot, relPath), "utf8");
+    const titleErrors: string[] = [];
+    validateGithubPrTitleContents(title, taskId, titleErrors);
+    errors.push(...titleErrors.map((message) => `${relPath}: ${message}`));
+  }
+  return {
+    ok: errors.length === 0,
+    checked_paths: checkedPaths,
+    errors,
+  };
+}

--- a/packages/agentplane/src/cli/run-cli/commands/core/preflight-report.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/core/preflight-report.ts
@@ -1,13 +1,8 @@
-import { readFile } from "node:fs/promises";
-import path from "node:path";
-
 import { loadConfig, type AgentplaneConfig } from "@agentplaneorg/core/config";
 import { GitContext } from "@agentplaneorg/core/git";
 import { resolveProject } from "@agentplaneorg/core/project";
-import { normalizeTaskStatus, readTask, type TaskStatus } from "@agentplaneorg/core/tasks";
 
 import { loadTaskBackend, toTaskSummary } from "../../../../backends/task-backend.js";
-import { validateGithubPrTitleContents } from "../../../../commands/pr/internal/review-template.js";
 import { gitCurrentBranch } from "../../../../commands/shared/git-ops.js";
 import { dedupeStrings } from "../../../../shared/strings.js";
 import {
@@ -16,43 +11,20 @@ import {
   workflowEnforcementEnvHint,
 } from "../../../../workflow-runtime/index.js";
 import { renderQuickstart } from "../../../command-guide.js";
+import {
+  detectTaskArtifactDrift,
+  emptyTaskArtifactDrift,
+  type TaskArtifactDrift,
+} from "./preflight-report-drift.js";
+import {
+  emptyMessageFormatGuard,
+  validateChangedGithubTitleArtifacts,
+  type MessageFormatGuard,
+} from "./preflight-report-message-guard.js";
 
 export type PreflightMode = "quick" | "full";
 type NextAction = { command: string; reason: string };
 type Probe = { ok: boolean; error?: string };
-type TaskArtifactKind = "task_readme" | "handoff" | "pr_artifact" | "blueprint" | "unknown";
-type TaskArtifactClassification =
-  | "active_parallel_task_artifact"
-  | "stale_done_handoff"
-  | "task_blueprint_evidence"
-  | "unknown_task_artifact";
-type TaskArtifactAction =
-  | "ignore_parallel_agent"
-  | "cleanup_candidate"
-  | "commit_with_task_evidence"
-  | "inspect";
-type TaskArtifactDriftItem = {
-  path: string;
-  task_id: string;
-  artifact_kind: TaskArtifactKind;
-  classification: TaskArtifactClassification;
-  action: TaskArtifactAction;
-  status: TaskStatus | "unknown";
-  reason: string;
-};
-type TaskArtifactDrift = {
-  present: boolean;
-  task_ids: string[];
-  paths: string[];
-  actionable: boolean;
-  items: TaskArtifactDriftItem[];
-  counts: Record<TaskArtifactClassification, number>;
-};
-type MessageFormatGuard = {
-  ok: boolean;
-  checked_paths: string[];
-  errors: string[];
-};
 
 export type PreflightReport = {
   mode: PreflightMode;
@@ -108,179 +80,6 @@ function inferApprovals(config: AgentplaneConfig | null): PreflightReport["appro
     require_plan: approvals.require_plan,
     require_verify: approvals.require_verify,
     require_network: approvals.require_network,
-  };
-}
-
-function normalizeRepoPath(value: string): string {
-  return value.replaceAll("\\", "/");
-}
-
-function inferTaskArtifactKind(relativeTaskPath: string): TaskArtifactKind {
-  if (relativeTaskPath === "README.md") return "task_readme";
-  if (relativeTaskPath.startsWith("handoff/")) return "handoff";
-  if (relativeTaskPath.startsWith("pr/")) return "pr_artifact";
-  if (relativeTaskPath.startsWith("blueprint/")) return "blueprint";
-  return "unknown";
-}
-
-function isActiveParallelStatus(status: TaskStatus | "unknown"): boolean {
-  return status === "TODO" || status === "DOING" || status === "BLOCKED";
-}
-
-function classifyTaskArtifactDriftItem(opts: {
-  path: string;
-  taskId: string;
-  artifactKind: TaskArtifactKind;
-  status: TaskStatus | "unknown";
-}): TaskArtifactDriftItem {
-  if (isActiveParallelStatus(opts.status) && opts.artifactKind === "task_readme") {
-    return {
-      path: opts.path,
-      task_id: opts.taskId,
-      artifact_kind: opts.artifactKind,
-      classification: "active_parallel_task_artifact",
-      action: "ignore_parallel_agent",
-      status: opts.status,
-      reason: "README belongs to an active task and may be owned by another parallel agent",
-    };
-  }
-  if (opts.status === "DONE" && opts.artifactKind === "handoff") {
-    return {
-      path: opts.path,
-      task_id: opts.taskId,
-      artifact_kind: opts.artifactKind,
-      classification: "stale_done_handoff",
-      action: "cleanup_candidate",
-      status: opts.status,
-      reason: "handoff artifact belongs to a completed task and may be stale closure residue",
-    };
-  }
-  if (opts.artifactKind === "blueprint") {
-    return {
-      path: opts.path,
-      task_id: opts.taskId,
-      artifact_kind: opts.artifactKind,
-      classification: "task_blueprint_evidence",
-      action: "commit_with_task_evidence",
-      status: opts.status,
-      reason:
-        "blueprint artifact is task-local verification evidence and must travel with the task artifact commit",
-    };
-  }
-  return {
-    path: opts.path,
-    task_id: opts.taskId,
-    artifact_kind: opts.artifactKind,
-    classification: "unknown_task_artifact",
-    action: "inspect",
-    status: opts.status,
-    reason: "artifact ownership could not be classified from task status and path",
-  };
-}
-
-async function resolveTaskStatus(opts: {
-  gitRoot: string;
-  taskId: string;
-}): Promise<TaskStatus | "unknown"> {
-  try {
-    const task = await readTask({
-      cwd: opts.gitRoot,
-      rootOverride: opts.gitRoot,
-      taskId: opts.taskId,
-    });
-    return normalizeTaskStatus(task.frontmatter.status);
-  } catch {
-    return "unknown";
-  }
-}
-
-async function detectTaskArtifactDrift(opts: {
-  gitRoot: string;
-  changedPaths: string[];
-  workflowDir: string;
-}): Promise<TaskArtifactDrift> {
-  const workflowDir = normalizeRepoPath(opts.workflowDir).replace(/\/+$/, "");
-  const prefix = `${workflowDir}/`;
-  const matched = opts.changedPaths
-    .map((value) => normalizeRepoPath(value))
-    .filter((value) => value.startsWith(prefix))
-    .toSorted((a, b) => a.localeCompare(b));
-  const taskIds = new Set<string>();
-  for (const matchedPath of matched) {
-    const relative = matchedPath.slice(prefix.length);
-    const [taskId] = relative.split("/", 1);
-    if (taskId && taskId !== "." && taskId !== "..") {
-      taskIds.add(taskId);
-    }
-  }
-  const taskStatusById = new Map<string, TaskStatus | "unknown">();
-  for (const taskId of taskIds) {
-    taskStatusById.set(taskId, await resolveTaskStatus({ gitRoot: opts.gitRoot, taskId }));
-  }
-  const items: TaskArtifactDriftItem[] = [];
-  for (const matchedPath of matched) {
-    const relative = matchedPath.slice(prefix.length);
-    const [taskId, ...artifactParts] = relative.split("/");
-    if (!taskId || taskId === "." || taskId === "..") continue;
-    const artifactKind = inferTaskArtifactKind(artifactParts.join("/"));
-    items.push(
-      classifyTaskArtifactDriftItem({
-        path: matchedPath,
-        taskId,
-        artifactKind,
-        status: taskStatusById.get(taskId) ?? "unknown",
-      }),
-    );
-  }
-  const counts: Record<TaskArtifactClassification, number> = {
-    active_parallel_task_artifact: 0,
-    stale_done_handoff: 0,
-    task_blueprint_evidence: 0,
-    unknown_task_artifact: 0,
-  };
-  for (const item of items) {
-    counts[item.classification] += 1;
-  }
-  const actionable = items.some((item) => item.action !== "ignore_parallel_agent");
-  return {
-    present: matched.length > 0,
-    task_ids: [...taskIds].toSorted((a, b) => a.localeCompare(b)),
-    paths: matched,
-    actionable,
-    items,
-    counts,
-  };
-}
-
-async function validateChangedGithubTitleArtifacts(opts: {
-  gitRoot: string;
-  changedPaths: string[];
-  workflowDir: string;
-}): Promise<MessageFormatGuard> {
-  const workflowDir = normalizeRepoPath(opts.workflowDir).replace(/\/+$/, "");
-  const prefix = `${workflowDir}/`;
-  const suffix = "/pr/github-title.txt";
-  const checkedPaths = opts.changedPaths
-    .map((value) => normalizeRepoPath(value))
-    .filter((value) => value.startsWith(prefix) && value.endsWith(suffix))
-    .toSorted((a, b) => a.localeCompare(b));
-  const errors: string[] = [];
-  for (const relPath of checkedPaths) {
-    const relative = relPath.slice(prefix.length);
-    const taskId = relative.slice(0, -suffix.length);
-    if (!taskId || taskId.includes("/")) {
-      errors.push(`${relPath}: cannot infer task id from PR title artifact path`);
-      continue;
-    }
-    const title = await readFile(path.join(opts.gitRoot, relPath), "utf8");
-    const titleErrors: string[] = [];
-    validateGithubPrTitleContents(title, taskId, titleErrors);
-    errors.push(...titleErrors.map((message) => `${relPath}: ${message}`));
-  }
-  return {
-    ok: errors.length === 0,
-    checked_paths: checkedPaths,
-    errors,
   };
 }
 
@@ -446,24 +245,8 @@ export async function buildPreflightReport(opts: {
     ok: false,
     error: "project not resolved",
   };
-  let taskArtifactDrift: TaskArtifactDrift = {
-    present: false,
-    task_ids: [],
-    paths: [],
-    actionable: false,
-    items: [],
-    counts: {
-      active_parallel_task_artifact: 0,
-      stale_done_handoff: 0,
-      task_blueprint_evidence: 0,
-      unknown_task_artifact: 0,
-    },
-  };
-  let messageFormatGuard: MessageFormatGuard = {
-    ok: true,
-    checked_paths: [],
-    errors: [],
-  };
+  let taskArtifactDrift: TaskArtifactDrift = emptyTaskArtifactDrift();
+  let messageFormatGuard: MessageFormatGuard = emptyMessageFormatGuard();
   let branch: PreflightReport["current_branch"] = {
     ok: false,
     error: "project not resolved",


### PR DESCRIPTION
Task: `202605290043-M9K6C0`
Title: Preflight report command decomposition
Canonical task record: `.agentplane/tasks/202605290043-M9K6C0/README.md`

## Summary

Preflight report command decomposition

Decompose packages/agentplane/src/cli/run-cli/commands/core/preflight-report.ts into focused preflight report modules while preserving CLI behavior and reducing runtime hotspot warnings.

## Scope

- In scope: Decompose packages/agentplane/src/cli/run-cli/commands/core/preflight-report.ts into focused preflight report modules while preserving CLI behavior and reducing runtime hotspot warnings.
- Out of scope: unrelated refactors not required for "Preflight report command decomposition".

## Verification

- State: ok
- Note:

```text
Verified preflight report decomposition. Commands passed: focused preflight readiness test, bun run
typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed,
hotspot report check. Runtime hotspot warnings decreased from 29 to 28; preflight-report.ts is 332
lines.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-29T00:43:29.282Z
- Branch: task/202605290043-M9K6C0/preflight-report-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../commands/core/preflight-report-drift.ts        | 187 ++++++++++++++++
 .../core/preflight-report-message-guard.ts         |  52 +++++
 .../cli/run-cli/commands/core/preflight-report.ts  | 241 +--------------------
 3 files changed, 251 insertions(+), 229 deletions(-)
```

</details>
