### PR TITLE
🚧 6Z78YD task: Require final untracked artifact audit [202605310631-6Z78YD]

### DIFF
--- a/.agentplane/policy/dod.core.md
+++ b/.agentplane/policy/dod.core.md
@@ -10,7 +10,7 @@ The task is complete only if all core checks are true:
 4. Required task documentation sections are populated.
 5. Verification steps are executed and results recorded.
 6. Drift was either absent or explicitly re-approved.
-7. Final repo state contains no unintended tracked changes.
+7. Final repo state contains no unintended tracked changes or unreviewed untracked artifacts; final evidence includes `git status --short --untracked-files=all`.
 
 <!-- /ap:fragment -->
 <!-- ap:fragment id="policy.dod.core.body.required.task.readme.contract" slot="body" mutability="replaceable" -->

--- a/.agentplane/tasks/202605310631-6Z78YD/README.md
+++ b/.agentplane/tasks/202605310631-6Z78YD/README.md
@@ -4,7 +4,7 @@ title: "Require final untracked artifact audit"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 7
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -25,6 +25,22 @@ verification:
   updated_by: "CODER"
   note: "Implemented final untracked artifact audit guidance across policy, bootstrap, preflight, finish diagnostics, docs, and tests. Checks passed: policy routing, Vitest targeted suite, bootstrap doc freshness, format:changed, doctor, preflight, and explicit git status --short --untracked-files=all review."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-31T06:40:50.902Z"
+  updated_by: "EVALUATOR"
+  note: "Final untracked artifact audit contract is implemented and covered by targeted tests."
+  evaluated_sha: "e81a505bee4d4264e548eb090d38692e74620629"
+  blueprint_digest: "45466522adf83962cc72bf150992932ca73f856e8ff9374524f3db709954eb58"
+  evidence_refs:
+    - ".agentplane/tasks/202605310631-6Z78YD/README.md"
+    - ".agentplane/tasks/202605310631-6Z78YD/quality/20260531-064050902-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605310631-6Z78YD/quality/20260531-064050902-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605310631-6Z78YD/quality/20260531-064050902-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605310631-6Z78YD/blueprint/resolved-snapshot.json"
+    - "node .agentplane/policy/check-routing.mjs; bunx vitest run packages/agentplane/src/cli/command-guide.test.ts packages/agentplane/src/cli/run-cli.core.branch-meta.readiness.test.ts packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts packages/agentplane/src/commands/task/finish.state.unit.test.ts; bun run docs:bootstrap:check; bun run format:changed; ap doctor; ap preflight --mode quick --role ORCHESTRATOR; git status --short --untracked-files=all"
+  findings:
+    - "Policy, bootstrap, preflight, finish diagnostics, and generated docs now require or surface git status --short --untracked-files=all without converting active parallel task README artifacts into blanket blockers."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202605310631-6Z78YD/README.md
+++ b/.agentplane/tasks/202605310631-6Z78YD/README.md
@@ -1,0 +1,164 @@
+---
+id: "202605310631-6Z78YD"
+title: "Require final untracked artifact audit"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 7
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "git"
+  - "lifecycle"
+  - "policy"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-31T06:32:16.010Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-31T06:38:55.691Z"
+  updated_by: "CODER"
+  note: "Implemented final untracked artifact audit guidance across policy, bootstrap, preflight, finish diagnostics, docs, and tests. Checks passed: policy routing, Vitest targeted suite, bootstrap doc freshness, format:changed, doctor, preflight, and explicit git status --short --untracked-files=all review."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement the approved final untracked artifact audit contract in the dedicated branch_pr worktree, keeping policy, CLI guidance, docs, and tests scoped to closeout visibility."
+events:
+  -
+    type: "status"
+    at: "2026-05-31T06:33:45.425Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement the approved final untracked artifact audit contract in the dedicated branch_pr worktree, keeping policy, CLI guidance, docs, and tests scoped to closeout visibility."
+  -
+    type: "verify"
+    at: "2026-05-31T06:38:55.691Z"
+    author: "CODER"
+    state: "ok"
+    note: "Implemented final untracked artifact audit guidance across policy, bootstrap, preflight, finish diagnostics, docs, and tests. Checks passed: policy routing, Vitest targeted suite, bootstrap doc freshness, format:changed, doctor, preflight, and explicit git status --short --untracked-files=all review."
+doc_version: 3
+doc_updated_at: "2026-05-31T06:38:55.708Z"
+doc_updated_by: "CODER"
+description: "Make AgentPlane closeout guidance require an explicit final git status with --untracked-files=all so agents cannot miss generated task or quality artifacts before reporting completion."
+sections:
+  Summary: |-
+    Require final untracked artifact audit
+
+    Make AgentPlane closeout guidance require an explicit final git status with --untracked-files=all so agents cannot miss generated task or quality artifacts before reporting completion.
+  Scope: |-
+    - In scope: Make AgentPlane closeout guidance require an explicit final git status with --untracked-files=all so agents cannot miss generated task or quality artifacts before reporting completion.
+    - Out of scope: unrelated refactors not required for "Require final untracked artifact audit".
+  Plan: |-
+    1. Update policy and bootstrap guidance so final closeout requires explicit full untracked visibility via git status --short --untracked-files=all.
+    2. Update CLI quickstart/preflight user-facing text and generated docs so agents see the full-status requirement before and after work.
+    3. Add or update targeted tests that lock the command/guidance contract and protect active parallel task README classification from becoming a blanket untracked blocker.
+    4. Run policy routing, targeted CLI tests, and a local preflight/status proof with --untracked-files=all before integration.
+  Verify Steps: |-
+    - Command: node .agentplane/policy/check-routing.mjs; Expect: policy routing and line-budget checks pass after policy/gateway edits.
+    - Command: bunx vitest run packages/agentplane/src/cli/command-guide.test.ts packages/agentplane/src/cli/run-cli.core.branch-meta.readiness.test.ts packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts packages/agentplane/src/commands/task/finish.state.unit.test.ts; Expect: quickstart/preflight/finish guidance covers final --untracked-files=all visibility and existing task-artifact classification remains bounded.
+    - Command: bun run docs:bootstrap:check; Expect: generated bootstrap docs stay aligned with the CLI renderer.
+    - Command: bun run format:changed; Expect: changed files satisfy Prettier.
+    - Command: ap doctor; Expect: workspace and workflow doctor pass with no errors.
+    - Command: ap preflight --mode quick --role ORCHESTRATOR; Expect: local backend loads active tasks and preflight reports both tracked-only status and full artifact-audit next actions.
+    - Command: git status --short --untracked-files=all; Expect: final report explicitly lists or confirms absence of untracked artifacts before closeout.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-31T06:38:55.691Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Implemented final untracked artifact audit guidance across policy, bootstrap, preflight, finish diagnostics, docs, and tests. Checks passed: policy routing, Vitest targeted suite, bootstrap doc freshness, format:changed, doctor, preflight, and explicit git status --short --untracked-files=all review.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-31T06:38:37.758Z, excerpt_hash=sha256:ad115caf15572ef94811d30f0f05477ec95a37749478a506608f948d939ba3d1
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605310631-6Z78YD-require-final-untracked-artifact-audit/.agentplane/tasks/202605310631-6Z78YD/blueprint/resolved-snapshot.json
+    - old_digest: 45466522adf83962cc72bf150992932ca73f856e8ff9374524f3db709954eb58
+    - current_digest: 45466522adf83962cc72bf150992932ca73f856e8ff9374524f3db709954eb58
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605310631-6Z78YD
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Closeout guidance previously allowed agents to stop at tracked-only status or directory-collapsed git status output.
+      Impact: Generated task, PR, or quality artifacts could remain unreviewed and uncommitted after finish/reporting.
+      Resolution: Require full untracked artifact visibility in final evidence and surface git status --short --untracked-files=all in bootstrap, preflight next actions, DoD, and finish diagnostics.
+id_source: "generated"
+---
+## Summary
+
+Require final untracked artifact audit
+
+Make AgentPlane closeout guidance require an explicit final git status with --untracked-files=all so agents cannot miss generated task or quality artifacts before reporting completion.
+
+## Scope
+
+- In scope: Make AgentPlane closeout guidance require an explicit final git status with --untracked-files=all so agents cannot miss generated task or quality artifacts before reporting completion.
+- Out of scope: unrelated refactors not required for "Require final untracked artifact audit".
+
+## Plan
+
+1. Update policy and bootstrap guidance so final closeout requires explicit full untracked visibility via git status --short --untracked-files=all.
+2. Update CLI quickstart/preflight user-facing text and generated docs so agents see the full-status requirement before and after work.
+3. Add or update targeted tests that lock the command/guidance contract and protect active parallel task README classification from becoming a blanket untracked blocker.
+4. Run policy routing, targeted CLI tests, and a local preflight/status proof with --untracked-files=all before integration.
+
+## Verify Steps
+
+- Command: node .agentplane/policy/check-routing.mjs; Expect: policy routing and line-budget checks pass after policy/gateway edits.
+- Command: bunx vitest run packages/agentplane/src/cli/command-guide.test.ts packages/agentplane/src/cli/run-cli.core.branch-meta.readiness.test.ts packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts packages/agentplane/src/commands/task/finish.state.unit.test.ts; Expect: quickstart/preflight/finish guidance covers final --untracked-files=all visibility and existing task-artifact classification remains bounded.
+- Command: bun run docs:bootstrap:check; Expect: generated bootstrap docs stay aligned with the CLI renderer.
+- Command: bun run format:changed; Expect: changed files satisfy Prettier.
+- Command: ap doctor; Expect: workspace and workflow doctor pass with no errors.
+- Command: ap preflight --mode quick --role ORCHESTRATOR; Expect: local backend loads active tasks and preflight reports both tracked-only status and full artifact-audit next actions.
+- Command: git status --short --untracked-files=all; Expect: final report explicitly lists or confirms absence of untracked artifacts before closeout.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-31T06:38:55.691Z — VERIFY — ok
+
+By: CODER
+
+Note: Implemented final untracked artifact audit guidance across policy, bootstrap, preflight, finish diagnostics, docs, and tests. Checks passed: policy routing, Vitest targeted suite, bootstrap doc freshness, format:changed, doctor, preflight, and explicit git status --short --untracked-files=all review.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-31T06:38:37.758Z, excerpt_hash=sha256:ad115caf15572ef94811d30f0f05477ec95a37749478a506608f948d939ba3d1
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605310631-6Z78YD-require-final-untracked-artifact-audit/.agentplane/tasks/202605310631-6Z78YD/blueprint/resolved-snapshot.json
+- old_digest: 45466522adf83962cc72bf150992932ca73f856e8ff9374524f3db709954eb58
+- current_digest: 45466522adf83962cc72bf150992932ca73f856e8ff9374524f3db709954eb58
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605310631-6Z78YD
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Closeout guidance previously allowed agents to stop at tracked-only status or directory-collapsed git status output.
+  Impact: Generated task, PR, or quality artifacts could remain unreviewed and uncommitted after finish/reporting.
+  Resolution: Require full untracked artifact visibility in final evidence and surface git status --short --untracked-files=all in bootstrap, preflight next actions, DoD, and finish diagnostics.

--- a/.agentplane/tasks/202605310631-6Z78YD/README.md
+++ b/.agentplane/tasks/202605310631-6Z78YD/README.md
@@ -4,7 +4,7 @@ title: "Require final untracked artifact audit"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 8
+revision: 9
 origin:
   system: "manual"
 depends_on: []
@@ -27,20 +27,20 @@ verification:
   attempts: 0
 quality_review:
   state: "pass"
-  updated_at: "2026-05-31T06:40:50.902Z"
+  updated_at: "2026-05-31T06:50:47.500Z"
   updated_by: "EVALUATOR"
-  note: "Final untracked artifact audit contract is implemented and covered by targeted tests."
-  evaluated_sha: "e81a505bee4d4264e548eb090d38692e74620629"
+  note: "Final untracked artifact audit contract is implemented and CI-contract fixes are covered."
+  evaluated_sha: "c479ae2fe3864fe2d60bc8983cd97156e59c0693"
   blueprint_digest: "45466522adf83962cc72bf150992932ca73f856e8ff9374524f3db709954eb58"
   evidence_refs:
     - ".agentplane/tasks/202605310631-6Z78YD/README.md"
-    - ".agentplane/tasks/202605310631-6Z78YD/quality/20260531-064050902-recovery-context/quality-report.json"
-    - ".agentplane/tasks/202605310631-6Z78YD/quality/20260531-064050902-recovery-context/evaluator-prompt.md"
-    - ".agentplane/tasks/202605310631-6Z78YD/quality/20260531-064050902-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605310631-6Z78YD/quality/20260531-065047500-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605310631-6Z78YD/quality/20260531-065047500-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605310631-6Z78YD/quality/20260531-065047500-recovery-context/evaluator-opinion.md"
     - ".agentplane/tasks/202605310631-6Z78YD/blueprint/resolved-snapshot.json"
-    - "node .agentplane/policy/check-routing.mjs; bunx vitest run packages/agentplane/src/cli/command-guide.test.ts packages/agentplane/src/cli/run-cli.core.branch-meta.readiness.test.ts packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts packages/agentplane/src/commands/task/finish.state.unit.test.ts; bun run docs:bootstrap:check; bun run format:changed; ap doctor; ap preflight --mode quick --role ORCHESTRATOR; git status --short --untracked-files=all"
+    - "bun run agents:check; bun run lint:core; bun run format:changed; bunx vitest run packages/agentplane/src/cli/command-guide.test.ts packages/agentplane/src/cli/run-cli.core.branch-meta.readiness.test.ts packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts packages/agentplane/src/commands/task/finish.state.unit.test.ts packages/agentplane/src/agents/agents-template.test.ts; bun run docs:bootstrap:check; bunx vitest run packages/agentplane/src/cli/release-smoke.test.ts -t 'upgrade --migrate-task-docs repairs incomplete policy tree drift'; bunx vitest run packages/agentplane/src/commands/release/bun-compiled-cli-smoke-script.test.ts"
   findings:
-    - "Policy, bootstrap, preflight, finish diagnostics, and generated docs now require or surface git status --short --untracked-files=all without converting active parallel task README artifacts into blanket blockers."
+    - "The implementation now updates both repo policy and bundled policy assets, uses lint-safe preflight next-action insertion, and keeps the finish diagnostic assertion type-safe."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202605310631-6Z78YD/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605310631-6Z78YD/blueprint/resolved-snapshot.json
@@ -1,0 +1,573 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605310631-6Z78YD",
+    "title": "Require final untracked artifact audit",
+    "description": "Make AgentPlane closeout guidance require an explicit final git status with --untracked-files=all so agents cannot miss generated task or quality artifacts before reporting completion.",
+    "tags": [
+      "code",
+      "git",
+      "lifecycle",
+      "policy"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605310631-6Z78YD",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "45466522adf83962cc72bf150992932ca73f856e8ff9374524f3db709954eb58"
+  }
+}

--- a/.agentplane/tasks/202605310631-6Z78YD/pr/diffstat.txt
+++ b/.agentplane/tasks/202605310631-6Z78YD/pr/diffstat.txt
@@ -1,0 +1,12 @@
+ .agentplane/policy/dod.core.md                     |  2 +-
+ docs/user/agent-bootstrap.generated.mdx            |  6 ++--
+ docs/user/task-lifecycle.mdx                       |  4 +--
+ docs/user/workflow.mdx                             |  2 +-
+ packages/agentplane/assets/AGENTS.md               |  2 +-
+ packages/agentplane/src/cli/bootstrap-guide.ts     |  4 +--
+ packages/agentplane/src/cli/command-guide.test.ts  |  4 +--
+ .../cli/run-cli.core.branch-meta.readiness.test.ts | 33 ++++++++++++++++++++++
+ .../cli/run-cli/commands/core/preflight-report.ts  |  4 +++
+ .../src/commands/task/finish-execute-close.ts      |  6 ++--
+ .../src/commands/task/finish.state.unit.test.ts    |  3 ++
+ 11 files changed, 56 insertions(+), 14 deletions(-)

--- a/.agentplane/tasks/202605310631-6Z78YD/pr/github-body.md
+++ b/.agentplane/tasks/202605310631-6Z78YD/pr/github-body.md
@@ -34,7 +34,18 @@ review.
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .agentplane/policy/dod.core.md                     |  2 +-
+ docs/user/agent-bootstrap.generated.mdx            |  6 ++--
+ docs/user/task-lifecycle.mdx                       |  4 +--
+ docs/user/workflow.mdx                             |  2 +-
+ packages/agentplane/assets/AGENTS.md               |  2 +-
+ packages/agentplane/src/cli/bootstrap-guide.ts     |  4 +--
+ packages/agentplane/src/cli/command-guide.test.ts  |  4 +--
+ .../cli/run-cli.core.branch-meta.readiness.test.ts | 33 ++++++++++++++++++++++
+ .../cli/run-cli/commands/core/preflight-report.ts  |  4 +++
+ .../src/commands/task/finish-execute-close.ts      |  6 ++--
+ .../src/commands/task/finish.state.unit.test.ts    |  3 ++
+ 11 files changed, 56 insertions(+), 14 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605310631-6Z78YD/pr/github-body.md
+++ b/.agentplane/tasks/202605310631-6Z78YD/pr/github-body.md
@@ -1,0 +1,40 @@
+Task: `202605310631-6Z78YD`
+Title: Require final untracked artifact audit
+Canonical task record: `.agentplane/tasks/202605310631-6Z78YD/README.md`
+
+## Summary
+
+Require final untracked artifact audit
+
+Make AgentPlane closeout guidance require an explicit final git status with --untracked-files=all so agents cannot miss generated task or quality artifacts before reporting completion.
+
+## Scope
+
+- In scope: Make AgentPlane closeout guidance require an explicit final git status with --untracked-files=all so agents cannot miss generated task or quality artifacts before reporting completion.
+- Out of scope: unrelated refactors not required for "Require final untracked artifact audit".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Implemented final untracked artifact audit guidance across policy, bootstrap, preflight, finish
+diagnostics, docs, and tests. Checks passed: policy routing, Vitest targeted suite, bootstrap doc
+freshness, format:changed, doctor, preflight, and explicit git status --short --untracked-files=all
+review.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-31T06:33:45.472Z
+- Branch: task/202605310631-6Z78YD/require-final-untracked-artifact-audit
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202605310631-6Z78YD/pr/github-title.txt
+++ b/.agentplane/tasks/202605310631-6Z78YD/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 6Z78YD task: Require final untracked artifact audit [202605310631-6Z78YD]

--- a/.agentplane/tasks/202605310631-6Z78YD/pr/meta.json
+++ b/.agentplane/tasks/202605310631-6Z78YD/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605310631-6Z78YD/require-final-untracked-artifact-audit",
+  "created_at": "2026-05-31T06:33:45.472Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": "2026-05-31T06:38:55.691Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202605310631-6Z78YD",
+  "updated_at": "2026-05-31T06:33:45.472Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605310631-6Z78YD/pr/meta.json
+++ b/.agentplane/tasks/202605310631-6Z78YD/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202605310631-6Z78YD/require-final-untracked-artifact-audit",
   "created_at": "2026-05-31T06:33:45.472Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "diffstat_sha256": "sha256:f404359a245e4ab7118046ea313876c267983e99818d142dcaa06050f7fa0cda",
   "last_verified_at": "2026-05-31T06:38:55.691Z",
   "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "schema_version": 1,

--- a/.agentplane/tasks/202605310631-6Z78YD/pr/review.md
+++ b/.agentplane/tasks/202605310631-6Z78YD/pr/review.md
@@ -29,7 +29,18 @@ Created: 2026-05-31T06:33:45.472Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .agentplane/policy/dod.core.md                     |  2 +-
+ docs/user/agent-bootstrap.generated.mdx            |  6 ++--
+ docs/user/task-lifecycle.mdx                       |  4 +--
+ docs/user/workflow.mdx                             |  2 +-
+ packages/agentplane/assets/AGENTS.md               |  2 +-
+ packages/agentplane/src/cli/bootstrap-guide.ts     |  4 +--
+ packages/agentplane/src/cli/command-guide.test.ts  |  4 +--
+ .../cli/run-cli.core.branch-meta.readiness.test.ts | 33 ++++++++++++++++++++++
+ .../cli/run-cli/commands/core/preflight-report.ts  |  4 +++
+ .../src/commands/task/finish-execute-close.ts      |  6 ++--
+ .../src/commands/task/finish.state.unit.test.ts    |  3 ++
+ 11 files changed, 56 insertions(+), 14 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202605310631-6Z78YD/pr/review.md
+++ b/.agentplane/tasks/202605310631-6Z78YD/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-05-31T06:33:45.472Z
+
+## Task
+
+- Task: `202605310631-6Z78YD`
+- Title: Require final untracked artifact audit
+- Status: DOING
+- Branch: `task/202605310631-6Z78YD/require-final-untracked-artifact-audit`
+- Canonical task record: `.agentplane/tasks/202605310631-6Z78YD/README.md`
+
+## Verification
+
+- State: ok
+- Note: Implemented final untracked artifact audit guidance across policy, bootstrap, preflight, finish diagnostics, docs, and tests. Checks passed: policy routing, Vitest targeted suite, bootstrap doc freshness, format:changed, doctor, preflight, and explicit git status --short --untracked-files=all review.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-31T06:33:45.472Z
+- Branch: task/202605310631-6Z78YD/require-final-untracked-artifact-audit
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202605310631-6Z78YD/quality/20260531-064050902-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605310631-6Z78YD/quality/20260531-064050902-recovery-context/evaluator-opinion.md
@@ -1,0 +1,19 @@
+# EVALUATOR opinion: pass
+
+Final untracked artifact audit contract is implemented and covered by targeted tests.
+
+## Findings
+- Policy, bootstrap, preflight, finish diagnostics, and generated docs now require or surface git status --short --untracked-files=all without converting active parallel task README artifacts into blanket blockers.
+
+## Evidence
+- .agentplane/tasks/202605310631-6Z78YD/README.md
+- node .agentplane/policy/check-routing.mjs; bunx vitest run packages/agentplane/src/cli/command-guide.test.ts packages/agentplane/src/cli/run-cli.core.branch-meta.readiness.test.ts packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts packages/agentplane/src/commands/task/finish.state.unit.test.ts; bun run docs:bootstrap:check; bun run format:changed; ap doctor; ap preflight --mode quick --role ORCHESTRATOR; git status --short --untracked-files=all
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- Untracked active parallel task README files remain visible by design and are not treated as automatic failure unless their artifact class is unknown/actionable.

--- a/.agentplane/tasks/202605310631-6Z78YD/quality/20260531-064050902-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605310631-6Z78YD/quality/20260531-064050902-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605310631-6Z78YD
+- task_readme: .agentplane/tasks/202605310631-6Z78YD/README.md
+- report_path: .agentplane/tasks/202605310631-6Z78YD/quality/20260531-064050902-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605310631-6Z78YD/quality/20260531-064050902-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605310631-6Z78YD/quality/20260531-064050902-recovery-context/quality-report.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "task_id": "202605310631-6Z78YD",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-31T06:40:50.902Z",
+  "verdict": "pass",
+  "summary": "Final untracked artifact audit contract is implemented and covered by targeted tests.",
+  "evaluated_sha": "e81a505bee4d4264e548eb090d38692e74620629",
+  "blueprint_digest": "45466522adf83962cc72bf150992932ca73f856e8ff9374524f3db709954eb58",
+  "findings": [
+    "Policy, bootstrap, preflight, finish diagnostics, and generated docs now require or surface git status --short --untracked-files=all without converting active parallel task README artifacts into blanket blockers."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605310631-6Z78YD/README.md",
+    "node .agentplane/policy/check-routing.mjs; bunx vitest run packages/agentplane/src/cli/command-guide.test.ts packages/agentplane/src/cli/run-cli.core.branch-meta.readiness.test.ts packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts packages/agentplane/src/commands/task/finish.state.unit.test.ts; bun run docs:bootstrap:check; bun run format:changed; ap doctor; ap preflight --mode quick --role ORCHESTRATOR; git status --short --untracked-files=all"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": [
+    "Untracked active parallel task README files remain visible by design and are not treated as automatic failure unless their artifact class is unknown/actionable."
+  ]
+}

--- a/.agentplane/tasks/202605310631-6Z78YD/quality/20260531-065047500-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605310631-6Z78YD/quality/20260531-065047500-recovery-context/evaluator-opinion.md
@@ -1,0 +1,19 @@
+# EVALUATOR opinion: pass
+
+Final untracked artifact audit contract is implemented and CI-contract fixes are covered.
+
+## Findings
+- The implementation now updates both repo policy and bundled policy assets, uses lint-safe preflight next-action insertion, and keeps the finish diagnostic assertion type-safe.
+
+## Evidence
+- .agentplane/tasks/202605310631-6Z78YD/README.md
+- bun run agents:check; bun run lint:core; bun run format:changed; bunx vitest run packages/agentplane/src/cli/command-guide.test.ts packages/agentplane/src/cli/run-cli.core.branch-meta.readiness.test.ts packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts packages/agentplane/src/commands/task/finish.state.unit.test.ts packages/agentplane/src/agents/agents-template.test.ts; bun run docs:bootstrap:check; bunx vitest run packages/agentplane/src/cli/release-smoke.test.ts -t 'upgrade --migrate-task-docs repairs incomplete policy tree drift'; bunx vitest run packages/agentplane/src/commands/release/bun-compiled-cli-smoke-script.test.ts
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- Full test:fast was interrupted by pre-rebuild/stale-dist and policy-asset failures before the fixes; the two failed test targets were rerun and passed after the fixes.

--- a/.agentplane/tasks/202605310631-6Z78YD/quality/20260531-065047500-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605310631-6Z78YD/quality/20260531-065047500-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605310631-6Z78YD
+- task_readme: .agentplane/tasks/202605310631-6Z78YD/README.md
+- report_path: .agentplane/tasks/202605310631-6Z78YD/quality/20260531-065047500-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605310631-6Z78YD/quality/20260531-065047500-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605310631-6Z78YD/quality/20260531-065047500-recovery-context/quality-report.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "task_id": "202605310631-6Z78YD",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-31T06:50:47.500Z",
+  "verdict": "pass",
+  "summary": "Final untracked artifact audit contract is implemented and CI-contract fixes are covered.",
+  "evaluated_sha": "c479ae2fe3864fe2d60bc8983cd97156e59c0693",
+  "blueprint_digest": "45466522adf83962cc72bf150992932ca73f856e8ff9374524f3db709954eb58",
+  "findings": [
+    "The implementation now updates both repo policy and bundled policy assets, uses lint-safe preflight next-action insertion, and keeps the finish diagnostic assertion type-safe."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605310631-6Z78YD/README.md",
+    "bun run agents:check; bun run lint:core; bun run format:changed; bunx vitest run packages/agentplane/src/cli/command-guide.test.ts packages/agentplane/src/cli/run-cli.core.branch-meta.readiness.test.ts packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts packages/agentplane/src/commands/task/finish.state.unit.test.ts packages/agentplane/src/agents/agents-template.test.ts; bun run docs:bootstrap:check; bunx vitest run packages/agentplane/src/cli/release-smoke.test.ts -t 'upgrade --migrate-task-docs repairs incomplete policy tree drift'; bunx vitest run packages/agentplane/src/commands/release/bun-compiled-cli-smoke-script.test.ts"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": [
+    "Full test:fast was interrupted by pre-rebuild/stale-dist and policy-asset failures before the fixes; the two failed test targets were rerun and passed after the fixes."
+  ]
+}

--- a/docs/user/agent-bootstrap.generated.mdx
+++ b/docs/user/agent-bootstrap.generated.mdx
@@ -15,7 +15,7 @@ agentplane quickstart
 agentplane task list
 agentplane task active
 git status --short --untracked-files=no
-git status --short
+git status --short --untracked-files=all
 git rev-parse --abbrev-ref HEAD
 ```
 
@@ -30,11 +30,11 @@ Establish workflow mode, current branch, active task candidates, tracked-only cl
 - `agentplane task list`
 - `agentplane task active`
 - `git status --short --untracked-files=no`
-- `git status --short`
+- `git status --short --untracked-files=all`
 - `git rev-parse --abbrev-ref HEAD`
 
 - Run this before any mutation.
-- `git status --short --untracked-files=no` is tracked-only; `git status --short` also exposes untracked files.
+- `git status --short --untracked-files=no` is tracked-only; `git status --short --untracked-files=all` is the final artifact audit.
 - If the project is not initialized, stop and use `agentplane init`; otherwise use `task brief <task-id>` before owner-scoped execution.
 
 ## 2. Agent context

--- a/docs/user/task-lifecycle.mdx
+++ b/docs/user/task-lifecycle.mdx
@@ -24,7 +24,7 @@ agentplane config show
 agentplane quickstart
 agentplane task list
 git status --short --untracked-files=no
-git status --short
+git status --short --untracked-files=all
 agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree
 agentplane task start-ready <task-id> --author <ROLE> --body "Start: ..."
 git add <changed-files>
@@ -82,7 +82,7 @@ agentplane config show
 agentplane quickstart
 agentplane task list
 git status --short --untracked-files=no
-git status --short
+git status --short --untracked-files=all
 agentplane task start-ready <task-id> --author <ROLE> --body "Start: ..."
 agentplane task verify-show <task-id>
 agentplane verify <task-id> --ok|--rework --by <ROLE> --note "..."

--- a/docs/user/workflow.mdx
+++ b/docs/user/workflow.mdx
@@ -32,7 +32,7 @@ agentplane config show
 agentplane quickstart
 agentplane task list
 git status --short --untracked-files=no
-git status --short
+git status --short --untracked-files=all
 agentplane work start <task-id> --agent CODER --slug <slug> --worktree
 cd .agentplane/worktrees/<task-id>-<slug>
 agentplane task start-ready <task-id> --author CODER --body "Start: ..."

--- a/packages/agentplane/assets/AGENTS.md
+++ b/packages/agentplane/assets/AGENTS.md
@@ -62,7 +62,7 @@ ap quickstart
 ap task list
 ap task active
 git status --short --untracked-files=no
-git status --short
+git status --short --untracked-files=all
 git rev-parse --abbrev-ref HEAD
 ```
 

--- a/packages/agentplane/assets/policy/dod.core.md
+++ b/packages/agentplane/assets/policy/dod.core.md
@@ -10,7 +10,7 @@ The task is complete only if all core checks are true:
 4. Required task documentation sections are populated.
 5. Verification steps are executed and results recorded.
 6. Drift was either absent or explicitly re-approved.
-7. Final repo state contains no unintended tracked changes.
+7. Final repo state contains no unintended tracked changes or unreviewed untracked artifacts; final evidence includes `git status --short --untracked-files=all`.
 
 <!-- /ap:fragment -->
 <!-- ap:fragment id="policy.dod.core.body.required.task.readme.contract" slot="body" mutability="replaceable" -->

--- a/packages/agentplane/src/cli/bootstrap-guide.ts
+++ b/packages/agentplane/src/cli/bootstrap-guide.ts
@@ -17,7 +17,7 @@ export const BOOTSTRAP_PREFLIGHT_COMMANDS = [
   COMMAND_SNIPPETS.core.taskList,
   COMMAND_SNIPPETS.core.taskActive,
   "git status --short --untracked-files=no",
-  "git status --short",
+  "git status --short --untracked-files=all",
   "git rev-parse --abbrev-ref HEAD",
 ] as const;
 
@@ -64,7 +64,7 @@ const BOOTSTRAP_SECTIONS: readonly BootstrapSection[] = [
     commands: BOOTSTRAP_PREFLIGHT_COMMANDS,
     notes: [
       "Run this before any mutation.",
-      "`git status --short --untracked-files=no` is tracked-only; `git status --short` also exposes untracked files.",
+      "`git status --short --untracked-files=no` is tracked-only; `git status --short --untracked-files=all` is the final artifact audit.",
       "If the project is not initialized, stop and use `agentplane init`; otherwise use `task brief <task-id>` before owner-scoped execution.",
     ],
   },

--- a/packages/agentplane/src/cli/command-guide.test.ts
+++ b/packages/agentplane/src/cli/command-guide.test.ts
@@ -90,7 +90,7 @@ describe("command-guide", () => {
     expect(text).toContain("authoritative_checkout");
     expect(text).toContain("primary_blocker");
     expect(text).toContain("git status --short --untracked-files=no");
-    expect(text).toContain("\ngit status --short\n");
+    expect(text).toContain("\ngit status --short --untracked-files=all\n");
     expect(text).toContain("source confidence");
     expect(text).toContain("agentplane task start-ready");
     expect(text).toContain("agentplane pr check <task-id>");
@@ -119,7 +119,7 @@ describe("command-guide", () => {
     expect(text).toContain("authoritative_checkout");
     expect(text).toContain("tracked-only cleanliness");
     expect(text).toContain("git status --short --untracked-files=no");
-    expect(text).toContain("\n- `git status --short`\n");
+    expect(text).toContain("\n- `git status --short --untracked-files=all`\n");
     expect(text).toContain("source confidence");
     expect(text).toContain("Use `agentplane role ORCHESTRATOR` during planning");
     expect(text).toContain("agentplane incidents advise <task-id>");

--- a/packages/agentplane/src/cli/run-cli.core.branch-meta.readiness.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.branch-meta.readiness.test.ts
@@ -379,6 +379,39 @@ describe("runCli", () => {
     }
   });
 
+  it("preflight --json suggests a full artifact audit when tracked files are dirty", async () => {
+    const root = await mkGitRepoRoot();
+    await writeDefaultConfig(root);
+    const execFileAsync = promisify(execFile);
+    await writeFile(path.join(root, "tracked.txt"), "clean\n", "utf8");
+    await execFileAsync("git", ["add", "tracked.txt"], { cwd: root });
+    await execFileAsync("git", ["commit", "-m", "seed tracked file"], { cwd: root });
+    await writeFile(path.join(root, "tracked.txt"), "dirty\n", "utf8");
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["preflight", "--json", "--root", root]);
+      expect(code).toBe(0);
+      const payload = JSON.parse(io.stdout) as {
+        working_tree_clean_tracked?: { value?: boolean };
+        next_actions?: { command?: string; reason?: string }[];
+      };
+      expect(payload.working_tree_clean_tracked?.value).toBe(false);
+      expect(payload.next_actions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            command: "git status --short --untracked-files=no",
+          }),
+          expect.objectContaining({
+            command: "git status --short --untracked-files=all",
+            reason: "review full working-tree artifacts before closeout",
+          }),
+        ]),
+      );
+    } finally {
+      io.restore();
+    }
+  });
+
   it("preflight --json treats active task artifacts as parallel-agent context, not harness drift", async () => {
     const root = await mkGitRepoRoot();
     await writeDefaultConfig(root);

--- a/packages/agentplane/src/cli/run-cli/commands/core/preflight-report.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/core/preflight-report.ts
@@ -272,14 +272,16 @@ export async function buildPreflightReport(opts: {
       workingTree = { ok: true, value: staged.length === 0 && unstagedTracked.length === 0 };
       if (!workingTree.value) {
         harnessHealthReasons.push("working_tree_dirty");
-        nextActions.push({
-          command: "git status --short --untracked-files=no",
-          reason: "tracked changes detected",
-        });
-        nextActions.push({
-          command: "git status --short --untracked-files=all",
-          reason: "review full working-tree artifacts before closeout",
-        });
+        nextActions.push(
+          {
+            command: "git status --short --untracked-files=no",
+            reason: "tracked changes detected",
+          },
+          {
+            command: "git status --short --untracked-files=all",
+            reason: "review full working-tree artifacts before closeout",
+          },
+        );
       }
       if (taskArtifactDrift.actionable) {
         harnessHealthReasons.push("task_artifact_drift");

--- a/packages/agentplane/src/cli/run-cli/commands/core/preflight-report.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/core/preflight-report.ts
@@ -276,6 +276,10 @@ export async function buildPreflightReport(opts: {
           command: "git status --short --untracked-files=no",
           reason: "tracked changes detected",
         });
+        nextActions.push({
+          command: "git status --short --untracked-files=all",
+          reason: "review full working-tree artifacts before closeout",
+        });
       }
       if (taskArtifactDrift.actionable) {
         harnessHealthReasons.push("task_artifact_drift");

--- a/packages/agentplane/src/commands/task/finish-execute-close.ts
+++ b/packages/agentplane/src/commands/task/finish-execute-close.ts
@@ -55,7 +55,8 @@ export async function assertCloseCommitCanMutateTaskState(opts: {
         "Why: close commit creation would fail after the task is marked DONE.",
         `Staged paths: ${staged.slice(0, 12).join(", ")}${staged.length > 12 ? ` (+${staged.length - 12} more)` : ""}`,
         "Fix: commit or unstage unrelated paths before rerunning finish, or pass --close-unstage-others to let finish unstage non-task paths first.",
-        "Safe command: git status --short --untracked-files=no",
+        "Tracked-state command: git status --short --untracked-files=no",
+        "Full artifact audit: git status --short --untracked-files=all",
       ].join("\n"),
       context: {
         command: "finish",
@@ -82,7 +83,8 @@ export async function assertCloseCommitCanMutateTaskState(opts: {
       `Why: deterministic ${ctx.config.workflow_mode} close commits stage only the finished task artifacts; other tracked changes would make commit creation fail after the task is marked DONE.`,
       `Dirty tracked paths: ${blockingUnstaged.slice(0, 12).join(", ")}${blockingUnstaged.length > 12 ? ` (+${blockingUnstaged.length - 12} more)` : ""}`,
       "Fix: commit, stash, or move unrelated lifecycle changes into a batch close branch before rerunning finish.",
-      "Safe command: git status --short --untracked-files=no",
+      "Tracked-state command: git status --short --untracked-files=no",
+      "Full artifact audit: git status --short --untracked-files=all",
     ].join("\n"),
   });
 }

--- a/packages/agentplane/src/commands/task/finish.state.unit.test.ts
+++ b/packages/agentplane/src/commands/task/finish.state.unit.test.ts
@@ -357,6 +357,9 @@ describeCompatible("task finish state and errors", () => {
       }),
     ).rejects.toMatchObject({
       code: "E_GIT",
+      message: expect.stringContaining(
+        "Full artifact audit: git status --short --untracked-files=all",
+      ),
       context: {
         reason_code: "git_close_commit_dirty_index",
         staged_paths: [".agentplane/tasks/T-2/README.md"],

--- a/packages/agentplane/src/commands/task/finish.state.unit.test.ts
+++ b/packages/agentplane/src/commands/task/finish.state.unit.test.ts
@@ -333,33 +333,32 @@ describeCompatible("task finish state and errors", () => {
     } as unknown as CommandContext["git"];
 
     const { cmdFinish } = await import("./finish-command.js");
-    await expect(
-      cmdFinish({
-        ctx,
-        cwd: "/repo",
-        taskIds: ["T-1"],
-        author: "A",
-        body: "Verified: direct finish should reject staged index before task mutation.",
-        result: "done",
-        breaking: false,
-        force: false,
-        commitFromComment: false,
-        commitAllow: [],
-        commitAutoAllow: false,
-        commitAllowTasks: false,
-        commitRequireClean: false,
-        statusCommit: false,
-        statusCommitAllow: [],
-        statusCommitAutoAllow: false,
-        statusCommitRequireClean: false,
-        confirmStatusCommit: false,
-        quiet: true,
-      }),
-    ).rejects.toMatchObject({
+    const finishAttempt = cmdFinish({
+      ctx,
+      cwd: "/repo",
+      taskIds: ["T-1"],
+      author: "A",
+      body: "Verified: direct finish should reject staged index before task mutation.",
+      result: "done",
+      breaking: false,
+      force: false,
+      commitFromComment: false,
+      commitAllow: [],
+      commitAutoAllow: false,
+      commitAllowTasks: false,
+      commitRequireClean: false,
+      statusCommit: false,
+      statusCommitAllow: [],
+      statusCommitAutoAllow: false,
+      statusCommitRequireClean: false,
+      confirmStatusCommit: false,
+      quiet: true,
+    });
+    await expect(finishAttempt).rejects.toThrow(
+      "Full artifact audit: git status --short --untracked-files=all",
+    );
+    await expect(finishAttempt).rejects.toMatchObject({
       code: "E_GIT",
-      message: expect.stringContaining(
-        "Full artifact audit: git status --short --untracked-files=all",
-      ),
       context: {
         reason_code: "git_close_commit_dirty_index",
         staged_paths: [".agentplane/tasks/T-2/README.md"],


### PR DESCRIPTION
Task: `202605310631-6Z78YD`
Title: Require final untracked artifact audit
Canonical task record: `.agentplane/tasks/202605310631-6Z78YD/README.md`

## Summary

Require final untracked artifact audit

Make AgentPlane closeout guidance require an explicit final git status with --untracked-files=all so agents cannot miss generated task or quality artifacts before reporting completion.

## Scope

- In scope: Make AgentPlane closeout guidance require an explicit final git status with --untracked-files=all so agents cannot miss generated task or quality artifacts before reporting completion.
- Out of scope: unrelated refactors not required for "Require final untracked artifact audit".

## Verification

- State: ok
- Note:

```text
Implemented final untracked artifact audit guidance across policy, bootstrap, preflight, finish
diagnostics, docs, and tests. Checks passed: policy routing, Vitest targeted suite, bootstrap doc
freshness, format:changed, doctor, preflight, and explicit git status --short --untracked-files=all
review.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-31T06:33:45.472Z
- Branch: task/202605310631-6Z78YD/require-final-untracked-artifact-audit
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .agentplane/policy/dod.core.md                     |  2 +-
 docs/user/agent-bootstrap.generated.mdx            |  6 ++--
 docs/user/task-lifecycle.mdx                       |  4 +--
 docs/user/workflow.mdx                             |  2 +-
 packages/agentplane/assets/AGENTS.md               |  2 +-
 packages/agentplane/src/cli/bootstrap-guide.ts     |  4 +--
 packages/agentplane/src/cli/command-guide.test.ts  |  4 +--
 .../cli/run-cli.core.branch-meta.readiness.test.ts | 33 ++++++++++++++++++++++
 .../cli/run-cli/commands/core/preflight-report.ts  |  4 +++
 .../src/commands/task/finish-execute-close.ts      |  6 ++--
 .../src/commands/task/finish.state.unit.test.ts    |  3 ++
 11 files changed, 56 insertions(+), 14 deletions(-)
```

</details>
