### PR TITLE
🚧 YV53ZN task: PR review template hosted formatting decomposition [202605290344-YV53ZN]

### DIFF
--- a/.agentplane/tasks/202605290344-YV53ZN/README.md
+++ b/.agentplane/tasks/202605290344-YV53ZN/README.md
@@ -4,7 +4,7 @@ title: "PR review template hosted formatting decomposition"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 4
+revision: 5
 origin:
   system: "manual"
 depends_on: []
@@ -18,10 +18,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-29T03:47:29.585Z"
+  updated_by: "CODER"
+  note: "Verified PR review template hosted formatting decomposition. Commands passed: bunx vitest run packages/agentplane/src/commands/pr/internal/review-template.test.ts packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts --config vitest.workspace.ts (12 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 17 to 16; review-template.ts is 368 lines, below the 400-line warning threshold."
   attempts: 0
 commit: null
 comments:
@@ -36,8 +36,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: extract hosted GitHub verification markdown formatting helpers from review-template.ts while preserving PR artifact rendering."
+  -
+    type: "verify"
+    at: "2026-05-29T03:47:29.585Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified PR review template hosted formatting decomposition. Commands passed: bunx vitest run packages/agentplane/src/commands/pr/internal/review-template.test.ts packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts --config vitest.workspace.ts (12 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 17 to 16; review-template.ts is 368 lines, below the 400-line warning threshold."
 doc_version: 3
-doc_updated_at: "2026-05-29T03:44:48.647Z"
+doc_updated_at: "2026-05-29T03:47:29.621Z"
 doc_updated_by: "CODER"
 description: "Decompose packages/agentplane/src/commands/pr/internal/review-template.ts by extracting hosted GitHub verification markdown command-wrapping helpers into a focused module, preserving PR artifact rendering and validation behavior while reducing hotspot count."
 sections:
@@ -72,6 +78,25 @@ sections:
     3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-29T03:47:29.585Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified PR review template hosted formatting decomposition. Commands passed: bunx vitest run packages/agentplane/src/commands/pr/internal/review-template.test.ts packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts --config vitest.workspace.ts (12 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 17 to 16; review-template.ts is 368 lines, below the 400-line warning threshold.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T03:44:48.647Z, excerpt_hash=sha256:b41763129fb03e3e0651deff32949d9a535c9970a25473632887b59cbdc28d9e
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: .agentplane/tasks/202605290344-YV53ZN/blueprint/resolved-snapshot.json
+    - old_digest: dd47b97593099f5d2eb206e9f738cbad5f0486f661708705740326c77fe01c14
+    - current_digest: dd47b97593099f5d2eb206e9f738cbad5f0486f661708705740326c77fe01c14
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605290344-YV53ZN
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -119,6 +144,25 @@ PLANNER fallback scaffold for "PR review template hosted formatting decompositio
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-29T03:47:29.585Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified PR review template hosted formatting decomposition. Commands passed: bunx vitest run packages/agentplane/src/commands/pr/internal/review-template.test.ts packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts --config vitest.workspace.ts (12 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 17 to 16; review-template.ts is 368 lines, below the 400-line warning threshold.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T03:44:48.647Z, excerpt_hash=sha256:b41763129fb03e3e0651deff32949d9a535c9970a25473632887b59cbdc28d9e
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: .agentplane/tasks/202605290344-YV53ZN/blueprint/resolved-snapshot.json
+- old_digest: dd47b97593099f5d2eb206e9f738cbad5f0486f661708705740326c77fe01c14
+- current_digest: dd47b97593099f5d2eb206e9f738cbad5f0486f661708705740326c77fe01c14
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605290344-YV53ZN
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605290344-YV53ZN/README.md
+++ b/.agentplane/tasks/202605290344-YV53ZN/README.md
@@ -1,0 +1,129 @@
+---
+id: "202605290344-YV53ZN"
+title: "PR review template hosted formatting decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "hotspot"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-29T03:44:27.700Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: extract hosted GitHub verification markdown formatting helpers from review-template.ts while preserving PR artifact rendering."
+events:
+  -
+    type: "status"
+    at: "2026-05-29T03:44:48.647Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: extract hosted GitHub verification markdown formatting helpers from review-template.ts while preserving PR artifact rendering."
+doc_version: 3
+doc_updated_at: "2026-05-29T03:44:48.647Z"
+doc_updated_by: "CODER"
+description: "Decompose packages/agentplane/src/commands/pr/internal/review-template.ts by extracting hosted GitHub verification markdown command-wrapping helpers into a focused module, preserving PR artifact rendering and validation behavior while reducing hotspot count."
+sections:
+  Summary: |-
+    PR review template hosted formatting decomposition
+
+    Decompose packages/agentplane/src/commands/pr/internal/review-template.ts by extracting hosted GitHub verification markdown command-wrapping helpers into a focused module, preserving PR artifact rendering and validation behavior while reducing hotspot count.
+  Scope: |-
+    - In scope: Decompose packages/agentplane/src/commands/pr/internal/review-template.ts by extracting hosted GitHub verification markdown command-wrapping helpers into a focused module, preserving PR artifact rendering and validation behavior while reducing hotspot count.
+    - Out of scope: unrelated refactors not required for "PR review template hosted formatting decomposition".
+  Plan: |-
+    Refactor PR review template hotspot with one behavior-preserving extraction.
+
+    Scope:
+    - Extract hosted GitHub verification markdown formatting helpers from packages/agentplane/src/commands/pr/internal/review-template.ts into a focused internal module.
+    - Preserve review.md/github-body.md rendering, long verification bullet wrapping, shell command detection, and validation behavior.
+    - Keep review-template.ts below the 400-line runtime hotspot warning threshold.
+
+    Verify:
+    - Run bunx vitest run packages/agentplane/src/commands/pr/internal/review-template.test.ts packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts --config vitest.workspace.ts.
+    - Run bun run typecheck.
+    - Run bun run arch:check.
+    - Run bun run knip:check.
+    - Run bun run lint:core.
+    - Run bun run format:changed.
+    - Run bun run hotspots:check and confirm runtime hotspot warnings decrease from 17 to 16.
+  Verify Steps: |-
+    PLANNER fallback scaffold for "PR review template hosted formatting decomposition". Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the requested outcome for "PR review template hosted formatting decomposition". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+PR review template hosted formatting decomposition
+
+Decompose packages/agentplane/src/commands/pr/internal/review-template.ts by extracting hosted GitHub verification markdown command-wrapping helpers into a focused module, preserving PR artifact rendering and validation behavior while reducing hotspot count.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/commands/pr/internal/review-template.ts by extracting hosted GitHub verification markdown command-wrapping helpers into a focused module, preserving PR artifact rendering and validation behavior while reducing hotspot count.
+- Out of scope: unrelated refactors not required for "PR review template hosted formatting decomposition".
+
+## Plan
+
+Refactor PR review template hotspot with one behavior-preserving extraction.
+
+Scope:
+- Extract hosted GitHub verification markdown formatting helpers from packages/agentplane/src/commands/pr/internal/review-template.ts into a focused internal module.
+- Preserve review.md/github-body.md rendering, long verification bullet wrapping, shell command detection, and validation behavior.
+- Keep review-template.ts below the 400-line runtime hotspot warning threshold.
+
+Verify:
+- Run bunx vitest run packages/agentplane/src/commands/pr/internal/review-template.test.ts packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts --config vitest.workspace.ts.
+- Run bun run typecheck.
+- Run bun run arch:check.
+- Run bun run knip:check.
+- Run bun run lint:core.
+- Run bun run format:changed.
+- Run bun run hotspots:check and confirm runtime hotspot warnings decrease from 17 to 16.
+
+## Verify Steps
+
+PLANNER fallback scaffold for "PR review template hosted formatting decomposition". Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the requested outcome for "PR review template hosted formatting decomposition". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605290344-YV53ZN/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605290344-YV53ZN/blueprint/resolved-snapshot.json
@@ -1,0 +1,361 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605290344-YV53ZN",
+    "title": "PR review template hosted formatting decomposition",
+    "description": "Decompose packages/agentplane/src/commands/pr/internal/review-template.ts by extracting hosted GitHub verification markdown command-wrapping helpers into a focused module, preserving PR artifact rendering and validation behavior while reducing hotspot count.",
+    "tags": [
+      "hotspot",
+      "refactor"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "none",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "analysis.light",
+    "version": 1,
+    "title": "Lightweight analysis",
+    "taskKinds": [
+      "analysis"
+    ],
+    "workflowModes": []
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "analysis.light",
+    "blueprintVersion": 1,
+    "title": "Lightweight analysis",
+    "taskId": "202605290344-YV53ZN",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "none"
+    },
+    "whySelected": [
+      "task kind resolved to analysis",
+      "workflow mode: branch_pr",
+      "mutation scope: none"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "context_manifest",
+          "sources"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "weak_links",
+          "final_output"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "analysis.sources",
+        "kind": "sources",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Sources used for analysis."
+      },
+      {
+        "id": "analysis.assumptions",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Assumptions and constraints."
+      },
+      {
+        "id": "analysis.weak_links",
+        "kind": "weak_links",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Weak links or uncertainty."
+      },
+      {
+        "id": "analysis.final",
+        "kind": "final_output",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Final answer or report."
+      },
+      {
+        "id": "analysis.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      }
+    ],
+    "policyModules": [],
+    "allowedCommands": [],
+    "contextBudget": {
+      "maxPolicyModules": 0,
+      "maxPromptBlocks": 6,
+      "rationale": "Lightweight analysis should load sources and task context without policy modules."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "context_manifest",
+        "sources"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "weak_links",
+        "final_output"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "analysis.sources",
+      "kind": "sources",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Sources used for analysis."
+    },
+    {
+      "id": "analysis.assumptions",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Assumptions and constraints."
+    },
+    {
+      "id": "analysis.weak_links",
+      "kind": "weak_links",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Weak links or uncertainty."
+    },
+    {
+      "id": "analysis.final",
+      "kind": "final_output",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Final answer or report."
+    },
+    {
+      "id": "analysis.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    }
+  ],
+  "policyModules": [],
+  "allowedCommands": [],
+  "contextBudget": {
+    "maxPolicyModules": 0,
+    "maxPromptBlocks": 6,
+    "rationale": "Lightweight analysis should load sources and task context without policy modules."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to analysis",
+    "workflow mode: branch_pr",
+    "mutation scope: none"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "dd47b97593099f5d2eb206e9f738cbad5f0486f661708705740326c77fe01c14"
+  }
+}

--- a/.agentplane/tasks/202605290344-YV53ZN/pr/diffstat.txt
+++ b/.agentplane/tasks/202605290344-YV53ZN/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../commands/pr/internal/review-hosted-format.ts   | 102 +++++++++++++++++++++
+ .../src/commands/pr/internal/review-template.ts    | 102 +--------------------
+ 2 files changed, 103 insertions(+), 101 deletions(-)

--- a/.agentplane/tasks/202605290344-YV53ZN/pr/github-body.md
+++ b/.agentplane/tasks/202605290344-YV53ZN/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605290344-YV53ZN`
+Title: PR review template hosted formatting decomposition
+Canonical task record: `.agentplane/tasks/202605290344-YV53ZN/README.md`
+
+## Summary
+
+PR review template hosted formatting decomposition
+
+Decompose packages/agentplane/src/commands/pr/internal/review-template.ts by extracting hosted GitHub verification markdown command-wrapping helpers into a focused module, preserving PR artifact rendering and validation behavior while reducing hotspot count.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/commands/pr/internal/review-template.ts by extracting hosted GitHub verification markdown command-wrapping helpers into a focused module, preserving PR artifact rendering and validation behavior while reducing hotspot count.
+- Out of scope: unrelated refactors not required for "PR review template hosted formatting decomposition".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T03:44:48.756Z
+- Branch: task/202605290344-YV53ZN/pr-review-template-hosted-formatting
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605290344-YV53ZN/pr/github-body.md
+++ b/.agentplane/tasks/202605290344-YV53ZN/pr/github-body.md
@@ -15,8 +15,17 @@ Decompose packages/agentplane/src/commands/pr/internal/review-template.ts by ext
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Verified PR review template hosted formatting decomposition. Commands passed: bunx vitest run
+packages/agentplane/src/commands/pr/internal/review-template.test.ts
+packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts --config
+vitest.workspace.ts (12 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run
+lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from
+17 to 16; review-template.ts is 368 lines, below the 400-line warning threshold.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
@@ -27,7 +36,9 @@ Decompose packages/agentplane/src/commands/pr/internal/review-template.ts by ext
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../commands/pr/internal/review-hosted-format.ts   | 102 +++++++++++++++++++++
+ .../src/commands/pr/internal/review-template.ts    | 102 +--------------------
+ 2 files changed, 103 insertions(+), 101 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605290344-YV53ZN/pr/github-title.txt
+++ b/.agentplane/tasks/202605290344-YV53ZN/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 YV53ZN task: PR review template hosted formatting decomposition [202605290344-YV53ZN]

--- a/.agentplane/tasks/202605290344-YV53ZN/pr/meta.json
+++ b/.agentplane/tasks/202605290344-YV53ZN/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202605290344-YV53ZN/pr-review-template-hosted-formatting",
+  "created_at": "2026-05-29T03:44:48.756Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202605290344-YV53ZN",
+  "updated_at": "2026-05-29T03:44:48.756Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605290344-YV53ZN/pr/meta.json
+++ b/.agentplane/tasks/202605290344-YV53ZN/pr/meta.json
@@ -2,12 +2,13 @@
   "base": "main",
   "branch": "task/202605290344-YV53ZN/pr-review-template-hosted-formatting",
   "created_at": "2026-05-29T03:44:48.756Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:84c1ef8eebe7a50032d20fb9c4c5565d957c9fbb82718675c1b646d5d32ab670",
+  "last_verified_at": "2026-05-29T03:47:29.585Z",
+  "last_verified_diffstat_sha256": "sha256:84c1ef8eebe7a50032d20fb9c4c5565d957c9fbb82718675c1b646d5d32ab670",
   "schema_version": 1,
   "task_id": "202605290344-YV53ZN",
   "updated_at": "2026-05-29T03:44:48.756Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605290344-YV53ZN/pr/review.md
+++ b/.agentplane/tasks/202605290344-YV53ZN/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-05-29T03:44:48.756Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified PR review template hosted formatting decomposition. Commands passed: bunx vitest run packages/agentplane/src/commands/pr/internal/review-template.test.ts packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts --config vitest.workspace.ts (12 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 17 to 16; review-template.ts is 368 lines, below the 400-line warning threshold.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -29,7 +29,9 @@ Created: 2026-05-29T03:44:48.756Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../commands/pr/internal/review-hosted-format.ts   | 102 +++++++++++++++++++++
+ .../src/commands/pr/internal/review-template.ts    | 102 +--------------------
+ 2 files changed, 103 insertions(+), 101 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605290344-YV53ZN/pr/review.md
+++ b/.agentplane/tasks/202605290344-YV53ZN/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-29T03:44:48.756Z
+
+## Task
+
+- Task: `202605290344-YV53ZN`
+- Title: PR review template hosted formatting decomposition
+- Status: DOING
+- Branch: `task/202605290344-YV53ZN/pr-review-template-hosted-formatting`
+- Canonical task record: `.agentplane/tasks/202605290344-YV53ZN/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T03:44:48.756Z
+- Branch: task/202605290344-YV53ZN/pr-review-template-hosted-formatting
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/pr/internal/review-hosted-format.ts
+++ b/packages/agentplane/src/commands/pr/internal/review-hosted-format.ts
@@ -1,0 +1,102 @@
+const HOSTED_COMMAND_LINE_MAX = 100;
+const HOSTED_COMMAND_BULLET_MIN = 120;
+const VERIFICATION_SECTION = "## Verification";
+const SHELL_COMMAND_PATTERN =
+  /^(?:[A-Z_][A-Z0-9_]*=\S+\s+)*(?:\.\/|ap\b|agentplane\b|bash\b|bun\b|eslint\b|gh\b|git\b|node\b|npm\b|npx\b|pnpm\b|prettier\b|sh\b|tsc\b|vitest\b|yarn\b)/u;
+
+function stripCommandLead(value: string): string {
+  return value
+    .trim()
+    .replace(/^`(.+)`$/u, "$1")
+    .replace(/^(?:check|command|execute|executed|run|running):\s*/iu, "")
+    .replace(/^run\s+/iu, "")
+    .trim();
+}
+
+function isLikelyShellCommand(value: string): boolean {
+  return SHELL_COMMAND_PATTERN.test(stripCommandLead(value));
+}
+
+function wrapWords(value: string, maxChars: number, continuationIndent = ""): string[] {
+  const clean = value.trim().replaceAll(/\s+/g, " ");
+  if (clean.length <= maxChars) return [clean];
+
+  const lines: string[] = [];
+  let current = "";
+
+  for (const token of clean.split(" ")) {
+    const next = current ? `${current} ${token}` : token;
+    if (next.length > maxChars && current) {
+      lines.push(current);
+      current = `${continuationIndent}${token}`;
+      continue;
+    }
+    current = next;
+  }
+
+  if (current) lines.push(current);
+  return lines;
+}
+
+function wrapHostedShellCommand(command: string): string[] {
+  const clean = stripCommandLead(command).replaceAll(/\s+/g, " ");
+  if (clean.length <= HOSTED_COMMAND_LINE_MAX) return [clean];
+
+  return wrapWords(clean, HOSTED_COMMAND_LINE_MAX, "  ").map((line, index, lines) =>
+    index < lines.length - 1 ? `${line} \\` : line,
+  );
+}
+
+function renderHostedLongBullet(line: string): string[] | null {
+  if (line.length < HOSTED_COMMAND_BULLET_MIN) return null;
+
+  const match = /^(?<indent>\s*)-\s+(?:(?<label>[A-Za-z][A-Za-z ]{0,24}):\s*)?(?<body>.+)$/u.exec(
+    line,
+  );
+  const body = match?.groups?.body?.trim() ?? "";
+  if (!body) return null;
+
+  const indent = match?.groups?.indent ?? "";
+  const shellCommand = isLikelyShellCommand(body);
+  const label = match?.groups?.label?.trim() ?? (shellCommand ? "Command" : "Note");
+  return [
+    `${indent}- ${label}:`,
+    "",
+    shellCommand ? "```bash" : "```text",
+    ...(shellCommand ? wrapHostedShellCommand(body) : wrapWords(body, HOSTED_COMMAND_LINE_MAX)),
+    "```",
+  ];
+}
+
+export function formatHostedVerificationMarkdown(markdown: string): string {
+  const lines = markdown.split("\n");
+  const formatted: string[] = [];
+  let inVerification = false;
+  let inFence = false;
+
+  for (const line of lines) {
+    if (line.startsWith("```")) {
+      inFence = !inFence;
+      formatted.push(line);
+      continue;
+    }
+
+    if (!inFence && line.startsWith("## ")) {
+      inVerification = line === VERIFICATION_SECTION;
+      formatted.push(line);
+      continue;
+    }
+
+    if (inVerification && !inFence) {
+      const hostedBullet = renderHostedLongBullet(line);
+      if (hostedBullet) {
+        formatted.push(...hostedBullet);
+        continue;
+      }
+    }
+
+    formatted.push(line);
+  }
+
+  return formatted.join("\n");
+}

--- a/packages/agentplane/src/commands/pr/internal/review-template.ts
+++ b/packages/agentplane/src/commands/pr/internal/review-template.ts
@@ -3,6 +3,7 @@ import type { AgentplaneConfig } from "@agentplaneorg/core/config";
 import type { PrHandoffNote } from "./note-store.js";
 import { extractTaskSuffix, parseTaskSubjectTemplate } from "@agentplaneorg/core/commit";
 import { normalizeTaskStatus } from "@agentplaneorg/core/tasks";
+import { formatHostedVerificationMarkdown } from "./review-hosted-format.js";
 
 const AUTO_SUMMARY_START = "<!-- BEGIN AUTO SUMMARY -->";
 const AUTO_SUMMARY_END = "<!-- END AUTO SUMMARY -->";
@@ -16,10 +17,6 @@ const HANDOFF_NOTES_MARKER = "## Handoff Notes";
 const TASK_ID_SUFFIX_PATTERN = /\s*\[[^\]]+\]\s*$/u;
 const COMMON_NON_ENGLISH_LATIN_MARKERS =
   /\b(?:avec|dans|des|est|este|esta|las|les|los|para|pero|por|que|sans|sont|una|une)\b/iu;
-const HOSTED_COMMAND_LINE_MAX = 100;
-const HOSTED_COMMAND_BULLET_MIN = 120;
-const SHELL_COMMAND_PATTERN =
-  /^(?:[A-Z_][A-Z0-9_]*=\S+\s+)*(?:\.\/|ap\b|agentplane\b|bash\b|bun\b|eslint\b|gh\b|git\b|node\b|npm\b|npx\b|pnpm\b|prettier\b|sh\b|tsc\b|vitest\b|yarn\b)/u;
 
 function sectionText(task: TaskData, name: string, fallback: string): string {
   const value = typeof task.sections?.[name] === "string" ? task.sections[name].trim() : "";
@@ -131,103 +128,6 @@ function renderGithubBodySections(task: TaskData): string[] {
     renderGithubVerificationSummary(task),
     "",
   ];
-}
-
-function stripCommandLead(value: string): string {
-  return value
-    .trim()
-    .replace(/^`(.+)`$/u, "$1")
-    .replace(/^(?:check|command|execute|executed|run|running):\s*/iu, "")
-    .replace(/^run\s+/iu, "")
-    .trim();
-}
-
-function isLikelyShellCommand(value: string): boolean {
-  return SHELL_COMMAND_PATTERN.test(stripCommandLead(value));
-}
-
-function wrapWords(value: string, maxChars: number, continuationIndent = ""): string[] {
-  const clean = value.trim().replaceAll(/\s+/g, " ");
-  if (clean.length <= maxChars) return [clean];
-
-  const lines: string[] = [];
-  let current = "";
-
-  for (const token of clean.split(" ")) {
-    const next = current ? `${current} ${token}` : token;
-    if (next.length > maxChars && current) {
-      lines.push(current);
-      current = `${continuationIndent}${token}`;
-      continue;
-    }
-    current = next;
-  }
-
-  if (current) lines.push(current);
-  return lines;
-}
-
-function wrapHostedShellCommand(command: string): string[] {
-  const clean = stripCommandLead(command).replaceAll(/\s+/g, " ");
-  if (clean.length <= HOSTED_COMMAND_LINE_MAX) return [clean];
-
-  return wrapWords(clean, HOSTED_COMMAND_LINE_MAX, "  ").map((line, index, lines) =>
-    index < lines.length - 1 ? `${line} \\` : line,
-  );
-}
-
-function renderHostedLongBullet(line: string): string[] | null {
-  if (line.length < HOSTED_COMMAND_BULLET_MIN) return null;
-
-  const match = /^(?<indent>\s*)-\s+(?:(?<label>[A-Za-z][A-Za-z ]{0,24}):\s*)?(?<body>.+)$/u.exec(
-    line,
-  );
-  const body = match?.groups?.body?.trim() ?? "";
-  if (!body) return null;
-
-  const indent = match?.groups?.indent ?? "";
-  const shellCommand = isLikelyShellCommand(body);
-  const label = match?.groups?.label?.trim() ?? (shellCommand ? "Command" : "Note");
-  return [
-    `${indent}- ${label}:`,
-    "",
-    shellCommand ? "```bash" : "```text",
-    ...(shellCommand ? wrapHostedShellCommand(body) : wrapWords(body, HOSTED_COMMAND_LINE_MAX)),
-    "```",
-  ];
-}
-
-function formatHostedVerificationMarkdown(markdown: string): string {
-  const lines = markdown.split("\n");
-  const formatted: string[] = [];
-  let inVerification = false;
-  let inFence = false;
-
-  for (const line of lines) {
-    if (line.startsWith("```")) {
-      inFence = !inFence;
-      formatted.push(line);
-      continue;
-    }
-
-    if (!inFence && line.startsWith("## ")) {
-      inVerification = line === VERIFICATION_SECTION;
-      formatted.push(line);
-      continue;
-    }
-
-    if (inVerification && !inFence) {
-      const hostedBullet = renderHostedLongBullet(line);
-      if (hostedBullet) {
-        formatted.push(...hostedBullet);
-        continue;
-      }
-    }
-
-    formatted.push(line);
-  }
-
-  return formatted.join("\n");
 }
 
 function renderGithubHandoffSection(notes: PrHandoffNote[]): string[] {


### PR DESCRIPTION
Task: `202605290344-YV53ZN`
Title: PR review template hosted formatting decomposition
Canonical task record: `.agentplane/tasks/202605290344-YV53ZN/README.md`

## Summary

PR review template hosted formatting decomposition

Decompose packages/agentplane/src/commands/pr/internal/review-template.ts by extracting hosted GitHub verification markdown command-wrapping helpers into a focused module, preserving PR artifact rendering and validation behavior while reducing hotspot count.

## Scope

- In scope: Decompose packages/agentplane/src/commands/pr/internal/review-template.ts by extracting hosted GitHub verification markdown command-wrapping helpers into a focused module, preserving PR artifact rendering and validation behavior while reducing hotspot count.
- Out of scope: unrelated refactors not required for "PR review template hosted formatting decomposition".

## Verification

- State: ok
- Note:

```text
Verified PR review template hosted formatting decomposition. Commands passed: bunx vitest run
packages/agentplane/src/commands/pr/internal/review-template.test.ts
packages/agentplane/src/commands/pr/internal/pr-artifact-snapshot.test.ts --config
vitest.workspace.ts (12 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run
lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from
17 to 16; review-template.ts is 368 lines, below the 400-line warning threshold.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-29T03:44:48.756Z
- Branch: task/202605290344-YV53ZN/pr-review-template-hosted-formatting
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../commands/pr/internal/review-hosted-format.ts   | 102 +++++++++++++++++++++
 .../src/commands/pr/internal/review-template.ts    | 102 +--------------------
 2 files changed, 103 insertions(+), 101 deletions(-)
```

</details>
