### PR TITLE
🚧 WSRP8V task: PR flow status render decomposition [202605290543-WSRP8V]

### DIFF
--- a/.agentplane/tasks/202605290543-WSRP8V/README.md
+++ b/.agentplane/tasks/202605290543-WSRP8V/README.md
@@ -1,0 +1,151 @@
+---
+id: "202605290543-WSRP8V"
+title: "PR flow status render decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "hotspot"
+  - "refactor"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-29T05:43:21.540Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-29T05:45:57.703Z"
+  updated_by: "CODER"
+  note: "PR flow status text rendering extracted into flow-status.render.ts; flow-status.ts reduced to 367 lines while preserving report resolution and output rows."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Extract PR flow status text rendering while preserving report resolution and output."
+events:
+  -
+    type: "status"
+    at: "2026-05-29T05:43:31.419Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Extract PR flow status text rendering while preserving report resolution and output."
+  -
+    type: "verify"
+    at: "2026-05-29T05:45:57.703Z"
+    author: "CODER"
+    state: "ok"
+    note: "PR flow status text rendering extracted into flow-status.render.ts; flow-status.ts reduced to 367 lines while preserving report resolution and output rows."
+doc_version: 3
+doc_updated_at: "2026-05-29T05:45:57.727Z"
+doc_updated_by: "CODER"
+description: "Extract text rendering helpers from packages/agentplane/src/commands/pr/flow-status.ts to reduce the runtime hotspot below the warning threshold without changing PR flow status resolution or output."
+sections:
+  Summary: |-
+    PR flow status render decomposition
+
+    Extract text rendering helpers from packages/agentplane/src/commands/pr/flow-status.ts to reduce the runtime hotspot below the warning threshold without changing PR flow status resolution or output.
+  Scope: |-
+    - In scope: Extract text rendering helpers from packages/agentplane/src/commands/pr/flow-status.ts to reduce the runtime hotspot below the warning threshold without changing PR flow status resolution or output.
+    - Out of scope: unrelated refactors not required for "PR flow status render decomposition".
+  Plan: "Scope: reduce packages/agentplane/src/commands/pr/flow-status.ts below the 400-line hotspot warning by extracting text rendering helpers into focused module(s). Preserve resolvePrFlowStatus behavior, JSON report shape, and text output labels/values. Acceptance: PR flow status tests pass, typecheck/arch/knip/lint/format pass, bun run hotspots:check shows one fewer runtime hotspot."
+  Verify Steps: |-
+    PLANNER fallback scaffold for "PR flow status render decomposition". Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the requested outcome for "PR flow status render decomposition". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-29T05:45:57.703Z — VERIFY — ok
+
+    By: CODER
+
+    Note: PR flow status text rendering extracted into flow-status.render.ts; flow-status.ts reduced to 367 lines while preserving report resolution and output rows.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T05:43:31.419Z, excerpt_hash=sha256:b07b78319475670b45d53649db996a8cb5d6c3f68a5f4cd2e37d71bacbd38f8b
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: .agentplane/tasks/202605290543-WSRP8V/blueprint/resolved-snapshot.json
+    - old_digest: 49c4bb2d80229e6eb79eb8228cf89ded9daba997ed23f788d44e16dc88861539
+    - current_digest: 49c4bb2d80229e6eb79eb8228cf89ded9daba997ed23f788d44e16dc88861539
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605290543-WSRP8V
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Commands passed: bun test packages/agentplane/src/cli/run-cli.core.pr-flow.status.test.ts packages/agentplane/src/commands/integrate-queue-recovery.test.ts; bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run hotspots:check.
+      Impact: JSON report shape, PR/close-tail resolution, hosted checks, review threads, queue, handoff, and text labels remain covered by PR flow status tests.
+      Resolution: Runtime hotspot warnings dropped from 7 to 6; flow-status.ts is now below 400 lines.
+id_source: "generated"
+---
+## Summary
+
+PR flow status render decomposition
+
+Extract text rendering helpers from packages/agentplane/src/commands/pr/flow-status.ts to reduce the runtime hotspot below the warning threshold without changing PR flow status resolution or output.
+
+## Scope
+
+- In scope: Extract text rendering helpers from packages/agentplane/src/commands/pr/flow-status.ts to reduce the runtime hotspot below the warning threshold without changing PR flow status resolution or output.
+- Out of scope: unrelated refactors not required for "PR flow status render decomposition".
+
+## Plan
+
+Scope: reduce packages/agentplane/src/commands/pr/flow-status.ts below the 400-line hotspot warning by extracting text rendering helpers into focused module(s). Preserve resolvePrFlowStatus behavior, JSON report shape, and text output labels/values. Acceptance: PR flow status tests pass, typecheck/arch/knip/lint/format pass, bun run hotspots:check shows one fewer runtime hotspot.
+
+## Verify Steps
+
+PLANNER fallback scaffold for "PR flow status render decomposition". Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the requested outcome for "PR flow status render decomposition". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-29T05:45:57.703Z — VERIFY — ok
+
+By: CODER
+
+Note: PR flow status text rendering extracted into flow-status.render.ts; flow-status.ts reduced to 367 lines while preserving report resolution and output rows.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T05:43:31.419Z, excerpt_hash=sha256:b07b78319475670b45d53649db996a8cb5d6c3f68a5f4cd2e37d71bacbd38f8b
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: .agentplane/tasks/202605290543-WSRP8V/blueprint/resolved-snapshot.json
+- old_digest: 49c4bb2d80229e6eb79eb8228cf89ded9daba997ed23f788d44e16dc88861539
+- current_digest: 49c4bb2d80229e6eb79eb8228cf89ded9daba997ed23f788d44e16dc88861539
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605290543-WSRP8V
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Commands passed: bun test packages/agentplane/src/cli/run-cli.core.pr-flow.status.test.ts packages/agentplane/src/commands/integrate-queue-recovery.test.ts; bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run hotspots:check.
+  Impact: JSON report shape, PR/close-tail resolution, hosted checks, review threads, queue, handoff, and text labels remain covered by PR flow status tests.
+  Resolution: Runtime hotspot warnings dropped from 7 to 6; flow-status.ts is now below 400 lines.

--- a/.agentplane/tasks/202605290543-WSRP8V/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605290543-WSRP8V/blueprint/resolved-snapshot.json
@@ -1,0 +1,361 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605290543-WSRP8V",
+    "title": "PR flow status render decomposition",
+    "description": "Extract text rendering helpers from packages/agentplane/src/commands/pr/flow-status.ts to reduce the runtime hotspot below the warning threshold without changing PR flow status resolution or output.",
+    "tags": [
+      "hotspot",
+      "refactor"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "none",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "analysis.light",
+    "version": 1,
+    "title": "Lightweight analysis",
+    "taskKinds": [
+      "analysis"
+    ],
+    "workflowModes": []
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "analysis.light",
+    "blueprintVersion": 1,
+    "title": "Lightweight analysis",
+    "taskId": "202605290543-WSRP8V",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "none"
+    },
+    "whySelected": [
+      "task kind resolved to analysis",
+      "workflow mode: branch_pr",
+      "mutation scope: none"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "context_manifest",
+          "sources"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "weak_links",
+          "final_output"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "analysis.sources",
+        "kind": "sources",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Sources used for analysis."
+      },
+      {
+        "id": "analysis.assumptions",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Assumptions and constraints."
+      },
+      {
+        "id": "analysis.weak_links",
+        "kind": "weak_links",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Weak links or uncertainty."
+      },
+      {
+        "id": "analysis.final",
+        "kind": "final_output",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Final answer or report."
+      },
+      {
+        "id": "analysis.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      }
+    ],
+    "policyModules": [],
+    "allowedCommands": [],
+    "contextBudget": {
+      "maxPolicyModules": 0,
+      "maxPromptBlocks": 6,
+      "rationale": "Lightweight analysis should load sources and task context without policy modules."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "context_manifest",
+        "sources"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "weak_links",
+        "final_output"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "analysis.sources",
+      "kind": "sources",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Sources used for analysis."
+    },
+    {
+      "id": "analysis.assumptions",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Assumptions and constraints."
+    },
+    {
+      "id": "analysis.weak_links",
+      "kind": "weak_links",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Weak links or uncertainty."
+    },
+    {
+      "id": "analysis.final",
+      "kind": "final_output",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Final answer or report."
+    },
+    {
+      "id": "analysis.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    }
+  ],
+  "policyModules": [],
+  "allowedCommands": [],
+  "contextBudget": {
+    "maxPolicyModules": 0,
+    "maxPromptBlocks": 6,
+    "rationale": "Lightweight analysis should load sources and task context without policy modules."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to analysis",
+    "workflow mode: branch_pr",
+    "mutation scope: none"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "49c4bb2d80229e6eb79eb8228cf89ded9daba997ed23f788d44e16dc88861539"
+  }
+}

--- a/.agentplane/tasks/202605290543-WSRP8V/pr/diffstat.txt
+++ b/.agentplane/tasks/202605290543-WSRP8V/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../src/commands/pr/flow-status.render.ts          | 66 ++++++++++++++++++++++
+ packages/agentplane/src/commands/pr/flow-status.ts | 59 +------------------
+ 2 files changed, 68 insertions(+), 57 deletions(-)

--- a/.agentplane/tasks/202605290543-WSRP8V/pr/github-body.md
+++ b/.agentplane/tasks/202605290543-WSRP8V/pr/github-body.md
@@ -1,0 +1,40 @@
+Task: `202605290543-WSRP8V`
+Title: PR flow status render decomposition
+Canonical task record: `.agentplane/tasks/202605290543-WSRP8V/README.md`
+
+## Summary
+
+PR flow status render decomposition
+
+Extract text rendering helpers from packages/agentplane/src/commands/pr/flow-status.ts to reduce the runtime hotspot below the warning threshold without changing PR flow status resolution or output.
+
+## Scope
+
+- In scope: Extract text rendering helpers from packages/agentplane/src/commands/pr/flow-status.ts to reduce the runtime hotspot below the warning threshold without changing PR flow status resolution or output.
+- Out of scope: unrelated refactors not required for "PR flow status render decomposition".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+PR flow status text rendering extracted into flow-status.render.ts; flow-status.ts reduced to 367
+lines while preserving report resolution and output rows.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T05:43:31.527Z
+- Branch: task/202605290543-WSRP8V/pr-flow-status-render-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/commands/pr/flow-status.render.ts          | 66 ++++++++++++++++++++++
+ packages/agentplane/src/commands/pr/flow-status.ts | 59 +------------------
+ 2 files changed, 68 insertions(+), 57 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605290543-WSRP8V/pr/github-title.txt
+++ b/.agentplane/tasks/202605290543-WSRP8V/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 WSRP8V task: PR flow status render decomposition [202605290543-WSRP8V]

--- a/.agentplane/tasks/202605290543-WSRP8V/pr/meta.json
+++ b/.agentplane/tasks/202605290543-WSRP8V/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605290543-WSRP8V/pr-flow-status-render-decomposition",
+  "created_at": "2026-05-29T05:43:31.527Z",
+  "diffstat_sha256": "sha256:f696658dc08973d8b201b886d202527630c0bebf6103581314ef859f62a5cb77",
+  "last_verified_at": "2026-05-29T05:45:57.703Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202605290543-WSRP8V",
+  "updated_at": "2026-05-29T05:43:31.527Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605290543-WSRP8V/pr/review.md
+++ b/.agentplane/tasks/202605290543-WSRP8V/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-05-29T05:43:31.527Z
+
+## Task
+
+- Task: `202605290543-WSRP8V`
+- Title: PR flow status render decomposition
+- Status: DOING
+- Branch: `task/202605290543-WSRP8V/pr-flow-status-render-decomposition`
+- Canonical task record: `.agentplane/tasks/202605290543-WSRP8V/README.md`
+
+## Verification
+
+- State: ok
+- Note: PR flow status text rendering extracted into flow-status.render.ts; flow-status.ts reduced to 367 lines while preserving report resolution and output rows.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T05:43:31.527Z
+- Branch: task/202605290543-WSRP8V/pr-flow-status-render-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/commands/pr/flow-status.render.ts          | 66 ++++++++++++++++++++++
+ packages/agentplane/src/commands/pr/flow-status.ts | 59 +------------------
+ 2 files changed, 68 insertions(+), 57 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/pr/flow-status.render.ts
+++ b/packages/agentplane/src/commands/pr/flow-status.render.ts
@@ -1,0 +1,66 @@
+import type { HostedChecksSummary } from "./hosted-checks.js";
+import type { PrFlowStatusReport } from "./flow-status.js";
+
+type ReportRow = { label: string; value: string };
+type RemotePrStatus = PrFlowStatusReport["pr"];
+type CloseTailStatus = PrFlowStatusReport["closeTail"];
+type ReviewThreadsStatus = PrFlowStatusReport["reviewThreads"];
+type QueueStatus = PrFlowStatusReport["queue"];
+type HandoffStatus = PrFlowStatusReport["handoff"];
+
+function shortSha(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed ? trimmed.slice(0, 12) : null;
+}
+
+function renderHostedChecksLine(status: HostedChecksSummary): string {
+  if (!status.checked) return `unchecked: ${status.reason}`;
+  return `total=${status.total} passing=${status.passing} pending=${status.pending} failing=${status.failing}`;
+}
+
+function renderReviewThreadsLine(status: ReviewThreadsStatus): string {
+  if (!status.checked) return `unchecked: ${status.reason}`;
+  return `unresolved=${status.unresolved}`;
+}
+
+function renderQueueLine(status: QueueStatus): string {
+  if (!status.present) return "not_queued";
+  return `${status.status}${status.reason ? `: ${status.reason}` : ""}`;
+}
+
+function renderHandoffLine(status: HandoffStatus): string {
+  if (!status.present) return "none";
+  return `${status.routeStatus ?? "recorded"}: ${status.reason}`;
+}
+
+function renderPrLine(pr: RemotePrStatus): string {
+  if (pr.state === "not_found") return `github: not_found (source=${pr.source})`;
+  const number = pr.prNumber ? `#${pr.prNumber}` : "no-number";
+  const url = pr.prUrl ? ` ${pr.prUrl}` : "";
+  return `github: ${pr.state} ${number}${url} (source=${pr.source})`;
+}
+
+function renderCloseTailLine(closeTail: CloseTailStatus): string {
+  if (closeTail.state === "not_applicable") return `not_applicable: ${closeTail.reason}`;
+  if (closeTail.state === "recorded_on_base") return `recorded_on_base: ${closeTail.base}`;
+  const number = closeTail.prNumber ? ` #${closeTail.prNumber}` : "";
+  const url = closeTail.prUrl ? ` ${closeTail.prUrl}` : "";
+  return `${closeTail.state}: ${closeTail.branch}${number}${url}`;
+}
+
+export function renderPrFlowStatusRows(report: PrFlowStatusReport): ReportRow[] {
+  return [
+    { label: "task", value: `${report.task.id} ${report.task.status}` },
+    { label: "verification", value: report.task.verification ?? "pending" },
+    { label: "branch", value: report.branch.name ?? "missing" },
+    { label: "branch_head", value: shortSha(report.branch.headSha) ?? "unknown" },
+    { label: "meta_head", value: shortSha(report.branch.metaHeadSha) ?? "unknown" },
+    { label: "remote_pr", value: renderPrLine(report.pr) },
+    { label: "hosted_checks", value: renderHostedChecksLine(report.hostedChecks) },
+    { label: "review_threads", value: renderReviewThreadsLine(report.reviewThreads) },
+    { label: "queue", value: renderQueueLine(report.queue) },
+    { label: "handoff", value: renderHandoffLine(report.handoff) },
+    { label: "close_tail", value: renderCloseTailLine(report.closeTail) },
+    { label: "next", value: report.nextAction },
+  ];
+}

--- a/packages/agentplane/src/commands/pr/flow-status.ts
+++ b/packages/agentplane/src/commands/pr/flow-status.ts
@@ -17,6 +17,7 @@ import { readTaskHandoffLatest, resolveTaskHandoffPaths } from "../shared/task-h
 import { readIntegrationQueue, type IntegrationQueueEntry } from "../pr/integrate/queue-state.js";
 import { checkGithubUnresolvedReviewThreads } from "./internal/github-review-threads.js";
 import { resolveHostedChecksStatus, type HostedChecksSummary } from "./hosted-checks.js";
+import { renderPrFlowStatusRows } from "./flow-status.render.js";
 
 import { resolvePrPaths } from "./internal/pr-paths.js";
 import { tryLookupExistingGithubPrByBranch } from "./internal/sync-github.js";
@@ -88,11 +89,6 @@ type HandoffStatus =
       routeStatus: string | null;
       nextActions: string[];
     };
-
-function shortSha(value: string | null | undefined): string | null {
-  const trimmed = value?.trim() ?? "";
-  return trimmed ? trimmed.slice(0, 12) : null;
-}
 
 async function readPrMetaIfPresent(metaPath: string, taskId: string): Promise<PrMeta | null> {
   try {
@@ -345,41 +341,6 @@ export async function resolvePrFlowStatus(opts: {
   return report;
 }
 
-function renderHostedChecksLine(status: HostedChecksSummary): string {
-  if (!status.checked) return `unchecked: ${status.reason}`;
-  return `total=${status.total} passing=${status.passing} pending=${status.pending} failing=${status.failing}`;
-}
-
-function renderReviewThreadsLine(status: ReviewThreadsStatus): string {
-  if (!status.checked) return `unchecked: ${status.reason}`;
-  return `unresolved=${status.unresolved}`;
-}
-
-function renderQueueLine(status: QueueStatus): string {
-  if (!status.present) return "not_queued";
-  return `${status.status}${status.reason ? `: ${status.reason}` : ""}`;
-}
-
-function renderHandoffLine(status: HandoffStatus): string {
-  if (!status.present) return "none";
-  return `${status.routeStatus ?? "recorded"}: ${status.reason}`;
-}
-
-function renderPrLine(pr: RemotePrStatus): string {
-  if (pr.state === "not_found") return `github: not_found (source=${pr.source})`;
-  const number = pr.prNumber ? `#${pr.prNumber}` : "no-number";
-  const url = pr.prUrl ? ` ${pr.prUrl}` : "";
-  return `github: ${pr.state} ${number}${url} (source=${pr.source})`;
-}
-
-function renderCloseTailLine(closeTail: CloseTailStatus): string {
-  if (closeTail.state === "not_applicable") return `not_applicable: ${closeTail.reason}`;
-  if (closeTail.state === "recorded_on_base") return `recorded_on_base: ${closeTail.base}`;
-  const number = closeTail.prNumber ? ` #${closeTail.prNumber}` : "";
-  const url = closeTail.prUrl ? ` ${closeTail.prUrl}` : "";
-  return `${closeTail.state}: ${closeTail.branch}${number}${url}`;
-}
-
 export async function cmdPrFlowStatus(opts: {
   ctx?: CommandContext;
   cwd: string;
@@ -397,23 +358,7 @@ export async function cmdPrFlowStatus(opts: {
       output.json(report);
       return 0;
     }
-    output.report(
-      [
-        { label: "task", value: `${report.task.id} ${report.task.status}` },
-        { label: "verification", value: report.task.verification ?? "pending" },
-        { label: "branch", value: report.branch.name ?? "missing" },
-        { label: "branch_head", value: shortSha(report.branch.headSha) ?? "unknown" },
-        { label: "meta_head", value: shortSha(report.branch.metaHeadSha) ?? "unknown" },
-        { label: "remote_pr", value: renderPrLine(report.pr) },
-        { label: "hosted_checks", value: renderHostedChecksLine(report.hostedChecks) },
-        { label: "review_threads", value: renderReviewThreadsLine(report.reviewThreads) },
-        { label: "queue", value: renderQueueLine(report.queue) },
-        { label: "handoff", value: renderHandoffLine(report.handoff) },
-        { label: "close_tail", value: renderCloseTailLine(report.closeTail) },
-        { label: "next", value: report.nextAction },
-      ],
-      { header: "PR flow status" },
-    );
+    output.report(renderPrFlowStatusRows(report), { header: "PR flow status" });
     return 0;
   } catch (err) {
     if (err instanceof CliError) throw err;


### PR DESCRIPTION
Task: `202605290543-WSRP8V`
Title: PR flow status render decomposition
Canonical task record: `.agentplane/tasks/202605290543-WSRP8V/README.md`

## Summary

PR flow status render decomposition

Extract text rendering helpers from packages/agentplane/src/commands/pr/flow-status.ts to reduce the runtime hotspot below the warning threshold without changing PR flow status resolution or output.

## Scope

- In scope: Extract text rendering helpers from packages/agentplane/src/commands/pr/flow-status.ts to reduce the runtime hotspot below the warning threshold without changing PR flow status resolution or output.
- Out of scope: unrelated refactors not required for "PR flow status render decomposition".

## Verification

- State: ok
- Note:

```text
PR flow status text rendering extracted into flow-status.render.ts; flow-status.ts reduced to 367
lines while preserving report resolution and output rows.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-29T05:43:31.527Z
- Branch: task/202605290543-WSRP8V/pr-flow-status-render-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/commands/pr/flow-status.render.ts          | 66 ++++++++++++++++++++++
 packages/agentplane/src/commands/pr/flow-status.ts | 59 +------------------
 2 files changed, 68 insertions(+), 57 deletions(-)
```

</details>
