### PR TITLE
🚧 41676W task: SQLite task cache decomposition [202605290508-41676W]

### DIFF
--- a/.agentplane/tasks/202605290508-41676W/README.md
+++ b/.agentplane/tasks/202605290508-41676W/README.md
@@ -1,0 +1,151 @@
+---
+id: "202605290508-41676W"
+title: "SQLite task cache decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "hotspot"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-29T05:08:14.769Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-29T05:13:51.058Z"
+  updated_by: "CODER"
+  note: "SQLite task projection cache helpers extracted into local-task-sqlite-cache-key.ts; local-task-sqlite-cache.ts reduced from hotspot range to 236 lines. Also resolved a main-branch knip blocker in the Obsidian projection facade by making the exported file type a real facade import/re-export."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Extract local task SQLite cache key and fingerprint helpers while preserving SQLite projection cache behavior."
+events:
+  -
+    type: "status"
+    at: "2026-05-29T05:08:26.875Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Extract local task SQLite cache key and fingerprint helpers while preserving SQLite projection cache behavior."
+  -
+    type: "verify"
+    at: "2026-05-29T05:13:51.058Z"
+    author: "CODER"
+    state: "ok"
+    note: "SQLite task projection cache helpers extracted into local-task-sqlite-cache-key.ts; local-task-sqlite-cache.ts reduced from hotspot range to 236 lines. Also resolved a main-branch knip blocker in the Obsidian projection facade by making the exported file type a real facade import/re-export."
+doc_version: 3
+doc_updated_at: "2026-05-29T05:13:51.083Z"
+doc_updated_by: "CODER"
+description: "Extract focused helpers from packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.ts to reduce the runtime hotspot below the warning threshold without changing local task SQLite cache behavior."
+sections:
+  Summary: |-
+    SQLite task cache decomposition
+
+    Extract focused helpers from packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.ts to reduce the runtime hotspot below the warning threshold without changing local task SQLite cache behavior.
+  Scope: |-
+    - In scope: Extract focused helpers from packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.ts to reduce the runtime hotspot below the warning threshold without changing local task SQLite cache behavior.
+    - Out of scope: unrelated refactors not required for "SQLite task cache decomposition".
+  Plan: "Scope: reduce packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.ts below the 400-line hotspot warning by extracting cache-key, git status, and README fingerprint helpers into focused module(s). Preserve public SQLite cache API and task projection behavior. Acceptance: relevant task backend/cache tests pass or nearest task backend test surface is documented, typecheck/arch/knip/lint/format pass, bun run hotspots:check shows one fewer runtime hotspot."
+  Verify Steps: |-
+    PLANNER fallback scaffold for "SQLite task cache decomposition". Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the requested outcome for "SQLite task cache decomposition". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-29T05:13:51.058Z — VERIFY — ok
+
+    By: CODER
+
+    Note: SQLite task projection cache helpers extracted into local-task-sqlite-cache-key.ts; local-task-sqlite-cache.ts reduced from hotspot range to 236 lines. Also resolved a main-branch knip blocker in the Obsidian projection facade by making the exported file type a real facade import/re-export.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T05:08:26.875Z, excerpt_hash=sha256:9400625f400d4a49fa27f0d710fbcc3f4eb57fe028a0a8b0a73d55b5804eb007
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: .agentplane/tasks/202605290508-41676W/blueprint/resolved-snapshot.json
+    - old_digest: cbd385c67351e163fce75e9b36c237a091d2355a82578161a8eb8449b0a3d70f
+    - current_digest: cbd385c67351e163fce75e9b36c237a091d2355a82578161a8eb8449b0a3d70f
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605290508-41676W
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Commands passed: bun test packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.test.ts packages/agentplane/src/backends/task-backend.local.test.ts; bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run hotspots:check.
+      Impact: SQLite cache key JSON structure, porcelain path parsing API, SQLite projection read/write API, and Obsidian facade type API are preserved.
+      Resolution: Runtime hotspot warnings dropped from 10 to 9; local-task-sqlite-cache.ts is now below 400 lines.
+id_source: "generated"
+---
+## Summary
+
+SQLite task cache decomposition
+
+Extract focused helpers from packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.ts to reduce the runtime hotspot below the warning threshold without changing local task SQLite cache behavior.
+
+## Scope
+
+- In scope: Extract focused helpers from packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.ts to reduce the runtime hotspot below the warning threshold without changing local task SQLite cache behavior.
+- Out of scope: unrelated refactors not required for "SQLite task cache decomposition".
+
+## Plan
+
+Scope: reduce packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.ts below the 400-line hotspot warning by extracting cache-key, git status, and README fingerprint helpers into focused module(s). Preserve public SQLite cache API and task projection behavior. Acceptance: relevant task backend/cache tests pass or nearest task backend test surface is documented, typecheck/arch/knip/lint/format pass, bun run hotspots:check shows one fewer runtime hotspot.
+
+## Verify Steps
+
+PLANNER fallback scaffold for "SQLite task cache decomposition". Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the requested outcome for "SQLite task cache decomposition". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-29T05:13:51.058Z — VERIFY — ok
+
+By: CODER
+
+Note: SQLite task projection cache helpers extracted into local-task-sqlite-cache-key.ts; local-task-sqlite-cache.ts reduced from hotspot range to 236 lines. Also resolved a main-branch knip blocker in the Obsidian projection facade by making the exported file type a real facade import/re-export.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T05:08:26.875Z, excerpt_hash=sha256:9400625f400d4a49fa27f0d710fbcc3f4eb57fe028a0a8b0a73d55b5804eb007
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: .agentplane/tasks/202605290508-41676W/blueprint/resolved-snapshot.json
+- old_digest: cbd385c67351e163fce75e9b36c237a091d2355a82578161a8eb8449b0a3d70f
+- current_digest: cbd385c67351e163fce75e9b36c237a091d2355a82578161a8eb8449b0a3d70f
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605290508-41676W
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Commands passed: bun test packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.test.ts packages/agentplane/src/backends/task-backend.local.test.ts; bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run hotspots:check.
+  Impact: SQLite cache key JSON structure, porcelain path parsing API, SQLite projection read/write API, and Obsidian facade type API are preserved.
+  Resolution: Runtime hotspot warnings dropped from 10 to 9; local-task-sqlite-cache.ts is now below 400 lines.

--- a/.agentplane/tasks/202605290508-41676W/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605290508-41676W/blueprint/resolved-snapshot.json
@@ -1,0 +1,361 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605290508-41676W",
+    "title": "SQLite task cache decomposition",
+    "description": "Extract focused helpers from packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.ts to reduce the runtime hotspot below the warning threshold without changing local task SQLite cache behavior.",
+    "tags": [
+      "hotspot",
+      "refactor"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "none",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "analysis.light",
+    "version": 1,
+    "title": "Lightweight analysis",
+    "taskKinds": [
+      "analysis"
+    ],
+    "workflowModes": []
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "analysis.light",
+    "blueprintVersion": 1,
+    "title": "Lightweight analysis",
+    "taskId": "202605290508-41676W",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "none"
+    },
+    "whySelected": [
+      "task kind resolved to analysis",
+      "workflow mode: branch_pr",
+      "mutation scope: none"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "context_manifest",
+          "sources"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "weak_links",
+          "final_output"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "analysis.sources",
+        "kind": "sources",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Sources used for analysis."
+      },
+      {
+        "id": "analysis.assumptions",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Assumptions and constraints."
+      },
+      {
+        "id": "analysis.weak_links",
+        "kind": "weak_links",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Weak links or uncertainty."
+      },
+      {
+        "id": "analysis.final",
+        "kind": "final_output",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Final answer or report."
+      },
+      {
+        "id": "analysis.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      }
+    ],
+    "policyModules": [],
+    "allowedCommands": [],
+    "contextBudget": {
+      "maxPolicyModules": 0,
+      "maxPromptBlocks": 6,
+      "rationale": "Lightweight analysis should load sources and task context without policy modules."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "context_manifest",
+        "sources"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "weak_links",
+        "final_output"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "analysis.sources",
+      "kind": "sources",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Sources used for analysis."
+    },
+    {
+      "id": "analysis.assumptions",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Assumptions and constraints."
+    },
+    {
+      "id": "analysis.weak_links",
+      "kind": "weak_links",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Weak links or uncertainty."
+    },
+    {
+      "id": "analysis.final",
+      "kind": "final_output",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Final answer or report."
+    },
+    {
+      "id": "analysis.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    }
+  ],
+  "policyModules": [],
+  "allowedCommands": [],
+  "contextBudget": {
+    "maxPolicyModules": 0,
+    "maxPromptBlocks": 6,
+    "rationale": "Lightweight analysis should load sources and task context without policy modules."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to analysis",
+    "workflow mode: branch_pr",
+    "mutation scope: none"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "cbd385c67351e163fce75e9b36c237a091d2355a82578161a8eb8449b0a3d70f"
+  }
+}

--- a/.agentplane/tasks/202605290508-41676W/pr/diffstat.txt
+++ b/.agentplane/tasks/202605290508-41676W/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ .../task-backend/local-task-sqlite-cache-key.ts    | 212 ++++++++++++++++++++
+ .../task-backend/local-task-sqlite-cache.ts        | 222 +--------------------
+ packages/agentplane/src/commands/task/obsidian.ts  |   3 +-
+ 3 files changed, 225 insertions(+), 212 deletions(-)

--- a/.agentplane/tasks/202605290508-41676W/pr/github-body.md
+++ b/.agentplane/tasks/202605290508-41676W/pr/github-body.md
@@ -1,0 +1,43 @@
+Task: `202605290508-41676W`
+Title: SQLite task cache decomposition
+Canonical task record: `.agentplane/tasks/202605290508-41676W/README.md`
+
+## Summary
+
+SQLite task cache decomposition
+
+Extract focused helpers from packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.ts to reduce the runtime hotspot below the warning threshold without changing local task SQLite cache behavior.
+
+## Scope
+
+- In scope: Extract focused helpers from packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.ts to reduce the runtime hotspot below the warning threshold without changing local task SQLite cache behavior.
+- Out of scope: unrelated refactors not required for "SQLite task cache decomposition".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+SQLite task projection cache helpers extracted into local-task-sqlite-cache-key.ts;
+local-task-sqlite-cache.ts reduced from hotspot range to 236 lines. Also resolved a main-branch knip
+blocker in the Obsidian projection facade by making the exported file type a real facade
+import/re-export.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T05:08:26.986Z
+- Branch: task/202605290508-41676W/sqlite-task-cache-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../task-backend/local-task-sqlite-cache-key.ts    | 212 ++++++++++++++++++++
+ .../task-backend/local-task-sqlite-cache.ts        | 222 +--------------------
+ packages/agentplane/src/commands/task/obsidian.ts  |   3 +-
+ 3 files changed, 225 insertions(+), 212 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605290508-41676W/pr/github-title.txt
+++ b/.agentplane/tasks/202605290508-41676W/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 41676W task: SQLite task cache decomposition [202605290508-41676W]

--- a/.agentplane/tasks/202605290508-41676W/pr/meta.json
+++ b/.agentplane/tasks/202605290508-41676W/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605290508-41676W/sqlite-task-cache-decomposition",
+  "created_at": "2026-05-29T05:08:26.986Z",
+  "diffstat_sha256": "sha256:dd6e619bda6e470d15bb7413d64ff80d615cab19bbb73ed6c5e65f073c3add5e",
+  "last_verified_at": "2026-05-29T05:13:51.058Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202605290508-41676W",
+  "updated_at": "2026-05-29T05:08:26.986Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605290508-41676W/pr/review.md
+++ b/.agentplane/tasks/202605290508-41676W/pr/review.md
@@ -1,0 +1,39 @@
+# PR Review
+
+Created: 2026-05-29T05:08:26.986Z
+
+## Task
+
+- Task: `202605290508-41676W`
+- Title: SQLite task cache decomposition
+- Status: DOING
+- Branch: `task/202605290508-41676W/sqlite-task-cache-decomposition`
+- Canonical task record: `.agentplane/tasks/202605290508-41676W/README.md`
+
+## Verification
+
+- State: ok
+- Note: SQLite task projection cache helpers extracted into local-task-sqlite-cache-key.ts; local-task-sqlite-cache.ts reduced from hotspot range to 236 lines. Also resolved a main-branch knip blocker in the Obsidian projection facade by making the exported file type a real facade import/re-export.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T05:08:26.986Z
+- Branch: task/202605290508-41676W/sqlite-task-cache-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../task-backend/local-task-sqlite-cache-key.ts    | 212 ++++++++++++++++++++
+ .../task-backend/local-task-sqlite-cache.ts        | 222 +--------------------
+ packages/agentplane/src/commands/task/obsidian.ts  |   3 +-
+ 3 files changed, 225 insertions(+), 212 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/backends/task-backend/local-task-sqlite-cache-key.ts
+++ b/packages/agentplane/src/backends/task-backend/local-task-sqlite-cache-key.ts
@@ -1,0 +1,212 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+export type TaskProjectionCacheKey =
+  | {
+      mode: "git";
+      gitRoot: string;
+      tasksPath: string;
+      head: string;
+      status: string[];
+      dirtyFiles: { path: string; sha256: string | null; size: number | null }[];
+    }
+  | {
+      mode: "fingerprint";
+      entries: { path: string; mtimeMs: number; size: number }[];
+    };
+
+function toPosix(value: string): string {
+  return value.split(path.sep).join("/");
+}
+
+function sha256Buffer(value: Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function maybeRepoRootFromTasksDir(tasksDir: string): string | null {
+  const resolved = path.resolve(tasksDir);
+  if (path.basename(resolved) !== "tasks") return null;
+  const agentplaneDir = path.dirname(resolved);
+  if (path.basename(agentplaneDir) !== ".agentplane") return null;
+  const gitRoot = path.dirname(agentplaneDir);
+  if (!existsSync(path.join(gitRoot, ".git"))) return null;
+  return gitRoot;
+}
+
+function gitOutput(gitRoot: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: gitRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+}
+
+function gitStatusPorcelainRecords(gitRoot: string, args: string[]): string[] {
+  const out = execFileSync("git", args, {
+    cwd: gitRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (!out) return [];
+  const parts = out.split("\0").filter((part) => part.length > 0);
+  const records: string[] = [];
+  for (let index = 0; index < parts.length; index += 1) {
+    const record = parts[index] ?? "";
+    records.push(record);
+    if (/[RC]/u.test(record.slice(0, 2))) {
+      index += 1;
+    }
+  }
+  return records;
+}
+
+function walkFilesSync(targetPath: string): string[] {
+  const details = statSync(targetPath);
+  if (details.isFile()) return [targetPath];
+  if (!details.isDirectory()) return [];
+  const files: string[] = [];
+  const entries = readdirSync(targetPath, { withFileTypes: true }).toSorted((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+  for (const entry of entries) {
+    const childPath = path.join(targetPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFilesSync(childPath));
+      continue;
+    }
+    if (entry.isFile()) files.push(childPath);
+  }
+  return files;
+}
+
+export function parseTaskProjectionPorcelainPath(line: string): string | null {
+  const statusCode = line.slice(0, 2);
+  const raw = line.length > 3 ? line.slice(3).trim() : "";
+  if (!raw) return null;
+  const renameSeparator = " -> ";
+  const pathToken =
+    /[RC]/u.test(statusCode) && raw.includes(renameSeparator)
+      ? (raw.split(renameSeparator).at(-1) ?? "")
+      : raw;
+  return unquotePorcelainPath(pathToken);
+}
+
+function unquotePorcelainPath(raw: string): string {
+  if (!(raw.startsWith('"') && raw.endsWith('"'))) return raw;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed === "string") return parsed;
+  } catch {
+    // Fall through to a conservative dequote below.
+  }
+  return raw
+    .slice(1, -1)
+    .replaceAll(String.raw`\"`, '"')
+    .replaceAll(String.raw`\\`, "\\");
+}
+
+function dirtyFileEntries(
+  gitRoot: string,
+  status: string[],
+): { path: string; sha256: string | null; size: number | null }[] {
+  const seen = new Set<string>();
+  const files: { path: string; sha256: string | null; size: number | null }[] = [];
+  for (const line of status) {
+    const relPath = parseTaskProjectionPorcelainPath(line);
+    if (!relPath || seen.has(relPath)) continue;
+    seen.add(relPath);
+    const absolutePath = path.join(gitRoot, relPath);
+    if (!existsSync(absolutePath)) {
+      files.push({ path: toPosix(relPath), sha256: null, size: null });
+      continue;
+    }
+    let targetFiles: string[] = [];
+    try {
+      targetFiles = walkFilesSync(absolutePath);
+    } catch {
+      files.push({ path: toPosix(relPath), sha256: null, size: null });
+      continue;
+    }
+    for (const targetFile of targetFiles) {
+      const relativeFile = toPosix(path.relative(gitRoot, targetFile));
+      if (seen.has(relativeFile)) continue;
+      seen.add(relativeFile);
+      const content = readFileSync(targetFile);
+      files.push({
+        path: relativeFile,
+        sha256: sha256Buffer(content),
+        size: content.byteLength,
+      });
+    }
+  }
+  return files.toSorted((a, b) => a.path.localeCompare(b.path));
+}
+
+export function buildGitCacheKey(tasksDir: string): TaskProjectionCacheKey | null {
+  const gitRoot = maybeRepoRootFromTasksDir(tasksDir);
+  if (!gitRoot) return null;
+  const relativeTasksPath = toPosix(path.relative(gitRoot, path.resolve(tasksDir)));
+  try {
+    const head = gitOutput(gitRoot, ["rev-parse", "HEAD"]);
+    const status = gitStatusPorcelainRecords(gitRoot, [
+      "status",
+      "--porcelain=v1",
+      "-z",
+      "--untracked-files=all",
+      "--",
+      relativeTasksPath,
+    ]);
+    return {
+      mode: "git",
+      gitRoot,
+      tasksPath: relativeTasksPath,
+      head,
+      status,
+      dirtyFiles: dirtyFileEntries(gitRoot, status),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function buildFingerprintCacheKey(
+  entries: readonly { path: string; mtimeMs: number; size: number }[],
+): TaskProjectionCacheKey {
+  return {
+    mode: "fingerprint",
+    entries: entries.map((entry) => ({
+      path: entry.path,
+      mtimeMs: entry.mtimeMs,
+      size: entry.size,
+    })),
+  };
+}
+
+export function buildReadmeFingerprintEntriesFromTasksDir(
+  tasksDir: string,
+): { path: string; mtimeMs: number; size: number }[] | null {
+  try {
+    const entries = readdirSync(tasksDir, { withFileTypes: true });
+    const readmes: { path: string; mtimeMs: number; size: number }[] = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const readmePath = path.join(tasksDir, entry.name, "README.md");
+      const stats = statSync(readmePath);
+      if (!stats.isFile()) return null;
+      readmes.push({
+        path: readmePath,
+        mtimeMs: stats.mtimeMs,
+        size: stats.size,
+      });
+    }
+    return readmes.toSorted((a, b) => a.path.localeCompare(b.path));
+  } catch {
+    return null;
+  }
+}
+
+export function stableCacheKeyJson(key: TaskProjectionCacheKey): string {
+  return JSON.stringify(key);
+}

--- a/packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.ts
+++ b/packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.ts
@@ -1,30 +1,24 @@
-import { createHash } from "node:crypto";
-import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
 
 import { resolveAgentplaneCacheSqlitePath } from "../../shared/cache-paths.js";
 import { ensureRuntimeSqliteGitignore } from "../../runtime/shared/runtime-gitignore.js";
 import { openSqliteDatabase, type SqliteDatabase } from "../../shared/sqlite-driver.js";
 import type { TaskSummary } from "./shared.js";
+import {
+  buildFingerprintCacheKey,
+  buildGitCacheKey,
+  buildReadmeFingerprintEntriesFromTasksDir,
+  maybeRepoRootFromTasksDir,
+  stableCacheKeyJson,
+  type TaskProjectionCacheKey,
+} from "./local-task-sqlite-cache-key.js";
+
+export { parseTaskProjectionPorcelainPath } from "./local-task-sqlite-cache-key.js";
 
 const TASK_SQLITE_SCHEMA_VERSION = 1;
 const TASK_SQLITE_CACHE_OWNER = "local-task-projection";
 const TASK_SQLITE_CACHE_FILENAME = "task-projection.sqlite";
-
-type TaskProjectionCacheKey =
-  | {
-      mode: "git";
-      gitRoot: string;
-      tasksPath: string;
-      head: string;
-      status: string[];
-      dirtyFiles: { path: string; sha256: string | null; size: number | null }[];
-    }
-  | {
-      mode: "fingerprint";
-      entries: { path: string; mtimeMs: number; size: number }[];
-    };
 
 type TaskProjectionMetadataRow = {
   owner?: unknown;
@@ -37,206 +31,12 @@ type TaskProjectionRow = {
   payload_json?: unknown;
 };
 
-function toPosix(value: string): string {
-  return value.split(path.sep).join("/");
-}
-
-function sha256Buffer(value: Buffer): string {
-  return createHash("sha256").update(value).digest("hex");
-}
-
-function maybeRepoRootFromTasksDir(tasksDir: string): string | null {
-  const resolved = path.resolve(tasksDir);
-  if (path.basename(resolved) !== "tasks") return null;
-  const agentplaneDir = path.dirname(resolved);
-  if (path.basename(agentplaneDir) !== ".agentplane") return null;
-  const gitRoot = path.dirname(agentplaneDir);
-  if (!existsSync(path.join(gitRoot, ".git"))) return null;
-  return gitRoot;
-}
-
 export function resolveTaskProjectionSqlitePath(tasksDir: string): string {
   const gitRoot = maybeRepoRootFromTasksDir(tasksDir);
   if (gitRoot) {
     return resolveAgentplaneCacheSqlitePath(gitRoot);
   }
   return path.join(tasksDir, ".cache", TASK_SQLITE_CACHE_FILENAME);
-}
-
-function gitOutput(gitRoot: string, args: string[]): string {
-  return execFileSync("git", args, {
-    cwd: gitRoot,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-  }).trim();
-}
-
-function gitStatusPorcelainRecords(gitRoot: string, args: string[]): string[] {
-  const out = execFileSync("git", args, {
-    cwd: gitRoot,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-  });
-  if (!out) return [];
-  const parts = out.split("\0").filter((part) => part.length > 0);
-  const records: string[] = [];
-  for (let index = 0; index < parts.length; index += 1) {
-    const record = parts[index] ?? "";
-    records.push(record);
-    if (/[RC]/u.test(record.slice(0, 2))) {
-      index += 1;
-    }
-  }
-  return records;
-}
-
-function walkFilesSync(targetPath: string): string[] {
-  const details = statSync(targetPath);
-  if (details.isFile()) return [targetPath];
-  if (!details.isDirectory()) return [];
-  const files: string[] = [];
-  const entries = readdirSync(targetPath, { withFileTypes: true }).toSorted((a, b) =>
-    a.name.localeCompare(b.name),
-  );
-  for (const entry of entries) {
-    const childPath = path.join(targetPath, entry.name);
-    if (entry.isDirectory()) {
-      files.push(...walkFilesSync(childPath));
-      continue;
-    }
-    if (entry.isFile()) files.push(childPath);
-  }
-  return files;
-}
-
-export function parseTaskProjectionPorcelainPath(line: string): string | null {
-  const statusCode = line.slice(0, 2);
-  const raw = line.length > 3 ? line.slice(3).trim() : "";
-  if (!raw) return null;
-  const renameSeparator = " -> ";
-  const pathToken =
-    /[RC]/u.test(statusCode) && raw.includes(renameSeparator)
-      ? (raw.split(renameSeparator).at(-1) ?? "")
-      : raw;
-  return unquotePorcelainPath(pathToken);
-}
-
-function unquotePorcelainPath(raw: string): string {
-  if (!(raw.startsWith('"') && raw.endsWith('"'))) return raw;
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (typeof parsed === "string") return parsed;
-  } catch {
-    // Fall through to a conservative dequote below.
-  }
-  return raw
-    .slice(1, -1)
-    .replaceAll(String.raw`\"`, '"')
-    .replaceAll(String.raw`\\`, "\\");
-}
-
-function dirtyFileEntries(
-  gitRoot: string,
-  status: string[],
-): { path: string; sha256: string | null; size: number | null }[] {
-  const seen = new Set<string>();
-  const files: { path: string; sha256: string | null; size: number | null }[] = [];
-  for (const line of status) {
-    const relPath = parseTaskProjectionPorcelainPath(line);
-    if (!relPath || seen.has(relPath)) continue;
-    seen.add(relPath);
-    const absolutePath = path.join(gitRoot, relPath);
-    if (!existsSync(absolutePath)) {
-      files.push({ path: toPosix(relPath), sha256: null, size: null });
-      continue;
-    }
-    let targetFiles: string[] = [];
-    try {
-      targetFiles = walkFilesSync(absolutePath);
-    } catch {
-      files.push({ path: toPosix(relPath), sha256: null, size: null });
-      continue;
-    }
-    for (const targetFile of targetFiles) {
-      const relativeFile = toPosix(path.relative(gitRoot, targetFile));
-      if (seen.has(relativeFile)) continue;
-      seen.add(relativeFile);
-      const content = readFileSync(targetFile);
-      files.push({
-        path: relativeFile,
-        sha256: sha256Buffer(content),
-        size: content.byteLength,
-      });
-    }
-  }
-  return files.toSorted((a, b) => a.path.localeCompare(b.path));
-}
-
-function buildGitCacheKey(tasksDir: string): TaskProjectionCacheKey | null {
-  const gitRoot = maybeRepoRootFromTasksDir(tasksDir);
-  if (!gitRoot) return null;
-  const relativeTasksPath = toPosix(path.relative(gitRoot, path.resolve(tasksDir)));
-  try {
-    const head = gitOutput(gitRoot, ["rev-parse", "HEAD"]);
-    const status = gitStatusPorcelainRecords(gitRoot, [
-      "status",
-      "--porcelain=v1",
-      "-z",
-      "--untracked-files=all",
-      "--",
-      relativeTasksPath,
-    ]);
-    return {
-      mode: "git",
-      gitRoot,
-      tasksPath: relativeTasksPath,
-      head,
-      status,
-      dirtyFiles: dirtyFileEntries(gitRoot, status),
-    };
-  } catch {
-    return null;
-  }
-}
-
-function buildFingerprintCacheKey(
-  entries: readonly { path: string; mtimeMs: number; size: number }[],
-): TaskProjectionCacheKey {
-  return {
-    mode: "fingerprint",
-    entries: entries.map((entry) => ({
-      path: entry.path,
-      mtimeMs: entry.mtimeMs,
-      size: entry.size,
-    })),
-  };
-}
-
-function buildReadmeFingerprintEntriesFromTasksDir(
-  tasksDir: string,
-): { path: string; mtimeMs: number; size: number }[] | null {
-  try {
-    const entries = readdirSync(tasksDir, { withFileTypes: true });
-    const readmes: { path: string; mtimeMs: number; size: number }[] = [];
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
-      const readmePath = path.join(tasksDir, entry.name, "README.md");
-      const stats = statSync(readmePath);
-      if (!stats.isFile()) return null;
-      readmes.push({
-        path: readmePath,
-        mtimeMs: stats.mtimeMs,
-        size: stats.size,
-      });
-    }
-    return readmes.toSorted((a, b) => a.path.localeCompare(b.path));
-  } catch {
-    return null;
-  }
-}
-
-function stableCacheKeyJson(key: TaskProjectionCacheKey): string {
-  return JSON.stringify(key);
 }
 
 function ensureTaskProjectionTables(db: SqliteDatabase): void {

--- a/packages/agentplane/src/commands/task/obsidian.ts
+++ b/packages/agentplane/src/commands/task/obsidian.ts
@@ -11,11 +11,14 @@ import { toTaskSummaries, type TaskSummary } from "../../backends/task-backend.j
 import {
   GENERATED_OBSIDIAN_NOTE,
   renderObsidianTaskProjection,
+  type ObsidianProjectionFile,
   type ObsidianProjectionResult,
 } from "./obsidian.render.js";
 
 export { renderObsidianTaskProjection } from "./obsidian.render.js";
-export type { ObsidianProjectionFile, ObsidianProjectionResult } from "./obsidian.render.js";
+// The explicit type re-export keeps Knip aware that the render type is part of this facade API.
+// eslint-disable-next-line unicorn/prefer-export-from
+export type { ObsidianProjectionFile, ObsidianProjectionResult };
 
 export type ObsidianCleanResult = {
   deleted: string[];


### PR DESCRIPTION
Task: `202605290508-41676W`
Title: SQLite task cache decomposition
Canonical task record: `.agentplane/tasks/202605290508-41676W/README.md`

## Summary

SQLite task cache decomposition

Extract focused helpers from packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.ts to reduce the runtime hotspot below the warning threshold without changing local task SQLite cache behavior.

## Scope

- In scope: Extract focused helpers from packages/agentplane/src/backends/task-backend/local-task-sqlite-cache.ts to reduce the runtime hotspot below the warning threshold without changing local task SQLite cache behavior.
- Out of scope: unrelated refactors not required for "SQLite task cache decomposition".

## Verification

- State: ok
- Note:

```text
SQLite task projection cache helpers extracted into local-task-sqlite-cache-key.ts;
local-task-sqlite-cache.ts reduced from hotspot range to 236 lines. Also resolved a main-branch knip
blocker in the Obsidian projection facade by making the exported file type a real facade
import/re-export.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-29T05:08:26.986Z
- Branch: task/202605290508-41676W/sqlite-task-cache-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../task-backend/local-task-sqlite-cache-key.ts    | 212 ++++++++++++++++++++
 .../task-backend/local-task-sqlite-cache.ts        | 222 +--------------------
 packages/agentplane/src/commands/task/obsidian.ts  |   3 +-
 3 files changed, 225 insertions(+), 212 deletions(-)
```

</details>
