### PR TITLE
Add cloud exit semantics ACR

### DIFF
--- a/.agentplane/tasks/202606010508-88AVPY/acr.json
+++ b/.agentplane/tasks/202606010508-88AVPY/acr.json
@@ -1,0 +1,232 @@
+{
+  "acr_version": "0.1.0",
+  "record_type": "agent_change_record",
+  "record_id": "acr_202606010508-88AVPY",
+  "created_at": "2026-06-01T05:22:30.047Z",
+  "producer": {
+    "name": "agentplane",
+    "version": "0.6.13"
+  },
+  "repository": {
+    "vcs": "git",
+    "remote": "https://github.com/basilisk-labs/agentplane.git",
+    "base_ref": "main",
+    "base_commit": "3edcc6346f1eeb64b548ee70459699ef597e5e6d",
+    "work_ref": "codex/post-merge-cloud-exit-acr",
+    "work_commit": "3edcc6346f1eeb64b548ee70459699ef597e5e6d"
+  },
+  "task": {
+    "task_id": "202606010508-88AVPY",
+    "title": "Fix cloud backend failure exit semantics",
+    "intent": "Fix GitHub issues #4343 and #4339. Ensure backend/cloud commands that surface E_BACKEND or E_NETWORK failures return nonzero exit codes and expose deterministic tests. No fallback or backwards-compatible aliases.",
+    "requested_by": {
+      "type": "agentplane_role",
+      "id": "ORCHESTRATOR"
+    }
+  },
+  "agent": {
+    "id": "CODER",
+    "name": "CODER",
+    "agent_type": "coding_agent",
+    "model": {
+      "provider": "openai",
+      "name": "gpt-5-codex",
+      "version": "unknown"
+    },
+    "toolchain": [
+      {
+        "name": "agentplane",
+        "version": "0.6.13"
+      }
+    ]
+  },
+  "plan": {
+    "status": "approved",
+    "artifact": {
+      "path": ".agentplane/tasks/202606010508-88AVPY/README.md",
+      "sha256": "sha256:70b7c3dbdca21292f8d5f677bd6fbe23d22fa7e1b38ead9b1e8c1decd74d40c8"
+    },
+    "approved_at": "2026-06-01T05:09:12.565Z",
+    "approved_by": {
+      "type": "agentplane_role",
+      "id": "ORCHESTRATOR"
+    }
+  },
+  "permissions": {
+    "network": {
+      "mode": "unknown"
+    },
+    "secrets": {
+      "access": "none"
+    },
+    "tools": [
+      {
+        "name": "shell",
+        "allowed": true
+      }
+    ]
+  },
+  "policy": {
+    "policy_version": "0.1.0",
+    "decisions": [
+      {
+        "rule_id": "plan.required",
+        "decision": "pass",
+        "reason": "Approved plan exists."
+      },
+      {
+        "rule_id": "verification.required",
+        "decision": "pass",
+        "reason": "Verification is recorded as ok."
+      }
+    ]
+  },
+  "changes": {
+    "summary": "Merged via PR #4344.",
+    "diff_stats": {
+      "files_changed": 0,
+      "insertions": 0,
+      "deletions": 0
+    },
+    "files": [],
+    "risk": {
+      "level": "medium",
+      "categories": [],
+      "protected_paths_touched": false
+    }
+  },
+  "verification": {
+    "status": "passed",
+    "checks": []
+  },
+  "approvals": [
+    {
+      "approval_id": "approval_202606010508-88AVPY_plan",
+      "type": "plan_approval",
+      "decision": "approved",
+      "approved_by": {
+        "type": "agentplane_role",
+        "id": "ORCHESTRATOR"
+      },
+      "approved_at": "2026-06-01T05:09:12.565Z",
+      "scope": "task"
+    }
+  ],
+  "evidence": [
+    {
+      "type": "task",
+      "path": ".agentplane/tasks/202606010508-88AVPY/README.md",
+      "sha256": "sha256:70b7c3dbdca21292f8d5f677bd6fbe23d22fa7e1b38ead9b1e8c1decd74d40c8"
+    },
+    {
+      "type": "plan",
+      "path": ".agentplane/tasks/202606010508-88AVPY/README.md",
+      "sha256": "sha256:70b7c3dbdca21292f8d5f677bd6fbe23d22fa7e1b38ead9b1e8c1decd74d40c8"
+    },
+    {
+      "type": "verification_log",
+      "path": ".agentplane/tasks/202606010508-88AVPY/README.md",
+      "sha256": "sha256:70b7c3dbdca21292f8d5f677bd6fbe23d22fa7e1b38ead9b1e8c1decd74d40c8"
+    },
+    {
+      "type": "other",
+      "path": ".agentplane/tasks/202606010508-88AVPY/blueprint/resolved-snapshot.json",
+      "sha256": "sha256:22b962457e6e23179a601e2314f0a35df0efa1439492533bf4d2344ccabf9f6d"
+    }
+  ],
+  "result": {
+    "status": "finished",
+    "merge_ready": false,
+    "residual_risks": [
+      "Passed verification has no checks."
+    ],
+    "rollback": {
+      "available": true,
+      "notes": "Revert work_commit 3edcc6346f1eeb64b548ee70459699ef597e5e6d if downstream validation fails."
+    }
+  },
+  "integrity": {
+    "digest_algorithm": "sha256",
+    "record_digest": "sha256:b61fe3de52bde11ea8a710b80a76f0163e65db279490c8ae3e7f372efd3721ea",
+    "canonicalization": "rfc8785-jcs",
+    "signatures": []
+  },
+  "extensions": {
+    "agentplane.blueprint": {
+      "blueprint_id": "code.branch_pr",
+      "blueprint_version": 1,
+      "workflow_mode": "branch_pr",
+      "route": [
+        "intake",
+        "scope",
+        "approval_gate",
+        "context_resolve",
+        "worktree_start",
+        "work_unit",
+        "fast_local_checks",
+        "pr_artifact",
+        "verify_record",
+        "quality_gate",
+        "hosted_checks",
+        "publish_or_integrate",
+        "finish"
+      ],
+      "required_evidence": [
+        {
+          "id": "code_pr.paths",
+          "kind": "changed_paths",
+          "produced_by": "work_unit",
+          "required": true
+        },
+        {
+          "id": "code_pr.fast_checks",
+          "kind": "check_result",
+          "produced_by": "fast_local_checks",
+          "required": true
+        },
+        {
+          "id": "code_pr.pr",
+          "kind": "external_link",
+          "produced_by": "pr_artifact",
+          "required": true
+        },
+        {
+          "id": "code_pr.verify",
+          "kind": "check_result",
+          "produced_by": "verify_record",
+          "required": true
+        },
+        {
+          "id": "code_pr.quality",
+          "kind": "quality_report",
+          "produced_by": "quality_gate",
+          "required": true
+        },
+        {
+          "id": "code_pr.hosted",
+          "kind": "check_result",
+          "produced_by": "hosted_checks",
+          "required": true
+        },
+        {
+          "id": "code_pr.commit",
+          "kind": "commit",
+          "produced_by": "publish_or_integrate",
+          "required": true
+        }
+      ],
+      "accepted_recipe_extensions": [],
+      "rejected_recipe_extensions": [],
+      "stop_reasons": [],
+      "snapshot": {
+        "state": "current",
+        "path": ".agentplane/tasks/202606010508-88AVPY/blueprint/resolved-snapshot.json",
+        "digest": "72148b189d649d301cbc3cdd91492ac9e86fb4de0b7db97e72034ea9e3136e70",
+        "current_digest": "72148b189d649d301cbc3cdd91492ac9e86fb4de0b7db97e72034ea9e3136e70",
+        "route_changed": false,
+        "artifact_sha256": "sha256:22b962457e6e23179a601e2314f0a35df0efa1439492533bf4d2344ccabf9f6d",
+        "safe_command": "agentplane blueprint snapshot 202606010508-88AVPY"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds the missing Agent Change Record for task 202606010508-88AVPY after PR #4344 and close-tail PR #4345 landed.\n\nVerification:\n- agentplane acr generate 202606010508-88AVPY --work-commit 3edcc6346f1eeb64b548ee70459699ef597e5e6d --agent CODER --model-provider openai --model-name gpt-5-codex --write --json\n- agentplane acr validate 202606010508-88AVPY --mode local --json\n- pre-push fast docs-policy bucket