### PR TITLE
🚧 KC9ANF task: Release plan command decomposition [202605290621-KC9ANF]

### DIFF
--- a/.agentplane/tasks/202605290621-KC9ANF/README.md
+++ b/.agentplane/tasks/202605290621-KC9ANF/README.md
@@ -1,0 +1,149 @@
+---
+id: "202605290621-KC9ANF"
+title: "Release plan command decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "hotspot"
+  - "release"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-29T06:21:25.839Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-29T06:26:03.144Z"
+  updated_by: "CODER"
+  note: "Release plan helpers extracted into packages/agentplane/src/commands/release/plan.helpers.ts; runReleasePlan behavior and generated release plan artifacts are preserved. Checks passed: release plan/apply matrix (31 pass); bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run hotspots:check (runtime hotspots 3 -> 2)."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: extracting release plan helper logic while preserving runReleasePlan validation, generated artifacts, protected base resolution, and release policy gates."
+events:
+  -
+    type: "status"
+    at: "2026-05-29T06:21:37.426Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: extracting release plan helper logic while preserving runReleasePlan validation, generated artifacts, protected base resolution, and release policy gates."
+  -
+    type: "verify"
+    at: "2026-05-29T06:26:03.144Z"
+    author: "CODER"
+    state: "ok"
+    note: "Release plan helpers extracted into packages/agentplane/src/commands/release/plan.helpers.ts; runReleasePlan behavior and generated release plan artifacts are preserved. Checks passed: release plan/apply matrix (31 pass); bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run hotspots:check (runtime hotspots 3 -> 2)."
+doc_version: 3
+doc_updated_at: "2026-05-29T06:26:03.161Z"
+doc_updated_by: "CODER"
+description: "Refactor packages/agentplane/src/commands/release/plan.command.ts below the 400-line hotspot warning by extracting semver/change rendering helpers into focused module(s). Preserve release plan validation, incident gate, protected base SHA resolution, generated version/changes/instructions files, and runReleasePlan public API. Acceptance: release plan tests pass, release apply tests importing runReleasePlan pass where relevant, typecheck/arch/knip/lint/format pass, and bun run hotspots:check shows one fewer runtime hotspot."
+sections:
+  Summary: |-
+    Release plan command decomposition
+
+    Refactor packages/agentplane/src/commands/release/plan.command.ts below the 400-line hotspot warning by extracting semver/change rendering helpers into focused module(s). Preserve release plan validation, incident gate, protected base SHA resolution, generated version/changes/instructions files, and runReleasePlan public API. Acceptance: release plan tests pass, release apply tests importing runReleasePlan pass where relevant, typecheck/arch/knip/lint/format pass, and bun run hotspots:check shows one fewer runtime hotspot.
+  Scope: |-
+    - In scope: Refactor packages/agentplane/src/commands/release/plan.command.ts below the 400-line hotspot warning by extracting semver/change rendering helpers into focused module(s). Preserve release plan validation, incident gate, protected base SHA resolution, generated version/changes/instructions files, and runReleasePlan public API. Acceptance: release plan tests pass, release apply tests importing runReleasePlan pass where relevant, typecheck/arch/knip/lint/format pass, and bun run hotspots:check shows one fewer runtime hotspot.
+    - Out of scope: unrelated refactors not required for "Release plan command decomposition".
+  Plan: "1. Extract release plan semver/change rendering helpers from packages/agentplane/src/commands/release/plan.command.ts into a focused helper module. 2. Keep runReleasePlan and releasePlanSpec exports stable and preserve all validation/error behavior. 3. Run targeted release plan tests plus relevant release apply import surfaces, then typecheck, arch, knip, lint, format, and hotspots checks. 4. Open PR, wait for hosted checks, merge, finish, cleanup."
+  Verify Steps: |-
+    1. `bun test packages/agentplane/src/commands/release/plan.test.ts packages/agentplane/src/commands/release/apply.version-mutation.test.ts packages/agentplane/src/commands/release/apply.preflight.test.ts packages/agentplane/src/commands/release/apply.apply-flow.test.ts packages/agentplane/src/commands/release/apply.push-recovery.test.ts`
+    2. `bun run typecheck`
+    3. `bun run arch:check`
+    4. `bun run knip:check`
+    5. `bun run lint:core`
+    6. `bun run format:changed`
+    7. `bun run hotspots:check`
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-29T06:26:03.144Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Release plan helpers extracted into packages/agentplane/src/commands/release/plan.helpers.ts; runReleasePlan behavior and generated release plan artifacts are preserved. Checks passed: release plan/apply matrix (31 pass); bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run hotspots:check (runtime hotspots 3 -> 2).
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T06:21:37.426Z, excerpt_hash=sha256:d2676e8246f664dce7eaf868d21eb3d86a9da67d60752e71be754324a30e9c01
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: .agentplane/tasks/202605290621-KC9ANF/blueprint/resolved-snapshot.json
+    - old_digest: 5969389e3998a84db7633271e74f94893b43676ef56cec1d696e914cc3210148
+    - current_digest: 5969389e3998a84db7633271e74f94893b43676ef56cec1d696e914cc3210148
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605290621-KC9ANF
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Release plan command decomposition
+
+Refactor packages/agentplane/src/commands/release/plan.command.ts below the 400-line hotspot warning by extracting semver/change rendering helpers into focused module(s). Preserve release plan validation, incident gate, protected base SHA resolution, generated version/changes/instructions files, and runReleasePlan public API. Acceptance: release plan tests pass, release apply tests importing runReleasePlan pass where relevant, typecheck/arch/knip/lint/format pass, and bun run hotspots:check shows one fewer runtime hotspot.
+
+## Scope
+
+- In scope: Refactor packages/agentplane/src/commands/release/plan.command.ts below the 400-line hotspot warning by extracting semver/change rendering helpers into focused module(s). Preserve release plan validation, incident gate, protected base SHA resolution, generated version/changes/instructions files, and runReleasePlan public API. Acceptance: release plan tests pass, release apply tests importing runReleasePlan pass where relevant, typecheck/arch/knip/lint/format pass, and bun run hotspots:check shows one fewer runtime hotspot.
+- Out of scope: unrelated refactors not required for "Release plan command decomposition".
+
+## Plan
+
+1. Extract release plan semver/change rendering helpers from packages/agentplane/src/commands/release/plan.command.ts into a focused helper module. 2. Keep runReleasePlan and releasePlanSpec exports stable and preserve all validation/error behavior. 3. Run targeted release plan tests plus relevant release apply import surfaces, then typecheck, arch, knip, lint, format, and hotspots checks. 4. Open PR, wait for hosted checks, merge, finish, cleanup.
+
+## Verify Steps
+
+1. `bun test packages/agentplane/src/commands/release/plan.test.ts packages/agentplane/src/commands/release/apply.version-mutation.test.ts packages/agentplane/src/commands/release/apply.preflight.test.ts packages/agentplane/src/commands/release/apply.apply-flow.test.ts packages/agentplane/src/commands/release/apply.push-recovery.test.ts`
+2. `bun run typecheck`
+3. `bun run arch:check`
+4. `bun run knip:check`
+5. `bun run lint:core`
+6. `bun run format:changed`
+7. `bun run hotspots:check`
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-29T06:26:03.144Z — VERIFY — ok
+
+By: CODER
+
+Note: Release plan helpers extracted into packages/agentplane/src/commands/release/plan.helpers.ts; runReleasePlan behavior and generated release plan artifacts are preserved. Checks passed: release plan/apply matrix (31 pass); bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run hotspots:check (runtime hotspots 3 -> 2).
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T06:21:37.426Z, excerpt_hash=sha256:d2676e8246f664dce7eaf868d21eb3d86a9da67d60752e71be754324a30e9c01
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: .agentplane/tasks/202605290621-KC9ANF/blueprint/resolved-snapshot.json
+- old_digest: 5969389e3998a84db7633271e74f94893b43676ef56cec1d696e914cc3210148
+- current_digest: 5969389e3998a84db7633271e74f94893b43676ef56cec1d696e914cc3210148
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605290621-KC9ANF
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605290621-KC9ANF/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605290621-KC9ANF/blueprint/resolved-snapshot.json
@@ -1,0 +1,455 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605290621-KC9ANF",
+    "title": "Release plan command decomposition",
+    "description": "Refactor packages/agentplane/src/commands/release/plan.command.ts below the 400-line hotspot warning by extracting semver/change rendering helpers into focused module(s). Preserve release plan validation, incident gate, protected base SHA resolution, generated version/changes/instructions files, and runReleasePlan public API. Acceptance: release plan tests pass, release apply tests importing runReleasePlan pass where relevant, typecheck/arch/knip/lint/format pass, and bun run hotspots:check shows one fewer runtime hotspot.",
+    "tags": [
+      "code",
+      "hotspot",
+      "release"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "release",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "release.strict",
+    "version": 1,
+    "title": "Strict release",
+    "taskKinds": [
+      "release"
+    ],
+    "workflowModes": [
+      "direct",
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "release.strict",
+    "blueprintVersion": 1,
+    "title": "Strict release",
+    "taskId": "202605290621-KC9ANF",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "release"
+    },
+    "whySelected": [
+      "task kind resolved to release",
+      "workflow mode: branch_pr",
+      "mutation scope: release"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.release.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "deterministic_check",
+        "kind": "deterministic_check",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "release.approval",
+        "kind": "approval",
+        "producedBy": "approval_gate",
+        "required": true,
+        "description": "Release approval."
+      },
+      {
+        "id": "release.plan",
+        "kind": "artifact",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Release plan or candidate artifact."
+      },
+      {
+        "id": "release.check",
+        "kind": "check_result",
+        "producedBy": "deterministic_check",
+        "required": true,
+        "description": "Release gates."
+      },
+      {
+        "id": "release.publish",
+        "kind": "external_link",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Publish evidence."
+      },
+      {
+        "id": "release.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Release commit."
+      },
+      {
+        "id": "release.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.release.md"
+    ],
+    "allowedCommands": [
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "publish commands after approval",
+      "release gates"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Release work needs strict release policy, approval evidence, and rollback context."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.release.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "deterministic_check",
+      "kind": "deterministic_check",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "release.approval",
+      "kind": "approval",
+      "producedBy": "approval_gate",
+      "required": true,
+      "description": "Release approval."
+    },
+    {
+      "id": "release.plan",
+      "kind": "artifact",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Release plan or candidate artifact."
+    },
+    {
+      "id": "release.check",
+      "kind": "check_result",
+      "producedBy": "deterministic_check",
+      "required": true,
+      "description": "Release gates."
+    },
+    {
+      "id": "release.publish",
+      "kind": "external_link",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Publish evidence."
+    },
+    {
+      "id": "release.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Release commit."
+    },
+    {
+      "id": "release.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.release.md"
+  ],
+  "allowedCommands": [
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "publish commands after approval",
+    "release gates"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Release work needs strict release policy, approval evidence, and rollback context."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to release",
+    "workflow mode: branch_pr",
+    "mutation scope: release"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "5969389e3998a84db7633271e74f94893b43676ef56cec1d696e914cc3210148"
+  }
+}

--- a/.agentplane/tasks/202605290621-KC9ANF/pr/diffstat.txt
+++ b/.agentplane/tasks/202605290621-KC9ANF/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../src/commands/release/plan.command.ts           | 122 ++-------------------
+ .../src/commands/release/plan.helpers.ts           | 113 +++++++++++++++++++
+ 2 files changed, 124 insertions(+), 111 deletions(-)

--- a/.agentplane/tasks/202605290621-KC9ANF/pr/github-body.md
+++ b/.agentplane/tasks/202605290621-KC9ANF/pr/github-body.md
@@ -1,0 +1,42 @@
+Task: `202605290621-KC9ANF`
+Title: Release plan command decomposition
+Canonical task record: `.agentplane/tasks/202605290621-KC9ANF/README.md`
+
+## Summary
+
+Release plan command decomposition
+
+Refactor packages/agentplane/src/commands/release/plan.command.ts below the 400-line hotspot warning by extracting semver/change rendering helpers into focused module(s). Preserve release plan validation, incident gate, protected base SHA resolution, generated version/changes/instructions files, and runReleasePlan public API. Acceptance: release plan tests pass, release apply tests importing runReleasePlan pass where relevant, typecheck/arch/knip/lint/format pass, and bun run hotspots:check shows one fewer runtime hotspot.
+
+## Scope
+
+- In scope: Refactor packages/agentplane/src/commands/release/plan.command.ts below the 400-line hotspot warning by extracting semver/change rendering helpers into focused module(s). Preserve release plan validation, incident gate, protected base SHA resolution, generated version/changes/instructions files, and runReleasePlan public API. Acceptance: release plan tests pass, release apply tests importing runReleasePlan pass where relevant, typecheck/arch/knip/lint/format pass, and bun run hotspots:check shows one fewer runtime hotspot.
+- Out of scope: unrelated refactors not required for "Release plan command decomposition".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Release plan helpers extracted into packages/agentplane/src/commands/release/plan.helpers.ts;
+runReleasePlan behavior and generated release plan artifacts are preserved. Checks passed: release
+plan/apply matrix (31 pass); bun run typecheck; bun run arch:check; bun run knip:check; bun run
+lint:core; bun run format:changed; bun run hotspots:check (runtime hotspots 3 -> 2).
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T06:21:37.555Z
+- Branch: task/202605290621-KC9ANF/release-plan-command-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/commands/release/plan.command.ts           | 122 ++-------------------
+ .../src/commands/release/plan.helpers.ts           | 113 +++++++++++++++++++
+ 2 files changed, 124 insertions(+), 111 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605290621-KC9ANF/pr/github-title.txt
+++ b/.agentplane/tasks/202605290621-KC9ANF/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 KC9ANF task: Release plan command decomposition [202605290621-KC9ANF]

--- a/.agentplane/tasks/202605290621-KC9ANF/pr/meta.json
+++ b/.agentplane/tasks/202605290621-KC9ANF/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605290621-KC9ANF/release-plan-command-decomposition",
+  "created_at": "2026-05-29T06:21:37.555Z",
+  "diffstat_sha256": "sha256:f648ec6d3a3a9c0a26ce083b910b1411b063ba1da3688a1cbc0f5062845ad684",
+  "last_verified_at": "2026-05-29T06:26:03.144Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202605290621-KC9ANF",
+  "updated_at": "2026-05-29T06:21:37.555Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605290621-KC9ANF/pr/meta.json
+++ b/.agentplane/tasks/202605290621-KC9ANF/pr/meta.json
@@ -4,7 +4,7 @@
   "created_at": "2026-05-29T06:21:37.555Z",
   "diffstat_sha256": "sha256:f648ec6d3a3a9c0a26ce083b910b1411b063ba1da3688a1cbc0f5062845ad684",
   "last_verified_at": "2026-05-29T06:26:03.144Z",
-  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_diffstat_sha256": "sha256:f648ec6d3a3a9c0a26ce083b910b1411b063ba1da3688a1cbc0f5062845ad684",
   "schema_version": 1,
   "task_id": "202605290621-KC9ANF",
   "updated_at": "2026-05-29T06:21:37.555Z",

--- a/.agentplane/tasks/202605290621-KC9ANF/pr/review.md
+++ b/.agentplane/tasks/202605290621-KC9ANF/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-05-29T06:21:37.555Z
+
+## Task
+
+- Task: `202605290621-KC9ANF`
+- Title: Release plan command decomposition
+- Status: DOING
+- Branch: `task/202605290621-KC9ANF/release-plan-command-decomposition`
+- Canonical task record: `.agentplane/tasks/202605290621-KC9ANF/README.md`
+
+## Verification
+
+- State: ok
+- Note: Release plan helpers extracted into packages/agentplane/src/commands/release/plan.helpers.ts; runReleasePlan behavior and generated release plan artifacts are preserved. Checks passed: release plan/apply matrix (31 pass); bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run hotspots:check (runtime hotspots 3 -> 2).
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T06:21:37.555Z
+- Branch: task/202605290621-KC9ANF/release-plan-command-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/commands/release/plan.command.ts           | 122 ++-------------------
+ .../src/commands/release/plan.helpers.ts           | 113 +++++++++++++++++++
+ 2 files changed, 124 insertions(+), 111 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/release/plan.command.ts
+++ b/packages/agentplane/src/commands/release/plan.command.ts
@@ -10,78 +10,20 @@ import { exitCodeForError } from "../../cli/exit-codes.js";
 import { withDiagnosticContext } from "../shared/diagnostics.js";
 import { CliError } from "../../shared/errors.js";
 import { execFileAsync } from "@agentplaneorg/core/process";
-import type { BumpKind, ReleasePlanParsed } from "./plan.spec.js";
+import type { ReleasePlanParsed } from "./plan.spec.js";
+import {
+  bumpVersion,
+  changesMarkdown,
+  compareSemver,
+  listMissingPatchTags,
+  normalizeTagVersion,
+  releaseInstructions,
+  requiredBulletCount,
+  type Change,
+} from "./plan.helpers.js";
 const output = createCliEmitter();
 
 export { releasePlanSpec } from "./plan.spec.js";
-
-type Change = {
-  hash: string;
-  authorDateIso: string;
-  subject: string;
-};
-
-function parseSemver(version: string): { major: number; minor: number; patch: number } | null {
-  const m = /^(\d+)\.(\d+)\.(\d+)$/u.exec(version.trim());
-  if (!m) return null;
-  const major = Number(m[1]);
-  const minor = Number(m[2]);
-  const patch = Number(m[3]);
-  if (![major, minor, patch].every((n) => Number.isInteger(n) && n >= 0)) return null;
-  return { major, minor, patch };
-}
-
-function compareSemver(left: string, right: string): number {
-  const leftParsed = parseSemver(left);
-  const rightParsed = parseSemver(right);
-  if (!leftParsed || !rightParsed) {
-    throw new CliError({
-      exitCode: exitCodeForError("E_VALIDATION"),
-      code: "E_VALIDATION",
-      message: `Invalid semver comparison: ${left} vs ${right}`,
-    });
-  }
-  if (leftParsed.major !== rightParsed.major) return leftParsed.major - rightParsed.major;
-  if (leftParsed.minor !== rightParsed.minor) return leftParsed.minor - rightParsed.minor;
-  return leftParsed.patch - rightParsed.patch;
-}
-
-function normalizeTagVersion(tag: string | null): string | null {
-  if (!tag) return null;
-  return tag.startsWith("v") ? tag.slice(1) : tag;
-}
-
-function listMissingPatchTags(fromVersion: string, toVersion: string): string[] {
-  const fromParsed = parseSemver(fromVersion);
-  const toParsed = parseSemver(toVersion);
-  if (!fromParsed || !toParsed) return [];
-  if (
-    fromParsed.major !== toParsed.major ||
-    fromParsed.minor !== toParsed.minor ||
-    toParsed.patch <= fromParsed.patch
-  ) {
-    return [];
-  }
-  const out: string[] = [];
-  for (let patch = fromParsed.patch + 1; patch <= toParsed.patch; patch += 1) {
-    out.push(`v${fromParsed.major}.${fromParsed.minor}.${patch}`);
-  }
-  return out;
-}
-
-function bumpVersion(version: string, bump: BumpKind): string {
-  const parsed = parseSemver(version);
-  if (!parsed) {
-    throw new CliError({
-      exitCode: exitCodeForError("E_VALIDATION"),
-      code: "E_VALIDATION",
-      message: `Invalid version (expected X.Y.Z): ${version}`,
-    });
-  }
-  if (bump === "patch") return `${parsed.major}.${parsed.minor}.${parsed.patch + 1}`;
-  if (bump === "minor") return `${parsed.major}.${parsed.minor + 1}.0`;
-  return `${parsed.major + 1}.0.0`;
-}
 
 async function readPackageVersion(pkgJsonPath: string): Promise<string> {
   const raw = JSON.parse(await readFile(pkgJsonPath, "utf8")) as { version?: unknown };
@@ -271,48 +213,6 @@ async function resolveProtectedBaseShaForPlan(opts: {
       },
     ),
   });
-}
-
-function changesMarkdown(changes: Change[]): string {
-  if (changes.length === 0) return "_No commits found in the selected range._\n";
-  return (
-    changes
-      .map((c) => `- ${c.subject} (${c.hash.slice(0, 7)})`)
-      .join("\n")
-      .trim() + "\n"
-  );
-}
-
-function requiredBulletCount(changeCount: number): number {
-  return Math.max(1, changeCount);
-}
-
-function releaseInstructions(opts: {
-  nextTag: string;
-  prevTag: string | null;
-  bump: BumpKind;
-  minBullets: number;
-}): string {
-  return (
-    `# Release plan\n\n` +
-    `## Target\n\n` +
-    `- Tag: \`${opts.nextTag}\`\n` +
-    (opts.prevTag
-      ? `- Since: \`${opts.prevTag}\`\n`
-      : "- Since: (no previous semver tag found)\n") +
-    `- Bump: \`${opts.bump}\`\n\n` +
-    `## Agent task: write release notes\n\n` +
-    `Write English release notes as \`docs/releases/${opts.nextTag}.md\`.\n\n` +
-    `Rules:\n` +
-    `- Use detailed, human-readable bullets focused on outcomes and user-facing improvements.\n` +
-    `- Cover all listed differences from \`changes.md\`; do not omit commits.\n` +
-    `- Keep one concrete bullet per listed change in plain language.\n` +
-    `- Write at least ${opts.minBullets} bullet points.\n` +
-    `- Do not include Cyrillic.\n` +
-    `- Use \`docs/releases/TEMPLATE.md\` as the structure.\n\n` +
-    `Inputs:\n` +
-    `- \`changes.md\` and \`changes.json\` in this directory.\n`
-  );
 }
 
 export const runReleasePlan: CommandHandler<ReleasePlanParsed> = async (ctx, flags) => {

--- a/packages/agentplane/src/commands/release/plan.helpers.ts
+++ b/packages/agentplane/src/commands/release/plan.helpers.ts
@@ -1,0 +1,113 @@
+import { exitCodeForError } from "../../cli/exit-codes.js";
+import { CliError } from "../../shared/errors.js";
+import type { BumpKind } from "./plan.spec.js";
+
+export type Change = {
+  hash: string;
+  authorDateIso: string;
+  subject: string;
+};
+
+function parseSemver(version: string): { major: number; minor: number; patch: number } | null {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/u.exec(version.trim());
+  if (!m) return null;
+  const major = Number(m[1]);
+  const minor = Number(m[2]);
+  const patch = Number(m[3]);
+  if (![major, minor, patch].every((n) => Number.isInteger(n) && n >= 0)) return null;
+  return { major, minor, patch };
+}
+
+export function compareSemver(left: string, right: string): number {
+  const leftParsed = parseSemver(left);
+  const rightParsed = parseSemver(right);
+  if (!leftParsed || !rightParsed) {
+    throw new CliError({
+      exitCode: exitCodeForError("E_VALIDATION"),
+      code: "E_VALIDATION",
+      message: `Invalid semver comparison: ${left} vs ${right}`,
+    });
+  }
+  if (leftParsed.major !== rightParsed.major) return leftParsed.major - rightParsed.major;
+  if (leftParsed.minor !== rightParsed.minor) return leftParsed.minor - rightParsed.minor;
+  return leftParsed.patch - rightParsed.patch;
+}
+
+export function normalizeTagVersion(tag: string | null): string | null {
+  if (!tag) return null;
+  return tag.startsWith("v") ? tag.slice(1) : tag;
+}
+
+export function listMissingPatchTags(fromVersion: string, toVersion: string): string[] {
+  const fromParsed = parseSemver(fromVersion);
+  const toParsed = parseSemver(toVersion);
+  if (!fromParsed || !toParsed) return [];
+  if (
+    fromParsed.major !== toParsed.major ||
+    fromParsed.minor !== toParsed.minor ||
+    toParsed.patch <= fromParsed.patch
+  ) {
+    return [];
+  }
+  const out: string[] = [];
+  for (let patch = fromParsed.patch + 1; patch <= toParsed.patch; patch += 1) {
+    out.push(`v${fromParsed.major}.${fromParsed.minor}.${patch}`);
+  }
+  return out;
+}
+
+export function bumpVersion(version: string, bump: BumpKind): string {
+  const parsed = parseSemver(version);
+  if (!parsed) {
+    throw new CliError({
+      exitCode: exitCodeForError("E_VALIDATION"),
+      code: "E_VALIDATION",
+      message: `Invalid version (expected X.Y.Z): ${version}`,
+    });
+  }
+  if (bump === "patch") return `${parsed.major}.${parsed.minor}.${parsed.patch + 1}`;
+  if (bump === "minor") return `${parsed.major}.${parsed.minor + 1}.0`;
+  return `${parsed.major + 1}.0.0`;
+}
+
+export function changesMarkdown(changes: Change[]): string {
+  if (changes.length === 0) return "_No commits found in the selected range._\n";
+  return (
+    changes
+      .map((c) => `- ${c.subject} (${c.hash.slice(0, 7)})`)
+      .join("\n")
+      .trim() + "\n"
+  );
+}
+
+export function requiredBulletCount(changeCount: number): number {
+  return Math.max(1, changeCount);
+}
+
+export function releaseInstructions(opts: {
+  nextTag: string;
+  prevTag: string | null;
+  bump: BumpKind;
+  minBullets: number;
+}): string {
+  return (
+    `# Release plan\n\n` +
+    `## Target\n\n` +
+    `- Tag: \`${opts.nextTag}\`\n` +
+    (opts.prevTag
+      ? `- Since: \`${opts.prevTag}\`\n`
+      : "- Since: (no previous semver tag found)\n") +
+    `- Bump: \`${opts.bump}\`\n\n` +
+    `## Agent task: write release notes\n\n` +
+    `Write English release notes as \`docs/releases/${opts.nextTag}.md\`.\n\n` +
+    `Rules:\n` +
+    `- Use detailed, human-readable bullets focused on outcomes and user-facing improvements.\n` +
+    `- Cover all listed differences from \`changes.md\`; do not omit commits.\n` +
+    `- Keep one concrete bullet per listed change in plain language.\n` +
+    `- Write at least ${opts.minBullets} bullet points.\n` +
+    `- Do not include Cyrillic.\n` +
+    `- Use \`docs/releases/TEMPLATE.md\` as the structure.\n\n` +
+    `Inputs:\n` +
+    `- \`changes.md\` and \`changes.json\` in this directory.\n`
+  );
+}


### PR DESCRIPTION
Task: `202605290621-KC9ANF`
Title: Release plan command decomposition
Canonical task record: `.agentplane/tasks/202605290621-KC9ANF/README.md`

## Summary

Release plan command decomposition

Refactor packages/agentplane/src/commands/release/plan.command.ts below the 400-line hotspot warning by extracting semver/change rendering helpers into focused module(s). Preserve release plan validation, incident gate, protected base SHA resolution, generated version/changes/instructions files, and runReleasePlan public API. Acceptance: release plan tests pass, release apply tests importing runReleasePlan pass where relevant, typecheck/arch/knip/lint/format pass, and bun run hotspots:check shows one fewer runtime hotspot.

## Scope

- In scope: Refactor packages/agentplane/src/commands/release/plan.command.ts below the 400-line hotspot warning by extracting semver/change rendering helpers into focused module(s). Preserve release plan validation, incident gate, protected base SHA resolution, generated version/changes/instructions files, and runReleasePlan public API. Acceptance: release plan tests pass, release apply tests importing runReleasePlan pass where relevant, typecheck/arch/knip/lint/format pass, and bun run hotspots:check shows one fewer runtime hotspot.
- Out of scope: unrelated refactors not required for "Release plan command decomposition".

## Verification

- State: ok
- Note:

```text
Release plan helpers extracted into packages/agentplane/src/commands/release/plan.helpers.ts;
runReleasePlan behavior and generated release plan artifacts are preserved. Checks passed: release
plan/apply matrix (31 pass); bun run typecheck; bun run arch:check; bun run knip:check; bun run
lint:core; bun run format:changed; bun run hotspots:check (runtime hotspots 3 -> 2).
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-29T06:21:37.555Z
- Branch: task/202605290621-KC9ANF/release-plan-command-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/commands/release/plan.command.ts           | 122 ++-------------------
 .../src/commands/release/plan.helpers.ts           | 113 +++++++++++++++++++
 2 files changed, 124 insertions(+), 111 deletions(-)
```

</details>
