### PR TITLE
🚧 V18P6W task: ACR command specs decomposition [202605290402-V18P6W]

### DIFF
--- a/.agentplane/tasks/202605290402-V18P6W/README.md
+++ b/.agentplane/tasks/202605290402-V18P6W/README.md
@@ -4,7 +4,7 @@ title: "ACR command specs decomposition"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 4
+revision: 5
 origin:
   system: "manual"
 depends_on: []
@@ -18,10 +18,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-05-29T04:08:04.296Z"
+  updated_by: "CODER"
+  note: "Verified ACR command specs decomposition. Commands passed: bunx vitest run packages/agentplane/src/commands/acr/acr.command.test.ts --config vitest.workspace.ts (11 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 15 to 14; acr.command.ts is 196 lines, below the 400-line warning threshold."
   attempts: 0
 commit: null
 comments:
@@ -36,8 +36,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: extract ACR parsed types and command specs into acr.specs.ts while preserving acr.command.ts public exports."
+  -
+    type: "verify"
+    at: "2026-05-29T04:08:04.296Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified ACR command specs decomposition. Commands passed: bunx vitest run packages/agentplane/src/commands/acr/acr.command.test.ts --config vitest.workspace.ts (11 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 15 to 14; acr.command.ts is 196 lines, below the 400-line warning threshold."
 doc_version: 3
-doc_updated_at: "2026-05-29T04:02:50.630Z"
+doc_updated_at: "2026-05-29T04:08:04.335Z"
 doc_updated_by: "CODER"
 description: "Decompose packages/agentplane/src/commands/acr/acr.command.ts by extracting ACR command specs and parsed types into a focused acr.specs module, preserving public exports and CLI parsing behavior while reducing runtime hotspot count."
 sections:
@@ -72,6 +78,25 @@ sections:
     3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-29T04:08:04.296Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified ACR command specs decomposition. Commands passed: bunx vitest run packages/agentplane/src/commands/acr/acr.command.test.ts --config vitest.workspace.ts (11 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 15 to 14; acr.command.ts is 196 lines, below the 400-line warning threshold.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T04:02:50.630Z, excerpt_hash=sha256:a4cac58a5c13790963ac280cfdd83fc40502cf6ca25b2e47748d13b74e20eb68
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: .agentplane/tasks/202605290402-V18P6W/blueprint/resolved-snapshot.json
+    - old_digest: 26e97421e0c637c5b34a7569ba40bd500e2b7ca167594363ad338d4b0c3f0728
+    - current_digest: 26e97421e0c637c5b34a7569ba40bd500e2b7ca167594363ad338d4b0c3f0728
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605290402-V18P6W
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -119,6 +144,25 @@ PLANNER fallback scaffold for "ACR command specs decomposition". Replace with ta
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-29T04:08:04.296Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified ACR command specs decomposition. Commands passed: bunx vitest run packages/agentplane/src/commands/acr/acr.command.test.ts --config vitest.workspace.ts (11 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 15 to 14; acr.command.ts is 196 lines, below the 400-line warning threshold.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T04:02:50.630Z, excerpt_hash=sha256:a4cac58a5c13790963ac280cfdd83fc40502cf6ca25b2e47748d13b74e20eb68
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: .agentplane/tasks/202605290402-V18P6W/blueprint/resolved-snapshot.json
+- old_digest: 26e97421e0c637c5b34a7569ba40bd500e2b7ca167594363ad338d4b0c3f0728
+- current_digest: 26e97421e0c637c5b34a7569ba40bd500e2b7ca167594363ad338d4b0c3f0728
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605290402-V18P6W
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202605290402-V18P6W/README.md
+++ b/.agentplane/tasks/202605290402-V18P6W/README.md
@@ -1,0 +1,129 @@
+---
+id: "202605290402-V18P6W"
+title: "ACR command specs decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "hotspot"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-29T04:02:39.306Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: extract ACR parsed types and command specs into acr.specs.ts while preserving acr.command.ts public exports."
+events:
+  -
+    type: "status"
+    at: "2026-05-29T04:02:50.630Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: extract ACR parsed types and command specs into acr.specs.ts while preserving acr.command.ts public exports."
+doc_version: 3
+doc_updated_at: "2026-05-29T04:02:50.630Z"
+doc_updated_by: "CODER"
+description: "Decompose packages/agentplane/src/commands/acr/acr.command.ts by extracting ACR command specs and parsed types into a focused acr.specs module, preserving public exports and CLI parsing behavior while reducing runtime hotspot count."
+sections:
+  Summary: |-
+    ACR command specs decomposition
+
+    Decompose packages/agentplane/src/commands/acr/acr.command.ts by extracting ACR command specs and parsed types into a focused acr.specs module, preserving public exports and CLI parsing behavior while reducing runtime hotspot count.
+  Scope: |-
+    - In scope: Decompose packages/agentplane/src/commands/acr/acr.command.ts by extracting ACR command specs and parsed types into a focused acr.specs module, preserving public exports and CLI parsing behavior while reducing runtime hotspot count.
+    - Out of scope: unrelated refactors not required for "ACR command specs decomposition".
+  Plan: |-
+    Refactor ACR command hotspot with one behavior-preserving extraction.
+
+    Scope:
+    - Extract ACR parsed types and command specs from packages/agentplane/src/commands/acr/acr.command.ts into packages/agentplane/src/commands/acr/acr.specs.ts.
+    - Preserve public exports from acr.command.ts and existing CLI parsing/usage behavior.
+    - Keep acr.command.ts below the 400-line runtime hotspot warning threshold.
+
+    Verify:
+    - Run bunx vitest run packages/agentplane/src/commands/acr/acr.command.test.ts --config vitest.workspace.ts.
+    - Run bun run typecheck.
+    - Run bun run arch:check.
+    - Run bun run knip:check.
+    - Run bun run lint:core.
+    - Run bun run format:changed.
+    - Run bun run hotspots:check and confirm runtime hotspot warnings decrease from 15 to 14.
+  Verify Steps: |-
+    PLANNER fallback scaffold for "ACR command specs decomposition". Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the requested outcome for "ACR command specs decomposition". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+ACR command specs decomposition
+
+Decompose packages/agentplane/src/commands/acr/acr.command.ts by extracting ACR command specs and parsed types into a focused acr.specs module, preserving public exports and CLI parsing behavior while reducing runtime hotspot count.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/commands/acr/acr.command.ts by extracting ACR command specs and parsed types into a focused acr.specs module, preserving public exports and CLI parsing behavior while reducing runtime hotspot count.
+- Out of scope: unrelated refactors not required for "ACR command specs decomposition".
+
+## Plan
+
+Refactor ACR command hotspot with one behavior-preserving extraction.
+
+Scope:
+- Extract ACR parsed types and command specs from packages/agentplane/src/commands/acr/acr.command.ts into packages/agentplane/src/commands/acr/acr.specs.ts.
+- Preserve public exports from acr.command.ts and existing CLI parsing/usage behavior.
+- Keep acr.command.ts below the 400-line runtime hotspot warning threshold.
+
+Verify:
+- Run bunx vitest run packages/agentplane/src/commands/acr/acr.command.test.ts --config vitest.workspace.ts.
+- Run bun run typecheck.
+- Run bun run arch:check.
+- Run bun run knip:check.
+- Run bun run lint:core.
+- Run bun run format:changed.
+- Run bun run hotspots:check and confirm runtime hotspot warnings decrease from 15 to 14.
+
+## Verify Steps
+
+PLANNER fallback scaffold for "ACR command specs decomposition". Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the requested outcome for "ACR command specs decomposition". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605290402-V18P6W/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605290402-V18P6W/blueprint/resolved-snapshot.json
@@ -1,0 +1,361 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605290402-V18P6W",
+    "title": "ACR command specs decomposition",
+    "description": "Decompose packages/agentplane/src/commands/acr/acr.command.ts by extracting ACR command specs and parsed types into a focused acr.specs module, preserving public exports and CLI parsing behavior while reducing runtime hotspot count.",
+    "tags": [
+      "hotspot",
+      "refactor"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "none",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "analysis.light",
+    "version": 1,
+    "title": "Lightweight analysis",
+    "taskKinds": [
+      "analysis"
+    ],
+    "workflowModes": []
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "analysis.light",
+    "blueprintVersion": 1,
+    "title": "Lightweight analysis",
+    "taskId": "202605290402-V18P6W",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "none"
+    },
+    "whySelected": [
+      "task kind resolved to analysis",
+      "workflow mode: branch_pr",
+      "mutation scope: none"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "context_manifest",
+          "sources"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "weak_links",
+          "final_output"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "analysis.sources",
+        "kind": "sources",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Sources used for analysis."
+      },
+      {
+        "id": "analysis.assumptions",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Assumptions and constraints."
+      },
+      {
+        "id": "analysis.weak_links",
+        "kind": "weak_links",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Weak links or uncertainty."
+      },
+      {
+        "id": "analysis.final",
+        "kind": "final_output",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Final answer or report."
+      },
+      {
+        "id": "analysis.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      }
+    ],
+    "policyModules": [],
+    "allowedCommands": [],
+    "contextBudget": {
+      "maxPolicyModules": 0,
+      "maxPromptBlocks": 6,
+      "rationale": "Lightweight analysis should load sources and task context without policy modules."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "context_manifest",
+        "sources"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "weak_links",
+        "final_output"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "analysis.sources",
+      "kind": "sources",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Sources used for analysis."
+    },
+    {
+      "id": "analysis.assumptions",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Assumptions and constraints."
+    },
+    {
+      "id": "analysis.weak_links",
+      "kind": "weak_links",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Weak links or uncertainty."
+    },
+    {
+      "id": "analysis.final",
+      "kind": "final_output",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Final answer or report."
+    },
+    {
+      "id": "analysis.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    }
+  ],
+  "policyModules": [],
+  "allowedCommands": [],
+  "contextBudget": {
+    "maxPolicyModules": 0,
+    "maxPromptBlocks": 6,
+    "rationale": "Lightweight analysis should load sources and task context without policy modules."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to analysis",
+    "workflow mode: branch_pr",
+    "mutation scope: none"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "26e97421e0c637c5b34a7569ba40bd500e2b7ca167594363ad338d4b0c3f0728"
+  }
+}

--- a/.agentplane/tasks/202605290402-V18P6W/pr/diffstat.txt
+++ b/.agentplane/tasks/202605290402-V18P6W/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../agentplane/src/commands/acr/acr.command.ts     | 305 ++-------------------
+ packages/agentplane/src/commands/acr/acr.specs.ts  | 281 +++++++++++++++++++
+ 2 files changed, 305 insertions(+), 281 deletions(-)

--- a/.agentplane/tasks/202605290402-V18P6W/pr/github-body.md
+++ b/.agentplane/tasks/202605290402-V18P6W/pr/github-body.md
@@ -15,8 +15,16 @@ Decompose packages/agentplane/src/commands/acr/acr.command.ts by extracting ACR 
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Verified ACR command specs decomposition. Commands passed: bunx vitest run
+packages/agentplane/src/commands/acr/acr.command.test.ts --config vitest.workspace.ts (11 tests),
+bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run
+format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 15 to 14;
+acr.command.ts is 196 lines, below the 400-line warning threshold.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
@@ -27,7 +35,9 @@ Decompose packages/agentplane/src/commands/acr/acr.command.ts by extracting ACR 
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../agentplane/src/commands/acr/acr.command.ts     | 305 ++-------------------
+ packages/agentplane/src/commands/acr/acr.specs.ts  | 281 +++++++++++++++++++
+ 2 files changed, 305 insertions(+), 281 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605290402-V18P6W/pr/github-body.md
+++ b/.agentplane/tasks/202605290402-V18P6W/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202605290402-V18P6W`
+Title: ACR command specs decomposition
+Canonical task record: `.agentplane/tasks/202605290402-V18P6W/README.md`
+
+## Summary
+
+ACR command specs decomposition
+
+Decompose packages/agentplane/src/commands/acr/acr.command.ts by extracting ACR command specs and parsed types into a focused acr.specs module, preserving public exports and CLI parsing behavior while reducing runtime hotspot count.
+
+## Scope
+
+- In scope: Decompose packages/agentplane/src/commands/acr/acr.command.ts by extracting ACR command specs and parsed types into a focused acr.specs module, preserving public exports and CLI parsing behavior while reducing runtime hotspot count.
+- Out of scope: unrelated refactors not required for "ACR command specs decomposition".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T04:02:50.740Z
+- Branch: task/202605290402-V18P6W/acr-command-specs-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605290402-V18P6W/pr/github-title.txt
+++ b/.agentplane/tasks/202605290402-V18P6W/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 V18P6W task: ACR command specs decomposition [202605290402-V18P6W]

--- a/.agentplane/tasks/202605290402-V18P6W/pr/meta.json
+++ b/.agentplane/tasks/202605290402-V18P6W/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202605290402-V18P6W/acr-command-specs-decomposition",
+  "created_at": "2026-05-29T04:02:50.740Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202605290402-V18P6W",
+  "updated_at": "2026-05-29T04:02:50.740Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202605290402-V18P6W/pr/meta.json
+++ b/.agentplane/tasks/202605290402-V18P6W/pr/meta.json
@@ -2,12 +2,13 @@
   "base": "main",
   "branch": "task/202605290402-V18P6W/acr-command-specs-decomposition",
   "created_at": "2026-05-29T04:02:50.740Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:5d914ff83dfe692aaa4be416e21fd5e0bf0bad854fb3ca1215abed5171f852d5",
+  "last_verified_at": "2026-05-29T04:08:04.296Z",
+  "last_verified_diffstat_sha256": "sha256:5d914ff83dfe692aaa4be416e21fd5e0bf0bad854fb3ca1215abed5171f852d5",
   "schema_version": 1,
   "task_id": "202605290402-V18P6W",
   "updated_at": "2026-05-29T04:02:50.740Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202605290402-V18P6W/pr/review.md
+++ b/.agentplane/tasks/202605290402-V18P6W/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-05-29T04:02:50.740Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified ACR command specs decomposition. Commands passed: bunx vitest run packages/agentplane/src/commands/acr/acr.command.test.ts --config vitest.workspace.ts (11 tests), bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 15 to 14; acr.command.ts is 196 lines, below the 400-line warning threshold.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -29,7 +29,9 @@ Created: 2026-05-29T04:02:50.740Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../agentplane/src/commands/acr/acr.command.ts     | 305 ++-------------------
+ packages/agentplane/src/commands/acr/acr.specs.ts  | 281 +++++++++++++++++++
+ 2 files changed, 305 insertions(+), 281 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605290402-V18P6W/pr/review.md
+++ b/.agentplane/tasks/202605290402-V18P6W/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-29T04:02:50.740Z
+
+## Task
+
+- Task: `202605290402-V18P6W`
+- Title: ACR command specs decomposition
+- Status: DOING
+- Branch: `task/202605290402-V18P6W/acr-command-specs-decomposition`
+- Canonical task record: `.agentplane/tasks/202605290402-V18P6W/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T04:02:50.740Z
+- Branch: task/202605290402-V18P6W/acr-command-specs-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/acr/acr.command.ts
+++ b/packages/agentplane/src/commands/acr/acr.command.ts
@@ -4,12 +4,10 @@ import path from "node:path";
 
 import {
   loadDirectSubcommandNames,
-  parseGroupCommand,
   throwGroupCommandUsage,
   type GroupCommandParsed,
 } from "../../cli/group-command.js";
-import { usageError } from "../../cli/spec/errors.js";
-import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
+import type { CommandCtx } from "../../cli/spec/spec.js";
 import { CliError } from "../../shared/errors.js";
 import { writeTextIfChanged } from "../../shared/write-if-changed.js";
 import type { CommandContext } from "../shared/task-backend.js";
@@ -17,286 +15,31 @@ import { generateAcr } from "./generate.js";
 import { acrValidationError } from "./remediation.js";
 import { renderAcrSummary, summarizeAcr } from "./summary.js";
 import { emitValidationResult, readAcrTarget, validateAcrTarget } from "./validate.js";
-
-type AcrMode = "schema" | "local" | "ci";
-
-export type AcrGenerateParsed = {
-  taskId: string;
-  workCommit?: string;
-  baseCommit?: string;
-  agent?: string;
-  agentName?: string;
-  modelProvider?: "anthropic" | "openai" | "cursor" | "aider" | "unknown" | "custom";
-  modelName?: string;
-  out?: string;
-  write: boolean;
-  stdout: boolean;
-  refresh: boolean;
-  json: boolean;
-};
-
-export type AcrValidateParsed = {
-  target: string;
-  mode: AcrMode;
-  strict: boolean;
-  json: boolean;
-};
-
-export type AcrCheckParsed = {
-  taskId: string;
-  mode: AcrMode;
-  requirePlanApproved: boolean;
-  requireVerification: boolean;
-  requirePolicyPass: boolean;
-  allowWaivedVerification: boolean;
-  allowManualOverride: boolean;
-  json: boolean;
-};
-
-export type AcrExplainParsed = {
-  target: string;
-  json: boolean;
-};
-
-export type AcrSchemaParsed = {
-  version: "0.1";
-  out?: string;
-};
+import {
+  acrSpec,
+  type AcrCheckParsed,
+  type AcrExplainParsed,
+  type AcrGenerateParsed,
+  type AcrSchemaParsed,
+  type AcrValidateParsed,
+} from "./acr.specs.js";
 
 export { assertAcrCiSemantics, validateAcrTarget } from "./validate.js";
-
-export const acrSpec: CommandSpec<GroupCommandParsed> = {
-  id: ["acr"],
-  group: "ACR",
-  summary: "Generate, validate, check, explain, and print Agent Change Record artifacts.",
-  description:
-    "This is a command group. Use a subcommand such as `agentplane acr generate ...`, `agentplane acr validate ...`, or `agentplane acr schema`.",
-  args: [{ name: "cmd", required: false, variadic: true, valueHint: "<cmd>" }],
-  examples: [
-    {
-      cmd: "agentplane acr generate 202605031625-886KZ6 --work-commit HEAD --write",
-      why: "Generate a task-local ACR.",
-    },
-  ],
-  parse: (raw) => parseGroupCommand(raw),
-};
-
-export const acrSchemaSpec: CommandSpec<AcrSchemaParsed> = {
-  id: ["acr", "schema"],
-  group: "ACR",
-  summary: "Print or write the ACR v0.1 JSON Schema.",
-  options: [
-    {
-      kind: "string",
-      name: "version",
-      valueHint: "<version>",
-      choices: ["0.1"],
-      default: "0.1",
-      description: "ACR schema version.",
-    },
-    {
-      kind: "string",
-      name: "out",
-      valueHint: "<path>",
-      description: "Write schema to a file instead of stdout.",
-    },
-  ],
-  examples: [
-    { cmd: "agentplane acr schema --version 0.1", why: "Print the bundled schema." },
-    {
-      cmd: "agentplane acr schema --version 0.1 --out schemas/acr-v0.1.schema.json",
-      why: "Write the bundled schema to a custom path.",
-    },
-  ],
-  parse: (raw) => ({
-    version: (raw.opts.version ?? "0.1") as "0.1",
-    out: typeof raw.opts.out === "string" ? raw.opts.out : undefined,
-  }),
-};
-
-export const acrGenerateSpec: CommandSpec<AcrGenerateParsed> = {
-  id: ["acr", "generate"],
-  group: "ACR",
-  summary: "Generate an Agent Change Record from task, Git, policy, and verification state.",
-  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
-  options: [
-    {
-      kind: "string",
-      name: "work-commit",
-      valueHint: "<rev>",
-      description: "Implementation revision.",
-    },
-    {
-      kind: "string",
-      name: "base-commit",
-      valueHint: "<rev>",
-      description: "Base revision override.",
-    },
-    {
-      kind: "string",
-      name: "agent",
-      valueHint: "<id>",
-      description: "Agentplane role or agent id.",
-    },
-    {
-      kind: "string",
-      name: "agent-name",
-      valueHint: "<name>",
-      description: "Human-readable agent name.",
-    },
-    {
-      kind: "string",
-      name: "model-provider",
-      valueHint: "<provider>",
-      choices: ["anthropic", "openai", "cursor", "aider", "unknown", "custom"],
-      description: "Model provider.",
-    },
-    { kind: "string", name: "model-name", valueHint: "<name>", description: "Model name." },
-    { kind: "string", name: "out", valueHint: "<path>", description: "Write ACR to custom path." },
-    { kind: "boolean", name: "write", default: false, description: "Write task-local ACR." },
-    { kind: "boolean", name: "stdout", default: false, description: "Print ACR JSON to stdout." },
-    { kind: "boolean", name: "refresh", default: false, description: "Overwrite existing ACR." },
-    { kind: "boolean", name: "json", default: false, description: "Emit machine-readable result." },
-  ],
-  examples: [
-    {
-      cmd: "agentplane acr generate 202605031625-886KZ6 --work-commit HEAD --write",
-      why: "Write `.agentplane/tasks/<task-id>/acr.json`.",
-    },
-  ],
-  validateRaw: (raw) => {
-    if (raw.opts.write === true && typeof raw.opts.out === "string") {
-      throw usageError({
-        spec: acrGenerateSpec,
-        command: "acr generate",
-        message: "--write and --out are mutually exclusive.",
-      });
-    }
-  },
-  parse: (raw) => ({
-    taskId: String(raw.args["task-id"]),
-    workCommit: typeof raw.opts["work-commit"] === "string" ? raw.opts["work-commit"] : undefined,
-    baseCommit: typeof raw.opts["base-commit"] === "string" ? raw.opts["base-commit"] : undefined,
-    agent: typeof raw.opts.agent === "string" ? raw.opts.agent : undefined,
-    agentName: typeof raw.opts["agent-name"] === "string" ? raw.opts["agent-name"] : undefined,
-    modelProvider: raw.opts["model-provider"] as AcrGenerateParsed["modelProvider"],
-    modelName: typeof raw.opts["model-name"] === "string" ? raw.opts["model-name"] : undefined,
-    out: typeof raw.opts.out === "string" ? raw.opts.out : undefined,
-    write: raw.opts.write === true,
-    stdout: raw.opts.stdout === true,
-    refresh: raw.opts.refresh === true,
-    json: raw.opts.json === true,
-  }),
-};
-
-export const acrValidateSpec: CommandSpec<AcrValidateParsed> = {
-  id: ["acr", "validate"],
-  group: "ACR",
-  summary: "Validate an ACR file by schema, local, or CI invariants.",
-  args: [{ name: "task-id-or-path", required: true, valueHint: "<task-id-or-path>" }],
-  options: [
-    {
-      kind: "string",
-      name: "mode",
-      valueHint: "<schema|local|ci>",
-      choices: ["schema", "local", "ci"],
-      default: "local",
-      description: "Validation mode.",
-    },
-    { kind: "boolean", name: "strict", default: false, description: "Treat warnings as failures." },
-    { kind: "boolean", name: "json", default: false, description: "Emit machine-readable result." },
-  ],
-  examples: [
-    { cmd: "agentplane acr validate 202605031625-886KZ6 --mode local", why: "Validate task ACR." },
-  ],
-  parse: (raw) => ({
-    target: String(raw.args["task-id-or-path"]),
-    mode: (raw.opts.mode ?? "local") as AcrMode,
-    strict: raw.opts.strict === true,
-    json: raw.opts.json === true,
-  }),
-};
-
-export const acrCheckSpec: CommandSpec<AcrCheckParsed> = {
-  id: ["acr", "check"],
-  group: "ACR",
-  summary: "Run the ACR merge-gate check for CI and branch review.",
-  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
-  options: [
-    {
-      kind: "string",
-      name: "mode",
-      valueHint: "<ci>",
-      choices: ["ci"],
-      default: "ci",
-      description: "Check mode.",
-    },
-    {
-      kind: "boolean",
-      name: "require-plan-approved",
-      default: true,
-      description: "Require approved plan.",
-    },
-    {
-      kind: "boolean",
-      name: "require-verification",
-      default: true,
-      description: "Require passed verification.",
-    },
-    {
-      kind: "boolean",
-      name: "require-policy-pass",
-      default: true,
-      description: "Reject failed policy decisions.",
-    },
-    {
-      kind: "boolean",
-      name: "allow-waived-verification",
-      default: false,
-      description: "Allow waived verification with approval.",
-    },
-    {
-      kind: "boolean",
-      name: "allow-manual-override",
-      default: false,
-      description: "Allow policy manual_override with approval.",
-    },
-    { kind: "boolean", name: "json", default: false, description: "Emit machine-readable result." },
-  ],
-  examples: [{ cmd: "agentplane acr check 202605031625-886KZ6 --mode ci", why: "Run merge gate." }],
-  parse: (raw) => ({
-    taskId: String(raw.args["task-id"]),
-    mode: (raw.opts.mode ?? "ci") as AcrMode,
-    requirePlanApproved: raw.opts["require-plan-approved"] !== false,
-    requireVerification: raw.opts["require-verification"] !== false,
-    requirePolicyPass: raw.opts["require-policy-pass"] !== false,
-    allowWaivedVerification: raw.opts["allow-waived-verification"] === true,
-    allowManualOverride: raw.opts["allow-manual-override"] === true,
-    json: raw.opts.json === true,
-  }),
-};
-
-export const acrExplainSpec: CommandSpec<AcrExplainParsed> = {
-  id: ["acr", "explain"],
-  group: "ACR",
-  summary: "Explain an ACR for human review.",
-  args: [{ name: "task-id-or-path", required: true, valueHint: "<task-id-or-path>" }],
-  options: [
-    {
-      kind: "boolean",
-      name: "json",
-      default: false,
-      description: "Emit machine-readable summary.",
-    },
-  ],
-  examples: [
-    { cmd: "agentplane acr explain 202605031625-886KZ6", why: "Summarize ACR readiness." },
-  ],
-  parse: (raw) => ({
-    target: String(raw.args["task-id-or-path"]),
-    json: raw.opts.json === true,
-  }),
-};
+export {
+  acrCheckSpec,
+  acrExplainSpec,
+  acrGenerateSpec,
+  acrSchemaSpec,
+  acrSpec,
+  acrValidateSpec,
+} from "./acr.specs.js";
+export type {
+  AcrCheckParsed,
+  AcrExplainParsed,
+  AcrGenerateParsed,
+  AcrSchemaParsed,
+  AcrValidateParsed,
+} from "./acr.specs.js";
 
 async function runAcrRootGroup(_ctx: CommandCtx, p: GroupCommandParsed): Promise<number> {
   throwGroupCommandUsage({

--- a/packages/agentplane/src/commands/acr/acr.specs.ts
+++ b/packages/agentplane/src/commands/acr/acr.specs.ts
@@ -1,0 +1,281 @@
+import { parseGroupCommand, type GroupCommandParsed } from "../../cli/group-command.js";
+import { usageError } from "../../cli/spec/errors.js";
+import type { CommandSpec } from "../../cli/spec/spec.js";
+
+type AcrMode = "schema" | "local" | "ci";
+
+export type AcrGenerateParsed = {
+  taskId: string;
+  workCommit?: string;
+  baseCommit?: string;
+  agent?: string;
+  agentName?: string;
+  modelProvider?: "anthropic" | "openai" | "cursor" | "aider" | "unknown" | "custom";
+  modelName?: string;
+  out?: string;
+  write: boolean;
+  stdout: boolean;
+  refresh: boolean;
+  json: boolean;
+};
+
+export type AcrValidateParsed = {
+  target: string;
+  mode: AcrMode;
+  strict: boolean;
+  json: boolean;
+};
+
+export type AcrCheckParsed = {
+  taskId: string;
+  mode: AcrMode;
+  requirePlanApproved: boolean;
+  requireVerification: boolean;
+  requirePolicyPass: boolean;
+  allowWaivedVerification: boolean;
+  allowManualOverride: boolean;
+  json: boolean;
+};
+
+export type AcrExplainParsed = {
+  target: string;
+  json: boolean;
+};
+
+export type AcrSchemaParsed = {
+  version: "0.1";
+  out?: string;
+};
+
+export const acrSpec: CommandSpec<GroupCommandParsed> = {
+  id: ["acr"],
+  group: "ACR",
+  summary: "Generate, validate, check, explain, and print Agent Change Record artifacts.",
+  description:
+    "This is a command group. Use a subcommand such as `agentplane acr generate ...`, `agentplane acr validate ...`, or `agentplane acr schema`.",
+  args: [{ name: "cmd", required: false, variadic: true, valueHint: "<cmd>" }],
+  examples: [
+    {
+      cmd: "agentplane acr generate 202605031625-886KZ6 --work-commit HEAD --write",
+      why: "Generate a task-local ACR.",
+    },
+  ],
+  parse: (raw) => parseGroupCommand(raw),
+};
+
+export const acrSchemaSpec: CommandSpec<AcrSchemaParsed> = {
+  id: ["acr", "schema"],
+  group: "ACR",
+  summary: "Print or write the ACR v0.1 JSON Schema.",
+  options: [
+    {
+      kind: "string",
+      name: "version",
+      valueHint: "<version>",
+      choices: ["0.1"],
+      default: "0.1",
+      description: "ACR schema version.",
+    },
+    {
+      kind: "string",
+      name: "out",
+      valueHint: "<path>",
+      description: "Write schema to a file instead of stdout.",
+    },
+  ],
+  examples: [
+    { cmd: "agentplane acr schema --version 0.1", why: "Print the bundled schema." },
+    {
+      cmd: "agentplane acr schema --version 0.1 --out schemas/acr-v0.1.schema.json",
+      why: "Write the bundled schema to a custom path.",
+    },
+  ],
+  parse: (raw) => ({
+    version: (raw.opts.version ?? "0.1") as "0.1",
+    out: typeof raw.opts.out === "string" ? raw.opts.out : undefined,
+  }),
+};
+
+export const acrGenerateSpec: CommandSpec<AcrGenerateParsed> = {
+  id: ["acr", "generate"],
+  group: "ACR",
+  summary: "Generate an Agent Change Record from task, Git, policy, and verification state.",
+  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
+  options: [
+    {
+      kind: "string",
+      name: "work-commit",
+      valueHint: "<rev>",
+      description: "Implementation revision.",
+    },
+    {
+      kind: "string",
+      name: "base-commit",
+      valueHint: "<rev>",
+      description: "Base revision override.",
+    },
+    {
+      kind: "string",
+      name: "agent",
+      valueHint: "<id>",
+      description: "Agentplane role or agent id.",
+    },
+    {
+      kind: "string",
+      name: "agent-name",
+      valueHint: "<name>",
+      description: "Human-readable agent name.",
+    },
+    {
+      kind: "string",
+      name: "model-provider",
+      valueHint: "<provider>",
+      choices: ["anthropic", "openai", "cursor", "aider", "unknown", "custom"],
+      description: "Model provider.",
+    },
+    { kind: "string", name: "model-name", valueHint: "<name>", description: "Model name." },
+    { kind: "string", name: "out", valueHint: "<path>", description: "Write ACR to custom path." },
+    { kind: "boolean", name: "write", default: false, description: "Write task-local ACR." },
+    { kind: "boolean", name: "stdout", default: false, description: "Print ACR JSON to stdout." },
+    { kind: "boolean", name: "refresh", default: false, description: "Overwrite existing ACR." },
+    { kind: "boolean", name: "json", default: false, description: "Emit machine-readable result." },
+  ],
+  examples: [
+    {
+      cmd: "agentplane acr generate 202605031625-886KZ6 --work-commit HEAD --write",
+      why: "Write `.agentplane/tasks/<task-id>/acr.json`.",
+    },
+  ],
+  validateRaw: (raw) => {
+    if (raw.opts.write === true && typeof raw.opts.out === "string") {
+      throw usageError({
+        spec: acrGenerateSpec,
+        command: "acr generate",
+        message: "--write and --out are mutually exclusive.",
+      });
+    }
+  },
+  parse: (raw) => ({
+    taskId: String(raw.args["task-id"]),
+    workCommit: typeof raw.opts["work-commit"] === "string" ? raw.opts["work-commit"] : undefined,
+    baseCommit: typeof raw.opts["base-commit"] === "string" ? raw.opts["base-commit"] : undefined,
+    agent: typeof raw.opts.agent === "string" ? raw.opts.agent : undefined,
+    agentName: typeof raw.opts["agent-name"] === "string" ? raw.opts["agent-name"] : undefined,
+    modelProvider: raw.opts["model-provider"] as AcrGenerateParsed["modelProvider"],
+    modelName: typeof raw.opts["model-name"] === "string" ? raw.opts["model-name"] : undefined,
+    out: typeof raw.opts.out === "string" ? raw.opts.out : undefined,
+    write: raw.opts.write === true,
+    stdout: raw.opts.stdout === true,
+    refresh: raw.opts.refresh === true,
+    json: raw.opts.json === true,
+  }),
+};
+
+export const acrValidateSpec: CommandSpec<AcrValidateParsed> = {
+  id: ["acr", "validate"],
+  group: "ACR",
+  summary: "Validate an ACR file by schema, local, or CI invariants.",
+  args: [{ name: "task-id-or-path", required: true, valueHint: "<task-id-or-path>" }],
+  options: [
+    {
+      kind: "string",
+      name: "mode",
+      valueHint: "<schema|local|ci>",
+      choices: ["schema", "local", "ci"],
+      default: "local",
+      description: "Validation mode.",
+    },
+    { kind: "boolean", name: "strict", default: false, description: "Treat warnings as failures." },
+    { kind: "boolean", name: "json", default: false, description: "Emit machine-readable result." },
+  ],
+  examples: [
+    { cmd: "agentplane acr validate 202605031625-886KZ6 --mode local", why: "Validate task ACR." },
+  ],
+  parse: (raw) => ({
+    target: String(raw.args["task-id-or-path"]),
+    mode: (raw.opts.mode ?? "local") as AcrMode,
+    strict: raw.opts.strict === true,
+    json: raw.opts.json === true,
+  }),
+};
+
+export const acrCheckSpec: CommandSpec<AcrCheckParsed> = {
+  id: ["acr", "check"],
+  group: "ACR",
+  summary: "Run the ACR merge-gate check for CI and branch review.",
+  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
+  options: [
+    {
+      kind: "string",
+      name: "mode",
+      valueHint: "<ci>",
+      choices: ["ci"],
+      default: "ci",
+      description: "Check mode.",
+    },
+    {
+      kind: "boolean",
+      name: "require-plan-approved",
+      default: true,
+      description: "Require approved plan.",
+    },
+    {
+      kind: "boolean",
+      name: "require-verification",
+      default: true,
+      description: "Require passed verification.",
+    },
+    {
+      kind: "boolean",
+      name: "require-policy-pass",
+      default: true,
+      description: "Reject failed policy decisions.",
+    },
+    {
+      kind: "boolean",
+      name: "allow-waived-verification",
+      default: false,
+      description: "Allow waived verification with approval.",
+    },
+    {
+      kind: "boolean",
+      name: "allow-manual-override",
+      default: false,
+      description: "Allow policy manual_override with approval.",
+    },
+    { kind: "boolean", name: "json", default: false, description: "Emit machine-readable result." },
+  ],
+  examples: [{ cmd: "agentplane acr check 202605031625-886KZ6 --mode ci", why: "Run merge gate." }],
+  parse: (raw) => ({
+    taskId: String(raw.args["task-id"]),
+    mode: (raw.opts.mode ?? "ci") as AcrMode,
+    requirePlanApproved: raw.opts["require-plan-approved"] !== false,
+    requireVerification: raw.opts["require-verification"] !== false,
+    requirePolicyPass: raw.opts["require-policy-pass"] !== false,
+    allowWaivedVerification: raw.opts["allow-waived-verification"] === true,
+    allowManualOverride: raw.opts["allow-manual-override"] === true,
+    json: raw.opts.json === true,
+  }),
+};
+
+export const acrExplainSpec: CommandSpec<AcrExplainParsed> = {
+  id: ["acr", "explain"],
+  group: "ACR",
+  summary: "Explain an ACR for human review.",
+  args: [{ name: "task-id-or-path", required: true, valueHint: "<task-id-or-path>" }],
+  options: [
+    {
+      kind: "boolean",
+      name: "json",
+      default: false,
+      description: "Emit machine-readable summary.",
+    },
+  ],
+  examples: [
+    { cmd: "agentplane acr explain 202605031625-886KZ6", why: "Summarize ACR readiness." },
+  ],
+  parse: (raw) => ({
+    target: String(raw.args["task-id-or-path"]),
+    json: raw.opts.json === true,
+  }),
+};


### PR DESCRIPTION
Task: `202605290402-V18P6W`
Title: ACR command specs decomposition
Canonical task record: `.agentplane/tasks/202605290402-V18P6W/README.md`

## Summary

ACR command specs decomposition

Decompose packages/agentplane/src/commands/acr/acr.command.ts by extracting ACR command specs and parsed types into a focused acr.specs module, preserving public exports and CLI parsing behavior while reducing runtime hotspot count.

## Scope

- In scope: Decompose packages/agentplane/src/commands/acr/acr.command.ts by extracting ACR command specs and parsed types into a focused acr.specs module, preserving public exports and CLI parsing behavior while reducing runtime hotspot count.
- Out of scope: unrelated refactors not required for "ACR command specs decomposition".

## Verification

- State: ok
- Note:

```text
Verified ACR command specs decomposition. Commands passed: bunx vitest run
packages/agentplane/src/commands/acr/acr.command.test.ts --config vitest.workspace.ts (11 tests),
bun run typecheck, bun run arch:check, bun run knip:check, bun run lint:core, bun run
format:changed, bun run hotspots:check. Runtime hotspot warnings decreased from 15 to 14;
acr.command.ts is 196 lines, below the 400-line warning threshold.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-29T04:02:50.740Z
- Branch: task/202605290402-V18P6W/acr-command-specs-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../agentplane/src/commands/acr/acr.command.ts     | 305 ++-------------------
 packages/agentplane/src/commands/acr/acr.specs.ts  | 281 +++++++++++++++++++
 2 files changed, 305 insertions(+), 281 deletions(-)
```

</details>
