### PR TITLE
🚧 7F362X task: Hosted close command type decomposition [202605290645-7F362X]

### DIFF
--- a/.agentplane/tasks/202605290645-7F362X/README.md
+++ b/.agentplane/tasks/202605290645-7F362X/README.md
@@ -1,0 +1,149 @@
+---
+id: "202605290645-7F362X"
+title: "Hosted close command type decomposition"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "hotspot"
+  - "task"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-29T06:45:25.219Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-29T06:47:14.751Z"
+  updated_by: "CODER"
+  note: "HostedCloseOutcome moved to packages/agentplane/src/commands/task/hosted-close.types.ts; hosted-close runtime behavior and public exports are preserved. Checks passed: hosted-close tests (6 pass); bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run hotspots:check (zero runtime hotspot warnings)."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: extracting hosted-close command type-only declarations while preserving hosted close recovery, batch close, and follow-up branch behavior."
+events:
+  -
+    type: "status"
+    at: "2026-05-29T06:45:34.890Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: extracting hosted-close command type-only declarations while preserving hosted close recovery, batch close, and follow-up branch behavior."
+  -
+    type: "verify"
+    at: "2026-05-29T06:47:14.751Z"
+    author: "CODER"
+    state: "ok"
+    note: "HostedCloseOutcome moved to packages/agentplane/src/commands/task/hosted-close.types.ts; hosted-close runtime behavior and public exports are preserved. Checks passed: hosted-close tests (6 pass); bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run hotspots:check (zero runtime hotspot warnings)."
+doc_version: 3
+doc_updated_at: "2026-05-29T06:47:14.765Z"
+doc_updated_by: "CODER"
+description: "Refactor packages/agentplane/src/commands/task/hosted-close.command.ts below the 400-line hotspot warning by extracting small type-only declarations into focused module(s). Preserve task hosted-close behavior, follow-up branch detection export, recovery paths, batch close behavior, and hosted close output. Acceptance: hosted-close command tests pass, typecheck/arch/knip/lint/format pass, and bun run hotspots:check reports zero runtime hotspots."
+sections:
+  Summary: |-
+    Hosted close command type decomposition
+
+    Refactor packages/agentplane/src/commands/task/hosted-close.command.ts below the 400-line hotspot warning by extracting small type-only declarations into focused module(s). Preserve task hosted-close behavior, follow-up branch detection export, recovery paths, batch close behavior, and hosted close output. Acceptance: hosted-close command tests pass, typecheck/arch/knip/lint/format pass, and bun run hotspots:check reports zero runtime hotspots.
+  Scope: |-
+    - In scope: Refactor packages/agentplane/src/commands/task/hosted-close.command.ts below the 400-line hotspot warning by extracting small type-only declarations into focused module(s). Preserve task hosted-close behavior, follow-up branch detection export, recovery paths, batch close behavior, and hosted close output. Acceptance: hosted-close command tests pass, typecheck/arch/knip/lint/format pass, and bun run hotspots:check reports zero runtime hotspots.
+    - Out of scope: unrelated refactors not required for "Hosted close command type decomposition".
+  Plan: "1. Extract HostedCloseOutcome from packages/agentplane/src/commands/task/hosted-close.command.ts into a type-only helper module. 2. Preserve all hosted-close runtime behavior and public exports. 3. Run hosted-close command tests plus typecheck, arch, knip, lint, format, and hotspots checks. 4. Open PR, wait for hosted checks, merge, finish, cleanup."
+  Verify Steps: |-
+    1. `bun test packages/agentplane/src/commands/task/hosted-close.command.test.ts packages/agentplane/src/cli/run-cli.core.task-hosted-close.test.ts`
+    2. `bun run typecheck`
+    3. `bun run arch:check`
+    4. `bun run knip:check`
+    5. `bun run lint:core`
+    6. `bun run format:changed`
+    7. `bun run hotspots:check`
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-29T06:47:14.751Z — VERIFY — ok
+
+    By: CODER
+
+    Note: HostedCloseOutcome moved to packages/agentplane/src/commands/task/hosted-close.types.ts; hosted-close runtime behavior and public exports are preserved. Checks passed: hosted-close tests (6 pass); bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run hotspots:check (zero runtime hotspot warnings).
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T06:45:34.890Z, excerpt_hash=sha256:0717a712b4572becf9eed0f2b809d209b104439687881dc917a32bddcfd1ffd8
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: .agentplane/tasks/202605290645-7F362X/blueprint/resolved-snapshot.json
+    - old_digest: a3a09e0a7d60f6b224bd6973fa57762536f67a410253b1b25880e531315f180b
+    - current_digest: a3a09e0a7d60f6b224bd6973fa57762536f67a410253b1b25880e531315f180b
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605290645-7F362X
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Hosted close command type decomposition
+
+Refactor packages/agentplane/src/commands/task/hosted-close.command.ts below the 400-line hotspot warning by extracting small type-only declarations into focused module(s). Preserve task hosted-close behavior, follow-up branch detection export, recovery paths, batch close behavior, and hosted close output. Acceptance: hosted-close command tests pass, typecheck/arch/knip/lint/format pass, and bun run hotspots:check reports zero runtime hotspots.
+
+## Scope
+
+- In scope: Refactor packages/agentplane/src/commands/task/hosted-close.command.ts below the 400-line hotspot warning by extracting small type-only declarations into focused module(s). Preserve task hosted-close behavior, follow-up branch detection export, recovery paths, batch close behavior, and hosted close output. Acceptance: hosted-close command tests pass, typecheck/arch/knip/lint/format pass, and bun run hotspots:check reports zero runtime hotspots.
+- Out of scope: unrelated refactors not required for "Hosted close command type decomposition".
+
+## Plan
+
+1. Extract HostedCloseOutcome from packages/agentplane/src/commands/task/hosted-close.command.ts into a type-only helper module. 2. Preserve all hosted-close runtime behavior and public exports. 3. Run hosted-close command tests plus typecheck, arch, knip, lint, format, and hotspots checks. 4. Open PR, wait for hosted checks, merge, finish, cleanup.
+
+## Verify Steps
+
+1. `bun test packages/agentplane/src/commands/task/hosted-close.command.test.ts packages/agentplane/src/cli/run-cli.core.task-hosted-close.test.ts`
+2. `bun run typecheck`
+3. `bun run arch:check`
+4. `bun run knip:check`
+5. `bun run lint:core`
+6. `bun run format:changed`
+7. `bun run hotspots:check`
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-29T06:47:14.751Z — VERIFY — ok
+
+By: CODER
+
+Note: HostedCloseOutcome moved to packages/agentplane/src/commands/task/hosted-close.types.ts; hosted-close runtime behavior and public exports are preserved. Checks passed: hosted-close tests (6 pass); bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run hotspots:check (zero runtime hotspot warnings).
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T06:45:34.890Z, excerpt_hash=sha256:0717a712b4572becf9eed0f2b809d209b104439687881dc917a32bddcfd1ffd8
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: .agentplane/tasks/202605290645-7F362X/blueprint/resolved-snapshot.json
+- old_digest: a3a09e0a7d60f6b224bd6973fa57762536f67a410253b1b25880e531315f180b
+- current_digest: a3a09e0a7d60f6b224bd6973fa57762536f67a410253b1b25880e531315f180b
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605290645-7F362X
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605290645-7F362X/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605290645-7F362X/blueprint/resolved-snapshot.json
@@ -1,0 +1,598 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605290645-7F362X",
+    "title": "Hosted close command type decomposition",
+    "description": "Refactor packages/agentplane/src/commands/task/hosted-close.command.ts below the 400-line hotspot warning by extracting small type-only declarations into focused module(s). Preserve task hosted-close behavior, follow-up branch detection export, recovery paths, batch close behavior, and hosted close output. Acceptance: hosted-close command tests pass, typecheck/arch/knip/lint/format pass, and bun run hotspots:check reports zero runtime hotspots.",
+    "tags": [
+      "code",
+      "hotspot",
+      "task"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "quality.regression",
+    "version": 1,
+    "title": "Quality regression",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "quality.regression",
+    "blueprintVersion": 1,
+    "title": "Quality regression",
+    "taskId": "202605290645-7F362X",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to quality.regression",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest",
+          "artifact"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "check_result"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "weak_links"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "regression.original_failure",
+        "kind": "artifact",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Original failure log or check output."
+      },
+      {
+        "id": "regression.reproduction",
+        "kind": "check_result",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Local reproduction or explicit non-reproduction result."
+      },
+      {
+        "id": "regression.focused_check",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Focused regression check."
+      },
+      {
+        "id": "regression.matrix_or_scope",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Affected test/check matrix or bounded scope."
+      },
+      {
+        "id": "regression.full_gate",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Full relevant gate or hosted check evidence."
+      },
+      {
+        "id": "regression.flake_classification",
+        "kind": "weak_links",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Flake classification or residual risk."
+      },
+      {
+        "id": "regression.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "regression.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "affected matrix or full relevant gate",
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "failure reproduction command",
+      "focused regression check",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest",
+        "artifact"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "check_result"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "weak_links"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "regression.original_failure",
+      "kind": "artifact",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Original failure log or check output."
+    },
+    {
+      "id": "regression.reproduction",
+      "kind": "check_result",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Local reproduction or explicit non-reproduction result."
+    },
+    {
+      "id": "regression.focused_check",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Focused regression check."
+    },
+    {
+      "id": "regression.matrix_or_scope",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Affected test/check matrix or bounded scope."
+    },
+    {
+      "id": "regression.full_gate",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Full relevant gate or hosted check evidence."
+    },
+    {
+      "id": "regression.flake_classification",
+      "kind": "weak_links",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Flake classification or residual risk."
+    },
+    {
+      "id": "regression.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "regression.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "affected matrix or full relevant gate",
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "failure reproduction command",
+    "focused regression check",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to quality.regression",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "a3a09e0a7d60f6b224bd6973fa57762536f67a410253b1b25880e531315f180b"
+  }
+}

--- a/.agentplane/tasks/202605290645-7F362X/pr/diffstat.txt
+++ b/.agentplane/tasks/202605290645-7F362X/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ packages/agentplane/src/commands/task/hosted-close.command.ts | 6 +-----
+ packages/agentplane/src/commands/task/hosted-close.types.ts   | 4 ++++
+ 2 files changed, 5 insertions(+), 5 deletions(-)

--- a/.agentplane/tasks/202605290645-7F362X/pr/github-body.md
+++ b/.agentplane/tasks/202605290645-7F362X/pr/github-body.md
@@ -1,0 +1,42 @@
+Task: `202605290645-7F362X`
+Title: Hosted close command type decomposition
+Canonical task record: `.agentplane/tasks/202605290645-7F362X/README.md`
+
+## Summary
+
+Hosted close command type decomposition
+
+Refactor packages/agentplane/src/commands/task/hosted-close.command.ts below the 400-line hotspot warning by extracting small type-only declarations into focused module(s). Preserve task hosted-close behavior, follow-up branch detection export, recovery paths, batch close behavior, and hosted close output. Acceptance: hosted-close command tests pass, typecheck/arch/knip/lint/format pass, and bun run hotspots:check reports zero runtime hotspots.
+
+## Scope
+
+- In scope: Refactor packages/agentplane/src/commands/task/hosted-close.command.ts below the 400-line hotspot warning by extracting small type-only declarations into focused module(s). Preserve task hosted-close behavior, follow-up branch detection export, recovery paths, batch close behavior, and hosted close output. Acceptance: hosted-close command tests pass, typecheck/arch/knip/lint/format pass, and bun run hotspots:check reports zero runtime hotspots.
+- Out of scope: unrelated refactors not required for "Hosted close command type decomposition".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+HostedCloseOutcome moved to packages/agentplane/src/commands/task/hosted-close.types.ts;
+hosted-close runtime behavior and public exports are preserved. Checks passed: hosted-close tests (6
+pass); bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run
+format:changed; bun run hotspots:check (zero runtime hotspot warnings).
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T06:45:34.955Z
+- Branch: task/202605290645-7F362X/hosted-close-command-type-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ packages/agentplane/src/commands/task/hosted-close.command.ts | 6 +-----
+ packages/agentplane/src/commands/task/hosted-close.types.ts   | 4 ++++
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202605290645-7F362X/pr/github-title.txt
+++ b/.agentplane/tasks/202605290645-7F362X/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 7F362X task: Hosted close command type decomposition [202605290645-7F362X]

--- a/.agentplane/tasks/202605290645-7F362X/pr/meta.json
+++ b/.agentplane/tasks/202605290645-7F362X/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605290645-7F362X/hosted-close-command-type-decomposition",
+  "created_at": "2026-05-29T06:45:34.955Z",
+  "diffstat_sha256": "sha256:8f0820da817254c50dce12bc5da6985a6a18f98e1adf17d86b3ba453fca191fd",
+  "last_verified_at": "2026-05-29T06:47:14.751Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202605290645-7F362X",
+  "updated_at": "2026-05-29T06:45:34.955Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605290645-7F362X/pr/review.md
+++ b/.agentplane/tasks/202605290645-7F362X/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-05-29T06:45:34.955Z
+
+## Task
+
+- Task: `202605290645-7F362X`
+- Title: Hosted close command type decomposition
+- Status: DOING
+- Branch: `task/202605290645-7F362X/hosted-close-command-type-decomposition`
+- Canonical task record: `.agentplane/tasks/202605290645-7F362X/README.md`
+
+## Verification
+
+- State: ok
+- Note: HostedCloseOutcome moved to packages/agentplane/src/commands/task/hosted-close.types.ts; hosted-close runtime behavior and public exports are preserved. Checks passed: hosted-close tests (6 pass); bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run format:changed; bun run hotspots:check (zero runtime hotspot warnings).
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T06:45:34.955Z
+- Branch: task/202605290645-7F362X/hosted-close-command-type-decomposition
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ packages/agentplane/src/commands/task/hosted-close.command.ts | 6 +-----
+ packages/agentplane/src/commands/task/hosted-close.types.ts   | 4 ++++
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/task/hosted-close.command.ts
+++ b/packages/agentplane/src/commands/task/hosted-close.command.ts
@@ -26,6 +26,7 @@ import { resolveHostedMergeTargetFromEvent } from "./hosted-merge-sync.js";
 import { collectTaskIncidents, renderIncidentCollectionPlanOutcome } from "../incidents/shared.js";
 import type { TaskData } from "../../backends/task-backend.js";
 import type { TaskHostedCloseParsed } from "./hosted-close.spec.js";
+import type { HostedCloseOutcome } from "./hosted-close.types.js";
 import {
   buildHostedTaskFromTrackedPrArtifacts,
   hasTaskArtifactChanges,
@@ -35,11 +36,6 @@ import {
 } from "./hosted-close-recovery.js";
 
 export { taskHostedCloseSpec } from "./hosted-close.spec.js";
-
-type HostedCloseOutcome =
-  | { outcome: "noop"; detail: string }
-  | { outcome: "closed"; taskId: string; mergeHash: string }
-  | { outcome: "meta-only"; taskId: string; mergeHash: string };
 
 async function loadHostedBatchTasks(opts: {
   ctx: CommandContext;

--- a/packages/agentplane/src/commands/task/hosted-close.types.ts
+++ b/packages/agentplane/src/commands/task/hosted-close.types.ts
@@ -1,0 +1,4 @@
+export type HostedCloseOutcome =
+  | { outcome: "noop"; detail: string }
+  | { outcome: "closed"; taskId: string; mergeHash: string }
+  | { outcome: "meta-only"; taskId: string; mergeHash: string };


### PR DESCRIPTION
Task: `202605290645-7F362X`
Title: Hosted close command type decomposition
Canonical task record: `.agentplane/tasks/202605290645-7F362X/README.md`

## Summary

Hosted close command type decomposition

Refactor packages/agentplane/src/commands/task/hosted-close.command.ts below the 400-line hotspot warning by extracting small type-only declarations into focused module(s). Preserve task hosted-close behavior, follow-up branch detection export, recovery paths, batch close behavior, and hosted close output. Acceptance: hosted-close command tests pass, typecheck/arch/knip/lint/format pass, and bun run hotspots:check reports zero runtime hotspots.

## Scope

- In scope: Refactor packages/agentplane/src/commands/task/hosted-close.command.ts below the 400-line hotspot warning by extracting small type-only declarations into focused module(s). Preserve task hosted-close behavior, follow-up branch detection export, recovery paths, batch close behavior, and hosted close output. Acceptance: hosted-close command tests pass, typecheck/arch/knip/lint/format pass, and bun run hotspots:check reports zero runtime hotspots.
- Out of scope: unrelated refactors not required for "Hosted close command type decomposition".

## Verification

- State: ok
- Note:

```text
HostedCloseOutcome moved to packages/agentplane/src/commands/task/hosted-close.types.ts;
hosted-close runtime behavior and public exports are preserved. Checks passed: hosted-close tests (6
pass); bun run typecheck; bun run arch:check; bun run knip:check; bun run lint:core; bun run
format:changed; bun run hotspots:check (zero runtime hotspot warnings).
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-29T06:45:34.955Z
- Branch: task/202605290645-7F362X/hosted-close-command-type-decomposition
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 packages/agentplane/src/commands/task/hosted-close.command.ts | 6 +-----
 packages/agentplane/src/commands/task/hosted-close.types.ts   | 4 ++++
 2 files changed, 5 insertions(+), 5 deletions(-)
```

</details>
