### PR TITLE
🚧 D97M2G task: Task observations command decomposition [202605290416-D97M2G]

### DIFF
--- a/.agentplane/tasks/202605290416-D97M2G/README.md
+++ b/.agentplane/tasks/202605290416-D97M2G/README.md
@@ -1,0 +1,151 @@
+---
+id: "202605290416-D97M2G"
+title: "Task observations command decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "hotspot"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-29T04:16:11.788Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-29T04:21:38.744Z"
+  updated_by: "CODER"
+  note: "Observed: observations command specs were extracted into observations.specs.ts; observations.command.ts is below hotspot threshold. Checks: observations.unit.test, typecheck, arch:check, knip:check, lint:core, format:changed, hotspots:check passed."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Extract task observations command specs and parsing helpers into focused modules while preserving CLI behavior."
+events:
+  -
+    type: "status"
+    at: "2026-05-29T04:16:20.905Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Extract task observations command specs and parsing helpers into focused modules while preserving CLI behavior."
+  -
+    type: "verify"
+    at: "2026-05-29T04:21:38.744Z"
+    author: "CODER"
+    state: "ok"
+    note: "Observed: observations command specs were extracted into observations.specs.ts; observations.command.ts is below hotspot threshold. Checks: observations.unit.test, typecheck, arch:check, knip:check, lint:core, format:changed, hotspots:check passed."
+doc_version: 3
+doc_updated_at: "2026-05-29T04:21:38.769Z"
+doc_updated_by: "CODER"
+description: "Extract command wiring or rendering helpers from packages/agentplane/src/commands/task/observations.command.ts to reduce the runtime hotspot below the warning threshold without changing user-visible task observations behavior."
+sections:
+  Summary: |-
+    Task observations command decomposition
+
+    Extract command wiring or rendering helpers from packages/agentplane/src/commands/task/observations.command.ts to reduce the runtime hotspot below the warning threshold without changing user-visible task observations behavior.
+  Scope: |-
+    - In scope: Extract command wiring or rendering helpers from packages/agentplane/src/commands/task/observations.command.ts to reduce the runtime hotspot below the warning threshold without changing user-visible task observations behavior.
+    - Out of scope: unrelated refactors not required for "Task observations command decomposition".
+  Plan: "Scope: reduce packages/agentplane/src/commands/task/observations.command.ts below the 400-line hotspot warning by extracting command specifications and parsed option helpers into focused module(s). Preserve public exports and CLI behavior for task observations add/list/check/triage/harvest. Acceptance: relevant task observations tests pass, typecheck/arch/knip/lint/format pass, bun run hotspots:check shows one fewer runtime hotspot or this file below threshold, no unrelated changes."
+  Verify Steps: |-
+    PLANNER fallback scaffold for "Task observations command decomposition". Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the requested outcome for "Task observations command decomposition". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-29T04:21:38.744Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Observed: observations command specs were extracted into observations.specs.ts; observations.command.ts is below hotspot threshold. Checks: observations.unit.test, typecheck, arch:check, knip:check, lint:core, format:changed, hotspots:check passed.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T04:16:20.905Z, excerpt_hash=sha256:2bf4f33384d7a7036db44b4c33394615a6dbf52c867b9ae9021e4d7908519d4f
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: .agentplane/tasks/202605290416-D97M2G/blueprint/resolved-snapshot.json
+    - old_digest: 588982b2ece6300fd7473e26d0c23315d20c1f79179807748302120f3f711768
+    - current_digest: 588982b2ece6300fd7473e26d0c23315d20c1f79179807748302120f3f711768
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605290416-D97M2G
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Runtime hotspot count decreased from 14 to 13; observations.command.ts is now 242 lines.
+      Impact: Keeps task observations CLI behavior intact while reducing command-module hotspot pressure.
+      Resolution: Preserved exports through observations.command.ts and moved only specs/parsing types to a focused module.
+id_source: "generated"
+---
+## Summary
+
+Task observations command decomposition
+
+Extract command wiring or rendering helpers from packages/agentplane/src/commands/task/observations.command.ts to reduce the runtime hotspot below the warning threshold without changing user-visible task observations behavior.
+
+## Scope
+
+- In scope: Extract command wiring or rendering helpers from packages/agentplane/src/commands/task/observations.command.ts to reduce the runtime hotspot below the warning threshold without changing user-visible task observations behavior.
+- Out of scope: unrelated refactors not required for "Task observations command decomposition".
+
+## Plan
+
+Scope: reduce packages/agentplane/src/commands/task/observations.command.ts below the 400-line hotspot warning by extracting command specifications and parsed option helpers into focused module(s). Preserve public exports and CLI behavior for task observations add/list/check/triage/harvest. Acceptance: relevant task observations tests pass, typecheck/arch/knip/lint/format pass, bun run hotspots:check shows one fewer runtime hotspot or this file below threshold, no unrelated changes.
+
+## Verify Steps
+
+PLANNER fallback scaffold for "Task observations command decomposition". Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the requested outcome for "Task observations command decomposition". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-29T04:21:38.744Z — VERIFY — ok
+
+By: CODER
+
+Note: Observed: observations command specs were extracted into observations.specs.ts; observations.command.ts is below hotspot threshold. Checks: observations.unit.test, typecheck, arch:check, knip:check, lint:core, format:changed, hotspots:check passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T04:16:20.905Z, excerpt_hash=sha256:2bf4f33384d7a7036db44b4c33394615a6dbf52c867b9ae9021e4d7908519d4f
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: .agentplane/tasks/202605290416-D97M2G/blueprint/resolved-snapshot.json
+- old_digest: 588982b2ece6300fd7473e26d0c23315d20c1f79179807748302120f3f711768
+- current_digest: 588982b2ece6300fd7473e26d0c23315d20c1f79179807748302120f3f711768
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605290416-D97M2G
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Runtime hotspot count decreased from 14 to 13; observations.command.ts is now 242 lines.
+  Impact: Keeps task observations CLI behavior intact while reducing command-module hotspot pressure.
+  Resolution: Preserved exports through observations.command.ts and moved only specs/parsing types to a focused module.

--- a/.agentplane/tasks/202605290416-D97M2G/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605290416-D97M2G/blueprint/resolved-snapshot.json
@@ -1,0 +1,361 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605290416-D97M2G",
+    "title": "Task observations command decomposition",
+    "description": "Extract command wiring or rendering helpers from packages/agentplane/src/commands/task/observations.command.ts to reduce the runtime hotspot below the warning threshold without changing user-visible task observations behavior.",
+    "tags": [
+      "hotspot",
+      "refactor"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "none",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "analysis.light",
+    "version": 1,
+    "title": "Lightweight analysis",
+    "taskKinds": [
+      "analysis"
+    ],
+    "workflowModes": []
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "analysis.light",
+    "blueprintVersion": 1,
+    "title": "Lightweight analysis",
+    "taskId": "202605290416-D97M2G",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "none"
+    },
+    "whySelected": [
+      "task kind resolved to analysis",
+      "workflow mode: branch_pr",
+      "mutation scope: none"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "context_manifest",
+          "sources"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "weak_links",
+          "final_output"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "analysis.sources",
+        "kind": "sources",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Sources used for analysis."
+      },
+      {
+        "id": "analysis.assumptions",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Assumptions and constraints."
+      },
+      {
+        "id": "analysis.weak_links",
+        "kind": "weak_links",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Weak links or uncertainty."
+      },
+      {
+        "id": "analysis.final",
+        "kind": "final_output",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Final answer or report."
+      },
+      {
+        "id": "analysis.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      }
+    ],
+    "policyModules": [],
+    "allowedCommands": [],
+    "contextBudget": {
+      "maxPolicyModules": 0,
+      "maxPromptBlocks": 6,
+      "rationale": "Lightweight analysis should load sources and task context without policy modules."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "context_manifest",
+        "sources"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "weak_links",
+        "final_output"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "analysis.sources",
+      "kind": "sources",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Sources used for analysis."
+    },
+    {
+      "id": "analysis.assumptions",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Assumptions and constraints."
+    },
+    {
+      "id": "analysis.weak_links",
+      "kind": "weak_links",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Weak links or uncertainty."
+    },
+    {
+      "id": "analysis.final",
+      "kind": "final_output",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Final answer or report."
+    },
+    {
+      "id": "analysis.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    }
+  ],
+  "policyModules": [],
+  "allowedCommands": [],
+  "contextBudget": {
+    "maxPolicyModules": 0,
+    "maxPromptBlocks": 6,
+    "rationale": "Lightweight analysis should load sources and task context without policy modules."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to analysis",
+    "workflow mode: branch_pr",
+    "mutation scope: none"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "588982b2ece6300fd7473e26d0c23315d20c1f79179807748302120f3f711768"
+  }
+}

--- a/.agentplane/tasks/202605290416-D97M2G/pr/diffstat.txt
+++ b/.agentplane/tasks/202605290416-D97M2G/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../src/commands/task/observations.command.ts      | 249 ++-------------------
+ .../src/commands/task/observations.specs.ts        | 230 +++++++++++++++++++
+ 2 files changed, 252 insertions(+), 227 deletions(-)

--- a/.agentplane/tasks/202605290416-D97M2G/pr/github-body.md
+++ b/.agentplane/tasks/202605290416-D97M2G/pr/github-body.md
@@ -1,0 +1,41 @@
+Task: `202605290416-D97M2G`
+Title: Task observations command decomposition
+Canonical task record: `.agentplane/tasks/202605290416-D97M2G/README.md`
+
+## Summary
+
+Task observations command decomposition
+
+Extract command wiring or rendering helpers from packages/agentplane/src/commands/task/observations.command.ts to reduce the runtime hotspot below the warning threshold without changing user-visible task observations behavior.
+
+## Scope
+
+- In scope: Extract command wiring or rendering helpers from packages/agentplane/src/commands/task/observations.command.ts to reduce the runtime hotspot below the warning threshold without changing user-visible task observations behavior.
+- Out of scope: unrelated refactors not required for "Task observations command decomposition".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Observed: observations command specs were extracted into observations.specs.ts;
+observations.command.ts is below hotspot threshold. Checks: observations.unit.test, typecheck,
+arch:check, knip:check, lint:core, format:changed, hotspots:check passed.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T04:16:21.019Z
+- Branch: task/202605290416-D97M2G/task-observations-command-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/commands/task/observations.command.ts      | 249 ++-------------------
+ .../src/commands/task/observations.specs.ts        | 230 +++++++++++++++++++
+ 2 files changed, 252 insertions(+), 227 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605290416-D97M2G/pr/github-title.txt
+++ b/.agentplane/tasks/202605290416-D97M2G/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 D97M2G task: Task observations command decomposition [202605290416-D97M2G]

--- a/.agentplane/tasks/202605290416-D97M2G/pr/meta.json
+++ b/.agentplane/tasks/202605290416-D97M2G/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605290416-D97M2G/task-observations-command-decomposition",
+  "created_at": "2026-05-29T04:16:21.019Z",
+  "diffstat_sha256": "sha256:8878237599aca0ea85988326cba77c024b0a41ec8498c7206610e508a0b5a7af",
+  "last_verified_at": "2026-05-29T04:21:38.744Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202605290416-D97M2G",
+  "updated_at": "2026-05-29T04:16:21.019Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605290416-D97M2G/pr/review.md
+++ b/.agentplane/tasks/202605290416-D97M2G/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-05-29T04:16:21.019Z
+
+## Task
+
+- Task: `202605290416-D97M2G`
+- Title: Task observations command decomposition
+- Status: DOING
+- Branch: `task/202605290416-D97M2G/task-observations-command-decomposition`
+- Canonical task record: `.agentplane/tasks/202605290416-D97M2G/README.md`
+
+## Verification
+
+- State: ok
+- Note: Observed: observations command specs were extracted into observations.specs.ts; observations.command.ts is below hotspot threshold. Checks: observations.unit.test, typecheck, arch:check, knip:check, lint:core, format:changed, hotspots:check passed.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T04:16:21.019Z
+- Branch: task/202605290416-D97M2G/task-observations-command-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/commands/task/observations.command.ts      | 249 ++-------------------
+ .../src/commands/task/observations.specs.ts        | 230 +++++++++++++++++++
+ 2 files changed, 252 insertions(+), 227 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/task/observations.command.ts
+++ b/packages/agentplane/src/commands/task/observations.command.ts
@@ -1,15 +1,7 @@
-import type {
-  TaskObservationAction,
-  TaskObservationKind,
-  TaskObservationPhase,
-  TaskObservationSeverity,
-  TaskObservationStatus,
-} from "@agentplaneorg/core/tasks";
 import path from "node:path";
 
 import { createCliEmitter } from "../../cli/output.js";
-import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
-import { usageError } from "../../cli/spec/errors.js";
+import type { CommandCtx } from "../../cli/spec/spec.js";
 import { loadDirectSubcommandNames, throwGroupCommandUsage } from "../../cli/group-command.js";
 import { CliError } from "../../shared/errors.js";
 import { loadCommandContext, type CommandContext } from "../shared/task-backend.js";
@@ -19,27 +11,34 @@ import {
   findBlockingObservationIssues,
   formatObservationCheckSummary,
   harvestTaskObservations,
-  observationEnumValues,
   readTaskObservations,
   summarizeObservationHarvest,
   summarizeObservationTriage,
 } from "./observations.js";
+import {
+  taskObservationsSpec,
+  type TaskObservationsAddParsed,
+  type TaskObservationsHarvestParsed,
+  type TaskObservationsParsed,
+  type TaskObservationsReadParsed,
+} from "./observations.specs.js";
 
 const output = createCliEmitter();
 
-export type TaskObservationsParsed = {
-  subcommand?: string;
-};
-
-export const taskObservationsSpec: CommandSpec<TaskObservationsParsed> = {
-  id: ["task", "observations"],
-  group: "Task",
-  summary: "Structured task-local observations journal commands.",
-  args: [{ name: "subcommand", required: false, valueHint: "<add|list|check|triage|harvest>" }],
-  parse: (raw) => ({
-    subcommand: typeof raw.args.subcommand === "string" ? raw.args.subcommand : undefined,
-  }),
-};
+export {
+  taskObservationsAddSpec,
+  taskObservationsCheckSpec,
+  taskObservationsHarvestSpec,
+  taskObservationsListSpec,
+  taskObservationsSpec,
+  taskObservationsTriageSpec,
+} from "./observations.specs.js";
+export type {
+  TaskObservationsAddParsed,
+  TaskObservationsHarvestParsed,
+  TaskObservationsParsed,
+  TaskObservationsReadParsed,
+} from "./observations.specs.js";
 
 export async function runTaskObservations(
   _ctx: CommandCtx,
@@ -51,166 +50,6 @@ export async function runTaskObservations(
     subcommands: await loadDirectSubcommandNames(["task", "observations"]),
   });
 }
-
-type TaskObservationsAddParsed = {
-  taskId: string;
-  kind: TaskObservationKind;
-  summary: string;
-  author: string;
-  phase: TaskObservationPhase;
-  severity: TaskObservationSeverity;
-  decision?: string;
-  impact?: string;
-  action: TaskObservationAction;
-  actionTitle?: string;
-  actionDetails?: string;
-  evidenceFiles: string[];
-  evidenceCommands: string[];
-  refs: string[];
-  tags: string[];
-  status: TaskObservationStatus;
-  json: boolean;
-};
-
-function enumList(values: readonly string[]): string {
-  return values.join("|");
-}
-
-function parseEnum<T extends string>(
-  spec: CommandSpec<unknown>,
-  name: string,
-  value: unknown,
-  values: readonly T[],
-): T {
-  if (typeof value !== "string" || !values.includes(value as T)) {
-    throw usageError({
-      spec,
-      message: `Invalid --${name}; expected one of: ${enumList(values)}.`,
-    });
-  }
-  return value as T;
-}
-
-function parseOptionalString(raw: unknown): string | undefined {
-  return typeof raw === "string" ? raw : undefined;
-}
-
-export const taskObservationsAddSpec: CommandSpec<TaskObservationsAddParsed> = {
-  id: ["task", "observations", "add"],
-  group: "Task",
-  summary: "Append one structured task observation to observations.jsonl.",
-  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
-  options: [
-    { kind: "string", name: "kind", valueHint: "<kind>", description: "Observation kind." },
-    { kind: "string", name: "summary", valueHint: "<text>", description: "Short summary." },
-    {
-      kind: "string",
-      name: "author",
-      valueHint: "<id>",
-      default: "AGENT",
-      description: "Author.",
-    },
-    {
-      kind: "string",
-      name: "phase",
-      valueHint: "<phase>",
-      default: "implementation",
-      description: "Phase.",
-    },
-    {
-      kind: "string",
-      name: "severity",
-      valueHint: "<level>",
-      default: "medium",
-      description: "Severity.",
-    },
-    { kind: "string", name: "decision", valueHint: "<text>", description: "Decision made." },
-    { kind: "string", name: "impact", valueHint: "<text>", description: "Why it matters." },
-    {
-      kind: "string",
-      name: "action",
-      valueHint: "<type>",
-      default: "none",
-      description: "Action.",
-    },
-    { kind: "string", name: "action-title", valueHint: "<text>", description: "Title." },
-    { kind: "string", name: "action-details", valueHint: "<text>", description: "Details." },
-    {
-      kind: "string",
-      name: "evidence-file",
-      valueHint: "<path>",
-      repeatable: true,
-      description: "Evidence file.",
-    },
-    {
-      kind: "string",
-      name: "evidence-command",
-      valueHint: "<command>",
-      repeatable: true,
-      description: "Evidence command.",
-    },
-    {
-      kind: "string",
-      name: "ref",
-      valueHint: "<ref>",
-      repeatable: true,
-      description: "Reference.",
-    },
-    {
-      kind: "string",
-      name: "tag",
-      valueHint: "<tag>",
-      repeatable: true,
-      description: "Tag.",
-    },
-    {
-      kind: "string",
-      name: "status",
-      valueHint: "<status>",
-      default: "open",
-      description: "Status.",
-    },
-    { kind: "boolean", name: "json", default: false, description: "Emit JSON." },
-  ],
-  validateRaw: (raw) => {
-    const kind = raw.opts.kind;
-    const summary = raw.opts.summary;
-    if (typeof kind !== "string" || kind.trim() === "") {
-      throw usageError({
-        spec: taskObservationsAddSpec,
-        message: "Missing required option: --kind.",
-      });
-    }
-    if (typeof summary !== "string" || summary.trim() === "") {
-      throw usageError({
-        spec: taskObservationsAddSpec,
-        message: "Missing required option: --summary.",
-      });
-    }
-  },
-  parse: (raw) => {
-    const enums = observationEnumValues();
-    return {
-      taskId: String(raw.args["task-id"]),
-      kind: parseEnum(taskObservationsAddSpec, "kind", raw.opts.kind, enums.kinds),
-      summary: String(raw.opts.summary),
-      author: parseOptionalString(raw.opts.author) ?? "AGENT",
-      phase: parseEnum(taskObservationsAddSpec, "phase", raw.opts.phase, enums.phases),
-      severity: parseEnum(taskObservationsAddSpec, "severity", raw.opts.severity, enums.severities),
-      decision: parseOptionalString(raw.opts.decision),
-      impact: parseOptionalString(raw.opts.impact),
-      action: parseEnum(taskObservationsAddSpec, "action", raw.opts.action, enums.actions),
-      actionTitle: parseOptionalString(raw.opts["action-title"]),
-      actionDetails: parseOptionalString(raw.opts["action-details"]),
-      evidenceFiles: (raw.opts["evidence-file"] as string[] | undefined) ?? [],
-      evidenceCommands: (raw.opts["evidence-command"] as string[] | undefined) ?? [],
-      refs: (raw.opts.ref as string[] | undefined) ?? [],
-      tags: (raw.opts.tag as string[] | undefined) ?? [],
-      status: parseEnum(taskObservationsAddSpec, "status", raw.opts.status, enums.statuses),
-      json: raw.opts.json === true,
-    };
-  },
-};
 
 async function resolveCtx(
   ctx: CommandCtx,
@@ -238,20 +77,6 @@ export function makeRunTaskObservationsAddHandler(
     return 0;
   };
 }
-
-type TaskObservationsReadParsed = {
-  taskId: string;
-  json: boolean;
-};
-
-export const taskObservationsListSpec: CommandSpec<TaskObservationsReadParsed> = {
-  id: ["task", "observations", "list"],
-  group: "Task",
-  summary: "List structured task observations.",
-  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
-  options: [{ kind: "boolean", name: "json", default: false, description: "Emit JSON." }],
-  parse: (raw) => ({ taskId: String(raw.args["task-id"]), json: raw.opts.json === true }),
-};
 
 function pathRelative(ctx: CommandContext, artifactPath: string): string {
   return path.relative(ctx.resolvedProject.gitRoot, artifactPath).replaceAll(path.sep, "/");
@@ -291,15 +116,6 @@ export function makeRunTaskObservationsListHandler(
   };
 }
 
-export const taskObservationsCheckSpec: CommandSpec<TaskObservationsReadParsed> = {
-  id: ["task", "observations", "check"],
-  group: "Task",
-  summary: "Validate observations.jsonl.",
-  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
-  options: [{ kind: "boolean", name: "json", default: false, description: "Emit JSON." }],
-  parse: (raw) => ({ taskId: String(raw.args["task-id"]), json: raw.opts.json === true }),
-};
-
 export function makeRunTaskObservationsCheckHandler(
   getCtx: (cmd: string) => Promise<CommandContext>,
 ) {
@@ -335,15 +151,6 @@ export function makeRunTaskObservationsCheckHandler(
     return 0;
   };
 }
-
-export const taskObservationsTriageSpec: CommandSpec<TaskObservationsReadParsed> = {
-  id: ["task", "observations", "triage"],
-  group: "Task",
-  summary: "Summarize observation actions.",
-  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
-  options: [{ kind: "boolean", name: "json", default: false, description: "Emit JSON." }],
-  parse: (raw) => ({ taskId: String(raw.args["task-id"]), json: raw.opts.json === true }),
-};
 
 export function makeRunTaskObservationsTriageHandler(
   getCtx: (cmd: string) => Promise<CommandContext>,
@@ -387,18 +194,6 @@ export function makeRunTaskObservationsTriageHandler(
     return 0;
   };
 }
-
-type TaskObservationsHarvestParsed = {
-  json: boolean;
-};
-
-export const taskObservationsHarvestSpec: CommandSpec<TaskObservationsHarvestParsed> = {
-  id: ["task", "observations", "harvest"],
-  group: "Task",
-  summary: "Harvest structured observations across all tasks.",
-  options: [{ kind: "boolean", name: "json", default: false, description: "Emit JSON." }],
-  parse: (raw) => ({ json: raw.opts.json === true }),
-};
 
 export function makeRunTaskObservationsHarvestHandler(
   getCtx: (cmd: string) => Promise<CommandContext>,

--- a/packages/agentplane/src/commands/task/observations.specs.ts
+++ b/packages/agentplane/src/commands/task/observations.specs.ts
@@ -1,0 +1,230 @@
+import type {
+  TaskObservationAction,
+  TaskObservationKind,
+  TaskObservationPhase,
+  TaskObservationSeverity,
+  TaskObservationStatus,
+} from "@agentplaneorg/core/tasks";
+
+import type { CommandSpec } from "../../cli/spec/spec.js";
+import { usageError } from "../../cli/spec/errors.js";
+
+import { observationEnumValues } from "./observations.js";
+
+export type TaskObservationsParsed = {
+  subcommand?: string;
+};
+
+export const taskObservationsSpec: CommandSpec<TaskObservationsParsed> = {
+  id: ["task", "observations"],
+  group: "Task",
+  summary: "Structured task-local observations journal commands.",
+  args: [{ name: "subcommand", required: false, valueHint: "<add|list|check|triage|harvest>" }],
+  parse: (raw) => ({
+    subcommand: typeof raw.args.subcommand === "string" ? raw.args.subcommand : undefined,
+  }),
+};
+
+export type TaskObservationsAddParsed = {
+  taskId: string;
+  kind: TaskObservationKind;
+  summary: string;
+  author: string;
+  phase: TaskObservationPhase;
+  severity: TaskObservationSeverity;
+  decision?: string;
+  impact?: string;
+  action: TaskObservationAction;
+  actionTitle?: string;
+  actionDetails?: string;
+  evidenceFiles: string[];
+  evidenceCommands: string[];
+  refs: string[];
+  tags: string[];
+  status: TaskObservationStatus;
+  json: boolean;
+};
+
+function enumList(values: readonly string[]): string {
+  return values.join("|");
+}
+
+function parseEnum<T extends string>(
+  spec: CommandSpec<unknown>,
+  name: string,
+  value: unknown,
+  values: readonly T[],
+): T {
+  if (typeof value !== "string" || !values.includes(value as T)) {
+    throw usageError({
+      spec,
+      message: `Invalid --${name}; expected one of: ${enumList(values)}.`,
+    });
+  }
+  return value as T;
+}
+
+function parseOptionalString(raw: unknown): string | undefined {
+  return typeof raw === "string" ? raw : undefined;
+}
+
+export const taskObservationsAddSpec: CommandSpec<TaskObservationsAddParsed> = {
+  id: ["task", "observations", "add"],
+  group: "Task",
+  summary: "Append one structured task observation to observations.jsonl.",
+  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
+  options: [
+    { kind: "string", name: "kind", valueHint: "<kind>", description: "Observation kind." },
+    { kind: "string", name: "summary", valueHint: "<text>", description: "Short summary." },
+    {
+      kind: "string",
+      name: "author",
+      valueHint: "<id>",
+      default: "AGENT",
+      description: "Author.",
+    },
+    {
+      kind: "string",
+      name: "phase",
+      valueHint: "<phase>",
+      default: "implementation",
+      description: "Phase.",
+    },
+    {
+      kind: "string",
+      name: "severity",
+      valueHint: "<level>",
+      default: "medium",
+      description: "Severity.",
+    },
+    { kind: "string", name: "decision", valueHint: "<text>", description: "Decision made." },
+    { kind: "string", name: "impact", valueHint: "<text>", description: "Why it matters." },
+    {
+      kind: "string",
+      name: "action",
+      valueHint: "<type>",
+      default: "none",
+      description: "Action.",
+    },
+    { kind: "string", name: "action-title", valueHint: "<text>", description: "Title." },
+    { kind: "string", name: "action-details", valueHint: "<text>", description: "Details." },
+    {
+      kind: "string",
+      name: "evidence-file",
+      valueHint: "<path>",
+      repeatable: true,
+      description: "Evidence file.",
+    },
+    {
+      kind: "string",
+      name: "evidence-command",
+      valueHint: "<command>",
+      repeatable: true,
+      description: "Evidence command.",
+    },
+    {
+      kind: "string",
+      name: "ref",
+      valueHint: "<ref>",
+      repeatable: true,
+      description: "Reference.",
+    },
+    {
+      kind: "string",
+      name: "tag",
+      valueHint: "<tag>",
+      repeatable: true,
+      description: "Tag.",
+    },
+    {
+      kind: "string",
+      name: "status",
+      valueHint: "<status>",
+      default: "open",
+      description: "Status.",
+    },
+    { kind: "boolean", name: "json", default: false, description: "Emit JSON." },
+  ],
+  validateRaw: (raw) => {
+    const kind = raw.opts.kind;
+    const summary = raw.opts.summary;
+    if (typeof kind !== "string" || kind.trim() === "") {
+      throw usageError({
+        spec: taskObservationsAddSpec,
+        message: "Missing required option: --kind.",
+      });
+    }
+    if (typeof summary !== "string" || summary.trim() === "") {
+      throw usageError({
+        spec: taskObservationsAddSpec,
+        message: "Missing required option: --summary.",
+      });
+    }
+  },
+  parse: (raw) => {
+    const enums = observationEnumValues();
+    return {
+      taskId: String(raw.args["task-id"]),
+      kind: parseEnum(taskObservationsAddSpec, "kind", raw.opts.kind, enums.kinds),
+      summary: String(raw.opts.summary),
+      author: parseOptionalString(raw.opts.author) ?? "AGENT",
+      phase: parseEnum(taskObservationsAddSpec, "phase", raw.opts.phase, enums.phases),
+      severity: parseEnum(taskObservationsAddSpec, "severity", raw.opts.severity, enums.severities),
+      decision: parseOptionalString(raw.opts.decision),
+      impact: parseOptionalString(raw.opts.impact),
+      action: parseEnum(taskObservationsAddSpec, "action", raw.opts.action, enums.actions),
+      actionTitle: parseOptionalString(raw.opts["action-title"]),
+      actionDetails: parseOptionalString(raw.opts["action-details"]),
+      evidenceFiles: (raw.opts["evidence-file"] as string[] | undefined) ?? [],
+      evidenceCommands: (raw.opts["evidence-command"] as string[] | undefined) ?? [],
+      refs: (raw.opts.ref as string[] | undefined) ?? [],
+      tags: (raw.opts.tag as string[] | undefined) ?? [],
+      status: parseEnum(taskObservationsAddSpec, "status", raw.opts.status, enums.statuses),
+      json: raw.opts.json === true,
+    };
+  },
+};
+
+export type TaskObservationsReadParsed = {
+  taskId: string;
+  json: boolean;
+};
+
+export const taskObservationsListSpec: CommandSpec<TaskObservationsReadParsed> = {
+  id: ["task", "observations", "list"],
+  group: "Task",
+  summary: "List structured task observations.",
+  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
+  options: [{ kind: "boolean", name: "json", default: false, description: "Emit JSON." }],
+  parse: (raw) => ({ taskId: String(raw.args["task-id"]), json: raw.opts.json === true }),
+};
+
+export const taskObservationsCheckSpec: CommandSpec<TaskObservationsReadParsed> = {
+  id: ["task", "observations", "check"],
+  group: "Task",
+  summary: "Validate observations.jsonl.",
+  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
+  options: [{ kind: "boolean", name: "json", default: false, description: "Emit JSON." }],
+  parse: (raw) => ({ taskId: String(raw.args["task-id"]), json: raw.opts.json === true }),
+};
+
+export const taskObservationsTriageSpec: CommandSpec<TaskObservationsReadParsed> = {
+  id: ["task", "observations", "triage"],
+  group: "Task",
+  summary: "Summarize observation actions.",
+  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
+  options: [{ kind: "boolean", name: "json", default: false, description: "Emit JSON." }],
+  parse: (raw) => ({ taskId: String(raw.args["task-id"]), json: raw.opts.json === true }),
+};
+
+export type TaskObservationsHarvestParsed = {
+  json: boolean;
+};
+
+export const taskObservationsHarvestSpec: CommandSpec<TaskObservationsHarvestParsed> = {
+  id: ["task", "observations", "harvest"],
+  group: "Task",
+  summary: "Harvest structured observations across all tasks.",
+  options: [{ kind: "boolean", name: "json", default: false, description: "Emit JSON." }],
+  parse: (raw) => ({ json: raw.opts.json === true }),
+};


### PR DESCRIPTION
Task: `202605290416-D97M2G`
Title: Task observations command decomposition
Canonical task record: `.agentplane/tasks/202605290416-D97M2G/README.md`

## Summary

Task observations command decomposition

Extract command wiring or rendering helpers from packages/agentplane/src/commands/task/observations.command.ts to reduce the runtime hotspot below the warning threshold without changing user-visible task observations behavior.

## Scope

- In scope: Extract command wiring or rendering helpers from packages/agentplane/src/commands/task/observations.command.ts to reduce the runtime hotspot below the warning threshold without changing user-visible task observations behavior.
- Out of scope: unrelated refactors not required for "Task observations command decomposition".

## Verification

- State: ok
- Note:

```text
Observed: observations command specs were extracted into observations.specs.ts;
observations.command.ts is below hotspot threshold. Checks: observations.unit.test, typecheck,
arch:check, knip:check, lint:core, format:changed, hotspots:check passed.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-29T04:16:21.019Z
- Branch: task/202605290416-D97M2G/task-observations-command-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/commands/task/observations.command.ts      | 249 ++-------------------
 .../src/commands/task/observations.specs.ts        | 230 +++++++++++++++++++
 2 files changed, 252 insertions(+), 227 deletions(-)
```

</details>
