### PR TITLE
Close merged release recovery tasks

### DIFF
--- a/.agentplane/tasks/202605311543-0VPDRD/README.md
+++ b/.agentplane/tasks/202605311543-0VPDRD/README.md
@@ -1,7 +1,8 @@
 ---
 id: "202605311543-0VPDRD"
 title: "Support finish closure branches in branch_pr"
-status: "DOING"
+result_summary: "Shipped on main and reconciled from local branch_pr state."
+status: "DONE"
 priority: "high"
 owner: "CODER"
 revision: 7
@@ -47,7 +48,9 @@ quality_review:
     - ".agentplane/policy/workflow.branch_pr.md"
   findings:
     - "Implementation commit c7c33342a addresses the approved task scope; targeted typecheck, formatting, policy, agents, route decision, cleanup, evaluator, PR open/lifecycle, and help snapshot checks passed."
-commit: null
+commit:
+  hash: "6da8e6202c2182ddb437feca9d15caafcac855d2"
+  message: "Shipped on main before canonical task closure"
 comments:
   -
     author: "CODER"
@@ -72,9 +75,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified: final branch head includes implementation, batch metadata, and quality reviews. Checks passed: typecheck, format:changed, policy routing, agents:check, targeted Vitest suites, PR open/lifecycle tests, and manual included-task route fixture."
+  -
+    type: "status"
+    at: "2026-05-31T17:36:55.194Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Local branch_pr reconciliation detected task commit 6da8e6202c21 on base main; canonical task state normalized after shipment."
 doc_version: 3
-doc_updated_at: "2026-05-31T16:09:41.640Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-31T17:36:55.194Z"
+doc_updated_by: "INTEGRATOR"
 description: "Make ap finish provide a safe branch_pr closeout path for metadata-only closure, including closure branch creation or explicit recovery hints when finish is attempted from the wrong checkout."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605311543-3H1G55/README.md
+++ b/.agentplane/tasks/202605311543-3H1G55/README.md
@@ -1,7 +1,8 @@
 ---
 id: "202605311543-3H1G55"
 title: "Use body files for PR publication"
-status: "DOING"
+result_summary: "Shipped on main and reconciled from local branch_pr state."
+status: "DONE"
 priority: "high"
 owner: "CODER"
 revision: 7
@@ -47,7 +48,9 @@ quality_review:
     - ".agentplane/policy/workflow.branch_pr.md"
   findings:
     - "Implementation commit c7c33342a addresses the approved task scope; targeted typecheck, formatting, policy, agents, route decision, cleanup, evaluator, PR open/lifecycle, and help snapshot checks passed."
-commit: null
+commit:
+  hash: "6da8e6202c2182ddb437feca9d15caafcac855d2"
+  message: "Shipped on main before canonical task closure"
 comments:
   -
     author: "CODER"
@@ -72,9 +75,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified: final branch head includes implementation, batch metadata, and quality reviews. Checks passed: typecheck, format:changed, policy routing, agents:check, targeted Vitest suites, PR open/lifecycle tests, and manual included-task route fixture."
+  -
+    type: "status"
+    at: "2026-05-31T17:36:55.195Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Local branch_pr reconciliation detected task commit 6da8e6202c21 on base main; canonical task state normalized after shipment."
 doc_version: 3
-doc_updated_at: "2026-05-31T16:09:51.674Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-31T17:36:55.195Z"
+doc_updated_by: "INTEGRATOR"
 description: "Update ap pr open/update to generate and pass markdown PR bodies via temporary body files, preventing shell execution of markdown backticks and other inline quoting hazards."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605311543-6N3TMM/README.md
+++ b/.agentplane/tasks/202605311543-6N3TMM/README.md
@@ -1,7 +1,8 @@
 ---
 id: "202605311543-6N3TMM"
 title: "Split implementation and closure commit metadata"
-status: "DOING"
+result_summary: "Shipped on main and reconciled from local branch_pr state."
+status: "DONE"
 priority: "med"
 owner: "CODER"
 revision: 7
@@ -47,7 +48,9 @@ quality_review:
     - ".agentplane/policy/workflow.branch_pr.md"
   findings:
     - "Implementation commit c7c33342a addresses the approved task scope; targeted typecheck, formatting, policy, agents, route decision, cleanup, evaluator, PR open/lifecycle, and help snapshot checks passed."
-commit: null
+commit:
+  hash: "6da8e6202c2182ddb437feca9d15caafcac855d2"
+  message: "Shipped on main before canonical task closure"
 comments:
   -
     author: "CODER"
@@ -72,9 +75,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified: final branch head includes implementation, batch metadata, and quality reviews. Checks passed: typecheck, format:changed, policy routing, agents:check, targeted Vitest suites, PR open/lifecycle tests, and manual included-task route fixture."
+  -
+    type: "status"
+    at: "2026-05-31T17:36:55.188Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Local branch_pr reconciliation detected task commit 6da8e6202c21 on base main; canonical task state normalized after shipment."
 doc_version: 3
-doc_updated_at: "2026-05-31T16:09:48.235Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-31T17:36:55.188Z"
+doc_updated_by: "INTEGRATOR"
 description: "Model implementation commit evidence separately from evaluator or closure commit evidence so included task finish records do not overload one --commit value with two meanings."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605311543-KS7B7N/README.md
+++ b/.agentplane/tasks/202605311543-KS7B7N/README.md
@@ -1,7 +1,8 @@
 ---
 id: "202605311543-KS7B7N"
 title: "Detect landed included tasks in route oracle"
-status: "DOING"
+result_summary: "Merged via PR #4332."
+status: "DONE"
 priority: "high"
 owner: "CODER"
 revision: 9
@@ -48,7 +49,9 @@ quality_review:
     - ".agentplane/policy/workflow.branch_pr.md"
   findings:
     - "Implementation commit c7c33342a addresses the approved task scope; targeted typecheck, formatting, policy, agents, route decision, cleanup, evaluator, PR open/lifecycle, and help snapshot checks passed."
-commit: null
+commit:
+  hash: "6da8e6202c2182ddb437feca9d15caafcac855d2"
+  message: "🚧 KS7B7N task: Detect landed included tasks in route oracle [202605311543-KS7B7N]"
 comments:
   -
     author: "CODER"
@@ -85,9 +88,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified: regression fix prevents primary batch tasks from being classified as included-task closure. Checks passed: bun test packages/agentplane/src/cli/run-cli.core.route-decision.test.ts; bun run format:changed; bun run --filter=agentplane typecheck; node .agentplane/policy/check-routing.mjs."
+  -
+    type: "status"
+    at: "2026-05-31T17:35:48Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Hosted PR #4332 merged on GitHub main; task projection reconciled from hosted PR artifacts."
 doc_version: 3
-doc_updated_at: "2026-05-31T16:19:52.061Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-31T17:35:48Z"
+doc_updated_by: "INTEGRATOR"
 description: "Teach branch_pr route oracle to classify verified included batch tasks whose implementation already landed but whose finish metadata is missing, instead of returning generic missing_pr_branch/worktree_needed."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605311543-KS7B7N/pr/meta.json
+++ b/.agentplane/tasks/202605311543-KS7B7N/pr/meta.json
@@ -18,8 +18,11 @@
   "branch": "task/202605311543-KS7B7N/release-recovery-cli-improvements",
   "created_at": "2026-05-31T15:53:25.815Z",
   "diffstat_sha256": "sha256:ecda168adbc1363b97d51c4eebbfbbb1c35ddeaf0edc0c5958da307b7c421abb",
+  "head_sha": "752582583bb2a7414c4017fd2b9c7901e53c01f2",
   "last_verified_at": "2026-05-31T16:19:52.034Z",
   "last_verified_diffstat_sha256": "sha256:ecda168adbc1363b97d51c4eebbfbbb1c35ddeaf0edc0c5958da307b7c421abb",
+  "merge_commit": "6da8e6202c2182ddb437feca9d15caafcac855d2",
+  "merged_at": "2026-05-31T17:35:48Z",
   "related_task_ids": [
     "202605311543-0VPDRD",
     "202605311543-3H1G55",
@@ -31,8 +34,9 @@
     "202605311543-SEMKC7"
   ],
   "schema_version": 1,
+  "status": "MERGED",
   "task_id": "202605311543-KS7B7N",
-  "updated_at": "2026-05-31T15:53:25.815Z",
+  "updated_at": "2026-05-31T17:35:48Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202605311543-NWXTSG/README.md
+++ b/.agentplane/tasks/202605311543-NWXTSG/README.md
@@ -1,7 +1,8 @@
 ---
 id: "202605311543-NWXTSG"
 title: "Add branch cleanup dry-run reports"
-status: "DOING"
+result_summary: "Shipped on main and reconciled from local branch_pr state."
+status: "DONE"
 priority: "med"
 owner: "CODER"
 revision: 7
@@ -47,7 +48,9 @@ quality_review:
     - ".agentplane/policy/workflow.branch_pr.md"
   findings:
     - "Implementation commit c7c33342a addresses the approved task scope; targeted typecheck, formatting, policy, agents, route decision, cleanup, evaluator, PR open/lifecycle, and help snapshot checks passed."
-commit: null
+commit:
+  hash: "6da8e6202c2182ddb437feca9d15caafcac855d2"
+  message: "Shipped on main before canonical task closure"
 comments:
   -
     author: "CODER"
@@ -72,9 +75,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified: final branch head includes implementation, batch metadata, and quality reviews. Checks passed: typecheck, format:changed, policy routing, agents:check, targeted Vitest suites, PR open/lifecycle tests, and manual included-task route fixture."
+  -
+    type: "status"
+    at: "2026-05-31T17:36:55.195Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Local branch_pr reconciliation detected task commit 6da8e6202c21 on base main; canonical task state normalized after shipment."
 doc_version: 3
-doc_updated_at: "2026-05-31T16:09:58.372Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-31T17:36:55.195Z"
+doc_updated_by: "INTEGRATOR"
 description: "Add a branch cleanup command that classifies merged, dirty, backup, active-worktree, and unmerged branches; supports dry-run; preserves dirty state with named stashes; and writes a cleanup report."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605311543-QH9XXK/README.md
+++ b/.agentplane/tasks/202605311543-QH9XXK/README.md
@@ -1,7 +1,8 @@
 ---
 id: "202605311543-QH9XXK"
 title: "Codify branch_pr release recovery prompt rules"
-status: "DOING"
+result_summary: "Shipped on main and reconciled from local branch_pr state."
+status: "DONE"
 priority: "med"
 owner: "DOCS"
 revision: 7
@@ -47,7 +48,9 @@ quality_review:
     - ".agentplane/policy/workflow.branch_pr.md"
   findings:
     - "Implementation commit c7c33342a addresses the approved task scope; targeted typecheck, formatting, policy, agents, route decision, cleanup, evaluator, PR open/lifecycle, and help snapshot checks passed."
-commit: null
+commit:
+  hash: "6da8e6202c2182ddb437feca9d15caafcac855d2"
+  message: "Shipped on main before canonical task closure"
 comments:
   -
     author: "CODER"
@@ -72,9 +75,16 @@ events:
     author: "DOCS"
     state: "ok"
     note: "Verified: final branch head includes implementation, batch metadata, and quality reviews. Checks passed: typecheck, format:changed, policy routing, agents:check, targeted Vitest suites, PR open/lifecycle tests, and manual included-task route fixture."
+  -
+    type: "status"
+    at: "2026-05-31T17:36:55.196Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Local branch_pr reconciliation detected task commit 6da8e6202c21 on base main; canonical task state normalized after shipment."
 doc_version: 3
-doc_updated_at: "2026-05-31T16:10:01.698Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-31T17:36:55.196Z"
+doc_updated_by: "INTEGRATOR"
 description: "Add or update agent-facing prompt/policy guidance for release recovery: classify route before mutation, use GitHub truth, pass markdown bodies by file, preserve dirty cleanup state, and use ap integrate before direct gh merge."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605311543-R282E5/README.md
+++ b/.agentplane/tasks/202605311543-R282E5/README.md
@@ -1,7 +1,8 @@
 ---
 id: "202605311543-R282E5"
 title: "Make evaluator recovery batch-friendly"
-status: "DOING"
+result_summary: "Shipped on main and reconciled from local branch_pr state."
+status: "DONE"
 priority: "med"
 owner: "CODER"
 revision: 7
@@ -47,7 +48,9 @@ quality_review:
     - ".agentplane/policy/workflow.branch_pr.md"
   findings:
     - "Implementation commit c7c33342a addresses the approved task scope; targeted typecheck, formatting, policy, agents, route decision, cleanup, evaluator, PR open/lifecycle, and help snapshot checks passed."
-commit: null
+commit:
+  hash: "6da8e6202c2182ddb437feca9d15caafcac855d2"
+  message: "Shipped on main before canonical task closure"
 comments:
   -
     author: "CODER"
@@ -72,9 +75,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified: final branch head includes implementation, batch metadata, and quality reviews. Checks passed: typecheck, format:changed, policy routing, agents:check, targeted Vitest suites, PR open/lifecycle tests, and manual included-task route fixture."
+  -
+    type: "status"
+    at: "2026-05-31T17:36:55.194Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Local branch_pr reconciliation detected task commit 6da8e6202c21 on base main; canonical task state normalized after shipment."
 doc_version: 3
-doc_updated_at: "2026-05-31T16:09:44.762Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-31T17:36:55.194Z"
+doc_updated_by: "INTEGRATOR"
 description: "Improve evaluator and finish sequencing for multiple related tasks by adding batch support or precise dirty-subtree recovery guidance after evaluator artifacts are written."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605311543-SCWWPR/README.md
+++ b/.agentplane/tasks/202605311543-SCWWPR/README.md
@@ -1,7 +1,8 @@
 ---
 id: "202605311543-SCWWPR"
 title: "Add release task reconciliation command"
-status: "DOING"
+result_summary: "Shipped on main and reconciled from local branch_pr state."
+status: "DONE"
 priority: "high"
 owner: "CODER"
 revision: 7
@@ -47,7 +48,9 @@ quality_review:
     - ".agentplane/policy/workflow.branch_pr.md"
   findings:
     - "Implementation commit c7c33342a addresses the approved task scope; targeted typecheck, formatting, policy, agents, route decision, cleanup, evaluator, PR open/lifecycle, and help snapshot checks passed."
-commit: null
+commit:
+  hash: "6da8e6202c2182ddb437feca9d15caafcac855d2"
+  message: "Shipped on main before canonical task closure"
 comments:
   -
     author: "CODER"
@@ -72,9 +75,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified: final branch head includes implementation, batch metadata, and quality reviews. Checks passed: typecheck, format:changed, policy routing, agents:check, targeted Vitest suites, PR open/lifecycle tests, and manual included-task route fixture."
+  -
+    type: "status"
+    at: "2026-05-31T17:36:55.198Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Local branch_pr reconciliation detected task commit 6da8e6202c21 on base main; canonical task state normalized after shipment."
 doc_version: 3
-doc_updated_at: "2026-05-31T16:09:38.483Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-31T17:36:55.198Z"
+doc_updated_by: "INTEGRATOR"
 description: "Add an operator command that reconciles release-blocking verified DOING tasks in batch, records landed PR evidence, writes evaluator/finish metadata, and prepares a safe closure branch."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202605311543-SEMKC7/README.md
+++ b/.agentplane/tasks/202605311543-SEMKC7/README.md
@@ -1,7 +1,8 @@
 ---
 id: "202605311543-SEMKC7"
 title: "Explain blocked GitHub merge states"
-status: "DOING"
+result_summary: "Shipped on main and reconciled from local branch_pr state."
+status: "DONE"
 priority: "med"
 owner: "CODER"
 revision: 7
@@ -49,7 +50,9 @@ quality_review:
     - ".agentplane/policy/workflow.branch_pr.md"
   findings:
     - "Implementation commit c7c33342a addresses the approved task scope; targeted typecheck, formatting, policy, agents, route decision, cleanup, evaluator, PR open/lifecycle, and help snapshot checks passed."
-commit: null
+commit:
+  hash: "6da8e6202c2182ddb437feca9d15caafcac855d2"
+  message: "Shipped on main before canonical task closure"
 comments:
   -
     author: "CODER"
@@ -74,9 +77,16 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified: final branch head includes implementation, batch metadata, and quality reviews. Checks passed: typecheck, format:changed, policy routing, agents:check, targeted Vitest suites, PR open/lifecycle tests, and manual included-task route fixture."
+  -
+    type: "status"
+    at: "2026-05-31T17:36:55.197Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Local branch_pr reconciliation detected task commit 6da8e6202c21 on base main; canonical task state normalized after shipment."
 doc_version: 3
-doc_updated_at: "2026-05-31T16:09:55.006Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-05-31T17:36:55.197Z"
+doc_updated_by: "INTEGRATOR"
 description: "Extend ap pr check to explain GitHub mergeStateStatus=BLOCKED with review/protection/auto-merge context and emit the next permitted action instead of only reporting green checks."
 sections:
   Summary: |-


### PR DESCRIPTION
Closes the merged release-recovery task batch after PR #4332 landed.\n\nSummary:\n- reconciles primary task metadata from merged PR #4332\n- closes eight included batch tasks from the primary landed commit\n- verifies release task registry readiness locally\n\nVerification:\n- bun run release:tasks:check\n- git diff --check HEAD~1..HEAD\n- pre-push docs-only gate