### PR TITLE
🚧 8GE5QM task: ACR generate decomposition [202605290253-8GE5QM]

### DIFF
--- a/.agentplane/tasks/202605290253-8GE5QM/README.md
+++ b/.agentplane/tasks/202605290253-8GE5QM/README.md
@@ -4,7 +4,7 @@ title: "ACR generate decomposition"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 4
+revision: 5
 origin:
   system: "manual"
 depends_on: []
@@ -19,10 +19,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-29T02:59:55.667Z"
+  updated_by: "CODER"
+  note: "Verified ACR generate decomposition. Commands passed: bunx vitest run packages/agentplane/src/commands/acr/acr.command.test.ts packages/agentplane/src/commands/task/finish.validation.unit.test.ts --config vitest.workspace.ts (33 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 21 to 20; generate.ts is 341 lines, below the 400-line warning threshold."
   attempts: 0
 commit: null
 comments:
@@ -37,8 +37,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: decompose ACR generate helpers while preserving generated record behavior and digest validation."
+  -
+    type: "verify"
+    at: "2026-05-29T02:59:55.667Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified ACR generate decomposition. Commands passed: bunx vitest run packages/agentplane/src/commands/acr/acr.command.test.ts packages/agentplane/src/commands/task/finish.validation.unit.test.ts --config vitest.workspace.ts (33 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 21 to 20; generate.ts is 341 lines, below the 400-line warning threshold."
 doc_version: 3
-doc_updated_at: "2026-05-29T02:54:05.771Z"
+doc_updated_at: "2026-05-29T02:59:55.692Z"
 doc_updated_by: "CODER"
 description: "Decompose packages/agentplane/src/commands/acr/generate.ts by extracting ACR extension and residual-risk helpers while preserving generated Agent Change Record behavior."
 sections:
@@ -70,6 +76,25 @@ sections:
     3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-29T02:59:55.667Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified ACR generate decomposition. Commands passed: bunx vitest run packages/agentplane/src/commands/acr/acr.command.test.ts packages/agentplane/src/commands/task/finish.validation.unit.test.ts --config vitest.workspace.ts (33 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 21 to 20; generate.ts is 341 lines, below the 400-line warning threshold.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T02:54:05.771Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: .agentplane/tasks/202605290253-8GE5QM/blueprint/resolved-snapshot.json
+    - old_digest: 8726c91028e18312e5e6027e4b9769ca4518eee90c3a0a74766df7c6a74a29b8
+    - current_digest: 8726c91028e18312e5e6027e4b9769ca4518eee90c3a0a74766df7c6a74a29b8
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605290253-8GE5QM
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -114,6 +139,25 @@ PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLA
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-29T02:59:55.667Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified ACR generate decomposition. Commands passed: bunx vitest run packages/agentplane/src/commands/acr/acr.command.test.ts packages/agentplane/src/commands/task/finish.validation.unit.test.ts --config vitest.workspace.ts (33 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 21 to 20; generate.ts is 341 lines, below the 400-line warning threshold.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T02:54:05.771Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: .agentplane/tasks/202605290253-8GE5QM/blueprint/resolved-snapshot.json
+- old_digest: 8726c91028e18312e5e6027e4b9769ca4518eee90c3a0a74766df7c6a74a29b8
+- current_digest: 8726c91028e18312e5e6027e4b9769ca4518eee90c3a0a74766df7c6a74a29b8
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605290253-8GE5QM
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605290253-8GE5QM/README.md
+++ b/.agentplane/tasks/202605290253-8GE5QM/README.md
@@ -1,0 +1,124 @@
+---
+id: "202605290253-8GE5QM"
+title: "ACR generate decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "acr"
+  - "code"
+  - "hotspot"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-29T02:53:49.093Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: decompose ACR generate helpers while preserving generated record behavior and digest validation."
+events:
+  -
+    type: "status"
+    at: "2026-05-29T02:54:05.771Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: decompose ACR generate helpers while preserving generated record behavior and digest validation."
+doc_version: 3
+doc_updated_at: "2026-05-29T02:54:05.771Z"
+doc_updated_by: "CODER"
+description: "Decompose packages/agentplane/src/commands/acr/generate.ts by extracting ACR extension and residual-risk helpers while preserving generated Agent Change Record behavior."
+sections:
+  Summary: |-
+    ACR generate decomposition
+
+    Decompose packages/agentplane/src/commands/acr/generate.ts by extracting ACR extension and residual-risk helpers while preserving generated Agent Change Record behavior.
+  Scope: |-
+    - In scope: Decompose packages/agentplane/src/commands/acr/generate.ts by extracting ACR extension and residual-risk helpers while preserving generated Agent Change Record behavior.
+    - Out of scope: unrelated refactors not required for "ACR generate decomposition".
+  Plan: |-
+    Plan:
+    1. Start a branch_pr worktree for CODER.
+    2. Extract ACR blueprint/context extension projection and residual-risk/check helper logic from packages/agentplane/src/commands/acr/generate.ts into focused modules.
+    3. Preserve generateAcr public API, ACR schema validation, record digest behavior, and output path behavior.
+    4. Verify with ACR command tests, typecheck, arch/knip/lint/format, and hotspot threshold report.
+    5. Open PR, wait for hosted checks, merge to main, close lifecycle, and clean worktree.
+
+    Acceptance:
+    - Generated ACR records remain schema-valid and digest-compatible for existing tests.
+    - generate.ts drops below the 400-line hotspot warning threshold.
+    - Runtime hotspot warning count decreases from 21 to 20 without introducing new warning-sized runtime modules.
+    - No unrelated ACR validate, diff, remediation, or CLI parsing changes.
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+ACR generate decomposition
+
+Decompose packages/agentplane/src/commands/acr/generate.ts by extracting ACR extension and residual-risk helpers while preserving generated Agent Change Record behavior.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/commands/acr/generate.ts by extracting ACR extension and residual-risk helpers while preserving generated Agent Change Record behavior.
+- Out of scope: unrelated refactors not required for "ACR generate decomposition".
+
+## Plan
+
+Plan:
+1. Start a branch_pr worktree for CODER.
+2. Extract ACR blueprint/context extension projection and residual-risk/check helper logic from packages/agentplane/src/commands/acr/generate.ts into focused modules.
+3. Preserve generateAcr public API, ACR schema validation, record digest behavior, and output path behavior.
+4. Verify with ACR command tests, typecheck, arch/knip/lint/format, and hotspot threshold report.
+5. Open PR, wait for hosted checks, merge to main, close lifecycle, and clean worktree.
+
+Acceptance:
+- Generated ACR records remain schema-valid and digest-compatible for existing tests.
+- generate.ts drops below the 400-line hotspot warning threshold.
+- Runtime hotspot warning count decreases from 21 to 20 without introducing new warning-sized runtime modules.
+- No unrelated ACR validate, diff, remediation, or CLI parsing changes.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605290253-8GE5QM/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605290253-8GE5QM/blueprint/resolved-snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605290253-8GE5QM",
+    "title": "ACR generate decomposition",
+    "description": "Decompose packages/agentplane/src/commands/acr/generate.ts by extracting ACR extension and residual-risk helpers while preserving generated Agent Change Record behavior.",
+    "tags": [
+      "acr",
+      "code",
+      "hotspot"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605290253-8GE5QM",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "8726c91028e18312e5e6027e4b9769ca4518eee90c3a0a74766df7c6a74a29b8"
+  }
+}

--- a/.agentplane/tasks/202605290253-8GE5QM/pr/diffstat.txt
+++ b/.agentplane/tasks/202605290253-8GE5QM/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../src/commands/acr/generate-extensions.ts        | 151 ++++++++++++++++++++
+ packages/agentplane/src/commands/acr/generate.ts   | 156 +--------------------
+ 2 files changed, 158 insertions(+), 149 deletions(-)

--- a/.agentplane/tasks/202605290253-8GE5QM/pr/github-body.md
+++ b/.agentplane/tasks/202605290253-8GE5QM/pr/github-body.md
@@ -15,8 +15,17 @@ Decompose packages/agentplane/src/commands/acr/generate.ts by extracting ACR ext
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Verified ACR generate decomposition. Commands passed: bunx vitest run
+packages/agentplane/src/commands/acr/acr.command.test.ts
+packages/agentplane/src/commands/task/finish.validation.unit.test.ts --config vitest.workspace.ts
+(33 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run
+format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 21 to 20;
+generate.ts is 341 lines, below the 400-line warning threshold.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
@@ -27,7 +36,9 @@ Decompose packages/agentplane/src/commands/acr/generate.ts by extracting ACR ext
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/commands/acr/generate-extensions.ts        | 151 ++++++++++++++++++++
+ packages/agentplane/src/commands/acr/generate.ts   | 156 +--------------------
+ 2 files changed, 158 insertions(+), 149 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605290253-8GE5QM/pr/github-body.md
+++ b/.agentplane/tasks/202605290253-8GE5QM/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605290253-8GE5QM`
+Title: ACR generate decomposition
+Canonical task record: `.agentplane/tasks/202605290253-8GE5QM/README.md`
+
+## Summary
+
+ACR generate decomposition
+
+Decompose packages/agentplane/src/commands/acr/generate.ts by extracting ACR extension and residual-risk helpers while preserving generated Agent Change Record behavior.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/commands/acr/generate.ts by extracting ACR extension and residual-risk helpers while preserving generated Agent Change Record behavior.
+- Out of scope: unrelated refactors not required for "ACR generate decomposition".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T02:54:05.885Z
+- Branch: task/202605290253-8GE5QM/acr-generate-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605290253-8GE5QM/pr/github-title.txt
+++ b/.agentplane/tasks/202605290253-8GE5QM/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 8GE5QM task: ACR generate decomposition [202605290253-8GE5QM]

--- a/.agentplane/tasks/202605290253-8GE5QM/pr/meta.json
+++ b/.agentplane/tasks/202605290253-8GE5QM/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202605290253-8GE5QM/acr-generate-decomposition",
+  "created_at": "2026-05-29T02:54:05.885Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202605290253-8GE5QM",
+  "updated_at": "2026-05-29T02:54:05.885Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605290253-8GE5QM/pr/meta.json
+++ b/.agentplane/tasks/202605290253-8GE5QM/pr/meta.json
@@ -2,12 +2,13 @@
   "base": "main",
   "branch": "task/202605290253-8GE5QM/acr-generate-decomposition",
   "created_at": "2026-05-29T02:54:05.885Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:f4fe5f2a37ec1fabadff8ea5547136b7371d70894808b5668233c31c305a185b",
+  "last_verified_at": "2026-05-29T02:59:55.667Z",
+  "last_verified_diffstat_sha256": "sha256:f4fe5f2a37ec1fabadff8ea5547136b7371d70894808b5668233c31c305a185b",
   "schema_version": 1,
   "task_id": "202605290253-8GE5QM",
   "updated_at": "2026-05-29T02:54:05.885Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605290253-8GE5QM/pr/review.md
+++ b/.agentplane/tasks/202605290253-8GE5QM/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-29T02:54:05.885Z
+
+## Task
+
+- Task: `202605290253-8GE5QM`
+- Title: ACR generate decomposition
+- Status: DOING
+- Branch: `task/202605290253-8GE5QM/acr-generate-decomposition`
+- Canonical task record: `.agentplane/tasks/202605290253-8GE5QM/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T02:54:05.885Z
+- Branch: task/202605290253-8GE5QM/acr-generate-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605290253-8GE5QM/pr/review.md
+++ b/.agentplane/tasks/202605290253-8GE5QM/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-05-29T02:54:05.885Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified ACR generate decomposition. Commands passed: bunx vitest run packages/agentplane/src/commands/acr/acr.command.test.ts packages/agentplane/src/commands/task/finish.validation.unit.test.ts --config vitest.workspace.ts (33 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 21 to 20; generate.ts is 341 lines, below the 400-line warning threshold.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -29,7 +29,9 @@ Created: 2026-05-29T02:54:05.885Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/commands/acr/generate-extensions.ts        | 151 ++++++++++++++++++++
+ packages/agentplane/src/commands/acr/generate.ts   | 156 +--------------------
+ 2 files changed, 158 insertions(+), 149 deletions(-)
 ```
 
 </details>

--- a/packages/agentplane/src/commands/acr/generate-extensions.ts
+++ b/packages/agentplane/src/commands/acr/generate-extensions.ts
@@ -1,0 +1,151 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { AgentChangeRecord } from "@agentplaneorg/core/schemas";
+
+import { explainResolvedBlueprint, resolveBlueprint } from "../../blueprints/index.js";
+import { isRecord } from "../../shared/guards.js";
+import { blueprintResolveInputFromTask } from "../blueprint/task-input.js";
+import { checkTaskBlueprintSnapshotDrift } from "../blueprint/snapshot-artifact.js";
+import type { CommandContext, loadTaskFromContext } from "../shared/task-backend.js";
+
+type AcrTask = Awaited<ReturnType<typeof loadTaskFromContext>>;
+
+export function buildAcrContextExtension(task: AcrTask): Record<string, unknown> {
+  if (task.task_kind !== "context") return {};
+  const extensions = isRecord(task.extensions) ? task.extensions : {};
+  const context = extensions["agentplane.context"];
+  if (!isRecord(context)) return {};
+  return {
+    "agentplane.context": {
+      ...structuredClone(context),
+      task_id: task.id,
+      task_kind: task.task_kind,
+      mutation_scope: task.mutation_scope ?? null,
+      blueprint_request: task.blueprint_request ?? null,
+    },
+  };
+}
+
+export async function buildAcrBlueprintExtension(opts: { task: AcrTask; ctx: CommandContext }) {
+  const input = blueprintResolveInputFromTask({ task: opts.task, config: opts.ctx.config });
+  const resolved = resolveBlueprint({ input });
+  const explained = explainResolvedBlueprint({ resolved, workflowMode: input.workflowMode });
+  const snapshot = await buildAcrBlueprintSnapshotProjection({
+    task: opts.task,
+    ctx: opts.ctx,
+  });
+  return {
+    blueprint_id: explained.blueprintId,
+    blueprint_version: explained.blueprintVersion,
+    workflow_mode: explained.workflowMode ?? null,
+    route: explained.route.map((node) => node.kind),
+    required_evidence: explained.requiredEvidence.map((item) => ({
+      id: item.id,
+      kind: item.kind,
+      produced_by: item.producedBy,
+      required: item.required,
+    })),
+    accepted_recipe_extensions: explained.acceptedRecipeExtensions.map((item) => ({
+      recipe_id: item.recipeId,
+      recipe_version: item.recipeVersion ?? null,
+      extension_id: item.extensionId ?? null,
+      kind: item.kind,
+      node_kind: item.nodeKind,
+      summary: item.summary ?? null,
+    })),
+    rejected_recipe_extensions: explained.rejectedRecipeExtensions.map((item) => ({
+      recipe_id: item.recipeId,
+      recipe_version: item.recipeVersion ?? null,
+      extension_id: item.extensionId ?? null,
+      kind: item.kind,
+      node_kind: item.nodeKind ?? null,
+      summary: item.summary ?? null,
+      reason: item.reason,
+    })),
+    stop_reasons: explained.stopReasons.map((item) => ({
+      id: item.id,
+      severity: item.severity,
+      reason: item.reason,
+    })),
+    snapshot,
+  };
+}
+
+async function buildAcrBlueprintSnapshotProjection(opts: {
+  task: AcrTask;
+  ctx: CommandContext;
+}): Promise<{
+  state: "current" | "missing" | "invalid" | "stale" | "unavailable";
+  path: string | null;
+  digest: string | null;
+  current_digest: string | null;
+  route_changed: boolean | null;
+  artifact_sha256: string | null;
+  safe_command: string;
+}> {
+  const safeCommand = `agentplane blueprint snapshot ${opts.task.id}`;
+  try {
+    const snapshot = await checkTaskBlueprintSnapshotDrift({ ctx: opts.ctx, task: opts.task });
+    const relativePath = path.relative(opts.ctx.resolvedProject.gitRoot, snapshot.path);
+    const artifactSha256 =
+      snapshot.state === "current" ? await hashFile(snapshot.path).catch(() => null) : null;
+    return {
+      state: snapshot.state,
+      path: relativePath,
+      digest: snapshot.previous.digest,
+      current_digest: snapshot.current.digest,
+      route_changed: snapshot.routeChanged,
+      artifact_sha256: artifactSha256,
+      safe_command: snapshot.safeCommand,
+    };
+  } catch {
+    return {
+      state: "unavailable",
+      path: null,
+      digest: null,
+      current_digest: null,
+      route_changed: null,
+      artifact_sha256: null,
+      safe_command: safeCommand,
+    };
+  }
+}
+
+export function inferCheckType(
+  command: string,
+): AgentChangeRecord["verification"]["checks"][number]["type"] {
+  if (command.includes("typecheck")) return "typecheck";
+  if (command.includes("lint")) return "lint";
+  if (command.includes("build")) return "build";
+  if (command.includes("schema")) return "schema_validation";
+  if (command.includes("test") || command.includes("vitest")) return "test";
+  return "other";
+}
+
+export async function hashFile(filePath: string): Promise<string> {
+  const bytes = await readFile(filePath);
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+export function buildResidualRisks(opts: {
+  taskHash: string | null;
+  planState: string;
+  verificationState: string;
+  verificationChecks: AgentChangeRecord["verification"]["checks"];
+  evidence: AgentChangeRecord["evidence"];
+}): string[] {
+  const risks: string[] = [];
+  if (opts.planState !== "approved") risks.push("Plan is not approved.");
+  if (opts.verificationState !== "ok") risks.push("Verification is not recorded as ok.");
+  if (opts.verificationState === "ok" && opts.verificationChecks.length === 0) {
+    risks.push("Passed verification has no checks.");
+  }
+  if (!opts.taskHash) risks.push("Task README evidence is missing.");
+  if (!opts.evidence.some((item) => item.type === "plan")) risks.push("Plan evidence is missing.");
+  if (!opts.evidence.some((item) => item.type === "verification_log")) {
+    risks.push("Verification log evidence is missing.");
+  }
+  return risks;
+}

--- a/packages/agentplane/src/commands/acr/generate.ts
+++ b/packages/agentplane/src/commands/acr/generate.ts
@@ -10,18 +10,19 @@ import {
   gitRevParse,
   resolveBaseBranch,
 } from "@agentplaneorg/core/git";
-import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
 import path from "node:path";
 
-import { explainResolvedBlueprint, resolveBlueprint } from "../../blueprints/index.js";
 import { getVersion } from "../../meta/version.js";
-import { isRecord } from "../../shared/guards.js";
-import { blueprintResolveInputFromTask } from "../blueprint/task-input.js";
-import { checkTaskBlueprintSnapshotDrift } from "../blueprint/snapshot-artifact.js";
 import { readTaskEvidenceBundleTrustExtension } from "../evidence/evidence.command.js";
 import { loadTaskFromContext, type CommandContext } from "../shared/task-backend.js";
 import { readDiffSummary } from "./diff.js";
+import {
+  buildAcrBlueprintExtension,
+  buildAcrContextExtension,
+  buildResidualRisks,
+  hashFile,
+  inferCheckType,
+} from "./generate-extensions.js";
 import { defaultAcrPath } from "./validate.js";
 
 type ModelProvider = "anthropic" | "openai" | "cursor" | "aider" | "unknown" | "custom";
@@ -307,112 +308,6 @@ export async function generateAcr(opts: {
   return { record, acrPath, warnings: [] };
 }
 
-function buildAcrContextExtension(
-  task: Awaited<ReturnType<typeof loadTaskFromContext>>,
-): Record<string, unknown> {
-  if (task.task_kind !== "context") return {};
-  const extensions = isRecord(task.extensions) ? task.extensions : {};
-  const context = extensions["agentplane.context"];
-  if (!isRecord(context)) return {};
-  return {
-    "agentplane.context": {
-      ...structuredClone(context),
-      task_id: task.id,
-      task_kind: task.task_kind,
-      mutation_scope: task.mutation_scope ?? null,
-      blueprint_request: task.blueprint_request ?? null,
-    },
-  };
-}
-
-async function buildAcrBlueprintExtension(opts: {
-  task: Awaited<ReturnType<typeof loadTaskFromContext>>;
-  ctx: CommandContext;
-}) {
-  const input = blueprintResolveInputFromTask({ task: opts.task, config: opts.ctx.config });
-  const resolved = resolveBlueprint({ input });
-  const explained = explainResolvedBlueprint({ resolved, workflowMode: input.workflowMode });
-  const snapshot = await buildAcrBlueprintSnapshotProjection({
-    task: opts.task,
-    ctx: opts.ctx,
-  });
-  return {
-    blueprint_id: explained.blueprintId,
-    blueprint_version: explained.blueprintVersion,
-    workflow_mode: explained.workflowMode ?? null,
-    route: explained.route.map((node) => node.kind),
-    required_evidence: explained.requiredEvidence.map((item) => ({
-      id: item.id,
-      kind: item.kind,
-      produced_by: item.producedBy,
-      required: item.required,
-    })),
-    accepted_recipe_extensions: explained.acceptedRecipeExtensions.map((item) => ({
-      recipe_id: item.recipeId,
-      recipe_version: item.recipeVersion ?? null,
-      extension_id: item.extensionId ?? null,
-      kind: item.kind,
-      node_kind: item.nodeKind,
-      summary: item.summary ?? null,
-    })),
-    rejected_recipe_extensions: explained.rejectedRecipeExtensions.map((item) => ({
-      recipe_id: item.recipeId,
-      recipe_version: item.recipeVersion ?? null,
-      extension_id: item.extensionId ?? null,
-      kind: item.kind,
-      node_kind: item.nodeKind ?? null,
-      summary: item.summary ?? null,
-      reason: item.reason,
-    })),
-    stop_reasons: explained.stopReasons.map((item) => ({
-      id: item.id,
-      severity: item.severity,
-      reason: item.reason,
-    })),
-    snapshot,
-  };
-}
-
-async function buildAcrBlueprintSnapshotProjection(opts: {
-  task: Awaited<ReturnType<typeof loadTaskFromContext>>;
-  ctx: CommandContext;
-}): Promise<{
-  state: "current" | "missing" | "invalid" | "stale" | "unavailable";
-  path: string | null;
-  digest: string | null;
-  current_digest: string | null;
-  route_changed: boolean | null;
-  artifact_sha256: string | null;
-  safe_command: string;
-}> {
-  const safeCommand = `agentplane blueprint snapshot ${opts.task.id}`;
-  try {
-    const snapshot = await checkTaskBlueprintSnapshotDrift({ ctx: opts.ctx, task: opts.task });
-    const relativePath = path.relative(opts.ctx.resolvedProject.gitRoot, snapshot.path);
-    const artifactSha256 =
-      snapshot.state === "current" ? await hashFile(snapshot.path).catch(() => null) : null;
-    return {
-      state: snapshot.state,
-      path: relativePath,
-      digest: snapshot.previous.digest,
-      current_digest: snapshot.current.digest,
-      route_changed: snapshot.routeChanged,
-      artifact_sha256: artifactSha256,
-      safe_command: snapshot.safeCommand,
-    };
-  } catch {
-    return {
-      state: "unavailable",
-      path: null,
-      digest: null,
-      current_digest: null,
-      route_changed: null,
-      artifact_sha256: null,
-      safe_command: safeCommand,
-    };
-  }
-}
-
 async function resolveBaseRef(
   ctx: CommandContext,
   cwd: string,
@@ -443,41 +338,4 @@ async function resolveBaseCommit(opts: {
 
 async function resolveCommit(gitRoot: string, rev: string): Promise<string> {
   return await gitRevParse(gitRoot, [rev]);
-}
-
-function inferCheckType(
-  command: string,
-): AgentChangeRecord["verification"]["checks"][number]["type"] {
-  if (command.includes("typecheck")) return "typecheck";
-  if (command.includes("lint")) return "lint";
-  if (command.includes("build")) return "build";
-  if (command.includes("schema")) return "schema_validation";
-  if (command.includes("test") || command.includes("vitest")) return "test";
-  return "other";
-}
-
-async function hashFile(filePath: string): Promise<string> {
-  const bytes = await readFile(filePath);
-  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
-}
-
-function buildResidualRisks(opts: {
-  taskHash: string | null;
-  planState: string;
-  verificationState: string;
-  verificationChecks: AgentChangeRecord["verification"]["checks"];
-  evidence: AgentChangeRecord["evidence"];
-}): string[] {
-  const risks: string[] = [];
-  if (opts.planState !== "approved") risks.push("Plan is not approved.");
-  if (opts.verificationState !== "ok") risks.push("Verification is not recorded as ok.");
-  if (opts.verificationState === "ok" && opts.verificationChecks.length === 0) {
-    risks.push("Passed verification has no checks.");
-  }
-  if (!opts.taskHash) risks.push("Task README evidence is missing.");
-  if (!opts.evidence.some((item) => item.type === "plan")) risks.push("Plan evidence is missing.");
-  if (!opts.evidence.some((item) => item.type === "verification_log")) {
-    risks.push("Verification log evidence is missing.");
-  }
-  return risks;
 }


### PR DESCRIPTION
Task: `202605290253-8GE5QM`
Title: ACR generate decomposition
Canonical task record: `.agentplane/tasks/202605290253-8GE5QM/README.md`

## Summary

ACR generate decomposition

Decompose packages/agentplane/src/commands/acr/generate.ts by extracting ACR extension and residual-risk helpers while preserving generated Agent Change Record behavior.

## Scope

- In scope: Decompose packages/agentplane/src/commands/acr/generate.ts by extracting ACR extension and residual-risk helpers while preserving generated Agent Change Record behavior.
- Out of scope: unrelated refactors not required for "ACR generate decomposition".

## Verification

- State: ok
- Note:

```text
Verified ACR generate decomposition. Commands passed: bunx vitest run
packages/agentplane/src/commands/acr/acr.command.test.ts
packages/agentplane/src/commands/task/finish.validation.unit.test.ts --config vitest.workspace.ts
(33 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run
format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 21 to 20;
generate.ts is 341 lines, below the 400-line warning threshold.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-29T02:54:05.885Z
- Branch: task/202605290253-8GE5QM/acr-generate-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/commands/acr/generate-extensions.ts        | 151 ++++++++++++++++++++
 packages/agentplane/src/commands/acr/generate.ts   | 156 +--------------------
 2 files changed, 158 insertions(+), 149 deletions(-)
```

</details>
