### PR TITLE
🚧 E5E8EF task: Blueprint validate decomposition [202605290203-E5E8EF]

### DIFF
--- a/.agentplane/tasks/202605290203-E5E8EF/README.md
+++ b/.agentplane/tasks/202605290203-E5E8EF/README.md
@@ -1,0 +1,124 @@
+---
+id: "202605290203-E5E8EF"
+title: "Blueprint validate decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "blueprints"
+  - "code"
+  - "hotspot"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-29T02:03:40.337Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: decompose blueprint validation helpers while preserving validateBlueprint, validateBlueprintRegistry, and validateBlueprintPlanArtifact behavior."
+events:
+  -
+    type: "status"
+    at: "2026-05-29T02:04:06.647Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: decompose blueprint validation helpers while preserving validateBlueprint, validateBlueprintRegistry, and validateBlueprintPlanArtifact behavior."
+doc_version: 3
+doc_updated_at: "2026-05-29T02:04:06.647Z"
+doc_updated_by: "CODER"
+description: "Decompose packages/agentplane/src/blueprints/validate.ts by extracting shared graph/evidence validation helpers while preserving blueprint and plan validation behavior and reducing runtime hotspot warnings."
+sections:
+  Summary: |-
+    Blueprint validate decomposition
+
+    Decompose packages/agentplane/src/blueprints/validate.ts by extracting shared graph/evidence validation helpers while preserving blueprint and plan validation behavior and reducing runtime hotspot warnings.
+  Scope: |-
+    - In scope: Decompose packages/agentplane/src/blueprints/validate.ts by extracting shared graph/evidence validation helpers while preserving blueprint and plan validation behavior and reducing runtime hotspot warnings.
+    - Out of scope: unrelated refactors not required for "Blueprint validate decomposition".
+  Plan: |-
+    Plan:
+    1. Start a branch_pr worktree for CODER.
+    2. Extract blueprint validation graph helpers and shared problem constructors from packages/agentplane/src/blueprints/validate.ts into focused modules.
+    3. Preserve validateBlueprint, validateBlueprintRegistry, and validateBlueprintPlanArtifact behavior and exports.
+    4. Verify with blueprint validation tests, typecheck, arch/knip/lint/format, and hotspot threshold report.
+    5. Open PR, wait for hosted checks, merge to main, close lifecycle, and clean worktree.
+
+    Acceptance:
+    - Blueprint validation behavior remains compatible, including negative-path tests.
+    - validate.ts drops below the 400-line hotspot warning threshold.
+    - Runtime hotspot warning count decreases from 24 to 23 without introducing new warning-sized runtime modules.
+    - No unrelated blueprint registry, routing, or model changes.
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Blueprint validate decomposition
+
+Decompose packages/agentplane/src/blueprints/validate.ts by extracting shared graph/evidence validation helpers while preserving blueprint and plan validation behavior and reducing runtime hotspot warnings.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/blueprints/validate.ts by extracting shared graph/evidence validation helpers while preserving blueprint and plan validation behavior and reducing runtime hotspot warnings.
+- Out of scope: unrelated refactors not required for "Blueprint validate decomposition".
+
+## Plan
+
+Plan:
+1. Start a branch_pr worktree for CODER.
+2. Extract blueprint validation graph helpers and shared problem constructors from packages/agentplane/src/blueprints/validate.ts into focused modules.
+3. Preserve validateBlueprint, validateBlueprintRegistry, and validateBlueprintPlanArtifact behavior and exports.
+4. Verify with blueprint validation tests, typecheck, arch/knip/lint/format, and hotspot threshold report.
+5. Open PR, wait for hosted checks, merge to main, close lifecycle, and clean worktree.
+
+Acceptance:
+- Blueprint validation behavior remains compatible, including negative-path tests.
+- validate.ts drops below the 400-line hotspot warning threshold.
+- Runtime hotspot warning count decreases from 24 to 23 without introducing new warning-sized runtime modules.
+- No unrelated blueprint registry, routing, or model changes.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605290203-E5E8EF/README.md
+++ b/.agentplane/tasks/202605290203-E5E8EF/README.md
@@ -4,7 +4,7 @@ title: "Blueprint validate decomposition"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 4
+revision: 5
 origin:
   system: "manual"
 depends_on: []
@@ -19,10 +19,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-29T02:13:21.445Z"
+  updated_by: "CODER"
+  note: "Verified blueprint validation helper decomposition. Commands passed: bunx vitest run packages/agentplane/src/blueprints/validate.test.ts --config vitest.workspace.ts (23 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 24 to 23; validate.ts is 390 lines, below the 400-line warning threshold."
   attempts: 0
 commit: null
 comments:
@@ -37,8 +37,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: decompose blueprint validation helpers while preserving validateBlueprint, validateBlueprintRegistry, and validateBlueprintPlanArtifact behavior."
+  -
+    type: "verify"
+    at: "2026-05-29T02:13:21.445Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified blueprint validation helper decomposition. Commands passed: bunx vitest run packages/agentplane/src/blueprints/validate.test.ts --config vitest.workspace.ts (23 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 24 to 23; validate.ts is 390 lines, below the 400-line warning threshold."
 doc_version: 3
-doc_updated_at: "2026-05-29T02:04:06.647Z"
+doc_updated_at: "2026-05-29T02:13:21.470Z"
 doc_updated_by: "CODER"
 description: "Decompose packages/agentplane/src/blueprints/validate.ts by extracting shared graph/evidence validation helpers while preserving blueprint and plan validation behavior and reducing runtime hotspot warnings."
 sections:
@@ -70,6 +76,25 @@ sections:
     3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-29T02:13:21.445Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified blueprint validation helper decomposition. Commands passed: bunx vitest run packages/agentplane/src/blueprints/validate.test.ts --config vitest.workspace.ts (23 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 24 to 23; validate.ts is 390 lines, below the 400-line warning threshold.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T02:04:06.647Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605290203-E5E8EF-blueprint-validate-decomposition/.agentplane/tasks/202605290203-E5E8EF/blueprint/resolved-snapshot.json
+    - old_digest: b770774286c9309b399a6d4e36ef03ce0194740ff988b3014182dcf7122ef8b7
+    - current_digest: b770774286c9309b399a6d4e36ef03ce0194740ff988b3014182dcf7122ef8b7
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605290203-E5E8EF
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -114,6 +139,25 @@ PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLA
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-29T02:13:21.445Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified blueprint validation helper decomposition. Commands passed: bunx vitest run packages/agentplane/src/blueprints/validate.test.ts --config vitest.workspace.ts (23 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 24 to 23; validate.ts is 390 lines, below the 400-line warning threshold.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T02:04:06.647Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605290203-E5E8EF-blueprint-validate-decomposition/.agentplane/tasks/202605290203-E5E8EF/blueprint/resolved-snapshot.json
+- old_digest: b770774286c9309b399a6d4e36ef03ce0194740ff988b3014182dcf7122ef8b7
+- current_digest: b770774286c9309b399a6d4e36ef03ce0194740ff988b3014182dcf7122ef8b7
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605290203-E5E8EF
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605290203-E5E8EF/README.md
+++ b/.agentplane/tasks/202605290203-E5E8EF/README.md
@@ -89,7 +89,7 @@ sections:
 
     BlueprintSnapshotRef:
     - state: current
-    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605290203-E5E8EF-blueprint-validate-decomposition/.agentplane/tasks/202605290203-E5E8EF/blueprint/resolved-snapshot.json
+    - path: .agentplane/tasks/202605290203-E5E8EF/blueprint/resolved-snapshot.json
     - old_digest: b770774286c9309b399a6d4e36ef03ce0194740ff988b3014182dcf7122ef8b7
     - current_digest: b770774286c9309b399a6d4e36ef03ce0194740ff988b3014182dcf7122ef8b7
     - route_changed: no
@@ -152,7 +152,7 @@ Details:
 
 BlueprintSnapshotRef:
 - state: current
-- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/hotspot-refactor-canonical/.agentplane/worktrees/202605290203-E5E8EF-blueprint-validate-decomposition/.agentplane/tasks/202605290203-E5E8EF/blueprint/resolved-snapshot.json
+- path: .agentplane/tasks/202605290203-E5E8EF/blueprint/resolved-snapshot.json
 - old_digest: b770774286c9309b399a6d4e36ef03ce0194740ff988b3014182dcf7122ef8b7
 - current_digest: b770774286c9309b399a6d4e36ef03ce0194740ff988b3014182dcf7122ef8b7
 - route_changed: no

--- a/.agentplane/tasks/202605290203-E5E8EF/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605290203-E5E8EF/blueprint/resolved-snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605290203-E5E8EF",
+    "title": "Blueprint validate decomposition",
+    "description": "Decompose packages/agentplane/src/blueprints/validate.ts by extracting shared graph/evidence validation helpers while preserving blueprint and plan validation behavior and reducing runtime hotspot warnings.",
+    "tags": [
+      "blueprints",
+      "code",
+      "hotspot"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605290203-E5E8EF",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "b770774286c9309b399a6d4e36ef03ce0194740ff988b3014182dcf7122ef8b7"
+  }
+}

--- a/.agentplane/tasks/202605290203-E5E8EF/pr/diffstat.txt
+++ b/.agentplane/tasks/202605290203-E5E8EF/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../agentplane/src/blueprints/validate-helpers.ts  | 124 +++++++++++++++++
+ packages/agentplane/src/blueprints/validate.ts     | 147 +++------------------
+ 2 files changed, 146 insertions(+), 125 deletions(-)

--- a/.agentplane/tasks/202605290203-E5E8EF/pr/github-body.md
+++ b/.agentplane/tasks/202605290203-E5E8EF/pr/github-body.md
@@ -15,8 +15,16 @@ Decompose packages/agentplane/src/blueprints/validate.ts by extracting shared gr
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Verified blueprint validation helper decomposition. Commands passed: bunx vitest run
+packages/agentplane/src/blueprints/validate.test.ts --config vitest.workspace.ts (23 tests), bun run
+typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun
+run hotspots:check. Runtime hotspot warnings decreased from 24 to 23; validate.ts is 390 lines,
+below the 400-line warning threshold.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
@@ -27,7 +35,9 @@ Decompose packages/agentplane/src/blueprints/validate.ts by extracting shared gr
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../agentplane/src/blueprints/validate-helpers.ts  | 124 +++++++++++++++++
+ packages/agentplane/src/blueprints/validate.ts     | 147 +++------------------
+ 2 files changed, 146 insertions(+), 125 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605290203-E5E8EF/pr/github-body.md
+++ b/.agentplane/tasks/202605290203-E5E8EF/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605290203-E5E8EF`
+Title: Blueprint validate decomposition
+Canonical task record: `.agentplane/tasks/202605290203-E5E8EF/README.md`
+
+## Summary
+
+Blueprint validate decomposition
+
+Decompose packages/agentplane/src/blueprints/validate.ts by extracting shared graph/evidence validation helpers while preserving blueprint and plan validation behavior and reducing runtime hotspot warnings.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/blueprints/validate.ts by extracting shared graph/evidence validation helpers while preserving blueprint and plan validation behavior and reducing runtime hotspot warnings.
+- Out of scope: unrelated refactors not required for "Blueprint validate decomposition".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T02:04:06.763Z
+- Branch: task/202605290203-E5E8EF/blueprint-validate-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605290203-E5E8EF/pr/github-title.txt
+++ b/.agentplane/tasks/202605290203-E5E8EF/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 E5E8EF task: Blueprint validate decomposition [202605290203-E5E8EF]

--- a/.agentplane/tasks/202605290203-E5E8EF/pr/meta.json
+++ b/.agentplane/tasks/202605290203-E5E8EF/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202605290203-E5E8EF/blueprint-validate-decomposition",
+  "created_at": "2026-05-29T02:04:06.763Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202605290203-E5E8EF",
+  "updated_at": "2026-05-29T02:04:06.763Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605290203-E5E8EF/pr/meta.json
+++ b/.agentplane/tasks/202605290203-E5E8EF/pr/meta.json
@@ -2,12 +2,13 @@
   "base": "main",
   "branch": "task/202605290203-E5E8EF/blueprint-validate-decomposition",
   "created_at": "2026-05-29T02:04:06.763Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:dd8ee2b6129cbc3bbd1a2a1112acfd63eb0d9e7fd3f3608ae8afe59dfc8570e8",
+  "last_verified_at": "2026-05-29T02:13:21.445Z",
+  "last_verified_diffstat_sha256": "sha256:dd8ee2b6129cbc3bbd1a2a1112acfd63eb0d9e7fd3f3608ae8afe59dfc8570e8",
   "schema_version": 1,
   "task_id": "202605290203-E5E8EF",
   "updated_at": "2026-05-29T02:04:06.763Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605290203-E5E8EF/pr/review.md
+++ b/.agentplane/tasks/202605290203-E5E8EF/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-29T02:04:06.763Z
+
+## Task
+
+- Task: `202605290203-E5E8EF`
+- Title: Blueprint validate decomposition
+- Status: DOING
+- Branch: `task/202605290203-E5E8EF/blueprint-validate-decomposition`
+- Canonical task record: `.agentplane/tasks/202605290203-E5E8EF/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T02:04:06.763Z
+- Branch: task/202605290203-E5E8EF/blueprint-validate-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605290203-E5E8EF/pr/review.md
+++ b/.agentplane/tasks/202605290203-E5E8EF/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-05-29T02:04:06.763Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified blueprint validation helper decomposition. Commands passed: bunx vitest run packages/agentplane/src/blueprints/validate.test.ts --config vitest.workspace.ts (23 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 24 to 23; validate.ts is 390 lines, below the 400-line warning threshold.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -29,7 +29,9 @@ Created: 2026-05-29T02:04:06.763Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../agentplane/src/blueprints/validate-helpers.ts  | 124 +++++++++++++++++
+ packages/agentplane/src/blueprints/validate.ts     | 147 +++------------------
+ 2 files changed, 146 insertions(+), 125 deletions(-)
 ```
 
 </details>

--- a/packages/agentplane/src/blueprints/validate-helpers.ts
+++ b/packages/agentplane/src/blueprints/validate-helpers.ts
@@ -1,0 +1,124 @@
+import type {
+  Blueprint,
+  BlueprintNodeKind,
+  BlueprintValidationProblem,
+  WorkflowMode,
+} from "./model.js";
+import type { BlueprintPlanValidationProblem } from "./model-core.js";
+
+export function problem(
+  code: BlueprintValidationProblem["code"],
+  message: string,
+  path?: string,
+): BlueprintValidationProblem {
+  return {
+    code,
+    message,
+    ...(path ? { path } : {}),
+  };
+}
+
+export function planProblem(
+  code: BlueprintPlanValidationProblem["code"],
+  message: string,
+  path?: string,
+): BlueprintPlanValidationProblem {
+  return {
+    code,
+    message,
+    ...(path ? { path } : {}),
+  };
+}
+
+export function hasText(value: string): boolean {
+  return value.trim().length > 0;
+}
+
+export function findDuplicates(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) {
+      duplicates.add(value);
+    }
+    seen.add(value);
+  }
+  return [...duplicates].toSorted();
+}
+
+export function nodeKinds(blueprint: Blueprint): Set<BlueprintNodeKind> {
+  return new Set(blueprint.nodes.map((node) => node.kind));
+}
+
+export function nodeIds(blueprint: Blueprint): Set<string> {
+  return new Set(blueprint.nodes.map((node) => node.id));
+}
+
+export function collectEntryNodeIds(blueprint: Blueprint): string[] {
+  const incoming = new Set(blueprint.edges.map((edge) => edge.to));
+  return blueprint.nodes.map((node) => node.id).filter((id) => !incoming.has(id));
+}
+
+export function hasCycle(blueprint: Blueprint): boolean {
+  const adjacency = new Map<string, string[]>();
+  for (const node of blueprint.nodes) {
+    adjacency.set(node.id, []);
+  }
+  for (const edge of blueprint.edges) {
+    adjacency.get(edge.from)?.push(edge.to);
+  }
+
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+
+  function visit(id: string): boolean {
+    if (visiting.has(id)) return true;
+    if (visited.has(id)) return false;
+
+    visiting.add(id);
+    for (const next of adjacency.get(id) ?? []) {
+      if (visit(next)) return true;
+    }
+    visiting.delete(id);
+    visited.add(id);
+    return false;
+  }
+
+  return blueprint.nodes.some((node) => visit(node.id));
+}
+
+export function evidenceKindsByProducer(blueprint: Blueprint): Map<string, Set<string>> {
+  const byNode = new Map<string, Set<string>>();
+  for (const node of blueprint.nodes) {
+    byNode.set(node.id, node.evidence ? new Set(node.evidence) : new Set());
+  }
+  return byNode;
+}
+
+export function blueprintPolicyModuleSet(blueprint: Blueprint): Set<string> {
+  return new Set([
+    ...blueprint.policyModules,
+    ...blueprint.nodes.flatMap((node) => node.policyModules ?? []),
+  ]);
+}
+
+export function hasEdge(blueprint: Blueprint, from: string, to: string): boolean {
+  return blueprint.edges.some((edge) => edge.from === from && edge.to === to);
+}
+
+export function isPolicyModulePath(value: string): boolean {
+  return value.startsWith(".agentplane/policy/");
+}
+
+export function hasWorkflowModes(blueprint: Blueprint, expected: readonly WorkflowMode[]): boolean {
+  const actual = blueprint.workflowModes ?? [];
+  return actual.length === expected.length && expected.every((mode) => actual.includes(mode));
+}
+
+export function hasApprovalGate(blueprint: Blueprint): boolean {
+  return blueprint.nodes.some((node) => node.kind === "approval_gate");
+}
+
+export function hasRollbackEvidence(blueprint: Blueprint): boolean {
+  return blueprint.requiredEvidence.some((evidence) => evidence.kind === "rollback");
+}

--- a/packages/agentplane/src/blueprints/validate.ts
+++ b/packages/agentplane/src/blueprints/validate.ts
@@ -2,13 +2,31 @@ import type {
   Blueprint,
   BlueprintNodeKind,
   BlueprintPlanArtifact,
-  BlueprintPlanValidationProblem,
-  BlueprintPlanValidationResult,
   BlueprintRegistry,
   BlueprintValidationProblem,
   BlueprintValidationResult,
-  WorkflowMode,
 } from "./model.js";
+import type {
+  BlueprintPlanValidationProblem,
+  BlueprintPlanValidationResult,
+} from "./model-core.js";
+import {
+  blueprintPolicyModuleSet,
+  collectEntryNodeIds,
+  evidenceKindsByProducer,
+  findDuplicates,
+  hasApprovalGate,
+  hasCycle,
+  hasEdge,
+  hasRollbackEvidence,
+  hasText,
+  hasWorkflowModes,
+  isPolicyModulePath,
+  nodeIds,
+  nodeKinds,
+  planProblem,
+  problem,
+} from "./validate-helpers.js";
 
 const REQUIRED_CORE_NODE_KINDS = [
   "intake",
@@ -27,108 +45,6 @@ const ANALYSIS_CONTENT_DISALLOWED_NODE_KINDS = [
   "hosted_checks",
   "publish_or_integrate",
 ] as const satisfies readonly BlueprintNodeKind[];
-
-function problem(
-  code: BlueprintValidationProblem["code"],
-  message: string,
-  path?: string,
-): BlueprintValidationProblem {
-  return {
-    code,
-    message,
-    ...(path ? { path } : {}),
-  };
-}
-
-function planProblem(
-  code: BlueprintPlanValidationProblem["code"],
-  message: string,
-  path?: string,
-): BlueprintPlanValidationProblem {
-  return {
-    code,
-    message,
-    ...(path ? { path } : {}),
-  };
-}
-
-function hasText(value: string): boolean {
-  return value.trim().length > 0;
-}
-
-function findDuplicates(values: readonly string[]): string[] {
-  const seen = new Set<string>();
-  const duplicates = new Set<string>();
-  for (const value of values) {
-    if (seen.has(value)) {
-      duplicates.add(value);
-    }
-    seen.add(value);
-  }
-  return [...duplicates].toSorted();
-}
-
-function nodeKinds(blueprint: Blueprint): Set<BlueprintNodeKind> {
-  return new Set(blueprint.nodes.map((node) => node.kind));
-}
-
-function nodeIds(blueprint: Blueprint): Set<string> {
-  return new Set(blueprint.nodes.map((node) => node.id));
-}
-
-function collectEntryNodeIds(blueprint: Blueprint): string[] {
-  const incoming = new Set(blueprint.edges.map((edge) => edge.to));
-  return blueprint.nodes.map((node) => node.id).filter((id) => !incoming.has(id));
-}
-
-function hasCycle(blueprint: Blueprint): boolean {
-  const adjacency = new Map<string, string[]>();
-  for (const node of blueprint.nodes) {
-    adjacency.set(node.id, []);
-  }
-  for (const edge of blueprint.edges) {
-    adjacency.get(edge.from)?.push(edge.to);
-  }
-
-  const visiting = new Set<string>();
-  const visited = new Set<string>();
-
-  function visit(id: string): boolean {
-    if (visiting.has(id)) return true;
-    if (visited.has(id)) return false;
-
-    visiting.add(id);
-    for (const next of adjacency.get(id) ?? []) {
-      if (visit(next)) return true;
-    }
-    visiting.delete(id);
-    visited.add(id);
-    return false;
-  }
-
-  return blueprint.nodes.some((node) => visit(node.id));
-}
-
-function hasWorkflowModes(blueprint: Blueprint, expected: readonly WorkflowMode[]): boolean {
-  const actual = blueprint.workflowModes ?? [];
-  return actual.length === expected.length && expected.every((mode) => actual.includes(mode));
-}
-
-function hasApprovalGate(blueprint: Blueprint): boolean {
-  return blueprint.nodes.some((node) => node.kind === "approval_gate");
-}
-
-function hasRollbackEvidence(blueprint: Blueprint): boolean {
-  return blueprint.requiredEvidence.some((evidence) => evidence.kind === "rollback");
-}
-
-function evidenceKindsByProducer(blueprint: Blueprint): Map<string, Set<string>> {
-  const byNode = new Map<string, Set<string>>();
-  for (const node of blueprint.nodes) {
-    byNode.set(node.id, node.evidence ? new Set(node.evidence) : new Set());
-  }
-  return byNode;
-}
 
 function validateRequiredText(blueprint: Blueprint, errors: BlueprintValidationProblem[]): void {
   if (!hasText(blueprint.id)) {
@@ -350,25 +266,6 @@ export function validateBlueprintRegistry(registry: BlueprintRegistry): Blueprin
   };
 }
 
-function blueprintPolicyModuleSet(blueprint: Blueprint): Set<string> {
-  return new Set([
-    ...blueprint.policyModules,
-    ...blueprint.nodes.flatMap((node) => node.policyModules ?? []),
-  ]);
-}
-
-function entryNodeIds(blueprint: Blueprint): string[] {
-  return collectEntryNodeIds(blueprint);
-}
-
-function hasEdge(blueprint: Blueprint, from: string, to: string): boolean {
-  return blueprint.edges.some((edge) => edge.from === from && edge.to === to);
-}
-
-function isPolicyModulePath(value: string): boolean {
-  return value.startsWith(".agentplane/policy/");
-}
-
 export function validateBlueprintPlanArtifact(opts: {
   blueprint: Blueprint;
   plan: BlueprintPlanArtifact;
@@ -447,7 +344,7 @@ export function validateBlueprintPlanArtifact(opts: {
     );
   }
 
-  for (const entryId of entryNodeIds(opts.blueprint)) {
+  for (const entryId of collectEntryNodeIds(opts.blueprint)) {
     if (!seenStateIds.has(entryId)) {
       errors.push(
         planProblem(


### PR DESCRIPTION
Task: `202605290203-E5E8EF`
Title: Blueprint validate decomposition
Canonical task record: `.agentplane/tasks/202605290203-E5E8EF/README.md`

## Summary

Blueprint validate decomposition

Decompose packages/agentplane/src/blueprints/validate.ts by extracting shared graph/evidence validation helpers while preserving blueprint and plan validation behavior and reducing runtime hotspot warnings.

## Scope

- In scope: Decompose packages/agentplane/src/blueprints/validate.ts by extracting shared graph/evidence validation helpers while preserving blueprint and plan validation behavior and reducing runtime hotspot warnings.
- Out of scope: unrelated refactors not required for "Blueprint validate decomposition".

## Verification

- State: ok
- Note:

```text
Verified blueprint validation helper decomposition. Commands passed: bunx vitest run
packages/agentplane/src/blueprints/validate.test.ts --config vitest.workspace.ts (23 tests), bun run
typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun
run hotspots:check. Runtime hotspot warnings decreased from 24 to 23; validate.ts is 390 lines,
below the 400-line warning threshold.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-29T02:04:06.763Z
- Branch: task/202605290203-E5E8EF/blueprint-validate-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../agentplane/src/blueprints/validate-helpers.ts  | 124 +++++++++++++++++
 packages/agentplane/src/blueprints/validate.ts     | 147 +++------------------
 2 files changed, 146 insertions(+), 125 deletions(-)
```

</details>
