### PR TITLE
🚧 40X015 task: Fix task-local artifact commit eligibility after finish [202606031634-40X015]

### DIFF
--- a/.agentplane/tasks/202606031634-40X015/README.md
+++ b/.agentplane/tasks/202606031634-40X015/README.md
@@ -4,7 +4,7 @@ title: "Fix task-local artifact commit eligibility after finish"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -19,10 +19,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-06-03T16:43:46.268Z"
+  updated_by: "CODER"
+  note: "Command: bunx vitest run packages/agentplane/src/commands/guard/impl/allow.test.ts packages/agentplane/src/policy/evaluate.test.ts packages/agentplane/src/commands/guard/impl/policy.test.ts packages/agentplane/src/commands/guard/impl/commands.commit-non-close.unit.test.ts --pool=forks --testTimeout 120000 --hookTimeout 120000. Result: pass, 4 files and 43 tests passed. Command: node .agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Command: ap doctor. Result: pass, doctor OK with unrelated historical DONE-task warnings 202605221745-8BHZSX and 202606011809-VCQPP7. Command: git diff --check HEAD~1..HEAD. Result: pass. Live guard evidence: ap commit without --allow-tasks auto-staged same-task README and blueprint artifacts from explicit .agentplane/tasks/202606031634-40X015 allowlist before pre-commit signal-9 fallback; explicit pre-commit hook then passed."
   attempts: 0
 commit: null
 comments:
@@ -37,8 +37,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: Investigating GitHub issue #4399 in the commit/lifecycle task artifact path, with scope limited to same-task generated artifacts and focused regression coverage."
+  -
+    type: "verify"
+    at: "2026-06-03T16:43:46.268Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: bunx vitest run packages/agentplane/src/commands/guard/impl/allow.test.ts packages/agentplane/src/policy/evaluate.test.ts packages/agentplane/src/commands/guard/impl/policy.test.ts packages/agentplane/src/commands/guard/impl/commands.commit-non-close.unit.test.ts --pool=forks --testTimeout 120000 --hookTimeout 120000. Result: pass, 4 files and 43 tests passed. Command: node .agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Command: ap doctor. Result: pass, doctor OK with unrelated historical DONE-task warnings 202605221745-8BHZSX and 202606011809-VCQPP7. Command: git diff --check HEAD~1..HEAD. Result: pass. Live guard evidence: ap commit without --allow-tasks auto-staged same-task README and blueprint artifacts from explicit .agentplane/tasks/202606031634-40X015 allowlist before pre-commit signal-9 fallback; explicit pre-commit hook then passed."
 doc_version: 3
-doc_updated_at: "2026-06-03T16:35:25.024Z"
+doc_updated_at: "2026-06-03T16:43:46.286Z"
 doc_updated_by: "CODER"
 description: "Resolve GitHub issue #4399: task-local generated blueprint/quality artifacts should not force a separate follow-up task or require --allow-tasks when committed for the same task."
 sections:
@@ -61,6 +67,25 @@ sections:
     4. Run agentplane doctor. Expected: required framework checks pass or any unrelated environment-only warning is recorded.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-06-03T16:43:46.268Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Command: bunx vitest run packages/agentplane/src/commands/guard/impl/allow.test.ts packages/agentplane/src/policy/evaluate.test.ts packages/agentplane/src/commands/guard/impl/policy.test.ts packages/agentplane/src/commands/guard/impl/commands.commit-non-close.unit.test.ts --pool=forks --testTimeout 120000 --hookTimeout 120000. Result: pass, 4 files and 43 tests passed. Command: node .agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Command: ap doctor. Result: pass, doctor OK with unrelated historical DONE-task warnings 202605221745-8BHZSX and 202606011809-VCQPP7. Command: git diff --check HEAD~1..HEAD. Result: pass. Live guard evidence: ap commit without --allow-tasks auto-staged same-task README and blueprint artifacts from explicit .agentplane/tasks/202606031634-40X015 allowlist before pre-commit signal-9 fallback; explicit pre-commit hook then passed.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-06-03T16:35:25.024Z, excerpt_hash=sha256:b939fba1687a542f6ca8c52efb286b332d540e94de08a5d2af7f09b181c89fe5
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202606031634-40X015-fix-task-local-artifact-commit-eligibility-after/.agentplane/tasks/202606031634-40X015/blueprint/resolved-snapshot.json
+    - old_digest: 51cf37ca1ccc156fd962076190d2e0dc4e5f9cfc417a4894de0fc5e603b6347c
+    - current_digest: 51cf37ca1ccc156fd962076190d2e0dc4e5f9cfc417a4894de0fc5e603b6347c
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202606031634-40X015
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -96,6 +121,25 @@ Resolve GitHub issue #4399: task-local generated blueprint/quality artifacts sho
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-06-03T16:43:46.268Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: bunx vitest run packages/agentplane/src/commands/guard/impl/allow.test.ts packages/agentplane/src/policy/evaluate.test.ts packages/agentplane/src/commands/guard/impl/policy.test.ts packages/agentplane/src/commands/guard/impl/commands.commit-non-close.unit.test.ts --pool=forks --testTimeout 120000 --hookTimeout 120000. Result: pass, 4 files and 43 tests passed. Command: node .agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Command: ap doctor. Result: pass, doctor OK with unrelated historical DONE-task warnings 202605221745-8BHZSX and 202606011809-VCQPP7. Command: git diff --check HEAD~1..HEAD. Result: pass. Live guard evidence: ap commit without --allow-tasks auto-staged same-task README and blueprint artifacts from explicit .agentplane/tasks/202606031634-40X015 allowlist before pre-commit signal-9 fallback; explicit pre-commit hook then passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-06-03T16:35:25.024Z, excerpt_hash=sha256:b939fba1687a542f6ca8c52efb286b332d540e94de08a5d2af7f09b181c89fe5
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202606031634-40X015-fix-task-local-artifact-commit-eligibility-after/.agentplane/tasks/202606031634-40X015/blueprint/resolved-snapshot.json
+- old_digest: 51cf37ca1ccc156fd962076190d2e0dc4e5f9cfc417a4894de0fc5e603b6347c
+- current_digest: 51cf37ca1ccc156fd962076190d2e0dc4e5f9cfc417a4894de0fc5e603b6347c
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202606031634-40X015
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202606031634-40X015/README.md
+++ b/.agentplane/tasks/202606031634-40X015/README.md
@@ -4,7 +4,7 @@ title: "Fix task-local artifact commit eligibility after finish"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -24,6 +24,23 @@ verification:
   updated_by: "CODER"
   note: "Command: bunx vitest run packages/agentplane/src/commands/guard/impl/allow.test.ts packages/agentplane/src/policy/evaluate.test.ts packages/agentplane/src/commands/guard/impl/policy.test.ts packages/agentplane/src/commands/guard/impl/commands.commit-non-close.unit.test.ts --pool=forks --testTimeout 120000 --hookTimeout 120000. Result: pass, 4 files and 43 tests passed. Command: node .agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Command: ap doctor. Result: pass, doctor OK with unrelated historical DONE-task warnings 202605221745-8BHZSX and 202606011809-VCQPP7. Command: git diff --check HEAD~1..HEAD. Result: pass. Live guard evidence: ap commit without --allow-tasks auto-staged same-task README and blueprint artifacts from explicit .agentplane/tasks/202606031634-40X015 allowlist before pre-commit signal-9 fallback; explicit pre-commit hook then passed."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-06-03T16:52:06.731Z"
+  updated_by: "EVALUATOR"
+  note: "Issue #4399 fixed: explicit same-task .agentplane/tasks/<task-id> allowlists now admit generated blueprint/quality artifacts without --allow-tasks while preserving protection for the task index and unrelated task artifacts."
+  evaluated_sha: "e119f14de2f7825bd68c7225aee4cef57edb2dcc"
+  blueprint_digest: "51cf37ca1ccc156fd962076190d2e0dc4e5f9cfc417a4894de0fc5e603b6347c"
+  evidence_refs:
+    - ".agentplane/tasks/202606031634-40X015/README.md"
+    - ".agentplane/tasks/202606031634-40X015/quality/20260603-165206731-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202606031634-40X015/quality/20260603-165206731-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202606031634-40X015/quality/20260603-165206731-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202606031634-40X015/blueprint/resolved-snapshot.json"
+    - "bunx vitest run packages/agentplane/src/commands/guard/impl/allow.test.ts packages/agentplane/src/policy/evaluate.test.ts packages/agentplane/src/commands/guard/impl/policy.test.ts packages/agentplane/src/commands/guard/impl/commands.commit-non-close.unit.test.ts --pool=forks --testTimeout 120000 --hookTimeout 120000"
+    - "gh pr checks 4400 --watch --interval 30"
+  findings:
+    - "Focused guard/policy regressions pass; live ap commit path auto-staged same-task task artifacts from explicit allowlist without --allow-tasks before an unrelated pre-commit signal-9 fallback; hosted PR checks are green."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202606031634-40X015/README.md
+++ b/.agentplane/tasks/202606031634-40X015/README.md
@@ -1,0 +1,106 @@
+---
+id: "202606031634-40X015"
+title: "Fix task-local artifact commit eligibility after finish"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "cli"
+  - "code"
+  - "issue-4399"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-06-03T16:35:20.660Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Investigating GitHub issue #4399 in the commit/lifecycle task artifact path, with scope limited to same-task generated artifacts and focused regression coverage."
+events:
+  -
+    type: "status"
+    at: "2026-06-03T16:35:25.024Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Investigating GitHub issue #4399 in the commit/lifecycle task artifact path, with scope limited to same-task generated artifacts and focused regression coverage."
+doc_version: 3
+doc_updated_at: "2026-06-03T16:35:25.024Z"
+doc_updated_by: "CODER"
+description: "Resolve GitHub issue #4399: task-local generated blueprint/quality artifacts should not force a separate follow-up task or require --allow-tasks when committed for the same task."
+sections:
+  Summary: |-
+    Fix task-local artifact commit eligibility after finish
+
+    Resolve GitHub issue #4399: task-local generated blueprint/quality artifacts should not force a separate follow-up task or require --allow-tasks when committed for the same task.
+  Scope: |-
+    - In scope: Resolve GitHub issue #4399: task-local generated blueprint/quality artifacts should not force a separate follow-up task or require --allow-tasks when committed for the same task.
+    - Out of scope: unrelated refactors not required for "Fix task-local artifact commit eligibility after finish".
+  Plan: |-
+    1. Locate the commit allowlist / task-artifact filtering path that rejects same-task .agentplane/tasks/<task-id> artifacts without --allow-tasks.
+    2. Change same-task artifact handling so task-local blueprint/quality artifacts are commit-eligible for that task without registering another task and without the extra artifact allow flag.
+    3. Add focused regression coverage for issue #4399 covering same-task generated artifacts under .agentplane/tasks/<task-id>.
+    4. Run the task Verify Steps, record verification, update PR artifacts, and hand off to integration.
+  Verify Steps: |-
+    1. Run focused regression coverage for task-local generated artifacts. Expected: same-task files under .agentplane/tasks/<task-id>/blueprint and .agentplane/tasks/<task-id>/quality are accepted by the task commit path without requiring a separate follow-up task or --allow-tasks.
+    2. Run the relevant CLI test suite for the touched commit/lifecycle module. Expected: all tests pass.
+    3. Run node .agentplane/policy/check-routing.mjs. Expected: policy routing checks pass.
+    4. Run agentplane doctor. Expected: required framework checks pass or any unrelated environment-only warning is recorded.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Fix task-local artifact commit eligibility after finish
+
+Resolve GitHub issue #4399: task-local generated blueprint/quality artifacts should not force a separate follow-up task or require --allow-tasks when committed for the same task.
+
+## Scope
+
+- In scope: Resolve GitHub issue #4399: task-local generated blueprint/quality artifacts should not force a separate follow-up task or require --allow-tasks when committed for the same task.
+- Out of scope: unrelated refactors not required for "Fix task-local artifact commit eligibility after finish".
+
+## Plan
+
+1. Locate the commit allowlist / task-artifact filtering path that rejects same-task .agentplane/tasks/<task-id> artifacts without --allow-tasks.
+2. Change same-task artifact handling so task-local blueprint/quality artifacts are commit-eligible for that task without registering another task and without the extra artifact allow flag.
+3. Add focused regression coverage for issue #4399 covering same-task generated artifacts under .agentplane/tasks/<task-id>.
+4. Run the task Verify Steps, record verification, update PR artifacts, and hand off to integration.
+
+## Verify Steps
+
+1. Run focused regression coverage for task-local generated artifacts. Expected: same-task files under .agentplane/tasks/<task-id>/blueprint and .agentplane/tasks/<task-id>/quality are accepted by the task commit path without requiring a separate follow-up task or --allow-tasks.
+2. Run the relevant CLI test suite for the touched commit/lifecycle module. Expected: all tests pass.
+3. Run node .agentplane/policy/check-routing.mjs. Expected: policy routing checks pass.
+4. Run agentplane doctor. Expected: required framework checks pass or any unrelated environment-only warning is recorded.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202606031634-40X015/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202606031634-40X015/blueprint/resolved-snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202606031634-40X015",
+    "title": "Fix task-local artifact commit eligibility after finish",
+    "description": "Resolve GitHub issue #4399: task-local generated blueprint/quality artifacts should not force a separate follow-up task or require --allow-tasks when committed for the same task.",
+    "tags": [
+      "cli",
+      "code",
+      "issue-4399"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202606031634-40X015",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "51cf37ca1ccc156fd962076190d2e0dc4e5f9cfc417a4894de0fc5e603b6347c"
+  }
+}

--- a/.agentplane/tasks/202606031634-40X015/pr/diffstat.txt
+++ b/.agentplane/tasks/202606031634-40X015/pr/diffstat.txt
@@ -1,0 +1,5 @@
+ .../src/commands/guard/impl/allow.test.ts          | 40 ++++++++++++++++++++++
+ .../agentplane/src/commands/guard/impl/allow.ts    | 25 +++++++++++++-
+ packages/agentplane/src/policy/evaluate.test.ts    | 32 +++++++++++++++++
+ .../agentplane/src/policy/rules/protected-paths.ts | 36 ++++++++++++++++++-
+ 4 files changed, 131 insertions(+), 2 deletions(-)

--- a/.agentplane/tasks/202606031634-40X015/pr/github-body.md
+++ b/.agentplane/tasks/202606031634-40X015/pr/github-body.md
@@ -1,0 +1,51 @@
+Task: `202606031634-40X015`
+Title: Fix task-local artifact commit eligibility after finish
+Canonical task record: `.agentplane/tasks/202606031634-40X015/README.md`
+
+## Summary
+
+Fix task-local artifact commit eligibility after finish
+
+Resolve GitHub issue #4399: task-local generated blueprint/quality artifacts should not force a separate follow-up task or require --allow-tasks when committed for the same task.
+
+## Scope
+
+- In scope: Resolve GitHub issue #4399: task-local generated blueprint/quality artifacts should not force a separate follow-up task or require --allow-tasks when committed for the same task.
+- Out of scope: unrelated refactors not required for "Fix task-local artifact commit eligibility after finish".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Command: bunx vitest run packages/agentplane/src/commands/guard/impl/allow.test.ts
+packages/agentplane/src/policy/evaluate.test.ts
+packages/agentplane/src/commands/guard/impl/policy.test.ts
+packages/agentplane/src/commands/guard/impl/commands.commit-non-close.unit.test.ts --pool=forks
+--testTimeout 120000 --hookTimeout 120000. Result: pass, 4 files and 43 tests passed. Command: node
+.agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Command: ap doctor. Result:
+pass, doctor OK with unrelated historical DONE-task warnings 202605221745-8BHZSX and
+202606011809-VCQPP7. Command: git diff --check HEAD~1..HEAD. Result: pass. Live guard evidence: ap
+commit without --allow-tasks auto-staged same-task README and blueprint artifacts from explicit
+.agentplane/tasks/202606031634-40X015 allowlist before pre-commit signal-9 fallback; explicit
+pre-commit hook then passed.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-06-03T16:43:46.319Z
+- Branch: task/202606031634-40X015/fix-task-local-artifact-commit-eligibility-after
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/commands/guard/impl/allow.test.ts          | 40 ++++++++++++++++++++++
+ .../agentplane/src/commands/guard/impl/allow.ts    | 25 +++++++++++++-
+ packages/agentplane/src/policy/evaluate.test.ts    | 32 +++++++++++++++++
+ .../agentplane/src/policy/rules/protected-paths.ts | 36 ++++++++++++++++++-
+ 4 files changed, 131 insertions(+), 2 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202606031634-40X015/pr/github-title.txt
+++ b/.agentplane/tasks/202606031634-40X015/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 40X015 task: Fix task-local artifact commit eligibility after finish [202606031634-40X015]

--- a/.agentplane/tasks/202606031634-40X015/pr/meta.json
+++ b/.agentplane/tasks/202606031634-40X015/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202606031634-40X015/fix-task-local-artifact-commit-eligibility-after",
+  "created_at": "2026-06-03T16:43:46.319Z",
+  "diffstat_sha256": "sha256:a504afe8fe06f9406290a240ac896130580ec3eebc4076d1e928080bfe3af9ef",
+  "last_verified_at": "2026-06-03T16:43:46.268Z",
+  "last_verified_diffstat_sha256": "sha256:a504afe8fe06f9406290a240ac896130580ec3eebc4076d1e928080bfe3af9ef",
+  "schema_version": 1,
+  "task_id": "202606031634-40X015",
+  "updated_at": "2026-06-03T16:43:46.319Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202606031634-40X015/pr/review.md
+++ b/.agentplane/tasks/202606031634-40X015/pr/review.md
@@ -1,0 +1,40 @@
+# PR Review
+
+Created: 2026-06-03T16:43:46.319Z
+
+## Task
+
+- Task: `202606031634-40X015`
+- Title: Fix task-local artifact commit eligibility after finish
+- Status: DOING
+- Branch: `task/202606031634-40X015/fix-task-local-artifact-commit-eligibility-after`
+- Canonical task record: `.agentplane/tasks/202606031634-40X015/README.md`
+
+## Verification
+
+- State: ok
+- Note: Command: bunx vitest run packages/agentplane/src/commands/guard/impl/allow.test.ts packages/agentplane/src/policy/evaluate.test.ts packages/agentplane/src/commands/guard/impl/policy.test.ts packages/agentplane/src/commands/guard/impl/commands.commit-non-close.unit.test.ts --pool=forks --testTimeout 120000 --hookTimeout 120000. Result: pass, 4 files and 43 tests passed. Command: node .agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Command: ap doctor. Result: pass, doctor OK with unrelated historical DONE-task warnings 202605221745-8BHZSX and 202606011809-VCQPP7. Command: git diff --check HEAD~1..HEAD. Result: pass. Live guard evidence: ap commit without --allow-tasks auto-staged same-task README and blueprint artifacts from explicit .agentplane/tasks/202606031634-40X015 allowlist before pre-commit signal-9 fallback; explicit pre-commit hook then passed.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-06-03T16:43:46.319Z
+- Branch: task/202606031634-40X015/fix-task-local-artifact-commit-eligibility-after
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/commands/guard/impl/allow.test.ts          | 40 ++++++++++++++++++++++
+ .../agentplane/src/commands/guard/impl/allow.ts    | 25 +++++++++++++-
+ packages/agentplane/src/policy/evaluate.test.ts    | 32 +++++++++++++++++
+ .../agentplane/src/policy/rules/protected-paths.ts | 36 ++++++++++++++++++-
+ 4 files changed, 131 insertions(+), 2 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202606031634-40X015/quality/20260603-165206731-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202606031634-40X015/quality/20260603-165206731-recovery-context/evaluator-opinion.md
@@ -1,0 +1,20 @@
+# EVALUATOR opinion: pass
+
+Issue #4399 fixed: explicit same-task .agentplane/tasks/<task-id> allowlists now admit generated blueprint/quality artifacts without --allow-tasks while preserving protection for the task index and unrelated task artifacts.
+
+## Findings
+- Focused guard/policy regressions pass; live ap commit path auto-staged same-task task artifacts from explicit allowlist without --allow-tasks before an unrelated pre-commit signal-9 fallback; hosted PR checks are green.
+
+## Evidence
+- .agentplane/tasks/202606031634-40X015/README.md
+- bunx vitest run packages/agentplane/src/commands/guard/impl/allow.test.ts packages/agentplane/src/policy/evaluate.test.ts packages/agentplane/src/commands/guard/impl/policy.test.ts packages/agentplane/src/commands/guard/impl/commands.commit-non-close.unit.test.ts --pool=forks --testTimeout 120000 --hookTimeout 120000
+- gh pr checks 4400 --watch --interval 30
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- The git commit hook invocation was twice killed by signal 9 after guard validation; explicit .agentplane/bin/agentplane hooks run pre-commit passed, so commits used --no-verify fallback. This appears to be a separate hook invocation/runtime issue, not the #4399 guard policy.

--- a/.agentplane/tasks/202606031634-40X015/quality/20260603-165206731-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202606031634-40X015/quality/20260603-165206731-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202606031634-40X015
+- task_readme: .agentplane/tasks/202606031634-40X015/README.md
+- report_path: .agentplane/tasks/202606031634-40X015/quality/20260603-165206731-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202606031634-40X015/quality/20260603-165206731-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202606031634-40X015/quality/20260603-165206731-recovery-context/quality-report.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "task_id": "202606031634-40X015",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-06-03T16:52:06.731Z",
+  "verdict": "pass",
+  "summary": "Issue #4399 fixed: explicit same-task .agentplane/tasks/<task-id> allowlists now admit generated blueprint/quality artifacts without --allow-tasks while preserving protection for the task index and unrelated task artifacts.",
+  "evaluated_sha": "e119f14de2f7825bd68c7225aee4cef57edb2dcc",
+  "blueprint_digest": "51cf37ca1ccc156fd962076190d2e0dc4e5f9cfc417a4894de0fc5e603b6347c",
+  "findings": [
+    "Focused guard/policy regressions pass; live ap commit path auto-staged same-task task artifacts from explicit allowlist without --allow-tasks before an unrelated pre-commit signal-9 fallback; hosted PR checks are green."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202606031634-40X015/README.md",
+    "bunx vitest run packages/agentplane/src/commands/guard/impl/allow.test.ts packages/agentplane/src/policy/evaluate.test.ts packages/agentplane/src/commands/guard/impl/policy.test.ts packages/agentplane/src/commands/guard/impl/commands.commit-non-close.unit.test.ts --pool=forks --testTimeout 120000 --hookTimeout 120000",
+    "gh pr checks 4400 --watch --interval 30"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": [
+    "The git commit hook invocation was twice killed by signal 9 after guard validation; explicit .agentplane/bin/agentplane hooks run pre-commit passed, so commits used --no-verify fallback. This appears to be a separate hook invocation/runtime issue, not the #4399 guard policy."
+  ]
+}

--- a/packages/agentplane/src/commands/guard/impl/allow.test.ts
+++ b/packages/agentplane/src/commands/guard/impl/allow.test.ts
@@ -293,6 +293,8 @@ describe("guard/impl/allow", () => {
           .mockResolvedValue([
             ".agentplane/tasks/202601010101-ABCDEF/blueprint/resolved-snapshot.json",
             ".agentplane/tasks/202601010101-ABCDEF/quality/20260101-recovery-context/quality-report.json",
+            ".agentplane/tasks/202601010101-ABCDEF/README.md",
+            ".agentplane/tasks/202601010101-ABCDEF/pr/meta.json",
             ".agentplane/tasks/202601010101-OTHER01/quality/quality-report.json",
           ]),
         stage: vi.fn().mockResolvedValue(),

--- a/packages/agentplane/src/commands/guard/impl/allow.test.ts
+++ b/packages/agentplane/src/commands/guard/impl/allow.test.ts
@@ -278,6 +278,46 @@ describe("guard/impl/allow", () => {
     ]);
   });
 
+  it("stageAllowlist admits explicitly allowed same-task generated artifacts without allowTasks", async () => {
+    const { stageAllowlist } = await import("./allow.js");
+    const ctx = {
+      resolvedProject: {
+        gitRoot: repoRoot,
+      },
+      config: {
+        workflow_mode: "branch_pr",
+      },
+      git: {
+        statusChangedPaths: vi
+          .fn()
+          .mockResolvedValue([
+            ".agentplane/tasks/202601010101-ABCDEF/blueprint/resolved-snapshot.json",
+            ".agentplane/tasks/202601010101-ABCDEF/quality/20260101-recovery-context/quality-report.json",
+            ".agentplane/tasks/202601010101-OTHER01/quality/quality-report.json",
+          ]),
+        stage: vi.fn().mockResolvedValue(),
+      },
+    };
+
+    const staged = await stageAllowlist({
+      ctx: ctx as never,
+      allow: [".agentplane/tasks/202601010101-ABCDEF"],
+      allowTasks: false,
+      tasksPath: ".agentplane/tasks.json",
+      workflowDir: ".agentplane/tasks",
+      taskId: "202601010101-ABCDEF",
+    });
+
+    expect(staged).toEqual([
+      ".agentplane/tasks/202601010101-ABCDEF/blueprint/resolved-snapshot.json",
+      ".agentplane/tasks/202601010101-ABCDEF/quality/20260101-recovery-context/quality-report.json",
+    ]);
+    expect(ctx.git.stage).toHaveBeenCalledWith([
+      ".agentplane/tasks/202601010101-ABCDEF/blueprint/resolved-snapshot.json",
+      ".agentplane/tasks/202601010101-ABCDEF/quality/20260101-recovery-context/quality-report.json",
+    ]);
+  });
+
   it("stageAllowlist can admit task-only changes when allowTaskOnly=true", async () => {
     const { stageAllowlist } = await import("./allow.js");
     const ctx = {

--- a/packages/agentplane/src/commands/guard/impl/allow.ts
+++ b/packages/agentplane/src/commands/guard/impl/allow.ts
@@ -67,6 +67,16 @@ function sameTaskArtifactPrefix(opts: { workflowDir?: string; taskId?: string })
   return normalizeGitPathPrefix(`${workflowDir}/${taskId}`);
 }
 
+function isGeneratedSameTaskArtifact(opts: {
+  filePath: string;
+  sameTaskPrefix: string | null;
+}): boolean {
+  if (opts.sameTaskPrefix === null) return false;
+  return ["blueprint", "quality"].some((dir) =>
+    gitPathIsUnderPrefix(opts.filePath, `${opts.sameTaskPrefix}/${dir}`),
+  );
+}
+
 export function suggestAllowPrefixes(paths: string[]): string[] {
   const out = new Set<string>();
   for (const filePath of paths) {
@@ -215,8 +225,7 @@ export async function stageAllowlist(opts: {
   const staged: string[] = [];
   for (const filePath of changed) {
     const explicitlyAllowedSameTaskArtifact =
-      sameTaskPrefix !== null &&
-      gitPathIsUnderPrefix(filePath, sameTaskPrefix) &&
+      isGeneratedSameTaskArtifact({ filePath, sameTaskPrefix }) &&
       allow.some((prefix) => gitPathIsUnderPrefix(filePath, prefix));
     if (
       denied.some((prefix) => gitPathIsUnderPrefix(filePath, prefix)) &&

--- a/packages/agentplane/src/commands/guard/impl/allow.ts
+++ b/packages/agentplane/src/commands/guard/impl/allow.ts
@@ -57,6 +57,16 @@ function normalizeAllowPrefixes(prefixes: string[]): string[] {
   return compact;
 }
 
+function sameTaskArtifactPrefix(opts: { workflowDir?: string; taskId?: string }): string | null {
+  const workflowDir = normalizeGitPathPrefix(opts.workflowDir ?? "");
+  const taskId = (opts.taskId ?? "").trim();
+  if (!workflowDir || !taskId) return null;
+  if (taskId === "." || taskId === ".." || taskId.includes("/") || taskId.includes("\\")) {
+    return null;
+  }
+  return normalizeGitPathPrefix(`${workflowDir}/${taskId}`);
+}
+
 export function suggestAllowPrefixes(paths: string[]): string[] {
   const out = new Set<string>();
   for (const filePath of paths) {
@@ -178,6 +188,10 @@ export async function stageAllowlist(opts: {
     allowCI: opts.allowCI,
   });
   const effectiveAllow = normalizeAllowPrefixes([...allow, ...protectedAllow]);
+  const sameTaskPrefix = sameTaskArtifactPrefix({
+    workflowDir: opts.workflowDir,
+    taskId: opts.taskId,
+  });
   if (
     effectiveAllow.length === 0 ||
     (allow.length === 0 && protectedAllow.length === 0 && opts.allowTaskOnly !== true)
@@ -200,7 +214,16 @@ export async function stageAllowlist(opts: {
 
   const staged: string[] = [];
   for (const filePath of changed) {
-    if (denied.some((prefix) => gitPathIsUnderPrefix(filePath, prefix))) continue;
+    const explicitlyAllowedSameTaskArtifact =
+      sameTaskPrefix !== null &&
+      gitPathIsUnderPrefix(filePath, sameTaskPrefix) &&
+      allow.some((prefix) => gitPathIsUnderPrefix(filePath, prefix));
+    if (
+      denied.some((prefix) => gitPathIsUnderPrefix(filePath, prefix)) &&
+      !explicitlyAllowedSameTaskArtifact
+    ) {
+      continue;
+    }
     if (effectiveAllow.some((prefix) => gitPathIsUnderPrefix(filePath, prefix))) {
       staged.push(filePath);
     }

--- a/packages/agentplane/src/policy/evaluate.test.ts
+++ b/packages/agentplane/src/policy/evaluate.test.ts
@@ -134,6 +134,38 @@ describe("policy/evaluatePolicy", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("allows explicitly allowlisted same-task generated artifacts without --allow-tasks", () => {
+    const taskId = "202602071329-TEST01";
+    const res = evaluatePolicy(
+      makeCtx({
+        taskId,
+        git: {
+          stagedPaths: [
+            `.agentplane/tasks/${taskId}/blueprint/resolved-snapshot.json`,
+            `.agentplane/tasks/${taskId}/quality/20260101-recovery-context/quality-report.json`,
+          ],
+        },
+        allow: { prefixes: [`.agentplane/tasks/${taskId}`], allowTasks: false },
+      }),
+    );
+    expect(res.ok).toBe(true);
+  });
+
+  it("keeps the task index protected even when explicitly allowlisted without --allow-tasks", () => {
+    const cfg = defaultConfig();
+    const res = evaluatePolicy(
+      makeCtx({
+        config: cfg,
+        git: { stagedPaths: [cfg.paths.tasks_path] },
+        allow: { prefixes: [cfg.paths.tasks_path], allowTasks: false },
+      }),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.errors.map((e) => e.message).join("\n")).toContain(
+      "Staged file is forbidden by default",
+    );
+  });
+
   it("allows task-only commit scope when --allow-tasks is set without explicit prefixes", () => {
     const taskId = "202602071329-TEST01";
     const res = evaluatePolicy(

--- a/packages/agentplane/src/policy/evaluate.test.ts
+++ b/packages/agentplane/src/policy/evaluate.test.ts
@@ -166,6 +166,26 @@ describe("policy/evaluatePolicy", () => {
     );
   });
 
+  it("keeps non-generated same-task artifacts protected without --allow-tasks", () => {
+    const taskId = "202602071329-TEST01";
+    const res = evaluatePolicy(
+      makeCtx({
+        taskId,
+        git: {
+          stagedPaths: [
+            `.agentplane/tasks/${taskId}/README.md`,
+            `.agentplane/tasks/${taskId}/pr/meta.json`,
+          ],
+        },
+        allow: { prefixes: [`.agentplane/tasks/${taskId}`], allowTasks: false },
+      }),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.errors.map((e) => e.message).join("\n")).toContain(
+      "Staged file is forbidden by default",
+    );
+  });
+
   it("allows task-only commit scope when --allow-tasks is set without explicit prefixes", () => {
     const taskId = "202602071329-TEST01";
     const res = evaluatePolicy(

--- a/packages/agentplane/src/policy/rules/protected-paths.ts
+++ b/packages/agentplane/src/policy/rules/protected-paths.ts
@@ -53,6 +53,12 @@ function isExplicitlyAllowedSameTaskArtifact(opts: {
     return false;
   }
   const filePath = normalizeGitPathPrefix(opts.filePath);
+  const taskPrefix = `${normalizeGitPathPrefix(opts.workflowDir)}/${opts.taskId}`;
+  if (
+    !["blueprint", "quality"].some((dir) => gitPathIsUnderPrefix(filePath, `${taskPrefix}/${dir}`))
+  ) {
+    return false;
+  }
   return opts.prefixes
     .map((prefix) => normalizeGitPathPrefix(prefix))
     .some((prefix) => gitPathIsUnderPrefix(filePath, prefix));

--- a/packages/agentplane/src/policy/rules/protected-paths.ts
+++ b/packages/agentplane/src/policy/rules/protected-paths.ts
@@ -35,11 +35,35 @@ function isHookAllowedTaskArtifact(opts: {
   );
 }
 
+function isExplicitlyAllowedSameTaskArtifact(opts: {
+  filePath: string;
+  prefixes: string[];
+  tasksPath: string;
+  workflowDir: string;
+  taskId: string | undefined;
+}): boolean {
+  if (
+    !isHookAllowedTaskArtifact({
+      filePath: opts.filePath,
+      tasksPath: opts.tasksPath,
+      workflowDir: opts.workflowDir,
+      taskId: opts.taskId,
+    })
+  ) {
+    return false;
+  }
+  const filePath = normalizeGitPathPrefix(opts.filePath);
+  return opts.prefixes
+    .map((prefix) => normalizeGitPathPrefix(prefix))
+    .some((prefix) => gitPathIsUnderPrefix(filePath, prefix));
+}
+
 export function protectedPathsRule(ctx: PolicyContext): PolicyResult {
   const staged = ctx.git.stagedPaths ?? [];
   if (staged.length === 0) return okResult();
 
   const tasksPath = ctx.config.paths.tasks_path;
+  const allowPrefixes = ctx.allow?.prefixes ?? [];
   const allowTasks = ctx.allow?.allowTasks === true;
   const allowPolicy = ctx.allow?.allowPolicy === true;
   const allowConfig = ctx.allow?.allowConfig === true;
@@ -70,7 +94,17 @@ export function protectedPathsRule(ctx: PolicyContext): PolicyResult {
       continue;
     }
 
-    if (kind === "tasks" && !allowTasks) {
+    if (
+      kind === "tasks" &&
+      !allowTasks &&
+      !isExplicitlyAllowedSameTaskArtifact({
+        filePath,
+        prefixes: allowPrefixes,
+        tasksPath,
+        workflowDir: ctx.config.paths.workflow_dir,
+        taskId: ctx.taskId,
+      })
+    ) {
       const override = getProtectedPathOverride(kind);
       errors.push(
         ctx.action === "hook_pre_commit"


### PR DESCRIPTION
Task: `202606031634-40X015`
Title: Fix task-local artifact commit eligibility after finish
Canonical task record: `.agentplane/tasks/202606031634-40X015/README.md`

## Summary

Fix task-local artifact commit eligibility after finish

Resolve GitHub issue #4399: task-local generated blueprint/quality artifacts should not force a separate follow-up task or require --allow-tasks when committed for the same task.

## Scope

- In scope: Resolve GitHub issue #4399: task-local generated blueprint/quality artifacts should not force a separate follow-up task or require --allow-tasks when committed for the same task.
- Out of scope: unrelated refactors not required for "Fix task-local artifact commit eligibility after finish".

## Verification

- State: ok
- Note:

```text
Command: bunx vitest run packages/agentplane/src/commands/guard/impl/allow.test.ts
packages/agentplane/src/policy/evaluate.test.ts
packages/agentplane/src/commands/guard/impl/policy.test.ts
packages/agentplane/src/commands/guard/impl/commands.commit-non-close.unit.test.ts --pool=forks
--testTimeout 120000 --hookTimeout 120000. Result: pass, 4 files and 43 tests passed. Command: node
.agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Command: ap doctor. Result:
pass, doctor OK with unrelated historical DONE-task warnings 202605221745-8BHZSX and
202606011809-VCQPP7. Command: git diff --check HEAD~1..HEAD. Result: pass. Live guard evidence: ap
commit without --allow-tasks auto-staged same-task README and blueprint artifacts from explicit
.agentplane/tasks/202606031634-40X015 allowlist before pre-commit signal-9 fallback; explicit
pre-commit hook then passed.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-06-03T16:43:46.319Z
- Branch: task/202606031634-40X015/fix-task-local-artifact-commit-eligibility-after
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/commands/guard/impl/allow.test.ts          | 40 ++++++++++++++++++++++
 .../agentplane/src/commands/guard/impl/allow.ts    | 25 +++++++++++++-
 packages/agentplane/src/policy/evaluate.test.ts    | 32 +++++++++++++++++
 .../agentplane/src/policy/rules/protected-paths.ts | 36 ++++++++++++++++++-
 4 files changed, 131 insertions(+), 2 deletions(-)
```

</details>
