### PR TITLE
✅ Close included v0.6.12 batch tasks

### DIFF
--- a/.agentplane/tasks/202605281707-6MNB2K/README.md
+++ b/.agentplane/tasks/202605281707-6MNB2K/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202605281707-6MNB2K"
 title: "Runner sibling conflict detection"
-status: "DOING"
+result_summary: "Closed included batch task from merged PR #4197"
+status: "DONE"
 priority: "med"
 owner: "CODER"
-revision: 6
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -24,11 +25,31 @@ verification:
   updated_by: "CODER"
   note: "Command: bunx vitest run packages/agentplane/src/runner/result-manifest.test.ts --config vitest.workspace.ts; Result: pass as part of focused suite. Evidence: result manifests now accept conflict_paths only with blocked_reason and recommended_parent_action. Scope: runner conflict reporting contract."
   attempts: 0
-commit: null
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-31T14:57:54.195Z"
+  updated_by: "EVALUATOR"
+  note: "Included task verified in merged batch PR #4197."
+  evaluated_sha: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  blueprint_digest: "33ab00d113d0a693f5b2299046653be1b2d03cf05cdef9e3e3e8aeaf2aec94a7"
+  evidence_refs:
+    - ".agentplane/tasks/202605281707-6MNB2K/README.md"
+    - ".agentplane/tasks/202605281707-6MNB2K/quality/20260531-145754195-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605281707-6MNB2K/quality/20260531-145754195-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605281707-6MNB2K/quality/20260531-145754195-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605281707-6MNB2K/blueprint/resolved-snapshot.json"
+  findings:
+    - "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
+commit:
+  hash: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  message: "Merge pull request #4329 from basilisk-labs/task/202605310706-GV6ECK/verify-ghost-progress"
 comments:
   -
     author: "CODER"
     body: "Start: Implementing runner sibling conflict detection as an included task in the approved v0.6.12 agent-efficiency batch worktree."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
 events:
   -
     type: "status"
@@ -43,9 +64,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Command: bunx vitest run packages/agentplane/src/runner/result-manifest.test.ts --config vitest.workspace.ts; Result: pass as part of focused suite. Evidence: result manifests now accept conflict_paths only with blocked_reason and recommended_parent_action. Scope: runner conflict reporting contract."
+  -
+    type: "status"
+    at: "2026-05-31T14:59:27.675Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
 doc_version: 3
-doc_updated_at: "2026-05-28T17:22:26.680Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-31T14:59:27.677Z"
+doc_updated_by: "INTEGRATOR"
 description: "Detect likely sibling runner write conflicts before execute-mode mutation and report blocked manifests with affected paths and parent action."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605281707-6MNB2K/README.md
+++ b/.agentplane/tasks/202605281707-6MNB2K/README.md
@@ -30,7 +30,7 @@ quality_review:
   updated_at: "2026-05-31T14:57:54.195Z"
   updated_by: "EVALUATOR"
   note: "Included task verified in merged batch PR #4197."
-  evaluated_sha: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  evaluated_sha: "26704abb70798fb4ecca714fa3c21050d3893c18"
   blueprint_digest: "33ab00d113d0a693f5b2299046653be1b2d03cf05cdef9e3e3e8aeaf2aec94a7"
   evidence_refs:
     - ".agentplane/tasks/202605281707-6MNB2K/README.md"
@@ -41,7 +41,7 @@ quality_review:
   findings:
     - "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
 commit:
-  hash: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  hash: "26704abb70798fb4ecca714fa3c21050d3893c18"
   message: "Merge pull request #4329 from basilisk-labs/task/202605310706-GV6ECK/verify-ghost-progress"
 comments:
   -
@@ -49,7 +49,7 @@ comments:
     body: "Start: Implementing runner sibling conflict detection as an included task in the approved v0.6.12 agent-efficiency batch worktree."
   -
     author: "INTEGRATOR"
-    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
+    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; task commit recorded SHA 26704abb70798fb4ecca714fa3c21050d3893c18."
 events:
   -
     type: "status"
@@ -70,7 +70,7 @@ events:
     author: "INTEGRATOR"
     from: "DOING"
     to: "DONE"
-    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
+    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; task commit recorded SHA 26704abb70798fb4ecca714fa3c21050d3893c18."
 doc_version: 3
 doc_updated_at: "2026-05-31T14:59:27.677Z"
 doc_updated_by: "INTEGRATOR"

--- a/.agentplane/tasks/202605281707-6MNB2K/quality/20260531-145754195-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605281707-6MNB2K/quality/20260531-145754195-recovery-context/evaluator-opinion.md
@@ -1,0 +1,18 @@
+# EVALUATOR opinion: pass
+
+Included task verified in merged batch PR #4197.
+
+## Findings
+- Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18.
+
+## Evidence
+- .agentplane/tasks/202605281707-6MNB2K/README.md
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202605281707-6MNB2K/quality/20260531-145754195-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605281707-6MNB2K/quality/20260531-145754195-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605281707-6MNB2K
+- task_readme: .agentplane/tasks/202605281707-6MNB2K/README.md
+- report_path: .agentplane/tasks/202605281707-6MNB2K/quality/20260531-145754195-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605281707-6MNB2K/quality/20260531-145754195-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605281707-6MNB2K/quality/20260531-145754195-recovery-context/quality-report.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "task_id": "202605281707-6MNB2K",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-31T14:57:54.195Z",
+  "verdict": "pass",
+  "summary": "Included task verified in merged batch PR #4197.",
+  "evaluated_sha": "c318cabc49a29ffcbf2b8246af76201f5ccbb324",
+  "blueprint_digest": "33ab00d113d0a693f5b2299046653be1b2d03cf05cdef9e3e3e8aeaf2aec94a7",
+  "findings": [
+    "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605281707-6MNB2K/README.md"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/.agentplane/tasks/202605281707-6MNB2K/quality/20260531-145754195-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605281707-6MNB2K/quality/20260531-145754195-recovery-context/quality-report.json
@@ -6,7 +6,7 @@
   "generated_at": "2026-05-31T14:57:54.195Z",
   "verdict": "pass",
   "summary": "Included task verified in merged batch PR #4197.",
-  "evaluated_sha": "c318cabc49a29ffcbf2b8246af76201f5ccbb324",
+  "evaluated_sha": "26704abb70798fb4ecca714fa3c21050d3893c18",
   "blueprint_digest": "33ab00d113d0a693f5b2299046653be1b2d03cf05cdef9e3e3e8aeaf2aec94a7",
   "findings": [
     "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."

--- a/.agentplane/tasks/202605281707-7FSSSP/README.md
+++ b/.agentplane/tasks/202605281707-7FSSSP/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202605281707-7FSSSP"
 title: "Evaluator bounded rework MVP"
-status: "DOING"
+result_summary: "Closed included batch task from merged PR #4197"
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -24,11 +25,31 @@ verification:
   updated_by: "CODER"
   note: "Command: bunx vitest run packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts --config vitest.workspace.ts; Result: pass as part of focused suite. Evidence: evaluator rework verdict now requires --rework-context and reports rework_context in quality artifacts. Scope: evaluator rework context MVP."
   attempts: 0
-commit: null
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-31T15:00:09.486Z"
+  updated_by: "EVALUATOR"
+  note: "Included task verified in merged batch PR #4197."
+  evaluated_sha: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  blueprint_digest: "c936b90b798eb562ce47647b552ecd9c91345ad8898a2e5165ff8c814d5e6767"
+  evidence_refs:
+    - ".agentplane/tasks/202605281707-7FSSSP/README.md"
+    - ".agentplane/tasks/202605281707-7FSSSP/quality/20260531-150009486-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605281707-7FSSSP/quality/20260531-150009486-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605281707-7FSSSP/quality/20260531-150009486-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605281707-7FSSSP/blueprint/resolved-snapshot.json"
+  findings:
+    - "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
+commit:
+  hash: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  message: "Merge pull request #4329 from basilisk-labs/task/202605310706-GV6ECK/verify-ghost-progress"
 comments:
   -
     author: "CODER"
     body: "Start: Implementing evaluator bounded rework semantics as an included task in the approved v0.6.12 agent-efficiency batch worktree."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
 events:
   -
     type: "status"
@@ -43,9 +64,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Command: bunx vitest run packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts --config vitest.workspace.ts; Result: pass as part of focused suite. Evidence: evaluator rework verdict now requires --rework-context and reports rework_context in quality artifacts. Scope: evaluator rework context MVP."
+  -
+    type: "status"
+    at: "2026-05-31T15:00:11.783Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
 doc_version: 3
-doc_updated_at: "2026-05-28T17:22:25.354Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-31T15:00:11.784Z"
+doc_updated_by: "INTEGRATOR"
 description: "Add machine-readable evaluator rework context and bounded retry semantics for runner-driven tasks."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605281707-7FSSSP/README.md
+++ b/.agentplane/tasks/202605281707-7FSSSP/README.md
@@ -30,7 +30,7 @@ quality_review:
   updated_at: "2026-05-31T15:00:09.486Z"
   updated_by: "EVALUATOR"
   note: "Included task verified in merged batch PR #4197."
-  evaluated_sha: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  evaluated_sha: "26704abb70798fb4ecca714fa3c21050d3893c18"
   blueprint_digest: "c936b90b798eb562ce47647b552ecd9c91345ad8898a2e5165ff8c814d5e6767"
   evidence_refs:
     - ".agentplane/tasks/202605281707-7FSSSP/README.md"
@@ -41,7 +41,7 @@ quality_review:
   findings:
     - "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
 commit:
-  hash: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  hash: "26704abb70798fb4ecca714fa3c21050d3893c18"
   message: "Merge pull request #4329 from basilisk-labs/task/202605310706-GV6ECK/verify-ghost-progress"
 comments:
   -
@@ -49,7 +49,7 @@ comments:
     body: "Start: Implementing evaluator bounded rework semantics as an included task in the approved v0.6.12 agent-efficiency batch worktree."
   -
     author: "INTEGRATOR"
-    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
+    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; task commit recorded SHA 26704abb70798fb4ecca714fa3c21050d3893c18."
 events:
   -
     type: "status"
@@ -70,7 +70,7 @@ events:
     author: "INTEGRATOR"
     from: "DOING"
     to: "DONE"
-    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
+    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; task commit recorded SHA 26704abb70798fb4ecca714fa3c21050d3893c18."
 doc_version: 3
 doc_updated_at: "2026-05-31T15:00:11.784Z"
 doc_updated_by: "INTEGRATOR"

--- a/.agentplane/tasks/202605281707-7FSSSP/quality/20260531-150009486-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605281707-7FSSSP/quality/20260531-150009486-recovery-context/evaluator-opinion.md
@@ -1,0 +1,18 @@
+# EVALUATOR opinion: pass
+
+Included task verified in merged batch PR #4197.
+
+## Findings
+- Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18.
+
+## Evidence
+- .agentplane/tasks/202605281707-7FSSSP/README.md
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202605281707-7FSSSP/quality/20260531-150009486-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605281707-7FSSSP/quality/20260531-150009486-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605281707-7FSSSP
+- task_readme: .agentplane/tasks/202605281707-7FSSSP/README.md
+- report_path: .agentplane/tasks/202605281707-7FSSSP/quality/20260531-150009486-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605281707-7FSSSP/quality/20260531-150009486-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605281707-7FSSSP/quality/20260531-150009486-recovery-context/quality-report.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "task_id": "202605281707-7FSSSP",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-31T15:00:09.486Z",
+  "verdict": "pass",
+  "summary": "Included task verified in merged batch PR #4197.",
+  "evaluated_sha": "c318cabc49a29ffcbf2b8246af76201f5ccbb324",
+  "blueprint_digest": "c936b90b798eb562ce47647b552ecd9c91345ad8898a2e5165ff8c814d5e6767",
+  "findings": [
+    "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605281707-7FSSSP/README.md"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/.agentplane/tasks/202605281707-7FSSSP/quality/20260531-150009486-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605281707-7FSSSP/quality/20260531-150009486-recovery-context/quality-report.json
@@ -6,7 +6,7 @@
   "generated_at": "2026-05-31T15:00:09.486Z",
   "verdict": "pass",
   "summary": "Included task verified in merged batch PR #4197.",
-  "evaluated_sha": "c318cabc49a29ffcbf2b8246af76201f5ccbb324",
+  "evaluated_sha": "26704abb70798fb4ecca714fa3c21050d3893c18",
   "blueprint_digest": "c936b90b798eb562ce47647b552ecd9c91345ad8898a2e5165ff8c814d5e6767",
   "findings": [
     "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."

--- a/.agentplane/tasks/202605281707-B1DQCY/README.md
+++ b/.agentplane/tasks/202605281707-B1DQCY/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202605281707-B1DQCY"
 title: "Runner manifest quality gate"
-status: "DOING"
+result_summary: "Closed included batch task from merged PR #4197"
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -24,11 +25,31 @@ verification:
   updated_by: "CODER"
   note: "Command: bunx vitest run packages/agentplane/src/runner/result-manifest.test.ts packages/agentplane/src/runner/result-manifest-policy.test.ts --config vitest.workspace.ts; Result: pass via focused suite coverage for result-manifest.test and existing policy tests. Evidence: success manifests require quality evidence; conflict paths require blocked reason and parent action. Scope: runner manifest quality gate."
   attempts: 0
-commit: null
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-31T15:00:14.604Z"
+  updated_by: "EVALUATOR"
+  note: "Included task verified in merged batch PR #4197."
+  evaluated_sha: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  blueprint_digest: "59f129015fb4df73291ebc52f46aac0a7aa1b40c4098f6e69b809b4077ea8855"
+  evidence_refs:
+    - ".agentplane/tasks/202605281707-B1DQCY/README.md"
+    - ".agentplane/tasks/202605281707-B1DQCY/quality/20260531-150014604-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605281707-B1DQCY/quality/20260531-150014604-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605281707-B1DQCY/quality/20260531-150014604-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605281707-B1DQCY/blueprint/resolved-snapshot.json"
+  findings:
+    - "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
+commit:
+  hash: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  message: "Merge pull request #4329 from basilisk-labs/task/202605310706-GV6ECK/verify-ghost-progress"
 comments:
   -
     author: "CODER"
     body: "Start: Implementing runner manifest quality gates as an included task in the approved v0.6.12 agent-efficiency batch worktree."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
 events:
   -
     type: "status"
@@ -43,9 +64,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Command: bunx vitest run packages/agentplane/src/runner/result-manifest.test.ts packages/agentplane/src/runner/result-manifest-policy.test.ts --config vitest.workspace.ts; Result: pass via focused suite coverage for result-manifest.test and existing policy tests. Evidence: success manifests require quality evidence; conflict paths require blocked reason and parent action. Scope: runner manifest quality gate."
+  -
+    type: "status"
+    at: "2026-05-31T15:00:16.910Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
 doc_version: 3
-doc_updated_at: "2026-05-28T17:22:23.775Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-31T15:00:16.910Z"
+doc_updated_by: "INTEGRATOR"
 description: "Validate runner result manifests for evidence paths, changed paths, blocked reasons, conflicts, and verification candidates before projecting outcomes to tasks."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605281707-B1DQCY/README.md
+++ b/.agentplane/tasks/202605281707-B1DQCY/README.md
@@ -30,7 +30,7 @@ quality_review:
   updated_at: "2026-05-31T15:00:14.604Z"
   updated_by: "EVALUATOR"
   note: "Included task verified in merged batch PR #4197."
-  evaluated_sha: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  evaluated_sha: "26704abb70798fb4ecca714fa3c21050d3893c18"
   blueprint_digest: "59f129015fb4df73291ebc52f46aac0a7aa1b40c4098f6e69b809b4077ea8855"
   evidence_refs:
     - ".agentplane/tasks/202605281707-B1DQCY/README.md"
@@ -41,7 +41,7 @@ quality_review:
   findings:
     - "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
 commit:
-  hash: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  hash: "26704abb70798fb4ecca714fa3c21050d3893c18"
   message: "Merge pull request #4329 from basilisk-labs/task/202605310706-GV6ECK/verify-ghost-progress"
 comments:
   -
@@ -49,7 +49,7 @@ comments:
     body: "Start: Implementing runner manifest quality gates as an included task in the approved v0.6.12 agent-efficiency batch worktree."
   -
     author: "INTEGRATOR"
-    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
+    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; task commit recorded SHA 26704abb70798fb4ecca714fa3c21050d3893c18."
 events:
   -
     type: "status"
@@ -70,7 +70,7 @@ events:
     author: "INTEGRATOR"
     from: "DOING"
     to: "DONE"
-    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
+    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; task commit recorded SHA 26704abb70798fb4ecca714fa3c21050d3893c18."
 doc_version: 3
 doc_updated_at: "2026-05-31T15:00:16.910Z"
 doc_updated_by: "INTEGRATOR"

--- a/.agentplane/tasks/202605281707-B1DQCY/quality/20260531-150014604-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605281707-B1DQCY/quality/20260531-150014604-recovery-context/evaluator-opinion.md
@@ -1,0 +1,18 @@
+# EVALUATOR opinion: pass
+
+Included task verified in merged batch PR #4197.
+
+## Findings
+- Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18.
+
+## Evidence
+- .agentplane/tasks/202605281707-B1DQCY/README.md
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202605281707-B1DQCY/quality/20260531-150014604-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605281707-B1DQCY/quality/20260531-150014604-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605281707-B1DQCY
+- task_readme: .agentplane/tasks/202605281707-B1DQCY/README.md
+- report_path: .agentplane/tasks/202605281707-B1DQCY/quality/20260531-150014604-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605281707-B1DQCY/quality/20260531-150014604-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605281707-B1DQCY/quality/20260531-150014604-recovery-context/quality-report.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "task_id": "202605281707-B1DQCY",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-31T15:00:14.604Z",
+  "verdict": "pass",
+  "summary": "Included task verified in merged batch PR #4197.",
+  "evaluated_sha": "c318cabc49a29ffcbf2b8246af76201f5ccbb324",
+  "blueprint_digest": "59f129015fb4df73291ebc52f46aac0a7aa1b40c4098f6e69b809b4077ea8855",
+  "findings": [
+    "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605281707-B1DQCY/README.md"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/.agentplane/tasks/202605281707-B1DQCY/quality/20260531-150014604-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605281707-B1DQCY/quality/20260531-150014604-recovery-context/quality-report.json
@@ -6,7 +6,7 @@
   "generated_at": "2026-05-31T15:00:14.604Z",
   "verdict": "pass",
   "summary": "Included task verified in merged batch PR #4197.",
-  "evaluated_sha": "c318cabc49a29ffcbf2b8246af76201f5ccbb324",
+  "evaluated_sha": "26704abb70798fb4ecca714fa3c21050d3893c18",
   "blueprint_digest": "59f129015fb4df73291ebc52f46aac0a7aa1b40c4098f6e69b809b4077ea8855",
   "findings": [
     "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."

--- a/.agentplane/tasks/202605281707-DPJKMR/README.md
+++ b/.agentplane/tasks/202605281707-DPJKMR/README.md
@@ -30,7 +30,7 @@ quality_review:
   updated_at: "2026-05-31T15:00:19.737Z"
   updated_by: "EVALUATOR"
   note: "Included task verified in merged batch PR #4197."
-  evaluated_sha: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  evaluated_sha: "26704abb70798fb4ecca714fa3c21050d3893c18"
   blueprint_digest: "fe4761068130926bd7b237935d2be033234702c06a4211fe950b0dd4d03516fa"
   evidence_refs:
     - ".agentplane/tasks/202605281707-DPJKMR/README.md"
@@ -41,7 +41,7 @@ quality_review:
   findings:
     - "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
 commit:
-  hash: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  hash: "26704abb70798fb4ecca714fa3c21050d3893c18"
   message: "Merge pull request #4329 from basilisk-labs/task/202605310706-GV6ECK/verify-ghost-progress"
 comments:
   -
@@ -49,7 +49,7 @@ comments:
     body: "Start: Implementing critical-path hotspot extraction as an included task in the approved v0.6.12 agent-efficiency batch worktree."
   -
     author: "INTEGRATOR"
-    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
+    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; task commit recorded SHA 26704abb70798fb4ecca714fa3c21050d3893c18."
 events:
   -
     type: "status"
@@ -70,7 +70,7 @@ events:
     author: "INTEGRATOR"
     from: "DOING"
     to: "DONE"
-    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
+    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; task commit recorded SHA 26704abb70798fb4ecca714fa3c21050d3893c18."
 doc_version: 3
 doc_updated_at: "2026-05-31T15:00:22.028Z"
 doc_updated_by: "INTEGRATOR"

--- a/.agentplane/tasks/202605281707-DPJKMR/README.md
+++ b/.agentplane/tasks/202605281707-DPJKMR/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202605281707-DPJKMR"
 title: "Critical path hotspot extraction"
-status: "DOING"
+result_summary: "Closed included batch task from merged PR #4197"
+status: "DONE"
 priority: "med"
 owner: "CODER"
-revision: 6
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -24,11 +25,31 @@ verification:
   updated_by: "CODER"
   note: "Command: bun run hotspots:check; Result: pass with warnings below configured thresholds. Command: bun run typecheck; Result: pass. Evidence: route packet helpers live in route-oracle, keeping added behavior isolated from CLI command renderers. Scope: critical path maintainability."
   attempts: 0
-commit: null
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-31T15:00:19.737Z"
+  updated_by: "EVALUATOR"
+  note: "Included task verified in merged batch PR #4197."
+  evaluated_sha: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  blueprint_digest: "fe4761068130926bd7b237935d2be033234702c06a4211fe950b0dd4d03516fa"
+  evidence_refs:
+    - ".agentplane/tasks/202605281707-DPJKMR/README.md"
+    - ".agentplane/tasks/202605281707-DPJKMR/quality/20260531-150019737-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605281707-DPJKMR/quality/20260531-150019737-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605281707-DPJKMR/quality/20260531-150019737-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605281707-DPJKMR/blueprint/resolved-snapshot.json"
+  findings:
+    - "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
+commit:
+  hash: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  message: "Merge pull request #4329 from basilisk-labs/task/202605310706-GV6ECK/verify-ghost-progress"
 comments:
   -
     author: "CODER"
     body: "Start: Implementing critical-path hotspot extraction as an included task in the approved v0.6.12 agent-efficiency batch worktree."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
 events:
   -
     type: "status"
@@ -43,9 +64,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Command: bun run hotspots:check; Result: pass with warnings below configured thresholds. Command: bun run typecheck; Result: pass. Evidence: route packet helpers live in route-oracle, keeping added behavior isolated from CLI command renderers. Scope: critical path maintainability."
+  -
+    type: "status"
+    at: "2026-05-31T15:00:22.027Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
 doc_version: 3
-doc_updated_at: "2026-05-28T17:22:30.150Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-31T15:00:22.028Z"
+doc_updated_by: "INTEGRATOR"
 description: "Extract pure builders from runner task-run and route-decision critical path modules without changing public CLI behavior."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605281707-DPJKMR/quality/20260531-150019737-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605281707-DPJKMR/quality/20260531-150019737-recovery-context/evaluator-opinion.md
@@ -1,0 +1,18 @@
+# EVALUATOR opinion: pass
+
+Included task verified in merged batch PR #4197.
+
+## Findings
+- Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18.
+
+## Evidence
+- .agentplane/tasks/202605281707-DPJKMR/README.md
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202605281707-DPJKMR/quality/20260531-150019737-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605281707-DPJKMR/quality/20260531-150019737-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605281707-DPJKMR
+- task_readme: .agentplane/tasks/202605281707-DPJKMR/README.md
+- report_path: .agentplane/tasks/202605281707-DPJKMR/quality/20260531-150019737-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605281707-DPJKMR/quality/20260531-150019737-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605281707-DPJKMR/quality/20260531-150019737-recovery-context/quality-report.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "task_id": "202605281707-DPJKMR",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-31T15:00:19.737Z",
+  "verdict": "pass",
+  "summary": "Included task verified in merged batch PR #4197.",
+  "evaluated_sha": "c318cabc49a29ffcbf2b8246af76201f5ccbb324",
+  "blueprint_digest": "fe4761068130926bd7b237935d2be033234702c06a4211fe950b0dd4d03516fa",
+  "findings": [
+    "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605281707-DPJKMR/README.md"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/.agentplane/tasks/202605281707-DPJKMR/quality/20260531-150019737-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605281707-DPJKMR/quality/20260531-150019737-recovery-context/quality-report.json
@@ -6,7 +6,7 @@
   "generated_at": "2026-05-31T15:00:19.737Z",
   "verdict": "pass",
   "summary": "Included task verified in merged batch PR #4197.",
-  "evaluated_sha": "c318cabc49a29ffcbf2b8246af76201f5ccbb324",
+  "evaluated_sha": "26704abb70798fb4ecca714fa3c21050d3893c18",
   "blueprint_digest": "fe4761068130926bd7b237935d2be033234702c06a4211fe950b0dd4d03516fa",
   "findings": [
     "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."

--- a/.agentplane/tasks/202605281707-FMY3FQ/README.md
+++ b/.agentplane/tasks/202605281707-FMY3FQ/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202605281707-FMY3FQ"
 title: "Targeted local CI buckets for agent-critical surfaces"
-status: "DOING"
+result_summary: "Closed included batch task from merged PR #4197"
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -24,11 +25,31 @@ verification:
   updated_by: "CODER"
   note: "Command: bunx vitest run packages/agentplane/src/cli/local-ci-selection.test.ts --config vitest.workspace.ts; Result: pass as part of focused suite. Evidence: runner, route-oracle, prompt-modules, and evaluator buckets route to targeted tests. Scope: local CI bucket selection."
   attempts: 0
-commit: null
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-31T15:00:24.930Z"
+  updated_by: "EVALUATOR"
+  note: "Included task verified in merged batch PR #4197."
+  evaluated_sha: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  blueprint_digest: "442c2c9b8ead7a7b9febe8d5a7cc6f484179b3fc495a9873621ef18474db5480"
+  evidence_refs:
+    - ".agentplane/tasks/202605281707-FMY3FQ/README.md"
+    - ".agentplane/tasks/202605281707-FMY3FQ/quality/20260531-150024930-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605281707-FMY3FQ/quality/20260531-150024930-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605281707-FMY3FQ/quality/20260531-150024930-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605281707-FMY3FQ/blueprint/resolved-snapshot.json"
+  findings:
+    - "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
+commit:
+  hash: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  message: "Merge pull request #4329 from basilisk-labs/task/202605310706-GV6ECK/verify-ghost-progress"
 comments:
   -
     author: "CODER"
     body: "Start: Implementing targeted local CI bucket routing as an included task in the approved v0.6.12 agent-efficiency batch worktree."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
 events:
   -
     type: "status"
@@ -43,9 +64,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Command: bunx vitest run packages/agentplane/src/cli/local-ci-selection.test.ts --config vitest.workspace.ts; Result: pass as part of focused suite. Evidence: runner, route-oracle, prompt-modules, and evaluator buckets route to targeted tests. Scope: local CI bucket selection."
+  -
+    type: "status"
+    at: "2026-05-31T15:00:27.342Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
 doc_version: 3
-doc_updated_at: "2026-05-28T17:22:22.643Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-31T15:00:27.342Z"
+doc_updated_by: "INTEGRATOR"
 description: "Add dedicated local CI selection buckets for runner, route oracle, prompt modules, and evaluator changes."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605281707-FMY3FQ/README.md
+++ b/.agentplane/tasks/202605281707-FMY3FQ/README.md
@@ -30,7 +30,7 @@ quality_review:
   updated_at: "2026-05-31T15:00:24.930Z"
   updated_by: "EVALUATOR"
   note: "Included task verified in merged batch PR #4197."
-  evaluated_sha: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  evaluated_sha: "26704abb70798fb4ecca714fa3c21050d3893c18"
   blueprint_digest: "442c2c9b8ead7a7b9febe8d5a7cc6f484179b3fc495a9873621ef18474db5480"
   evidence_refs:
     - ".agentplane/tasks/202605281707-FMY3FQ/README.md"
@@ -41,7 +41,7 @@ quality_review:
   findings:
     - "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
 commit:
-  hash: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  hash: "26704abb70798fb4ecca714fa3c21050d3893c18"
   message: "Merge pull request #4329 from basilisk-labs/task/202605310706-GV6ECK/verify-ghost-progress"
 comments:
   -
@@ -49,7 +49,7 @@ comments:
     body: "Start: Implementing targeted local CI bucket routing as an included task in the approved v0.6.12 agent-efficiency batch worktree."
   -
     author: "INTEGRATOR"
-    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
+    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; task commit recorded SHA 26704abb70798fb4ecca714fa3c21050d3893c18."
 events:
   -
     type: "status"
@@ -70,7 +70,7 @@ events:
     author: "INTEGRATOR"
     from: "DOING"
     to: "DONE"
-    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
+    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; task commit recorded SHA 26704abb70798fb4ecca714fa3c21050d3893c18."
 doc_version: 3
 doc_updated_at: "2026-05-31T15:00:27.342Z"
 doc_updated_by: "INTEGRATOR"

--- a/.agentplane/tasks/202605281707-FMY3FQ/quality/20260531-150024930-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605281707-FMY3FQ/quality/20260531-150024930-recovery-context/evaluator-opinion.md
@@ -1,0 +1,18 @@
+# EVALUATOR opinion: pass
+
+Included task verified in merged batch PR #4197.
+
+## Findings
+- Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18.
+
+## Evidence
+- .agentplane/tasks/202605281707-FMY3FQ/README.md
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202605281707-FMY3FQ/quality/20260531-150024930-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605281707-FMY3FQ/quality/20260531-150024930-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605281707-FMY3FQ
+- task_readme: .agentplane/tasks/202605281707-FMY3FQ/README.md
+- report_path: .agentplane/tasks/202605281707-FMY3FQ/quality/20260531-150024930-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605281707-FMY3FQ/quality/20260531-150024930-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605281707-FMY3FQ/quality/20260531-150024930-recovery-context/quality-report.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "task_id": "202605281707-FMY3FQ",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-31T15:00:24.930Z",
+  "verdict": "pass",
+  "summary": "Included task verified in merged batch PR #4197.",
+  "evaluated_sha": "c318cabc49a29ffcbf2b8246af76201f5ccbb324",
+  "blueprint_digest": "442c2c9b8ead7a7b9febe8d5a7cc6f484179b3fc495a9873621ef18474db5480",
+  "findings": [
+    "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605281707-FMY3FQ/README.md"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/.agentplane/tasks/202605281707-FMY3FQ/quality/20260531-150024930-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605281707-FMY3FQ/quality/20260531-150024930-recovery-context/quality-report.json
@@ -6,7 +6,7 @@
   "generated_at": "2026-05-31T15:00:24.930Z",
   "verdict": "pass",
   "summary": "Included task verified in merged batch PR #4197.",
-  "evaluated_sha": "c318cabc49a29ffcbf2b8246af76201f5ccbb324",
+  "evaluated_sha": "26704abb70798fb4ecca714fa3c21050d3893c18",
   "blueprint_digest": "442c2c9b8ead7a7b9febe8d5a7cc6f484179b3fc495a9873621ef18474db5480",
   "findings": [
     "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."

--- a/.agentplane/tasks/202605281707-QEW595/README.md
+++ b/.agentplane/tasks/202605281707-QEW595/README.md
@@ -30,7 +30,7 @@ quality_review:
   updated_at: "2026-05-31T15:00:30.123Z"
   updated_by: "EVALUATOR"
   note: "Included task verified in merged batch PR #4197."
-  evaluated_sha: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  evaluated_sha: "26704abb70798fb4ecca714fa3c21050d3893c18"
   blueprint_digest: "1ff282e85c56892bef4b861eaf0c9e776ab83254bb629d1ead531b714741ae91"
   evidence_refs:
     - ".agentplane/tasks/202605281707-QEW595/README.md"
@@ -41,7 +41,7 @@ quality_review:
   findings:
     - "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
 commit:
-  hash: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  hash: "26704abb70798fb4ecca714fa3c21050d3893c18"
   message: "Merge pull request #4329 from basilisk-labs/task/202605310706-GV6ECK/verify-ghost-progress"
 comments:
   -
@@ -49,7 +49,7 @@ comments:
     body: "Start: Implementing compact prompt diagnostics explain as an included task in the approved v0.6.12 agent-efficiency batch worktree."
   -
     author: "INTEGRATOR"
-    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
+    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; task commit recorded SHA 26704abb70798fb4ecca714fa3c21050d3893c18."
 events:
   -
     type: "status"
@@ -70,7 +70,7 @@ events:
     author: "INTEGRATOR"
     from: "DOING"
     to: "DONE"
-    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
+    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; task commit recorded SHA 26704abb70798fb4ecca714fa3c21050d3893c18."
 doc_version: 3
 doc_updated_at: "2026-05-31T15:00:32.290Z"
 doc_updated_by: "INTEGRATOR"

--- a/.agentplane/tasks/202605281707-QEW595/README.md
+++ b/.agentplane/tasks/202605281707-QEW595/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202605281707-QEW595"
 title: "Compact prompt diagnostics explain surface"
-status: "DOING"
+result_summary: "Closed included batch task from merged PR #4197"
+status: "DONE"
 priority: "med"
 owner: "CODER"
-revision: 6
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -24,11 +25,31 @@ verification:
   updated_by: "CODER"
   note: "Command: bun run docs:cli:check and ap doctor; Result: pass. Evidence: runtime explain exposes --compact JSON promptDiagnosticsCompact with winning fragments and diagnostics. Scope: compact prompt diagnostics explain surface."
   attempts: 0
-commit: null
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-31T15:00:30.123Z"
+  updated_by: "EVALUATOR"
+  note: "Included task verified in merged batch PR #4197."
+  evaluated_sha: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  blueprint_digest: "1ff282e85c56892bef4b861eaf0c9e776ab83254bb629d1ead531b714741ae91"
+  evidence_refs:
+    - ".agentplane/tasks/202605281707-QEW595/README.md"
+    - ".agentplane/tasks/202605281707-QEW595/quality/20260531-150030123-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605281707-QEW595/quality/20260531-150030123-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605281707-QEW595/quality/20260531-150030123-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605281707-QEW595/blueprint/resolved-snapshot.json"
+  findings:
+    - "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
+commit:
+  hash: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  message: "Merge pull request #4329 from basilisk-labs/task/202605310706-GV6ECK/verify-ghost-progress"
 comments:
   -
     author: "CODER"
     body: "Start: Implementing compact prompt diagnostics explain as an included task in the approved v0.6.12 agent-efficiency batch worktree."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
 events:
   -
     type: "status"
@@ -43,9 +64,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Command: bun run docs:cli:check and ap doctor; Result: pass. Evidence: runtime explain exposes --compact JSON promptDiagnosticsCompact with winning fragments and diagnostics. Scope: compact prompt diagnostics explain surface."
+  -
+    type: "status"
+    at: "2026-05-31T15:00:32.289Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
 doc_version: 3
-doc_updated_at: "2026-05-28T17:22:31.297Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-31T15:00:32.290Z"
+doc_updated_by: "INTEGRATOR"
 description: "Expose compact JSON diagnostics for winning prompt fragments, overrides, recipe mutations, and prompt-module provenance."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605281707-QEW595/quality/20260531-150030123-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605281707-QEW595/quality/20260531-150030123-recovery-context/evaluator-opinion.md
@@ -1,0 +1,18 @@
+# EVALUATOR opinion: pass
+
+Included task verified in merged batch PR #4197.
+
+## Findings
+- Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18.
+
+## Evidence
+- .agentplane/tasks/202605281707-QEW595/README.md
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202605281707-QEW595/quality/20260531-150030123-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605281707-QEW595/quality/20260531-150030123-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605281707-QEW595
+- task_readme: .agentplane/tasks/202605281707-QEW595/README.md
+- report_path: .agentplane/tasks/202605281707-QEW595/quality/20260531-150030123-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605281707-QEW595/quality/20260531-150030123-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605281707-QEW595/quality/20260531-150030123-recovery-context/quality-report.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "task_id": "202605281707-QEW595",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-31T15:00:30.123Z",
+  "verdict": "pass",
+  "summary": "Included task verified in merged batch PR #4197.",
+  "evaluated_sha": "c318cabc49a29ffcbf2b8246af76201f5ccbb324",
+  "blueprint_digest": "1ff282e85c56892bef4b861eaf0c9e776ab83254bb629d1ead531b714741ae91",
+  "findings": [
+    "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605281707-QEW595/README.md"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/.agentplane/tasks/202605281707-QEW595/quality/20260531-150030123-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605281707-QEW595/quality/20260531-150030123-recovery-context/quality-report.json
@@ -6,7 +6,7 @@
   "generated_at": "2026-05-31T15:00:30.123Z",
   "verdict": "pass",
   "summary": "Included task verified in merged batch PR #4197.",
-  "evaluated_sha": "c318cabc49a29ffcbf2b8246af76201f5ccbb324",
+  "evaluated_sha": "26704abb70798fb4ecca714fa3c21050d3893c18",
   "blueprint_digest": "1ff282e85c56892bef4b861eaf0c9e776ab83254bb629d1ead531b714741ae91",
   "findings": [
     "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."

--- a/.agentplane/tasks/202605281707-VP74QA/README.md
+++ b/.agentplane/tasks/202605281707-VP74QA/README.md
@@ -30,7 +30,7 @@ quality_review:
   updated_at: "2026-05-31T15:00:35.085Z"
   updated_by: "EVALUATOR"
   note: "Included task verified in merged batch PR #4197."
-  evaluated_sha: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  evaluated_sha: "26704abb70798fb4ecca714fa3c21050d3893c18"
   blueprint_digest: "a65708690dc6a515db2625cd6f6b8b464eceadfff105744ede545916abef0e6f"
   evidence_refs:
     - ".agentplane/tasks/202605281707-VP74QA/README.md"
@@ -41,7 +41,7 @@ quality_review:
   findings:
     - "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
 commit:
-  hash: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  hash: "26704abb70798fb4ecca714fa3c21050d3893c18"
   message: "Merge pull request #4329 from basilisk-labs/task/202605310706-GV6ECK/verify-ghost-progress"
 comments:
   -
@@ -49,7 +49,7 @@ comments:
     body: "Start: Implementing provider-lane next-action hardening as an included task in the approved v0.6.12 agent-efficiency batch worktree."
   -
     author: "INTEGRATOR"
-    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
+    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; task commit recorded SHA 26704abb70798fb4ecca714fa3c21050d3893c18."
 events:
   -
     type: "status"
@@ -70,7 +70,7 @@ events:
     author: "INTEGRATOR"
     from: "DOING"
     to: "DONE"
-    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
+    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; task commit recorded SHA 26704abb70798fb4ecca714fa3c21050d3893c18."
 doc_version: 3
 doc_updated_at: "2026-05-31T15:00:37.290Z"
 doc_updated_by: "INTEGRATOR"

--- a/.agentplane/tasks/202605281707-VP74QA/README.md
+++ b/.agentplane/tasks/202605281707-VP74QA/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202605281707-VP74QA"
 title: "Provider lane hardening for PR and release tails"
-status: "DOING"
+result_summary: "Closed included batch task from merged PR #4197"
+status: "DONE"
 priority: "med"
 owner: "CODER"
-revision: 6
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -24,11 +25,31 @@ verification:
   updated_by: "CODER"
   note: "Command: bunx vitest run packages/agentplane/src/cli/run-cli.core.route-decision.test.ts --config vitest.workspace.ts; Result: pass as part of focused suite. Evidence: execution_packet distinguishes local_command/provider_action/wait/stop and exposes provider-action flags. Scope: PR/close-tail provider lane hardening."
   attempts: 0
-commit: null
+quality_review:
+  state: "pass"
+  updated_at: "2026-05-31T15:00:35.085Z"
+  updated_by: "EVALUATOR"
+  note: "Included task verified in merged batch PR #4197."
+  evaluated_sha: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  blueprint_digest: "a65708690dc6a515db2625cd6f6b8b464eceadfff105744ede545916abef0e6f"
+  evidence_refs:
+    - ".agentplane/tasks/202605281707-VP74QA/README.md"
+    - ".agentplane/tasks/202605281707-VP74QA/quality/20260531-150035085-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202605281707-VP74QA/quality/20260531-150035085-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202605281707-VP74QA/quality/20260531-150035085-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202605281707-VP74QA/blueprint/resolved-snapshot.json"
+  findings:
+    - "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
+commit:
+  hash: "c318cabc49a29ffcbf2b8246af76201f5ccbb324"
+  message: "Merge pull request #4329 from basilisk-labs/task/202605310706-GV6ECK/verify-ghost-progress"
 comments:
   -
     author: "CODER"
     body: "Start: Implementing provider-lane next-action hardening as an included task in the approved v0.6.12 agent-efficiency batch worktree."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
 events:
   -
     type: "status"
@@ -43,9 +64,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Command: bunx vitest run packages/agentplane/src/cli/run-cli.core.route-decision.test.ts --config vitest.workspace.ts; Result: pass as part of focused suite. Evidence: execution_packet distinguishes local_command/provider_action/wait/stop and exposes provider-action flags. Scope: PR/close-tail provider lane hardening."
+  -
+    type: "status"
+    at: "2026-05-31T15:00:37.289Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: closed included batch task after merged PR #4197 landed implementation commit 26704abb70798fb4ecca714fa3c21050d3893c18; evaluator review recorded SHA c318cabc49a29ffcbf2b8246af76201f5ccbb324."
 doc_version: 3
-doc_updated_at: "2026-05-28T17:22:28.141Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-31T15:00:37.290Z"
+doc_updated_by: "INTEGRATOR"
 description: "Make PR, close-tail, and release next-action surfaces distinguish local commands, provider actions, wait states, and stop conditions explicitly."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605281707-VP74QA/quality/20260531-150035085-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202605281707-VP74QA/quality/20260531-150035085-recovery-context/evaluator-opinion.md
@@ -1,0 +1,18 @@
+# EVALUATOR opinion: pass
+
+Included task verified in merged batch PR #4197.
+
+## Findings
+- Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18.
+
+## Evidence
+- .agentplane/tasks/202605281707-VP74QA/README.md
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202605281707-VP74QA/quality/20260531-150035085-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202605281707-VP74QA/quality/20260531-150035085-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202605281707-VP74QA
+- task_readme: .agentplane/tasks/202605281707-VP74QA/README.md
+- report_path: .agentplane/tasks/202605281707-VP74QA/quality/20260531-150035085-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202605281707-VP74QA/quality/20260531-150035085-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605281707-VP74QA/quality/20260531-150035085-recovery-context/quality-report.json
@@ -6,7 +6,7 @@
   "generated_at": "2026-05-31T15:00:35.085Z",
   "verdict": "pass",
   "summary": "Included task verified in merged batch PR #4197.",
-  "evaluated_sha": "c318cabc49a29ffcbf2b8246af76201f5ccbb324",
+  "evaluated_sha": "26704abb70798fb4ecca714fa3c21050d3893c18",
   "blueprint_digest": "a65708690dc6a515db2625cd6f6b8b464eceadfff105744ede545916abef0e6f",
   "findings": [
     "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."

--- a/.agentplane/tasks/202605281707-VP74QA/quality/20260531-150035085-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202605281707-VP74QA/quality/20260531-150035085-recovery-context/quality-report.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "task_id": "202605281707-VP74QA",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-05-31T15:00:35.085Z",
+  "verdict": "pass",
+  "summary": "Included task verified in merged batch PR #4197.",
+  "evaluated_sha": "c318cabc49a29ffcbf2b8246af76201f5ccbb324",
+  "blueprint_digest": "a65708690dc6a515db2625cd6f6b8b464eceadfff105744ede545916abef0e6f",
+  "findings": [
+    "Task has verification.ok evidence and was included in the 51DD0G route-packet-v2 batch merged to main at 26704abb70798fb4ecca714fa3c21050d3893c18."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202605281707-VP74QA/README.md"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}


### PR DESCRIPTION
## Summary
- Close seven included tasks from the merged 51DD0G batch.
- Record EVALUATOR pass artifacts for each included task.
- Clear the release task-registry blocker for the next patch release.

## Evidence
- Merged implementation PR: #4197, commit 26704abb70798fb4ecca714fa3c21050d3893c18.
- Merged close-tail PR for primary task: #4327, commit e92182cb0d5c4ba88a49d0ab1deb84acb69c082b.

## Local checks
- bun run release:tasks:check
- bun run release:parity
- node .agentplane/policy/check-routing.mjs
- git diff --check origin/main..HEAD
- ap doctor
- bun run release:check
- pre-push fast local CI