### PR TITLE
🚧 88AVPY task: Fix cloud backend failure exit semantics [202606010508-88AVPY]

### DIFF
--- a/.agentplane/tasks/202606010508-88AVPY/README.md
+++ b/.agentplane/tasks/202606010508-88AVPY/README.md
@@ -1,0 +1,108 @@
+---
+id: "202606010508-88AVPY"
+title: "Fix cloud backend failure exit semantics"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "backend"
+  - "cloud"
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-06-01T05:09:12.565Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Investigating cloud/backend command failure propagation for issues #4343 and #4339, adding regression coverage, and keeping the fix limited to nonzero exit semantics without compatibility fallbacks."
+events:
+  -
+    type: "status"
+    at: "2026-06-01T05:09:45.879Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Investigating cloud/backend command failure propagation for issues #4343 and #4339, adding regression coverage, and keeping the fix limited to nonzero exit semantics without compatibility fallbacks."
+doc_version: 3
+doc_updated_at: "2026-06-01T05:09:45.879Z"
+doc_updated_by: "CODER"
+description: "Fix GitHub issues #4343 and #4339. Ensure backend/cloud commands that surface E_BACKEND or E_NETWORK failures return nonzero exit codes and expose deterministic tests. No fallback or backwards-compatible aliases."
+sections:
+  Summary: |-
+    Fix cloud backend failure exit semantics
+
+    Fix GitHub issues #4343 and #4339. Ensure backend/cloud commands that surface E_BACKEND or E_NETWORK failures return nonzero exit codes and expose deterministic tests. No fallback or backwards-compatible aliases.
+  Scope: |-
+    - In scope: Fix GitHub issues #4343 and #4339. Ensure backend/cloud commands that surface E_BACKEND or E_NETWORK failures return nonzero exit codes and expose deterministic tests. No fallback or backwards-compatible aliases.
+    - Out of scope: unrelated refactors not required for "Fix cloud backend failure exit semantics".
+  Plan: |-
+    Plan:
+    1. Reproduce/locate backend cloud command paths for issue #4343 and #4339.
+    2. Add or update tests proving cloud/backend sync and task cloud fetch failures exit nonzero when E_BACKEND/E_NETWORK is raised.
+    3. Fix command/error propagation without legacy fallback paths or compatibility aliases.
+    4. Run targeted tests plus routing/policy checks.
+    5. Open a branch_pr PR, merge it to main after hosted checks, then close issues #4343 and #4339 with evidence.
+  Verify Steps: |-
+    1. Add or update regression tests that simulate backend/cloud `E_BACKEND` and `E_NETWORK` failures. Expected: command execution rejects or exits nonzero instead of reporting success.
+    2. Run targeted backend/cloud command tests. Expected: all targeted tests pass and cover issues #4343 and #4339.
+    3. Run routing/policy checks for the touched implementation. Expected: no policy, formatting, or command-contract regressions.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Fix cloud backend failure exit semantics
+
+Fix GitHub issues #4343 and #4339. Ensure backend/cloud commands that surface E_BACKEND or E_NETWORK failures return nonzero exit codes and expose deterministic tests. No fallback or backwards-compatible aliases.
+
+## Scope
+
+- In scope: Fix GitHub issues #4343 and #4339. Ensure backend/cloud commands that surface E_BACKEND or E_NETWORK failures return nonzero exit codes and expose deterministic tests. No fallback or backwards-compatible aliases.
+- Out of scope: unrelated refactors not required for "Fix cloud backend failure exit semantics".
+
+## Plan
+
+Plan:
+1. Reproduce/locate backend cloud command paths for issue #4343 and #4339.
+2. Add or update tests proving cloud/backend sync and task cloud fetch failures exit nonzero when E_BACKEND/E_NETWORK is raised.
+3. Fix command/error propagation without legacy fallback paths or compatibility aliases.
+4. Run targeted tests plus routing/policy checks.
+5. Open a branch_pr PR, merge it to main after hosted checks, then close issues #4343 and #4339 with evidence.
+
+## Verify Steps
+
+1. Add or update regression tests that simulate backend/cloud `E_BACKEND` and `E_NETWORK` failures. Expected: command execution rejects or exits nonzero instead of reporting success.
+2. Run targeted backend/cloud command tests. Expected: all targeted tests pass and cover issues #4343 and #4339.
+3. Run routing/policy checks for the touched implementation. Expected: no policy, formatting, or command-contract regressions.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202606010508-88AVPY/README.md
+++ b/.agentplane/tasks/202606010508-88AVPY/README.md
@@ -4,7 +4,7 @@ title: "Fix cloud backend failure exit semantics"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 4
+revision: 5
 origin:
   system: "manual"
 depends_on: []
@@ -19,10 +19,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-06-01T05:14:32.755Z"
+  updated_by: "CODER"
+  note: "Command: bun x vitest run packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts. Result: pass, 19 tests. Evidence: regression coverage now asserts cloud push HTTP 502 exits with E_BACKEND/6 and cloud read autosync fetch failure exits with E_NETWORK/7, covering GitHub issues #4343 and #4339. Command: bun run format:changed. Result: pass. Command: node .agentplane/policy/check-routing.mjs. Result: pass."
   attempts: 0
 commit: null
 comments:
@@ -37,8 +37,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: Investigating cloud/backend command failure propagation for issues #4343 and #4339, adding regression coverage, and keeping the fix limited to nonzero exit semantics without compatibility fallbacks."
+  -
+    type: "verify"
+    at: "2026-06-01T05:14:32.755Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: bun x vitest run packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts. Result: pass, 19 tests. Evidence: regression coverage now asserts cloud push HTTP 502 exits with E_BACKEND/6 and cloud read autosync fetch failure exits with E_NETWORK/7, covering GitHub issues #4343 and #4339. Command: bun run format:changed. Result: pass. Command: node .agentplane/policy/check-routing.mjs. Result: pass."
 doc_version: 3
-doc_updated_at: "2026-06-01T05:09:45.879Z"
+doc_updated_at: "2026-06-01T05:14:32.777Z"
 doc_updated_by: "CODER"
 description: "Fix GitHub issues #4343 and #4339. Ensure backend/cloud commands that surface E_BACKEND or E_NETWORK failures return nonzero exit codes and expose deterministic tests. No fallback or backwards-compatible aliases."
 sections:
@@ -62,6 +68,25 @@ sections:
     3. Run routing/policy checks for the touched implementation. Expected: no policy, formatting, or command-contract regressions.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-06-01T05:14:32.755Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Command: bun x vitest run packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts. Result: pass, 19 tests. Evidence: regression coverage now asserts cloud push HTTP 502 exits with E_BACKEND/6 and cloud read autosync fetch failure exits with E_NETWORK/7, covering GitHub issues #4343 and #4339. Command: bun run format:changed. Result: pass. Command: node .agentplane/policy/check-routing.mjs. Result: pass.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-06-01T05:09:45.879Z, excerpt_hash=sha256:b84f3ece872b461cb297841026814e13e3db4a371bf723128635edbb1761f025
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202606010508-88AVPY-fix-cloud-backend-failure-exit-semantics/.agentplane/tasks/202606010508-88AVPY/blueprint/resolved-snapshot.json
+    - old_digest: 72148b189d649d301cbc3cdd91492ac9e86fb4de0b7db97e72034ea9e3136e70
+    - current_digest: 72148b189d649d301cbc3cdd91492ac9e86fb4de0b7db97e72034ea9e3136e70
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202606010508-88AVPY
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -98,6 +123,25 @@ Plan:
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-06-01T05:14:32.755Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: bun x vitest run packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts. Result: pass, 19 tests. Evidence: regression coverage now asserts cloud push HTTP 502 exits with E_BACKEND/6 and cloud read autosync fetch failure exits with E_NETWORK/7, covering GitHub issues #4343 and #4339. Command: bun run format:changed. Result: pass. Command: node .agentplane/policy/check-routing.mjs. Result: pass.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-06-01T05:09:45.879Z, excerpt_hash=sha256:b84f3ece872b461cb297841026814e13e3db4a371bf723128635edbb1761f025
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202606010508-88AVPY-fix-cloud-backend-failure-exit-semantics/.agentplane/tasks/202606010508-88AVPY/blueprint/resolved-snapshot.json
+- old_digest: 72148b189d649d301cbc3cdd91492ac9e86fb4de0b7db97e72034ea9e3136e70
+- current_digest: 72148b189d649d301cbc3cdd91492ac9e86fb4de0b7db97e72034ea9e3136e70
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202606010508-88AVPY
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202606010508-88AVPY/README.md
+++ b/.agentplane/tasks/202606010508-88AVPY/README.md
@@ -4,7 +4,7 @@ title: "Fix cloud backend failure exit semantics"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -24,6 +24,22 @@ verification:
   updated_by: "CODER"
   note: "Command: bun x vitest run packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts. Result: pass, 19 tests. Evidence: regression coverage now asserts cloud push HTTP 502 exits with E_BACKEND/6 and cloud read autosync fetch failure exits with E_NETWORK/7, covering GitHub issues #4343 and #4339. Command: bun run format:changed. Result: pass. Command: node .agentplane/policy/check-routing.mjs. Result: pass."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-06-01T05:14:57.307Z"
+  updated_by: "EVALUATOR"
+  note: "Regression tests now cover cloud backend E_BACKEND/E_NETWORK nonzero exit semantics for GitHub issues #4343 and #4339."
+  evaluated_sha: "5986865edd175765da4c56bad02debb20de4cf01"
+  blueprint_digest: "72148b189d649d301cbc3cdd91492ac9e86fb4de0b7db97e72034ea9e3136e70"
+  evidence_refs:
+    - ".agentplane/tasks/202606010508-88AVPY/README.md"
+    - ".agentplane/tasks/202606010508-88AVPY/quality/20260601-051457307-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202606010508-88AVPY/quality/20260601-051457307-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202606010508-88AVPY/quality/20260601-051457307-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202606010508-88AVPY/blueprint/resolved-snapshot.json"
+    - "packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts"
+  findings:
+    - "Covered backend sync cloud HTTP 502 -> E_BACKEND/6 and task show cloud autosync fetch failure -> E_NETWORK/7 in runCli."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202606010508-88AVPY/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202606010508-88AVPY/blueprint/resolved-snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202606010508-88AVPY",
+    "title": "Fix cloud backend failure exit semantics",
+    "description": "Fix GitHub issues #4343 and #4339. Ensure backend/cloud commands that surface E_BACKEND or E_NETWORK failures return nonzero exit codes and expose deterministic tests. No fallback or backwards-compatible aliases.",
+    "tags": [
+      "backend",
+      "cloud",
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202606010508-88AVPY",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "72148b189d649d301cbc3cdd91492ac9e86fb4de0b7db97e72034ea9e3136e70"
+  }
+}

--- a/.agentplane/tasks/202606010508-88AVPY/pr/diffstat.txt
+++ b/.agentplane/tasks/202606010508-88AVPY/pr/diffstat.txt
@@ -1,0 +1,2 @@
+ .../src/cli/run-cli.core.backend-sync.test.ts      | 102 +++++++++++++++++++++
+ 1 file changed, 102 insertions(+)

--- a/.agentplane/tasks/202606010508-88AVPY/pr/github-body.md
+++ b/.agentplane/tasks/202606010508-88AVPY/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202606010508-88AVPY`
+Title: Fix cloud backend failure exit semantics
+Canonical task record: `.agentplane/tasks/202606010508-88AVPY/README.md`
+
+## Summary
+
+Fix cloud backend failure exit semantics
+
+Fix GitHub issues #4343 and #4339. Ensure backend/cloud commands that surface E_BACKEND or E_NETWORK failures return nonzero exit codes and expose deterministic tests. No fallback or backwards-compatible aliases.
+
+## Scope
+
+- In scope: Fix GitHub issues #4343 and #4339. Ensure backend/cloud commands that surface E_BACKEND or E_NETWORK failures return nonzero exit codes and expose deterministic tests. No fallback or backwards-compatible aliases.
+- Out of scope: unrelated refactors not required for "Fix cloud backend failure exit semantics".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-06-01T05:09:45.941Z
+- Branch: task/202606010508-88AVPY/fix-cloud-backend-failure-exit-semantics
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202606010508-88AVPY/pr/github-body.md
+++ b/.agentplane/tasks/202606010508-88AVPY/pr/github-body.md
@@ -15,8 +15,16 @@ Fix GitHub issues #4343 and #4339. Ensure backend/cloud commands that surface E_
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```bash
+bun x vitest run packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts. Result: pass, 19 \
+  tests. Evidence: regression coverage now asserts cloud push HTTP 502 exits with E_BACKEND/6 and \
+  cloud read autosync fetch failure exits with E_NETWORK/7, covering GitHub issues #4343 and #4339. \
+  Command: bun run format:changed. Result: pass. Command: node .agentplane/policy/check-routing.mjs. \
+  Result: pass.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
@@ -27,7 +35,8 @@ Fix GitHub issues #4343 and #4339. Ensure backend/cloud commands that surface E_
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/cli/run-cli.core.backend-sync.test.ts      | 102 +++++++++++++++++++++
+ 1 file changed, 102 insertions(+)
 ```
 
 </details>

--- a/.agentplane/tasks/202606010508-88AVPY/pr/github-body.md
+++ b/.agentplane/tasks/202606010508-88AVPY/pr/github-body.md
@@ -8,6 +8,9 @@ Fix cloud backend failure exit semantics
 
 Fix GitHub issues #4343 and #4339. Ensure backend/cloud commands that surface E_BACKEND or E_NETWORK failures return nonzero exit codes and expose deterministic tests. No fallback or backwards-compatible aliases.
 
+Fixes #4343.
+Fixes #4339.
+
 ## Scope
 
 - In scope: Fix GitHub issues #4343 and #4339. Ensure backend/cloud commands that surface E_BACKEND or E_NETWORK failures return nonzero exit codes and expose deterministic tests. No fallback or backwards-compatible aliases.

--- a/.agentplane/tasks/202606010508-88AVPY/pr/github-title.txt
+++ b/.agentplane/tasks/202606010508-88AVPY/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 88AVPY task: Fix cloud backend failure exit semantics [202606010508-88AVPY]

--- a/.agentplane/tasks/202606010508-88AVPY/pr/meta.json
+++ b/.agentplane/tasks/202606010508-88AVPY/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202606010508-88AVPY/fix-cloud-backend-failure-exit-semantics",
+  "created_at": "2026-06-01T05:09:45.941Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202606010508-88AVPY",
+  "updated_at": "2026-06-01T05:09:45.941Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202606010508-88AVPY/pr/meta.json
+++ b/.agentplane/tasks/202606010508-88AVPY/pr/meta.json
@@ -2,12 +2,13 @@
   "base": "main",
   "branch": "task/202606010508-88AVPY/fix-cloud-backend-failure-exit-semantics",
   "created_at": "2026-06-01T05:09:45.941Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:4ab98bf6228c0754b89e13a7765946780d023dfb1cb296e0a8d4141ae4e101d6",
+  "last_verified_at": "2026-06-01T05:14:32.755Z",
+  "last_verified_diffstat_sha256": "sha256:4ab98bf6228c0754b89e13a7765946780d023dfb1cb296e0a8d4141ae4e101d6",
   "schema_version": 1,
   "task_id": "202606010508-88AVPY",
   "updated_at": "2026-06-01T05:09:45.941Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202606010508-88AVPY/pr/review.md
+++ b/.agentplane/tasks/202606010508-88AVPY/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-06-01T05:09:45.941Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Command: bun x vitest run packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts. Result: pass, 19 tests. Evidence: regression coverage now asserts cloud push HTTP 502 exits with E_BACKEND/6 and cloud read autosync fetch failure exits with E_NETWORK/7, covering GitHub issues #4343 and #4339. Command: bun run format:changed. Result: pass. Command: node .agentplane/policy/check-routing.mjs. Result: pass.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -29,7 +29,8 @@ Created: 2026-06-01T05:09:45.941Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/cli/run-cli.core.backend-sync.test.ts      | 102 +++++++++++++++++++++
+ 1 file changed, 102 insertions(+)
 ```
 
 </details>

--- a/.agentplane/tasks/202606010508-88AVPY/pr/review.md
+++ b/.agentplane/tasks/202606010508-88AVPY/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-06-01T05:09:45.941Z
+
+## Task
+
+- Task: `202606010508-88AVPY`
+- Title: Fix cloud backend failure exit semantics
+- Status: DOING
+- Branch: `task/202606010508-88AVPY/fix-cloud-backend-failure-exit-semantics`
+- Canonical task record: `.agentplane/tasks/202606010508-88AVPY/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-06-01T05:09:45.941Z
+- Branch: task/202606010508-88AVPY/fix-cloud-backend-failure-exit-semantics
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202606010508-88AVPY/quality/20260601-051457307-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202606010508-88AVPY/quality/20260601-051457307-recovery-context/evaluator-opinion.md
@@ -1,0 +1,19 @@
+# EVALUATOR opinion: pass
+
+Regression tests now cover cloud backend E_BACKEND/E_NETWORK nonzero exit semantics for GitHub issues #4343 and #4339.
+
+## Findings
+- Covered backend sync cloud HTTP 502 -> E_BACKEND/6 and task show cloud autosync fetch failure -> E_NETWORK/7 in runCli.
+
+## Evidence
+- .agentplane/tasks/202606010508-88AVPY/README.md
+- packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202606010508-88AVPY/quality/20260601-051457307-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202606010508-88AVPY/quality/20260601-051457307-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202606010508-88AVPY
+- task_readme: .agentplane/tasks/202606010508-88AVPY/README.md
+- report_path: .agentplane/tasks/202606010508-88AVPY/quality/20260601-051457307-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202606010508-88AVPY/quality/20260601-051457307-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202606010508-88AVPY/quality/20260601-051457307-recovery-context/quality-report.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "task_id": "202606010508-88AVPY",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-06-01T05:14:57.307Z",
+  "verdict": "pass",
+  "summary": "Regression tests now cover cloud backend E_BACKEND/E_NETWORK nonzero exit semantics for GitHub issues #4343 and #4339.",
+  "evaluated_sha": "5986865edd175765da4c56bad02debb20de4cf01",
+  "blueprint_digest": "72148b189d649d301cbc3cdd91492ac9e86fb4de0b7db97e72034ea9e3136e70",
+  "findings": [
+    "Covered backend sync cloud HTTP 502 -> E_BACKEND/6 and task show cloud autosync fetch failure -> E_NETWORK/7 in runCli."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202606010508-88AVPY/README.md",
+    "packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts
@@ -57,6 +57,34 @@ function normalizeSlashes(value: string): string {
 
 installRunCliIntegrationHarness();
 
+async function writeCloudBackendProject(root: string): Promise<void> {
+  const config = defaultConfig();
+  config.tasks_backend.config_path = ".agentplane/backends/cloud/backend.json";
+  config.agents.approvals.require_network = false;
+  await writeConfig(root, config);
+  const backendDir = path.join(root, ".agentplane", "backends", "cloud");
+  await mkdir(backendDir, { recursive: true });
+  await writeFile(
+    path.join(backendDir, "backend.json"),
+    `${JSON.stringify(
+      {
+        id: "cloud",
+        version: 1,
+        settings: {
+          endpoint: "https://cloud.example",
+          token: "token",
+          project_id: "project-1",
+          cache_dir: ".agentplane/tasks",
+          stale_after_seconds: 1,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+}
+
 describe("runCli", () => {
   it("backend rejects unknown subcommands", async () => {
     const root = await mkGitRepoRoot();
@@ -549,6 +577,80 @@ describe("runCli", () => {
     } finally {
       io.restore();
       spy.mockRestore();
+    }
+  });
+
+  it("backend sync cloud exits nonzero when the cloud push endpoint returns E_BACKEND", async () => {
+    const root = await mkGitRepoRoot();
+    await writeCloudBackendProject(root);
+    const cache = new taskBackend.LocalBackend({
+      dir: path.join(root, ".agentplane", "tasks"),
+    });
+    await cache.writeTask({
+      id: "202605311957-A1B2C3",
+      title: "Cloud task",
+      description: "Push this task",
+      status: "TODO",
+      priority: "med",
+      owner: "CODER",
+      depends_on: [],
+      tags: ["cloud"],
+      verify: [],
+    });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(Response.json({ error: "upstream unavailable" }, { status: 502 }));
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli([
+        "backend",
+        "sync",
+        "cloud",
+        "--direction",
+        "push",
+        "--conflict",
+        "fail",
+        "--yes",
+        "--root",
+        root,
+      ]);
+      expect(code).toBe(6);
+      expect(io.stderr).toContain("error [E_BACKEND]");
+      expect(io.stderr).toContain("Cloud backend request failed: HTTP 502");
+    } finally {
+      io.restore();
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("task show exits nonzero when cloud read autosync fails before a response", async () => {
+    const root = await mkGitRepoRoot();
+    await writeCloudBackendProject(root);
+    await mkdir(path.join(root, ".agentplane", "backends", "cloud"), { recursive: true });
+    await writeFile(
+      path.join(root, ".agentplane", "backends", "cloud", "state.json"),
+      `${JSON.stringify({ last_checked_at: "2026-05-01T00:00:00.000Z" }, null, 2)}\n`,
+      "utf8",
+    );
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const href =
+        typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (href.endsWith("/sync/state")) {
+        return Promise.resolve(Response.json({ error: "sync state unavailable" }, { status: 502 }));
+      }
+      return Promise.reject(new TypeError("fetch failed"));
+    });
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["task", "show", "202605311957-A1B2C3", "--root", root]);
+      expect(code).toBe(7);
+      expect(io.stderr).toContain("error [E_NETWORK]");
+      expect(io.stderr).toContain("Cloud backend request failed before a response was received");
+    } finally {
+      io.restore();
+      fetchSpy.mockRestore();
     }
   });
 


### PR DESCRIPTION
Task: `202606010508-88AVPY`
Title: Fix cloud backend failure exit semantics
Canonical task record: `.agentplane/tasks/202606010508-88AVPY/README.md`

## Summary

Fix cloud backend failure exit semantics

Fix GitHub issues #4343 and #4339. Ensure backend/cloud commands that surface E_BACKEND or E_NETWORK failures return nonzero exit codes and expose deterministic tests. No fallback or backwards-compatible aliases.

Fixes #4343.
Fixes #4339.

## Scope

- In scope: Fix GitHub issues #4343 and #4339. Ensure backend/cloud commands that surface E_BACKEND or E_NETWORK failures return nonzero exit codes and expose deterministic tests. No fallback or backwards-compatible aliases.
- Out of scope: unrelated refactors not required for "Fix cloud backend failure exit semantics".

## Verification

- State: ok
- Note:

```bash
bun x vitest run packages/agentplane/src/cli/run-cli.core.backend-sync.test.ts. Result: pass, 19 \
  tests. Evidence: regression coverage now asserts cloud push HTTP 502 exits with E_BACKEND/6 and \
  cloud read autosync fetch failure exits with E_NETWORK/7, covering GitHub issues #4343 and #4339. \
  Command: bun run format:changed. Result: pass. Command: node .agentplane/policy/check-routing.mjs. \
  Result: pass.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-06-01T05:09:45.941Z
- Branch: task/202606010508-88AVPY/fix-cloud-backend-failure-exit-semantics
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/cli/run-cli.core.backend-sync.test.ts      | 102 +++++++++++++++++++++
 1 file changed, 102 insertions(+)
```

</details>
