### PR TITLE
🚧 HM89S8 task: Blueprint builtins registry decomposition [202605290133-HM89S8]

### DIFF
--- a/.agentplane/tasks/202605290133-HM89S8/README.md
+++ b/.agentplane/tasks/202605290133-HM89S8/README.md
@@ -1,0 +1,124 @@
+---
+id: "202605290133-HM89S8"
+title: "Blueprint builtins registry decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "blueprints"
+  - "code"
+  - "hotspot"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-29T01:33:36.249Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: decompose builtin blueprint registry into focused modules while preserving blueprint ordering, ids, and validation semantics."
+events:
+  -
+    type: "status"
+    at: "2026-05-29T01:33:59.380Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: decompose builtin blueprint registry into focused modules while preserving blueprint ordering, ids, and validation semantics."
+doc_version: 3
+doc_updated_at: "2026-05-29T01:33:59.380Z"
+doc_updated_by: "CODER"
+description: "Decompose packages/agentplane/src/blueprints/builtins.ts by extracting builtin node sequences and common blueprint entries while preserving builtin blueprint registry semantics and reducing the runtime hotspot warning count."
+sections:
+  Summary: |-
+    Blueprint builtins registry decomposition
+
+    Decompose packages/agentplane/src/blueprints/builtins.ts by extracting builtin node sequences and common blueprint entries while preserving builtin blueprint registry semantics and reducing the runtime hotspot warning count.
+  Scope: |-
+    - In scope: Decompose packages/agentplane/src/blueprints/builtins.ts by extracting builtin node sequences and common blueprint entries while preserving builtin blueprint registry semantics and reducing the runtime hotspot warning count.
+    - Out of scope: unrelated refactors not required for "Blueprint builtins registry decomposition".
+  Plan: |-
+    Plan:
+    1. Start a branch_pr worktree for CODER.
+    2. Extract builtin node sequences and common blueprint entry groups from packages/agentplane/src/blueprints/builtins.ts into focused modules.
+    3. Preserve BUILTIN_BLUEPRINTS ordering and all blueprint ids/evidence/policy semantics.
+    4. Verify with blueprint validation tests, typecheck, arch/knip/lint/format, and hotspot threshold report.
+    5. Open PR, wait for hosted checks, merge to main, close lifecycle, and clean worktree.
+
+    Acceptance:
+    - BUILTIN_BLUEPRINTS remains behaviorally equivalent: same ids, order, node/evidence metadata, and specialized blueprint insertion point.
+    - builtins.ts drops below the 400-line hotspot warning threshold.
+    - Runtime hotspot warning count decreases from 26 to 25 without introducing new warning-sized runtime modules.
+    - No unrelated blueprint validation or routing behavior changes.
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Blueprint builtins registry decomposition
+
+Decompose packages/agentplane/src/blueprints/builtins.ts by extracting builtin node sequences and common blueprint entries while preserving builtin blueprint registry semantics and reducing the runtime hotspot warning count.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/blueprints/builtins.ts by extracting builtin node sequences and common blueprint entries while preserving builtin blueprint registry semantics and reducing the runtime hotspot warning count.
+- Out of scope: unrelated refactors not required for "Blueprint builtins registry decomposition".
+
+## Plan
+
+Plan:
+1. Start a branch_pr worktree for CODER.
+2. Extract builtin node sequences and common blueprint entry groups from packages/agentplane/src/blueprints/builtins.ts into focused modules.
+3. Preserve BUILTIN_BLUEPRINTS ordering and all blueprint ids/evidence/policy semantics.
+4. Verify with blueprint validation tests, typecheck, arch/knip/lint/format, and hotspot threshold report.
+5. Open PR, wait for hosted checks, merge to main, close lifecycle, and clean worktree.
+
+Acceptance:
+- BUILTIN_BLUEPRINTS remains behaviorally equivalent: same ids, order, node/evidence metadata, and specialized blueprint insertion point.
+- builtins.ts drops below the 400-line hotspot warning threshold.
+- Runtime hotspot warning count decreases from 26 to 25 without introducing new warning-sized runtime modules.
+- No unrelated blueprint validation or routing behavior changes.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605290133-HM89S8/README.md
+++ b/.agentplane/tasks/202605290133-HM89S8/README.md
@@ -4,7 +4,7 @@ title: "Blueprint builtins registry decomposition"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 4
+revision: 5
 origin:
   system: "manual"
 depends_on: []
@@ -19,10 +19,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-29T01:36:56.535Z"
+  updated_by: "CODER"
+  note: "Verified builtin blueprint registry decomposition. Commands passed: blueprint focused vitest suite (2 files, 26 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 26 to 25; builtins.ts is 384 lines."
   attempts: 0
 commit: null
 comments:
@@ -37,8 +37,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: decompose builtin blueprint registry into focused modules while preserving blueprint ordering, ids, and validation semantics."
+  -
+    type: "verify"
+    at: "2026-05-29T01:36:56.535Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified builtin blueprint registry decomposition. Commands passed: blueprint focused vitest suite (2 files, 26 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 26 to 25; builtins.ts is 384 lines."
 doc_version: 3
-doc_updated_at: "2026-05-29T01:33:59.380Z"
+doc_updated_at: "2026-05-29T01:36:56.574Z"
 doc_updated_by: "CODER"
 description: "Decompose packages/agentplane/src/blueprints/builtins.ts by extracting builtin node sequences and common blueprint entries while preserving builtin blueprint registry semantics and reducing the runtime hotspot warning count."
 sections:
@@ -70,6 +76,25 @@ sections:
     3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-29T01:36:56.535Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified builtin blueprint registry decomposition. Commands passed: blueprint focused vitest suite (2 files, 26 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 26 to 25; builtins.ts is 384 lines.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T01:33:59.380Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605290133-HM89S8-blueprint-builtins-decomposition/.agentplane/tasks/202605290133-HM89S8/blueprint/resolved-snapshot.json
+    - old_digest: 84d733849b2c5eae070a53271a92949dce35bbd85f3614bf0f3a4287f5423086
+    - current_digest: 84d733849b2c5eae070a53271a92949dce35bbd85f3614bf0f3a4287f5423086
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605290133-HM89S8
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -114,6 +139,25 @@ PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLA
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-29T01:36:56.535Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified builtin blueprint registry decomposition. Commands passed: blueprint focused vitest suite (2 files, 26 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 26 to 25; builtins.ts is 384 lines.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T01:33:59.380Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605290133-HM89S8-blueprint-builtins-decomposition/.agentplane/tasks/202605290133-HM89S8/blueprint/resolved-snapshot.json
+- old_digest: 84d733849b2c5eae070a53271a92949dce35bbd85f3614bf0f3a4287f5423086
+- current_digest: 84d733849b2c5eae070a53271a92949dce35bbd85f3614bf0f3a4287f5423086
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605290133-HM89S8
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605290133-HM89S8/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605290133-HM89S8/blueprint/resolved-snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605290133-HM89S8",
+    "title": "Blueprint builtins registry decomposition",
+    "description": "Decompose packages/agentplane/src/blueprints/builtins.ts by extracting builtin node sequences and common blueprint entries while preserving builtin blueprint registry semantics and reducing the runtime hotspot warning count.",
+    "tags": [
+      "blueprints",
+      "code",
+      "hotspot"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605290133-HM89S8",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "84d733849b2c5eae070a53271a92949dce35bbd85f3614bf0f3a4287f5423086"
+  }
+}

--- a/.agentplane/tasks/202605290133-HM89S8/pr/diffstat.txt
+++ b/.agentplane/tasks/202605290133-HM89S8/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../agentplane/src/blueprints/builtin-nodes.ts     | 124 +++++++++++++++++++
+ packages/agentplane/src/blueprints/builtins.ts     | 133 ++-------------------
+ 2 files changed, 133 insertions(+), 124 deletions(-)

--- a/.agentplane/tasks/202605290133-HM89S8/pr/github-body.md
+++ b/.agentplane/tasks/202605290133-HM89S8/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605290133-HM89S8`
+Title: Blueprint builtins registry decomposition
+Canonical task record: `.agentplane/tasks/202605290133-HM89S8/README.md`
+
+## Summary
+
+Blueprint builtins registry decomposition
+
+Decompose packages/agentplane/src/blueprints/builtins.ts by extracting builtin node sequences and common blueprint entries while preserving builtin blueprint registry semantics and reducing the runtime hotspot warning count.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/blueprints/builtins.ts by extracting builtin node sequences and common blueprint entries while preserving builtin blueprint registry semantics and reducing the runtime hotspot warning count.
+- Out of scope: unrelated refactors not required for "Blueprint builtins registry decomposition".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T01:33:59.494Z
+- Branch: task/202605290133-HM89S8/blueprint-builtins-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605290133-HM89S8/pr/github-body.md
+++ b/.agentplane/tasks/202605290133-HM89S8/pr/github-body.md
@@ -15,8 +15,15 @@ Decompose packages/agentplane/src/blueprints/builtins.ts by extracting builtin n
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Verified builtin blueprint registry decomposition. Commands passed: blueprint focused vitest suite
+(2 files, 26 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core,
+bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 26 to 25;
+builtins.ts is 384 lines.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
@@ -27,7 +34,9 @@ Decompose packages/agentplane/src/blueprints/builtins.ts by extracting builtin n
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../agentplane/src/blueprints/builtin-nodes.ts     | 124 +++++++++++++++++++
+ packages/agentplane/src/blueprints/builtins.ts     | 133 ++-------------------
+ 2 files changed, 133 insertions(+), 124 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605290133-HM89S8/pr/github-title.txt
+++ b/.agentplane/tasks/202605290133-HM89S8/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 HM89S8 task: Blueprint builtins registry decomposition [202605290133-HM89S8]

--- a/.agentplane/tasks/202605290133-HM89S8/pr/meta.json
+++ b/.agentplane/tasks/202605290133-HM89S8/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202605290133-HM89S8/blueprint-builtins-decomposition",
+  "created_at": "2026-05-29T01:33:59.494Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202605290133-HM89S8",
+  "updated_at": "2026-05-29T01:33:59.494Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605290133-HM89S8/pr/meta.json
+++ b/.agentplane/tasks/202605290133-HM89S8/pr/meta.json
@@ -2,12 +2,13 @@
   "base": "main",
   "branch": "task/202605290133-HM89S8/blueprint-builtins-decomposition",
   "created_at": "2026-05-29T01:33:59.494Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:99b56eb3795e252b10db8cfbf06d6757e5a7e6860dd99fbf7df814357e4cf287",
+  "last_verified_at": "2026-05-29T01:36:56.535Z",
+  "last_verified_diffstat_sha256": "sha256:99b56eb3795e252b10db8cfbf06d6757e5a7e6860dd99fbf7df814357e4cf287",
   "schema_version": 1,
   "task_id": "202605290133-HM89S8",
   "updated_at": "2026-05-29T01:33:59.494Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605290133-HM89S8/pr/review.md
+++ b/.agentplane/tasks/202605290133-HM89S8/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-29T01:33:59.494Z
+
+## Task
+
+- Task: `202605290133-HM89S8`
+- Title: Blueprint builtins registry decomposition
+- Status: DOING
+- Branch: `task/202605290133-HM89S8/blueprint-builtins-decomposition`
+- Canonical task record: `.agentplane/tasks/202605290133-HM89S8/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T01:33:59.494Z
+- Branch: task/202605290133-HM89S8/blueprint-builtins-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605290133-HM89S8/pr/review.md
+++ b/.agentplane/tasks/202605290133-HM89S8/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-05-29T01:33:59.494Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified builtin blueprint registry decomposition. Commands passed: blueprint focused vitest suite (2 files, 26 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 26 to 25; builtins.ts is 384 lines.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -29,7 +29,9 @@ Created: 2026-05-29T01:33:59.494Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../agentplane/src/blueprints/builtin-nodes.ts     | 124 +++++++++++++++++++
+ packages/agentplane/src/blueprints/builtins.ts     | 133 ++-------------------
+ 2 files changed, 133 insertions(+), 124 deletions(-)
 ```
 
 </details>

--- a/packages/agentplane/src/blueprints/builtin-nodes.ts
+++ b/packages/agentplane/src/blueprints/builtin-nodes.ts
@@ -1,0 +1,124 @@
+import { node } from "./builtin-builder.js";
+
+export const analysisNodes = [
+  node({ kind: "intake" }),
+  node({ kind: "scope", evidence: ["assumptions"] }),
+  node({
+    kind: "context_resolve",
+    evidence: ["context_manifest", "sources"],
+    policyModules: [],
+  }),
+  node({ kind: "work_unit", evidence: ["weak_links", "final_output"] }),
+  node({ kind: "artifact_write", evidence: ["artifact"] }),
+  node({ kind: "verify_record", evidence: ["final_output"], protected: true }),
+  node({ kind: "quality_gate", evidence: ["quality_report"], protected: true }),
+  node({ kind: "finish", evidence: ["final_output"], protected: true }),
+] as const;
+
+export const contentNodes = [
+  node({ kind: "intake" }),
+  node({ kind: "scope", evidence: ["assumptions"] }),
+  node({
+    kind: "context_resolve",
+    evidence: ["context_manifest", "sources"],
+    policyModules: [],
+  }),
+  node({ kind: "work_unit", evidence: ["artifact", "final_output"] }),
+  node({ kind: "deterministic_check", evidence: ["check_result"] }),
+  node({ kind: "artifact_write", evidence: ["artifact"] }),
+  node({ kind: "verify_record", evidence: ["final_output"], protected: true }),
+  node({ kind: "quality_gate", evidence: ["quality_report"], protected: true }),
+  node({ kind: "finish", evidence: ["final_output"], protected: true }),
+] as const;
+
+export const docsNodes = [
+  node({ kind: "intake" }),
+  node({ kind: "scope", evidence: ["assumptions"] }),
+  node({
+    kind: "context_resolve",
+    evidence: ["context_manifest"],
+    policyModules: [
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/dod.docs.md",
+    ],
+  }),
+  node({ kind: "work_unit", evidence: ["changed_paths", "artifact"] }),
+  node({ kind: "deterministic_check", evidence: ["check_result"] }),
+  node({ kind: "artifact_write", evidence: ["artifact"] }),
+  node({ kind: "verify_record", evidence: ["check_result"], protected: true }),
+  node({ kind: "quality_gate", evidence: ["quality_report"], protected: true }),
+  node({ kind: "finish", evidence: ["commit"], protected: true }),
+] as const;
+
+export const releaseNodes = [
+  node({ kind: "intake" }),
+  node({ kind: "scope", evidence: ["assumptions"] }),
+  node({ kind: "approval_gate", evidence: ["approval"], protected: true }),
+  node({
+    kind: "context_resolve",
+    evidence: ["context_manifest"],
+    policyModules: [
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/workflow.release.md",
+    ],
+  }),
+  node({ kind: "work_unit", evidence: ["artifact"] }),
+  node({ kind: "deterministic_check", evidence: ["check_result"] }),
+  node({ kind: "publish_or_integrate", evidence: ["commit", "external_link"], protected: true }),
+  node({ kind: "verify_record", evidence: ["check_result"], protected: true }),
+  node({ kind: "quality_gate", evidence: ["quality_report"], protected: true }),
+  node({ kind: "finish", evidence: ["commit"], protected: true }),
+] as const;
+
+export const opsNodes = [
+  node({ kind: "intake" }),
+  node({ kind: "scope", evidence: ["assumptions", "rollback"] }),
+  node({ kind: "approval_gate", evidence: ["approval"], protected: true }),
+  node({
+    kind: "context_resolve",
+    evidence: ["context_manifest"],
+    policyModules: [".agentplane/policy/security.must.md", ".agentplane/policy/dod.core.md"],
+  }),
+  node({ kind: "work_unit", evidence: ["artifact", "rollback"] }),
+  node({ kind: "deterministic_check", evidence: ["check_result"] }),
+  node({ kind: "artifact_write", evidence: ["artifact"] }),
+  node({ kind: "verify_record", evidence: ["check_result"], protected: true }),
+  node({ kind: "quality_gate", evidence: ["quality_report"], protected: true }),
+  node({ kind: "finish", evidence: ["final_output"], protected: true }),
+] as const;
+
+export const contextAssimilationNodes = [
+  node({ kind: "intake", evidence: ["sources"] }),
+  node({ kind: "scope", evidence: ["assumptions"] }),
+  node({
+    kind: "context_resolve",
+    evidence: ["context_manifest", "sources"],
+    policyModules: [
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/context.must.md",
+    ],
+  }),
+  node({ kind: "work_unit", evidence: ["changed_paths", "artifact", "weak_links"] }),
+  node({
+    kind: "deterministic_check",
+    evidence: ["check_result"],
+    allowedCommands: [
+      "agentplane context reindex --include-raw",
+      "agentplane context wiki lint context/wiki",
+      "agentplane context wiki index context/wiki",
+      "agentplane context verify-task <task-id>",
+      "agentplane context doctor",
+      "agentplane context graph validate",
+      "agentplane context search <query> --format json",
+      "agentplane acr check <task-id>",
+    ],
+  }),
+  node({ kind: "artifact_write", evidence: ["artifact"] }),
+  node({ kind: "verify_record", evidence: ["check_result", "weak_links"], protected: true }),
+  node({ kind: "quality_gate", evidence: ["quality_report"], protected: true }),
+  node({ kind: "finish", evidence: ["commit"], protected: true }),
+] as const;

--- a/packages/agentplane/src/blueprints/builtins.ts
+++ b/packages/agentplane/src/blueprints/builtins.ts
@@ -1,134 +1,19 @@
 import type { Blueprint } from "./model.js";
 import { SPECIALIZED_CODE_BLUEPRINTS } from "./builtins-specialized.js";
-import { blueprint, evidence, node } from "./builtin-builder.js";
+import { blueprint, evidence } from "./builtin-builder.js";
+import {
+  analysisNodes,
+  contentNodes,
+  contextAssimilationNodes,
+  docsNodes,
+  opsNodes,
+  releaseNodes,
+} from "./builtin-nodes.js";
 import { codeBranchPrNodes, codeDirectNodes } from "./builtin-routes.js";
 import {
   contextMaximumAssimilationEvidence,
   contextMaximumAssimilationStopRules,
 } from "./context-maximum-assimilation.js";
-
-const analysisNodes = [
-  node({ kind: "intake" }),
-  node({ kind: "scope", evidence: ["assumptions"] }),
-  node({
-    kind: "context_resolve",
-    evidence: ["context_manifest", "sources"],
-    policyModules: [],
-  }),
-  node({ kind: "work_unit", evidence: ["weak_links", "final_output"] }),
-  node({ kind: "artifact_write", evidence: ["artifact"] }),
-  node({ kind: "verify_record", evidence: ["final_output"], protected: true }),
-  node({ kind: "quality_gate", evidence: ["quality_report"], protected: true }),
-  node({ kind: "finish", evidence: ["final_output"], protected: true }),
-] as const;
-
-const contentNodes = [
-  node({ kind: "intake" }),
-  node({ kind: "scope", evidence: ["assumptions"] }),
-  node({
-    kind: "context_resolve",
-    evidence: ["context_manifest", "sources"],
-    policyModules: [],
-  }),
-  node({ kind: "work_unit", evidence: ["artifact", "final_output"] }),
-  node({ kind: "deterministic_check", evidence: ["check_result"] }),
-  node({ kind: "artifact_write", evidence: ["artifact"] }),
-  node({ kind: "verify_record", evidence: ["final_output"], protected: true }),
-  node({ kind: "quality_gate", evidence: ["quality_report"], protected: true }),
-  node({ kind: "finish", evidence: ["final_output"], protected: true }),
-] as const;
-
-const docsNodes = [
-  node({ kind: "intake" }),
-  node({ kind: "scope", evidence: ["assumptions"] }),
-  node({
-    kind: "context_resolve",
-    evidence: ["context_manifest"],
-    policyModules: [
-      ".agentplane/policy/security.must.md",
-      ".agentplane/policy/dod.core.md",
-      ".agentplane/policy/dod.docs.md",
-    ],
-  }),
-  node({ kind: "work_unit", evidence: ["changed_paths", "artifact"] }),
-  node({ kind: "deterministic_check", evidence: ["check_result"] }),
-  node({ kind: "artifact_write", evidence: ["artifact"] }),
-  node({ kind: "verify_record", evidence: ["check_result"], protected: true }),
-  node({ kind: "quality_gate", evidence: ["quality_report"], protected: true }),
-  node({ kind: "finish", evidence: ["commit"], protected: true }),
-] as const;
-
-const releaseNodes = [
-  node({ kind: "intake" }),
-  node({ kind: "scope", evidence: ["assumptions"] }),
-  node({ kind: "approval_gate", evidence: ["approval"], protected: true }),
-  node({
-    kind: "context_resolve",
-    evidence: ["context_manifest"],
-    policyModules: [
-      ".agentplane/policy/security.must.md",
-      ".agentplane/policy/dod.core.md",
-      ".agentplane/policy/dod.code.md",
-      ".agentplane/policy/workflow.release.md",
-    ],
-  }),
-  node({ kind: "work_unit", evidence: ["artifact"] }),
-  node({ kind: "deterministic_check", evidence: ["check_result"] }),
-  node({ kind: "publish_or_integrate", evidence: ["commit", "external_link"], protected: true }),
-  node({ kind: "verify_record", evidence: ["check_result"], protected: true }),
-  node({ kind: "quality_gate", evidence: ["quality_report"], protected: true }),
-  node({ kind: "finish", evidence: ["commit"], protected: true }),
-] as const;
-
-const opsNodes = [
-  node({ kind: "intake" }),
-  node({ kind: "scope", evidence: ["assumptions", "rollback"] }),
-  node({ kind: "approval_gate", evidence: ["approval"], protected: true }),
-  node({
-    kind: "context_resolve",
-    evidence: ["context_manifest"],
-    policyModules: [".agentplane/policy/security.must.md", ".agentplane/policy/dod.core.md"],
-  }),
-  node({ kind: "work_unit", evidence: ["artifact", "rollback"] }),
-  node({ kind: "deterministic_check", evidence: ["check_result"] }),
-  node({ kind: "artifact_write", evidence: ["artifact"] }),
-  node({ kind: "verify_record", evidence: ["check_result"], protected: true }),
-  node({ kind: "quality_gate", evidence: ["quality_report"], protected: true }),
-  node({ kind: "finish", evidence: ["final_output"], protected: true }),
-] as const;
-
-const contextAssimilationNodes = [
-  node({ kind: "intake", evidence: ["sources"] }),
-  node({ kind: "scope", evidence: ["assumptions"] }),
-  node({
-    kind: "context_resolve",
-    evidence: ["context_manifest", "sources"],
-    policyModules: [
-      ".agentplane/policy/security.must.md",
-      ".agentplane/policy/dod.core.md",
-      ".agentplane/policy/context.must.md",
-    ],
-  }),
-  node({ kind: "work_unit", evidence: ["changed_paths", "artifact", "weak_links"] }),
-  node({
-    kind: "deterministic_check",
-    evidence: ["check_result"],
-    allowedCommands: [
-      "agentplane context reindex --include-raw",
-      "agentplane context wiki lint context/wiki",
-      "agentplane context wiki index context/wiki",
-      "agentplane context verify-task <task-id>",
-      "agentplane context doctor",
-      "agentplane context graph validate",
-      "agentplane context search <query> --format json",
-      "agentplane acr check <task-id>",
-    ],
-  }),
-  node({ kind: "artifact_write", evidence: ["artifact"] }),
-  node({ kind: "verify_record", evidence: ["check_result", "weak_links"], protected: true }),
-  node({ kind: "quality_gate", evidence: ["quality_report"], protected: true }),
-  node({ kind: "finish", evidence: ["commit"], protected: true }),
-] as const;
 
 export const BUILTIN_BLUEPRINTS = [
   blueprint({


### PR DESCRIPTION
Task: `202605290133-HM89S8`
Title: Blueprint builtins registry decomposition
Canonical task record: `.agentplane/tasks/202605290133-HM89S8/README.md`

## Summary

Blueprint builtins registry decomposition

Decompose packages/agentplane/src/blueprints/builtins.ts by extracting builtin node sequences and common blueprint entries while preserving builtin blueprint registry semantics and reducing the runtime hotspot warning count.

## Scope

- In scope: Decompose packages/agentplane/src/blueprints/builtins.ts by extracting builtin node sequences and common blueprint entries while preserving builtin blueprint registry semantics and reducing the runtime hotspot warning count.
- Out of scope: unrelated refactors not required for "Blueprint builtins registry decomposition".

## Verification

- State: ok
- Note:

```text
Verified builtin blueprint registry decomposition. Commands passed: blueprint focused vitest suite
(2 files, 26 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core,
bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 26 to 25;
builtins.ts is 384 lines.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-29T01:33:59.494Z
- Branch: task/202605290133-HM89S8/blueprint-builtins-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../agentplane/src/blueprints/builtin-nodes.ts     | 124 +++++++++++++++++++
 packages/agentplane/src/blueprints/builtins.ts     | 133 ++-------------------
 2 files changed, 133 insertions(+), 124 deletions(-)
```

</details>
