### PR TITLE
🚧 CR056N task: Blueprint project-local decomposition [202605290053-CR056N]

### DIFF
--- a/.agentplane/tasks/202605290053-CR056N/README.md
+++ b/.agentplane/tasks/202605290053-CR056N/README.md
@@ -4,7 +4,7 @@ title: "Blueprint project-local decomposition"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 4
+revision: 5
 origin:
   system: "manual"
 depends_on: []
@@ -19,10 +19,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-29T01:06:18.246Z"
+  updated_by: "CODER"
+  note: "Verified project-local blueprint decomposition. Commands passed: project-local focused tests, bun run typecheck, bun run arch:check, bun run knip:check after reviewed baseline remap, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 28 to 27; project-local.ts is below the 400-line warning threshold."
   attempts: 0
 commit: null
 comments:
@@ -37,8 +37,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: Decompose project-local blueprint trust/config and file parsing helpers while preserving public API behavior."
+  -
+    type: "verify"
+    at: "2026-05-29T01:06:18.246Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified project-local blueprint decomposition. Commands passed: project-local focused tests, bun run typecheck, bun run arch:check, bun run knip:check after reviewed baseline remap, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 28 to 27; project-local.ts is below the 400-line warning threshold."
 doc_version: 3
-doc_updated_at: "2026-05-29T00:54:58.996Z"
+doc_updated_at: "2026-05-29T01:06:18.272Z"
 doc_updated_by: "CODER"
 description: "Decompose packages/agentplane/src/blueprints/project-local.ts into focused project-local blueprint modules while preserving behavior and reducing runtime hotspot warnings."
 sections:
@@ -69,6 +75,25 @@ sections:
     3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-29T01:06:18.246Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified project-local blueprint decomposition. Commands passed: project-local focused tests, bun run typecheck, bun run arch:check, bun run knip:check after reviewed baseline remap, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 28 to 27; project-local.ts is below the 400-line warning threshold.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T00:54:58.996Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605290053-CR056N-blueprint-project-local-decomposition/.agentplane/tasks/202605290053-CR056N/blueprint/resolved-snapshot.json
+    - old_digest: 1f309aff64eadf6c1ce96967b4bed57ef33a11b3b5a35192ef8d8a73a9601c9a
+    - current_digest: 1f309aff64eadf6c1ce96967b4bed57ef33a11b3b5a35192ef8d8a73a9601c9a
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605290053-CR056N
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -112,6 +137,25 @@ PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLA
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-29T01:06:18.246Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified project-local blueprint decomposition. Commands passed: project-local focused tests, bun run typecheck, bun run arch:check, bun run knip:check after reviewed baseline remap, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 28 to 27; project-local.ts is below the 400-line warning threshold.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T00:54:58.996Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605290053-CR056N-blueprint-project-local-decomposition/.agentplane/tasks/202605290053-CR056N/blueprint/resolved-snapshot.json
+- old_digest: 1f309aff64eadf6c1ce96967b4bed57ef33a11b3b5a35192ef8d8a73a9601c9a
+- current_digest: 1f309aff64eadf6c1ce96967b4bed57ef33a11b3b5a35192ef8d8a73a9601c9a
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605290053-CR056N
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605290053-CR056N/README.md
+++ b/.agentplane/tasks/202605290053-CR056N/README.md
@@ -1,0 +1,122 @@
+---
+id: "202605290053-CR056N"
+title: "Blueprint project-local decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "hotspot"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-29T00:54:44.855Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Decompose project-local blueprint trust/config and file parsing helpers while preserving public API behavior."
+events:
+  -
+    type: "status"
+    at: "2026-05-29T00:54:58.996Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Decompose project-local blueprint trust/config and file parsing helpers while preserving public API behavior."
+doc_version: 3
+doc_updated_at: "2026-05-29T00:54:58.996Z"
+doc_updated_by: "CODER"
+description: "Decompose packages/agentplane/src/blueprints/project-local.ts into focused project-local blueprint modules while preserving behavior and reducing runtime hotspot warnings."
+sections:
+  Summary: |-
+    Blueprint project-local decomposition
+
+    Decompose packages/agentplane/src/blueprints/project-local.ts into focused project-local blueprint modules while preserving behavior and reducing runtime hotspot warnings.
+  Scope: |-
+    - In scope: Decompose packages/agentplane/src/blueprints/project-local.ts into focused project-local blueprint modules while preserving behavior and reducing runtime hotspot warnings.
+    - Out of scope: unrelated refactors not required for "Blueprint project-local decomposition".
+  Plan: |-
+    Plan:
+    1. Start branch_pr worktree for CODER.
+    2. Extract project-local blueprint trust/config helpers and file parsing/loading helpers from packages/agentplane/src/blueprints/project-local.ts into focused modules.
+    3. Keep public project-local functions and behavior compatible.
+    4. Verify with project-local blueprint tests, typecheck, arch/knip/lint/format, and hotspot threshold report.
+    5. Open PR, wait for hosted checks, merge to main, close lifecycle, and clean worktree.
+
+    Acceptance:
+    - project-local blueprint loading, trust config, compatibility report, and scaffold behavior remain compatible.
+    - project-local.ts drops below the 400-line hotspot warning threshold.
+    - runtime hotspot warning count decreases from 28 to 27 without adding new warning-sized runtime modules.
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Blueprint project-local decomposition
+
+Decompose packages/agentplane/src/blueprints/project-local.ts into focused project-local blueprint modules while preserving behavior and reducing runtime hotspot warnings.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/blueprints/project-local.ts into focused project-local blueprint modules while preserving behavior and reducing runtime hotspot warnings.
+- Out of scope: unrelated refactors not required for "Blueprint project-local decomposition".
+
+## Plan
+
+Plan:
+1. Start branch_pr worktree for CODER.
+2. Extract project-local blueprint trust/config helpers and file parsing/loading helpers from packages/agentplane/src/blueprints/project-local.ts into focused modules.
+3. Keep public project-local functions and behavior compatible.
+4. Verify with project-local blueprint tests, typecheck, arch/knip/lint/format, and hotspot threshold report.
+5. Open PR, wait for hosted checks, merge to main, close lifecycle, and clean worktree.
+
+Acceptance:
+- project-local blueprint loading, trust config, compatibility report, and scaffold behavior remain compatible.
+- project-local.ts drops below the 400-line hotspot warning threshold.
+- runtime hotspot warning count decreases from 28 to 27 without adding new warning-sized runtime modules.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605290053-CR056N/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605290053-CR056N/blueprint/resolved-snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605290053-CR056N",
+    "title": "Blueprint project-local decomposition",
+    "description": "Decompose packages/agentplane/src/blueprints/project-local.ts into focused project-local blueprint modules while preserving behavior and reducing runtime hotspot warnings.",
+    "tags": [
+      "code",
+      "hotspot",
+      "refactor"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605290053-CR056N",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "1f309aff64eadf6c1ce96967b4bed57ef33a11b3b5a35192ef8d8a73a9601c9a"
+  }
+}

--- a/.agentplane/tasks/202605290053-CR056N/pr/diffstat.txt
+++ b/.agentplane/tasks/202605290053-CR056N/pr/diffstat.txt
@@ -1,0 +1,6 @@
+ .../src/blueprints/project-local-files.ts          | 152 ++++++++
+ .../src/blueprints/project-local-model.ts          | 111 ++++++
+ .../src/blueprints/project-local-trust.ts          | 138 +++++++
+ .../agentplane/src/blueprints/project-local.ts     | 417 +++------------------
+ scripts/baselines/knip-baseline.json               |  55 ++-
+ 5 files changed, 484 insertions(+), 389 deletions(-)

--- a/.agentplane/tasks/202605290053-CR056N/pr/github-body.md
+++ b/.agentplane/tasks/202605290053-CR056N/pr/github-body.md
@@ -15,8 +15,15 @@ Decompose packages/agentplane/src/blueprints/project-local.ts into focused proje
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Verified project-local blueprint decomposition. Commands passed: project-local focused tests, bun
+run typecheck, bun run arch:check, bun run knip:check after reviewed baseline remap, bun run
+lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from
+28 to 27; project-local.ts is below the 400-line warning threshold.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
@@ -27,7 +34,12 @@ Decompose packages/agentplane/src/blueprints/project-local.ts into focused proje
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/blueprints/project-local-files.ts          | 152 ++++++++
+ .../src/blueprints/project-local-model.ts          | 111 ++++++
+ .../src/blueprints/project-local-trust.ts          | 138 +++++++
+ .../agentplane/src/blueprints/project-local.ts     | 417 +++------------------
+ scripts/baselines/knip-baseline.json               |  55 ++-
+ 5 files changed, 484 insertions(+), 389 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605290053-CR056N/pr/github-body.md
+++ b/.agentplane/tasks/202605290053-CR056N/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605290053-CR056N`
+Title: Blueprint project-local decomposition
+Canonical task record: `.agentplane/tasks/202605290053-CR056N/README.md`
+
+## Summary
+
+Blueprint project-local decomposition
+
+Decompose packages/agentplane/src/blueprints/project-local.ts into focused project-local blueprint modules while preserving behavior and reducing runtime hotspot warnings.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/blueprints/project-local.ts into focused project-local blueprint modules while preserving behavior and reducing runtime hotspot warnings.
+- Out of scope: unrelated refactors not required for "Blueprint project-local decomposition".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T00:54:59.111Z
+- Branch: task/202605290053-CR056N/blueprint-project-local-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605290053-CR056N/pr/github-title.txt
+++ b/.agentplane/tasks/202605290053-CR056N/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 CR056N task: Blueprint project-local decomposition [202605290053-CR056N]

--- a/.agentplane/tasks/202605290053-CR056N/pr/meta.json
+++ b/.agentplane/tasks/202605290053-CR056N/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202605290053-CR056N/blueprint-project-local-decomposition",
+  "created_at": "2026-05-29T00:54:59.111Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202605290053-CR056N",
+  "updated_at": "2026-05-29T00:54:59.111Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605290053-CR056N/pr/meta.json
+++ b/.agentplane/tasks/202605290053-CR056N/pr/meta.json
@@ -2,12 +2,13 @@
   "base": "main",
   "branch": "task/202605290053-CR056N/blueprint-project-local-decomposition",
   "created_at": "2026-05-29T00:54:59.111Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:1f2f2eff947408c4ebecc3e2071be61be4d398cbf2f32076ac06bece0f810edf",
+  "last_verified_at": "2026-05-29T01:06:18.246Z",
+  "last_verified_diffstat_sha256": "sha256:1f2f2eff947408c4ebecc3e2071be61be4d398cbf2f32076ac06bece0f810edf",
   "schema_version": 1,
   "task_id": "202605290053-CR056N",
   "updated_at": "2026-05-29T00:54:59.111Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605290053-CR056N/pr/review.md
+++ b/.agentplane/tasks/202605290053-CR056N/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-29T00:54:59.111Z
+
+## Task
+
+- Task: `202605290053-CR056N`
+- Title: Blueprint project-local decomposition
+- Status: DOING
+- Branch: `task/202605290053-CR056N/blueprint-project-local-decomposition`
+- Canonical task record: `.agentplane/tasks/202605290053-CR056N/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T00:54:59.111Z
+- Branch: task/202605290053-CR056N/blueprint-project-local-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605290053-CR056N/pr/review.md
+++ b/.agentplane/tasks/202605290053-CR056N/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-05-29T00:54:59.111Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified project-local blueprint decomposition. Commands passed: project-local focused tests, bun run typecheck, bun run arch:check, bun run knip:check after reviewed baseline remap, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 28 to 27; project-local.ts is below the 400-line warning threshold.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -29,7 +29,12 @@ Created: 2026-05-29T00:54:59.111Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/blueprints/project-local-files.ts          | 152 ++++++++
+ .../src/blueprints/project-local-model.ts          | 111 ++++++
+ .../src/blueprints/project-local-trust.ts          | 138 +++++++
+ .../agentplane/src/blueprints/project-local.ts     | 417 +++------------------
+ scripts/baselines/knip-baseline.json               |  55 ++-
+ 5 files changed, 484 insertions(+), 389 deletions(-)
 ```
 
 </details>

--- a/packages/agentplane/src/blueprints/project-local-files.ts
+++ b/packages/agentplane/src/blueprints/project-local-files.ts
@@ -1,0 +1,152 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { validateBlueprint } from "./validate.js";
+import type { Blueprint, BlueprintValidationResult } from "./model.js";
+import {
+  PROJECT_BLUEPRINTS_CONFIG_NAME,
+  problem,
+  type ProjectBlueprintDirectoryResult,
+  type ProjectBlueprintFileResult,
+  type ProjectBlueprintProblem,
+} from "./project-local-model.js";
+
+function requireObjectResult(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function requiredArrayFieldErrors(
+  value: Record<string, unknown>,
+  filePath: string,
+): ProjectBlueprintProblem[] {
+  const errors: ProjectBlueprintProblem[] = [];
+  for (const field of [
+    "taskKinds",
+    "allowedCommands",
+    "policyModules",
+    "nodes",
+    "edges",
+    "requiredEvidence",
+    "stopRules",
+  ]) {
+    if (!Array.isArray(value[field])) {
+      errors.push(
+        problem(
+          "invalid_shape",
+          `Blueprint file ${JSON.stringify(filePath)} is missing array field ${JSON.stringify(field)}.`,
+          field,
+        ),
+      );
+    }
+  }
+  return errors;
+}
+
+export function parseProjectBlueprintJsonInternal(
+  raw: string,
+  filePath: string,
+): ProjectBlueprintFileResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return {
+      ok: false,
+      path: filePath,
+      errors: [
+        problem(
+          "invalid_json",
+          `Blueprint file ${JSON.stringify(filePath)} is not valid JSON: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        ),
+      ],
+    };
+  }
+
+  if (!requireObjectResult(parsed)) {
+    return {
+      ok: false,
+      path: filePath,
+      errors: [
+        problem(
+          "invalid_shape",
+          `Blueprint file ${JSON.stringify(filePath)} must contain one JSON object.`,
+        ),
+      ],
+    };
+  }
+
+  const shapeErrors = requiredArrayFieldErrors(parsed, filePath);
+  if (shapeErrors.length > 0) {
+    return {
+      ok: false,
+      path: filePath,
+      blueprintId: typeof parsed.id === "string" ? parsed.id : undefined,
+      errors: shapeErrors,
+    };
+  }
+
+  const blueprint = parsed as Blueprint;
+  let validation: BlueprintValidationResult;
+  try {
+    validation = validateBlueprint(blueprint);
+  } catch (err) {
+    return {
+      ok: false,
+      path: filePath,
+      blueprintId: typeof parsed.id === "string" ? parsed.id : undefined,
+      errors: [
+        problem(
+          "invalid_shape",
+          `Blueprint file ${JSON.stringify(filePath)} has an invalid blueprint shape: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        ),
+      ],
+    };
+  }
+  return {
+    ok: validation.ok,
+    path: filePath,
+    blueprint,
+    blueprintId: typeof blueprint.id === "string" ? blueprint.id : undefined,
+    errors: validation.errors,
+  };
+}
+
+export async function validateProjectBlueprintFile(
+  filePath: string,
+): Promise<ProjectBlueprintFileResult> {
+  return parseProjectBlueprintJsonInternal(await readFile(filePath, "utf8"), filePath);
+}
+
+async function listJsonFiles(directory: string): Promise<string[]> {
+  try {
+    const entries = await readdir(directory, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+      .filter((entry) => entry.name !== PROJECT_BLUEPRINTS_CONFIG_NAME)
+      .map((entry) => path.join(directory, entry.name))
+      .toSorted();
+  } catch (err) {
+    if (err instanceof Error && "code" in err && err.code === "ENOENT") return [];
+    throw err;
+  }
+}
+
+export async function validateProjectBlueprintDirectory(
+  directory: string,
+): Promise<ProjectBlueprintDirectoryResult> {
+  const jsonFiles = await listJsonFiles(directory);
+  const files = await Promise.all(
+    jsonFiles.map((filePath) => validateProjectBlueprintFile(filePath)),
+  );
+  const errors = files.flatMap((file) => file.errors);
+  return {
+    ok: errors.length === 0,
+    directory,
+    files,
+    errors,
+  };
+}

--- a/packages/agentplane/src/blueprints/project-local-model.ts
+++ b/packages/agentplane/src/blueprints/project-local-model.ts
@@ -1,0 +1,111 @@
+import path from "node:path";
+
+import type { Blueprint, BlueprintId, BlueprintValidationProblem } from "./model.js";
+
+export const PROJECT_BLUEPRINTS_DIR = ".agentplane/blueprints";
+export const PROJECT_BLUEPRINTS_CONFIG_NAME = "config.json";
+
+export type ProjectBlueprintProblemCode =
+  | BlueprintValidationProblem["code"]
+  | "builtin_shadow"
+  | "invalid_json"
+  | "invalid_shape"
+  | "invalid_trust_config"
+  | "missing_blueprint_directory";
+
+export type ProjectBlueprintProblem = {
+  code: ProjectBlueprintProblemCode;
+  message: string;
+  path?: string;
+};
+
+export type ProjectBlueprintFileResult = {
+  ok: boolean;
+  path: string;
+  blueprint?: Blueprint;
+  blueprintId?: string;
+  errors: ProjectBlueprintProblem[];
+};
+
+export type ProjectBlueprintDirectoryResult = {
+  ok: boolean;
+  directory: string;
+  files: ProjectBlueprintFileResult[];
+  errors: ProjectBlueprintProblem[];
+};
+
+export type ProjectBlueprintTrustConfig = {
+  schemaVersion: 1;
+  trustModel: "explicit_allowlist";
+  enabled: boolean;
+  allowedIds: readonly BlueprintId[];
+  selection: "explicit_only";
+};
+
+export type ProjectBlueprintTrustConfigResult = {
+  ok: boolean;
+  path: string;
+  exists: boolean;
+  config: ProjectBlueprintTrustConfig;
+  errors: ProjectBlueprintProblem[];
+};
+
+export type TrustedProjectBlueprintRegistryResult = {
+  ok: boolean;
+  directory: string;
+  trustConfig: ProjectBlueprintTrustConfigResult;
+  files: ProjectBlueprintFileResult[];
+  trustedBlueprints: Blueprint[];
+  errors: ProjectBlueprintProblem[];
+};
+
+export type ProjectBlueprintCompatibilityReport = {
+  schemaVersion: 1;
+  compatible: boolean;
+  directory: string;
+  trustConfig: {
+    path: string;
+    exists: boolean;
+    ok: boolean;
+    config: ProjectBlueprintTrustConfig;
+  };
+  blueprints: {
+    path: string;
+    ok: boolean;
+    blueprintId?: string;
+    trusted: boolean;
+    errors: ProjectBlueprintProblem[];
+  }[];
+  trustedBlueprintIds: readonly BlueprintId[];
+  errors: ProjectBlueprintProblem[];
+};
+
+export type ScaffoldProjectBlueprintOptions = {
+  projectRoot: string;
+  id: BlueprintId;
+  from?: BlueprintId;
+  out?: string;
+  force?: boolean;
+};
+
+export function problem(
+  code: ProjectBlueprintProblemCode,
+  message: string,
+  path?: string,
+): ProjectBlueprintProblem {
+  return { code, message, ...(path ? { path } : {}) };
+}
+
+export function defaultTrustConfig(): ProjectBlueprintTrustConfig {
+  return {
+    schemaVersion: 1,
+    trustModel: "explicit_allowlist",
+    enabled: false,
+    allowedIds: [],
+    selection: "explicit_only",
+  };
+}
+
+export function projectBlueprintsDirectory(projectRoot: string): string {
+  return path.join(projectRoot, PROJECT_BLUEPRINTS_DIR);
+}

--- a/packages/agentplane/src/blueprints/project-local-trust.ts
+++ b/packages/agentplane/src/blueprints/project-local-trust.ts
@@ -1,0 +1,138 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { BlueprintId } from "./model.js";
+import {
+  PROJECT_BLUEPRINTS_CONFIG_NAME,
+  defaultTrustConfig,
+  problem,
+  projectBlueprintsDirectory,
+  type ProjectBlueprintProblem,
+  type ProjectBlueprintTrustConfigResult,
+} from "./project-local-model.js";
+
+function requireObjectResult(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function parseTrustConfigJson(raw: string, filePath: string): ProjectBlueprintTrustConfigResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return {
+      ok: false,
+      path: filePath,
+      exists: true,
+      config: defaultTrustConfig(),
+      errors: [
+        problem(
+          "invalid_json",
+          `Blueprint trust config ${JSON.stringify(filePath)} is not valid JSON: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        ),
+      ],
+    };
+  }
+
+  if (!requireObjectResult(parsed)) {
+    return {
+      ok: false,
+      path: filePath,
+      exists: true,
+      config: defaultTrustConfig(),
+      errors: [
+        problem(
+          "invalid_trust_config",
+          `Blueprint trust config ${JSON.stringify(filePath)} must contain one JSON object.`,
+        ),
+      ],
+    };
+  }
+
+  const errors: ProjectBlueprintProblem[] = [];
+  const schemaVersion = parsed.schema_version === undefined ? 1 : parsed.schema_version;
+  if (schemaVersion !== 1) {
+    errors.push(
+      problem("invalid_trust_config", "Blueprint trust config schema_version must be 1."),
+    );
+  }
+  const trustModel = parsed.trust_model === undefined ? "explicit_allowlist" : parsed.trust_model;
+  if (trustModel !== "explicit_allowlist") {
+    errors.push(
+      problem(
+        "invalid_trust_config",
+        "Blueprint trust config trust_model must be explicit_allowlist.",
+      ),
+    );
+  }
+  const enabled = parsed.enabled === true;
+  if ("enabled" in parsed && typeof parsed.enabled !== "boolean") {
+    errors.push(problem("invalid_trust_config", "Blueprint trust config enabled must be boolean."));
+  }
+  const allowedIds: string[] = [];
+  if ("allowed_ids" in parsed && !Array.isArray(parsed.allowed_ids)) {
+    errors.push(
+      problem("invalid_trust_config", "Blueprint trust config allowed_ids must be an array."),
+    );
+  }
+  if (Array.isArray(parsed.allowed_ids)) {
+    for (const [index, item] of parsed.allowed_ids.entries()) {
+      if (typeof item !== "string" || item.trim().length === 0) {
+        errors.push(
+          problem(
+            "invalid_trust_config",
+            `Blueprint trust config allowed_ids[${index}] must be a non-empty string.`,
+          ),
+        );
+        continue;
+      }
+      allowedIds.push(item.trim());
+    }
+  }
+  const selection = parsed.selection === undefined ? "explicit_only" : parsed.selection;
+  if (selection !== "explicit_only") {
+    errors.push(
+      problem("invalid_trust_config", "Blueprint trust config selection must be explicit_only."),
+    );
+  }
+
+  return {
+    ok: errors.length === 0,
+    path: filePath,
+    exists: true,
+    config: {
+      schemaVersion: 1,
+      trustModel: "explicit_allowlist",
+      enabled,
+      allowedIds: allowedIds.map((id) => id.trim() as BlueprintId),
+      selection: "explicit_only",
+    },
+    errors,
+  };
+}
+
+export function projectBlueprintsConfigPath(projectRoot: string): string {
+  return path.join(projectBlueprintsDirectory(projectRoot), PROJECT_BLUEPRINTS_CONFIG_NAME);
+}
+
+export async function loadProjectBlueprintTrustConfig(
+  projectRoot: string,
+): Promise<ProjectBlueprintTrustConfigResult> {
+  const configPath = projectBlueprintsConfigPath(projectRoot);
+  try {
+    return parseTrustConfigJson(await readFile(configPath, "utf8"), configPath);
+  } catch (err) {
+    if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+      return {
+        ok: true,
+        path: configPath,
+        exists: false,
+        config: defaultTrustConfig(),
+        errors: [],
+      };
+    }
+    throw err;
+  }
+}

--- a/packages/agentplane/src/blueprints/project-local.ts
+++ b/packages/agentplane/src/blueprints/project-local.ts
@@ -1,381 +1,54 @@
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { createBlueprintRegistry, getBlueprint, requireBlueprint } from "./registry.js";
-import { validateBlueprint } from "./validate.js";
 import type {
   Blueprint,
   BlueprintId,
   BlueprintRegistry,
-  BlueprintValidationProblem,
   BlueprintValidationResult,
 } from "./model.js";
+import { createBlueprintRegistry, getBlueprint, requireBlueprint } from "./registry.js";
+import { validateBlueprint } from "./validate.js";
+import {
+  problem,
+  projectBlueprintsDirectory,
+  type ProjectBlueprintCompatibilityReport,
+  type ProjectBlueprintProblem,
+  type ScaffoldProjectBlueprintOptions,
+  type TrustedProjectBlueprintRegistryResult,
+} from "./project-local-model.js";
+import { loadProjectBlueprintTrustConfig } from "./project-local-trust.js";
+import {
+  parseProjectBlueprintJsonInternal,
+  validateProjectBlueprintDirectory,
+} from "./project-local-files.js";
 
-export const PROJECT_BLUEPRINTS_DIR = ".agentplane/blueprints";
-export const PROJECT_BLUEPRINTS_CONFIG_NAME = "config.json";
+export {
+  PROJECT_BLUEPRINTS_CONFIG_NAME,
+  PROJECT_BLUEPRINTS_DIR,
+  projectBlueprintsDirectory,
+  type ProjectBlueprintCompatibilityReport,
+  type ProjectBlueprintDirectoryResult,
+  type ProjectBlueprintFileResult,
+  type ProjectBlueprintProblem,
+  type ProjectBlueprintProblemCode,
+  type ProjectBlueprintTrustConfig,
+  type ProjectBlueprintTrustConfigResult,
+  type ScaffoldProjectBlueprintOptions,
+  type TrustedProjectBlueprintRegistryResult,
+} from "./project-local-model.js";
+export {
+  validateProjectBlueprintDirectory,
+  validateProjectBlueprintFile,
+} from "./project-local-files.js";
+export {
+  loadProjectBlueprintTrustConfig,
+  projectBlueprintsConfigPath,
+} from "./project-local-trust.js";
 
-export type ProjectBlueprintProblemCode =
-  | BlueprintValidationProblem["code"]
-  | "builtin_shadow"
-  | "invalid_json"
-  | "invalid_shape"
-  | "invalid_trust_config"
-  | "missing_blueprint_directory";
-
-export type ProjectBlueprintProblem = {
-  code: ProjectBlueprintProblemCode;
-  message: string;
-  path?: string;
-};
-
-export type ProjectBlueprintFileResult = {
-  ok: boolean;
-  path: string;
-  blueprint?: Blueprint;
-  blueprintId?: string;
-  errors: ProjectBlueprintProblem[];
-};
-
-export type ProjectBlueprintDirectoryResult = {
-  ok: boolean;
-  directory: string;
-  files: ProjectBlueprintFileResult[];
-  errors: ProjectBlueprintProblem[];
-};
-
-export type ProjectBlueprintTrustConfig = {
-  schemaVersion: 1;
-  trustModel: "explicit_allowlist";
-  enabled: boolean;
-  allowedIds: readonly BlueprintId[];
-  selection: "explicit_only";
-};
-
-export type ProjectBlueprintTrustConfigResult = {
-  ok: boolean;
-  path: string;
-  exists: boolean;
-  config: ProjectBlueprintTrustConfig;
-  errors: ProjectBlueprintProblem[];
-};
-
-export type TrustedProjectBlueprintRegistryResult = {
-  ok: boolean;
-  directory: string;
-  trustConfig: ProjectBlueprintTrustConfigResult;
-  files: ProjectBlueprintFileResult[];
-  trustedBlueprints: Blueprint[];
-  errors: ProjectBlueprintProblem[];
-};
-
-export type ProjectBlueprintCompatibilityReport = {
-  schemaVersion: 1;
-  compatible: boolean;
-  directory: string;
-  trustConfig: {
-    path: string;
-    exists: boolean;
-    ok: boolean;
-    config: ProjectBlueprintTrustConfig;
-  };
-  blueprints: {
-    path: string;
-    ok: boolean;
-    blueprintId?: string;
-    trusted: boolean;
-    errors: ProjectBlueprintProblem[];
-  }[];
-  trustedBlueprintIds: readonly BlueprintId[];
-  errors: ProjectBlueprintProblem[];
-};
-
-export type ScaffoldProjectBlueprintOptions = {
-  projectRoot: string;
-  id: BlueprintId;
-  from?: BlueprintId;
-  out?: string;
-  force?: boolean;
-};
-
-function problem(
-  code: ProjectBlueprintProblemCode,
-  message: string,
-  path?: string,
-): ProjectBlueprintProblem {
-  return { code, message, ...(path ? { path } : {}) };
-}
-
-function defaultTrustConfig(): ProjectBlueprintTrustConfig {
-  return {
-    schemaVersion: 1,
-    trustModel: "explicit_allowlist",
-    enabled: false,
-    allowedIds: [],
-    selection: "explicit_only",
-  };
-}
-
-function parseTrustConfigJson(raw: string, filePath: string): ProjectBlueprintTrustConfigResult {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (err) {
-    return {
-      ok: false,
-      path: filePath,
-      exists: true,
-      config: defaultTrustConfig(),
-      errors: [
-        problem(
-          "invalid_json",
-          `Blueprint trust config ${JSON.stringify(filePath)} is not valid JSON: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        ),
-      ],
-    };
-  }
-
-  if (!requireObjectResult(parsed)) {
-    return {
-      ok: false,
-      path: filePath,
-      exists: true,
-      config: defaultTrustConfig(),
-      errors: [
-        problem(
-          "invalid_trust_config",
-          `Blueprint trust config ${JSON.stringify(filePath)} must contain one JSON object.`,
-        ),
-      ],
-    };
-  }
-
-  const errors: ProjectBlueprintProblem[] = [];
-  const schemaVersion = parsed.schema_version === undefined ? 1 : parsed.schema_version;
-  if (schemaVersion !== 1) {
-    errors.push(
-      problem("invalid_trust_config", "Blueprint trust config schema_version must be 1."),
-    );
-  }
-  const trustModel = parsed.trust_model === undefined ? "explicit_allowlist" : parsed.trust_model;
-  if (trustModel !== "explicit_allowlist") {
-    errors.push(
-      problem(
-        "invalid_trust_config",
-        "Blueprint trust config trust_model must be explicit_allowlist.",
-      ),
-    );
-  }
-  const enabled = parsed.enabled === true;
-  if ("enabled" in parsed && typeof parsed.enabled !== "boolean") {
-    errors.push(problem("invalid_trust_config", "Blueprint trust config enabled must be boolean."));
-  }
-  const allowedIds: string[] = [];
-  if ("allowed_ids" in parsed && !Array.isArray(parsed.allowed_ids)) {
-    errors.push(
-      problem("invalid_trust_config", "Blueprint trust config allowed_ids must be an array."),
-    );
-  }
-  if (Array.isArray(parsed.allowed_ids)) {
-    for (const [index, item] of parsed.allowed_ids.entries()) {
-      if (typeof item !== "string" || item.trim().length === 0) {
-        errors.push(
-          problem(
-            "invalid_trust_config",
-            `Blueprint trust config allowed_ids[${index}] must be a non-empty string.`,
-          ),
-        );
-        continue;
-      }
-      allowedIds.push(item.trim());
-    }
-  }
-  const selection = parsed.selection === undefined ? "explicit_only" : parsed.selection;
-  if (selection !== "explicit_only") {
-    errors.push(
-      problem("invalid_trust_config", "Blueprint trust config selection must be explicit_only."),
-    );
-  }
-
-  return {
-    ok: errors.length === 0,
-    path: filePath,
-    exists: true,
-    config: {
-      schemaVersion: 1,
-      trustModel: "explicit_allowlist",
-      enabled,
-      allowedIds: allowedIds.map((id) => id.trim() as BlueprintId),
-      selection: "explicit_only",
-    },
-    errors,
-  };
-}
-
-function requireObjectResult(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
-}
-
-function requiredArrayFieldErrors(
-  value: Record<string, unknown>,
-  filePath: string,
-): ProjectBlueprintProblem[] {
-  const errors: ProjectBlueprintProblem[] = [];
-  for (const field of [
-    "taskKinds",
-    "allowedCommands",
-    "policyModules",
-    "nodes",
-    "edges",
-    "requiredEvidence",
-    "stopRules",
-  ]) {
-    if (!Array.isArray(value[field])) {
-      errors.push(
-        problem(
-          "invalid_shape",
-          `Blueprint file ${JSON.stringify(filePath)} is missing array field ${JSON.stringify(field)}.`,
-          field,
-        ),
-      );
-    }
-  }
-  return errors;
-}
-
-export function parseProjectBlueprintJson(
-  raw: string,
-  filePath: string,
-): ProjectBlueprintFileResult {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (err) {
-    return {
-      ok: false,
-      path: filePath,
-      errors: [
-        problem(
-          "invalid_json",
-          `Blueprint file ${JSON.stringify(filePath)} is not valid JSON: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        ),
-      ],
-    };
-  }
-
-  if (!requireObjectResult(parsed)) {
-    return {
-      ok: false,
-      path: filePath,
-      errors: [
-        problem(
-          "invalid_shape",
-          `Blueprint file ${JSON.stringify(filePath)} must contain one JSON object.`,
-        ),
-      ],
-    };
-  }
-
-  const shapeErrors = requiredArrayFieldErrors(parsed, filePath);
-  if (shapeErrors.length > 0) {
-    return {
-      ok: false,
-      path: filePath,
-      blueprintId: typeof parsed.id === "string" ? parsed.id : undefined,
-      errors: shapeErrors,
-    };
-  }
-
-  const blueprint = parsed as Blueprint;
-  let validation: BlueprintValidationResult;
-  try {
-    validation = validateBlueprint(blueprint);
-  } catch (err) {
-    return {
-      ok: false,
-      path: filePath,
-      blueprintId: typeof parsed.id === "string" ? parsed.id : undefined,
-      errors: [
-        problem(
-          "invalid_shape",
-          `Blueprint file ${JSON.stringify(filePath)} has an invalid blueprint shape: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        ),
-      ],
-    };
-  }
-  return {
-    ok: validation.ok,
-    path: filePath,
-    blueprint,
-    blueprintId: typeof blueprint.id === "string" ? blueprint.id : undefined,
-    errors: validation.errors,
-  };
-}
-
-export async function validateProjectBlueprintFile(
-  filePath: string,
-): Promise<ProjectBlueprintFileResult> {
-  return parseProjectBlueprintJson(await readFile(filePath, "utf8"), filePath);
-}
-
-async function listJsonFiles(directory: string): Promise<string[]> {
-  try {
-    const entries = await readdir(directory, { withFileTypes: true });
-    return entries
-      .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
-      .filter((entry) => entry.name !== PROJECT_BLUEPRINTS_CONFIG_NAME)
-      .map((entry) => path.join(directory, entry.name))
-      .toSorted();
-  } catch (err) {
-    if (err instanceof Error && "code" in err && err.code === "ENOENT") return [];
-    throw err;
-  }
-}
-
-export async function validateProjectBlueprintDirectory(
-  directory: string,
-): Promise<ProjectBlueprintDirectoryResult> {
-  const jsonFiles = await listJsonFiles(directory);
-  const files = await Promise.all(
-    jsonFiles.map((filePath) => validateProjectBlueprintFile(filePath)),
-  );
-  const errors = files.flatMap((file) => file.errors);
-  return {
-    ok: errors.length === 0,
-    directory,
-    files,
-    errors,
-  };
-}
-
-export function projectBlueprintsConfigPath(projectRoot: string): string {
-  return path.join(projectBlueprintsDirectory(projectRoot), PROJECT_BLUEPRINTS_CONFIG_NAME);
-}
-
-export async function loadProjectBlueprintTrustConfig(
-  projectRoot: string,
-): Promise<ProjectBlueprintTrustConfigResult> {
-  const configPath = projectBlueprintsConfigPath(projectRoot);
-  try {
-    return parseTrustConfigJson(await readFile(configPath, "utf8"), configPath);
-  } catch (err) {
-    if (err instanceof Error && "code" in err && err.code === "ENOENT") {
-      return {
-        ok: true,
-        path: configPath,
-        exists: false,
-        config: defaultTrustConfig(),
-        errors: [],
-      };
-    }
-    throw err;
-  }
-}
+// Keep the public name on the compatibility surface without exporting the internal helper module API.
+// eslint-disable-next-line unicorn/prefer-export-from
+export const parseProjectBlueprintJson = parseProjectBlueprintJsonInternal;
 
 function duplicateIds(ids: readonly BlueprintId[]): BlueprintId[] {
   const seen = new Set<string>();
@@ -496,10 +169,6 @@ export async function buildProjectBlueprintCompatibilityReport(
     trustedBlueprintIds: trusted.trustedBlueprints.map((blueprint) => blueprint.id),
     errors: trusted.errors,
   };
-}
-
-export function projectBlueprintsDirectory(projectRoot: string): string {
-  return path.join(projectRoot, PROJECT_BLUEPRINTS_DIR);
 }
 
 function filenameForBlueprintId(id: string): string {

--- a/scripts/baselines/knip-baseline.json
+++ b/scripts/baselines/knip-baseline.json
@@ -540,39 +540,64 @@
       ]
     },
     {
+      "file": "packages/agentplane/src/blueprints/project-local-model.ts",
+      "exports": [
+        {
+          "name": "PROJECT_BLUEPRINTS_DIR",
+          "line": 5,
+          "col": 14
+        }
+      ]
+    },
+    {
       "file": "packages/agentplane/src/blueprints/project-local.ts",
       "exports": [
         {
           "name": "parseProjectBlueprintJson",
-          "line": 247,
-          "col": 17
+          "line": 49,
+          "col": 14
         },
         {
           "name": "PROJECT_BLUEPRINTS_CONFIG_NAME",
-          "line": 15,
-          "col": 14
+          "line": 27,
+          "col": 3
         },
         {
           "name": "PROJECT_BLUEPRINTS_DIR",
-          "line": 14,
-          "col": 14
+          "line": 28,
+          "col": 3
         }
       ],
       "types": [
         {
+          "name": "ProjectBlueprintDirectoryResult",
+          "line": 31,
+          "col": 8
+        },
+        {
+          "name": "ProjectBlueprintFileResult",
+          "line": 32,
+          "col": 8
+        },
+        {
           "name": "ProjectBlueprintProblem",
-          "line": 25,
-          "col": 13
+          "line": 33,
+          "col": 8
         },
         {
           "name": "ProjectBlueprintProblemCode",
-          "line": 17,
-          "col": 13
+          "line": 34,
+          "col": 8
         },
         {
           "name": "ProjectBlueprintTrustConfig",
-          "line": 46,
-          "col": 13
+          "line": 35,
+          "col": 8
+        },
+        {
+          "name": "ProjectBlueprintTrustConfigResult",
+          "line": 36,
+          "col": 8
         }
       ]
     },
@@ -3658,10 +3683,10 @@
   ],
   "counts": {
     "files": 1,
-    "exports": 207,
-    "types": 356,
+    "exports": 208,
+    "types": 359,
     "enumMembers": 0,
     "namespaceMembers": 0,
-    "total": 564
+    "total": 568
   }
 }


### PR DESCRIPTION
Task: `202605290053-CR056N`
Title: Blueprint project-local decomposition
Canonical task record: `.agentplane/tasks/202605290053-CR056N/README.md`

## Summary

Blueprint project-local decomposition

Decompose packages/agentplane/src/blueprints/project-local.ts into focused project-local blueprint modules while preserving behavior and reducing runtime hotspot warnings.

## Scope

- In scope: Decompose packages/agentplane/src/blueprints/project-local.ts into focused project-local blueprint modules while preserving behavior and reducing runtime hotspot warnings.
- Out of scope: unrelated refactors not required for "Blueprint project-local decomposition".

## Verification

- State: ok
- Note:

```text
Verified project-local blueprint decomposition. Commands passed: project-local focused tests, bun
run typecheck, bun run arch:check, bun run knip:check after reviewed baseline remap, bun run
lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from
28 to 27; project-local.ts is below the 400-line warning threshold.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-29T00:54:59.111Z
- Branch: task/202605290053-CR056N/blueprint-project-local-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/blueprints/project-local-files.ts          | 152 ++++++++
 .../src/blueprints/project-local-model.ts          | 111 ++++++
 .../src/blueprints/project-local-trust.ts          | 138 +++++++
 .../agentplane/src/blueprints/project-local.ts     | 417 +++------------------
 scripts/baselines/knip-baseline.json               |  55 ++-
 5 files changed, 484 insertions(+), 389 deletions(-)
```

</details>
