### PR TITLE
🚧 X3NHBJ task: Blueprint command listing decomposition [202605290332-X3NHBJ]

### DIFF
--- a/.agentplane/tasks/202605290332-X3NHBJ/README.md
+++ b/.agentplane/tasks/202605290332-X3NHBJ/README.md
@@ -1,0 +1,131 @@
+---
+id: "202605290332-X3NHBJ"
+title: "Blueprint command listing decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "hotspot"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-29T03:33:13.066Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: extract blueprint examples/list handlers into a focused module while preserving command exports and CLI output."
+events:
+  -
+    type: "status"
+    at: "2026-05-29T03:33:22.706Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: extract blueprint examples/list handlers into a focused module while preserving command exports and CLI output."
+doc_version: 3
+doc_updated_at: "2026-05-29T03:33:22.706Z"
+doc_updated_by: "CODER"
+description: "Decompose packages/agentplane/src/commands/blueprint/blueprint.command.ts by extracting blueprint list/examples command handlers into a focused module, preserving command-loader exports and CLI output while reducing runtime hotspot count."
+sections:
+  Summary: |-
+    Blueprint command listing decomposition
+
+    Decompose packages/agentplane/src/commands/blueprint/blueprint.command.ts by extracting blueprint list/examples command handlers into a focused module, preserving command-loader exports and CLI output while reducing runtime hotspot count.
+  Scope: |-
+    - In scope: Decompose packages/agentplane/src/commands/blueprint/blueprint.command.ts by extracting blueprint list/examples command handlers into a focused module, preserving command-loader exports and CLI output while reducing runtime hotspot count.
+    - Out of scope: unrelated refactors not required for "Blueprint command listing decomposition".
+  Plan: |-
+    Refactor blueprint command hotspot with a single behavior-preserving extraction.
+
+    Scope:
+    - Extract blueprint examples and blueprint list route formatting/validation helpers from packages/agentplane/src/commands/blueprint/blueprint.command.ts into a focused module.
+    - Preserve command-loader imports by re-exporting handlers from blueprint.command.ts.
+    - Preserve JSON/text output, validation errors, and project-local blueprint trust behavior.
+    - Keep blueprint.command.ts below the 400-line runtime hotspot warning threshold.
+
+    Verify:
+    - Run bunx vitest run packages/agentplane/src/cli/run-cli.core.blueprint.test.ts packages/agentplane/src/commands/blueprint/task-input.test.ts packages/agentplane/src/commands/blueprint/snapshot-artifact.test.ts --config vitest.workspace.ts.
+    - Run bun run typecheck.
+    - Run bun run arch:check.
+    - Run bun run knip:check.
+    - Run bun run lint:core.
+    - Run bun run format:changed.
+    - Run bun run hotspots:check and confirm runtime hotspot warnings decrease from 18 to 17.
+  Verify Steps: |-
+    PLANNER fallback scaffold for "Blueprint command listing decomposition". Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the requested outcome for "Blueprint command listing decomposition". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Blueprint command listing decomposition
+
+Decompose packages/agentplane/src/commands/blueprint/blueprint.command.ts by extracting blueprint list/examples command handlers into a focused module, preserving command-loader exports and CLI output while reducing runtime hotspot count.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/commands/blueprint/blueprint.command.ts by extracting blueprint list/examples command handlers into a focused module, preserving command-loader exports and CLI output while reducing runtime hotspot count.
+- Out of scope: unrelated refactors not required for "Blueprint command listing decomposition".
+
+## Plan
+
+Refactor blueprint command hotspot with a single behavior-preserving extraction.
+
+Scope:
+- Extract blueprint examples and blueprint list route formatting/validation helpers from packages/agentplane/src/commands/blueprint/blueprint.command.ts into a focused module.
+- Preserve command-loader imports by re-exporting handlers from blueprint.command.ts.
+- Preserve JSON/text output, validation errors, and project-local blueprint trust behavior.
+- Keep blueprint.command.ts below the 400-line runtime hotspot warning threshold.
+
+Verify:
+- Run bunx vitest run packages/agentplane/src/cli/run-cli.core.blueprint.test.ts packages/agentplane/src/commands/blueprint/task-input.test.ts packages/agentplane/src/commands/blueprint/snapshot-artifact.test.ts --config vitest.workspace.ts.
+- Run bun run typecheck.
+- Run bun run arch:check.
+- Run bun run knip:check.
+- Run bun run lint:core.
+- Run bun run format:changed.
+- Run bun run hotspots:check and confirm runtime hotspot warnings decrease from 18 to 17.
+
+## Verify Steps
+
+PLANNER fallback scaffold for "Blueprint command listing decomposition". Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the requested outcome for "Blueprint command listing decomposition". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605290332-X3NHBJ/README.md
+++ b/.agentplane/tasks/202605290332-X3NHBJ/README.md
@@ -4,7 +4,7 @@ title: "Blueprint command listing decomposition"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 4
+revision: 5
 origin:
   system: "manual"
 depends_on: []
@@ -18,10 +18,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-29T03:37:02.570Z"
+  updated_by: "CODER"
+  note: "Verified blueprint command listing decomposition. Commands passed: bunx vitest run packages/agentplane/src/cli/run-cli.core.blueprint.test.ts packages/agentplane/src/commands/blueprint/task-input.test.ts packages/agentplane/src/commands/blueprint/snapshot-artifact.test.ts --config vitest.workspace.ts (29 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 18 to 17; blueprint.command.ts is 336 lines, below the 400-line warning threshold."
   attempts: 0
 commit: null
 comments:
@@ -36,8 +36,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: extract blueprint examples/list handlers into a focused module while preserving command exports and CLI output."
+  -
+    type: "verify"
+    at: "2026-05-29T03:37:02.570Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified blueprint command listing decomposition. Commands passed: bunx vitest run packages/agentplane/src/cli/run-cli.core.blueprint.test.ts packages/agentplane/src/commands/blueprint/task-input.test.ts packages/agentplane/src/commands/blueprint/snapshot-artifact.test.ts --config vitest.workspace.ts (29 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 18 to 17; blueprint.command.ts is 336 lines, below the 400-line warning threshold."
 doc_version: 3
-doc_updated_at: "2026-05-29T03:33:22.706Z"
+doc_updated_at: "2026-05-29T03:37:02.608Z"
 doc_updated_by: "CODER"
 description: "Decompose packages/agentplane/src/commands/blueprint/blueprint.command.ts by extracting blueprint list/examples command handlers into a focused module, preserving command-loader exports and CLI output while reducing runtime hotspot count."
 sections:
@@ -73,6 +79,25 @@ sections:
     3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-29T03:37:02.570Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified blueprint command listing decomposition. Commands passed: bunx vitest run packages/agentplane/src/cli/run-cli.core.blueprint.test.ts packages/agentplane/src/commands/blueprint/task-input.test.ts packages/agentplane/src/commands/blueprint/snapshot-artifact.test.ts --config vitest.workspace.ts (29 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 18 to 17; blueprint.command.ts is 336 lines, below the 400-line warning threshold.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T03:33:22.706Z, excerpt_hash=sha256:865891e195871975ec552f0ad30c4c359a5e97cca429e9a5bd044ee62cc81c8c
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: .agentplane/tasks/202605290332-X3NHBJ/blueprint/resolved-snapshot.json
+    - old_digest: 4567f910fd09f75235e481f26e4e9912805eb7dfcf6a9aceebc69d63cba7e760
+    - current_digest: 4567f910fd09f75235e481f26e4e9912805eb7dfcf6a9aceebc69d63cba7e760
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605290332-X3NHBJ
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -121,6 +146,25 @@ PLANNER fallback scaffold for "Blueprint command listing decomposition". Replace
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-29T03:37:02.570Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified blueprint command listing decomposition. Commands passed: bunx vitest run packages/agentplane/src/cli/run-cli.core.blueprint.test.ts packages/agentplane/src/commands/blueprint/task-input.test.ts packages/agentplane/src/commands/blueprint/snapshot-artifact.test.ts --config vitest.workspace.ts (29 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 18 to 17; blueprint.command.ts is 336 lines, below the 400-line warning threshold.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T03:33:22.706Z, excerpt_hash=sha256:865891e195871975ec552f0ad30c4c359a5e97cca429e9a5bd044ee62cc81c8c
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: .agentplane/tasks/202605290332-X3NHBJ/blueprint/resolved-snapshot.json
+- old_digest: 4567f910fd09f75235e481f26e4e9912805eb7dfcf6a9aceebc69d63cba7e760
+- current_digest: 4567f910fd09f75235e481f26e4e9912805eb7dfcf6a9aceebc69d63cba7e760
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605290332-X3NHBJ
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605290332-X3NHBJ/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605290332-X3NHBJ/blueprint/resolved-snapshot.json
@@ -1,0 +1,361 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605290332-X3NHBJ",
+    "title": "Blueprint command listing decomposition",
+    "description": "Decompose packages/agentplane/src/commands/blueprint/blueprint.command.ts by extracting blueprint list/examples command handlers into a focused module, preserving command-loader exports and CLI output while reducing runtime hotspot count.",
+    "tags": [
+      "hotspot",
+      "refactor"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "none",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "analysis.light",
+    "version": 1,
+    "title": "Lightweight analysis",
+    "taskKinds": [
+      "analysis"
+    ],
+    "workflowModes": []
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "analysis.light",
+    "blueprintVersion": 1,
+    "title": "Lightweight analysis",
+    "taskId": "202605290332-X3NHBJ",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "none"
+    },
+    "whySelected": [
+      "task kind resolved to analysis",
+      "workflow mode: branch_pr",
+      "mutation scope: none"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "context_manifest",
+          "sources"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "weak_links",
+          "final_output"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "analysis.sources",
+        "kind": "sources",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Sources used for analysis."
+      },
+      {
+        "id": "analysis.assumptions",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Assumptions and constraints."
+      },
+      {
+        "id": "analysis.weak_links",
+        "kind": "weak_links",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Weak links or uncertainty."
+      },
+      {
+        "id": "analysis.final",
+        "kind": "final_output",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Final answer or report."
+      },
+      {
+        "id": "analysis.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      }
+    ],
+    "policyModules": [],
+    "allowedCommands": [],
+    "contextBudget": {
+      "maxPolicyModules": 0,
+      "maxPromptBlocks": 6,
+      "rationale": "Lightweight analysis should load sources and task context without policy modules."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "context_manifest",
+        "sources"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "weak_links",
+        "final_output"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "analysis.sources",
+      "kind": "sources",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Sources used for analysis."
+    },
+    {
+      "id": "analysis.assumptions",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Assumptions and constraints."
+    },
+    {
+      "id": "analysis.weak_links",
+      "kind": "weak_links",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Weak links or uncertainty."
+    },
+    {
+      "id": "analysis.final",
+      "kind": "final_output",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Final answer or report."
+    },
+    {
+      "id": "analysis.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    }
+  ],
+  "policyModules": [],
+  "allowedCommands": [],
+  "contextBudget": {
+    "maxPolicyModules": 0,
+    "maxPromptBlocks": 6,
+    "rationale": "Lightweight analysis should load sources and task context without policy modules."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to analysis",
+    "workflow mode: branch_pr",
+    "mutation scope: none"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "4567f910fd09f75235e481f26e4e9912805eb7dfcf6a9aceebc69d63cba7e760"
+  }
+}

--- a/.agentplane/tasks/202605290332-X3NHBJ/pr/diffstat.txt
+++ b/.agentplane/tasks/202605290332-X3NHBJ/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../src/commands/blueprint/blueprint-listing.ts    | 151 +++++++++++++++++++++
+ .../src/commands/blueprint/blueprint.command.ts    | 135 +-----------------
+ 2 files changed, 152 insertions(+), 134 deletions(-)

--- a/.agentplane/tasks/202605290332-X3NHBJ/pr/github-body.md
+++ b/.agentplane/tasks/202605290332-X3NHBJ/pr/github-body.md
@@ -15,8 +15,18 @@ Decompose packages/agentplane/src/commands/blueprint/blueprint.command.ts by ext
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Verified blueprint command listing decomposition. Commands passed: bunx vitest run
+packages/agentplane/src/cli/run-cli.core.blueprint.test.ts
+packages/agentplane/src/commands/blueprint/task-input.test.ts
+packages/agentplane/src/commands/blueprint/snapshot-artifact.test.ts --config vitest.workspace.ts
+(29 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run
+format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 18 to 17;
+blueprint.command.ts is 336 lines, below the 400-line warning threshold.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
@@ -27,7 +37,9 @@ Decompose packages/agentplane/src/commands/blueprint/blueprint.command.ts by ext
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/commands/blueprint/blueprint-listing.ts    | 151 +++++++++++++++++++++
+ .../src/commands/blueprint/blueprint.command.ts    | 135 +-----------------
+ 2 files changed, 152 insertions(+), 134 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605290332-X3NHBJ/pr/github-body.md
+++ b/.agentplane/tasks/202605290332-X3NHBJ/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605290332-X3NHBJ`
+Title: Blueprint command listing decomposition
+Canonical task record: `.agentplane/tasks/202605290332-X3NHBJ/README.md`
+
+## Summary
+
+Blueprint command listing decomposition
+
+Decompose packages/agentplane/src/commands/blueprint/blueprint.command.ts by extracting blueprint list/examples command handlers into a focused module, preserving command-loader exports and CLI output while reducing runtime hotspot count.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/commands/blueprint/blueprint.command.ts by extracting blueprint list/examples command handlers into a focused module, preserving command-loader exports and CLI output while reducing runtime hotspot count.
+- Out of scope: unrelated refactors not required for "Blueprint command listing decomposition".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T03:33:22.818Z
+- Branch: task/202605290332-X3NHBJ/blueprint-command-listing-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605290332-X3NHBJ/pr/github-title.txt
+++ b/.agentplane/tasks/202605290332-X3NHBJ/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 X3NHBJ task: Blueprint command listing decomposition [202605290332-X3NHBJ]

--- a/.agentplane/tasks/202605290332-X3NHBJ/pr/meta.json
+++ b/.agentplane/tasks/202605290332-X3NHBJ/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202605290332-X3NHBJ/blueprint-command-listing-decomposition",
+  "created_at": "2026-05-29T03:33:22.818Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202605290332-X3NHBJ",
+  "updated_at": "2026-05-29T03:33:22.818Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605290332-X3NHBJ/pr/meta.json
+++ b/.agentplane/tasks/202605290332-X3NHBJ/pr/meta.json
@@ -2,12 +2,13 @@
   "base": "main",
   "branch": "task/202605290332-X3NHBJ/blueprint-command-listing-decomposition",
   "created_at": "2026-05-29T03:33:22.818Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:52352afdff8156b894a8d73f6567368dece0ad9fcfda612e7624958b5be78dd7",
+  "last_verified_at": "2026-05-29T03:37:02.570Z",
+  "last_verified_diffstat_sha256": "sha256:52352afdff8156b894a8d73f6567368dece0ad9fcfda612e7624958b5be78dd7",
   "schema_version": 1,
   "task_id": "202605290332-X3NHBJ",
   "updated_at": "2026-05-29T03:33:22.818Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605290332-X3NHBJ/pr/review.md
+++ b/.agentplane/tasks/202605290332-X3NHBJ/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-29T03:33:22.818Z
+
+## Task
+
+- Task: `202605290332-X3NHBJ`
+- Title: Blueprint command listing decomposition
+- Status: DOING
+- Branch: `task/202605290332-X3NHBJ/blueprint-command-listing-decomposition`
+- Canonical task record: `.agentplane/tasks/202605290332-X3NHBJ/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T03:33:22.818Z
+- Branch: task/202605290332-X3NHBJ/blueprint-command-listing-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605290332-X3NHBJ/pr/review.md
+++ b/.agentplane/tasks/202605290332-X3NHBJ/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-05-29T03:33:22.818Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified blueprint command listing decomposition. Commands passed: bunx vitest run packages/agentplane/src/cli/run-cli.core.blueprint.test.ts packages/agentplane/src/commands/blueprint/task-input.test.ts packages/agentplane/src/commands/blueprint/snapshot-artifact.test.ts --config vitest.workspace.ts (29 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 18 to 17; blueprint.command.ts is 336 lines, below the 400-line warning threshold.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -29,7 +29,9 @@ Created: 2026-05-29T03:33:22.818Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/commands/blueprint/blueprint-listing.ts    | 151 +++++++++++++++++++++
+ .../src/commands/blueprint/blueprint.command.ts    | 135 +-----------------
+ 2 files changed, 152 insertions(+), 134 deletions(-)
 ```
 
 </details>

--- a/packages/agentplane/src/commands/blueprint/blueprint-listing.ts
+++ b/packages/agentplane/src/commands/blueprint/blueprint-listing.ts
@@ -1,0 +1,151 @@
+import { resolveProject } from "@agentplaneorg/core/project";
+
+import {
+  createBlueprintRegistry,
+  loadTrustedProjectBlueprintRegistry,
+  listBlueprints,
+  type Blueprint,
+} from "../../blueprints/index.js";
+import type { CommandHandler } from "../../cli/spec/spec.js";
+import { ValidationError } from "../../shared/errors.js";
+import type { BlueprintExamplesParsed, BlueprintListParsed } from "./blueprint.specs.js";
+
+function blueprintRoute(blueprint: Blueprint, source: "builtin" | "project", filePath?: string) {
+  return {
+    id: blueprint.id,
+    version: blueprint.version,
+    title: blueprint.title,
+    source,
+    ...(filePath ? { path: filePath } : {}),
+    task_kinds: blueprint.taskKinds,
+    workflow_modes: blueprint.workflowModes ?? ["direct", "branch_pr"],
+    route: blueprint.nodes.map((node) => node.kind),
+  };
+}
+
+function validationErrorFromProjectFile(
+  filePath: string,
+  errors: readonly { code: string; message: string }[],
+) {
+  return new ValidationError({
+    message: `Project blueprint ${JSON.stringify(filePath)} is invalid:\n${errors
+      .map((error) => `- ${error.code}: ${error.message}`)
+      .join("\n")}`,
+    context: { path: filePath },
+  });
+}
+
+const BLUEPRINT_ROUTE_EXAMPLES = [
+  {
+    id: "analysis.readonly",
+    title: "Read-only analysis",
+    command: "agentplane blueprint explain --kind analysis --mutation none",
+    expected: "analysis.light",
+    note: "No CI, PR, worktree, or merge gates.",
+  },
+  {
+    id: "content.readonly",
+    title: "Content generation",
+    command: "agentplane blueprint explain --kind content --mutation none",
+    expected: "content.light",
+    note: "Evidence and final output, not code lifecycle.",
+  },
+  {
+    id: "docs.change",
+    title: "Documentation change",
+    command: "agentplane blueprint explain --kind docs --mutation docs",
+    expected: "docs.change",
+    note: "Docs verification without code checks by default.",
+  },
+  {
+    id: "code.branch_pr",
+    title: "Code change in branch_pr",
+    command: "agentplane blueprint explain --kind code --mutation code --workflow-mode branch_pr",
+    expected: "code.branch_pr",
+    note: "Task branch, local checks, PR artifact, integration gate.",
+  },
+  {
+    id: "release.strict",
+    title: "Release or publish",
+    command:
+      "agentplane blueprint explain --kind release --mutation release --risk external_publish",
+    expected: "release.strict",
+    note: "Version, manifest, parity, and publish safety gates.",
+  },
+  {
+    id: "existing.task",
+    title: "Existing task",
+    command: "agentplane blueprint explain <task-id>",
+    expected: "task-specific route",
+    note: "Uses task fields, tags, workflow mode, mutation scope, and risk hints.",
+  },
+] as const;
+
+export const runBlueprintExamples: CommandHandler<BlueprintExamplesParsed> = (_ctx, p) => {
+  if (p.json) {
+    process.stdout.write(`${JSON.stringify({ examples: BLUEPRINT_ROUTE_EXAMPLES }, null, 2)}\n`);
+    return Promise.resolve(0);
+  }
+  process.stdout.write("Blueprint route inspection examples\n");
+  for (const example of BLUEPRINT_ROUTE_EXAMPLES) {
+    process.stdout.write(`\n- ${example.title}\n`);
+    process.stdout.write(`  command: ${example.command}\n`);
+    process.stdout.write(`  expected: ${example.expected}\n`);
+    process.stdout.write(`  note: ${example.note}\n`);
+  }
+  process.stdout.write("\nNext commands:\n");
+  process.stdout.write("- agentplane blueprint list\n");
+  process.stdout.write("- agentplane blueprint report\n");
+  process.stdout.write("- agentplane help blueprint explain --compact\n");
+  return Promise.resolve(0);
+};
+
+export const runBlueprintList: CommandHandler<BlueprintListParsed> = async (ctx, p) => {
+  const registry = createBlueprintRegistry();
+  const routes = listBlueprints(registry).map((blueprint) => blueprintRoute(blueprint, "builtin"));
+  let trustedIds = new Set<string>();
+  let trustConfig: unknown = null;
+  if (p.project || p.trusted) {
+    const resolved = await resolveProject({ cwd: ctx.cwd, rootOverride: ctx.rootOverride ?? null });
+    const trusted = await loadTrustedProjectBlueprintRegistry(resolved.gitRoot);
+    if (!trusted.ok) {
+      throw new ValidationError({
+        message: `Invalid project-local blueprint trust registry:\n${trusted.errors
+          .map((error) => `- ${error.code}: ${error.message}`)
+          .join("\n")}`,
+      });
+    }
+    trustedIds = new Set(trusted.trustedBlueprints.map((blueprint) => blueprint.id));
+    trustConfig = {
+      enabled: trusted.trustConfig.config.enabled,
+      exists: trusted.trustConfig.exists,
+      allowed_ids: trusted.trustConfig.config.allowedIds,
+      selection: trusted.trustConfig.config.selection,
+    };
+    const invalid = trusted.files.find((file) => !file.ok);
+    if (invalid) throw validationErrorFromProjectFile(invalid.path, invalid.errors);
+    routes.push(
+      ...trusted.files.flatMap((file) =>
+        file.blueprint ? [blueprintRoute(file.blueprint, "project", file.path)] : [],
+      ),
+    );
+  }
+  const outputRoutes = routes.map((route) => ({
+    ...route,
+    ...(p.trusted && route.source === "project" ? { trusted: trustedIds.has(route.id) } : {}),
+  }));
+  if (p.json) {
+    process.stdout.write(
+      `${JSON.stringify({ blueprints: outputRoutes, ...(p.trusted ? { trust: trustConfig } : {}) }, null, 2)}\n`,
+    );
+    return 0;
+  }
+  for (const route of outputRoutes) {
+    const trustLabel =
+      p.trusted && route.source === "project" ? ` trusted=${route.trusted ? "yes" : "no"}` : "";
+    process.stdout.write(
+      `${route.source}${trustLabel} ${route.id}@${route.version} ${route.route.join(" -> ")}\n`,
+    );
+  }
+  return 0;
+};

--- a/packages/agentplane/src/commands/blueprint/blueprint.command.ts
+++ b/packages/agentplane/src/commands/blueprint/blueprint.command.ts
@@ -4,19 +4,16 @@ import { resolveProject } from "@agentplaneorg/core/project";
 
 import {
   buildProjectBlueprintCompatibilityReport,
-  createBlueprintRegistry,
   createTrustedProjectBlueprintRegistry,
   explainResolvedBlueprint,
   formatBlueprintExplain,
   loadTrustedProjectBlueprintRegistry,
-  listBlueprints,
   projectBlueprintsDirectory,
   resolveBlueprint,
   scaffoldProjectBlueprint,
   validateProjectBlueprintDirectory,
   validateProjectBlueprintFile,
   validateBlueprint,
-  type Blueprint,
   type BlueprintResolveInput,
   type TaskKind,
 } from "../../blueprints/index.js";
@@ -40,11 +37,10 @@ export {
   blueprintSpec,
   blueprintValidateSpec,
 } from "./blueprint.specs.js";
+export { runBlueprintExamples, runBlueprintList } from "./blueprint-listing.js";
 import type {
   BlueprintDriftParsed,
-  BlueprintExamplesParsed,
   BlueprintExplainParsed,
-  BlueprintListParsed,
   BlueprintReportParsed,
   BlueprintScaffoldParsed,
   BlueprintSnapshotParsed,
@@ -84,19 +80,6 @@ export function makeRunBlueprintHandler(_getCtx: (cmd: string) => Promise<Comman
   return runBlueprintRoot;
 }
 
-function blueprintRoute(blueprint: Blueprint, source: "builtin" | "project", filePath?: string) {
-  return {
-    id: blueprint.id,
-    version: blueprint.version,
-    title: blueprint.title,
-    source,
-    ...(filePath ? { path: filePath } : {}),
-    task_kinds: blueprint.taskKinds,
-    workflow_modes: blueprint.workflowModes ?? ["direct", "branch_pr"],
-    route: blueprint.nodes.map((node) => node.kind),
-  };
-}
-
 function validationErrorFromProjectFile(
   filePath: string,
   errors: readonly { code: string; message: string }[],
@@ -108,122 +91,6 @@ function validationErrorFromProjectFile(
     context: { path: filePath },
   });
 }
-
-const BLUEPRINT_ROUTE_EXAMPLES = [
-  {
-    id: "analysis.readonly",
-    title: "Read-only analysis",
-    command: "agentplane blueprint explain --kind analysis --mutation none",
-    expected: "analysis.light",
-    note: "No CI, PR, worktree, or merge gates.",
-  },
-  {
-    id: "content.readonly",
-    title: "Content generation",
-    command: "agentplane blueprint explain --kind content --mutation none",
-    expected: "content.light",
-    note: "Evidence and final output, not code lifecycle.",
-  },
-  {
-    id: "docs.change",
-    title: "Documentation change",
-    command: "agentplane blueprint explain --kind docs --mutation docs",
-    expected: "docs.change",
-    note: "Docs verification without code checks by default.",
-  },
-  {
-    id: "code.branch_pr",
-    title: "Code change in branch_pr",
-    command: "agentplane blueprint explain --kind code --mutation code --workflow-mode branch_pr",
-    expected: "code.branch_pr",
-    note: "Task branch, local checks, PR artifact, integration gate.",
-  },
-  {
-    id: "release.strict",
-    title: "Release or publish",
-    command:
-      "agentplane blueprint explain --kind release --mutation release --risk external_publish",
-    expected: "release.strict",
-    note: "Version, manifest, parity, and publish safety gates.",
-  },
-  {
-    id: "existing.task",
-    title: "Existing task",
-    command: "agentplane blueprint explain <task-id>",
-    expected: "task-specific route",
-    note: "Uses task fields, tags, workflow mode, mutation scope, and risk hints.",
-  },
-] as const;
-
-export const runBlueprintExamples: CommandHandler<BlueprintExamplesParsed> = (_ctx, p) => {
-  if (p.json) {
-    process.stdout.write(`${JSON.stringify({ examples: BLUEPRINT_ROUTE_EXAMPLES }, null, 2)}\n`);
-    return Promise.resolve(0);
-  }
-  process.stdout.write("Blueprint route inspection examples\n");
-  for (const example of BLUEPRINT_ROUTE_EXAMPLES) {
-    process.stdout.write(`\n- ${example.title}\n`);
-    process.stdout.write(`  command: ${example.command}\n`);
-    process.stdout.write(`  expected: ${example.expected}\n`);
-    process.stdout.write(`  note: ${example.note}\n`);
-  }
-  process.stdout.write("\nNext commands:\n");
-  process.stdout.write("- agentplane blueprint list\n");
-  process.stdout.write("- agentplane blueprint report\n");
-  process.stdout.write("- agentplane help blueprint explain --compact\n");
-  return Promise.resolve(0);
-};
-
-export const runBlueprintList: CommandHandler<BlueprintListParsed> = async (ctx, p) => {
-  const registry = createBlueprintRegistry();
-  const routes = listBlueprints(registry).map((blueprint) => blueprintRoute(blueprint, "builtin"));
-  let trustedIds = new Set<string>();
-  let trustConfig: unknown = null;
-  if (p.project || p.trusted) {
-    const resolved = await resolveProject({ cwd: ctx.cwd, rootOverride: ctx.rootOverride ?? null });
-    const trusted = await loadTrustedProjectBlueprintRegistry(resolved.gitRoot);
-    if (!trusted.ok) {
-      throw new ValidationError({
-        message: `Invalid project-local blueprint trust registry:\n${trusted.errors
-          .map((error) => `- ${error.code}: ${error.message}`)
-          .join("\n")}`,
-      });
-    }
-    trustedIds = new Set(trusted.trustedBlueprints.map((blueprint) => blueprint.id));
-    trustConfig = {
-      enabled: trusted.trustConfig.config.enabled,
-      exists: trusted.trustConfig.exists,
-      allowed_ids: trusted.trustConfig.config.allowedIds,
-      selection: trusted.trustConfig.config.selection,
-    };
-    const local = trusted;
-    const invalid = local.files.find((file) => !file.ok);
-    if (invalid) throw validationErrorFromProjectFile(invalid.path, invalid.errors);
-    routes.push(
-      ...local.files.flatMap((file) =>
-        file.blueprint ? [blueprintRoute(file.blueprint, "project", file.path)] : [],
-      ),
-    );
-  }
-  const outputRoutes = routes.map((route) => ({
-    ...route,
-    ...(p.trusted && route.source === "project" ? { trusted: trustedIds.has(route.id) } : {}),
-  }));
-  if (p.json) {
-    process.stdout.write(
-      `${JSON.stringify({ blueprints: outputRoutes, ...(p.trusted ? { trust: trustConfig } : {}) }, null, 2)}\n`,
-    );
-    return 0;
-  }
-  for (const route of outputRoutes) {
-    const trustLabel =
-      p.trusted && route.source === "project" ? ` trusted=${route.trusted ? "yes" : "no"}` : "";
-    process.stdout.write(
-      `${route.source}${trustLabel} ${route.id}@${route.version} ${route.route.join(" -> ")}\n`,
-    );
-  }
-  return 0;
-};
 
 export function makeRunBlueprintExplainHandler(getCtx: (cmd: string) => Promise<CommandContext>) {
   return async (_ctx: CommandCtx, p: BlueprintExplainParsed): Promise<number> => {


### PR DESCRIPTION
Task: `202605290332-X3NHBJ`
Title: Blueprint command listing decomposition
Canonical task record: `.agentplane/tasks/202605290332-X3NHBJ/README.md`

## Summary

Blueprint command listing decomposition

Decompose packages/agentplane/src/commands/blueprint/blueprint.command.ts by extracting blueprint list/examples command handlers into a focused module, preserving command-loader exports and CLI output while reducing runtime hotspot count.

## Scope

- In scope: Decompose packages/agentplane/src/commands/blueprint/blueprint.command.ts by extracting blueprint list/examples command handlers into a focused module, preserving command-loader exports and CLI output while reducing runtime hotspot count.
- Out of scope: unrelated refactors not required for "Blueprint command listing decomposition".

## Verification

- State: ok
- Note:

```text
Verified blueprint command listing decomposition. Commands passed: bunx vitest run
packages/agentplane/src/cli/run-cli.core.blueprint.test.ts
packages/agentplane/src/commands/blueprint/task-input.test.ts
packages/agentplane/src/commands/blueprint/snapshot-artifact.test.ts --config vitest.workspace.ts
(29 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run
format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 18 to 17;
blueprint.command.ts is 336 lines, below the 400-line warning threshold.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-29T03:33:22.818Z
- Branch: task/202605290332-X3NHBJ/blueprint-command-listing-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/commands/blueprint/blueprint-listing.ts    | 151 +++++++++++++++++++++
 .../src/commands/blueprint/blueprint.command.ts    | 135 +-----------------
 2 files changed, 152 insertions(+), 134 deletions(-)
```

</details>
