### PR TITLE
🚧 BEYQXA task: Fix Hermes task launch profile gaps [202606010530-BEYQXA]

### DIFF
--- a/.agentplane/tasks/202606010530-BEYQXA/README.md
+++ b/.agentplane/tasks/202606010530-BEYQXA/README.md
@@ -1,0 +1,148 @@
+---
+id: "202606010530-BEYQXA"
+title: "Fix Hermes task launch profile gaps"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "bug"
+  - "code"
+  - "hermes"
+  - "runner"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-06-01T05:31:07.241Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-06-01T05:39:04.298Z"
+  updated_by: "CODER"
+  note: "Verified: Hermes supervise now allowlists same-task task run through typed args, init --tool hermes seeds the custom Hermes runner profile, and targeted tests/type/docs/routing checks pass."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement the approved Hermes launch fixes for issue #4347 in the task worktree, then run targeted Hermes, runner, init, schema, and routing checks before PR handoff."
+events:
+  -
+    type: "status"
+    at: "2026-06-01T05:31:21.101Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement the approved Hermes launch fixes for issue #4347 in the task worktree, then run targeted Hermes, runner, init, schema, and routing checks before PR handoff."
+  -
+    type: "verify"
+    at: "2026-06-01T05:39:04.298Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: Hermes supervise now allowlists same-task task run through typed args, init --tool hermes seeds the custom Hermes runner profile, and targeted tests/type/docs/routing checks pass."
+doc_version: 3
+doc_updated_at: "2026-06-01T05:39:04.313Z"
+doc_updated_by: "CODER"
+description: "Resolve GitHub issue #4347 by allowing hermes supervise to execute the same-task task-run route step safely and by adding a first-class Hermes init/runner profile path."
+sections:
+  Summary: |-
+    Fix Hermes task launch profile gaps
+
+    Resolve GitHub issue #4347 by allowing hermes supervise to execute the same-task task-run route step safely and by adding a first-class Hermes init/runner profile path.
+  Scope: |-
+    - In scope: Resolve GitHub issue #4347 by allowing hermes supervise to execute the same-task task-run route step safely and by adding a first-class Hermes init/runner profile path.
+    - Out of scope: unrelated refactors not required for "Fix Hermes task launch profile gaps".
+  Plan: "Goal: close GitHub issue #4347 by making Hermes a usable task launch/execution path. Scope: (1) update hermes supervise route-step allowlisting so --execute-step accepts the same-task 'agentplane task run <task-id>' route action and still routes execution through runAgentplaneStep without raw-shell escape; cover dry-run and child failure-code propagation in hermes tests. (2) add a first-class Hermes init/profile path or explicit init token that configures Hermes execution through runner.custom without requiring Codex by default; update schema/help/docs/tests for the chosen existing init/config surfaces. Verification: run ap task verify-show 202606010530-BEYQXA, targeted hermes/runner/init/schema tests, node .agentplane/policy/check-routing.mjs, and final git status --short --untracked-files=all."
+  Verify Steps: |-
+    1. Run `ap task verify-show 202606010530-BEYQXA`. Expected: task-specific verification contract is visible and no fallback scaffold remains.
+    2. Run `bunx vitest run packages/agentplane/src/commands/hermes/hermes.command.test.ts packages/agentplane/src/runner/config.test.ts packages/agentplane/src/cli/run-cli.core.init.test.ts packages/core/src/config/config.test.ts`. Expected: Hermes supervise accepts the same-task `agentplane task run <task-id>` step, child exit codes propagate, and `init --tool hermes` writes a custom Hermes runner profile.
+    3. Run `node .agentplane/policy/check-routing.mjs`. Expected: policy routing and size budgets still pass.
+    4. Run `git status --short --untracked-files=all`. Expected: only intentional task/code/docs artifacts are present before commit/PR handoff.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-06-01T05:39:04.298Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified: Hermes supervise now allowlists same-task task run through typed args, init --tool hermes seeds the custom Hermes runner profile, and targeted tests/type/docs/routing checks pass.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-06-01T05:31:21.101Z, excerpt_hash=sha256:691e2e910a25965848775349bd9dddc98cd3618a5ec239ce8e2ec15eb118cc74
+
+    Details:
+
+    Command: ap task verify-show 202606010530-BEYQXA; Result: pass; Evidence: task-specific Verify Steps rendered and blueprint snapshot current. Command: bunx vitest run packages/agentplane/src/commands/hermes/hermes.command.test.ts packages/agentplane/src/runner/config.test.ts packages/agentplane/src/runner/adapters/custom.test.ts packages/agentplane/src/cli/run-cli.core.init.test.ts packages/core/src/config/config.test.ts; Result: pass; Evidence: 5 files, 80 tests passed. Command: bun run --filter=agentplane typecheck; Result: pass. Command: node .agentplane/policy/check-routing.mjs; Result: pass, policy routing OK. Command: bun run docs:cli:check; Result: pass, generated CLI reference up to date. Command: bun run format:changed and git diff --check; Result: pass.
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202606010530-BEYQXA-fix-hermes-task-launch/.agentplane/tasks/202606010530-BEYQXA/blueprint/resolved-snapshot.json
+    - old_digest: c22d3c6d19bcfb3ffe8a337ea69c6026f3c836dd54ad89af4b2ecba4fbfdef40
+    - current_digest: c22d3c6d19bcfb3ffe8a337ea69c6026f3c836dd54ad89af4b2ecba4fbfdef40
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202606010530-BEYQXA
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Fix Hermes task launch profile gaps
+
+Resolve GitHub issue #4347 by allowing hermes supervise to execute the same-task task-run route step safely and by adding a first-class Hermes init/runner profile path.
+
+## Scope
+
+- In scope: Resolve GitHub issue #4347 by allowing hermes supervise to execute the same-task task-run route step safely and by adding a first-class Hermes init/runner profile path.
+- Out of scope: unrelated refactors not required for "Fix Hermes task launch profile gaps".
+
+## Plan
+
+Goal: close GitHub issue #4347 by making Hermes a usable task launch/execution path. Scope: (1) update hermes supervise route-step allowlisting so --execute-step accepts the same-task 'agentplane task run <task-id>' route action and still routes execution through runAgentplaneStep without raw-shell escape; cover dry-run and child failure-code propagation in hermes tests. (2) add a first-class Hermes init/profile path or explicit init token that configures Hermes execution through runner.custom without requiring Codex by default; update schema/help/docs/tests for the chosen existing init/config surfaces. Verification: run ap task verify-show 202606010530-BEYQXA, targeted hermes/runner/init/schema tests, node .agentplane/policy/check-routing.mjs, and final git status --short --untracked-files=all.
+
+## Verify Steps
+
+1. Run `ap task verify-show 202606010530-BEYQXA`. Expected: task-specific verification contract is visible and no fallback scaffold remains.
+2. Run `bunx vitest run packages/agentplane/src/commands/hermes/hermes.command.test.ts packages/agentplane/src/runner/config.test.ts packages/agentplane/src/cli/run-cli.core.init.test.ts packages/core/src/config/config.test.ts`. Expected: Hermes supervise accepts the same-task `agentplane task run <task-id>` step, child exit codes propagate, and `init --tool hermes` writes a custom Hermes runner profile.
+3. Run `node .agentplane/policy/check-routing.mjs`. Expected: policy routing and size budgets still pass.
+4. Run `git status --short --untracked-files=all`. Expected: only intentional task/code/docs artifacts are present before commit/PR handoff.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-06-01T05:39:04.298Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: Hermes supervise now allowlists same-task task run through typed args, init --tool hermes seeds the custom Hermes runner profile, and targeted tests/type/docs/routing checks pass.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-06-01T05:31:21.101Z, excerpt_hash=sha256:691e2e910a25965848775349bd9dddc98cd3618a5ec239ce8e2ec15eb118cc74
+
+Details:
+
+Command: ap task verify-show 202606010530-BEYQXA; Result: pass; Evidence: task-specific Verify Steps rendered and blueprint snapshot current. Command: bunx vitest run packages/agentplane/src/commands/hermes/hermes.command.test.ts packages/agentplane/src/runner/config.test.ts packages/agentplane/src/runner/adapters/custom.test.ts packages/agentplane/src/cli/run-cli.core.init.test.ts packages/core/src/config/config.test.ts; Result: pass; Evidence: 5 files, 80 tests passed. Command: bun run --filter=agentplane typecheck; Result: pass. Command: node .agentplane/policy/check-routing.mjs; Result: pass, policy routing OK. Command: bun run docs:cli:check; Result: pass, generated CLI reference up to date. Command: bun run format:changed and git diff --check; Result: pass.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202606010530-BEYQXA-fix-hermes-task-launch/.agentplane/tasks/202606010530-BEYQXA/blueprint/resolved-snapshot.json
+- old_digest: c22d3c6d19bcfb3ffe8a337ea69c6026f3c836dd54ad89af4b2ecba4fbfdef40
+- current_digest: c22d3c6d19bcfb3ffe8a337ea69c6026f3c836dd54ad89af4b2ecba4fbfdef40
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202606010530-BEYQXA
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202606010530-BEYQXA/README.md
+++ b/.agentplane/tasks/202606010530-BEYQXA/README.md
@@ -4,7 +4,7 @@ title: "Fix Hermes task launch profile gaps"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -25,6 +25,25 @@ verification:
   updated_by: "CODER"
   note: "Verified: Hermes supervise now allowlists same-task task run through typed args, init --tool hermes seeds the custom Hermes runner profile, and targeted tests/type/docs/routing checks pass."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-06-01T05:46:00.860Z"
+  updated_by: "EVALUATOR"
+  note: "Hermes task launch gaps are fixed within approved scope: supervise executes same-task task-run route steps through typed Agentplane args, init --tool hermes configures runner.custom, and docs/tests cover the behavior."
+  evaluated_sha: "1ce894445022d85e090d8faf19d54e92a678ab79"
+  blueprint_digest: "c22d3c6d19bcfb3ffe8a337ea69c6026f3c836dd54ad89af4b2ecba4fbfdef40"
+  evidence_refs:
+    - ".agentplane/tasks/202606010530-BEYQXA/README.md"
+    - ".agentplane/tasks/202606010530-BEYQXA/quality/20260601-054600860-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202606010530-BEYQXA/quality/20260601-054600860-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202606010530-BEYQXA/quality/20260601-054600860-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202606010530-BEYQXA/blueprint/resolved-snapshot.json"
+    - "bunx vitest run packages/agentplane/src/commands/hermes/hermes.command.test.ts packages/agentplane/src/runner/config.test.ts packages/agentplane/src/runner/adapters/custom.test.ts packages/agentplane/src/cli/run-cli.core.init.test.ts packages/core/src/config/config.test.ts"
+    - "bun run --filter=agentplane typecheck"
+    - "bun run docs:cli:check"
+    - "node .agentplane/policy/check-routing.mjs"
+  findings:
+    - "No rework required. Residual risk is limited to the external Hermes CLI/plugin implementing the documented hermes agentplane run entrypoint."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202606010530-BEYQXA/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202606010530-BEYQXA/blueprint/resolved-snapshot.json
@@ -1,0 +1,573 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202606010530-BEYQXA",
+    "title": "Fix Hermes task launch profile gaps",
+    "description": "Resolve GitHub issue #4347 by allowing hermes supervise to execute the same-task task-run route step safely and by adding a first-class Hermes init/runner profile path.",
+    "tags": [
+      "bug",
+      "code",
+      "hermes",
+      "runner"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202606010530-BEYQXA",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "c22d3c6d19bcfb3ffe8a337ea69c6026f3c836dd54ad89af4b2ecba4fbfdef40"
+  }
+}

--- a/.agentplane/tasks/202606010530-BEYQXA/pr/diffstat.txt
+++ b/.agentplane/tasks/202606010530-BEYQXA/pr/diffstat.txt
@@ -1,0 +1,18 @@
+ docs/recipes/hermes-agentplane.mdx                 | 12 +++++++
+ docs/user/cli-reference.generated.mdx              |  8 ++++-
+ docs/user/configuration.mdx                        |  5 ++-
+ .../agentplane/src/cli/run-cli.core.init.test.ts   | 31 +++++++++++++++++
+ .../src/cli/run-cli/commands/init/answers.ts       |  4 +++
+ .../src/cli/run-cli/commands/init/execution.ts     |  2 ++
+ .../src/cli/run-cli/commands/init/init-plan.ts     |  1 +
+ .../src/cli/run-cli/commands/init/model.ts         | 12 ++++++-
+ .../src/cli/run-cli/commands/init/modes.ts         | 10 ++++++
+ .../src/cli/run-cli/commands/init/orchestrate.ts   |  1 +
+ .../src/cli/run-cli/commands/init/presets.ts       |  1 +
+ .../src/cli/run-cli/commands/init/spec.ts          |  8 +++--
+ .../src/cli/run-cli/commands/init/write-config.ts  | 18 +++++++++-
+ .../src/commands/hermes/hermes-runtime.ts          |  5 ++-
+ .../src/commands/hermes/hermes.command.test.ts     | 40 ++++++++++++++++++++++
+ .../src/runner/adapters/custom-preparation.ts      |  3 ++
+ .../agentplane/src/runner/adapters/custom.test.ts  |  1 +
+ 17 files changed, 155 insertions(+), 7 deletions(-)

--- a/.agentplane/tasks/202606010530-BEYQXA/pr/github-body.md
+++ b/.agentplane/tasks/202606010530-BEYQXA/pr/github-body.md
@@ -1,0 +1,55 @@
+Task: `202606010530-BEYQXA`
+Title: Fix Hermes task launch profile gaps
+Canonical task record: `.agentplane/tasks/202606010530-BEYQXA/README.md`
+
+## Summary
+
+Fix Hermes task launch profile gaps
+
+Resolve GitHub issue #4347 by allowing hermes supervise to execute the same-task task-run route step safely and by adding a first-class Hermes init/runner profile path.
+
+## Scope
+
+- In scope: Resolve GitHub issue #4347 by allowing hermes supervise to execute the same-task task-run route step safely and by adding a first-class Hermes init/runner profile path.
+- Out of scope: unrelated refactors not required for "Fix Hermes task launch profile gaps".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Verified: Hermes supervise now allowlists same-task task run through typed args, init --tool hermes
+seeds the custom Hermes runner profile, and targeted tests/type/docs/routing checks pass.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-06-01T05:31:21.158Z
+- Branch: task/202606010530-BEYQXA/fix-hermes-task-launch
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ docs/recipes/hermes-agentplane.mdx                 | 12 +++++++
+ docs/user/cli-reference.generated.mdx              |  8 ++++-
+ docs/user/configuration.mdx                        |  5 ++-
+ .../agentplane/src/cli/run-cli.core.init.test.ts   | 31 +++++++++++++++++
+ .../src/cli/run-cli/commands/init/answers.ts       |  4 +++
+ .../src/cli/run-cli/commands/init/execution.ts     |  2 ++
+ .../src/cli/run-cli/commands/init/init-plan.ts     |  1 +
+ .../src/cli/run-cli/commands/init/model.ts         | 12 ++++++-
+ .../src/cli/run-cli/commands/init/modes.ts         | 10 ++++++
+ .../src/cli/run-cli/commands/init/orchestrate.ts   |  1 +
+ .../src/cli/run-cli/commands/init/presets.ts       |  1 +
+ .../src/cli/run-cli/commands/init/spec.ts          |  8 +++--
+ .../src/cli/run-cli/commands/init/write-config.ts  | 18 +++++++++-
+ .../src/commands/hermes/hermes-runtime.ts          |  5 ++-
+ .../src/commands/hermes/hermes.command.test.ts     | 40 ++++++++++++++++++++++
+ .../src/runner/adapters/custom-preparation.ts      |  3 ++
+ .../agentplane/src/runner/adapters/custom.test.ts  |  1 +
+ 17 files changed, 155 insertions(+), 7 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202606010530-BEYQXA/pr/github-title.txt
+++ b/.agentplane/tasks/202606010530-BEYQXA/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 BEYQXA task: Fix Hermes task launch profile gaps [202606010530-BEYQXA]

--- a/.agentplane/tasks/202606010530-BEYQXA/pr/meta.json
+++ b/.agentplane/tasks/202606010530-BEYQXA/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202606010530-BEYQXA/fix-hermes-task-launch",
+  "created_at": "2026-06-01T05:31:21.158Z",
+  "diffstat_sha256": "sha256:496ffd01c78d62c7b00c83afb7061125671bdf8bc5007c7bd04f8df298221cba",
+  "last_verified_at": "2026-06-01T05:39:04.298Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202606010530-BEYQXA",
+  "updated_at": "2026-06-01T05:31:21.158Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202606010530-BEYQXA/pr/review.md
+++ b/.agentplane/tasks/202606010530-BEYQXA/pr/review.md
@@ -1,0 +1,53 @@
+# PR Review
+
+Created: 2026-06-01T05:31:21.158Z
+
+## Task
+
+- Task: `202606010530-BEYQXA`
+- Title: Fix Hermes task launch profile gaps
+- Status: DOING
+- Branch: `task/202606010530-BEYQXA/fix-hermes-task-launch`
+- Canonical task record: `.agentplane/tasks/202606010530-BEYQXA/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified: Hermes supervise now allowlists same-task task run through typed args, init --tool hermes seeds the custom Hermes runner profile, and targeted tests/type/docs/routing checks pass.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-06-01T05:31:21.158Z
+- Branch: task/202606010530-BEYQXA/fix-hermes-task-launch
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ docs/recipes/hermes-agentplane.mdx                 | 12 +++++++
+ docs/user/cli-reference.generated.mdx              |  8 ++++-
+ docs/user/configuration.mdx                        |  5 ++-
+ .../agentplane/src/cli/run-cli.core.init.test.ts   | 31 +++++++++++++++++
+ .../src/cli/run-cli/commands/init/answers.ts       |  4 +++
+ .../src/cli/run-cli/commands/init/execution.ts     |  2 ++
+ .../src/cli/run-cli/commands/init/init-plan.ts     |  1 +
+ .../src/cli/run-cli/commands/init/model.ts         | 12 ++++++-
+ .../src/cli/run-cli/commands/init/modes.ts         | 10 ++++++
+ .../src/cli/run-cli/commands/init/orchestrate.ts   |  1 +
+ .../src/cli/run-cli/commands/init/presets.ts       |  1 +
+ .../src/cli/run-cli/commands/init/spec.ts          |  8 +++--
+ .../src/cli/run-cli/commands/init/write-config.ts  | 18 +++++++++-
+ .../src/commands/hermes/hermes-runtime.ts          |  5 ++-
+ .../src/commands/hermes/hermes.command.test.ts     | 40 ++++++++++++++++++++++
+ .../src/runner/adapters/custom-preparation.ts      |  3 ++
+ .../agentplane/src/runner/adapters/custom.test.ts  |  1 +
+ 17 files changed, 155 insertions(+), 7 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202606010530-BEYQXA/quality/20260601-054600860-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202606010530-BEYQXA/quality/20260601-054600860-recovery-context/evaluator-opinion.md
@@ -1,0 +1,22 @@
+# EVALUATOR opinion: pass
+
+Hermes task launch gaps are fixed within approved scope: supervise executes same-task task-run route steps through typed Agentplane args, init --tool hermes configures runner.custom, and docs/tests cover the behavior.
+
+## Findings
+- No rework required. Residual risk is limited to the external Hermes CLI/plugin implementing the documented hermes agentplane run entrypoint.
+
+## Evidence
+- .agentplane/tasks/202606010530-BEYQXA/README.md
+- bunx vitest run packages/agentplane/src/commands/hermes/hermes.command.test.ts packages/agentplane/src/runner/config.test.ts packages/agentplane/src/runner/adapters/custom.test.ts packages/agentplane/src/cli/run-cli.core.init.test.ts packages/core/src/config/config.test.ts
+- bun run --filter=agentplane typecheck
+- bun run docs:cli:check
+- node .agentplane/policy/check-routing.mjs
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202606010530-BEYQXA/quality/20260601-054600860-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202606010530-BEYQXA/quality/20260601-054600860-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202606010530-BEYQXA
+- task_readme: .agentplane/tasks/202606010530-BEYQXA/README.md
+- report_path: .agentplane/tasks/202606010530-BEYQXA/quality/20260601-054600860-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202606010530-BEYQXA/quality/20260601-054600860-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202606010530-BEYQXA/quality/20260601-054600860-recovery-context/quality-report.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "task_id": "202606010530-BEYQXA",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-06-01T05:46:00.860Z",
+  "verdict": "pass",
+  "summary": "Hermes task launch gaps are fixed within approved scope: supervise executes same-task task-run route steps through typed Agentplane args, init --tool hermes configures runner.custom, and docs/tests cover the behavior.",
+  "evaluated_sha": "1ce894445022d85e090d8faf19d54e92a678ab79",
+  "blueprint_digest": "c22d3c6d19bcfb3ffe8a337ea69c6026f3c836dd54ad89af4b2ecba4fbfdef40",
+  "findings": [
+    "No rework required. Residual risk is limited to the external Hermes CLI/plugin implementing the documented hermes agentplane run entrypoint."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202606010530-BEYQXA/README.md",
+    "bunx vitest run packages/agentplane/src/commands/hermes/hermes.command.test.ts packages/agentplane/src/runner/config.test.ts packages/agentplane/src/runner/adapters/custom.test.ts packages/agentplane/src/cli/run-cli.core.init.test.ts packages/core/src/config/config.test.ts",
+    "bun run --filter=agentplane typecheck",
+    "bun run docs:cli:check",
+    "node .agentplane/policy/check-routing.mjs"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/docs/recipes/hermes-agentplane.mdx
+++ b/docs/recipes/hermes-agentplane.mdx
@@ -38,6 +38,16 @@ agentplane recipes add hermes-agentplane
 agentplane recipes explain hermes-agentplane
 ```
 
+For new repositories that should avoid Codex as the default task runner, initialize with the Hermes
+tool profile:
+
+```bash
+agentplane init --quick --tool hermes
+```
+
+That profile keeps the normal Agentplane policy gateway and configures `agentplane task run` through
+the `custom` runner adapter with `runner.custom.command=["hermes","agentplane","run"]`.
+
 ## Expected adapter commands
 
 ```bash
@@ -63,6 +73,8 @@ HERMES_KANBAN_CLAIM_LOCK=<claim-lock>
 
 `agentplane hermes doctor --json` reports missing Hermes environment values and lane-registry
 state. The Agentplane side uses `AGENTPLANE_HERMES_LANE_REGISTRY` as the registry input.
+Task-runner invocations also export `AGENTPLANE_RUNNER_TASK_ID` when the run target is an Agentplane
+task, so Hermes launchers can bind the external worker run back to the canonical task id.
 
 ## Visibility contract
 

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -2118,7 +2118,7 @@ Options:
 - `--init-mode <quick|guided|advanced|ci>`: User-facing init route. TTY defaults to guided; --yes defaults to ci for automation. (choices=quick|guided|advanced|ci)
 - `--quick`: Alias for --init-mode quick. (default=false)
 - `--advanced`: Alias for --init-mode advanced. (default=false)
-- `--tool <codex|claude|cursor|windsurf|multiple|manual>`: AI surface that should read project instructions. Granular --policy-gateway/--ide flags override this mapping. (choices=codex|claude|cursor|windsurf|multiple|manual)
+- `--tool <codex|claude|cursor|windsurf|hermes|multiple|manual>`: AI surface that should read project instructions. Granular --policy-gateway/--ide flags override this mapping. (choices=codex|claude|cursor|windsurf|hermes|multiple|manual)
 - `--setup-profile <light|normal|full-harness>`: Setup profile preset. Preferred values: light, normal, full-harness. (choices=light|normal|full-harness|developer|vibecoder|manager)
 - `--policy-gateway <codex|claude>`: Policy gateway file to install (codex -&gt; AGENTS.md, claude -&gt; CLAUDE.md). (choices=codex|claude)
 - `--ide <codex|cursor|windsurf>`: IDE rules integration target (default: codex). (choices=codex|cursor|windsurf)
@@ -2198,6 +2198,12 @@ agentplane init --quick --tool cursor
 ```
 
 - Use the quick first-run route and install AGENTS.md plus Cursor rules.
+
+```sh
+agentplane init --quick --tool hermes
+```
+
+- Use the quick first-run route and configure task runs through the Hermes custom runner profile.
 
 ### upgrade
 

--- a/docs/user/configuration.mdx
+++ b/docs/user/configuration.mdx
@@ -116,7 +116,10 @@ the prompt with `/goal ...`. Runner state, events, trace, and stderr artifacts a
 
 ### runner.custom
 
-Custom runner configuration controls the `custom` adapter command and enforcement settings.
+Custom runner configuration controls the `custom` adapter command and enforcement settings. `init
+--tool hermes` selects the custom adapter and seeds `runner.custom.command` as `["hermes",
+"agentplane", "run"]`; the custom adapter also exports `AGENTPLANE_RUNNER_TASK_ID` for task-targeted
+Hermes launchers.
 
 ### feedback
 

--- a/packages/agentplane/src/cli/run-cli.core.init.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.init.test.ts
@@ -807,6 +807,37 @@ describe("runCli", () => {
     expect(await pathExists(path.join(root, ".agentplane"))).toBe(false);
   });
 
+  it("init --quick --tool hermes configures the Hermes custom runner profile", async () => {
+    const root = await mkTempDir();
+    const io = captureStdIO();
+    try {
+      const code = await runCli([
+        "init",
+        "--yes",
+        "--quick",
+        "--tool",
+        "hermes",
+        "--root",
+        root,
+        "--gitignore-agents",
+      ]);
+      expect(code).toBe(0);
+    } finally {
+      io.restore();
+    }
+
+    const loaded = await loadConfig(path.join(root, ".agentplane"));
+    expect(loaded.config.runner.default_adapter).toBe("custom");
+    expect(loaded.config.runner.custom).toMatchObject({
+      command: ["hermes", "agentplane", "run"],
+      env: {},
+      enforcement: {
+        mode: "none",
+        platform: "auto",
+      },
+    });
+  });
+
   it("init plan records explicit GitHub issue feedback opt-in", async () => {
     const root = await mkTempDir();
     const io = captureStdIO();

--- a/packages/agentplane/src/cli/run-cli/commands/init/answers.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/answers.ts
@@ -23,6 +23,7 @@ import { introLogo, section } from "./ui.js";
 import {
   resolveIdeFromFlags,
   resolvePolicyGatewayFromFlags,
+  resolveRunnerProfileFromFlags,
   resolveToolDefaults,
 } from "./modes.js";
 
@@ -44,6 +45,7 @@ export type InitAnswers = {
   executionProfile: ExecutionProfile;
   strictUnsafeConfirm: boolean;
   blueprints: string[];
+  runnerProfile: "codex" | "hermes";
 };
 
 export function assertConfirmed(clack: InitClackPrompts, value: boolean | symbol): boolean {
@@ -75,6 +77,7 @@ export function buildNonInteractiveAnswers(flags: InitParsed): InitAnswers {
     executionProfile: flags.executionProfile ?? preset.defaultExecutionProfile,
     strictUnsafeConfirm: flags.strictUnsafeConfirm ?? preset.defaultStrictUnsafeConfirm,
     blueprints: flags.blueprints ?? INIT_DEFAULTS.blueprints,
+    runnerProfile: resolveRunnerProfileFromFlags(flags, "codex"),
   };
 }
 
@@ -150,5 +153,6 @@ export async function promptInteractiveAnswers(opts: {
     executionProfile: advanced.executionProfile,
     strictUnsafeConfirm: advanced.strictUnsafeConfirm,
     blueprints: blueprintSelection.blueprints,
+    runnerProfile: toolDefaults.runnerProfile ?? "codex",
   };
 }

--- a/packages/agentplane/src/cli/run-cli/commands/init/execution.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/execution.ts
@@ -47,6 +47,7 @@ export async function maybeConfirmInteractiveApply(opts: {
     { label: "Profile", value: opts.answers.setupProfileDescription },
     { label: "Gateway", value: opts.answers.policyGateway },
     { label: "Workflow", value: opts.answers.workflow },
+    { label: "Runner", value: opts.answers.runnerProfile },
     { label: "Backend", value: opts.answers.backend },
     { label: "Hooks", value: opts.answers.hooks },
     { label: "Feedback issues", value: opts.answers.feedbackGithubIssues },
@@ -144,6 +145,7 @@ export async function applyInitPlan(opts: {
           execution: buildExecutionProfile(opts.answers.executionProfile, {
             strictUnsafeConfirm: opts.answers.strictUnsafeConfirm,
           }),
+          runnerProfile: opts.answers.runnerProfile,
         });
         await writeBackendStubs({
           backend: opts.answers.backend,

--- a/packages/agentplane/src/cli/run-cli/commands/init/init-plan.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/init-plan.ts
@@ -204,6 +204,7 @@ export function buildInitPlan(opts: {
       strictUnsafeConfirm: opts.answers.strictUnsafeConfirm,
       recipes: [...opts.answers.recipes],
       blueprints: [...opts.answers.blueprints],
+      runnerProfile: opts.answers.runnerProfile,
     },
     context: {
       gitRootExisted: opts.paths.gitRootExisted,

--- a/packages/agentplane/src/cli/run-cli/commands/init/model.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/model.ts
@@ -8,8 +8,16 @@ export type InitIde = "codex" | "cursor" | "windsurf";
 export type SetupProfilePreset = "light" | "normal" | "full-harness";
 export type InitMode = "quick" | "guided" | "advanced" | "ci";
 export type UserFacingProfile = "solo" | "team" | "strict" | "custom";
-export type InitTool = "codex" | "claude" | "cursor" | "windsurf" | "multiple" | "manual";
+export type InitTool =
+  | "codex"
+  | "claude"
+  | "cursor"
+  | "windsurf"
+  | "hermes"
+  | "multiple"
+  | "manual";
 export type InitBackend = "local" | "cloud";
+export type InitRunnerProfile = "codex" | "hermes";
 
 export type InitFlags = {
   initMode?: InitMode;
@@ -55,6 +63,7 @@ export type InitDefaults = {
   executionProfile: ExecutionProfile;
   strictUnsafeConfirm: boolean;
   blueprints: string[];
+  runnerProfile: InitRunnerProfile;
 };
 
 export type InitEffectKind =
@@ -104,6 +113,7 @@ export type InitPlan = {
     strictUnsafeConfirm: boolean;
     recipes: string[];
     blueprints: string[];
+    runnerProfile: InitRunnerProfile;
   };
   context: {
     gitRootExisted: boolean;

--- a/packages/agentplane/src/cli/run-cli/commands/init/modes.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/modes.ts
@@ -3,6 +3,7 @@ import type {
   InitIde,
   InitMode,
   InitParsed,
+  InitRunnerProfile,
   InitTool,
   SetupProfilePreset,
   UserFacingProfile,
@@ -25,12 +26,21 @@ export function setupProfileToUserFacingProfile(profile: SetupProfilePreset): Us
 export function resolveToolDefaults(tool: InitTool | undefined): {
   policyGateway?: PolicyGatewayFlavor;
   ide?: InitIde;
+  runnerProfile?: InitRunnerProfile;
 } {
   if (!tool || tool === "multiple" || tool === "manual") return {};
   if (tool === "claude") return { policyGateway: "claude", ide: "codex" };
   if (tool === "cursor") return { policyGateway: "codex", ide: "cursor" };
   if (tool === "windsurf") return { policyGateway: "codex", ide: "windsurf" };
+  if (tool === "hermes") return { policyGateway: "codex", ide: "codex", runnerProfile: "hermes" };
   return { policyGateway: "codex", ide: "codex" };
+}
+
+export function resolveRunnerProfileFromFlags(
+  flags: Pick<InitFlags, "tool">,
+  fallback: InitRunnerProfile,
+): InitRunnerProfile {
+  return resolveToolDefaults(flags.tool).runnerProfile ?? fallback;
 }
 
 export function resolvePolicyGatewayFromFlags(

--- a/packages/agentplane/src/cli/run-cli/commands/init/orchestrate.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/orchestrate.ts
@@ -53,6 +53,7 @@ function renderDryRunPlanText(plan: ReturnType<typeof buildInitPlan>): string {
     `Mode: ${plan.mode}`,
     `Profile: ${plan.profile} (${plan.internalSetupProfile})`,
     `Workflow: ${plan.answers.workflow}`,
+    `Runner: ${plan.answers.runnerProfile}`,
     `Backend: ${plan.answers.backend}`,
     `Git init: ${String(!plan.context.gitRootExisted)}`,
     `Parent Git: ${plan.context.parentGitRoot ?? "none"}`,

--- a/packages/agentplane/src/cli/run-cli/commands/init/presets.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/presets.ts
@@ -16,6 +16,7 @@ export const INIT_DEFAULTS: InitDefaults = {
   executionProfile: "balanced",
   strictUnsafeConfirm: false,
   blueprints: [],
+  runnerProfile: "codex",
 };
 
 export const setupProfilePresets: Record<

--- a/packages/agentplane/src/cli/run-cli/commands/init/spec.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/spec.ts
@@ -42,8 +42,8 @@ export const initSpec: CommandSpec<InitParsed> = {
     {
       kind: "string",
       name: "tool",
-      valueHint: "<codex|claude|cursor|windsurf|multiple|manual>",
-      choices: ["codex", "claude", "cursor", "windsurf", "multiple", "manual"],
+      valueHint: "<codex|claude|cursor|windsurf|hermes|multiple|manual>",
+      choices: ["codex", "claude", "cursor", "windsurf", "hermes", "multiple", "manual"],
       coerce: (raw) => raw.trim().toLowerCase(),
       description:
         "AI surface that should read project instructions. Granular --policy-gateway/--ide flags override this mapping.",
@@ -237,6 +237,10 @@ export const initSpec: CommandSpec<InitParsed> = {
     {
       cmd: "agentplane init --quick --tool cursor",
       why: "Use the quick first-run route and install AGENTS.md plus Cursor rules.",
+    },
+    {
+      cmd: "agentplane init --quick --tool hermes",
+      why: "Use the quick first-run route and configure task runs through the Hermes custom runner profile.",
     },
   ],
   validateRaw: (raw) => {

--- a/packages/agentplane/src/cli/run-cli/commands/init/write-config.ts
+++ b/packages/agentplane/src/cli/run-cli/commands/init/write-config.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import { writeJsonStableIfChanged } from "../../../../shared/write-if-changed.js";
 import { getVersion } from "../../../../meta/version.js";
-import type { InitBackend } from "./model.js";
+import type { InitBackend, InitRunnerProfile } from "./model.js";
 
 type InitExecutionConfig = {
   profile: "conservative" | "balanced" | "aggressive";
@@ -44,6 +44,7 @@ export async function writeInitConfig(opts: {
   feedbackGithubIssues: boolean;
   feedbackAnonymousCloud: boolean;
   execution: InitExecutionConfig;
+  runnerProfile: InitRunnerProfile;
 }): Promise<void> {
   const rawConfig = defaultConfig() as unknown as Record<string, unknown>;
   setByDottedKey(rawConfig, "workflow_mode", opts.workflow);
@@ -76,6 +77,21 @@ export async function writeInitConfig(opts: {
   );
   setByDottedKey(rawConfig, "framework.cli.expected_version", getVersion());
   setByDottedKey(rawConfig, "execution", JSON.stringify(opts.execution));
+  if (opts.runnerProfile === "hermes") {
+    setByDottedKey(rawConfig, "runner.default_adapter", "custom");
+    setByDottedKey(
+      rawConfig,
+      "runner.custom",
+      JSON.stringify({
+        command: ["hermes", "agentplane", "run"],
+        env: {},
+        enforcement: {
+          mode: "none",
+          platform: "auto",
+        },
+      }),
+    );
+  }
   await saveConfig(opts.agentplaneDir, rawConfig);
 }
 

--- a/packages/agentplane/src/commands/hermes/hermes-runtime.ts
+++ b/packages/agentplane/src/commands/hermes/hermes-runtime.ts
@@ -285,7 +285,10 @@ export function executableStepFor(packet: HermesRoutePacketForExecution): {
   if (
     commandParts[0] === "agentplane" &&
     commandParts[1] === "task" &&
-    (subcommand === "verify-show" || subcommand === "status" || subcommand === "brief") &&
+    (subcommand === "run" ||
+      subcommand === "verify-show" ||
+      subcommand === "status" ||
+      subcommand === "brief") &&
     commandParts[3] === taskId
   ) {
     return { code: packet.next_action.code, args: ["task", subcommand, taskId], reason: null };

--- a/packages/agentplane/src/commands/hermes/hermes.command.test.ts
+++ b/packages/agentplane/src/commands/hermes/hermes.command.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { runCli } from "../../cli/run-cli.js";
+import { executableStepFor } from "./hermes-runtime.js";
 import { captureStdIO, mkGitRepoRoot, runCliSilent } from "@agentplane/testkit";
 import { chmod, mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
@@ -192,6 +193,45 @@ describe("hermes adapter commands", () => {
     } finally {
       io.restore();
     }
+  });
+
+  it("classifies same-task task run route steps as executable without raw shell", () => {
+    const step = executableStepFor({
+      task: {
+        id: "202606010530-BEYQXA",
+        title: "Hermes task launch",
+        owner: "CODER",
+      },
+      next_action: {
+        code: "run",
+        command: "agentplane task run 202606010530-BEYQXA",
+        summary: "launch the Agentplane task runner",
+      },
+    });
+
+    expect(step).toEqual({
+      code: "run",
+      args: ["task", "run", "202606010530-BEYQXA"],
+      reason: null,
+    });
+  });
+
+  it("rejects task run route steps for a different task id", () => {
+    const step = executableStepFor({
+      task: {
+        id: "202606010530-BEYQXA",
+        title: "Hermes task launch",
+        owner: "CODER",
+      },
+      next_action: {
+        code: "run",
+        command: "agentplane task run 202606010531-OTHER1",
+        summary: "launch another task runner",
+      },
+    });
+
+    expect(step.args).toBeNull();
+    expect(step.reason).toContain("unsupported Agentplane Hermes route action");
   });
 
   it("supervise returns the child Agentplane command failure code", async () => {

--- a/packages/agentplane/src/runner/adapters/custom-preparation.ts
+++ b/packages/agentplane/src/runner/adapters/custom-preparation.ts
@@ -214,6 +214,9 @@ export function buildCustomInvocation(opts: {
       AGENTPLANE_RUNNER_MODE: execution.mode,
       AGENTPLANE_RUNNER_API_VERSION: opts.bundle.runner_api_version,
       AGENTPLANE_RUNNER_TARGET: opts.bundle.target.kind,
+      ...(opts.bundle.target.kind === "task"
+        ? { AGENTPLANE_RUNNER_TASK_ID: opts.bundle.target.task_id }
+        : {}),
       AGENTPLANE_RUNNER_BUNDLE_PATH: execution.artifact_paths.bundle_path,
       AGENTPLANE_RUNNER_RUN_DIR: execution.artifact_paths.run_dir,
       AGENTPLANE_RUNNER_BOOTSTRAP_PATH: execution.artifact_paths.bootstrap_path,

--- a/packages/agentplane/src/runner/adapters/custom.test.ts
+++ b/packages/agentplane/src/runner/adapters/custom.test.ts
@@ -116,6 +116,7 @@ describe("CustomRunnerAdapter", () => {
       AGENTPLANE_RUNNER_ADAPTER: "custom",
       AGENTPLANE_RUNNER_MODE: "dry_run",
       AGENTPLANE_RUNNER_TARGET: "task",
+      AGENTPLANE_RUNNER_TASK_ID: "202603231410-XYZ789",
       AGENTPLANE_RUNNER_BUNDLE_PATH:
         "/repo/.agentplane/tasks/202603231410-XYZ789/runs/run-789/bundle.json",
       AGENTPLANE_RUNNER_BOOTSTRAP_PATH:


### PR DESCRIPTION
Task: `202606010530-BEYQXA`
Title: Fix Hermes task launch profile gaps
Canonical task record: `.agentplane/tasks/202606010530-BEYQXA/README.md`

## Summary

Fix Hermes task launch profile gaps

Resolve GitHub issue #4347 by allowing hermes supervise to execute the same-task task-run route step safely and by adding a first-class Hermes init/runner profile path.

## Scope

- In scope: Resolve GitHub issue #4347 by allowing hermes supervise to execute the same-task task-run route step safely and by adding a first-class Hermes init/runner profile path.
- Out of scope: unrelated refactors not required for "Fix Hermes task launch profile gaps".

## Verification

- State: ok
- Note:

```text
Verified: Hermes supervise now allowlists same-task task run through typed args, init --tool hermes
seeds the custom Hermes runner profile, and targeted tests/type/docs/routing checks pass.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-06-01T05:31:21.158Z
- Branch: task/202606010530-BEYQXA/fix-hermes-task-launch
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 docs/recipes/hermes-agentplane.mdx                 | 12 +++++++
 docs/user/cli-reference.generated.mdx              |  8 ++++-
 docs/user/configuration.mdx                        |  5 ++-
 .../agentplane/src/cli/run-cli.core.init.test.ts   | 31 +++++++++++++++++
 .../src/cli/run-cli/commands/init/answers.ts       |  4 +++
 .../src/cli/run-cli/commands/init/execution.ts     |  2 ++
 .../src/cli/run-cli/commands/init/init-plan.ts     |  1 +
 .../src/cli/run-cli/commands/init/model.ts         | 12 ++++++-
 .../src/cli/run-cli/commands/init/modes.ts         | 10 ++++++
 .../src/cli/run-cli/commands/init/orchestrate.ts   |  1 +
 .../src/cli/run-cli/commands/init/presets.ts       |  1 +
 .../src/cli/run-cli/commands/init/spec.ts          |  8 +++--
 .../src/cli/run-cli/commands/init/write-config.ts  | 18 +++++++++-
 .../src/commands/hermes/hermes-runtime.ts          |  5 ++-
 .../src/commands/hermes/hermes.command.test.ts     | 40 ++++++++++++++++++++++
 .../src/runner/adapters/custom-preparation.ts      |  3 ++
 .../agentplane/src/runner/adapters/custom.test.ts  |  1 +
 17 files changed, 155 insertions(+), 7 deletions(-)
```

</details>
