### PR TITLE
🚧 R6288F task: Context reindex projection decomposition [202605290610-R6288F]

### DIFF
--- a/.agentplane/tasks/202605290610-R6288F/README.md
+++ b/.agentplane/tasks/202605290610-R6288F/README.md
@@ -1,0 +1,149 @@
+---
+id: "202605290610-R6288F"
+title: "Context reindex projection decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "context"
+  - "hotspot"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-29T06:10:14.517Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-29T06:14:58.566Z"
+  updated_by: "CODER"
+  note: "Context reindex projection row helpers extracted into packages/agentplane/src/context/reindex-projection.ts; cmdContextReindex and readContextProjection semantics are preserved. Checks passed: bun test packages/agentplane/src/commands/context/release-readiness.test.ts (21 pass); bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run hotspots:check (runtime hotspots 4 -> 3)."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: extracting context reindex projection row helpers while preserving CLI reindex behavior, SQLite projection payloads, and read fallback semantics."
+events:
+  -
+    type: "status"
+    at: "2026-05-29T06:10:23.186Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: extracting context reindex projection row helpers while preserving CLI reindex behavior, SQLite projection payloads, and read fallback semantics."
+  -
+    type: "verify"
+    at: "2026-05-29T06:14:58.566Z"
+    author: "CODER"
+    state: "ok"
+    note: "Context reindex projection row helpers extracted into packages/agentplane/src/context/reindex-projection.ts; cmdContextReindex and readContextProjection semantics are preserved. Checks passed: bun test packages/agentplane/src/commands/context/release-readiness.test.ts (21 pass); bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run hotspots:check (runtime hotspots 4 -> 3)."
+doc_version: 3
+doc_updated_at: "2026-05-29T06:14:58.591Z"
+doc_updated_by: "CODER"
+description: "Refactor packages/agentplane/src/context/reindex.ts below the 400-line hotspot warning by extracting projection row helpers into focused module(s). Preserve cmdContextReindex behavior, projection metadata, path selection, markdown/jsonl/text row generation, SQLite projection writes, and readContextProjection fallback semantics. Acceptance: context release-readiness tests pass, typecheck/arch/knip/lint/format pass, and bun run hotspots:check shows one fewer runtime hotspot."
+sections:
+  Summary: |-
+    Context reindex projection decomposition
+
+    Refactor packages/agentplane/src/context/reindex.ts below the 400-line hotspot warning by extracting projection row helpers into focused module(s). Preserve cmdContextReindex behavior, projection metadata, path selection, markdown/jsonl/text row generation, SQLite projection writes, and readContextProjection fallback semantics. Acceptance: context release-readiness tests pass, typecheck/arch/knip/lint/format pass, and bun run hotspots:check shows one fewer runtime hotspot.
+  Scope: |-
+    - In scope: Refactor packages/agentplane/src/context/reindex.ts below the 400-line hotspot warning by extracting projection row helpers into focused module(s). Preserve cmdContextReindex behavior, projection metadata, path selection, markdown/jsonl/text row generation, SQLite projection writes, and readContextProjection fallback semantics. Acceptance: context release-readiness tests pass, typecheck/arch/knip/lint/format pass, and bun run hotspots:check shows one fewer runtime hotspot.
+    - Out of scope: unrelated refactors not required for "Context reindex projection decomposition".
+  Plan: "1. Extract projection helper types/functions from packages/agentplane/src/context/reindex.ts into a focused projection module. 2. Keep cmdContextReindex and readContextProjection behavior stable; only update imports and exported helper boundaries needed by tests. 3. Run context release-readiness coverage plus typecheck, arch, knip, lint, format, and hotspots checks. 4. Open the branch_pr PR, wait for hosted checks, merge, record evaluator/finish evidence, and cleanup."
+  Verify Steps: |-
+    1. `bun test packages/agentplane/src/commands/context/release-readiness.test.ts`
+    2. `bun run typecheck`
+    3. `bun run arch:check`
+    4. `bun run knip:check`
+    5. `bun run lint:core`
+    6. `bun run format:changed`
+    7. `bun run hotspots:check`
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-29T06:14:58.566Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Context reindex projection row helpers extracted into packages/agentplane/src/context/reindex-projection.ts; cmdContextReindex and readContextProjection semantics are preserved. Checks passed: bun test packages/agentplane/src/commands/context/release-readiness.test.ts (21 pass); bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run hotspots:check (runtime hotspots 4 -> 3).
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T06:10:23.186Z, excerpt_hash=sha256:0f88d27226edb785e64b1c61b9f3cd8c026e132d100276c77c25a3c1964cf958
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: .agentplane/tasks/202605290610-R6288F/blueprint/resolved-snapshot.json
+    - old_digest: bbb48196e13d88d509f1c15f8dfeaaaf5daa084d6258cb356d0dd7ea28a47c0d
+    - current_digest: bbb48196e13d88d509f1c15f8dfeaaaf5daa084d6258cb356d0dd7ea28a47c0d
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605290610-R6288F
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Context reindex projection decomposition
+
+Refactor packages/agentplane/src/context/reindex.ts below the 400-line hotspot warning by extracting projection row helpers into focused module(s). Preserve cmdContextReindex behavior, projection metadata, path selection, markdown/jsonl/text row generation, SQLite projection writes, and readContextProjection fallback semantics. Acceptance: context release-readiness tests pass, typecheck/arch/knip/lint/format pass, and bun run hotspots:check shows one fewer runtime hotspot.
+
+## Scope
+
+- In scope: Refactor packages/agentplane/src/context/reindex.ts below the 400-line hotspot warning by extracting projection row helpers into focused module(s). Preserve cmdContextReindex behavior, projection metadata, path selection, markdown/jsonl/text row generation, SQLite projection writes, and readContextProjection fallback semantics. Acceptance: context release-readiness tests pass, typecheck/arch/knip/lint/format pass, and bun run hotspots:check shows one fewer runtime hotspot.
+- Out of scope: unrelated refactors not required for "Context reindex projection decomposition".
+
+## Plan
+
+1. Extract projection helper types/functions from packages/agentplane/src/context/reindex.ts into a focused projection module. 2. Keep cmdContextReindex and readContextProjection behavior stable; only update imports and exported helper boundaries needed by tests. 3. Run context release-readiness coverage plus typecheck, arch, knip, lint, format, and hotspots checks. 4. Open the branch_pr PR, wait for hosted checks, merge, record evaluator/finish evidence, and cleanup.
+
+## Verify Steps
+
+1. `bun test packages/agentplane/src/commands/context/release-readiness.test.ts`
+2. `bun run typecheck`
+3. `bun run arch:check`
+4. `bun run knip:check`
+5. `bun run lint:core`
+6. `bun run format:changed`
+7. `bun run hotspots:check`
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-29T06:14:58.566Z — VERIFY — ok
+
+By: CODER
+
+Note: Context reindex projection row helpers extracted into packages/agentplane/src/context/reindex-projection.ts; cmdContextReindex and readContextProjection semantics are preserved. Checks passed: bun test packages/agentplane/src/commands/context/release-readiness.test.ts (21 pass); bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run hotspots:check (runtime hotspots 4 -> 3).
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T06:10:23.186Z, excerpt_hash=sha256:0f88d27226edb785e64b1c61b9f3cd8c026e132d100276c77c25a3c1964cf958
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: .agentplane/tasks/202605290610-R6288F/blueprint/resolved-snapshot.json
+- old_digest: bbb48196e13d88d509f1c15f8dfeaaaf5daa084d6258cb356d0dd7ea28a47c0d
+- current_digest: bbb48196e13d88d509f1c15f8dfeaaaf5daa084d6258cb356d0dd7ea28a47c0d
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605290610-R6288F
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605290610-R6288F/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605290610-R6288F/blueprint/resolved-snapshot.json
@@ -1,0 +1,598 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605290610-R6288F",
+    "title": "Context reindex projection decomposition",
+    "description": "Refactor packages/agentplane/src/context/reindex.ts below the 400-line hotspot warning by extracting projection row helpers into focused module(s). Preserve cmdContextReindex behavior, projection metadata, path selection, markdown/jsonl/text row generation, SQLite projection writes, and readContextProjection fallback semantics. Acceptance: context release-readiness tests pass, typecheck/arch/knip/lint/format pass, and bun run hotspots:check shows one fewer runtime hotspot.",
+    "tags": [
+      "code",
+      "context",
+      "hotspot"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "quality.regression",
+    "version": 1,
+    "title": "Quality regression",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "quality.regression",
+    "blueprintVersion": 1,
+    "title": "Quality regression",
+    "taskId": "202605290610-R6288F",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to quality.regression",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest",
+          "artifact"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "check_result"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "weak_links"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "regression.original_failure",
+        "kind": "artifact",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Original failure log or check output."
+      },
+      {
+        "id": "regression.reproduction",
+        "kind": "check_result",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Local reproduction or explicit non-reproduction result."
+      },
+      {
+        "id": "regression.focused_check",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Focused regression check."
+      },
+      {
+        "id": "regression.matrix_or_scope",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Affected test/check matrix or bounded scope."
+      },
+      {
+        "id": "regression.full_gate",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Full relevant gate or hosted check evidence."
+      },
+      {
+        "id": "regression.flake_classification",
+        "kind": "weak_links",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Flake classification or residual risk."
+      },
+      {
+        "id": "regression.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "regression.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "affected matrix or full relevant gate",
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "failure reproduction command",
+      "focused regression check",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest",
+        "artifact"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "check_result"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "weak_links"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "regression.original_failure",
+      "kind": "artifact",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Original failure log or check output."
+    },
+    {
+      "id": "regression.reproduction",
+      "kind": "check_result",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Local reproduction or explicit non-reproduction result."
+    },
+    {
+      "id": "regression.focused_check",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Focused regression check."
+    },
+    {
+      "id": "regression.matrix_or_scope",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Affected test/check matrix or bounded scope."
+    },
+    {
+      "id": "regression.full_gate",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Full relevant gate or hosted check evidence."
+    },
+    {
+      "id": "regression.flake_classification",
+      "kind": "weak_links",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Flake classification or residual risk."
+    },
+    {
+      "id": "regression.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "regression.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "affected matrix or full relevant gate",
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "failure reproduction command",
+    "focused regression check",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to quality.regression",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "bbb48196e13d88d509f1c15f8dfeaaaf5daa084d6258cb356d0dd7ea28a47c0d"
+  }
+}

--- a/.agentplane/tasks/202605290610-R6288F/pr/diffstat.txt
+++ b/.agentplane/tasks/202605290610-R6288F/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../agentplane/src/context/reindex-projection.ts   | 242 ++++++++++++++++++++
+ packages/agentplane/src/context/reindex.ts         | 251 +--------------------
+ 2 files changed, 248 insertions(+), 245 deletions(-)

--- a/.agentplane/tasks/202605290610-R6288F/pr/github-body.md
+++ b/.agentplane/tasks/202605290610-R6288F/pr/github-body.md
@@ -1,0 +1,44 @@
+Task: `202605290610-R6288F`
+Title: Context reindex projection decomposition
+Canonical task record: `.agentplane/tasks/202605290610-R6288F/README.md`
+
+## Summary
+
+Context reindex projection decomposition
+
+Refactor packages/agentplane/src/context/reindex.ts below the 400-line hotspot warning by extracting projection row helpers into focused module(s). Preserve cmdContextReindex behavior, projection metadata, path selection, markdown/jsonl/text row generation, SQLite projection writes, and readContextProjection fallback semantics. Acceptance: context release-readiness tests pass, typecheck/arch/knip/lint/format pass, and bun run hotspots:check shows one fewer runtime hotspot.
+
+## Scope
+
+- In scope: Refactor packages/agentplane/src/context/reindex.ts below the 400-line hotspot warning by extracting projection row helpers into focused module(s). Preserve cmdContextReindex behavior, projection metadata, path selection, markdown/jsonl/text row generation, SQLite projection writes, and readContextProjection fallback semantics. Acceptance: context release-readiness tests pass, typecheck/arch/knip/lint/format pass, and bun run hotspots:check shows one fewer runtime hotspot.
+- Out of scope: unrelated refactors not required for "Context reindex projection decomposition".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Context reindex projection row helpers extracted into
+packages/agentplane/src/context/reindex-projection.ts; cmdContextReindex and readContextProjection
+semantics are preserved. Checks passed: bun test
+packages/agentplane/src/commands/context/release-readiness.test.ts (21 pass); bun run typecheck; bun
+run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run
+hotspots:check (runtime hotspots 4 -> 3).
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T06:10:23.294Z
+- Branch: task/202605290610-R6288F/context-reindex-projection-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../agentplane/src/context/reindex-projection.ts   | 242 ++++++++++++++++++++
+ packages/agentplane/src/context/reindex.ts         | 251 +--------------------
+ 2 files changed, 248 insertions(+), 245 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605290610-R6288F/pr/github-title.txt
+++ b/.agentplane/tasks/202605290610-R6288F/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 R6288F task: Context reindex projection decomposition [202605290610-R6288F]

--- a/.agentplane/tasks/202605290610-R6288F/pr/meta.json
+++ b/.agentplane/tasks/202605290610-R6288F/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605290610-R6288F/context-reindex-projection-decomposition",
+  "created_at": "2026-05-29T06:10:23.294Z",
+  "diffstat_sha256": "sha256:43862aa8e774fc78adfebf4929410db89dc26e3af497d9390361a724a0542db2",
+  "last_verified_at": "2026-05-29T06:14:58.566Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202605290610-R6288F",
+  "updated_at": "2026-05-29T06:10:23.294Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605290610-R6288F/pr/review.md
+++ b/.agentplane/tasks/202605290610-R6288F/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-05-29T06:10:23.294Z
+
+## Task
+
+- Task: `202605290610-R6288F`
+- Title: Context reindex projection decomposition
+- Status: DOING
+- Branch: `task/202605290610-R6288F/context-reindex-projection-decomposition`
+- Canonical task record: `.agentplane/tasks/202605290610-R6288F/README.md`
+
+## Verification
+
+- State: ok
+- Note: Context reindex projection row helpers extracted into packages/agentplane/src/context/reindex-projection.ts; cmdContextReindex and readContextProjection semantics are preserved. Checks passed: bun test packages/agentplane/src/commands/context/release-readiness.test.ts (21 pass); bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run hotspots:check (runtime hotspots 4 -> 3).
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T06:10:23.294Z
+- Branch: task/202605290610-R6288F/context-reindex-projection-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../agentplane/src/context/reindex-projection.ts   | 242 ++++++++++++++++++++
+ packages/agentplane/src/context/reindex.ts         | 251 +--------------------
+ 2 files changed, 248 insertions(+), 245 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/context/reindex-projection.ts
+++ b/packages/agentplane/src/context/reindex-projection.ts
@@ -1,0 +1,242 @@
+/* eslint-disable @typescript-eslint/no-base-to-string */
+import { createHash } from "node:crypto";
+
+import { parseJsonlLines, toPosix } from "./context-utils.js";
+
+export type ProjectionSourceRow = {
+  path: string;
+  sha256: string;
+  content_type: string;
+  kind: string;
+  body: string;
+  size_bytes: number;
+  source_refs?: string[];
+};
+
+function pickProjectionPayload(input: string): string {
+  const text = input.toLowerCase();
+  const lines = text.split(/\r?\n/);
+  if (lines.length <= 40) return text;
+  return lines.slice(0, 36).join("\n");
+}
+
+function slug(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/gu, "-")
+    .replaceAll(/^-+|-+$/gu, "");
+}
+
+function lineWindowRef(filePath: string, start: number, end: number): string {
+  return `${toPosix(filePath)}#lines=${start}-${end}`;
+}
+
+export function isSupportedProjectionPath(filePath: string): boolean {
+  if (filePath.includes("/.git/")) return false;
+  const lower = filePath.toLowerCase();
+  return (
+    lower.endsWith(".md") ||
+    lower.endsWith(".mdx") ||
+    lower.endsWith(".json") ||
+    lower.endsWith(".jsonl") ||
+    lower.endsWith(".yaml") ||
+    lower.endsWith(".yml") ||
+    lower.endsWith(".txt") ||
+    lower.endsWith(".rst") ||
+    lower.endsWith(".ts") ||
+    lower.endsWith(".tsx") ||
+    lower.endsWith(".js") ||
+    lower.endsWith(".jsx") ||
+    lower.endsWith(".py")
+  );
+}
+
+function deriveContentType(filePath: string): string {
+  const lower = filePath.toLowerCase();
+  if (lower.endsWith(".md") || lower.endsWith(".mdx")) return "text/markdown";
+  if (lower.endsWith(".json") || lower.endsWith(".jsonl")) return "application/json";
+  if (lower.endsWith(".yaml") || lower.endsWith(".yml")) return "text/yaml";
+  if (lower.endsWith(".txt") || lower.endsWith(".rst")) return "text/plain";
+  if (/\.(ts|tsx|js|jsx|py|rs|go|sh|java|cpp|c|h|cs|rb|php|swift|kt|scala)$/.test(lower))
+    return "text/plain";
+  return "application/octet-stream";
+}
+
+function toProjectionRowKind(filePath: string): string {
+  if (filePath.endsWith(".jsonl")) return "jsonl";
+  if (filePath.endsWith(".json")) return "json";
+  if (filePath.endsWith(".md") || filePath.endsWith(".mdx")) return "markdown";
+  return "text";
+}
+
+function selectorForJsonlRow(filePath: string): string {
+  const normalized = toPosix(filePath);
+  if (normalized.includes("/facts/")) return "fact";
+  if (normalized.endsWith("/entities.jsonl")) return "entity";
+  if (normalized.endsWith("/edges.jsonl")) return "edge";
+  if (normalized.includes("/capabilities/")) return "capability";
+  if (normalized.includes("/tasks/")) return "task";
+  return "row";
+}
+
+function sourceRefsForJsonlRow(row: unknown, fallback: string): string[] {
+  if (!row || typeof row !== "object") return [fallback];
+  const record = row as Record<string, unknown>;
+  const refs: string[] = [];
+  if (typeof record.source_ref === "string" && record.source_ref.trim()) {
+    refs.push(record.source_ref);
+  }
+  if (typeof record.source === "string" && record.source.trim()) {
+    refs.push(record.source);
+  }
+  if (Array.isArray(record.source_refs)) {
+    refs.push(...record.source_refs.filter((value): value is string => typeof value === "string"));
+  }
+  return refs.length > 0 ? [...new Set(refs)] : [fallback];
+}
+
+function projectMarkdownRows(filePath: string, content: string): ProjectionSourceRow[] {
+  const rel = toPosix(filePath);
+  const lines = content.split(/\r?\n/);
+  const fileSha256 = `sha256:${createHash("sha256").update(content).digest("hex")}`;
+  const sectionSlugCounts = new Map<string, number>();
+  const rows: ProjectionSourceRow[] = [
+    {
+      path: rel,
+      sha256: fileSha256,
+      content_type: deriveContentType(filePath),
+      kind: "markdown",
+      source_refs: [rel],
+      body: pickProjectionPayload(content),
+      size_bytes: content.length,
+    },
+  ];
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    if (!/^#{1,6}\s+/.test(line)) continue;
+    const heading = line.replace(/^#{1,6}\s+/, "").trim();
+    const headingSlug = slug(heading);
+    if (!headingSlug) continue;
+    const slugCount = (sectionSlugCounts.get(headingSlug) ?? 0) + 1;
+    sectionSlugCounts.set(headingSlug, slugCount);
+    const sectionSlug = slugCount === 1 ? headingSlug : `${headingSlug}-${slugCount}`;
+    let end = lines.length;
+    for (let next = index + 1; next < lines.length; next += 1) {
+      if (/^#{1,6}\s+/.test(lines[next] ?? "")) {
+        end = next;
+        break;
+      }
+    }
+    const startLine = index + 1;
+    const endLine = Math.max(startLine, end);
+    const body = lines.slice(index, end).join("\n");
+    rows.push({
+      path: `${rel}#section=${sectionSlug}`,
+      sha256: fileSha256,
+      content_type: deriveContentType(filePath),
+      kind: "markdown-section",
+      source_refs: [`${rel}#section=${sectionSlug}`, lineWindowRef(rel, startLine, endLine)],
+      body: pickProjectionPayload(body),
+      size_bytes: body.length,
+    });
+  }
+  return rows;
+}
+
+function projectPlainTextRows(filePath: string, content: string): ProjectionSourceRow[] {
+  const rel = toPosix(filePath);
+  const lines = content.split(/\r?\n/);
+  const rows: ProjectionSourceRow[] = [
+    {
+      path: rel,
+      sha256: `sha256:${createHash("sha256").update(content).digest("hex")}`,
+      content_type: deriveContentType(filePath),
+      kind: toProjectionRowKind(filePath),
+      source_refs: [rel],
+      body: pickProjectionPayload(content),
+      size_bytes: content.length,
+    },
+  ];
+  const windowSize = 80;
+  for (let start = 0; start < lines.length; start += windowSize) {
+    const body = lines.slice(start, start + windowSize).join("\n");
+    if (!body.trim()) continue;
+    const startLine = start + 1;
+    const endLine = Math.min(lines.length, start + windowSize);
+    rows.push({
+      path: lineWindowRef(rel, startLine, endLine),
+      sha256: `sha256:${createHash("sha256").update(body).digest("hex")}`,
+      content_type: deriveContentType(filePath),
+      kind: "text-window",
+      source_refs: [lineWindowRef(rel, startLine, endLine)],
+      body: pickProjectionPayload(body),
+      size_bytes: body.length,
+    });
+  }
+  return rows;
+}
+
+export function projectRowsForFile(filePath: string, content: string): ProjectionSourceRow[] {
+  const rel = toPosix(filePath);
+  if (filePath.endsWith(".jsonl")) {
+    const rows = parseJsonlLines(content);
+    const selector = selectorForJsonlRow(filePath);
+    if (rows.length === 0) {
+      return [
+        {
+          path: rel,
+          sha256: `sha256:${createHash("sha256").update(content).digest("hex")}`,
+          content_type: deriveContentType(filePath),
+          kind: "jsonl-file",
+          source_refs: [toPosix(filePath)],
+          body: pickProjectionPayload(content),
+          size_bytes: content.length,
+        },
+      ];
+    }
+    return rows.map((row, index) => {
+      const serialized = JSON.stringify(row);
+      const id = String((row as { id?: unknown }).id ?? index + 1);
+      return {
+        path: `${rel}#${selector}=${id}`,
+        sha256: `sha256:${createHash("sha256").update(serialized).digest("hex")}`,
+        content_type: deriveContentType(filePath),
+        kind: "jsonl-row",
+        source_refs: sourceRefsForJsonlRow(row, `${rel}#${selector}=${id}`),
+        body: serialized,
+        size_bytes: serialized.length,
+      };
+    });
+  }
+  if (filePath.endsWith(".json")) {
+    return [
+      {
+        path: rel,
+        sha256: `sha256:${createHash("sha256").update(content).digest("hex")}`,
+        content_type: deriveContentType(filePath),
+        kind: toProjectionRowKind(filePath),
+        source_refs: [toPosix(filePath)],
+        body: pickProjectionPayload(content),
+        size_bytes: content.length,
+      },
+    ];
+  }
+  if (filePath.endsWith(".md") || filePath.endsWith(".mdx")) {
+    return projectMarkdownRows(filePath, content);
+  }
+  if (deriveContentType(filePath) === "text/plain") {
+    return projectPlainTextRows(filePath, content);
+  }
+  return [
+    {
+      path: rel,
+      sha256: `sha256:${createHash("sha256").update(content).digest("hex")}`,
+      content_type: deriveContentType(filePath),
+      kind: toProjectionRowKind(filePath),
+      source_refs: [toPosix(filePath)],
+      body: pickProjectionPayload(content),
+      size_bytes: content.length,
+    },
+  ];
+}

--- a/packages/agentplane/src/context/reindex.ts
+++ b/packages/agentplane/src/context/reindex.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-base-to-string, @typescript-eslint/no-empty-function, unicorn/no-array-sort */
+/* eslint-disable @typescript-eslint/no-empty-function, unicorn/no-array-sort */
 import { createHash } from "node:crypto";
 import { access, stat, mkdir, rm, readFile } from "node:fs/promises";
 import path from "node:path";
@@ -6,26 +6,15 @@ import path from "node:path";
 import { infoMessage, warnMessage } from "../cli/output.js";
 import { ensureRuntimeSqliteGitignore } from "../runtime/shared/runtime-gitignore.js";
 import { resolveAgentplaneCacheSqlitePath } from "../shared/cache-paths.js";
+import { collectMatchingFiles, fileExists, readText, toPosix } from "./context-utils.js";
 import {
-  collectMatchingFiles,
-  parseJsonlLines,
-  fileExists,
-  readText,
-  toPosix,
-} from "./context-utils.js";
+  isSupportedProjectionPath,
+  projectRowsForFile,
+  type ProjectionSourceRow,
+} from "./reindex-projection.js";
 import { readSqliteProjection, writeSqliteProjection } from "./sqlite.js";
 
 const PROJECTION_VERSION = 1;
-
-type ProjectionSourceRow = {
-  path: string;
-  sha256: string;
-  content_type: string;
-  kind: string;
-  body: string;
-  size_bytes: number;
-  source_refs?: string[];
-};
 
 type ProjectionIndex = {
   metadata: {
@@ -50,234 +39,6 @@ type ProjectionIndex = {
 
 function defaultWorkspaceHash(root: string): string {
   return `sha256:${createHash("sha256").update(root).digest("hex").slice(0, 16)}`;
-}
-
-function pickProjectionPayload(input: string): string {
-  const text = input.toLowerCase();
-  const lines = text.split(/\r?\n/);
-  if (lines.length <= 40) return text;
-  return lines.slice(0, 36).join("\n");
-}
-
-function slug(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replaceAll(/[^a-z0-9]+/gu, "-")
-    .replaceAll(/^-+|-+$/gu, "");
-}
-
-function lineWindowRef(filePath: string, start: number, end: number): string {
-  return `${toPosix(filePath)}#lines=${start}-${end}`;
-}
-
-function isSupportedProjectionPath(filePath: string): boolean {
-  if (filePath.includes("/.git/")) return false;
-  const lower = filePath.toLowerCase();
-  return (
-    lower.endsWith(".md") ||
-    lower.endsWith(".mdx") ||
-    lower.endsWith(".json") ||
-    lower.endsWith(".jsonl") ||
-    lower.endsWith(".yaml") ||
-    lower.endsWith(".yml") ||
-    lower.endsWith(".txt") ||
-    lower.endsWith(".rst") ||
-    lower.endsWith(".ts") ||
-    lower.endsWith(".tsx") ||
-    lower.endsWith(".js") ||
-    lower.endsWith(".jsx") ||
-    lower.endsWith(".py")
-  );
-}
-
-function deriveContentType(filePath: string): string {
-  const lower = filePath.toLowerCase();
-  if (lower.endsWith(".md") || lower.endsWith(".mdx")) return "text/markdown";
-  if (lower.endsWith(".json") || lower.endsWith(".jsonl")) return "application/json";
-  if (lower.endsWith(".yaml") || lower.endsWith(".yml")) return "text/yaml";
-  if (lower.endsWith(".txt") || lower.endsWith(".rst")) return "text/plain";
-  if (/\.(ts|tsx|js|jsx|py|rs|go|sh|java|cpp|c|h|cs|rb|php|swift|kt|scala)$/.test(lower))
-    return "text/plain";
-  return "application/octet-stream";
-}
-
-function toProjectionRowKind(filePath: string): string {
-  if (filePath.endsWith(".jsonl")) return "jsonl";
-  if (filePath.endsWith(".json")) return "json";
-  if (filePath.endsWith(".md") || filePath.endsWith(".mdx")) return "markdown";
-  return "text";
-}
-
-function selectorForJsonlRow(filePath: string): string {
-  const normalized = toPosix(filePath);
-  if (normalized.includes("/facts/")) return "fact";
-  if (normalized.endsWith("/entities.jsonl")) return "entity";
-  if (normalized.endsWith("/edges.jsonl")) return "edge";
-  if (normalized.includes("/capabilities/")) return "capability";
-  if (normalized.includes("/tasks/")) return "task";
-  return "row";
-}
-
-function sourceRefsForJsonlRow(row: unknown, fallback: string): string[] {
-  if (!row || typeof row !== "object") return [fallback];
-  const record = row as Record<string, unknown>;
-  const refs: string[] = [];
-  if (typeof record.source_ref === "string" && record.source_ref.trim()) {
-    refs.push(record.source_ref);
-  }
-  if (typeof record.source === "string" && record.source.trim()) {
-    refs.push(record.source);
-  }
-  if (Array.isArray(record.source_refs)) {
-    refs.push(...record.source_refs.filter((value): value is string => typeof value === "string"));
-  }
-  return refs.length > 0 ? [...new Set(refs)] : [fallback];
-}
-
-function projectMarkdownRows(filePath: string, content: string): ProjectionSourceRow[] {
-  const rel = toPosix(filePath);
-  const lines = content.split(/\r?\n/);
-  const fileSha256 = `sha256:${createHash("sha256").update(content).digest("hex")}`;
-  const sectionSlugCounts = new Map<string, number>();
-  const rows: ProjectionSourceRow[] = [
-    {
-      path: rel,
-      sha256: fileSha256,
-      content_type: deriveContentType(filePath),
-      kind: "markdown",
-      source_refs: [rel],
-      body: pickProjectionPayload(content),
-      size_bytes: content.length,
-    },
-  ];
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index] ?? "";
-    if (!/^#{1,6}\s+/.test(line)) continue;
-    const heading = line.replace(/^#{1,6}\s+/, "").trim();
-    const headingSlug = slug(heading);
-    if (!headingSlug) continue;
-    const slugCount = (sectionSlugCounts.get(headingSlug) ?? 0) + 1;
-    sectionSlugCounts.set(headingSlug, slugCount);
-    const sectionSlug = slugCount === 1 ? headingSlug : `${headingSlug}-${slugCount}`;
-    let end = lines.length;
-    for (let next = index + 1; next < lines.length; next += 1) {
-      if (/^#{1,6}\s+/.test(lines[next] ?? "")) {
-        end = next;
-        break;
-      }
-    }
-    const startLine = index + 1;
-    const endLine = Math.max(startLine, end);
-    const body = lines.slice(index, end).join("\n");
-    rows.push({
-      path: `${rel}#section=${sectionSlug}`,
-      sha256: fileSha256,
-      content_type: deriveContentType(filePath),
-      kind: "markdown-section",
-      source_refs: [`${rel}#section=${sectionSlug}`, lineWindowRef(rel, startLine, endLine)],
-      body: pickProjectionPayload(body),
-      size_bytes: body.length,
-    });
-  }
-  return rows;
-}
-
-function projectPlainTextRows(filePath: string, content: string): ProjectionSourceRow[] {
-  const rel = toPosix(filePath);
-  const lines = content.split(/\r?\n/);
-  const rows: ProjectionSourceRow[] = [
-    {
-      path: rel,
-      sha256: `sha256:${createHash("sha256").update(content).digest("hex")}`,
-      content_type: deriveContentType(filePath),
-      kind: toProjectionRowKind(filePath),
-      source_refs: [rel],
-      body: pickProjectionPayload(content),
-      size_bytes: content.length,
-    },
-  ];
-  const windowSize = 80;
-  for (let start = 0; start < lines.length; start += windowSize) {
-    const body = lines.slice(start, start + windowSize).join("\n");
-    if (!body.trim()) continue;
-    const startLine = start + 1;
-    const endLine = Math.min(lines.length, start + windowSize);
-    rows.push({
-      path: lineWindowRef(rel, startLine, endLine),
-      sha256: `sha256:${createHash("sha256").update(body).digest("hex")}`,
-      content_type: deriveContentType(filePath),
-      kind: "text-window",
-      source_refs: [lineWindowRef(rel, startLine, endLine)],
-      body: pickProjectionPayload(body),
-      size_bytes: body.length,
-    });
-  }
-  return rows;
-}
-
-function projectRowsForFile(filePath: string, content: string): ProjectionSourceRow[] {
-  const rel = toPosix(filePath);
-  if (filePath.endsWith(".jsonl")) {
-    const rows = parseJsonlLines(content);
-    const selector = selectorForJsonlRow(filePath);
-    if (rows.length === 0) {
-      return [
-        {
-          path: rel,
-          sha256: `sha256:${createHash("sha256").update(content).digest("hex")}`,
-          content_type: deriveContentType(filePath),
-          kind: "jsonl-file",
-          source_refs: [toPosix(filePath)],
-          body: pickProjectionPayload(content),
-          size_bytes: content.length,
-        },
-      ];
-    }
-    return rows.map((row, index) => {
-      const serialized = JSON.stringify(row);
-      const id = String((row as { id?: unknown }).id ?? index + 1);
-      return {
-        path: `${rel}#${selector}=${id}`,
-        sha256: `sha256:${createHash("sha256").update(serialized).digest("hex")}`,
-        content_type: deriveContentType(filePath),
-        kind: "jsonl-row",
-        source_refs: sourceRefsForJsonlRow(row, `${rel}#${selector}=${id}`),
-        body: serialized,
-        size_bytes: serialized.length,
-      };
-    });
-  }
-  if (filePath.endsWith(".json")) {
-    return [
-      {
-        path: rel,
-        sha256: `sha256:${createHash("sha256").update(content).digest("hex")}`,
-        content_type: deriveContentType(filePath),
-        kind: toProjectionRowKind(filePath),
-        source_refs: [toPosix(filePath)],
-        body: pickProjectionPayload(content),
-        size_bytes: content.length,
-      },
-    ];
-  }
-  if (filePath.endsWith(".md") || filePath.endsWith(".mdx")) {
-    return projectMarkdownRows(filePath, content);
-  }
-  if (deriveContentType(filePath) === "text/plain") {
-    return projectPlainTextRows(filePath, content);
-  }
-  return [
-    {
-      path: rel,
-      sha256: `sha256:${createHash("sha256").update(content).digest("hex")}`,
-      content_type: deriveContentType(filePath),
-      kind: toProjectionRowKind(filePath),
-      source_refs: [toPosix(filePath)],
-      body: pickProjectionPayload(content),
-      size_bytes: content.length,
-    },
-  ];
 }
 
 async function enumerateSourceFiles(


### PR DESCRIPTION
Task: `202605290610-R6288F`
Title: Context reindex projection decomposition
Canonical task record: `.agentplane/tasks/202605290610-R6288F/README.md`

## Summary

Context reindex projection decomposition

Refactor packages/agentplane/src/context/reindex.ts below the 400-line hotspot warning by extracting projection row helpers into focused module(s). Preserve cmdContextReindex behavior, projection metadata, path selection, markdown/jsonl/text row generation, SQLite projection writes, and readContextProjection fallback semantics. Acceptance: context release-readiness tests pass, typecheck/arch/knip/lint/format pass, and bun run hotspots:check shows one fewer runtime hotspot.

## Scope

- In scope: Refactor packages/agentplane/src/context/reindex.ts below the 400-line hotspot warning by extracting projection row helpers into focused module(s). Preserve cmdContextReindex behavior, projection metadata, path selection, markdown/jsonl/text row generation, SQLite projection writes, and readContextProjection fallback semantics. Acceptance: context release-readiness tests pass, typecheck/arch/knip/lint/format pass, and bun run hotspots:check shows one fewer runtime hotspot.
- Out of scope: unrelated refactors not required for "Context reindex projection decomposition".

## Verification

- State: ok
- Note:

```text
Context reindex projection row helpers extracted into
packages/agentplane/src/context/reindex-projection.ts; cmdContextReindex and readContextProjection
semantics are preserved. Checks passed: bun test
packages/agentplane/src/commands/context/release-readiness.test.ts (21 pass); bun run typecheck; bun
run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run
hotspots:check (runtime hotspots 4 -> 3).
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-29T06:10:23.294Z
- Branch: task/202605290610-R6288F/context-reindex-projection-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../agentplane/src/context/reindex-projection.ts   | 242 ++++++++++++++++++++
 packages/agentplane/src/context/reindex.ts         | 251 +--------------------
 2 files changed, 248 insertions(+), 245 deletions(-)
```

</details>
