### PR TITLE
🚧 1H64FF task: Close commits must include all task artifacts [202606010805-1H64FF]

### DIFF
--- a/.agentplane/tasks/202606010805-1H64FF/README.md
+++ b/.agentplane/tasks/202606010805-1H64FF/README.md
@@ -4,7 +4,7 @@ title: "Close commits must include all task artifacts"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -22,6 +22,24 @@ verification:
   updated_by: "CODER"
   note: "Command: bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/guard/impl/commands.commit-close.unit.test.ts => pass, 12 tests; Command: bun vitest --config vitest.config.ts run packages/agentplane/src/cli/run-cli.core.guard.commit-wrapper.close.test.ts => pass, 5 tests; Command: bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts => pass, 13 tests; Command: bun run docs:cli:check => pass; Command: node .agentplane/policy/check-routing.mjs => policy routing OK; Command: git diff --check => pass; Command: git status --short --untracked-files=all => only intentional task implementation and task evidence changes remain."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-06-01T08:22:50.903Z"
+  updated_by: "EVALUATOR"
+  note: "Close commit regression fixed: deterministic close staging now includes active task-local artifacts, and CLI/help wording no longer claims README-only behavior."
+  evaluated_sha: "5e6a96489ea336c749a60c5faf53b7ab0c0cb1da"
+  blueprint_digest: "a7888ca1aacbc0f7564dd2b53435b003bd648a9dfb9697fa8950bdbadd2ea095"
+  evidence_refs:
+    - ".agentplane/tasks/202606010805-1H64FF/README.md"
+    - ".agentplane/tasks/202606010805-1H64FF/quality/20260601-082250903-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202606010805-1H64FF/quality/20260601-082250903-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202606010805-1H64FF/quality/20260601-082250903-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202606010805-1H64FF/blueprint/resolved-snapshot.json"
+    - "packages/agentplane/src/commands/guard/impl/commands.commit-close.unit.test.ts"
+    - "packages/agentplane/src/cli/run-cli.core.guard.commit-wrapper.close.test.ts"
+    - "packages/agentplane/src/commands/guard/impl/commit-stage.ts"
+  findings:
+    - "Regression coverage includes non-README task artifacts in both unit close staging and CLI wrapper close commit output."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202606010805-1H64FF/README.md
+++ b/.agentplane/tasks/202606010805-1H64FF/README.md
@@ -1,0 +1,152 @@
+---
+id: "202606010805-1H64FF"
+title: "Close commits must include all task artifacts"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-06-01T08:16:08.262Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-06-01T08:22:02.358Z"
+  updated_by: "CODER"
+  note: "Command: bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/guard/impl/commands.commit-close.unit.test.ts => pass, 12 tests; Command: bun vitest --config vitest.config.ts run packages/agentplane/src/cli/run-cli.core.guard.commit-wrapper.close.test.ts => pass, 5 tests; Command: bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts => pass, 13 tests; Command: bun run docs:cli:check => pass; Command: node .agentplane/policy/check-routing.mjs => policy routing OK; Command: git diff --check => pass; Command: git status --short --untracked-files=all => only intentional task implementation and task evidence changes remain."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement the approved closeout artifact regression fix with focused lifecycle coverage and no scope expansion beyond deterministic task artifact commits."
+events:
+  -
+    type: "status"
+    at: "2026-06-01T08:16:22.409Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement the approved closeout artifact regression fix with focused lifecycle coverage and no scope expansion beyond deterministic task artifact commits."
+  -
+    type: "verify"
+    at: "2026-06-01T08:22:02.358Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/guard/impl/commands.commit-close.unit.test.ts => pass, 12 tests; Command: bun vitest --config vitest.config.ts run packages/agentplane/src/cli/run-cli.core.guard.commit-wrapper.close.test.ts => pass, 5 tests; Command: bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts => pass, 13 tests; Command: bun run docs:cli:check => pass; Command: node .agentplane/policy/check-routing.mjs => policy routing OK; Command: git diff --check => pass; Command: git status --short --untracked-files=all => only intentional task implementation and task evidence changes remain."
+doc_version: 3
+doc_updated_at: "2026-06-01T08:22:02.372Z"
+doc_updated_by: "CODER"
+description: "Regression fix: when task artifacts are generated or left untracked during recovery/closeout, deterministic close commits must include the active task artifact scope or block before marking closure complete."
+sections:
+  Summary: |-
+    Close commits must include all task artifacts
+
+    Regression fix: when task artifacts are generated or left untracked during recovery/closeout, deterministic close commits must include the active task artifact scope or block before marking closure complete.
+  Scope: |-
+    - In scope: Regression fix: when task artifacts are generated or left untracked during recovery/closeout, deterministic close commits must include the active task artifact scope or block before marking closure complete.
+    - Out of scope: unrelated refactors not required for "Close commits must include all task artifacts".
+  Plan: |-
+    1. Reproduce the recovery closeout gap with a regression test: task-local non-README artifacts must not remain uncommitted after close/finish close-tail.
+    2. Update deterministic close commit behavior so close commits stage the full active task artifact scope where allowed, not only README.md, or fail before closure state is recorded.
+    3. Refresh command/help wording if it still says close commits stage only README.md.
+    4. Verify with the focused lifecycle/guard tests, routing validation, and final git status --short --untracked-files=all.
+  Verify Steps: |-
+    1. Run: bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/guard/impl/commands.commit-close.unit.test.ts. Expected: close commit unit coverage passes, including staging non-README active task artifacts.
+    2. Run: bun vitest --config vitest.config.ts run packages/agentplane/src/cli/run-cli.core.guard.commit-wrapper.close.test.ts. Expected: CLI wrapper close commit includes task-local evidence files.
+    3. Run: bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts. Expected: branch_pr close-tail lifecycle remains green.
+    4. Run: bun run docs:cli:check. Expected: generated CLI reference is fresh after wording changes.
+    5. Run: node .agentplane/policy/check-routing.mjs. Expected: policy routing OK.
+    6. Run: git status --short --untracked-files=all. Expected: only intentional task-scoped changes remain before commit/PR handoff.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-06-01T08:22:02.358Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Command: bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/guard/impl/commands.commit-close.unit.test.ts => pass, 12 tests; Command: bun vitest --config vitest.config.ts run packages/agentplane/src/cli/run-cli.core.guard.commit-wrapper.close.test.ts => pass, 5 tests; Command: bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts => pass, 13 tests; Command: bun run docs:cli:check => pass; Command: node .agentplane/policy/check-routing.mjs => policy routing OK; Command: git diff --check => pass; Command: git status --short --untracked-files=all => only intentional task implementation and task evidence changes remain.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-06-01T08:21:24.511Z, excerpt_hash=sha256:320c3cef8e900ee8394adfe9e1ab3d9d2dfdd0d3ce33226b3d6529f4b0177289
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202606010805-1H64FF-close-commits-must-include-all-task-artifacts/.agentplane/tasks/202606010805-1H64FF/blueprint/resolved-snapshot.json
+    - old_digest: a7888ca1aacbc0f7564dd2b53435b003bd648a9dfb9697fa8950bdbadd2ea095
+    - current_digest: a7888ca1aacbc0f7564dd2b53435b003bd648a9dfb9697fa8950bdbadd2ea095
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202606010805-1H64FF
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Close commits must include all task artifacts
+
+Regression fix: when task artifacts are generated or left untracked during recovery/closeout, deterministic close commits must include the active task artifact scope or block before marking closure complete.
+
+## Scope
+
+- In scope: Regression fix: when task artifacts are generated or left untracked during recovery/closeout, deterministic close commits must include the active task artifact scope or block before marking closure complete.
+- Out of scope: unrelated refactors not required for "Close commits must include all task artifacts".
+
+## Plan
+
+1. Reproduce the recovery closeout gap with a regression test: task-local non-README artifacts must not remain uncommitted after close/finish close-tail.
+2. Update deterministic close commit behavior so close commits stage the full active task artifact scope where allowed, not only README.md, or fail before closure state is recorded.
+3. Refresh command/help wording if it still says close commits stage only README.md.
+4. Verify with the focused lifecycle/guard tests, routing validation, and final git status --short --untracked-files=all.
+
+## Verify Steps
+
+1. Run: bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/guard/impl/commands.commit-close.unit.test.ts. Expected: close commit unit coverage passes, including staging non-README active task artifacts.
+2. Run: bun vitest --config vitest.config.ts run packages/agentplane/src/cli/run-cli.core.guard.commit-wrapper.close.test.ts. Expected: CLI wrapper close commit includes task-local evidence files.
+3. Run: bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts. Expected: branch_pr close-tail lifecycle remains green.
+4. Run: bun run docs:cli:check. Expected: generated CLI reference is fresh after wording changes.
+5. Run: node .agentplane/policy/check-routing.mjs. Expected: policy routing OK.
+6. Run: git status --short --untracked-files=all. Expected: only intentional task-scoped changes remain before commit/PR handoff.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-06-01T08:22:02.358Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/guard/impl/commands.commit-close.unit.test.ts => pass, 12 tests; Command: bun vitest --config vitest.config.ts run packages/agentplane/src/cli/run-cli.core.guard.commit-wrapper.close.test.ts => pass, 5 tests; Command: bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts => pass, 13 tests; Command: bun run docs:cli:check => pass; Command: node .agentplane/policy/check-routing.mjs => policy routing OK; Command: git diff --check => pass; Command: git status --short --untracked-files=all => only intentional task implementation and task evidence changes remain.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-06-01T08:21:24.511Z, excerpt_hash=sha256:320c3cef8e900ee8394adfe9e1ab3d9d2dfdd0d3ce33226b3d6529f4b0177289
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202606010805-1H64FF-close-commits-must-include-all-task-artifacts/.agentplane/tasks/202606010805-1H64FF/blueprint/resolved-snapshot.json
+- old_digest: a7888ca1aacbc0f7564dd2b53435b003bd648a9dfb9697fa8950bdbadd2ea095
+- current_digest: a7888ca1aacbc0f7564dd2b53435b003bd648a9dfb9697fa8950bdbadd2ea095
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202606010805-1H64FF
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202606010805-1H64FF/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202606010805-1H64FF/blueprint/resolved-snapshot.json
@@ -1,0 +1,596 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202606010805-1H64FF",
+    "title": "Close commits must include all task artifacts",
+    "description": "Regression fix: when task artifacts are generated or left untracked during recovery/closeout, deterministic close commits must include the active task artifact scope or block before marking closure complete.",
+    "tags": [
+      "code"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "quality.regression",
+    "version": 1,
+    "title": "Quality regression",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "quality.regression",
+    "blueprintVersion": 1,
+    "title": "Quality regression",
+    "taskId": "202606010805-1H64FF",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to quality.regression",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest",
+          "artifact"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "check_result"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "weak_links"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "regression.original_failure",
+        "kind": "artifact",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Original failure log or check output."
+      },
+      {
+        "id": "regression.reproduction",
+        "kind": "check_result",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Local reproduction or explicit non-reproduction result."
+      },
+      {
+        "id": "regression.focused_check",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Focused regression check."
+      },
+      {
+        "id": "regression.matrix_or_scope",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Affected test/check matrix or bounded scope."
+      },
+      {
+        "id": "regression.full_gate",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Full relevant gate or hosted check evidence."
+      },
+      {
+        "id": "regression.flake_classification",
+        "kind": "weak_links",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Flake classification or residual risk."
+      },
+      {
+        "id": "regression.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "regression.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "affected matrix or full relevant gate",
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "failure reproduction command",
+      "focused regression check",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest",
+        "artifact"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "check_result"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "weak_links"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "regression.original_failure",
+      "kind": "artifact",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Original failure log or check output."
+    },
+    {
+      "id": "regression.reproduction",
+      "kind": "check_result",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Local reproduction or explicit non-reproduction result."
+    },
+    {
+      "id": "regression.focused_check",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Focused regression check."
+    },
+    {
+      "id": "regression.matrix_or_scope",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Affected test/check matrix or bounded scope."
+    },
+    {
+      "id": "regression.full_gate",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Full relevant gate or hosted check evidence."
+    },
+    {
+      "id": "regression.flake_classification",
+      "kind": "weak_links",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Flake classification or residual risk."
+    },
+    {
+      "id": "regression.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "regression.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "affected matrix or full relevant gate",
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "failure reproduction command",
+    "focused regression check",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to quality.regression",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "a7888ca1aacbc0f7564dd2b53435b003bd648a9dfb9697fa8950bdbadd2ea095"
+  }
+}

--- a/.agentplane/tasks/202606010805-1H64FF/pr/diffstat.txt
+++ b/.agentplane/tasks/202606010805-1H64FF/pr/diffstat.txt
@@ -1,0 +1,8 @@
+ docs/user/cli-reference.generated.mdx              | 10 ++---
+ packages/agentplane/src/cli/reason-codes.ts        |  2 +-
+ ...run-cli.core.guard.commit-wrapper.close.test.ts | 10 +++--
+ packages/agentplane/src/commands/commit.spec.ts    |  6 +--
+ packages/agentplane/src/commands/finish.spec.ts    |  4 +-
+ .../guard/impl/commands.commit-close.unit.test.ts  | 46 ++++++++++++++++++++++
+ .../src/commands/guard/impl/commit-stage.ts        | 14 ++++++-
+ 7 files changed, 77 insertions(+), 15 deletions(-)

--- a/.agentplane/tasks/202606010805-1H64FF/pr/github-body.md
+++ b/.agentplane/tasks/202606010805-1H64FF/pr/github-body.md
@@ -1,0 +1,52 @@
+Task: `202606010805-1H64FF`
+Title: Close commits must include all task artifacts
+Canonical task record: `.agentplane/tasks/202606010805-1H64FF/README.md`
+
+## Summary
+
+Close commits must include all task artifacts
+
+Regression fix: when task artifacts are generated or left untracked during recovery/closeout, deterministic close commits must include the active task artifact scope or block before marking closure complete.
+
+## Scope
+
+- In scope: Regression fix: when task artifacts are generated or left untracked during recovery/closeout, deterministic close commits must include the active task artifact scope or block before marking closure complete.
+- Out of scope: unrelated refactors not required for "Close commits must include all task artifacts".
+
+## Verification
+
+- State: ok
+- Note:
+
+```bash
+bun vitest --config vitest.workspace.ts run --project agentplane \
+  packages/agentplane/src/commands/guard/impl/commands.commit-close.unit.test.ts => pass, 12 tests; \
+  Command: bun vitest --config vitest.config.ts run \
+  packages/agentplane/src/cli/run-cli.core.guard.commit-wrapper.close.test.ts => pass, 5 tests; \
+  Command: bun vitest --config vitest.workspace.ts run --project agentplane \
+  packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts => pass, 13 tests; Command: \
+  bun run docs:cli:check => pass; Command: node .agentplane/policy/check-routing.mjs => policy \
+  routing OK; Command: git diff --check => pass; Command: git status --short --untracked-files=all \
+  => only intentional task implementation and task evidence changes remain.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-06-01T08:22:02.401Z
+- Branch: task/202606010805-1H64FF/close-commits-must-include-all-task-artifacts
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ docs/user/cli-reference.generated.mdx              | 10 ++---
+ packages/agentplane/src/cli/reason-codes.ts        |  2 +-
+ ...run-cli.core.guard.commit-wrapper.close.test.ts | 10 +++--
+ packages/agentplane/src/commands/commit.spec.ts    |  6 +--
+ packages/agentplane/src/commands/finish.spec.ts    |  4 +-
+ .../guard/impl/commands.commit-close.unit.test.ts  | 46 ++++++++++++++++++++++
+ .../src/commands/guard/impl/commit-stage.ts        | 14 ++++++-
+ 7 files changed, 77 insertions(+), 15 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202606010805-1H64FF/pr/github-title.txt
+++ b/.agentplane/tasks/202606010805-1H64FF/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 1H64FF task: Close commits must include all task artifacts [202606010805-1H64FF]

--- a/.agentplane/tasks/202606010805-1H64FF/pr/meta.json
+++ b/.agentplane/tasks/202606010805-1H64FF/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202606010805-1H64FF/close-commits-must-include-all-task-artifacts",
+  "created_at": "2026-06-01T08:22:02.401Z",
+  "diffstat_sha256": "sha256:e15a8197902243caeb082f94ae6c2e0306f95f538676738798765d879437d8c3",
+  "last_verified_at": "2026-06-01T08:22:02.358Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202606010805-1H64FF",
+  "updated_at": "2026-06-01T08:22:02.401Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202606010805-1H64FF/pr/review.md
+++ b/.agentplane/tasks/202606010805-1H64FF/pr/review.md
@@ -1,0 +1,43 @@
+# PR Review
+
+Created: 2026-06-01T08:22:02.401Z
+
+## Task
+
+- Task: `202606010805-1H64FF`
+- Title: Close commits must include all task artifacts
+- Status: DOING
+- Branch: `task/202606010805-1H64FF/close-commits-must-include-all-task-artifacts`
+- Canonical task record: `.agentplane/tasks/202606010805-1H64FF/README.md`
+
+## Verification
+
+- State: ok
+- Note: Command: bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/guard/impl/commands.commit-close.unit.test.ts => pass, 12 tests; Command: bun vitest --config vitest.config.ts run packages/agentplane/src/cli/run-cli.core.guard.commit-wrapper.close.test.ts => pass, 5 tests; Command: bun vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts => pass, 13 tests; Command: bun run docs:cli:check => pass; Command: node .agentplane/policy/check-routing.mjs => policy routing OK; Command: git diff --check => pass; Command: git status --short --untracked-files=all => only intentional task implementation and task evidence changes remain.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-06-01T08:22:02.401Z
+- Branch: task/202606010805-1H64FF/close-commits-must-include-all-task-artifacts
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ docs/user/cli-reference.generated.mdx              | 10 ++---
+ packages/agentplane/src/cli/reason-codes.ts        |  2 +-
+ ...run-cli.core.guard.commit-wrapper.close.test.ts | 10 +++--
+ packages/agentplane/src/commands/commit.spec.ts    |  6 +--
+ packages/agentplane/src/commands/finish.spec.ts    |  4 +-
+ .../guard/impl/commands.commit-close.unit.test.ts  | 46 ++++++++++++++++++++++
+ .../src/commands/guard/impl/commit-stage.ts        | 14 ++++++-
+ 7 files changed, 77 insertions(+), 15 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202606010805-1H64FF/quality/20260601-082250903-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202606010805-1H64FF/quality/20260601-082250903-recovery-context/evaluator-opinion.md
@@ -1,0 +1,21 @@
+# EVALUATOR opinion: pass
+
+Close commit regression fixed: deterministic close staging now includes active task-local artifacts, and CLI/help wording no longer claims README-only behavior.
+
+## Findings
+- Regression coverage includes non-README task artifacts in both unit close staging and CLI wrapper close commit output.
+
+## Evidence
+- .agentplane/tasks/202606010805-1H64FF/README.md
+- packages/agentplane/src/commands/guard/impl/commands.commit-close.unit.test.ts
+- packages/agentplane/src/cli/run-cli.core.guard.commit-wrapper.close.test.ts
+- packages/agentplane/src/commands/guard/impl/commit-stage.ts
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202606010805-1H64FF/quality/20260601-082250903-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202606010805-1H64FF/quality/20260601-082250903-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202606010805-1H64FF
+- task_readme: .agentplane/tasks/202606010805-1H64FF/README.md
+- report_path: .agentplane/tasks/202606010805-1H64FF/quality/20260601-082250903-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202606010805-1H64FF/quality/20260601-082250903-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202606010805-1H64FF/quality/20260601-082250903-recovery-context/quality-report.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "task_id": "202606010805-1H64FF",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-06-01T08:22:50.903Z",
+  "verdict": "pass",
+  "summary": "Close commit regression fixed: deterministic close staging now includes active task-local artifacts, and CLI/help wording no longer claims README-only behavior.",
+  "evaluated_sha": "5e6a96489ea336c749a60c5faf53b7ab0c0cb1da",
+  "blueprint_digest": "a7888ca1aacbc0f7564dd2b53435b003bd648a9dfb9697fa8950bdbadd2ea095",
+  "findings": [
+    "Regression coverage includes non-README task artifacts in both unit close staging and CLI wrapper close commit output."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202606010805-1H64FF/README.md",
+    "packages/agentplane/src/commands/guard/impl/commands.commit-close.unit.test.ts",
+    "packages/agentplane/src/cli/run-cli.core.guard.commit-wrapper.close.test.ts",
+    "packages/agentplane/src/commands/guard/impl/commit-stage.ts"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -1180,10 +1180,10 @@ Options:
 - `--status-commit-allow <path-prefix>`: Repeatable. Allowlist path prefixes to stage for the status commit (used with --status-commit). Use minimal prefixes; '.' is rejected. (repeatable)
 - `--status-commit-require-clean`: Require a clean working tree for the status commit (used with --status-commit). (default=false)
 - `--confirm-status-commit`: Confirm status commit creation when status_commit_policy=confirm (used with --commit-from-comment or --status-commit). (default=false)
-- `--close-commit`: After finishing, run a deterministic close commit for the task README (single-task only). (default=false)
+- `--close-commit`: After finishing, run a deterministic close commit for the active task artifact scope (single-task only). (default=false)
 - `--no-close-commit`: Disable the default deterministic close commit in direct mode (single-task only). (default=false)
 - `--no-write-acr`: Disable automatic ACR refresh for this finish call when acr.write_on_finish is enabled. (default=false)
-- `--close-unstage-others`: With --close-commit: unstage any currently staged paths before staging the task README. (default=false)
+- `--close-unstage-others`: With --close-commit: unstage any currently staged paths before staging the active task artifact scope. (default=false)
 - `--base <branch>`: Optional explicit base branch override for branch_pr finish validation and close-commit reconciliation.
 - `--observation <text>`: Structured finding observation to append with the verification.
 - `--impact <text>`: Structured finding impact to append with the verification.
@@ -3261,8 +3261,8 @@ agentplane commit <task-id> [options]
 Options:
 
 - `-m, --message <message>`: Commit subject (must follow policy). Required unless --close is used.
-- `--close`: Generate a deterministic close commit message from task snapshot + verification + recorded implementation commit; stages only the task README. (default=false)
-- `--unstage-others`: With --close: unstage any currently staged paths before staging the task README. (default=false)
+- `--close`: Generate a deterministic close commit message from task snapshot + verification + recorded implementation commit; stages the active task artifact scope. (default=false)
+- `--unstage-others`: With --close: unstage any currently staged paths before staging the active task artifact scope. (default=false)
 - `--check-only`: With --close: run preflight checks and print the planned close commit subject without creating a commit. (default=false)
 - `--allow <path-prefix>`: Repeatable. Allowed path prefix (git-path). Use minimal prefixes; repo-wide '.' is rejected (tip: \`agentplane guard suggest-allow --format args\`). (repeatable)
 - `--allow-tasks`: Allow the optional tasks export snapshot plus artifacts under the active task subtree; standalone path scope. (default=false)
@@ -3301,7 +3301,7 @@ agentplane commit 202602030608-F1Q8AB -m "✨ F1Q8AB task: update publish workfl
 agentplane commit 202602030608-F1Q8AB --close
 ```
 
-- Create a close commit for the task README using a deterministic message builder.
+- Create a close commit for the task artifacts using a deterministic message builder.
 
 ### guard clean
 

--- a/packages/agentplane/src/cli/reason-codes.ts
+++ b/packages/agentplane/src/cli/reason-codes.ts
@@ -79,7 +79,7 @@ const REASON_CODE_MAP: Readonly<Record<string, ReasonCodeMeta>> = {
   git_close_commit_blocked: {
     code: "git_close_commit_blocked",
     category: "git",
-    summary: "deterministic close commit was blocked after staging the task README",
+    summary: "deterministic close commit was blocked after staging task artifacts",
     action: "inspect the staged close payload and fix the blocking hook or policy failure",
   },
   git_close_commit_dirty_index: {

--- a/packages/agentplane/src/cli/run-cli.core.guard.commit-wrapper.close.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.guard.commit-wrapper.close.test.ts
@@ -21,7 +21,7 @@ const COMMIT_WRAPPER_SUITE_TIMEOUT_MS = 120_000;
 
 describe("runCli commit wrapper: close", { timeout: COMMIT_WRAPPER_SUITE_TIMEOUT_MS }, () => {
   it(
-    "commit wrapper supports --close and stages only the task README",
+    "commit wrapper supports --close and stages active task artifacts",
     async () => {
       const root = await mkGitRepoRoot();
       await writeDefaultConfig(root);
@@ -74,6 +74,7 @@ describe("runCli commit wrapper: close", { timeout: COMMIT_WRAPPER_SUITE_TIMEOUT
         "## Summary\n\nTest task\n",
       );
       await writeFile(path.join(taskDir, "README.md"), readme, "utf8");
+      await writeFile(path.join(taskDir, "evaluator-opinion.md"), "Evaluator evidence\n", "utf8");
 
       const io = captureStdIO();
       try {
@@ -96,7 +97,7 @@ describe("runCli commit wrapper: close", { timeout: COMMIT_WRAPPER_SUITE_TIMEOUT
       expect(body).toContain("Key files:\n- src/app.ts");
       expect(body).toContain("Refs:\n- Agentplane task: R18Y1Q");
 
-      // Close commit should touch only the task README.
+      // Close commit should carry the task-local closure evidence, not just README.md.
       const showRes = await execFileAsync("git", ["show", "--name-only", "--format="], {
         cwd: root,
       });
@@ -104,7 +105,10 @@ describe("runCli commit wrapper: close", { timeout: COMMIT_WRAPPER_SUITE_TIMEOUT
         .split("\n")
         .map((s) => s.trim())
         .filter(Boolean);
-      expect(changed).toEqual([`.agentplane/tasks/${taskId}/README.md`]);
+      expect(changed).toEqual([
+        `.agentplane/tasks/${taskId}/README.md`,
+        `.agentplane/tasks/${taskId}/evaluator-opinion.md`,
+      ]);
     },
     COMMIT_WRAPPER_CLOSE_CHECK_ONLY_TIMEOUT_MS,
   );

--- a/packages/agentplane/src/commands/commit.spec.ts
+++ b/packages/agentplane/src/commands/commit.spec.ts
@@ -42,14 +42,14 @@ export const commitSpec: CommandSpec<CommitParsed> = {
       name: "close",
       default: false,
       description:
-        "Generate a deterministic close commit message from task snapshot + verification + recorded implementation commit; stages only the task README.",
+        "Generate a deterministic close commit message from task snapshot + verification + recorded implementation commit; stages the active task artifact scope.",
     },
     {
       kind: "boolean",
       name: "unstage-others",
       default: false,
       description:
-        "With --close: unstage any currently staged paths before staging the task README.",
+        "With --close: unstage any currently staged paths before staging the active task artifact scope.",
     },
     {
       kind: "boolean",
@@ -129,7 +129,7 @@ export const commitSpec: CommandSpec<CommitParsed> = {
     },
     {
       cmd: "agentplane commit 202602030608-F1Q8AB --close",
-      why: "Create a close commit for the task README using a deterministic message builder.",
+      why: "Create a close commit for the task artifacts using a deterministic message builder.",
     },
   ],
   notes: [

--- a/packages/agentplane/src/commands/finish.spec.ts
+++ b/packages/agentplane/src/commands/finish.spec.ts
@@ -174,7 +174,7 @@ export const finishSpec: CommandSpec<FinishParsed> = {
       name: "close-commit",
       default: false,
       description:
-        "After finishing, run a deterministic close commit for the task README (single-task only).",
+        "After finishing, run a deterministic close commit for the active task artifact scope (single-task only).",
     },
     {
       kind: "boolean",
@@ -195,7 +195,7 @@ export const finishSpec: CommandSpec<FinishParsed> = {
       name: "close-unstage-others",
       default: false,
       description:
-        "With --close-commit: unstage any currently staged paths before staging the task README.",
+        "With --close-commit: unstage any currently staged paths before staging the active task artifact scope.",
     },
     {
       kind: "string",

--- a/packages/agentplane/src/commands/guard/impl/commands.commit-close.unit.test.ts
+++ b/packages/agentplane/src/commands/guard/impl/commands.commit-close.unit.test.ts
@@ -176,6 +176,52 @@ describe("guard command implementations: commit close", () => {
     expect(mocks.ensureReconciledBeforeMutation).not.toHaveBeenCalled();
   });
 
+  it("cmdCommit close stages non-README artifacts from the active task scope by default", async () => {
+    const { cmdCommit } = await import("./commit.js");
+    const ctx = mkCtx();
+    ctx.git.statusChangedPaths.mockResolvedValue([
+      ".agentplane/tasks/T-2/README.md",
+      ".agentplane/tasks/T-2/evaluator-opinion.md",
+      ".agentplane/tasks/T-2/blueprint/resolved-snapshot.json",
+      ".agentplane/tasks/T-99/README.md",
+      "src/outside.ts",
+    ]);
+    mocks.loadTaskFromContext.mockResolvedValue({ id: "T-2" });
+    mocks.buildCloseCommitMessage.mockResolvedValue({
+      subject: "✅ ABC123 close: done",
+      body: "body",
+    });
+    mocks.taskReadmePathForTask.mockReturnValue("/repo/.agentplane/tasks/T-2/README.md");
+    mocks.buildGitCommitEnv.mockReturnValue({ AGENTPLANE_TASK_ID: "T-2" });
+
+    const rc = await cmdCommit({
+      ctx: ctx as never,
+      cwd: "/repo",
+      taskId: "T-2",
+      message: "",
+      close: true,
+      allow: [],
+      autoAllow: false,
+      allowTasks: false,
+      allowBase: false,
+      allowPolicy: false,
+      allowConfig: false,
+      allowHooks: false,
+      allowCI: false,
+      requireClean: false,
+      quiet: true,
+      closeCheckOnly: false,
+      closeUnstageOthers: false,
+    });
+
+    expect(rc).toBe(0);
+    expect(ctx.git.stage).toHaveBeenCalledWith([
+      ".agentplane/tasks/T-2/blueprint/resolved-snapshot.json",
+      ".agentplane/tasks/T-2/evaluator-opinion.md",
+      ".agentplane/tasks/T-2/README.md",
+    ]);
+  });
+
   it("cmdCommit close rejects a dirty index unless --unstage-others is set", async () => {
     const { cmdCommit } = await import("./commit.js");
     const ctx = mkCtx();

--- a/packages/agentplane/src/commands/guard/impl/commit-stage.ts
+++ b/packages/agentplane/src/commands/guard/impl/commit-stage.ts
@@ -66,8 +66,20 @@ export async function stageCloseCommitPaths(opts: {
   allowPolicy: boolean;
 }): Promise<void> {
   const stagePaths = new Set<string>([opts.readmeRel]);
+  const changedPaths = await opts.ctx.git.statusChangedPaths();
+  for (const relPath of changedPaths) {
+    if (
+      isTaskLocalAdvancePath({
+        workflowDir: opts.ctx.config.paths.workflow_dir,
+        taskId: opts.taskId,
+        tasksPath: opts.ctx.config.paths.tasks_path,
+        relPath,
+      })
+    ) {
+      stagePaths.add(relPath);
+    }
+  }
   if (opts.allowPolicy) {
-    const changedPaths = await opts.ctx.git.statusChangedPaths();
     for (const relPath of changedPaths) {
       if (
         protectedPathKindForFile({


### PR DESCRIPTION
Task: `202606010805-1H64FF`
Title: Close commits must include all task artifacts
Canonical task record: `.agentplane/tasks/202606010805-1H64FF/README.md`

## Summary

Close commits must include all task artifacts

Regression fix: when task artifacts are generated or left untracked during recovery/closeout, deterministic close commits must include the active task artifact scope or block before marking closure complete.

## Scope

- In scope: Regression fix: when task artifacts are generated or left untracked during recovery/closeout, deterministic close commits must include the active task artifact scope or block before marking closure complete.
- Out of scope: unrelated refactors not required for "Close commits must include all task artifacts".

## Verification

- State: ok
- Note:

```bash
bun vitest --config vitest.workspace.ts run --project agentplane \
  packages/agentplane/src/commands/guard/impl/commands.commit-close.unit.test.ts => pass, 12 tests; \
  Command: bun vitest --config vitest.config.ts run \
  packages/agentplane/src/cli/run-cli.core.guard.commit-wrapper.close.test.ts => pass, 5 tests; \
  Command: bun vitest --config vitest.workspace.ts run --project agentplane \
  packages/agentplane/src/commands/task/finish.close-tail.unit.test.ts => pass, 13 tests; Command: \
  bun run docs:cli:check => pass; Command: node .agentplane/policy/check-routing.mjs => policy \
  routing OK; Command: git diff --check => pass; Command: git status --short --untracked-files=all \
  => only intentional task implementation and task evidence changes remain.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-06-01T08:22:02.401Z
- Branch: task/202606010805-1H64FF/close-commits-must-include-all-task-artifacts
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 docs/user/cli-reference.generated.mdx              | 10 ++---
 packages/agentplane/src/cli/reason-codes.ts        |  2 +-
 ...run-cli.core.guard.commit-wrapper.close.test.ts | 10 +++--
 packages/agentplane/src/commands/commit.spec.ts    |  6 +--
 packages/agentplane/src/commands/finish.spec.ts    |  4 +-
 .../guard/impl/commands.commit-close.unit.test.ts  | 46 ++++++++++++++++++++++
 .../src/commands/guard/impl/commit-stage.ts        | 14 ++++++-
 7 files changed, 77 insertions(+), 15 deletions(-)
```

</details>
