### PR TITLE
🚧 WVKXG8 task: Prompt module compiler decomposition [202605290438-WVKXG8]

### DIFF
--- a/.agentplane/tasks/202605290438-WVKXG8/README.md
+++ b/.agentplane/tasks/202605290438-WVKXG8/README.md
@@ -1,0 +1,151 @@
+---
+id: "202605290438-WVKXG8"
+title: "Prompt module compiler decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "hotspot"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-29T04:38:33.947Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-29T04:44:24.056Z"
+  updated_by: "CODER"
+  note: "Observed: prompt module compiler context normalization and load-condition matching moved into compiler.context.ts; compiler.ts is below hotspot threshold. Checks: compiler.test, mutations.test, registry.test, typecheck, arch:check, knip:check, lint:core, format:changed, hotspots:check passed."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Extract prompt module compiler context and matching helpers while preserving compilePromptModuleGraph behavior."
+events:
+  -
+    type: "status"
+    at: "2026-05-29T04:38:43.773Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Extract prompt module compiler context and matching helpers while preserving compilePromptModuleGraph behavior."
+  -
+    type: "verify"
+    at: "2026-05-29T04:44:24.056Z"
+    author: "CODER"
+    state: "ok"
+    note: "Observed: prompt module compiler context normalization and load-condition matching moved into compiler.context.ts; compiler.ts is below hotspot threshold. Checks: compiler.test, mutations.test, registry.test, typecheck, arch:check, knip:check, lint:core, format:changed, hotspots:check passed."
+doc_version: 3
+doc_updated_at: "2026-05-29T04:44:24.081Z"
+doc_updated_by: "CODER"
+description: "Extract focused helpers from packages/agentplane/src/runtime/prompt-modules/compiler.ts to reduce the runtime hotspot below the warning threshold without changing prompt module compilation behavior."
+sections:
+  Summary: |-
+    Prompt module compiler decomposition
+
+    Extract focused helpers from packages/agentplane/src/runtime/prompt-modules/compiler.ts to reduce the runtime hotspot below the warning threshold without changing prompt module compilation behavior.
+  Scope: |-
+    - In scope: Extract focused helpers from packages/agentplane/src/runtime/prompt-modules/compiler.ts to reduce the runtime hotspot below the warning threshold without changing prompt module compilation behavior.
+    - Out of scope: unrelated refactors not required for "Prompt module compiler decomposition".
+  Plan: "Scope: reduce packages/agentplane/src/runtime/prompt-modules/compiler.ts below the 400-line hotspot warning by extracting compiler context normalization and load-condition matching helpers into focused module(s). Preserve exported compiler API and prompt module compilation behavior. Acceptance: prompt-module related tests pass, typecheck/arch/knip/lint/format pass, bun run hotspots:check shows one fewer runtime hotspot."
+  Verify Steps: |-
+    PLANNER fallback scaffold for "Prompt module compiler decomposition". Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the requested outcome for "Prompt module compiler decomposition". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-29T04:44:24.056Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Observed: prompt module compiler context normalization and load-condition matching moved into compiler.context.ts; compiler.ts is below hotspot threshold. Checks: compiler.test, mutations.test, registry.test, typecheck, arch:check, knip:check, lint:core, format:changed, hotspots:check passed.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T04:38:43.773Z, excerpt_hash=sha256:c97736db7fca74b36b4abba3f446d48302a5a2caef68fa66b1814c76cba2d810
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: .agentplane/tasks/202605290438-WVKXG8/blueprint/resolved-snapshot.json
+    - old_digest: c7b013e2a1e61dc34693562a8ff8e321cbbf6718bc974c1ad87020e011783789
+    - current_digest: c7b013e2a1e61dc34693562a8ff8e321cbbf6718bc974c1ad87020e011783789
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605290438-WVKXG8
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Runtime hotspot count decreased from 12 to 11; compiler.ts is now 232 lines.
+      Impact: Keeps prompt module compilation behavior stable while reducing compiler module size and separating context normalization.
+      Resolution: Preserved compiler.ts exports through re-export-from declarations and kept compilePromptModuleGraph in compiler.ts.
+id_source: "generated"
+---
+## Summary
+
+Prompt module compiler decomposition
+
+Extract focused helpers from packages/agentplane/src/runtime/prompt-modules/compiler.ts to reduce the runtime hotspot below the warning threshold without changing prompt module compilation behavior.
+
+## Scope
+
+- In scope: Extract focused helpers from packages/agentplane/src/runtime/prompt-modules/compiler.ts to reduce the runtime hotspot below the warning threshold without changing prompt module compilation behavior.
+- Out of scope: unrelated refactors not required for "Prompt module compiler decomposition".
+
+## Plan
+
+Scope: reduce packages/agentplane/src/runtime/prompt-modules/compiler.ts below the 400-line hotspot warning by extracting compiler context normalization and load-condition matching helpers into focused module(s). Preserve exported compiler API and prompt module compilation behavior. Acceptance: prompt-module related tests pass, typecheck/arch/knip/lint/format pass, bun run hotspots:check shows one fewer runtime hotspot.
+
+## Verify Steps
+
+PLANNER fallback scaffold for "Prompt module compiler decomposition". Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the requested outcome for "Prompt module compiler decomposition". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-29T04:44:24.056Z — VERIFY — ok
+
+By: CODER
+
+Note: Observed: prompt module compiler context normalization and load-condition matching moved into compiler.context.ts; compiler.ts is below hotspot threshold. Checks: compiler.test, mutations.test, registry.test, typecheck, arch:check, knip:check, lint:core, format:changed, hotspots:check passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T04:38:43.773Z, excerpt_hash=sha256:c97736db7fca74b36b4abba3f446d48302a5a2caef68fa66b1814c76cba2d810
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: .agentplane/tasks/202605290438-WVKXG8/blueprint/resolved-snapshot.json
+- old_digest: c7b013e2a1e61dc34693562a8ff8e321cbbf6718bc974c1ad87020e011783789
+- current_digest: c7b013e2a1e61dc34693562a8ff8e321cbbf6718bc974c1ad87020e011783789
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605290438-WVKXG8
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Runtime hotspot count decreased from 12 to 11; compiler.ts is now 232 lines.
+  Impact: Keeps prompt module compilation behavior stable while reducing compiler module size and separating context normalization.
+  Resolution: Preserved compiler.ts exports through re-export-from declarations and kept compilePromptModuleGraph in compiler.ts.

--- a/.agentplane/tasks/202605290438-WVKXG8/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605290438-WVKXG8/blueprint/resolved-snapshot.json
@@ -1,0 +1,361 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605290438-WVKXG8",
+    "title": "Prompt module compiler decomposition",
+    "description": "Extract focused helpers from packages/agentplane/src/runtime/prompt-modules/compiler.ts to reduce the runtime hotspot below the warning threshold without changing prompt module compilation behavior.",
+    "tags": [
+      "hotspot",
+      "refactor"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "none",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "analysis.light",
+    "version": 1,
+    "title": "Lightweight analysis",
+    "taskKinds": [
+      "analysis"
+    ],
+    "workflowModes": []
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "analysis.light",
+    "blueprintVersion": 1,
+    "title": "Lightweight analysis",
+    "taskId": "202605290438-WVKXG8",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "none"
+    },
+    "whySelected": [
+      "task kind resolved to analysis",
+      "workflow mode: branch_pr",
+      "mutation scope: none"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "context_manifest",
+          "sources"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "weak_links",
+          "final_output"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "analysis.sources",
+        "kind": "sources",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Sources used for analysis."
+      },
+      {
+        "id": "analysis.assumptions",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Assumptions and constraints."
+      },
+      {
+        "id": "analysis.weak_links",
+        "kind": "weak_links",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Weak links or uncertainty."
+      },
+      {
+        "id": "analysis.final",
+        "kind": "final_output",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Final answer or report."
+      },
+      {
+        "id": "analysis.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      }
+    ],
+    "policyModules": [],
+    "allowedCommands": [],
+    "contextBudget": {
+      "maxPolicyModules": 0,
+      "maxPromptBlocks": 6,
+      "rationale": "Lightweight analysis should load sources and task context without policy modules."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "context_manifest",
+        "sources"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "weak_links",
+        "final_output"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "analysis.sources",
+      "kind": "sources",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Sources used for analysis."
+    },
+    {
+      "id": "analysis.assumptions",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Assumptions and constraints."
+    },
+    {
+      "id": "analysis.weak_links",
+      "kind": "weak_links",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Weak links or uncertainty."
+    },
+    {
+      "id": "analysis.final",
+      "kind": "final_output",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Final answer or report."
+    },
+    {
+      "id": "analysis.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    }
+  ],
+  "policyModules": [],
+  "allowedCommands": [],
+  "contextBudget": {
+    "maxPolicyModules": 0,
+    "maxPromptBlocks": 6,
+    "rationale": "Lightweight analysis should load sources and task context without policy modules."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to analysis",
+    "workflow mode: branch_pr",
+    "mutation scope: none"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "c7b013e2a1e61dc34693562a8ff8e321cbbf6718bc974c1ad87020e011783789"
+  }
+}

--- a/.agentplane/tasks/202605290438-WVKXG8/pr/diffstat.txt
+++ b/.agentplane/tasks/202605290438-WVKXG8/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../src/runtime/prompt-modules/compiler.context.ts | 222 +++++++++++++++++++
+ .../src/runtime/prompt-modules/compiler.ts         | 244 ++-------------------
+ 2 files changed, 238 insertions(+), 228 deletions(-)

--- a/.agentplane/tasks/202605290438-WVKXG8/pr/github-body.md
+++ b/.agentplane/tasks/202605290438-WVKXG8/pr/github-body.md
@@ -1,0 +1,41 @@
+Task: `202605290438-WVKXG8`
+Title: Prompt module compiler decomposition
+Canonical task record: `.agentplane/tasks/202605290438-WVKXG8/README.md`
+
+## Summary
+
+Prompt module compiler decomposition
+
+Extract focused helpers from packages/agentplane/src/runtime/prompt-modules/compiler.ts to reduce the runtime hotspot below the warning threshold without changing prompt module compilation behavior.
+
+## Scope
+
+- In scope: Extract focused helpers from packages/agentplane/src/runtime/prompt-modules/compiler.ts to reduce the runtime hotspot below the warning threshold without changing prompt module compilation behavior.
+- Out of scope: unrelated refactors not required for "Prompt module compiler decomposition".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Observed: prompt module compiler context normalization and load-condition matching moved into
+compiler.context.ts; compiler.ts is below hotspot threshold. Checks: compiler.test, mutations.test,
+registry.test, typecheck, arch:check, knip:check, lint:core, format:changed, hotspots:check passed.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T04:38:43.884Z
+- Branch: task/202605290438-WVKXG8/prompt-module-compiler-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/runtime/prompt-modules/compiler.context.ts | 222 +++++++++++++++++++
+ .../src/runtime/prompt-modules/compiler.ts         | 244 ++-------------------
+ 2 files changed, 238 insertions(+), 228 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605290438-WVKXG8/pr/github-title.txt
+++ b/.agentplane/tasks/202605290438-WVKXG8/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 WVKXG8 task: Prompt module compiler decomposition [202605290438-WVKXG8]

--- a/.agentplane/tasks/202605290438-WVKXG8/pr/meta.json
+++ b/.agentplane/tasks/202605290438-WVKXG8/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605290438-WVKXG8/prompt-module-compiler-decomposition",
+  "created_at": "2026-05-29T04:38:43.884Z",
+  "diffstat_sha256": "sha256:8b2c33543cd850cf7e8d7f1f7a969284c92c6f94eab6ef6615ff2c56daea5042",
+  "last_verified_at": "2026-05-29T04:44:24.056Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202605290438-WVKXG8",
+  "updated_at": "2026-05-29T04:38:43.884Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605290438-WVKXG8/pr/review.md
+++ b/.agentplane/tasks/202605290438-WVKXG8/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-05-29T04:38:43.884Z
+
+## Task
+
+- Task: `202605290438-WVKXG8`
+- Title: Prompt module compiler decomposition
+- Status: DOING
+- Branch: `task/202605290438-WVKXG8/prompt-module-compiler-decomposition`
+- Canonical task record: `.agentplane/tasks/202605290438-WVKXG8/README.md`
+
+## Verification
+
+- State: ok
+- Note: Observed: prompt module compiler context normalization and load-condition matching moved into compiler.context.ts; compiler.ts is below hotspot threshold. Checks: compiler.test, mutations.test, registry.test, typecheck, arch:check, knip:check, lint:core, format:changed, hotspots:check passed.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T04:38:43.884Z
+- Branch: task/202605290438-WVKXG8/prompt-module-compiler-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/runtime/prompt-modules/compiler.context.ts | 222 +++++++++++++++++++
+ .../src/runtime/prompt-modules/compiler.ts         | 244 ++-------------------
+ 2 files changed, 238 insertions(+), 228 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/runtime/prompt-modules/compiler.context.ts
+++ b/packages/agentplane/src/runtime/prompt-modules/compiler.context.ts
@@ -1,0 +1,218 @@
+import type { PromptModuleLoadCondition } from "./model.js";
+import { uniqueStrings } from "./compiler.shared.js";
+import type { PromptModuleValidatorPhase } from "./mutations.js";
+import type { PromptModuleDiagnostic } from "./compiler.js";
+
+type PromptModulePolicyGateway = NonNullable<PromptModuleLoadCondition["policy_gateways"]>[number];
+type PromptModuleWorkflowMode = NonNullable<PromptModuleLoadCondition["workflow_modes"]>[number];
+
+export type PromptModuleCompilerContext = {
+  workflow_mode?: PromptModuleWorkflowMode;
+  policy_gateway?: PromptModulePolicyGateway;
+  roles?: string[];
+  command?: string;
+  commands?: string[];
+  task_tags?: string[];
+  repo_type?: string;
+  repo_types?: string[];
+  recipe_ids?: string[];
+  available_commands?: string[];
+  validator_phases?: PromptModuleValidatorPhase[];
+};
+
+const PROMPT_MODULE_WORKFLOW_MODE_VALUES = ["direct", "branch_pr"] as const;
+const PROMPT_MODULE_POLICY_GATEWAY_VALUES = ["codex", "claude"] as const;
+const PROMPT_MODULE_VALIDATOR_PHASE_VALUES = ["resolve", "compile", "emit", "doctor"] as const;
+
+function hasAllowedValue<TValue extends string>(
+  value: string,
+  allowedValues: readonly TValue[],
+): value is TValue {
+  return (allowedValues as readonly string[]).includes(value);
+}
+
+function contextValueLabel(value: unknown): string {
+  if (typeof value === "string") return JSON.stringify(value);
+  if (value === undefined) return "undefined";
+  return Object.prototype.toString.call(value);
+}
+
+function hasControlCharacter(value: string): boolean {
+  for (const character of value) {
+    const code = character.codePointAt(0) ?? 0;
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
+
+function reportDiscardedContextValue(
+  diagnostics: PromptModuleDiagnostic[],
+  field: string,
+  value: unknown,
+  reason: string,
+): void {
+  diagnostics.push({
+    severity: "warning",
+    code: "compiler_context_value_discarded",
+    message: `Discarded compiler context value ${field}=${contextValueLabel(value)}: ${reason}.`,
+  });
+}
+
+function normalizeContextString<TValue extends string = string>(
+  value: unknown,
+  field: string,
+  diagnostics: PromptModuleDiagnostic[],
+  allowedValues?: readonly TValue[],
+): TValue | string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") {
+    reportDiscardedContextValue(diagnostics, field, value, "expected string");
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    reportDiscardedContextValue(diagnostics, field, value, "empty after trimming");
+    return undefined;
+  }
+  if (hasControlCharacter(trimmed)) {
+    reportDiscardedContextValue(diagnostics, field, value, "contains control characters");
+    return undefined;
+  }
+  if (allowedValues && !hasAllowedValue(trimmed, allowedValues)) {
+    reportDiscardedContextValue(
+      diagnostics,
+      field,
+      value,
+      `expected one of ${allowedValues.join(", ")}`,
+    );
+    return undefined;
+  }
+  return trimmed;
+}
+
+function normalizeContextStringList<TValue extends string = string>(
+  value: unknown,
+  field: string,
+  diagnostics: PromptModuleDiagnostic[],
+  allowedValues?: readonly TValue[],
+): TValue[] | string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    reportDiscardedContextValue(diagnostics, field, value, "expected string array");
+    return undefined;
+  }
+
+  const normalized: string[] = [];
+  for (const [index, item] of value.entries()) {
+    const normalizedItem = normalizeContextString(
+      item,
+      `${field}[${index}]`,
+      diagnostics,
+      allowedValues,
+    );
+    if (normalizedItem !== undefined) normalized.push(normalizedItem);
+  }
+  return uniqueStrings(normalized);
+}
+
+export function normalizePromptModuleCompilerContext(
+  context: PromptModuleCompilerContext = {},
+  diagnostics: PromptModuleDiagnostic[] = [],
+): PromptModuleCompilerContext {
+  const raw = context as Record<string, unknown>;
+  const normalized: PromptModuleCompilerContext = {};
+
+  const workflowMode = normalizeContextString(
+    raw.workflow_mode,
+    "workflow_mode",
+    diagnostics,
+    PROMPT_MODULE_WORKFLOW_MODE_VALUES,
+  );
+  if (workflowMode !== undefined) {
+    normalized.workflow_mode = workflowMode as PromptModuleWorkflowMode;
+  }
+
+  const policyGateway = normalizeContextString(
+    raw.policy_gateway,
+    "policy_gateway",
+    diagnostics,
+    PROMPT_MODULE_POLICY_GATEWAY_VALUES,
+  );
+  if (policyGateway !== undefined) {
+    normalized.policy_gateway = policyGateway as PromptModulePolicyGateway;
+  }
+
+  const command = normalizeContextString(raw.command, "command", diagnostics);
+  if (command !== undefined) normalized.command = command;
+
+  const repoType = normalizeContextString(raw.repo_type, "repo_type", diagnostics);
+  if (repoType !== undefined) normalized.repo_type = repoType;
+
+  const roles = normalizeContextStringList(raw.roles, "roles", diagnostics);
+  if (roles !== undefined) normalized.roles = roles;
+
+  const commands = normalizeContextStringList(raw.commands, "commands", diagnostics);
+  if (commands !== undefined) normalized.commands = commands;
+
+  const taskTags = normalizeContextStringList(raw.task_tags, "task_tags", diagnostics);
+  if (taskTags !== undefined) normalized.task_tags = taskTags;
+
+  const repoTypes = normalizeContextStringList(raw.repo_types, "repo_types", diagnostics);
+  if (repoTypes !== undefined) normalized.repo_types = repoTypes;
+
+  const recipeIds = normalizeContextStringList(raw.recipe_ids, "recipe_ids", diagnostics);
+  if (recipeIds !== undefined) normalized.recipe_ids = recipeIds;
+
+  const availableCommands = normalizeContextStringList(
+    raw.available_commands,
+    "available_commands",
+    diagnostics,
+  );
+  if (availableCommands !== undefined) normalized.available_commands = availableCommands;
+
+  const validatorPhases = normalizeContextStringList(
+    raw.validator_phases,
+    "validator_phases",
+    diagnostics,
+    PROMPT_MODULE_VALIDATOR_PHASE_VALUES,
+  );
+  if (validatorPhases !== undefined) {
+    normalized.validator_phases = validatorPhases as PromptModuleValidatorPhase[];
+  }
+
+  return normalized;
+}
+
+export function contextCommands(context: PromptModuleCompilerContext): string[] {
+  return uniqueStrings([context.command ?? "", ...(context.commands ?? [])]);
+}
+
+function contextRepoTypes(context: PromptModuleCompilerContext): string[] {
+  return uniqueStrings([context.repo_type ?? "", ...(context.repo_types ?? [])]);
+}
+
+function intersects<T>(expected: readonly T[] | undefined, actual: readonly T[]): boolean {
+  if (!expected || expected.length === 0) return true;
+  return expected.some((value) => actual.includes(value));
+}
+
+function includesValue<T>(expected: readonly T[] | undefined, actual: T | undefined): boolean {
+  if (!expected || expected.length === 0) return true;
+  return actual === undefined ? false : expected.includes(actual);
+}
+
+export function matchesPromptModuleLoadCondition(
+  condition: PromptModuleLoadCondition | undefined,
+  context: PromptModuleCompilerContext,
+): boolean {
+  if (!condition) return true;
+  return (
+    includesValue(condition.workflow_modes, context.workflow_mode) &&
+    includesValue(condition.policy_gateways, context.policy_gateway) &&
+    intersects(condition.roles, context.roles ?? []) &&
+    intersects(condition.commands, contextCommands(context)) &&
+    intersects(condition.task_tags_any, context.task_tags ?? []) &&
+    intersects(condition.repo_types, contextRepoTypes(context)) &&
+    intersects(condition.recipe_ids, context.recipe_ids ?? [])
+  );
+}

--- a/packages/agentplane/src/runtime/prompt-modules/compiler.ts
+++ b/packages/agentplane/src/runtime/prompt-modules/compiler.ts
@@ -6,12 +6,13 @@ import type {
 } from "./model.js";
 import { PROMPT_MODULE_CONTRACT_SCHEMA_VERSION } from "./schema.js";
 import { mergeDuplicateNodes } from "./compiler.merge.js";
+import { copyModule, moduleAddress, type WorkingPromptModuleNode } from "./compiler.shared.js";
 import {
-  copyModule,
-  moduleAddress,
-  uniqueStrings,
-  type WorkingPromptModuleNode,
-} from "./compiler.shared.js";
+  contextCommands,
+  matchesPromptModuleLoadCondition,
+  normalizePromptModuleCompilerContext,
+  type PromptModuleCompilerContext,
+} from "./compiler.context.js";
 import { applyPromptModuleMutation, describePromptModuleSelector } from "./mutations-engine.js";
 import type {
   PromptModuleBinding,
@@ -22,26 +23,18 @@ import type {
   PromptModuleValidatorPhase,
 } from "./mutations.js";
 
+export {
+  matchesPromptModuleLoadCondition,
+  normalizePromptModuleCompilerContext,
+} from "./compiler.context.js";
+export type { PromptModuleCompilerContext } from "./compiler.context.js";
+
 export type PromptModulePolicyGateway = NonNullable<
   PromptModuleLoadCondition["policy_gateways"]
 >[number];
 export type PromptModuleWorkflowMode = NonNullable<
   PromptModuleLoadCondition["workflow_modes"]
 >[number];
-
-export type PromptModuleCompilerContext = {
-  workflow_mode?: PromptModuleWorkflowMode;
-  policy_gateway?: PromptModulePolicyGateway;
-  roles?: string[];
-  command?: string;
-  commands?: string[];
-  task_tags?: string[];
-  repo_type?: string;
-  repo_types?: string[];
-  recipe_ids?: string[];
-  available_commands?: string[];
-  validator_phases?: PromptModuleValidatorPhase[];
-};
 
 export type PromptModuleDiagnosticSeverity = "error" | "warning";
 
@@ -70,203 +63,6 @@ export type PromptModuleCompiledGraph = PromptModuleGraph & {
   bindings: PromptModuleBinding[];
   ok: boolean;
 };
-
-const PROMPT_MODULE_WORKFLOW_MODE_VALUES = ["direct", "branch_pr"] as const;
-const PROMPT_MODULE_POLICY_GATEWAY_VALUES = ["codex", "claude"] as const;
-const PROMPT_MODULE_VALIDATOR_PHASE_VALUES = ["resolve", "compile", "emit", "doctor"] as const;
-
-function hasAllowedValue<TValue extends string>(
-  value: string,
-  allowedValues: readonly TValue[],
-): value is TValue {
-  return (allowedValues as readonly string[]).includes(value);
-}
-
-function contextValueLabel(value: unknown): string {
-  if (typeof value === "string") return JSON.stringify(value);
-  if (value === undefined) return "undefined";
-  return Object.prototype.toString.call(value);
-}
-
-function hasControlCharacter(value: string): boolean {
-  for (const character of value) {
-    const code = character.codePointAt(0) ?? 0;
-    if (code <= 0x1f || code === 0x7f) return true;
-  }
-  return false;
-}
-
-function reportDiscardedContextValue(
-  diagnostics: PromptModuleDiagnostic[],
-  field: string,
-  value: unknown,
-  reason: string,
-): void {
-  diagnostics.push({
-    severity: "warning",
-    code: "compiler_context_value_discarded",
-    message: `Discarded compiler context value ${field}=${contextValueLabel(value)}: ${reason}.`,
-  });
-}
-
-function normalizeContextString<TValue extends string = string>(
-  value: unknown,
-  field: string,
-  diagnostics: PromptModuleDiagnostic[],
-  allowedValues?: readonly TValue[],
-): TValue | string | undefined {
-  if (value === undefined) return undefined;
-  if (typeof value !== "string") {
-    reportDiscardedContextValue(diagnostics, field, value, "expected string");
-    return undefined;
-  }
-  const trimmed = value.trim();
-  if (!trimmed) {
-    reportDiscardedContextValue(diagnostics, field, value, "empty after trimming");
-    return undefined;
-  }
-  if (hasControlCharacter(trimmed)) {
-    reportDiscardedContextValue(diagnostics, field, value, "contains control characters");
-    return undefined;
-  }
-  if (allowedValues && !hasAllowedValue(trimmed, allowedValues)) {
-    reportDiscardedContextValue(
-      diagnostics,
-      field,
-      value,
-      `expected one of ${allowedValues.join(", ")}`,
-    );
-    return undefined;
-  }
-  return trimmed;
-}
-
-function normalizeContextStringList<TValue extends string = string>(
-  value: unknown,
-  field: string,
-  diagnostics: PromptModuleDiagnostic[],
-  allowedValues?: readonly TValue[],
-): TValue[] | string[] | undefined {
-  if (value === undefined) return undefined;
-  if (!Array.isArray(value)) {
-    reportDiscardedContextValue(diagnostics, field, value, "expected string array");
-    return undefined;
-  }
-
-  const normalized: string[] = [];
-  for (const [index, item] of value.entries()) {
-    const normalizedItem = normalizeContextString(
-      item,
-      `${field}[${index}]`,
-      diagnostics,
-      allowedValues,
-    );
-    if (normalizedItem !== undefined) normalized.push(normalizedItem);
-  }
-  return uniqueStrings(normalized);
-}
-
-export function normalizePromptModuleCompilerContext(
-  context: PromptModuleCompilerContext = {},
-  diagnostics: PromptModuleDiagnostic[] = [],
-): PromptModuleCompilerContext {
-  const raw = context as Record<string, unknown>;
-  const normalized: PromptModuleCompilerContext = {};
-
-  const workflowMode = normalizeContextString(
-    raw.workflow_mode,
-    "workflow_mode",
-    diagnostics,
-    PROMPT_MODULE_WORKFLOW_MODE_VALUES,
-  );
-  if (workflowMode !== undefined) {
-    normalized.workflow_mode = workflowMode as PromptModuleWorkflowMode;
-  }
-
-  const policyGateway = normalizeContextString(
-    raw.policy_gateway,
-    "policy_gateway",
-    diagnostics,
-    PROMPT_MODULE_POLICY_GATEWAY_VALUES,
-  );
-  if (policyGateway !== undefined) {
-    normalized.policy_gateway = policyGateway as PromptModulePolicyGateway;
-  }
-
-  const command = normalizeContextString(raw.command, "command", diagnostics);
-  if (command !== undefined) normalized.command = command;
-
-  const repoType = normalizeContextString(raw.repo_type, "repo_type", diagnostics);
-  if (repoType !== undefined) normalized.repo_type = repoType;
-
-  const roles = normalizeContextStringList(raw.roles, "roles", diagnostics);
-  if (roles !== undefined) normalized.roles = roles;
-
-  const commands = normalizeContextStringList(raw.commands, "commands", diagnostics);
-  if (commands !== undefined) normalized.commands = commands;
-
-  const taskTags = normalizeContextStringList(raw.task_tags, "task_tags", diagnostics);
-  if (taskTags !== undefined) normalized.task_tags = taskTags;
-
-  const repoTypes = normalizeContextStringList(raw.repo_types, "repo_types", diagnostics);
-  if (repoTypes !== undefined) normalized.repo_types = repoTypes;
-
-  const recipeIds = normalizeContextStringList(raw.recipe_ids, "recipe_ids", diagnostics);
-  if (recipeIds !== undefined) normalized.recipe_ids = recipeIds;
-
-  const availableCommands = normalizeContextStringList(
-    raw.available_commands,
-    "available_commands",
-    diagnostics,
-  );
-  if (availableCommands !== undefined) normalized.available_commands = availableCommands;
-
-  const validatorPhases = normalizeContextStringList(
-    raw.validator_phases,
-    "validator_phases",
-    diagnostics,
-    PROMPT_MODULE_VALIDATOR_PHASE_VALUES,
-  );
-  if (validatorPhases !== undefined) {
-    normalized.validator_phases = validatorPhases as PromptModuleValidatorPhase[];
-  }
-
-  return normalized;
-}
-
-function contextCommands(context: PromptModuleCompilerContext): string[] {
-  return uniqueStrings([context.command ?? "", ...(context.commands ?? [])]);
-}
-
-function contextRepoTypes(context: PromptModuleCompilerContext): string[] {
-  return uniqueStrings([context.repo_type ?? "", ...(context.repo_types ?? [])]);
-}
-
-function intersects<T>(expected: readonly T[] | undefined, actual: readonly T[]): boolean {
-  if (!expected || expected.length === 0) return true;
-  return expected.some((value) => actual.includes(value));
-}
-
-function includesValue<T>(expected: readonly T[] | undefined, actual: T | undefined): boolean {
-  if (!expected || expected.length === 0) return true;
-  return actual === undefined ? false : expected.includes(actual);
-}
-
-export function matchesPromptModuleLoadCondition(
-  condition: PromptModuleLoadCondition | undefined,
-  context: PromptModuleCompilerContext,
-): boolean {
-  if (!condition) return true;
-  return (
-    includesValue(condition.workflow_modes, context.workflow_mode) &&
-    includesValue(condition.policy_gateways, context.policy_gateway) &&
-    intersects(condition.roles, context.roles ?? []) &&
-    intersects(condition.commands, contextCommands(context)) &&
-    intersects(condition.task_tags_any, context.task_tags ?? []) &&
-    intersects(condition.repo_types, contextRepoTypes(context)) &&
-    intersects(condition.recipe_ids, context.recipe_ids ?? [])
-  );
-}
 
 function moduleRecipeId(module: PromptModule): string | undefined {
   if (module.owner.kind === "recipe") return module.owner.recipe_id;


### PR DESCRIPTION
Task: `202605290438-WVKXG8`
Title: Prompt module compiler decomposition
Canonical task record: `.agentplane/tasks/202605290438-WVKXG8/README.md`

## Summary

Prompt module compiler decomposition

Extract focused helpers from packages/agentplane/src/runtime/prompt-modules/compiler.ts to reduce the runtime hotspot below the warning threshold without changing prompt module compilation behavior.

## Scope

- In scope: Extract focused helpers from packages/agentplane/src/runtime/prompt-modules/compiler.ts to reduce the runtime hotspot below the warning threshold without changing prompt module compilation behavior.
- Out of scope: unrelated refactors not required for "Prompt module compiler decomposition".

## Verification

- State: ok
- Note:

```text
Observed: prompt module compiler context normalization and load-condition matching moved into
compiler.context.ts; compiler.ts is below hotspot threshold. Checks: compiler.test, mutations.test,
registry.test, typecheck, arch:check, knip:check, lint:core, format:changed, hotspots:check passed.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-29T04:38:43.884Z
- Branch: task/202605290438-WVKXG8/prompt-module-compiler-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/runtime/prompt-modules/compiler.context.ts | 222 +++++++++++++++++++
 .../src/runtime/prompt-modules/compiler.ts         | 244 ++-------------------
 2 files changed, 238 insertions(+), 228 deletions(-)
```

</details>
