### PR TITLE
🚧 HSNCNJ task: Init execution decomposition [202605290115-HSNCNJ]

### DIFF
--- a/.agentplane/tasks/202605290115-HSNCNJ/README.md
+++ b/.agentplane/tasks/202605290115-HSNCNJ/README.md
@@ -4,7 +4,7 @@ title: "Init execution decomposition"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 4
+revision: 5
 origin:
   system: "manual"
 depends_on: []
@@ -19,10 +19,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-29T01:22:52.543Z"
+  updated_by: "CODER"
+  note: "Verified init execution decomposition. Commands passed: init focused vitest suite (4 files, 55 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 27 to 26; execution.ts is 253 lines."
   attempts: 0
 commit: null
 comments:
@@ -37,8 +37,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: decompose init execution planning helpers in a task worktree, preserve init behavior, and verify hotspot reduction with focused init tests plus static checks."
+  -
+    type: "verify"
+    at: "2026-05-29T01:22:52.543Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified init execution decomposition. Commands passed: init focused vitest suite (4 files, 55 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 27 to 26; execution.ts is 253 lines."
 doc_version: 3
-doc_updated_at: "2026-05-29T01:16:22.265Z"
+doc_updated_at: "2026-05-29T01:22:52.568Z"
 doc_updated_by: "CODER"
 description: "Decompose packages/agentplane/src/cli/run-cli/commands/init/execution.ts by extracting focused init planning/effect helpers while preserving init behavior and reducing the runtime hotspot warning count."
 sections:
@@ -70,6 +76,25 @@ sections:
     3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-29T01:22:52.543Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified init execution decomposition. Commands passed: init focused vitest suite (4 files, 55 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 27 to 26; execution.ts is 253 lines.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T01:16:22.265Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605290115-HSNCNJ-init-execution-decomposition/.agentplane/tasks/202605290115-HSNCNJ/blueprint/resolved-snapshot.json
+    - old_digest: 0a77629d4323a11f152631dbea83a1a93bafd23fbf85a69b17415888b3598862
+    - current_digest: 0a77629d4323a11f152631dbea83a1a93bafd23fbf85a69b17415888b3598862
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605290115-HSNCNJ
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -114,6 +139,25 @@ PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLA
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-29T01:22:52.543Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified init execution decomposition. Commands passed: init focused vitest suite (4 files, 55 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 27 to 26; execution.ts is 253 lines.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T01:16:22.265Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605290115-HSNCNJ-init-execution-decomposition/.agentplane/tasks/202605290115-HSNCNJ/blueprint/resolved-snapshot.json
+- old_digest: 0a77629d4323a11f152631dbea83a1a93bafd23fbf85a69b17415888b3598862
+- current_digest: 0a77629d4323a11f152631dbea83a1a93bafd23fbf85a69b17415888b3598862
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605290115-HSNCNJ
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605290115-HSNCNJ/README.md
+++ b/.agentplane/tasks/202605290115-HSNCNJ/README.md
@@ -1,0 +1,124 @@
+---
+id: "202605290115-HSNCNJ"
+title: "Init execution decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "hotspot"
+  - "init"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-29T01:16:08.138Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: decompose init execution planning helpers in a task worktree, preserve init behavior, and verify hotspot reduction with focused init tests plus static checks."
+events:
+  -
+    type: "status"
+    at: "2026-05-29T01:16:22.265Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: decompose init execution planning helpers in a task worktree, preserve init behavior, and verify hotspot reduction with focused init tests plus static checks."
+doc_version: 3
+doc_updated_at: "2026-05-29T01:16:22.265Z"
+doc_updated_by: "CODER"
+description: "Decompose packages/agentplane/src/cli/run-cli/commands/init/execution.ts by extracting focused init planning/effect helpers while preserving init behavior and reducing the runtime hotspot warning count."
+sections:
+  Summary: |-
+    Init execution decomposition
+
+    Decompose packages/agentplane/src/cli/run-cli/commands/init/execution.ts by extracting focused init planning/effect helpers while preserving init behavior and reducing the runtime hotspot warning count.
+  Scope: |-
+    - In scope: Decompose packages/agentplane/src/cli/run-cli/commands/init/execution.ts by extracting focused init planning/effect helpers while preserving init behavior and reducing the runtime hotspot warning count.
+    - Out of scope: unrelated refactors not required for "Init execution decomposition".
+  Plan: |-
+    Plan:
+    1. Start a branch_pr worktree for CODER.
+    2. Extract init execution planning helpers from packages/agentplane/src/cli/run-cli/commands/init/execution.ts into focused modules for path/effect/plan support.
+    3. Preserve public exports and init behavior for plan/apply/preview flows.
+    4. Verify with init execution tests, init CLI focused tests, typecheck, arch/knip/lint/format, and hotspot threshold report.
+    5. Open PR, wait for hosted checks, merge to main, close lifecycle, and clean worktree.
+
+    Acceptance:
+    - Init planning/apply behavior remains compatible.
+    - execution.ts drops below the 400-line hotspot warning threshold.
+    - Runtime hotspot warning count decreases from 27 to 26 without introducing new warning-sized runtime modules.
+    - No unrelated task or release surface changes.
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Init execution decomposition
+
+Decompose packages/agentplane/src/cli/run-cli/commands/init/execution.ts by extracting focused init planning/effect helpers while preserving init behavior and reducing the runtime hotspot warning count.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/cli/run-cli/commands/init/execution.ts by extracting focused init planning/effect helpers while preserving init behavior and reducing the runtime hotspot warning count.
+- Out of scope: unrelated refactors not required for "Init execution decomposition".
+
+## Plan
+
+Plan:
+1. Start a branch_pr worktree for CODER.
+2. Extract init execution planning helpers from packages/agentplane/src/cli/run-cli/commands/init/execution.ts into focused modules for path/effect/plan support.
+3. Preserve public exports and init behavior for plan/apply/preview flows.
+4. Verify with init execution tests, init CLI focused tests, typecheck, arch/knip/lint/format, and hotspot threshold report.
+5. Open PR, wait for hosted checks, merge to main, close lifecycle, and clean worktree.
+
+Acceptance:
+- Init planning/apply behavior remains compatible.
+- execution.ts drops below the 400-line hotspot warning threshold.
+- Runtime hotspot warning count decreases from 27 to 26 without introducing new warning-sized runtime modules.
+- No unrelated task or release surface changes.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605290115-HSNCNJ/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605290115-HSNCNJ/blueprint/resolved-snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605290115-HSNCNJ",
+    "title": "Init execution decomposition",
+    "description": "Decompose packages/agentplane/src/cli/run-cli/commands/init/execution.ts by extracting focused init planning/effect helpers while preserving init behavior and reducing the runtime hotspot warning count.",
+    "tags": [
+      "code",
+      "hotspot",
+      "init"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605290115-HSNCNJ",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "0a77629d4323a11f152631dbea83a1a93bafd23fbf85a69b17415888b3598862"
+  }
+}

--- a/.agentplane/tasks/202605290115-HSNCNJ/pr/diffstat.txt
+++ b/.agentplane/tasks/202605290115-HSNCNJ/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ .../src/cli/run-cli/commands/init/execution.ts     | 302 +--------------------
+ .../src/cli/run-cli/commands/init/init-paths.ts    |  79 ++++++
+ .../src/cli/run-cli/commands/init/init-plan.ts     | 219 +++++++++++++++
+ 3 files changed, 311 insertions(+), 289 deletions(-)

--- a/.agentplane/tasks/202605290115-HSNCNJ/pr/github-body.md
+++ b/.agentplane/tasks/202605290115-HSNCNJ/pr/github-body.md
@@ -15,8 +15,15 @@ Decompose packages/agentplane/src/cli/run-cli/commands/init/execution.ts by extr
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Verified init execution decomposition. Commands passed: init focused vitest suite (4 files, 55
+tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run
+format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 27 to 26;
+execution.ts is 253 lines.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
@@ -27,7 +34,10 @@ Decompose packages/agentplane/src/cli/run-cli/commands/init/execution.ts by extr
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/cli/run-cli/commands/init/execution.ts     | 302 +--------------------
+ .../src/cli/run-cli/commands/init/init-paths.ts    |  79 ++++++
+ .../src/cli/run-cli/commands/init/init-plan.ts     | 219 +++++++++++++++
+ 3 files changed, 311 insertions(+), 289 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605290115-HSNCNJ/pr/github-body.md
+++ b/.agentplane/tasks/202605290115-HSNCNJ/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605290115-HSNCNJ`
+Title: Init execution decomposition
+Canonical task record: `.agentplane/tasks/202605290115-HSNCNJ/README.md`
+
+## Summary
+
+Init execution decomposition
+
+Decompose packages/agentplane/src/cli/run-cli/commands/init/execution.ts by extracting focused init planning/effect helpers while preserving init behavior and reducing the runtime hotspot warning count.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/cli/run-cli/commands/init/execution.ts by extracting focused init planning/effect helpers while preserving init behavior and reducing the runtime hotspot warning count.
+- Out of scope: unrelated refactors not required for "Init execution decomposition".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T01:16:22.379Z
+- Branch: task/202605290115-HSNCNJ/init-execution-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605290115-HSNCNJ/pr/github-title.txt
+++ b/.agentplane/tasks/202605290115-HSNCNJ/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 HSNCNJ task: Init execution decomposition [202605290115-HSNCNJ]

--- a/.agentplane/tasks/202605290115-HSNCNJ/pr/meta.json
+++ b/.agentplane/tasks/202605290115-HSNCNJ/pr/meta.json
@@ -2,12 +2,13 @@
   "base": "main",
   "branch": "task/202605290115-HSNCNJ/init-execution-decomposition",
   "created_at": "2026-05-29T01:16:22.379Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:774e9e8639f584376cb01cb67e4dc617c3b60b8dce420bfb643a036c5ff82651",
+  "last_verified_at": "2026-05-29T01:22:52.543Z",
+  "last_verified_diffstat_sha256": "sha256:774e9e8639f584376cb01cb67e4dc617c3b60b8dce420bfb643a036c5ff82651",
   "schema_version": 1,
   "task_id": "202605290115-HSNCNJ",
   "updated_at": "2026-05-29T01:16:22.379Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605290115-HSNCNJ/pr/meta.json
+++ b/.agentplane/tasks/202605290115-HSNCNJ/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202605290115-HSNCNJ/init-execution-decomposition",
+  "created_at": "2026-05-29T01:16:22.379Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202605290115-HSNCNJ",
+  "updated_at": "2026-05-29T01:16:22.379Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605290115-HSNCNJ/pr/review.md
+++ b/.agentplane/tasks/202605290115-HSNCNJ/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-05-29T01:16:22.379Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified init execution decomposition. Commands passed: init focused vitest suite (4 files, 55 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 27 to 26; execution.ts is 253 lines.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -29,7 +29,10 @@ Created: 2026-05-29T01:16:22.379Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/cli/run-cli/commands/init/execution.ts     | 302 +--------------------
+ .../src/cli/run-cli/commands/init/init-paths.ts    |  79 ++++++
+ .../src/cli/run-cli/commands/init/init-plan.ts     | 219 +++++++++++++++
+ 3 files changed, 311 insertions(+), 289 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605290115-HSNCNJ/pr/review.md
+++ b/.agentplane/tasks/202605290115-HSNCNJ/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-29T01:16:22.379Z
+
+## Task
+
+- Task: `202605290115-HSNCNJ`
+- Title: Init execution decomposition
+- Status: DOING
+- Branch: `task/202605290115-HSNCNJ/init-execution-decomposition`
+- Canonical task record: `.agentplane/tasks/202605290115-HSNCNJ/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T01:16:22.379Z
+- Branch: task/202605290115-HSNCNJ/init-execution-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/cli/run-cli/commands/init/execution.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/execution.ts
@@ -2,17 +2,14 @@ import path from "node:path";
 
 import { buildExecutionProfile } from "@agentplaneorg/core/config";
 import { setPinnedBaseBranch } from "@agentplaneorg/core/git";
-import { runProcess } from "@agentplaneorg/core/process";
 
-import { collectHooksInstallConflicts } from "../../../../commands/hooks/install.js";
 import { cmdHooksInstall, ensureInitCommit } from "../../../../commands/workflow.js";
 import { getVersion } from "../../../../meta/version.js";
-import { getPathKind } from "../../../fs-utils.js";
 import { InitAborted, type InitClackPrompts } from "./prompts.js";
-import type { InitEffect, InitFlags, InitParsed, InitPlan } from "./model.js";
+import type { InitParsed, InitPlan } from "./model.js";
 import type { InitAnswers } from "./answers.js";
 import { applyInitBaseBranchSelection, type InitBaseBranchSelection } from "./base-branch.js";
-import { collectInitConflicts, handleInitConflicts } from "./conflicts.js";
+import { handleInitConflicts } from "./conflicts.js";
 import { maybeSyncIde } from "./ide-sync.js";
 import { promptConflictResolverStep, applyInitWithProgress } from "./steps/index.js";
 import type { InitPromptClack } from "./steps/contracts.js";
@@ -24,291 +21,18 @@ import { ensureInitCloudEnvTemplate, ensureInitRedmineEnvTemplate } from "./writ
 import { ensureInitGitignore } from "./write-gitignore.js";
 import { ensureInitWorkflow } from "./write-workflow.js";
 import { assertConfirmed } from "./answers.js";
-import { setupProfileToUserFacingProfile } from "./modes.js";
-import { detectParentGitRoot } from "./git.js";
+import type { ResolvedInitPaths } from "./init-paths.js";
 
-export type ResolvedInitPaths = {
-  gitRoot: string;
-  gitRootExisted: boolean;
-  parentGitRoot: string | null;
-  agentplaneDir: string;
-  workflowPath: string;
-  legacyConfigPath: string;
-  backendPath: string;
-};
-
-export async function resolveInitPaths(opts: {
-  cwd: string;
-  rootOverride?: string;
-  backend: NonNullable<InitFlags["backend"]>;
-}): Promise<ResolvedInitPaths> {
-  const initRoot = path.resolve(opts.rootOverride ?? opts.cwd);
-  const gitRoot = initRoot;
-  const gitRootExisted = (await getPathKind(path.join(gitRoot, ".git"))) === "dir";
-  const parentGitRoot = gitRootExisted ? null : await detectParentGitRoot(gitRoot);
-  const agentplaneDir = path.join(gitRoot, ".agentplane");
-  const workflowPath = path.join(agentplaneDir, "WORKFLOW.md");
-  const legacyConfigPath = path.join(agentplaneDir, "config.json");
-  const localBackendPath = path.join(agentplaneDir, "backends", "local", "backend.json");
-  const redmineBackendPath = path.join(agentplaneDir, "backends", "redmine", "backend.json");
-  const cloudBackendPath = path.join(agentplaneDir, "backends", "cloud", "backend.json");
-  const backendPath =
-    opts.backend === "redmine"
-      ? redmineBackendPath
-      : opts.backend === "cloud"
-        ? cloudBackendPath
-        : localBackendPath;
-  return {
-    gitRoot,
-    gitRootExisted,
-    parentGitRoot,
-    agentplaneDir,
-    workflowPath,
-    legacyConfigPath,
-    backendPath,
-  };
-}
-
-export async function collectInitAndHookConflicts(opts: {
-  paths: ResolvedInitPaths;
-  answers: InitAnswers;
-}): Promise<string[]> {
-  const initDirs = [
-    opts.paths.agentplaneDir,
-    path.join(opts.paths.agentplaneDir, "tasks"),
-    path.join(opts.paths.agentplaneDir, "agents"),
-    path.join(opts.paths.agentplaneDir, "evaluators"),
-    path.join(opts.paths.agentplaneDir, "cache"),
-    path.join(opts.paths.agentplaneDir, "backends"),
-    path.join(opts.paths.agentplaneDir, "backends", opts.answers.backend),
-  ];
-  const initFiles = [opts.paths.workflowPath, opts.paths.legacyConfigPath, opts.paths.backendPath];
-  const initConflicts = await collectInitConflicts({ initDirs, initFiles });
-  const hookConflicts =
-    opts.answers.hooks && opts.paths.gitRootExisted
-      ? await collectHooksInstallConflicts({
-          gitRoot: opts.paths.gitRoot,
-          agentplaneDir: opts.paths.agentplaneDir,
-        })
-      : [];
-  return [...new Set([...initConflicts, ...hookConflicts])];
-}
-
-function rel(root: string, filePath: string): string {
-  return path.relative(root, filePath) || ".";
-}
-
-export const GITHUB_CLI_INIT_RECOMMENDATION =
-  "GitHub CLI (gh) is recommended for branch_pr PR merges. Install it yourself (macOS: `brew install gh`; Windows: `winget install --id GitHub.cli`; Linux: see `https://cli.github.com/manual/installation`), then run `gh auth login`. AgentPlane will not install it for you; explicit GH_TOKEN/GITHUB_TOKEN can be used as the API fallback.";
-
-export async function detectGithubCliInstalled(cwd: string): Promise<boolean> {
-  try {
-    await runProcess({
-      command: "gh",
-      args: ["--version"],
-      cwd,
-      encoding: "utf8",
-      stdout: "ignore",
-      stderr: "ignore",
-      timeoutMs: 3000,
-    });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function initWriteEffects(opts: { paths: ResolvedInitPaths; answers: InitAnswers }): InitEffect[] {
-  const gateway = opts.answers.policyGateway === "claude" ? "CLAUDE.md" : "AGENTS.md";
-  const effects: InitEffect[] = [
-    {
-      kind: "write_file",
-      path: ".agentplane/WORKFLOW.md",
-      summary: "Write workflow contract",
-      destructive: false,
-      reversible: true,
-      requiresNetwork: false,
-      risk: "low",
-    },
-    {
-      kind: "write_file",
-      path: rel(opts.paths.gitRoot, opts.paths.backendPath),
-      summary: `Write ${opts.answers.backend} backend stub`,
-      destructive: false,
-      reversible: true,
-      requiresNetwork: false,
-      risk: "low",
-    },
-    {
-      kind: "write_file",
-      path: gateway,
-      summary: `Write ${opts.answers.policyGateway} policy gateway`,
-      destructive: false,
-      reversible: true,
-      requiresNetwork: false,
-      risk: "low",
-    },
-    {
-      kind: "write_file",
-      path: ".agentplane/evaluators/recovery-context.md",
-      summary: "Write evaluator prompt module catalog",
-      destructive: false,
-      reversible: true,
-      requiresNetwork: false,
-      risk: "low",
-    },
-    {
-      kind: "write_file",
-      path: ".gitignore",
-      summary: "Update repository ignore rules",
-      destructive: false,
-      reversible: true,
-      requiresNetwork: false,
-      risk: "low",
-    },
-  ];
-  if (!opts.paths.gitRootExisted) {
-    effects.unshift({
-      kind: "git_init",
-      summary: "Initialize git repository after final confirmation",
-      destructive: false,
-      reversible: true,
-      requiresNetwork: false,
-      risk: "medium",
-    });
-  }
-  if (opts.answers.hooks) {
-    effects.push({
-      kind: "install_hooks",
-      path: ".git/hooks",
-      summary: "Install managed git hooks",
-      destructive: false,
-      reversible: true,
-      requiresNetwork: false,
-      risk: "medium",
-    });
-  }
-  if (opts.answers.ide !== "codex") {
-    effects.push({
-      kind: "sync_ide",
-      summary: `Sync ${opts.answers.ide} rules`,
-      destructive: false,
-      reversible: true,
-      requiresNetwork: false,
-      risk: "low",
-    });
-  }
-  for (const recipe of opts.answers.recipes) {
-    effects.push({
-      kind: "vendor_recipe",
-      summary: `Materialize cached recipe ${recipe}`,
-      destructive: false,
-      reversible: true,
-      requiresNetwork: false,
-      risk: "low",
-    });
-  }
-  for (const blueprint of opts.answers.blueprints) {
-    effects.push({
-      kind: "install_blueprint",
-      summary: `Install cached blueprint catalog entry ${blueprint}`,
-      destructive: false,
-      reversible: true,
-      requiresNetwork: false,
-      risk: "low",
-    });
-  }
-  return effects;
-}
-
-export function buildInitPlan(opts: {
-  paths: ResolvedInitPaths;
-  answers: InitAnswers;
-  conflicts: string[];
-  conflictMode: { backup: boolean; force: boolean };
-  outputMode: "text" | "json";
-  includeInstallCommit: boolean;
-  initMode: InitPlan["mode"];
-  githubCliInstalled?: boolean | null;
-}): InitPlan {
-  const hasConflictStrategy = opts.conflictMode.backup || opts.conflictMode.force;
-  const conflictEffects: InitEffect[] = hasConflictStrategy
-    ? opts.conflicts.map((conflict) => ({
-        kind: opts.conflictMode.backup ? "backup_path" : "delete_path",
-        path: rel(opts.paths.gitRoot, conflict),
-        summary: opts.conflictMode.backup ? "Back up conflicting path" : "Delete conflicting path",
-        destructive: opts.conflictMode.force,
-        reversible: opts.conflictMode.backup,
-        requiresNetwork: false,
-        risk: opts.conflictMode.force ? "high" : "medium",
-      }))
-    : [];
-  const effects = [
-    ...conflictEffects,
-    ...initWriteEffects({ paths: opts.paths, answers: opts.answers }),
-  ];
-  if (opts.includeInstallCommit) {
-    effects.push({
-      kind: "git_commit",
-      summary: `Create initial AgentPlane install commit for ${getVersion()}`,
-      destructive: false,
-      reversible: true,
-      requiresNetwork: false,
-      risk: "medium",
-    });
-  }
-  const githubCliInstalled =
-    opts.answers.workflow === "branch_pr" ? (opts.githubCliInstalled ?? null) : null;
-  const warnings = [
-    ...(opts.conflicts.length > 0 && !hasConflictStrategy
-      ? ["Conflicts require --backup or --force before apply."]
-      : []),
-    ...(opts.answers.workflow === "branch_pr" && githubCliInstalled === false
-      ? [GITHUB_CLI_INIT_RECOMMENDATION]
-      : []),
-  ];
-  const nextSteps = [
-    ...(opts.answers.workflow === "branch_pr" && githubCliInstalled === false
-      ? ["Install GitHub CLI yourself, then run `gh auth login`."]
-      : []),
-    "agentplane quickstart",
-    'agentplane task new --title "Trace first AI-assisted change" --owner CODER --tag code',
-  ];
-  return {
-    schemaVersion: "init-plan/v1",
-    agentplaneVersion: getVersion(),
-    root: opts.paths.gitRoot,
-    mode: opts.initMode,
-    profile: setupProfileToUserFacingProfile(opts.answers.setupProfile),
-    internalSetupProfile: opts.answers.setupProfile,
-    answers: {
-      policyGateway: opts.answers.policyGateway,
-      ide: opts.answers.ide,
-      workflow: opts.answers.workflow,
-      backend: opts.answers.backend,
-      hooks: opts.answers.hooks,
-      requirePlanApproval: opts.answers.requirePlanApproval,
-      requireNetworkApproval: opts.answers.requireNetworkApproval,
-      requireVerifyApproval: opts.answers.requireVerifyApproval,
-      feedbackGithubIssues: opts.answers.feedbackGithubIssues,
-      feedbackAnonymousCloud: opts.answers.feedbackAnonymousCloud,
-      executionProfile: opts.answers.executionProfile,
-      strictUnsafeConfirm: opts.answers.strictUnsafeConfirm,
-      recipes: [...opts.answers.recipes],
-      blueprints: [...opts.answers.blueprints],
-    },
-    context: {
-      gitRootExisted: opts.paths.gitRootExisted,
-      parentGitRoot: opts.paths.parentGitRoot,
-      outputMode: opts.outputMode,
-      githubCliInstalled,
-    },
-    effects,
-    conflicts: opts.conflicts.map((conflict) => rel(opts.paths.gitRoot, conflict)),
-    warnings,
-    nextSteps,
-  };
-}
+export {
+  collectInitAndHookConflicts,
+  resolveInitPaths,
+  type ResolvedInitPaths,
+} from "./init-paths.js";
+export {
+  buildInitPlan,
+  detectGithubCliInstalled,
+  GITHUB_CLI_INIT_RECOMMENDATION,
+} from "./init-plan.js";
 
 export async function maybeConfirmInteractiveApply(opts: {
   clack: InitClackPrompts | null;

--- a/packages/agentplane/src/cli/run-cli/commands/init/init-paths.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/init-paths.ts
@@ -1,0 +1,79 @@
+import path from "node:path";
+
+import { collectHooksInstallConflicts } from "../../../../commands/hooks/install.js";
+import { getPathKind } from "../../../fs-utils.js";
+import type { InitAnswers } from "./answers.js";
+import { collectInitConflicts } from "./conflicts.js";
+import { detectParentGitRoot } from "./git.js";
+import type { InitFlags } from "./model.js";
+
+export type ResolvedInitPaths = {
+  gitRoot: string;
+  gitRootExisted: boolean;
+  parentGitRoot: string | null;
+  agentplaneDir: string;
+  workflowPath: string;
+  legacyConfigPath: string;
+  backendPath: string;
+};
+
+export async function resolveInitPaths(opts: {
+  cwd: string;
+  rootOverride?: string;
+  backend: NonNullable<InitFlags["backend"]>;
+}): Promise<ResolvedInitPaths> {
+  const initRoot = path.resolve(opts.rootOverride ?? opts.cwd);
+  const gitRoot = initRoot;
+  const gitRootExisted = (await getPathKind(path.join(gitRoot, ".git"))) === "dir";
+  const parentGitRoot = gitRootExisted ? null : await detectParentGitRoot(gitRoot);
+  const agentplaneDir = path.join(gitRoot, ".agentplane");
+  const workflowPath = path.join(agentplaneDir, "WORKFLOW.md");
+  const legacyConfigPath = path.join(agentplaneDir, "config.json");
+  const localBackendPath = path.join(agentplaneDir, "backends", "local", "backend.json");
+  const redmineBackendPath = path.join(agentplaneDir, "backends", "redmine", "backend.json");
+  const cloudBackendPath = path.join(agentplaneDir, "backends", "cloud", "backend.json");
+  const backendPath =
+    opts.backend === "redmine"
+      ? redmineBackendPath
+      : opts.backend === "cloud"
+        ? cloudBackendPath
+        : localBackendPath;
+  return {
+    gitRoot,
+    gitRootExisted,
+    parentGitRoot,
+    agentplaneDir,
+    workflowPath,
+    legacyConfigPath,
+    backendPath,
+  };
+}
+
+export async function collectInitAndHookConflicts(opts: {
+  paths: ResolvedInitPaths;
+  answers: InitAnswers;
+}): Promise<string[]> {
+  const initDirs = [
+    opts.paths.agentplaneDir,
+    path.join(opts.paths.agentplaneDir, "tasks"),
+    path.join(opts.paths.agentplaneDir, "agents"),
+    path.join(opts.paths.agentplaneDir, "evaluators"),
+    path.join(opts.paths.agentplaneDir, "cache"),
+    path.join(opts.paths.agentplaneDir, "backends"),
+    path.join(opts.paths.agentplaneDir, "backends", opts.answers.backend),
+  ];
+  const initFiles = [opts.paths.workflowPath, opts.paths.legacyConfigPath, opts.paths.backendPath];
+  const initConflicts = await collectInitConflicts({ initDirs, initFiles });
+  const hookConflicts =
+    opts.answers.hooks && opts.paths.gitRootExisted
+      ? await collectHooksInstallConflicts({
+          gitRoot: opts.paths.gitRoot,
+          agentplaneDir: opts.paths.agentplaneDir,
+        })
+      : [];
+  return [...new Set([...initConflicts, ...hookConflicts])];
+}
+
+export function initRel(root: string, filePath: string): string {
+  return path.relative(root, filePath) || ".";
+}

--- a/packages/agentplane/src/cli/run-cli/commands/init/init-plan.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/init-plan.ts
@@ -1,0 +1,219 @@
+import { runProcess } from "@agentplaneorg/core/process";
+
+import { getVersion } from "../../../../meta/version.js";
+import type { InitAnswers } from "./answers.js";
+import { initRel, type ResolvedInitPaths } from "./init-paths.js";
+import type { InitEffect, InitPlan } from "./model.js";
+import { setupProfileToUserFacingProfile } from "./modes.js";
+
+export const GITHUB_CLI_INIT_RECOMMENDATION =
+  "GitHub CLI (gh) is recommended for branch_pr PR merges. Install it yourself (macOS: `brew install gh`; Windows: `winget install --id GitHub.cli`; Linux: see `https://cli.github.com/manual/installation`), then run `gh auth login`. AgentPlane will not install it for you; explicit GH_TOKEN/GITHUB_TOKEN can be used as the API fallback.";
+
+export async function detectGithubCliInstalled(cwd: string): Promise<boolean> {
+  try {
+    await runProcess({
+      command: "gh",
+      args: ["--version"],
+      cwd,
+      encoding: "utf8",
+      stdout: "ignore",
+      stderr: "ignore",
+      timeoutMs: 3000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function initWriteEffects(opts: { paths: ResolvedInitPaths; answers: InitAnswers }): InitEffect[] {
+  const gateway = opts.answers.policyGateway === "claude" ? "CLAUDE.md" : "AGENTS.md";
+  const effects: InitEffect[] = [
+    {
+      kind: "write_file",
+      path: ".agentplane/WORKFLOW.md",
+      summary: "Write workflow contract",
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "low",
+    },
+    {
+      kind: "write_file",
+      path: initRel(opts.paths.gitRoot, opts.paths.backendPath),
+      summary: `Write ${opts.answers.backend} backend stub`,
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "low",
+    },
+    {
+      kind: "write_file",
+      path: gateway,
+      summary: `Write ${opts.answers.policyGateway} policy gateway`,
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "low",
+    },
+    {
+      kind: "write_file",
+      path: ".agentplane/evaluators/recovery-context.md",
+      summary: "Write evaluator prompt module catalog",
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "low",
+    },
+    {
+      kind: "write_file",
+      path: ".gitignore",
+      summary: "Update repository ignore rules",
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "low",
+    },
+  ];
+  if (!opts.paths.gitRootExisted) {
+    effects.unshift({
+      kind: "git_init",
+      summary: "Initialize git repository after final confirmation",
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "medium",
+    });
+  }
+  if (opts.answers.hooks) {
+    effects.push({
+      kind: "install_hooks",
+      path: ".git/hooks",
+      summary: "Install managed git hooks",
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "medium",
+    });
+  }
+  if (opts.answers.ide !== "codex") {
+    effects.push({
+      kind: "sync_ide",
+      summary: `Sync ${opts.answers.ide} rules`,
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "low",
+    });
+  }
+  for (const recipe of opts.answers.recipes) {
+    effects.push({
+      kind: "vendor_recipe",
+      summary: `Materialize cached recipe ${recipe}`,
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "low",
+    });
+  }
+  for (const blueprint of opts.answers.blueprints) {
+    effects.push({
+      kind: "install_blueprint",
+      summary: `Install cached blueprint catalog entry ${blueprint}`,
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "low",
+    });
+  }
+  return effects;
+}
+
+export function buildInitPlan(opts: {
+  paths: ResolvedInitPaths;
+  answers: InitAnswers;
+  conflicts: string[];
+  conflictMode: { backup: boolean; force: boolean };
+  outputMode: "text" | "json";
+  includeInstallCommit: boolean;
+  initMode: InitPlan["mode"];
+  githubCliInstalled?: boolean | null;
+}): InitPlan {
+  const hasConflictStrategy = opts.conflictMode.backup || opts.conflictMode.force;
+  const conflictEffects: InitEffect[] = hasConflictStrategy
+    ? opts.conflicts.map((conflict) => ({
+        kind: opts.conflictMode.backup ? "backup_path" : "delete_path",
+        path: initRel(opts.paths.gitRoot, conflict),
+        summary: opts.conflictMode.backup ? "Back up conflicting path" : "Delete conflicting path",
+        destructive: opts.conflictMode.force,
+        reversible: opts.conflictMode.backup,
+        requiresNetwork: false,
+        risk: opts.conflictMode.force ? "high" : "medium",
+      }))
+    : [];
+  const effects = [
+    ...conflictEffects,
+    ...initWriteEffects({ paths: opts.paths, answers: opts.answers }),
+  ];
+  if (opts.includeInstallCommit) {
+    effects.push({
+      kind: "git_commit",
+      summary: `Create initial AgentPlane install commit for ${getVersion()}`,
+      destructive: false,
+      reversible: true,
+      requiresNetwork: false,
+      risk: "medium",
+    });
+  }
+  const githubCliInstalled =
+    opts.answers.workflow === "branch_pr" ? (opts.githubCliInstalled ?? null) : null;
+  const warnings = [
+    ...(opts.conflicts.length > 0 && !hasConflictStrategy
+      ? ["Conflicts require --backup or --force before apply."]
+      : []),
+    ...(opts.answers.workflow === "branch_pr" && githubCliInstalled === false
+      ? [GITHUB_CLI_INIT_RECOMMENDATION]
+      : []),
+  ];
+  const nextSteps = [
+    ...(opts.answers.workflow === "branch_pr" && githubCliInstalled === false
+      ? ["Install GitHub CLI yourself, then run `gh auth login`."]
+      : []),
+    "agentplane quickstart",
+    'agentplane task new --title "Trace first AI-assisted change" --owner CODER --tag code',
+  ];
+  return {
+    schemaVersion: "init-plan/v1",
+    agentplaneVersion: getVersion(),
+    root: opts.paths.gitRoot,
+    mode: opts.initMode,
+    profile: setupProfileToUserFacingProfile(opts.answers.setupProfile),
+    internalSetupProfile: opts.answers.setupProfile,
+    answers: {
+      policyGateway: opts.answers.policyGateway,
+      ide: opts.answers.ide,
+      workflow: opts.answers.workflow,
+      backend: opts.answers.backend,
+      hooks: opts.answers.hooks,
+      requirePlanApproval: opts.answers.requirePlanApproval,
+      requireNetworkApproval: opts.answers.requireNetworkApproval,
+      requireVerifyApproval: opts.answers.requireVerifyApproval,
+      feedbackGithubIssues: opts.answers.feedbackGithubIssues,
+      feedbackAnonymousCloud: opts.answers.feedbackAnonymousCloud,
+      executionProfile: opts.answers.executionProfile,
+      strictUnsafeConfirm: opts.answers.strictUnsafeConfirm,
+      recipes: [...opts.answers.recipes],
+      blueprints: [...opts.answers.blueprints],
+    },
+    context: {
+      gitRootExisted: opts.paths.gitRootExisted,
+      parentGitRoot: opts.paths.parentGitRoot,
+      outputMode: opts.outputMode,
+      githubCliInstalled,
+    },
+    effects,
+    conflicts: opts.conflicts.map((conflict) => initRel(opts.paths.gitRoot, conflict)),
+    warnings,
+    nextSteps,
+  };
+}


### PR DESCRIPTION
Task: `202605290115-HSNCNJ`
Title: Init execution decomposition
Canonical task record: `.agentplane/tasks/202605290115-HSNCNJ/README.md`

## Summary

Init execution decomposition

Decompose packages/agentplane/src/cli/run-cli/commands/init/execution.ts by extracting focused init planning/effect helpers while preserving init behavior and reducing the runtime hotspot warning count.

## Scope

- In scope: Decompose packages/agentplane/src/cli/run-cli/commands/init/execution.ts by extracting focused init planning/effect helpers while preserving init behavior and reducing the runtime hotspot warning count.
- Out of scope: unrelated refactors not required for "Init execution decomposition".

## Verification

- State: ok
- Note:

```text
Verified init execution decomposition. Commands passed: init focused vitest suite (4 files, 55
tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run
format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 27 to 26;
execution.ts is 253 lines.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-29T01:16:22.379Z
- Branch: task/202605290115-HSNCNJ/init-execution-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/cli/run-cli/commands/init/execution.ts     | 302 +--------------------
 .../src/cli/run-cli/commands/init/init-paths.ts    |  79 ++++++
 .../src/cli/run-cli/commands/init/init-plan.ts     | 219 +++++++++++++++
 3 files changed, 311 insertions(+), 289 deletions(-)
```

</details>
