### PR TITLE
🚧 QRQK1M task: Preserve staged index on policy hook refusal [202605292132-QRQK1M]

### DIFF
--- a/.agentplane/tasks/202605292132-QRQK1M/README.md
+++ b/.agentplane/tasks/202605292132-QRQK1M/README.md
@@ -4,7 +4,7 @@ title: "Preserve staged index on policy hook refusal"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -24,6 +24,22 @@ verification:
   updated_by: "CODER"
   note: "Focused regression passes: bun test packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts -t 'hooks run pre-commit blocks AGENTS.md without env override'. Static checks pass: bun run typecheck, bun run lint:core, bun run format:check, node .agentplane/policy/check-routing.mjs."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-29T21:38:31.533Z"
+  updated_by: "EVALUATOR"
+  note: "Issue #4313 regression coverage is present and hosted PR #4321 checks are green."
+  evaluated_sha: "c711524a983a10ffa0fc4a21874ea6812b8ec673"
+  blueprint_digest: "332d0080b09edf570920448a9f3dcbec331be6b0f345b7476c52da7b9ad08565"
+  evidence_refs:
+    - ".agentplane/tasks/202605292132-QRQK1M/README.md"
+    - ".agentplane/tasks/202605292132-QRQK1M/quality/20260529-213831533-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605292132-QRQK1M/quality/20260529-213831533-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605292132-QRQK1M/quality/20260529-213831533-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605292132-QRQK1M/blueprint/resolved-snapshot.json"
+    - "PR #4321 required checks passed"
+  findings:
+    - "PASS: managed pre-commit protected-policy refusal preserves AGENTS.md in the staged index, and retry with AGENTPLANE_ALLOW_POLICY=1 succeeds without restaging."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202605292132-QRQK1M/README.md
+++ b/.agentplane/tasks/202605292132-QRQK1M/README.md
@@ -1,0 +1,145 @@
+---
+id: "202605292132-QRQK1M"
+title: "Preserve staged index on policy hook refusal"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "bug"
+  - "code"
+  - "hooks"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-29T21:32:51.551Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-29T21:34:37.417Z"
+  updated_by: "CODER"
+  note: "Focused regression passes: bun test packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts -t 'hooks run pre-commit blocks AGENTS.md without env override'. Static checks pass: bun run typecheck, bun run lint:core, bun run format:check, node .agentplane/policy/check-routing.mjs."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: add regression coverage for issue #4313 preserving staged index after protected-policy hook refusal."
+events:
+  -
+    type: "status"
+    at: "2026-05-29T21:33:04.586Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: add regression coverage for issue #4313 preserving staged index after protected-policy hook refusal."
+  -
+    type: "verify"
+    at: "2026-05-29T21:34:37.417Z"
+    author: "CODER"
+    state: "ok"
+    note: "Focused regression passes: bun test packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts -t 'hooks run pre-commit blocks AGENTS.md without env override'. Static checks pass: bun run typecheck, bun run lint:core, bun run format:check, node .agentplane/policy/check-routing.mjs."
+doc_version: 3
+doc_updated_at: "2026-05-29T21:34:37.431Z"
+doc_updated_by: "CODER"
+description: "Add regression coverage for GitHub issue #4313 so managed pre-commit protected-policy refusal preserves the staged index for retry with AGENTPLANE_ALLOW_POLICY=1."
+sections:
+  Summary: |-
+    Preserve staged index on policy hook refusal
+
+    Add regression coverage for GitHub issue #4313 so managed pre-commit protected-policy refusal preserves the staged index for retry with AGENTPLANE_ALLOW_POLICY=1.
+  Scope: |-
+    - In scope: Add regression coverage for GitHub issue #4313 so managed pre-commit protected-policy refusal preserves the staged index for retry with AGENTPLANE_ALLOW_POLICY=1.
+    - Out of scope: unrelated refactors not required for "Preserve staged index on policy hook refusal".
+  Plan: "1. Add focused regression coverage for issue #4313 proving managed pre-commit protected-policy refusal leaves staged files intact. 2. Verify the focused hook test and lightweight static checks. 3. Open PR and merge after hosted checks."
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-29T21:34:37.417Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Focused regression passes: bun test packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts -t 'hooks run pre-commit blocks AGENTS.md without env override'. Static checks pass: bun run typecheck, bun run lint:core, bun run format:check, node .agentplane/policy/check-routing.mjs.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T21:33:04.586Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605292132-QRQK1M-preserve-policy-hook-index/.agentplane/tasks/202605292132-QRQK1M/blueprint/resolved-snapshot.json
+    - old_digest: 332d0080b09edf570920448a9f3dcbec331be6b0f345b7476c52da7b9ad08565
+    - current_digest: 332d0080b09edf570920448a9f3dcbec331be6b0f345b7476c52da7b9ad08565
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605292132-QRQK1M
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Preserve staged index on policy hook refusal
+
+Add regression coverage for GitHub issue #4313 so managed pre-commit protected-policy refusal preserves the staged index for retry with AGENTPLANE_ALLOW_POLICY=1.
+
+## Scope
+
+- In scope: Add regression coverage for GitHub issue #4313 so managed pre-commit protected-policy refusal preserves the staged index for retry with AGENTPLANE_ALLOW_POLICY=1.
+- Out of scope: unrelated refactors not required for "Preserve staged index on policy hook refusal".
+
+## Plan
+
+1. Add focused regression coverage for issue #4313 proving managed pre-commit protected-policy refusal leaves staged files intact. 2. Verify the focused hook test and lightweight static checks. 3. Open PR and merge after hosted checks.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-29T21:34:37.417Z — VERIFY — ok
+
+By: CODER
+
+Note: Focused regression passes: bun test packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts -t 'hooks run pre-commit blocks AGENTS.md without env override'. Static checks pass: bun run typecheck, bun run lint:core, bun run format:check, node .agentplane/policy/check-routing.mjs.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-29T21:33:04.586Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605292132-QRQK1M-preserve-policy-hook-index/.agentplane/tasks/202605292132-QRQK1M/blueprint/resolved-snapshot.json
+- old_digest: 332d0080b09edf570920448a9f3dcbec331be6b0f345b7476c52da7b9ad08565
+- current_digest: 332d0080b09edf570920448a9f3dcbec331be6b0f345b7476c52da7b9ad08565
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605292132-QRQK1M
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605292132-QRQK1M/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605292132-QRQK1M/blueprint/resolved-snapshot.json
@@ -1,0 +1,598 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605292132-QRQK1M",
+    "title": "Preserve staged index on policy hook refusal",
+    "description": "Add regression coverage for GitHub issue #4313 so managed pre-commit protected-policy refusal preserves the staged index for retry with AGENTPLANE_ALLOW_POLICY=1.",
+    "tags": [
+      "bug",
+      "code",
+      "hooks"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "quality.regression",
+    "version": 1,
+    "title": "Quality regression",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "quality.regression",
+    "blueprintVersion": 1,
+    "title": "Quality regression",
+    "taskId": "202605292132-QRQK1M",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to quality.regression",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest",
+          "artifact"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "check_result"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "weak_links"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "regression.original_failure",
+        "kind": "artifact",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Original failure log or check output."
+      },
+      {
+        "id": "regression.reproduction",
+        "kind": "check_result",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Local reproduction or explicit non-reproduction result."
+      },
+      {
+        "id": "regression.focused_check",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Focused regression check."
+      },
+      {
+        "id": "regression.matrix_or_scope",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Affected test/check matrix or bounded scope."
+      },
+      {
+        "id": "regression.full_gate",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Full relevant gate or hosted check evidence."
+      },
+      {
+        "id": "regression.flake_classification",
+        "kind": "weak_links",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Flake classification or residual risk."
+      },
+      {
+        "id": "regression.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "regression.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "affected matrix or full relevant gate",
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "failure reproduction command",
+      "focused regression check",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest",
+        "artifact"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "check_result"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "weak_links"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "regression.original_failure",
+      "kind": "artifact",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Original failure log or check output."
+    },
+    {
+      "id": "regression.reproduction",
+      "kind": "check_result",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Local reproduction or explicit non-reproduction result."
+    },
+    {
+      "id": "regression.focused_check",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Focused regression check."
+    },
+    {
+      "id": "regression.matrix_or_scope",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Affected test/check matrix or bounded scope."
+    },
+    {
+      "id": "regression.full_gate",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Full relevant gate or hosted check evidence."
+    },
+    {
+      "id": "regression.flake_classification",
+      "kind": "weak_links",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Flake classification or residual risk."
+    },
+    {
+      "id": "regression.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "regression.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "affected matrix or full relevant gate",
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "failure reproduction command",
+    "focused regression check",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to quality.regression",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "332d0080b09edf570920448a9f3dcbec331be6b0f345b7476c52da7b9ad08565"
+  }
+}

--- a/.agentplane/tasks/202605292132-QRQK1M/pr/diffstat.txt
+++ b/.agentplane/tasks/202605292132-QRQK1M/pr/diffstat.txt
@@ -1,0 +1,2 @@
+ .../agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)

--- a/.agentplane/tasks/202605292132-QRQK1M/pr/github-body.md
+++ b/.agentplane/tasks/202605292132-QRQK1M/pr/github-body.md
@@ -1,0 +1,41 @@
+Task: `202605292132-QRQK1M`
+Title: Preserve staged index on policy hook refusal
+Canonical task record: `.agentplane/tasks/202605292132-QRQK1M/README.md`
+
+## Summary
+
+Preserve staged index on policy hook refusal
+
+Add regression coverage for GitHub issue #4313 so managed pre-commit protected-policy refusal preserves the staged index for retry with AGENTPLANE_ALLOW_POLICY=1.
+
+## Scope
+
+- In scope: Add regression coverage for GitHub issue #4313 so managed pre-commit protected-policy refusal preserves the staged index for retry with AGENTPLANE_ALLOW_POLICY=1.
+- Out of scope: unrelated refactors not required for "Preserve staged index on policy hook refusal".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Focused regression passes: bun test
+packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts -t 'hooks run pre-commit blocks
+AGENTS.md without env override'. Static checks pass: bun run typecheck, bun run lint:core, bun run
+format:check, node .agentplane/policy/check-routing.mjs.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T21:33:04.651Z
+- Branch: task/202605292132-QRQK1M/preserve-policy-hook-index
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+```
+
+</details>

--- a/.agentplane/tasks/202605292132-QRQK1M/pr/github-title.txt
+++ b/.agentplane/tasks/202605292132-QRQK1M/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 QRQK1M task: Preserve staged index on policy hook refusal [202605292132-QRQK1M]

--- a/.agentplane/tasks/202605292132-QRQK1M/pr/meta.json
+++ b/.agentplane/tasks/202605292132-QRQK1M/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605292132-QRQK1M/preserve-policy-hook-index",
+  "created_at": "2026-05-29T21:33:04.651Z",
+  "diffstat_sha256": "sha256:197dc2994e53caef6d0555c031bd531839b6e7ca398004aba65101ae0d9eb19b",
+  "last_verified_at": "2026-05-29T21:34:37.417Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202605292132-QRQK1M",
+  "updated_at": "2026-05-29T21:33:04.651Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605292132-QRQK1M/pr/review.md
+++ b/.agentplane/tasks/202605292132-QRQK1M/pr/review.md
@@ -1,0 +1,37 @@
+# PR Review
+
+Created: 2026-05-29T21:33:04.651Z
+
+## Task
+
+- Task: `202605292132-QRQK1M`
+- Title: Preserve staged index on policy hook refusal
+- Status: DOING
+- Branch: `task/202605292132-QRQK1M/preserve-policy-hook-index`
+- Canonical task record: `.agentplane/tasks/202605292132-QRQK1M/README.md`
+
+## Verification
+
+- State: ok
+- Note: Focused regression passes: bun test packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts -t 'hooks run pre-commit blocks AGENTS.md without env override'. Static checks pass: bun run typecheck, bun run lint:core, bun run format:check, node .agentplane/policy/check-routing.mjs.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-29T21:33:04.651Z
+- Branch: task/202605292132-QRQK1M/preserve-policy-hook-index
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605292132-QRQK1M/quality/20260529-213831533-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605292132-QRQK1M/quality/20260529-213831533-recovery-context/evaluator-opinion.md
@@ -1,0 +1,19 @@
+# EVALUATOR opinion: pass
+
+Issue #4313 regression coverage is present and hosted PR #4321 checks are green.
+
+## Findings
+- PASS: managed pre-commit protected-policy refusal preserves AGENTS.md in the staged index, and retry with AGENTPLANE_ALLOW_POLICY=1 succeeds without restaging.
+
+## Evidence
+- .agentplane/tasks/202605292132-QRQK1M/README.md
+- PR #4321 required checks passed
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202605292132-QRQK1M/quality/20260529-213831533-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605292132-QRQK1M/quality/20260529-213831533-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605292132-QRQK1M
+- task_readme: .agentplane/tasks/202605292132-QRQK1M/README.md
+- report_path: .agentplane/tasks/202605292132-QRQK1M/quality/20260529-213831533-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605292132-QRQK1M/quality/20260529-213831533-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605292132-QRQK1M/quality/20260529-213831533-recovery-context/quality-report.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "task_id": "202605292132-QRQK1M",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-29T21:38:31.533Z",
+  "verdict": "pass",
+  "summary": "Issue #4313 regression coverage is present and hosted PR #4321 checks are green.",
+  "evaluated_sha": "c711524a983a10ffa0fc4a21874ea6812b8ec673",
+  "blueprint_digest": "332d0080b09edf570920448a9f3dcbec331be6b0f345b7476c52da7b9ad08565",
+  "findings": [
+    "PASS: managed pre-commit protected-policy refusal preserves AGENTS.md in the staged index, and retry with AGENTPLANE_ALLOW_POLICY=1 succeeds without restaging."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605292132-QRQK1M/README.md",
+    "PR #4321 required checks passed"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts
@@ -322,6 +322,18 @@ describe("runCli hooks pre-commit guards", () => {
       expect(code).toBe(5);
       expect(io.stderr).toContain("AGENTS.md is protected by agentplane hooks");
       expect(io.stderr).toContain("AGENTPLANE_ALLOW_POLICY=1");
+      const stagedAfterRefusal = await execFileAsync("git", ["diff", "--cached", "--name-only"], {
+        cwd: root,
+      });
+      expect(stagedAfterRefusal.stdout.trim()).toBe("AGENTS.md");
+
+      process.env.AGENTPLANE_ALLOW_POLICY = "1";
+      const retryCode = await runCli(["hooks", "run", "pre-commit", "--root", root]);
+      expect(retryCode).toBe(0);
+      const stagedAfterRetry = await execFileAsync("git", ["diff", "--cached", "--name-only"], {
+        cwd: root,
+      });
+      expect(stagedAfterRetry.stdout.trim()).toBe("AGENTS.md");
     } finally {
       io.restore();
       restoreEnv("AGENTPLANE_ALLOW_POLICY", prev);


### PR DESCRIPTION
Task: `202605292132-QRQK1M`
Title: Preserve staged index on policy hook refusal
Canonical task record: `.agentplane/tasks/202605292132-QRQK1M/README.md`

## Summary

Preserve staged index on policy hook refusal

Add regression coverage for GitHub issue #4313 so managed pre-commit protected-policy refusal preserves the staged index for retry with AGENTPLANE_ALLOW_POLICY=1.

## Scope

- In scope: Add regression coverage for GitHub issue #4313 so managed pre-commit protected-policy refusal preserves the staged index for retry with AGENTPLANE_ALLOW_POLICY=1.
- Out of scope: unrelated refactors not required for "Preserve staged index on policy hook refusal".

## Verification

- State: ok
- Note:

```text
Focused regression passes: bun test
packages/agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts -t 'hooks run pre-commit blocks
AGENTS.md without env override'. Static checks pass: bun run typecheck, bun run lint:core, bun run
format:check, node .agentplane/policy/check-routing.mjs.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-29T21:33:04.651Z
- Branch: task/202605292132-QRQK1M/preserve-policy-hook-index
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../agentplane/src/cli/run-cli.core.hooks.pre-commit.test.ts | 12 ++++++++++++
 1 file changed, 12 insertions(+)
```

</details>
