### PR TITLE
🚧 43ZECH task: Backend command decomposition [202605290321-43ZECH]

### DIFF
--- a/.agentplane/tasks/202605290321-43ZECH/README.md
+++ b/.agentplane/tasks/202605290321-43ZECH/README.md
@@ -1,0 +1,129 @@
+---
+id: "202605290321-43ZECH"
+title: "Backend command decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "hotspot"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-29T03:21:39.440Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: extract backend connect config/dotenv helpers from backend.ts into a focused module, preserving command behavior and reducing runtime hotspot count."
+events:
+  -
+    type: "status"
+    at: "2026-05-29T03:21:56.722Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: extract backend connect config/dotenv helpers from backend.ts into a focused module, preserving command behavior and reducing runtime hotspot count."
+doc_version: 3
+doc_updated_at: "2026-05-29T03:21:56.722Z"
+doc_updated_by: "CODER"
+description: "Decompose packages/agentplane/src/commands/backend.ts by extracting backend connect configuration and dotenv helpers into a focused module, preserving CLI behavior while bringing backend.ts under the 400-line hotspot warning threshold."
+sections:
+  Summary: |-
+    Backend command decomposition
+
+    Decompose packages/agentplane/src/commands/backend.ts by extracting backend connect configuration and dotenv helpers into a focused module, preserving CLI behavior while bringing backend.ts under the 400-line hotspot warning threshold.
+  Scope: |-
+    - In scope: Decompose packages/agentplane/src/commands/backend.ts by extracting backend connect configuration and dotenv helpers into a focused module, preserving CLI behavior while bringing backend.ts under the 400-line hotspot warning threshold.
+    - Out of scope: unrelated refactors not required for "Backend command decomposition".
+  Plan: |-
+    Refactor backend command hotspot with a single behavior-preserving extraction.
+
+    Scope:
+    - Extract backend connect config writing and dotenv upsert/quoting helpers from packages/agentplane/src/commands/backend.ts into a focused backend-connect module.
+    - Keep public command entrypoint behavior, output text, error mapping, and network approval behavior unchanged.
+    - Keep backend.ts below the 400-line runtime hotspot warning threshold.
+
+    Verify:
+    - Run targeted backend command tests if present, or the closest CLI/core tests covering backend commands.
+    - Run bun run typecheck.
+    - Run bun run arch:check.
+    - Run bun run knip:check.
+    - Run bun run lint:core.
+    - Run bun run format:changed.
+    - Run bun run hotspots:check and confirm runtime hotspot warnings decrease from 19 to 18.
+  Verify Steps: |-
+    PLANNER fallback scaffold for "Backend command decomposition". Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the requested outcome for "Backend command decomposition". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Backend command decomposition
+
+Decompose packages/agentplane/src/commands/backend.ts by extracting backend connect configuration and dotenv helpers into a focused module, preserving CLI behavior while bringing backend.ts under the 400-line hotspot warning threshold.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/commands/backend.ts by extracting backend connect configuration and dotenv helpers into a focused module, preserving CLI behavior while bringing backend.ts under the 400-line hotspot warning threshold.
+- Out of scope: unrelated refactors not required for "Backend command decomposition".
+
+## Plan
+
+Refactor backend command hotspot with a single behavior-preserving extraction.
+
+Scope:
+- Extract backend connect config writing and dotenv upsert/quoting helpers from packages/agentplane/src/commands/backend.ts into a focused backend-connect module.
+- Keep public command entrypoint behavior, output text, error mapping, and network approval behavior unchanged.
+- Keep backend.ts below the 400-line runtime hotspot warning threshold.
+
+Verify:
+- Run targeted backend command tests if present, or the closest CLI/core tests covering backend commands.
+- Run bun run typecheck.
+- Run bun run arch:check.
+- Run bun run knip:check.
+- Run bun run lint:core.
+- Run bun run format:changed.
+- Run bun run hotspots:check and confirm runtime hotspot warnings decrease from 19 to 18.
+
+## Verify Steps
+
+PLANNER fallback scaffold for "Backend command decomposition". Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the requested outcome for "Backend command decomposition". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605290321-43ZECH/README.md
+++ b/.agentplane/tasks/202605290321-43ZECH/README.md
@@ -4,7 +4,7 @@ title: "Backend command decomposition"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 4
+revision: 5
 origin:
   system: "manual"
 depends_on: []
@@ -18,10 +18,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-29T03:26:01.290Z"
+  updated_by: "CODER"
+  note: "Verified backend command decomposition. Commands passed: bunx vitest run packages/agentplane/src/commands/backend.test.ts packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts --config vitest.workspace.ts (21 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 19 to 18; backend.ts is 352 lines, below the 400-line warning threshold."
   attempts: 0
 commit: null
 comments:
@@ -36,8 +36,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: extract backend connect config/dotenv helpers from backend.ts into a focused module, preserving command behavior and reducing runtime hotspot count."
+  -
+    type: "verify"
+    at: "2026-05-29T03:26:01.290Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified backend command decomposition. Commands passed: bunx vitest run packages/agentplane/src/commands/backend.test.ts packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts --config vitest.workspace.ts (21 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 19 to 18; backend.ts is 352 lines, below the 400-line warning threshold."
 doc_version: 3
-doc_updated_at: "2026-05-29T03:21:56.722Z"
+doc_updated_at: "2026-05-29T03:26:01.326Z"
 doc_updated_by: "CODER"
 description: "Decompose packages/agentplane/src/commands/backend.ts by extracting backend connect configuration and dotenv helpers into a focused module, preserving CLI behavior while bringing backend.ts under the 400-line hotspot warning threshold."
 sections:
@@ -72,6 +78,25 @@ sections:
     3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-29T03:26:01.290Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified backend command decomposition. Commands passed: bunx vitest run packages/agentplane/src/commands/backend.test.ts packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts --config vitest.workspace.ts (21 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 19 to 18; backend.ts is 352 lines, below the 400-line warning threshold.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T03:21:56.722Z, excerpt_hash=sha256:6da40d103f05f78a7444f9a581aab8801f4109e0d3d9986a098dc76e76a268fa
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: .agentplane/tasks/202605290321-43ZECH/blueprint/resolved-snapshot.json
+    - old_digest: ed164bce3041f2f4d28cfec7e54e0b7a3795e1b9321c2200d613767c277842ad
+    - current_digest: ed164bce3041f2f4d28cfec7e54e0b7a3795e1b9321c2200d613767c277842ad
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605290321-43ZECH
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -119,6 +144,25 @@ PLANNER fallback scaffold for "Backend command decomposition". Replace with task
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-29T03:26:01.290Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified backend command decomposition. Commands passed: bunx vitest run packages/agentplane/src/commands/backend.test.ts packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts --config vitest.workspace.ts (21 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 19 to 18; backend.ts is 352 lines, below the 400-line warning threshold.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T03:21:56.722Z, excerpt_hash=sha256:6da40d103f05f78a7444f9a581aab8801f4109e0d3d9986a098dc76e76a268fa
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: .agentplane/tasks/202605290321-43ZECH/blueprint/resolved-snapshot.json
+- old_digest: ed164bce3041f2f4d28cfec7e54e0b7a3795e1b9321c2200d613767c277842ad
+- current_digest: ed164bce3041f2f4d28cfec7e54e0b7a3795e1b9321c2200d613767c277842ad
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605290321-43ZECH
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605290321-43ZECH/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605290321-43ZECH/blueprint/resolved-snapshot.json
@@ -1,0 +1,361 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605290321-43ZECH",
+    "title": "Backend command decomposition",
+    "description": "Decompose packages/agentplane/src/commands/backend.ts by extracting backend connect configuration and dotenv helpers into a focused module, preserving CLI behavior while bringing backend.ts under the 400-line hotspot warning threshold.",
+    "tags": [
+      "hotspot",
+      "refactor"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "none",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "analysis.light",
+    "version": 1,
+    "title": "Lightweight analysis",
+    "taskKinds": [
+      "analysis"
+    ],
+    "workflowModes": []
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "analysis.light",
+    "blueprintVersion": 1,
+    "title": "Lightweight analysis",
+    "taskId": "202605290321-43ZECH",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "none"
+    },
+    "whySelected": [
+      "task kind resolved to analysis",
+      "workflow mode: branch_pr",
+      "mutation scope: none"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "context_manifest",
+          "sources"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "weak_links",
+          "final_output"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "analysis.sources",
+        "kind": "sources",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Sources used for analysis."
+      },
+      {
+        "id": "analysis.assumptions",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Assumptions and constraints."
+      },
+      {
+        "id": "analysis.weak_links",
+        "kind": "weak_links",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Weak links or uncertainty."
+      },
+      {
+        "id": "analysis.final",
+        "kind": "final_output",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Final answer or report."
+      },
+      {
+        "id": "analysis.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      }
+    ],
+    "policyModules": [],
+    "allowedCommands": [],
+    "contextBudget": {
+      "maxPolicyModules": 0,
+      "maxPromptBlocks": 6,
+      "rationale": "Lightweight analysis should load sources and task context without policy modules."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "context_manifest",
+        "sources"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "weak_links",
+        "final_output"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "analysis.sources",
+      "kind": "sources",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Sources used for analysis."
+    },
+    {
+      "id": "analysis.assumptions",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Assumptions and constraints."
+    },
+    {
+      "id": "analysis.weak_links",
+      "kind": "weak_links",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Weak links or uncertainty."
+    },
+    {
+      "id": "analysis.final",
+      "kind": "final_output",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Final answer or report."
+    },
+    {
+      "id": "analysis.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    }
+  ],
+  "policyModules": [],
+  "allowedCommands": [],
+  "contextBudget": {
+    "maxPolicyModules": 0,
+    "maxPromptBlocks": 6,
+    "rationale": "Lightweight analysis should load sources and task context without policy modules."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to analysis",
+    "workflow mode: branch_pr",
+    "mutation scope: none"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "ed164bce3041f2f4d28cfec7e54e0b7a3795e1b9321c2200d613767c277842ad"
+  }
+}

--- a/.agentplane/tasks/202605290321-43ZECH/pr/diffstat.txt
+++ b/.agentplane/tasks/202605290321-43ZECH/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../agentplane/src/commands/backend-connect.ts     | 140 +++++++++++++++++++++
+ packages/agentplane/src/commands/backend.ts        | 127 +------------------
+ 2 files changed, 142 insertions(+), 125 deletions(-)

--- a/.agentplane/tasks/202605290321-43ZECH/pr/github-body.md
+++ b/.agentplane/tasks/202605290321-43ZECH/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605290321-43ZECH`
+Title: Backend command decomposition
+Canonical task record: `.agentplane/tasks/202605290321-43ZECH/README.md`
+
+## Summary
+
+Backend command decomposition
+
+Decompose packages/agentplane/src/commands/backend.ts by extracting backend connect configuration and dotenv helpers into a focused module, preserving CLI behavior while bringing backend.ts under the 400-line hotspot warning threshold.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/commands/backend.ts by extracting backend connect configuration and dotenv helpers into a focused module, preserving CLI behavior while bringing backend.ts under the 400-line hotspot warning threshold.
+- Out of scope: unrelated refactors not required for "Backend command decomposition".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T03:21:56.833Z
+- Branch: task/202605290321-43ZECH/backend-command-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605290321-43ZECH/pr/github-body.md
+++ b/.agentplane/tasks/202605290321-43ZECH/pr/github-body.md
@@ -15,8 +15,17 @@ Decompose packages/agentplane/src/commands/backend.ts by extracting backend conn
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Verified backend command decomposition. Commands passed: bunx vitest run
+packages/agentplane/src/commands/backend.test.ts
+packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts --config vitest.workspace.ts (21
+tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run
+format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 19 to 18; backend.ts
+is 352 lines, below the 400-line warning threshold.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
@@ -27,7 +36,9 @@ Decompose packages/agentplane/src/commands/backend.ts by extracting backend conn
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../agentplane/src/commands/backend-connect.ts     | 140 +++++++++++++++++++++
+ packages/agentplane/src/commands/backend.ts        | 127 +------------------
+ 2 files changed, 142 insertions(+), 125 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605290321-43ZECH/pr/github-title.txt
+++ b/.agentplane/tasks/202605290321-43ZECH/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 43ZECH task: Backend command decomposition [202605290321-43ZECH]

--- a/.agentplane/tasks/202605290321-43ZECH/pr/meta.json
+++ b/.agentplane/tasks/202605290321-43ZECH/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202605290321-43ZECH/backend-command-decomposition",
+  "created_at": "2026-05-29T03:21:56.833Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202605290321-43ZECH",
+  "updated_at": "2026-05-29T03:21:56.833Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605290321-43ZECH/pr/meta.json
+++ b/.agentplane/tasks/202605290321-43ZECH/pr/meta.json
@@ -2,12 +2,13 @@
   "base": "main",
   "branch": "task/202605290321-43ZECH/backend-command-decomposition",
   "created_at": "2026-05-29T03:21:56.833Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:be4d67f0d448d8ea02dedb2364be1ede65ecd6e5c54ce4bab159343f9c8da91b",
+  "last_verified_at": "2026-05-29T03:26:01.290Z",
+  "last_verified_diffstat_sha256": "sha256:be4d67f0d448d8ea02dedb2364be1ede65ecd6e5c54ce4bab159343f9c8da91b",
   "schema_version": 1,
   "task_id": "202605290321-43ZECH",
   "updated_at": "2026-05-29T03:21:56.833Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605290321-43ZECH/pr/review.md
+++ b/.agentplane/tasks/202605290321-43ZECH/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-05-29T03:21:56.833Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified backend command decomposition. Commands passed: bunx vitest run packages/agentplane/src/commands/backend.test.ts packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts --config vitest.workspace.ts (21 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 19 to 18; backend.ts is 352 lines, below the 400-line warning threshold.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -29,7 +29,9 @@ Created: 2026-05-29T03:21:56.833Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../agentplane/src/commands/backend-connect.ts     | 140 +++++++++++++++++++++
+ packages/agentplane/src/commands/backend.ts        | 127 +------------------
+ 2 files changed, 142 insertions(+), 125 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605290321-43ZECH/pr/review.md
+++ b/.agentplane/tasks/202605290321-43ZECH/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-29T03:21:56.833Z
+
+## Task
+
+- Task: `202605290321-43ZECH`
+- Title: Backend command decomposition
+- Status: DOING
+- Branch: `task/202605290321-43ZECH/backend-command-decomposition`
+- Canonical task record: `.agentplane/tasks/202605290321-43ZECH/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T03:21:56.833Z
+- Branch: task/202605290321-43ZECH/backend-command-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/backend-connect.ts
+++ b/packages/agentplane/src/commands/backend-connect.ts
@@ -1,0 +1,140 @@
+import path from "node:path";
+import { readFile, writeFile } from "node:fs/promises";
+
+import { createCliEmitter } from "../cli/output.js";
+import { mapBackendError } from "../cli/error-map.js";
+import { CliError } from "../shared/errors.js";
+import { resolveDotEnvRoot } from "../shared/env.js";
+import { isRecord } from "../shared/guards.js";
+import { loadCommandContext, type CommandContext } from "./shared/task-backend.js";
+
+const output = createCliEmitter();
+
+export type BackendConnectParsed = {
+  backendId: string;
+  endpoint: string | null;
+  projectId: string | null;
+  provider: string | null;
+  token: string | null;
+  yes: boolean;
+  quiet: boolean;
+};
+
+export async function cmdBackendConnectParsed(opts: {
+  ctx?: CommandContext;
+  cwd: string;
+  rootOverride?: string;
+  flags: BackendConnectParsed;
+}): Promise<number> {
+  try {
+    const ctx =
+      opts.ctx ??
+      (await loadCommandContext({ cwd: opts.cwd, rootOverride: opts.rootOverride ?? null }));
+    if (opts.flags.backendId !== "cloud") {
+      throw new CliError({
+        exitCode: 2,
+        code: "E_USAGE",
+        message: "backend connect currently supports cloud only",
+        context: { command: "backend connect", reason_code: "connect_backend_unsupported" },
+      });
+    }
+    if (ctx.backendId !== "cloud") {
+      throw new CliError({
+        exitCode: 2,
+        code: "E_USAGE",
+        message: `Configured backend is "${ctx.backendId}", not "cloud"`,
+        context: { command: "backend connect", reason_code: "connect_backend_mismatch" },
+      });
+    }
+    await applyBackendConnectConfiguration({ ctx, flags: opts.flags });
+    if (!opts.flags.quiet) {
+      output.success(
+        "backend connect",
+        undefined,
+        `backend=cloud endpoint=${opts.flags.endpoint ?? "unchanged"} project=${opts.flags.projectId ?? "unchanged"}`,
+      );
+      if (opts.flags.token) {
+        output.line("stored AGENTPLANE_CLOUD_TOKEN in ignored project .env");
+      } else {
+        output.line("set AGENTPLANE_CLOUD_TOKEN in the environment or local secret store");
+      }
+      output.line("next: agentplane backend inspect cloud --yes");
+    }
+    return 0;
+  } catch (err) {
+    if (err instanceof CliError) throw err;
+    throw mapBackendError(err, { command: "backend connect", root: opts.rootOverride ?? null });
+  }
+}
+
+async function applyBackendConnectConfiguration(opts: {
+  ctx: CommandContext;
+  flags: BackendConnectParsed;
+}): Promise<void> {
+  const current = await readBackendConfig(opts.ctx.backendConfigPath);
+  const settings = isRecord(current.settings) ? current.settings : {};
+  const next = {
+    ...current,
+    id: "cloud",
+    version: typeof current.version === "number" ? current.version : 1,
+    settings: {
+      ...settings,
+      ...(opts.flags.endpoint ? { endpoint: opts.flags.endpoint.replaceAll(/\/+$/gu, "") } : {}),
+      ...(opts.flags.projectId ? { project_id: opts.flags.projectId } : {}),
+      ...(opts.flags.provider ? { provider: opts.flags.provider } : {}),
+    },
+  };
+  await writeFile(opts.ctx.backendConfigPath, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+
+  if (opts.flags.token) {
+    const envRoot = await resolveDotEnvRoot(opts.ctx.resolvedProject.gitRoot);
+    await upsertDotEnvValues(path.join(envRoot, ".env"), {
+      AGENTPLANE_CLOUD_TOKEN: opts.flags.token,
+    });
+  }
+}
+
+async function readBackendConfig(configPath: string): Promise<Record<string, unknown>> {
+  try {
+    const raw = JSON.parse(await readFile(configPath, "utf8")) as unknown;
+    return isRecord(raw) ? raw : {};
+  } catch (err) {
+    const code = (err as { code?: string } | null)?.code;
+    if (code === "ENOENT") return {};
+    throw err;
+  }
+}
+
+async function upsertDotEnvValues(filePath: string, values: Record<string, string>): Promise<void> {
+  let existing = "";
+  try {
+    existing = await readFile(filePath, "utf8");
+  } catch (err) {
+    const code = (err as { code?: string } | null)?.code;
+    if (code !== "ENOENT") throw err;
+  }
+
+  const pending = new Map(Object.entries(values));
+  const lines = existing.split(/\r?\n/u);
+  const nextLines = lines.map((line) => {
+    const match = /^([A-Za-z_][A-Za-z0-9_]*)\s*=/u.exec(line);
+    const key = match?.[1];
+    if (!key || !pending.has(key)) return line;
+    const value = pending.get(key) ?? "";
+    pending.delete(key);
+    return `${key}=${quoteDotEnvValue(value)}`;
+  });
+
+  if (nextLines.length > 0 && nextLines.at(-1) === "") {
+    nextLines.pop();
+  }
+  for (const [key, value] of pending) {
+    nextLines.push(`${key}=${quoteDotEnvValue(value)}`);
+  }
+  await writeFile(filePath, `${nextLines.join("\n")}\n`, "utf8");
+}
+
+function quoteDotEnvValue(value: string): string {
+  if (/^[A-Za-z0-9_./:@+-]+$/u.test(value)) return value;
+  return JSON.stringify(value);
+}

--- a/packages/agentplane/src/commands/backend.ts
+++ b/packages/agentplane/src/commands/backend.ts
@@ -1,15 +1,13 @@
-import path from "node:path";
-import { readFile, writeFile } from "node:fs/promises";
 import { setTimeout as sleepTimeout } from "node:timers/promises";
 
 import { backendNotSupportedMessage, createCliEmitter } from "../cli/output.js";
 import { mapBackendError } from "../cli/error-map.js";
 import { CliError } from "../shared/errors.js";
-import { resolveDotEnvRoot } from "../shared/env.js";
-import { isRecord } from "../shared/guards.js";
 import type { TaskBackend } from "../backends/task-backend.js";
 import { loadCommandContext, type CommandContext } from "./shared/task-backend.js";
 import { ensureNetworkApproved } from "./shared/network-approval.js";
+
+export { cmdBackendConnectParsed, type BackendConnectParsed } from "./backend-connect.js";
 const output = createCliEmitter();
 
 export type BackendSyncParsed = {
@@ -39,16 +37,6 @@ export type BackendMigrateCanonicalStateParsed = {
 
 export type BackendInspectParsed = {
   backendId: string;
-  yes: boolean;
-  quiet: boolean;
-};
-
-export type BackendConnectParsed = {
-  backendId: string;
-  endpoint: string | null;
-  projectId: string | null;
-  provider: string | null;
-  token: string | null;
   yes: boolean;
   quiet: boolean;
 };
@@ -361,115 +349,4 @@ export async function cmdBackendInspectParsed(opts: {
     if (err instanceof CliError) throw err;
     throw mapBackendError(err, { command: "backend inspect", root: opts.rootOverride ?? null });
   }
-}
-
-export async function cmdBackendConnectParsed(opts: {
-  ctx?: CommandContext;
-  cwd: string;
-  rootOverride?: string;
-  flags: BackendConnectParsed;
-}): Promise<number> {
-  try {
-    const ctx =
-      opts.ctx ??
-      (await loadCommandContext({ cwd: opts.cwd, rootOverride: opts.rootOverride ?? null }));
-    if (opts.flags.backendId !== "cloud") {
-      throw new CliError({
-        exitCode: 2,
-        code: "E_USAGE",
-        message: "backend connect currently supports cloud only",
-        context: { command: "backend connect", reason_code: "connect_backend_unsupported" },
-      });
-    }
-    if (ctx.backendId !== "cloud") {
-      throw new CliError({
-        exitCode: 2,
-        code: "E_USAGE",
-        message: `Configured backend is "${ctx.backendId}", not "cloud"`,
-        context: { command: "backend connect", reason_code: "connect_backend_mismatch" },
-      });
-    }
-    const current = await readBackendConfig(ctx.backendConfigPath);
-    const settings = isRecord(current.settings) ? current.settings : {};
-    const next = {
-      ...current,
-      id: "cloud",
-      version: typeof current.version === "number" ? current.version : 1,
-      settings: {
-        ...settings,
-        ...(opts.flags.endpoint ? { endpoint: opts.flags.endpoint.replaceAll(/\/+$/gu, "") } : {}),
-        ...(opts.flags.projectId ? { project_id: opts.flags.projectId } : {}),
-        ...(opts.flags.provider ? { provider: opts.flags.provider } : {}),
-      },
-    };
-    await writeFile(ctx.backendConfigPath, `${JSON.stringify(next, null, 2)}\n`, "utf8");
-    if (opts.flags.token) {
-      const envRoot = await resolveDotEnvRoot(ctx.resolvedProject.gitRoot);
-      await upsertDotEnvValues(path.join(envRoot, ".env"), {
-        AGENTPLANE_CLOUD_TOKEN: opts.flags.token,
-      });
-    }
-    if (!opts.flags.quiet) {
-      output.success(
-        "backend connect",
-        undefined,
-        `backend=cloud endpoint=${opts.flags.endpoint ?? "unchanged"} project=${opts.flags.projectId ?? "unchanged"}`,
-      );
-      if (opts.flags.token) {
-        output.line("stored AGENTPLANE_CLOUD_TOKEN in ignored project .env");
-      } else {
-        output.line("set AGENTPLANE_CLOUD_TOKEN in the environment or local secret store");
-      }
-      output.line("next: agentplane backend inspect cloud --yes");
-    }
-    return 0;
-  } catch (err) {
-    if (err instanceof CliError) throw err;
-    throw mapBackendError(err, { command: "backend connect", root: opts.rootOverride ?? null });
-  }
-}
-
-async function readBackendConfig(configPath: string): Promise<Record<string, unknown>> {
-  try {
-    const raw = JSON.parse(await readFile(configPath, "utf8")) as unknown;
-    return isRecord(raw) ? raw : {};
-  } catch (err) {
-    const code = (err as { code?: string } | null)?.code;
-    if (code === "ENOENT") return {};
-    throw err;
-  }
-}
-
-async function upsertDotEnvValues(filePath: string, values: Record<string, string>): Promise<void> {
-  let existing = "";
-  try {
-    existing = await readFile(filePath, "utf8");
-  } catch (err) {
-    const code = (err as { code?: string } | null)?.code;
-    if (code !== "ENOENT") throw err;
-  }
-
-  const pending = new Map(Object.entries(values));
-  const lines = existing.split(/\r?\n/u);
-  const nextLines = lines.map((line) => {
-    const match = /^([A-Za-z_][A-Za-z0-9_]*)\s*=/u.exec(line);
-    const key = match?.[1];
-    if (!key || !pending.has(key)) return line;
-    const value = pending.get(key) ?? "";
-    pending.delete(key);
-    return `${key}=${quoteDotEnvValue(value)}`;
-  });
-
-  if (nextLines.length > 0 && nextLines.at(-1) === "") {
-    nextLines.pop();
-  }
-  for (const [key, value] of pending) {
-    nextLines.push(`${key}=${quoteDotEnvValue(value)}`);
-  }
-  await writeFile(filePath, `${nextLines.join("\n")}\n`, "utf8");
-}
-
-function quoteDotEnvValue(value: string): string {
-  if (/^[A-Za-z0-9_./:@+-]+$/u.test(value)) return value;
-  return JSON.stringify(value);
 }


### PR DESCRIPTION
Task: `202605290321-43ZECH`
Title: Backend command decomposition
Canonical task record: `.agentplane/tasks/202605290321-43ZECH/README.md`

## Summary

Backend command decomposition

Decompose packages/agentplane/src/commands/backend.ts by extracting backend connect configuration and dotenv helpers into a focused module, preserving CLI behavior while bringing backend.ts under the 400-line hotspot warning threshold.

## Scope

- In scope: Decompose packages/agentplane/src/commands/backend.ts by extracting backend connect configuration and dotenv helpers into a focused module, preserving CLI behavior while bringing backend.ts under the 400-line hotspot warning threshold.
- Out of scope: unrelated refactors not required for "Backend command decomposition".

## Verification

- State: ok
- Note:

```text
Verified backend command decomposition. Commands passed: bunx vitest run
packages/agentplane/src/commands/backend.test.ts
packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts --config vitest.workspace.ts (21
tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run
format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 19 to 18; backend.ts
is 352 lines, below the 400-line warning threshold.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-29T03:21:56.833Z
- Branch: task/202605290321-43ZECH/backend-command-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../agentplane/src/commands/backend-connect.ts     | 140 +++++++++++++++++++++
 packages/agentplane/src/commands/backend.ts        | 127 +------------------
 2 files changed, 142 insertions(+), 125 deletions(-)
```

</details>
