### PR TITLE
branch_pr: surface website dependency requirements in worktrees

### DIFF
--- a/packages/agentplane/src/cli/bootstrap-framework-dev-script.test.ts
+++ b/packages/agentplane/src/cli/bootstrap-framework-dev-script.test.ts
@@ -39,6 +39,7 @@ async function mkFrameworkRepo() {
   await mkdir(path.join(repoRoot, ".agentplane"), { recursive: true });
   await mkdir(path.join(repoRoot, "packages", "agentplane"), { recursive: true });
   await mkdir(path.join(repoRoot, "packages", "core"), { recursive: true });
+  await mkdir(path.join(repoRoot, "website"), { recursive: true });
   await writeFile(path.join(repoRoot, ".agentplane", "config.json"), "{}\n", "utf8");
   await writeFile(path.join(repoRoot, "package.json"), '{ "name": "agentplane-repo" }\n', "utf8");
   await writeFile(
@@ -51,6 +52,7 @@ async function mkFrameworkRepo() {
     '{ "name": "@agentplaneorg/core" }\n',
     "utf8",
   );
+  await writeFile(path.join(repoRoot, "website", "package.json"), '{ "name": "website" }\n', "utf8");
   return repoRoot;
 }
 
@@ -191,6 +193,7 @@ describe("bootstrap-framework-dev script", () => {
     await mkdir(path.join(repoRoot, "packages", "agentplane", "node_modules"), {
       recursive: true,
     });
+    await mkdir(path.join(repoRoot, "website", "node_modules"), { recursive: true });
     await mkdir(path.join(repoRoot, "agentplane-recipes"), { recursive: true });
     await writeFile(path.join(repoRoot, "agentplane-recipes", "index.json"), "{}\n", "utf8");
     const calls: string[] = [];
@@ -223,6 +226,7 @@ describe("bootstrap-framework-dev script", () => {
     await mkdir(path.join(repoRoot, "packages", "agentplane", "node_modules"), {
       recursive: true,
     });
+    await mkdir(path.join(repoRoot, "website", "node_modules"), { recursive: true });
     await mkdir(path.join(repoRoot, "agentplane-recipes"), { recursive: true });
     await writeFile(path.join(repoRoot, "agentplane-recipes", "index.json"), "{}\n", "utf8");
     await writeFile(
@@ -260,6 +264,7 @@ describe("bootstrap-framework-dev script", () => {
     await mkdir(path.join(commonRepoRoot, "packages", "agentplane", "node_modules"), {
       recursive: true,
     });
+    await mkdir(path.join(commonRepoRoot, "website", "node_modules"), { recursive: true });
     await mkdir(path.join(commonRepoRoot, "agentplane-recipes"), { recursive: true });
     await writeFile(path.join(commonRepoRoot, "agentplane-recipes", "index.json"), "{}\n", "utf8");
     const calls: string[] = [];
@@ -314,6 +319,7 @@ describe("bootstrap-framework-dev script", () => {
     await mkdir(path.join(commonRepoRoot, "packages", "agentplane", "node_modules"), {
       recursive: true,
     });
+    await mkdir(path.join(commonRepoRoot, "website", "node_modules"), { recursive: true });
     await mkdir(path.join(commonRepoRoot, "agentplane-recipes"), { recursive: true });
     await writeFile(path.join(commonRepoRoot, "agentplane-recipes", "index.json"), "{}\n", "utf8");
     await fs.promises.symlink(
@@ -324,6 +330,11 @@ describe("bootstrap-framework-dev script", () => {
     await fs.promises.symlink(
       path.join(commonRepoRoot, "packages", "agentplane", "node_modules"),
       path.join(repoRoot, "packages", "agentplane", "node_modules"),
+      "dir",
+    );
+    await fs.promises.symlink(
+      path.join(commonRepoRoot, "website", "node_modules"),
+      path.join(repoRoot, "website", "node_modules"),
       "dir",
     );
     const calls: string[] = [];
@@ -346,6 +357,7 @@ describe("bootstrap-framework-dev script", () => {
     await expect(
       lstat(path.join(repoRoot, "packages", "agentplane", "node_modules")),
     ).rejects.toThrow();
+    await expect(lstat(path.join(repoRoot, "website", "node_modules"))).rejects.toThrow();
   });
 
   it("repairs legacy lefthook-generated hooks after building the repo-local runtime", async () => {
@@ -356,6 +368,7 @@ describe("bootstrap-framework-dev script", () => {
     await mkdir(path.join(repoRoot, "packages", "agentplane", "node_modules"), {
       recursive: true,
     });
+    await mkdir(path.join(repoRoot, "website", "node_modules"), { recursive: true });
     await mkdir(path.join(repoRoot, "agentplane-recipes"), { recursive: true });
     await writeFile(path.join(repoRoot, "agentplane-recipes", "index.json"), "{}\n", "utf8");
     await writeFile(

--- a/packages/agentplane/src/cli/bootstrap-framework-dev-script.test.ts
+++ b/packages/agentplane/src/cli/bootstrap-framework-dev-script.test.ts
@@ -52,7 +52,11 @@ async function mkFrameworkRepo() {
     '{ "name": "@agentplaneorg/core" }\n',
     "utf8",
   );
-  await writeFile(path.join(repoRoot, "website", "package.json"), '{ "name": "website" }\n', "utf8");
+  await writeFile(
+    path.join(repoRoot, "website", "package.json"),
+    '{ "name": "website" }\n',
+    "utf8",
+  );
   return repoRoot;
 }
 

--- a/packages/agentplane/src/cli/run-cli.core.pr-flow.worktree-runtime.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.pr-flow.worktree-runtime.test.ts
@@ -98,6 +98,14 @@ async function seedRepoLocalNodeModules(root: string): Promise<void> {
   );
 }
 
+async function seedRepoLocalWebsiteNodeModules(root: string): Promise<void> {
+  const target = path.join(root, "website", "node_modules");
+  await mkdir(path.dirname(target), { recursive: true });
+  await writeFile(path.join(root, "website", "package.json"), '{ "name": "website" }\n', "utf8");
+  await mkdir(target, { recursive: true });
+  await writeFile(path.join(target, ".agentplane-worktree-test"), "website deps\n", "utf8");
+}
+
 async function seedRepoLocalCorePackage(root: string): Promise<void> {
   const packageDir = path.join(root, "packages", "agentplane", "node_modules", "@agentplaneorg");
   await mkdir(packageDir, { recursive: true });
@@ -255,6 +263,7 @@ describe(
         await seedRepoLocalBinArtifacts(root);
         await seedRepoLocalDistArtifacts(root);
         await seedRepoLocalNodeModules(root);
+        await seedRepoLocalWebsiteNodeModules(root);
         await seedRepoLocalCorePackage(root);
         await mkdir(path.join(root, "agentplane-recipes"), { recursive: true });
         await writeFile(
@@ -319,6 +328,7 @@ describe(
         expect(
           await pathExists(path.join(worktreePath, "packages", "agentplane", "node_modules")),
         ).toBe(true);
+        expect(await pathExists(path.join(worktreePath, "website", "node_modules"))).toBe(true);
         expect(await pathExists(path.join(worktreePath, "agentplane-recipes", "index.json"))).toBe(
           true,
         );
@@ -447,6 +457,7 @@ describe(
         expect(
           await pathExists(path.join(worktreePath, "packages", "agentplane", "node_modules")),
         ).toBe(true);
+        expect(await pathExists(path.join(worktreePath, "website", "node_modules"))).toBe(true);
 
         const runtime = await execFileAsync(
           process.execPath,

--- a/packages/agentplane/src/commands/branch/work-start.materialize.ts
+++ b/packages/agentplane/src/commands/branch/work-start.materialize.ts
@@ -138,6 +138,7 @@ export async function materializeRepoLocalInstallLayoutForWorktree(opts: {
     "node_modules",
     path.join("packages", "core", "node_modules"),
     path.join("packages", "agentplane", "node_modules"),
+    path.join("website", "node_modules"),
     "agentplane-recipes",
   ];
   for (const relativePath of linkTargets) {

--- a/scripts/workflow/bootstrap-framework-dev.mjs
+++ b/scripts/workflow/bootstrap-framework-dev.mjs
@@ -89,6 +89,7 @@ function removeForeignInstallLayouts(repoRoot) {
     path.join(repoRoot, "node_modules"),
     path.join(repoRoot, "packages", "core", "node_modules"),
     path.join(repoRoot, "packages", "agentplane", "node_modules"),
+    path.join(repoRoot, "website", "node_modules"),
   ];
   for (const targetPath of installLayoutPaths) {
     if (!fs.existsSync(targetPath)) continue;
@@ -101,7 +102,8 @@ function hasBootstrapBuildInstallLayout(repoRoot) {
   return (
     hasWorkspaceNodeModules(repoRoot) &&
     pathResolvesWithinRepo(repoRoot, path.join(repoRoot, "packages", "core", "node_modules")) &&
-    pathResolvesWithinRepo(repoRoot, path.join(repoRoot, "packages", "agentplane", "node_modules"))
+    pathResolvesWithinRepo(repoRoot, path.join(repoRoot, "packages", "agentplane", "node_modules")) &&
+    pathResolvesWithinRepo(repoRoot, path.join(repoRoot, "website", "node_modules"))
   );
 }
 

--- a/scripts/workflow/bootstrap-framework-dev.mjs
+++ b/scripts/workflow/bootstrap-framework-dev.mjs
@@ -102,7 +102,10 @@ function hasBootstrapBuildInstallLayout(repoRoot) {
   return (
     hasWorkspaceNodeModules(repoRoot) &&
     pathResolvesWithinRepo(repoRoot, path.join(repoRoot, "packages", "core", "node_modules")) &&
-    pathResolvesWithinRepo(repoRoot, path.join(repoRoot, "packages", "agentplane", "node_modules")) &&
+    pathResolvesWithinRepo(
+      repoRoot,
+      path.join(repoRoot, "packages", "agentplane", "node_modules"),
+    ) &&
     pathResolvesWithinRepo(repoRoot, path.join(repoRoot, "website", "node_modules"))
   );
 }


### PR DESCRIPTION
## Summary
- surface `website/node_modules` as part of branch_pr worktree install-layout materialization
- treat the website dependency surface as required when recognizing a repo-local framework bootstrap layout
- extend bootstrap/worktree regression fixtures to cover the website dependency surface

## Verification
- `git diff --check`
- `ap doctor`
- `node .agentplane/policy/check-routing.mjs`

## Not Run
- `bun test packages/agentplane/src/cli/bootstrap-framework-dev-script.test.ts`
- `bun test packages/agentplane/src/cli/run-cli.core.pr-flow.worktree-runtime.test.ts`

`bun` is not installed in this environment, and there is no repo-local `vitest` binary available in the clean worktree, so the focused test commands could not be executed here.

Closes #4419.
