### PR TITLE
🚧 GV6ECK task: Fix verify ghost session progress output [202605310706-GV6ECK]

### DIFF
--- a/.agentplane/tasks/202605310706-GV6ECK/README.md
+++ b/.agentplane/tasks/202605310706-GV6ECK/README.md
@@ -1,0 +1,195 @@
+---
+id: "202605310706-GV6ECK"
+title: "Fix verify ghost session progress output"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 7
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "bug"
+  - "code"
+verify:
+  - "bunx vitest run packages/agentplane/src/commands/task/verify-record.unit.test.ts --config vitest.workspace.ts"
+  - "bun run typecheck"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-05-31T07:07:10.794Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-05-31T07:13:45.530Z"
+  updated_by: "CODER"
+  note: "Verified: early verify progress remains covered; focused unit test, typecheck, format:changed, check-routing, doctor, and hotspots:check pass after tightening the test under the oversized baseline."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: fix non-quiet verify progress visibility for issue #4324."
+events:
+  -
+    type: "status"
+    at: "2026-05-31T07:07:15.774Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: fix non-quiet verify progress visibility for issue #4324."
+  -
+    type: "verify"
+    at: "2026-05-31T07:09:59.445Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: early non-quiet verify progress output added before backend mutation; focused verify-record unit coverage and typecheck pass."
+  -
+    type: "verify"
+    at: "2026-05-31T07:13:45.530Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: early verify progress remains covered; focused unit test, typecheck, format:changed, check-routing, doctor, and hotspots:check pass after tightening the test under the oversized baseline."
+doc_version: 3
+doc_updated_at: "2026-05-31T07:13:45.544Z"
+doc_updated_by: "CODER"
+description: "Resolve GitHub issue #4324 by ensuring agentplane verify emits an early non-quiet progress line before backend mutation work, so cloud backend waits are visible instead of appearing as a no-output ghost session."
+sections:
+  Summary: |-
+    Fix verify ghost session progress output
+
+    Resolve GitHub issue #4324 by ensuring agentplane verify emits an early non-quiet progress line before backend mutation work, so cloud backend waits are visible instead of appearing as a no-output ghost session.
+  Scope: |-
+    - In scope: Resolve GitHub issue #4324 by ensuring agentplane verify emits an early non-quiet progress line before backend mutation work, so cloud backend waits are visible instead of appearing as a no-output ghost session.
+    - Out of scope: unrelated refactors not required for "Fix verify ghost session progress output".
+  Plan: |-
+    1. Reproduce the weak behavior in the verify record path: non-quiet verify can enter backend/reconcile/cloud work before any user-visible output.
+    2. Add a narrowly scoped early progress line for non-quiet agentplane verify before backend mutation, preserving quiet mode and existing success/error handling.
+    3. Add unit coverage proving verify emits the early line before backend work and quiet mode remains silent.
+    4. Run focused verify-record tests plus typecheck, then open/merge a branch_pr that closes GitHub issue #4324.
+  Verify Steps: |-
+    1. Command: bunx vitest run packages/agentplane/src/commands/task/verify-record.unit.test.ts --config vitest.workspace.ts; Expect: verify recording emits early non-quiet progress before backend write and quiet mode remains silent.
+    2. Command: bun run typecheck; Expect: TypeScript project references pass after verify path changes.
+    3. Command: node .agentplane/policy/check-routing.mjs; Expect: policy routing remains valid.
+    4. Command: ap doctor; Expect: workspace doctor reports no errors.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-05-31T07:09:59.445Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified: early non-quiet verify progress output added before backend mutation; focused verify-record unit coverage and typecheck pass.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-31T07:09:40.534Z, excerpt_hash=sha256:41a1ec4c9e02162d74f1c2b7581670d91516176b6e8b15a897bb99648ea396a4
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605310706-GV6ECK-verify-ghost-progress/.agentplane/tasks/202605310706-GV6ECK/blueprint/resolved-snapshot.json
+    - old_digest: 346658127f7271181b0dfe17846518f31c304f22174c18988946b5b11ecb31ec
+    - current_digest: 346658127f7271181b0dfe17846518f31c304f22174c18988946b5b11ecb31ec
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605310706-GV6ECK
+
+    ### 2026-05-31T07:13:45.530Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified: early verify progress remains covered; focused unit test, typecheck, format:changed, check-routing, doctor, and hotspots:check pass after tightening the test under the oversized baseline.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-31T07:09:59.462Z, excerpt_hash=sha256:41a1ec4c9e02162d74f1c2b7581670d91516176b6e8b15a897bb99648ea396a4
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605310706-GV6ECK-verify-ghost-progress/.agentplane/tasks/202605310706-GV6ECK/blueprint/resolved-snapshot.json
+    - old_digest: 346658127f7271181b0dfe17846518f31c304f22174c18988946b5b11ecb31ec
+    - current_digest: 346658127f7271181b0dfe17846518f31c304f22174c18988946b5b11ecb31ec
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202605310706-GV6ECK
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Fix verify ghost session progress output
+
+Resolve GitHub issue #4324 by ensuring agentplane verify emits an early non-quiet progress line before backend mutation work, so cloud backend waits are visible instead of appearing as a no-output ghost session.
+
+## Scope
+
+- In scope: Resolve GitHub issue #4324 by ensuring agentplane verify emits an early non-quiet progress line before backend mutation work, so cloud backend waits are visible instead of appearing as a no-output ghost session.
+- Out of scope: unrelated refactors not required for "Fix verify ghost session progress output".
+
+## Plan
+
+1. Reproduce the weak behavior in the verify record path: non-quiet verify can enter backend/reconcile/cloud work before any user-visible output.
+2. Add a narrowly scoped early progress line for non-quiet agentplane verify before backend mutation, preserving quiet mode and existing success/error handling.
+3. Add unit coverage proving verify emits the early line before backend work and quiet mode remains silent.
+4. Run focused verify-record tests plus typecheck, then open/merge a branch_pr that closes GitHub issue #4324.
+
+## Verify Steps
+
+1. Command: bunx vitest run packages/agentplane/src/commands/task/verify-record.unit.test.ts --config vitest.workspace.ts; Expect: verify recording emits early non-quiet progress before backend write and quiet mode remains silent.
+2. Command: bun run typecheck; Expect: TypeScript project references pass after verify path changes.
+3. Command: node .agentplane/policy/check-routing.mjs; Expect: policy routing remains valid.
+4. Command: ap doctor; Expect: workspace doctor reports no errors.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-05-31T07:09:59.445Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: early non-quiet verify progress output added before backend mutation; focused verify-record unit coverage and typecheck pass.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-31T07:09:40.534Z, excerpt_hash=sha256:41a1ec4c9e02162d74f1c2b7581670d91516176b6e8b15a897bb99648ea396a4
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605310706-GV6ECK-verify-ghost-progress/.agentplane/tasks/202605310706-GV6ECK/blueprint/resolved-snapshot.json
+- old_digest: 346658127f7271181b0dfe17846518f31c304f22174c18988946b5b11ecb31ec
+- current_digest: 346658127f7271181b0dfe17846518f31c304f22174c18988946b5b11ecb31ec
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605310706-GV6ECK
+
+### 2026-05-31T07:13:45.530Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: early verify progress remains covered; focused unit test, typecheck, format:changed, check-routing, doctor, and hotspots:check pass after tightening the test under the oversized baseline.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-05-31T07:09:59.462Z, excerpt_hash=sha256:41a1ec4c9e02162d74f1c2b7581670d91516176b6e8b15a897bb99648ea396a4
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202605310706-GV6ECK-verify-ghost-progress/.agentplane/tasks/202605310706-GV6ECK/blueprint/resolved-snapshot.json
+- old_digest: 346658127f7271181b0dfe17846518f31c304f22174c18988946b5b11ecb31ec
+- current_digest: 346658127f7271181b0dfe17846518f31c304f22174c18988946b5b11ecb31ec
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202605310706-GV6ECK
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202605310706-GV6ECK/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202605310706-GV6ECK/blueprint/resolved-snapshot.json
@@ -1,0 +1,571 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202605310706-GV6ECK",
+    "title": "Fix verify ghost session progress output",
+    "description": "Resolve GitHub issue #4324 by ensuring agentplane verify emits an early non-quiet progress line before backend mutation work, so cloud backend waits are visible instead of appearing as a no-output ghost session.",
+    "tags": [
+      "bug",
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202605310706-GV6ECK",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "346658127f7271181b0dfe17846518f31c304f22174c18988946b5b11ecb31ec"
+  }
+}

--- a/.agentplane/tasks/202605310706-GV6ECK/pr/diffstat.txt
+++ b/.agentplane/tasks/202605310706-GV6ECK/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../src/commands/task/verify-record-execute.ts     |  5 ++
+ .../src/commands/task/verify-record.unit.test.ts   | 62 ++++++++++++++++++++++
+ 2 files changed, 67 insertions(+)

--- a/.agentplane/tasks/202605310706-GV6ECK/pr/github-body.md
+++ b/.agentplane/tasks/202605310706-GV6ECK/pr/github-body.md
@@ -1,0 +1,41 @@
+Task: `202605310706-GV6ECK`
+Title: Fix verify ghost session progress output
+Canonical task record: `.agentplane/tasks/202605310706-GV6ECK/README.md`
+
+## Summary
+
+Fix verify ghost session progress output
+
+Resolve GitHub issue #4324 by ensuring agentplane verify emits an early non-quiet progress line before backend mutation work, so cloud backend waits are visible instead of appearing as a no-output ghost session.
+
+## Scope
+
+- In scope: Resolve GitHub issue #4324 by ensuring agentplane verify emits an early non-quiet progress line before backend mutation work, so cloud backend waits are visible instead of appearing as a no-output ghost session.
+- Out of scope: unrelated refactors not required for "Fix verify ghost session progress output".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Verified: early verify progress remains covered; focused unit test, typecheck, format:changed,
+check-routing, doctor, and hotspots:check pass after tightening the test under the oversized
+baseline.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-31T07:09:59.491Z
+- Branch: task/202605310706-GV6ECK/verify-ghost-progress
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/commands/task/verify-record-execute.ts     |  5 ++
+ .../src/commands/task/verify-record.unit.test.ts   | 62 ++++++++++++++++++++++
+ 2 files changed, 67 insertions(+)
+```
+
+</details>

--- a/.agentplane/tasks/202605310706-GV6ECK/pr/github-title.txt
+++ b/.agentplane/tasks/202605310706-GV6ECK/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 GV6ECK task: Fix verify ghost session progress output [202605310706-GV6ECK]

--- a/.agentplane/tasks/202605310706-GV6ECK/pr/meta.json
+++ b/.agentplane/tasks/202605310706-GV6ECK/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202605310706-GV6ECK/verify-ghost-progress",
+  "created_at": "2026-05-31T07:09:59.491Z",
+  "diffstat_sha256": "sha256:a7c382c792b9cf284cb8d41124b4f9914dbec211a3494a1a92fed024f5eafdbb",
+  "last_verified_at": "2026-05-31T07:13:45.530Z",
+  "last_verified_diffstat_sha256": "sha256:a7c382c792b9cf284cb8d41124b4f9914dbec211a3494a1a92fed024f5eafdbb",
+  "schema_version": 1,
+  "task_id": "202605310706-GV6ECK",
+  "updated_at": "2026-05-31T07:09:59.491Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202605310706-GV6ECK/pr/review.md
+++ b/.agentplane/tasks/202605310706-GV6ECK/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-05-31T07:09:59.491Z
+
+## Task
+
+- Task: `202605310706-GV6ECK`
+- Title: Fix verify ghost session progress output
+- Status: DOING
+- Branch: `task/202605310706-GV6ECK/verify-ghost-progress`
+- Canonical task record: `.agentplane/tasks/202605310706-GV6ECK/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified: early verify progress remains covered; focused unit test, typecheck, format:changed, check-routing, doctor, and hotspots:check pass after tightening the test under the oversized baseline.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-05-31T07:09:59.491Z
+- Branch: task/202605310706-GV6ECK/verify-ghost-progress
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/commands/task/verify-record-execute.ts     |  5 ++
+ .../src/commands/task/verify-record.unit.test.ts   | 62 ++++++++++++++++++++++
+ 2 files changed, 67 insertions(+)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/packages/agentplane/src/commands/task/verify-record-execute.ts
+++ b/packages/agentplane/src/commands/task/verify-record-execute.ts
@@ -269,6 +269,11 @@ export async function executeVerifyRecordCommand(
   opts: ExecuteVerifyRecordCommandOptions,
 ): Promise<number> {
   const input = await resolveVerifyRecordInput(opts);
+  if (!opts.quiet) {
+    process.stdout.write(
+      `${infoMessage(`recording verification ${opts.taskId} state=${opts.state}`)}\n`,
+    );
+  }
 
   try {
     await recordVerificationResult({

--- a/packages/agentplane/src/commands/task/verify-record.unit.test.ts
+++ b/packages/agentplane/src/commands/task/verify-record.unit.test.ts
@@ -400,6 +400,31 @@ describe("task verify record (unit)", () => {
     writeSpy.mockRestore();
   });
 
+  it("cmdTaskVerifyOk emits early progress before backend context load when quiet=false", async () => {
+    const writes: string[] = [];
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      writes.push(String(chunk));
+      return true;
+    });
+    mocks.loadCommandContext.mockImplementationOnce(() => {
+      expect(writes.join("")).toContain("recording verification T-1 state=ok");
+      return Promise.reject(new Error("stop after early progress"));
+    });
+
+    const { cmdTaskVerifyOk } = await import("./verify-record.js");
+    await expect(
+      cmdTaskVerifyOk({
+        cwd: "/repo",
+        taskId: "T-1",
+        by: "REVIEWER",
+        note: "Looks good",
+        quiet: false,
+      }),
+    ).rejects.toThrow();
+
+    writeSpy.mockRestore();
+  });
+
   it("cmdTaskVerifyOk preserves legacy verification scaffold for doc_version=2", async () => {
     const writes: string[] = [];
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {


### PR DESCRIPTION
Task: `202605310706-GV6ECK`
Title: Fix verify ghost session progress output
Canonical task record: `.agentplane/tasks/202605310706-GV6ECK/README.md`

## Summary

Fix verify ghost session progress output

Resolve GitHub issue #4324 by ensuring agentplane verify emits an early non-quiet progress line before backend mutation work, so cloud backend waits are visible instead of appearing as a no-output ghost session.

## Scope

- In scope: Resolve GitHub issue #4324 by ensuring agentplane verify emits an early non-quiet progress line before backend mutation work, so cloud backend waits are visible instead of appearing as a no-output ghost session.
- Out of scope: unrelated refactors not required for "Fix verify ghost session progress output".

## Verification

- State: ok
- Note:

```text
Verified: early non-quiet verify progress output added before backend mutation; focused
verify-record unit coverage and typecheck pass.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-05-31T07:09:59.491Z
- Branch: task/202605310706-GV6ECK/verify-ghost-progress
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/commands/task/verify-record-execute.ts     |  5 ++
 .../src/commands/task/verify-record.unit.test.ts   | 62 ++++++++++++++++++++++
 2 files changed, 67 insertions(+)
```

</details>

Closes #4324