### PR TITLE
🚧 X81Y8X task: Blueprint resolve decomposition [202605290307-X81Y8X]

### DIFF
--- a/.agentplane/tasks/202605290307-X81Y8X/README.md
+++ b/.agentplane/tasks/202605290307-X81Y8X/README.md
@@ -1,0 +1,124 @@
+---
+id: "202605290307-X81Y8X"
+title: "Blueprint resolve decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "blueprints"
+  - "code"
+  - "hotspot"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-29T03:07:15.420Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: extract recipe hint validation helpers while preserving blueprint resolve behavior and exports."
+events:
+  -
+    type: "status"
+    at: "2026-05-29T03:07:30.299Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: extract recipe hint validation helpers while preserving blueprint resolve behavior and exports."
+doc_version: 3
+doc_updated_at: "2026-05-29T03:07:30.299Z"
+doc_updated_by: "CODER"
+description: "Decompose packages/agentplane/src/blueprints/resolve.ts by extracting recipe hint validation helpers while preserving blueprint resolution and explanation behavior."
+sections:
+  Summary: |-
+    Blueprint resolve decomposition
+
+    Decompose packages/agentplane/src/blueprints/resolve.ts by extracting recipe hint validation helpers while preserving blueprint resolution and explanation behavior.
+  Scope: |-
+    - In scope: Decompose packages/agentplane/src/blueprints/resolve.ts by extracting recipe hint validation helpers while preserving blueprint resolution and explanation behavior.
+    - Out of scope: unrelated refactors not required for "Blueprint resolve decomposition".
+  Plan: |-
+    Plan:
+    1. Start a branch_pr worktree for CODER.
+    2. Extract recipe hint target/accept/reject validation from packages/agentplane/src/blueprints/resolve.ts into a focused helper module.
+    3. Preserve resolveBlueprint, validateRecipeHintsForBlueprint, and inferBlueprintTaskKind public behavior and exports.
+    4. Verify with blueprint resolve/recipe hint/snapshot tests, typecheck, arch/knip/lint/format, and hotspot threshold report.
+    5. Open PR, wait for hosted checks, merge to main, close lifecycle, and clean worktree.
+
+    Acceptance:
+    - Existing blueprint selection and recipe hint acceptance/rejection behavior remains compatible.
+    - resolve.ts drops below the 400-line hotspot warning threshold.
+    - Runtime hotspot warning count decreases from 20 to 19 without introducing new warning-sized runtime modules.
+    - No unrelated registry, model, explain, or validation changes.
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Blueprint resolve decomposition
+
+Decompose packages/agentplane/src/blueprints/resolve.ts by extracting recipe hint validation helpers while preserving blueprint resolution and explanation behavior.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/blueprints/resolve.ts by extracting recipe hint validation helpers while preserving blueprint resolution and explanation behavior.
+- Out of scope: unrelated refactors not required for "Blueprint resolve decomposition".
+
+## Plan
+
+Plan:
+1. Start a branch_pr worktree for CODER.
+2. Extract recipe hint target/accept/reject validation from packages/agentplane/src/blueprints/resolve.ts into a focused helper module.
+3. Preserve resolveBlueprint, validateRecipeHintsForBlueprint, and inferBlueprintTaskKind public behavior and exports.
+4. Verify with blueprint resolve/recipe hint/snapshot tests, typecheck, arch/knip/lint/format, and hotspot threshold report.
+5. Open PR, wait for hosted checks, merge to main, close lifecycle, and clean worktree.
+
+Acceptance:
+- Existing blueprint selection and recipe hint acceptance/rejection behavior remains compatible.
+- resolve.ts drops below the 400-line hotspot warning threshold.
+- Runtime hotspot warning count decreases from 20 to 19 without introducing new warning-sized runtime modules.
+- No unrelated registry, model, explain, or validation changes.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605290307-X81Y8X/README.md
+++ b/.agentplane/tasks/202605290307-X81Y8X/README.md
@@ -4,7 +4,7 @@ title: "Blueprint resolve decomposition"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 4
+revision: 5
 origin:
   system: "manual"
 depends_on: []
@@ -19,10 +19,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-29T03:13:16.388Z"
+  updated_by: "CODER"
+  note: "Verified blueprint resolve decomposition. Commands passed: bunx vitest run packages/agentplane/src/blueprints/resolve.test.ts packages/agentplane/src/blueprints/recipe-hints.test.ts packages/agentplane/src/blueprints/snapshot.test.ts packages/agentplane/src/blueprints/validate.test.ts --config vitest.workspace.ts (56 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 20 to 19; resolve.ts is 346 lines, below the 400-line warning threshold."
   attempts: 0
 commit: null
 comments:
@@ -37,8 +37,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: extract recipe hint validation helpers while preserving blueprint resolve behavior and exports."
+  -
+    type: "verify"
+    at: "2026-05-29T03:13:16.388Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified blueprint resolve decomposition. Commands passed: bunx vitest run packages/agentplane/src/blueprints/resolve.test.ts packages/agentplane/src/blueprints/recipe-hints.test.ts packages/agentplane/src/blueprints/snapshot.test.ts packages/agentplane/src/blueprints/validate.test.ts --config vitest.workspace.ts (56 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 20 to 19; resolve.ts is 346 lines, below the 400-line warning threshold."
 doc_version: 3
-doc_updated_at: "2026-05-29T03:07:30.299Z"
+doc_updated_at: "2026-05-29T03:13:16.412Z"
 doc_updated_by: "CODER"
 description: "Decompose packages/agentplane/src/blueprints/resolve.ts by extracting recipe hint validation helpers while preserving blueprint resolution and explanation behavior."
 sections:
@@ -70,6 +76,25 @@ sections:
     3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-29T03:13:16.388Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified blueprint resolve decomposition. Commands passed: bunx vitest run packages/agentplane/src/blueprints/resolve.test.ts packages/agentplane/src/blueprints/recipe-hints.test.ts packages/agentplane/src/blueprints/snapshot.test.ts packages/agentplane/src/blueprints/validate.test.ts --config vitest.workspace.ts (56 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 20 to 19; resolve.ts is 346 lines, below the 400-line warning threshold.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T03:07:30.299Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: .agentplane/tasks/202605290307-X81Y8X/blueprint/resolved-snapshot.json
+    - old_digest: 1ef3084ba6c5f2457bc7e333a613514829ce3f4c8da437f5a5ca8e914333fca1
+    - current_digest: 1ef3084ba6c5f2457bc7e333a613514829ce3f4c8da437f5a5ca8e914333fca1
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605290307-X81Y8X
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -114,6 +139,25 @@ PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLA
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-29T03:13:16.388Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified blueprint resolve decomposition. Commands passed: bunx vitest run packages/agentplane/src/blueprints/resolve.test.ts packages/agentplane/src/blueprints/recipe-hints.test.ts packages/agentplane/src/blueprints/snapshot.test.ts packages/agentplane/src/blueprints/validate.test.ts --config vitest.workspace.ts (56 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 20 to 19; resolve.ts is 346 lines, below the 400-line warning threshold.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T03:07:30.299Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: .agentplane/tasks/202605290307-X81Y8X/blueprint/resolved-snapshot.json
+- old_digest: 1ef3084ba6c5f2457bc7e333a613514829ce3f4c8da437f5a5ca8e914333fca1
+- current_digest: 1ef3084ba6c5f2457bc7e333a613514829ce3f4c8da437f5a5ca8e914333fca1
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605290307-X81Y8X
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605290307-X81Y8X/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605290307-X81Y8X/blueprint/resolved-snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605290307-X81Y8X",
+    "title": "Blueprint resolve decomposition",
+    "description": "Decompose packages/agentplane/src/blueprints/resolve.ts by extracting recipe hint validation helpers while preserving blueprint resolution and explanation behavior.",
+    "tags": [
+      "blueprints",
+      "code",
+      "hotspot"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605290307-X81Y8X",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "1ef3084ba6c5f2457bc7e333a613514829ce3f4c8da437f5a5ca8e914333fca1"
+  }
+}

--- a/.agentplane/tasks/202605290307-X81Y8X/pr/diffstat.txt
+++ b/.agentplane/tasks/202605290307-X81Y8X/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../src/blueprints/resolve-recipe-hints.ts         | 135 ++++++++++++++++++++
+ packages/agentplane/src/blueprints/resolve.ts      | 136 +--------------------
+ 2 files changed, 138 insertions(+), 133 deletions(-)

--- a/.agentplane/tasks/202605290307-X81Y8X/pr/github-body.md
+++ b/.agentplane/tasks/202605290307-X81Y8X/pr/github-body.md
@@ -15,8 +15,19 @@ Decompose packages/agentplane/src/blueprints/resolve.ts by extracting recipe hin
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Verified blueprint resolve decomposition. Commands passed: bunx vitest run
+packages/agentplane/src/blueprints/resolve.test.ts
+packages/agentplane/src/blueprints/recipe-hints.test.ts
+packages/agentplane/src/blueprints/snapshot.test.ts
+packages/agentplane/src/blueprints/validate.test.ts --config vitest.workspace.ts (56 tests), bun run
+typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun
+run hotspots:check. Runtime hotspot warnings decreased from 20 to 19; resolve.ts is 346 lines, below
+the 400-line warning threshold.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
@@ -27,7 +38,9 @@ Decompose packages/agentplane/src/blueprints/resolve.ts by extracting recipe hin
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/blueprints/resolve-recipe-hints.ts         | 135 ++++++++++++++++++++
+ packages/agentplane/src/blueprints/resolve.ts      | 136 +--------------------
+ 2 files changed, 138 insertions(+), 133 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605290307-X81Y8X/pr/github-body.md
+++ b/.agentplane/tasks/202605290307-X81Y8X/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605290307-X81Y8X`
+Title: Blueprint resolve decomposition
+Canonical task record: `.agentplane/tasks/202605290307-X81Y8X/README.md`
+
+## Summary
+
+Blueprint resolve decomposition
+
+Decompose packages/agentplane/src/blueprints/resolve.ts by extracting recipe hint validation helpers while preserving blueprint resolution and explanation behavior.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/blueprints/resolve.ts by extracting recipe hint validation helpers while preserving blueprint resolution and explanation behavior.
+- Out of scope: unrelated refactors not required for "Blueprint resolve decomposition".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T03:07:30.419Z
+- Branch: task/202605290307-X81Y8X/blueprint-resolve-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605290307-X81Y8X/pr/github-title.txt
+++ b/.agentplane/tasks/202605290307-X81Y8X/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 X81Y8X task: Blueprint resolve decomposition [202605290307-X81Y8X]

--- a/.agentplane/tasks/202605290307-X81Y8X/pr/meta.json
+++ b/.agentplane/tasks/202605290307-X81Y8X/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202605290307-X81Y8X/blueprint-resolve-decomposition",
+  "created_at": "2026-05-29T03:07:30.419Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202605290307-X81Y8X",
+  "updated_at": "2026-05-29T03:07:30.419Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605290307-X81Y8X/pr/meta.json
+++ b/.agentplane/tasks/202605290307-X81Y8X/pr/meta.json
@@ -2,12 +2,13 @@
   "base": "main",
   "branch": "task/202605290307-X81Y8X/blueprint-resolve-decomposition",
   "created_at": "2026-05-29T03:07:30.419Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:2630cd121f310309409bd0cc1435adb44f1ff1f20fc7932df1c0bee945dcfb95",
+  "last_verified_at": "2026-05-29T03:13:16.388Z",
+  "last_verified_diffstat_sha256": "sha256:2630cd121f310309409bd0cc1435adb44f1ff1f20fc7932df1c0bee945dcfb95",
   "schema_version": 1,
   "task_id": "202605290307-X81Y8X",
   "updated_at": "2026-05-29T03:07:30.419Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605290307-X81Y8X/pr/review.md
+++ b/.agentplane/tasks/202605290307-X81Y8X/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-05-29T03:07:30.419Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified blueprint resolve decomposition. Commands passed: bunx vitest run packages/agentplane/src/blueprints/resolve.test.ts packages/agentplane/src/blueprints/recipe-hints.test.ts packages/agentplane/src/blueprints/snapshot.test.ts packages/agentplane/src/blueprints/validate.test.ts --config vitest.workspace.ts (56 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 20 to 19; resolve.ts is 346 lines, below the 400-line warning threshold.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -29,7 +29,9 @@ Created: 2026-05-29T03:07:30.419Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/blueprints/resolve-recipe-hints.ts         | 135 ++++++++++++++++++++
+ packages/agentplane/src/blueprints/resolve.ts      | 136 +--------------------
+ 2 files changed, 138 insertions(+), 133 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605290307-X81Y8X/pr/review.md
+++ b/.agentplane/tasks/202605290307-X81Y8X/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-29T03:07:30.419Z
+
+## Task
+
+- Task: `202605290307-X81Y8X`
+- Title: Blueprint resolve decomposition
+- Status: DOING
+- Branch: `task/202605290307-X81Y8X/blueprint-resolve-decomposition`
+- Canonical task record: `.agentplane/tasks/202605290307-X81Y8X/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T03:07:30.419Z
+- Branch: task/202605290307-X81Y8X/blueprint-resolve-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/blueprints/resolve-recipe-hints.ts
+++ b/packages/agentplane/src/blueprints/resolve-recipe-hints.ts
@@ -1,0 +1,135 @@
+import type {
+  AcceptedRecipeExtension,
+  Blueprint,
+  BlueprintNodeKind,
+  RecipeHint,
+  RejectedRecipeExtension,
+} from "./model.js";
+
+function extensionPointFor(
+  blueprint: Blueprint,
+  nodeKind: BlueprintNodeKind,
+): { allowed: readonly RecipeHint["kind"][]; rejected: readonly string[] } | undefined {
+  return blueprint.recipeExtensionPoints?.find((point) => point.nodeKind === nodeKind);
+}
+
+function targetNodeKindForHint(hint: RecipeHint): BlueprintNodeKind | undefined {
+  if (hint.kind === "preferred_blueprint") return undefined;
+  if (hint.targetNodeKind) return hint.targetNodeKind;
+  if (hint.kind === "context_hint" || hint.kind === "risk_hint") return "context_resolve";
+  if (hint.kind === "check_suggestion") return "deterministic_check";
+  if (hint.kind === "output_schema" || hint.kind === "artifact_template") return "work_unit";
+  if (hint.kind === "evidence_requirement") return "verify_record";
+  return undefined;
+}
+
+function acceptedRecipeExtension(opts: {
+  hint: RecipeHint;
+  nodeKind: BlueprintNodeKind;
+  reason: string;
+}): AcceptedRecipeExtension {
+  return {
+    recipeId: opts.hint.recipeId,
+    ...(opts.hint.recipeVersion ? { recipeVersion: opts.hint.recipeVersion } : {}),
+    ...(opts.hint.recipeName ? { recipeName: opts.hint.recipeName } : {}),
+    ...(opts.hint.extensionId ? { extensionId: opts.hint.extensionId } : {}),
+    nodeKind: opts.nodeKind,
+    kind: opts.hint.kind,
+    ...(opts.hint.summary ? { summary: opts.hint.summary } : {}),
+    value: opts.hint.value,
+    reason: opts.reason,
+  };
+}
+
+function rejectedRecipeExtension(opts: {
+  hint: RecipeHint;
+  nodeKind?: BlueprintNodeKind;
+  reason: string;
+}): RejectedRecipeExtension {
+  return {
+    recipeId: opts.hint.recipeId,
+    ...(opts.hint.recipeVersion ? { recipeVersion: opts.hint.recipeVersion } : {}),
+    ...(opts.hint.recipeName ? { recipeName: opts.hint.recipeName } : {}),
+    ...(opts.hint.extensionId ? { extensionId: opts.hint.extensionId } : {}),
+    ...(opts.nodeKind ? { nodeKind: opts.nodeKind } : {}),
+    kind: opts.hint.kind,
+    ...(opts.hint.summary ? { summary: opts.hint.summary } : {}),
+    value: opts.hint.value,
+    reason: opts.reason,
+  };
+}
+
+export function validateRecipeHintsForBlueprint(opts: {
+  blueprint: Blueprint;
+  recipeHints: readonly RecipeHint[];
+}): {
+  acceptedRecipeExtensions: AcceptedRecipeExtension[];
+  rejectedRecipeExtensions: RejectedRecipeExtension[];
+} {
+  const acceptedRecipeExtensions: AcceptedRecipeExtension[] = [];
+  const rejectedRecipeExtensions: RejectedRecipeExtension[] = [];
+  const nodeKinds = new Set(opts.blueprint.nodes.map((node) => node.kind));
+
+  for (const hint of opts.recipeHints) {
+    if (hint.kind === "preferred_blueprint") {
+      const value = hint.value;
+      const blueprintId =
+        typeof value === "object" && value !== null && "blueprint_id" in value
+          ? (value as { blueprint_id?: unknown }).blueprint_id
+          : value;
+      if (blueprintId === opts.blueprint.id) {
+        acceptedRecipeExtensions.push(
+          acceptedRecipeExtension({
+            hint,
+            nodeKind: "intake",
+            reason: `Recipe preferred blueprint ${opts.blueprint.id} accepted.`,
+          }),
+        );
+      } else {
+        rejectedRecipeExtensions.push(
+          rejectedRecipeExtension({
+            hint,
+            reason: `Recipe preferred blueprint ${
+              typeof blueprintId === "string" ? blueprintId : "unknown"
+            } did not match the resolved safe route ${opts.blueprint.id}.`,
+          }),
+        );
+      }
+      continue;
+    }
+
+    const nodeKind = targetNodeKindForHint(hint);
+    if (!nodeKind || !nodeKinds.has(nodeKind)) {
+      rejectedRecipeExtensions.push(
+        rejectedRecipeExtension({
+          hint,
+          nodeKind,
+          reason: "Recipe hint targets a node kind that is not active in the selected blueprint.",
+        }),
+      );
+      continue;
+    }
+
+    const point = extensionPointFor(opts.blueprint, nodeKind);
+    if (!point?.allowed.includes(hint.kind)) {
+      rejectedRecipeExtensions.push(
+        rejectedRecipeExtension({
+          hint,
+          nodeKind,
+          reason: "Recipe hint is not allowed for this protected route extension point.",
+        }),
+      );
+      continue;
+    }
+
+    acceptedRecipeExtensions.push(
+      acceptedRecipeExtension({
+        hint,
+        nodeKind,
+        reason: `Recipe hint ${hint.kind} accepted for ${nodeKind}.`,
+      }),
+    );
+  }
+
+  return { acceptedRecipeExtensions, rejectedRecipeExtensions };
+}

--- a/packages/agentplane/src/blueprints/resolve.ts
+++ b/packages/agentplane/src/blueprints/resolve.ts
@@ -1,14 +1,9 @@
 import type {
-  AcceptedRecipeExtension,
   Blueprint,
   BlueprintId,
-  BlueprintNodeKind,
   BlueprintRegistry,
   BlueprintResolveInput,
   MutationKind,
-  RecipeExtensionKind,
-  RecipeHint,
-  RejectedRecipeExtension,
   ResolvedBlueprint,
   RiskFlag,
   StopReason,
@@ -16,6 +11,9 @@ import type {
   WorkflowMode,
 } from "./model.js";
 import { createBlueprintRegistry, getBlueprint } from "./registry.js";
+import { validateRecipeHintsForBlueprint } from "./resolve-recipe-hints.js";
+
+export { validateRecipeHintsForBlueprint } from "./resolve-recipe-hints.js";
 
 const RISK_ROUTE_PRIORITY = [
   "credentials",
@@ -307,134 +305,6 @@ function selectBlueprint(opts: { input: BlueprintResolveInput; registry: Bluepri
 
   stopReasons.push(...riskStops(riskFlags));
   return { blueprint, reasons, stopReasons };
-}
-
-function extensionPointFor(
-  blueprint: Blueprint,
-  nodeKind: BlueprintNodeKind,
-): { allowed: readonly RecipeExtensionKind[]; rejected: readonly string[] } | undefined {
-  return blueprint.recipeExtensionPoints?.find((point) => point.nodeKind === nodeKind);
-}
-
-function targetNodeKindForHint(hint: RecipeHint): BlueprintNodeKind | undefined {
-  if (hint.kind === "preferred_blueprint") return undefined;
-  if (hint.targetNodeKind) return hint.targetNodeKind;
-  if (hint.kind === "context_hint" || hint.kind === "risk_hint") return "context_resolve";
-  if (hint.kind === "check_suggestion") return "deterministic_check";
-  if (hint.kind === "output_schema" || hint.kind === "artifact_template") return "work_unit";
-  if (hint.kind === "evidence_requirement") return "verify_record";
-  return undefined;
-}
-
-function acceptedRecipeExtension(opts: {
-  hint: RecipeHint;
-  nodeKind: BlueprintNodeKind;
-  reason: string;
-}): AcceptedRecipeExtension {
-  return {
-    recipeId: opts.hint.recipeId,
-    ...(opts.hint.recipeVersion ? { recipeVersion: opts.hint.recipeVersion } : {}),
-    ...(opts.hint.recipeName ? { recipeName: opts.hint.recipeName } : {}),
-    ...(opts.hint.extensionId ? { extensionId: opts.hint.extensionId } : {}),
-    nodeKind: opts.nodeKind,
-    kind: opts.hint.kind,
-    ...(opts.hint.summary ? { summary: opts.hint.summary } : {}),
-    value: opts.hint.value,
-    reason: opts.reason,
-  };
-}
-
-function rejectedRecipeExtension(opts: {
-  hint: RecipeHint;
-  nodeKind?: BlueprintNodeKind;
-  reason: string;
-}): RejectedRecipeExtension {
-  return {
-    recipeId: opts.hint.recipeId,
-    ...(opts.hint.recipeVersion ? { recipeVersion: opts.hint.recipeVersion } : {}),
-    ...(opts.hint.recipeName ? { recipeName: opts.hint.recipeName } : {}),
-    ...(opts.hint.extensionId ? { extensionId: opts.hint.extensionId } : {}),
-    ...(opts.nodeKind ? { nodeKind: opts.nodeKind } : {}),
-    kind: opts.hint.kind,
-    ...(opts.hint.summary ? { summary: opts.hint.summary } : {}),
-    value: opts.hint.value,
-    reason: opts.reason,
-  };
-}
-
-export function validateRecipeHintsForBlueprint(opts: {
-  blueprint: Blueprint;
-  recipeHints: readonly RecipeHint[];
-}): {
-  acceptedRecipeExtensions: AcceptedRecipeExtension[];
-  rejectedRecipeExtensions: RejectedRecipeExtension[];
-} {
-  const acceptedRecipeExtensions: AcceptedRecipeExtension[] = [];
-  const rejectedRecipeExtensions: RejectedRecipeExtension[] = [];
-  const nodeKinds = new Set(opts.blueprint.nodes.map((node) => node.kind));
-
-  for (const hint of opts.recipeHints) {
-    if (hint.kind === "preferred_blueprint") {
-      const value = hint.value;
-      const blueprintId =
-        typeof value === "object" && value !== null && "blueprint_id" in value
-          ? (value as { blueprint_id?: unknown }).blueprint_id
-          : value;
-      if (blueprintId === opts.blueprint.id) {
-        acceptedRecipeExtensions.push(
-          acceptedRecipeExtension({
-            hint,
-            nodeKind: "intake",
-            reason: `Recipe preferred blueprint ${opts.blueprint.id} accepted.`,
-          }),
-        );
-      } else {
-        rejectedRecipeExtensions.push(
-          rejectedRecipeExtension({
-            hint,
-            reason: `Recipe preferred blueprint ${
-              typeof blueprintId === "string" ? blueprintId : "unknown"
-            } did not match the resolved safe route ${opts.blueprint.id}.`,
-          }),
-        );
-      }
-      continue;
-    }
-
-    const nodeKind = targetNodeKindForHint(hint);
-    if (!nodeKind || !nodeKinds.has(nodeKind)) {
-      rejectedRecipeExtensions.push(
-        rejectedRecipeExtension({
-          hint,
-          nodeKind,
-          reason: "Recipe hint targets a node kind that is not active in the selected blueprint.",
-        }),
-      );
-      continue;
-    }
-
-    const point = extensionPointFor(opts.blueprint, nodeKind);
-    if (!point?.allowed.includes(hint.kind)) {
-      rejectedRecipeExtensions.push(
-        rejectedRecipeExtension({
-          hint,
-          nodeKind,
-          reason: "Recipe hint is not allowed for this protected route extension point.",
-        }),
-      );
-      continue;
-    }
-
-    acceptedRecipeExtensions.push(
-      acceptedRecipeExtension({
-        hint,
-        nodeKind,
-        reason: `Recipe hint ${hint.kind} accepted for ${nodeKind}.`,
-      }),
-    );
-  }
-
-  return { acceptedRecipeExtensions, rejectedRecipeExtensions };
 }
 
 export function resolveBlueprint(opts: {


### PR DESCRIPTION
Task: `202605290307-X81Y8X`
Title: Blueprint resolve decomposition
Canonical task record: `.agentplane/tasks/202605290307-X81Y8X/README.md`

## Summary

Blueprint resolve decomposition

Decompose packages/agentplane/src/blueprints/resolve.ts by extracting recipe hint validation helpers while preserving blueprint resolution and explanation behavior.

## Scope

- In scope: Decompose packages/agentplane/src/blueprints/resolve.ts by extracting recipe hint validation helpers while preserving blueprint resolution and explanation behavior.
- Out of scope: unrelated refactors not required for "Blueprint resolve decomposition".

## Verification

- State: ok
- Note:

```text
Verified blueprint resolve decomposition. Commands passed: bunx vitest run
packages/agentplane/src/blueprints/resolve.test.ts
packages/agentplane/src/blueprints/recipe-hints.test.ts
packages/agentplane/src/blueprints/snapshot.test.ts
packages/agentplane/src/blueprints/validate.test.ts --config vitest.workspace.ts (56 tests), bun run
typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun
run hotspots:check. Runtime hotspot warnings decreased from 20 to 19; resolve.ts is 346 lines, below
the 400-line warning threshold.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-29T03:07:30.419Z
- Branch: task/202605290307-X81Y8X/blueprint-resolve-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/blueprints/resolve-recipe-hints.ts         | 135 ++++++++++++++++++++
 packages/agentplane/src/blueprints/resolve.ts      | 136 +--------------------
 2 files changed, 138 insertions(+), 133 deletions(-)
```

</details>
