### PR TITLE
🚧 K1E9GB task: Prompt module validation decomposition [202605290229-K1E9GB]

### DIFF
--- a/.agentplane/tasks/202605290229-K1E9GB/README.md
+++ b/.agentplane/tasks/202605290229-K1E9GB/README.md
@@ -1,0 +1,124 @@
+---
+id: "202605290229-K1E9GB"
+title: "Prompt module validation decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "hotspot"
+  - "prompt-modules"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-29T02:29:23.246Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: decompose prompt module validation constants and primitive guards while preserving public validation exports and runtime behavior."
+events:
+  -
+    type: "status"
+    at: "2026-05-29T02:29:48.514Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: decompose prompt module validation constants and primitive guards while preserving public validation exports and runtime behavior."
+doc_version: 3
+doc_updated_at: "2026-05-29T02:29:48.514Z"
+doc_updated_by: "CODER"
+description: "Decompose packages/agentplane/src/runtime/prompt-modules/validation.ts by extracting prompt module validation constants and primitive field guards while preserving runtime prompt module, mutation set, and compiled graph validation behavior."
+sections:
+  Summary: |-
+    Prompt module validation decomposition
+
+    Decompose packages/agentplane/src/runtime/prompt-modules/validation.ts by extracting prompt module validation constants and primitive field guards while preserving runtime prompt module, mutation set, and compiled graph validation behavior.
+  Scope: |-
+    - In scope: Decompose packages/agentplane/src/runtime/prompt-modules/validation.ts by extracting prompt module validation constants and primitive field guards while preserving runtime prompt module, mutation set, and compiled graph validation behavior.
+    - Out of scope: unrelated refactors not required for "Prompt module validation decomposition".
+  Plan: |-
+    Plan:
+    1. Start a branch_pr worktree for CODER.
+    2. Extract prompt module validation enum domains and primitive guard helpers from packages/agentplane/src/runtime/prompt-modules/validation.ts into focused modules.
+    3. Preserve validatePromptModule, validatePromptModuleMutationSet, validatePromptModuleCompiledGraph, and ValidatedPromptModuleMutation exports and behavior.
+    4. Verify with prompt module model/mutation/registry tests, typecheck, arch/knip/lint/format, and hotspot threshold report.
+    5. Open PR, wait for hosted checks, merge to main, close lifecycle, and clean worktree.
+
+    Acceptance:
+    - Prompt module validation tests remain compatible, including negative-path validation errors.
+    - validation.ts drops below the 400-line hotspot warning threshold.
+    - Runtime hotspot warning count decreases from 23 to 22 without introducing new warning-sized runtime modules.
+    - No compiler, registry, schema, or mutation semantics change beyond shared helper imports.
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Prompt module validation decomposition
+
+Decompose packages/agentplane/src/runtime/prompt-modules/validation.ts by extracting prompt module validation constants and primitive field guards while preserving runtime prompt module, mutation set, and compiled graph validation behavior.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/runtime/prompt-modules/validation.ts by extracting prompt module validation constants and primitive field guards while preserving runtime prompt module, mutation set, and compiled graph validation behavior.
+- Out of scope: unrelated refactors not required for "Prompt module validation decomposition".
+
+## Plan
+
+Plan:
+1. Start a branch_pr worktree for CODER.
+2. Extract prompt module validation enum domains and primitive guard helpers from packages/agentplane/src/runtime/prompt-modules/validation.ts into focused modules.
+3. Preserve validatePromptModule, validatePromptModuleMutationSet, validatePromptModuleCompiledGraph, and ValidatedPromptModuleMutation exports and behavior.
+4. Verify with prompt module model/mutation/registry tests, typecheck, arch/knip/lint/format, and hotspot threshold report.
+5. Open PR, wait for hosted checks, merge to main, close lifecycle, and clean worktree.
+
+Acceptance:
+- Prompt module validation tests remain compatible, including negative-path validation errors.
+- validation.ts drops below the 400-line hotspot warning threshold.
+- Runtime hotspot warning count decreases from 23 to 22 without introducing new warning-sized runtime modules.
+- No compiler, registry, schema, or mutation semantics change beyond shared helper imports.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605290229-K1E9GB/README.md
+++ b/.agentplane/tasks/202605290229-K1E9GB/README.md
@@ -4,7 +4,7 @@ title: "Prompt module validation decomposition"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 4
+revision: 5
 origin:
   system: "manual"
 depends_on: []
@@ -19,10 +19,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-29T02:35:06.121Z"
+  updated_by: "CODER"
+  note: "Verified prompt module validation decomposition. Commands passed: bunx vitest run packages/agentplane/src/runtime/prompt-modules/model.test.ts packages/agentplane/src/runtime/prompt-modules/mutations.test.ts packages/agentplane/src/runtime/prompt-modules/registry.test.ts --config vitest.workspace.ts (13 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 23 to 22; validation.ts is 342 lines, below the 400-line warning threshold."
   attempts: 0
 commit: null
 comments:
@@ -37,8 +37,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: decompose prompt module validation constants and primitive guards while preserving public validation exports and runtime behavior."
+  -
+    type: "verify"
+    at: "2026-05-29T02:35:06.121Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified prompt module validation decomposition. Commands passed: bunx vitest run packages/agentplane/src/runtime/prompt-modules/model.test.ts packages/agentplane/src/runtime/prompt-modules/mutations.test.ts packages/agentplane/src/runtime/prompt-modules/registry.test.ts --config vitest.workspace.ts (13 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 23 to 22; validation.ts is 342 lines, below the 400-line warning threshold."
 doc_version: 3
-doc_updated_at: "2026-05-29T02:29:48.514Z"
+doc_updated_at: "2026-05-29T02:35:06.148Z"
 doc_updated_by: "CODER"
 description: "Decompose packages/agentplane/src/runtime/prompt-modules/validation.ts by extracting prompt module validation constants and primitive field guards while preserving runtime prompt module, mutation set, and compiled graph validation behavior."
 sections:
@@ -70,6 +76,25 @@ sections:
     3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-29T02:35:06.121Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified prompt module validation decomposition. Commands passed: bunx vitest run packages/agentplane/src/runtime/prompt-modules/model.test.ts packages/agentplane/src/runtime/prompt-modules/mutations.test.ts packages/agentplane/src/runtime/prompt-modules/registry.test.ts --config vitest.workspace.ts (13 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 23 to 22; validation.ts is 342 lines, below the 400-line warning threshold.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T02:29:48.514Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: .agentplane/tasks/202605290229-K1E9GB/blueprint/resolved-snapshot.json
+    - old_digest: 771cbd40ebe2e3d9d8f16c2bce9a3f2c1386d4ca8e48c4095af84fb1c10b9b6e
+    - current_digest: 771cbd40ebe2e3d9d8f16c2bce9a3f2c1386d4ca8e48c4095af84fb1c10b9b6e
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605290229-K1E9GB
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -114,6 +139,25 @@ PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLA
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-29T02:35:06.121Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified prompt module validation decomposition. Commands passed: bunx vitest run packages/agentplane/src/runtime/prompt-modules/model.test.ts packages/agentplane/src/runtime/prompt-modules/mutations.test.ts packages/agentplane/src/runtime/prompt-modules/registry.test.ts --config vitest.workspace.ts (13 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 23 to 22; validation.ts is 342 lines, below the 400-line warning threshold.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T02:29:48.514Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: .agentplane/tasks/202605290229-K1E9GB/blueprint/resolved-snapshot.json
+- old_digest: 771cbd40ebe2e3d9d8f16c2bce9a3f2c1386d4ca8e48c4095af84fb1c10b9b6e
+- current_digest: 771cbd40ebe2e3d9d8f16c2bce9a3f2c1386d4ca8e48c4095af84fb1c10b9b6e
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605290229-K1E9GB
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605290229-K1E9GB/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605290229-K1E9GB/blueprint/resolved-snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605290229-K1E9GB",
+    "title": "Prompt module validation decomposition",
+    "description": "Decompose packages/agentplane/src/runtime/prompt-modules/validation.ts by extracting prompt module validation constants and primitive field guards while preserving runtime prompt module, mutation set, and compiled graph validation behavior.",
+    "tags": [
+      "code",
+      "hotspot",
+      "prompt-modules"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605290229-K1E9GB",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "771cbd40ebe2e3d9d8f16c2bce9a3f2c1386d4ca8e48c4095af84fb1c10b9b6e"
+  }
+}

--- a/.agentplane/tasks/202605290229-K1E9GB/pr/diffstat.txt
+++ b/.agentplane/tasks/202605290229-K1E9GB/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ .../runtime/prompt-modules/validation-constants.ts | 119 ++++++++++++
+ .../runtime/prompt-modules/validation-guards.ts    |  73 +++++++
+ .../src/runtime/prompt-modules/validation.ts       | 213 +++------------------
+ 3 files changed, 223 insertions(+), 182 deletions(-)

--- a/.agentplane/tasks/202605290229-K1E9GB/pr/github-body.md
+++ b/.agentplane/tasks/202605290229-K1E9GB/pr/github-body.md
@@ -15,8 +15,18 @@ Decompose packages/agentplane/src/runtime/prompt-modules/validation.ts by extrac
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Verified prompt module validation decomposition. Commands passed: bunx vitest run
+packages/agentplane/src/runtime/prompt-modules/model.test.ts
+packages/agentplane/src/runtime/prompt-modules/mutations.test.ts
+packages/agentplane/src/runtime/prompt-modules/registry.test.ts --config vitest.workspace.ts (13
+tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run
+format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 23 to 22;
+validation.ts is 342 lines, below the 400-line warning threshold.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
@@ -27,7 +37,10 @@ Decompose packages/agentplane/src/runtime/prompt-modules/validation.ts by extrac
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../runtime/prompt-modules/validation-constants.ts | 119 ++++++++++++
+ .../runtime/prompt-modules/validation-guards.ts    |  73 +++++++
+ .../src/runtime/prompt-modules/validation.ts       | 213 +++------------------
+ 3 files changed, 223 insertions(+), 182 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605290229-K1E9GB/pr/github-body.md
+++ b/.agentplane/tasks/202605290229-K1E9GB/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605290229-K1E9GB`
+Title: Prompt module validation decomposition
+Canonical task record: `.agentplane/tasks/202605290229-K1E9GB/README.md`
+
+## Summary
+
+Prompt module validation decomposition
+
+Decompose packages/agentplane/src/runtime/prompt-modules/validation.ts by extracting prompt module validation constants and primitive field guards while preserving runtime prompt module, mutation set, and compiled graph validation behavior.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/runtime/prompt-modules/validation.ts by extracting prompt module validation constants and primitive field guards while preserving runtime prompt module, mutation set, and compiled graph validation behavior.
+- Out of scope: unrelated refactors not required for "Prompt module validation decomposition".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T02:29:48.627Z
+- Branch: task/202605290229-K1E9GB/prompt-validation-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605290229-K1E9GB/pr/github-title.txt
+++ b/.agentplane/tasks/202605290229-K1E9GB/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 K1E9GB task: Prompt module validation decomposition [202605290229-K1E9GB]

--- a/.agentplane/tasks/202605290229-K1E9GB/pr/meta.json
+++ b/.agentplane/tasks/202605290229-K1E9GB/pr/meta.json
@@ -2,12 +2,13 @@
   "base": "main",
   "branch": "task/202605290229-K1E9GB/prompt-validation-decomposition",
   "created_at": "2026-05-29T02:29:48.627Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:c32ecd92c5b940a8adc6e2c85e0e499992228b4991a48757b8a8bc07562b6d71",
+  "last_verified_at": "2026-05-29T02:35:06.121Z",
+  "last_verified_diffstat_sha256": "sha256:c32ecd92c5b940a8adc6e2c85e0e499992228b4991a48757b8a8bc07562b6d71",
   "schema_version": 1,
   "task_id": "202605290229-K1E9GB",
   "updated_at": "2026-05-29T02:29:48.627Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605290229-K1E9GB/pr/meta.json
+++ b/.agentplane/tasks/202605290229-K1E9GB/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202605290229-K1E9GB/prompt-validation-decomposition",
+  "created_at": "2026-05-29T02:29:48.627Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202605290229-K1E9GB",
+  "updated_at": "2026-05-29T02:29:48.627Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605290229-K1E9GB/pr/review.md
+++ b/.agentplane/tasks/202605290229-K1E9GB/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-05-29T02:29:48.627Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified prompt module validation decomposition. Commands passed: bunx vitest run packages/agentplane/src/runtime/prompt-modules/model.test.ts packages/agentplane/src/runtime/prompt-modules/mutations.test.ts packages/agentplane/src/runtime/prompt-modules/registry.test.ts --config vitest.workspace.ts (13 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 23 to 22; validation.ts is 342 lines, below the 400-line warning threshold.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -29,7 +29,10 @@ Created: 2026-05-29T02:29:48.627Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../runtime/prompt-modules/validation-constants.ts | 119 ++++++++++++
+ .../runtime/prompt-modules/validation-guards.ts    |  73 +++++++
+ .../src/runtime/prompt-modules/validation.ts       | 213 +++------------------
+ 3 files changed, 223 insertions(+), 182 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605290229-K1E9GB/pr/review.md
+++ b/.agentplane/tasks/202605290229-K1E9GB/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-29T02:29:48.627Z
+
+## Task
+
+- Task: `202605290229-K1E9GB`
+- Title: Prompt module validation decomposition
+- Status: DOING
+- Branch: `task/202605290229-K1E9GB/prompt-validation-decomposition`
+- Canonical task record: `.agentplane/tasks/202605290229-K1E9GB/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T02:29:48.627Z
+- Branch: task/202605290229-K1E9GB/prompt-validation-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/runtime/prompt-modules/validation-constants.ts
+++ b/packages/agentplane/src/runtime/prompt-modules/validation-constants.ts
@@ -1,0 +1,119 @@
+import type { PromptModuleBindingKind, PromptModuleValidatorPhase } from "./mutations.js";
+import type {
+  PromptModuleConflictPolicy,
+  PromptModuleContentKind,
+  PromptModuleMergeMode,
+  PromptModuleMutability,
+  PromptModuleSlot,
+  PromptModuleSourceKind,
+  PromptModuleSurface,
+  PromptModuleTarget,
+} from "./model.js";
+
+export const PROMPT_MODULE_SURFACES: PromptModuleSurface[] = [
+  "gateway",
+  "policy",
+  "agent_profile",
+  "runner",
+  "validator",
+  "template",
+];
+
+export const PROMPT_MODULE_TARGETS: PromptModuleTarget[] = [
+  "AGENTS.md",
+  "CLAUDE.md",
+  ".agentplane/policy",
+  ".agentplane/agents",
+  "runner.bundle",
+  "recipe.manifest",
+  "generated.artifact",
+];
+
+export const PROMPT_MODULE_SLOTS: PromptModuleSlot[] = [
+  "frontmatter",
+  "purpose",
+  "startup",
+  "commands",
+  "load_rules",
+  "source_of_truth",
+  "hard_constraint",
+  "body",
+  "example",
+  "identity",
+  "inputs",
+  "outputs",
+  "permissions",
+  "workflow",
+  "cli_notes",
+  "context",
+  "schema",
+  "check",
+  "partial",
+  "file",
+];
+
+export const CONTENT_KINDS: PromptModuleContentKind[] = [
+  "markdown",
+  "json",
+  "text",
+  "typescript",
+  "command",
+];
+
+export const MUTABILITIES: PromptModuleMutability[] = [
+  "locked",
+  "replaceable",
+  "extendable",
+  "append_only",
+];
+
+export const MERGE_MODES: PromptModuleMergeMode[] = [
+  "pick_one",
+  "replace",
+  "prepend",
+  "append",
+  "merge_object",
+  "union_by_id",
+];
+
+export const CONFLICT_POLICIES: PromptModuleConflictPolicy[] = [
+  "error",
+  "highest_precedence",
+  "last_writer_wins",
+  "keep_all",
+];
+
+export const SOURCE_KINDS: PromptModuleSourceKind[] = [
+  "framework_builtin",
+  "project_file",
+  "recipe_asset",
+  "generated",
+  "runtime",
+];
+
+export const OWNER_KINDS = ["framework", "project", "recipe", "runtime"] as const;
+export const WORKFLOW_MODES = ["direct", "branch_pr"] as const;
+export const POLICY_GATEWAYS = ["codex", "claude"] as const;
+export const BINDING_KINDS: PromptModuleBindingKind[] = [
+  "extends",
+  "replaces",
+  "requires",
+  "feeds",
+  "validates",
+];
+export const VALIDATOR_PHASES: PromptModuleValidatorPhase[] = [
+  "resolve",
+  "compile",
+  "emit",
+  "doctor",
+];
+export const VALIDATOR_KINDS = ["required_module", "forbidden_module", "required_command"] as const;
+export const MUTATION_OPS = [
+  "add_module",
+  "replace_module",
+  "patch_module",
+  "disable_module",
+  "bind_module",
+  "add_validator",
+  "disable_validator",
+] as const;

--- a/packages/agentplane/src/runtime/prompt-modules/validation-guards.ts
+++ b/packages/agentplane/src/runtime/prompt-modules/validation-guards.ts
@@ -1,0 +1,73 @@
+import { isRecord } from "../../shared/guards.js";
+import type { PromptModuleAddress } from "./model.js";
+
+export function invalid(field: string, expected: string): Error {
+  return new Error(`Invalid field ${field}: expected ${expected}`);
+}
+
+export function requireRecord(raw: unknown, field: string): Record<string, unknown> {
+  if (!isRecord(raw)) throw invalid(field, "object");
+  return raw;
+}
+
+export function requireString(raw: unknown, field: string): string {
+  if (typeof raw !== "string" || !raw.trim()) throw invalid(field, "non-empty string");
+  return raw.trim();
+}
+
+export function optionalString(raw: unknown, field: string): string | undefined {
+  if (raw === undefined) return undefined;
+  return requireString(raw, field);
+}
+
+export function optionalBoolean(raw: unknown, field: string): boolean | undefined {
+  if (raw === undefined) return undefined;
+  if (typeof raw !== "boolean") throw invalid(field, "boolean");
+  return raw;
+}
+
+export function optionalNumber(raw: unknown, field: string): number | undefined {
+  if (raw === undefined) return undefined;
+  if (typeof raw !== "number" || Number.isNaN(raw)) throw invalid(field, "number");
+  return raw;
+}
+
+export function validateEnum<T extends string>(
+  raw: unknown,
+  field: string,
+  allowed: readonly T[],
+): T {
+  const value = requireString(raw, field);
+  if (!allowed.includes(value as T))
+    throw invalid(field, allowed.map((item) => `"${item}"`).join(" | "));
+  return value as T;
+}
+
+export function validateOptionalStringList(raw: unknown, field: string): string[] | undefined {
+  if (raw === undefined) return undefined;
+  if (!Array.isArray(raw)) throw invalid(field, "string[]");
+  return raw.map((entry, index) => requireString(entry, `${field}[${index}]`));
+}
+
+export function validateOptionalEnumList<T extends string>(
+  raw: unknown,
+  field: string,
+  allowed: readonly T[],
+): T[] | undefined {
+  if (raw === undefined) return undefined;
+  if (!Array.isArray(raw)) throw invalid(field, "array");
+  return raw.map((entry, index) => validateEnum(entry, `${field}[${index}]`, allowed));
+}
+
+export function validateNamespace(raw: unknown, field: string): PromptModuleAddress["namespace"] {
+  const namespace = requireString(raw, field);
+  if (
+    namespace === "framework" ||
+    namespace === "project" ||
+    namespace === "runtime" ||
+    /^recipe\.[^/\\\s]+$/.test(namespace)
+  ) {
+    return namespace as PromptModuleAddress["namespace"];
+  }
+  throw invalid(field, '"framework" | "project" | "runtime" | "recipe.<id>"');
+}

--- a/packages/agentplane/src/runtime/prompt-modules/validation.ts
+++ b/packages/agentplane/src/runtime/prompt-modules/validation.ts
@@ -1,201 +1,49 @@
 import type {
   PromptModule,
   PromptModuleAddress,
-  PromptModuleConflictPolicy,
-  PromptModuleContentKind,
   PromptModuleDependency,
   PromptModuleLoadCondition,
-  PromptModuleMergeMode,
   PromptModuleMergePolicy,
-  PromptModuleMutability,
   PromptModuleOwner,
   PromptModuleProvenance,
-  PromptModuleSlot,
-  PromptModuleSourceKind,
-  PromptModuleSurface,
-  PromptModuleTarget,
 } from "./model.js";
 import type { PromptModuleCompiledGraph } from "./compiler.js";
 import { migratePromptModuleSchemaVersion } from "./schema.js";
-import { isRecord } from "../../shared/guards.js";
 import type {
-  PromptModuleBindingKind,
   PromptModuleMutation,
   PromptModuleMutationSet,
   PromptModuleMutationWhen,
   PromptModuleSelector,
-  PromptModuleValidatorPhase,
 } from "./mutations.js";
-
-const PROMPT_MODULE_SURFACES: PromptModuleSurface[] = [
-  "gateway",
-  "policy",
-  "agent_profile",
-  "runner",
-  "validator",
-  "template",
-];
-
-const PROMPT_MODULE_TARGETS: PromptModuleTarget[] = [
-  "AGENTS.md",
-  "CLAUDE.md",
-  ".agentplane/policy",
-  ".agentplane/agents",
-  "runner.bundle",
-  "recipe.manifest",
-  "generated.artifact",
-];
-
-const PROMPT_MODULE_SLOTS: PromptModuleSlot[] = [
-  "frontmatter",
-  "purpose",
-  "startup",
-  "commands",
-  "load_rules",
-  "source_of_truth",
-  "hard_constraint",
-  "body",
-  "example",
-  "identity",
-  "inputs",
-  "outputs",
-  "permissions",
-  "workflow",
-  "cli_notes",
-  "context",
-  "schema",
-  "check",
-  "partial",
-  "file",
-];
-
-const CONTENT_KINDS: PromptModuleContentKind[] = [
-  "markdown",
-  "json",
-  "text",
-  "typescript",
-  "command",
-];
-
-const MUTABILITIES: PromptModuleMutability[] = [
-  "locked",
-  "replaceable",
-  "extendable",
-  "append_only",
-];
-
-const MERGE_MODES: PromptModuleMergeMode[] = [
-  "pick_one",
-  "replace",
-  "prepend",
-  "append",
-  "merge_object",
-  "union_by_id",
-];
-
-const CONFLICT_POLICIES: PromptModuleConflictPolicy[] = [
-  "error",
-  "highest_precedence",
-  "last_writer_wins",
-  "keep_all",
-];
-
-const SOURCE_KINDS: PromptModuleSourceKind[] = [
-  "framework_builtin",
-  "project_file",
-  "recipe_asset",
-  "generated",
-  "runtime",
-];
-
-const OWNER_KINDS = ["framework", "project", "recipe", "runtime"] as const;
-const WORKFLOW_MODES = ["direct", "branch_pr"] as const;
-const POLICY_GATEWAYS = ["codex", "claude"] as const;
-const BINDING_KINDS: PromptModuleBindingKind[] = [
-  "extends",
-  "replaces",
-  "requires",
-  "feeds",
-  "validates",
-];
-const VALIDATOR_PHASES: PromptModuleValidatorPhase[] = ["resolve", "compile", "emit", "doctor"];
-const VALIDATOR_KINDS = ["required_module", "forbidden_module", "required_command"] as const;
-const MUTATION_OPS = [
-  "add_module",
-  "replace_module",
-  "patch_module",
-  "disable_module",
-  "bind_module",
-  "add_validator",
-  "disable_validator",
-] as const;
-
-function invalid(field: string, expected: string): Error {
-  return new Error(`Invalid field ${field}: expected ${expected}`);
-}
-
-function requireRecord(raw: unknown, field: string): Record<string, unknown> {
-  if (!isRecord(raw)) throw invalid(field, "object");
-  return raw;
-}
-
-function requireString(raw: unknown, field: string): string {
-  if (typeof raw !== "string" || !raw.trim()) throw invalid(field, "non-empty string");
-  return raw.trim();
-}
-
-function optionalString(raw: unknown, field: string): string | undefined {
-  if (raw === undefined) return undefined;
-  return requireString(raw, field);
-}
-
-function optionalBoolean(raw: unknown, field: string): boolean | undefined {
-  if (raw === undefined) return undefined;
-  if (typeof raw !== "boolean") throw invalid(field, "boolean");
-  return raw;
-}
-
-function optionalNumber(raw: unknown, field: string): number | undefined {
-  if (raw === undefined) return undefined;
-  if (typeof raw !== "number" || Number.isNaN(raw)) throw invalid(field, "number");
-  return raw;
-}
-
-function validateEnum<T extends string>(raw: unknown, field: string, allowed: readonly T[]): T {
-  const value = requireString(raw, field);
-  if (!allowed.includes(value as T))
-    throw invalid(field, allowed.map((item) => `"${item}"`).join(" | "));
-  return value as T;
-}
-
-function validateOptionalStringList(raw: unknown, field: string): string[] | undefined {
-  if (raw === undefined) return undefined;
-  if (!Array.isArray(raw)) throw invalid(field, "string[]");
-  return raw.map((entry, index) => requireString(entry, `${field}[${index}]`));
-}
-
-function validateOptionalEnumList<T extends string>(
-  raw: unknown,
-  field: string,
-  allowed: readonly T[],
-): T[] | undefined {
-  if (raw === undefined) return undefined;
-  if (!Array.isArray(raw)) throw invalid(field, "array");
-  return raw.map((entry, index) => validateEnum(entry, `${field}[${index}]`, allowed));
-}
-
-function validateNamespace(raw: unknown, field: string): PromptModuleAddress["namespace"] {
-  const namespace = requireString(raw, field);
-  if (
-    namespace === "framework" ||
-    namespace === "project" ||
-    namespace === "runtime" ||
-    /^recipe\.[^/\\\s]+$/.test(namespace)
-  ) {
-    return namespace as PromptModuleAddress["namespace"];
-  }
-  throw invalid(field, '"framework" | "project" | "runtime" | "recipe.<id>"');
-}
+import {
+  BINDING_KINDS,
+  CONFLICT_POLICIES,
+  CONTENT_KINDS,
+  MERGE_MODES,
+  MUTABILITIES,
+  MUTATION_OPS,
+  OWNER_KINDS,
+  POLICY_GATEWAYS,
+  PROMPT_MODULE_SLOTS,
+  PROMPT_MODULE_SURFACES,
+  PROMPT_MODULE_TARGETS,
+  SOURCE_KINDS,
+  VALIDATOR_KINDS,
+  VALIDATOR_PHASES,
+  WORKFLOW_MODES,
+} from "./validation-constants.js";
+import {
+  invalid,
+  optionalBoolean,
+  optionalNumber,
+  optionalString,
+  requireRecord,
+  requireString,
+  validateEnum,
+  validateNamespace,
+  validateOptionalEnumList,
+  validateOptionalStringList,
+} from "./validation-guards.js";
 
 function validateAddress(raw: unknown, field: string): PromptModuleAddress {
   const address = requireRecord(raw, field);
@@ -304,7 +152,8 @@ function validateDependencies(raw: unknown, field: string): PromptModuleDependen
 }
 
 function validateModuleContent(raw: unknown, field: string): void {
-  if (typeof raw === "string" || isRecord(raw)) return;
+  if (typeof raw === "string") return;
+  if (Boolean(raw) && typeof raw === "object" && !Array.isArray(raw)) return;
   throw invalid(field, "string | object");
 }
 


### PR DESCRIPTION
Task: `202605290229-K1E9GB`
Title: Prompt module validation decomposition
Canonical task record: `.agentplane/tasks/202605290229-K1E9GB/README.md`

## Summary

Prompt module validation decomposition

Decompose packages/agentplane/src/runtime/prompt-modules/validation.ts by extracting prompt module validation constants and primitive field guards while preserving runtime prompt module, mutation set, and compiled graph validation behavior.

## Scope

- In scope: Decompose packages/agentplane/src/runtime/prompt-modules/validation.ts by extracting prompt module validation constants and primitive field guards while preserving runtime prompt module, mutation set, and compiled graph validation behavior.
- Out of scope: unrelated refactors not required for "Prompt module validation decomposition".

## Verification

- State: ok
- Note:

```text
Verified prompt module validation decomposition. Commands passed: bunx vitest run
packages/agentplane/src/runtime/prompt-modules/model.test.ts
packages/agentplane/src/runtime/prompt-modules/mutations.test.ts
packages/agentplane/src/runtime/prompt-modules/registry.test.ts --config vitest.workspace.ts (13
tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run
format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 23 to 22;
validation.ts is 342 lines, below the 400-line warning threshold.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-29T02:29:48.627Z
- Branch: task/202605290229-K1E9GB/prompt-validation-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../runtime/prompt-modules/validation-constants.ts | 119 ++++++++++++
 .../runtime/prompt-modules/validation-guards.ts    |  73 +++++++
 .../src/runtime/prompt-modules/validation.ts       | 213 +++------------------
 3 files changed, 223 insertions(+), 182 deletions(-)
```

</details>
