### PR TITLE
Fix compiled CLI smoke git context

### DIFF
--- a/scripts/release/smoke-bun-compiled-cli.mjs
+++ b/scripts/release/smoke-bun-compiled-cli.mjs
@@ -81,6 +81,10 @@ function assertFile(filePath, label) {
   if (!stat.isFile()) throw new Error(`Expected ${label} to be a file: ${filePath}`);
 }
 
+function initSmokeGitRepo(cwd) {
+  run("git", ["init"], { cwd });
+}
+
 function inferTarget(artifactPath) {
   const name = path.basename(artifactPath);
   const target = TARGETS.find((candidate) =>
@@ -125,6 +129,7 @@ function smokeBunArchive(args) {
     if (versionOutput !== version) {
       throw new Error(`Expected Bun archive version ${version}, got ${versionOutput}`);
     }
+    initSmokeGitRepo(extractDir);
     const quickstartOutput = run(executable, ["quickstart"], { cwd: extractDir });
     assertIncludes(quickstartOutput, "agentplane quickstart", "quickstart");
     return {
@@ -169,6 +174,7 @@ function smokeBunCompiledCli(args, repoRoot) {
       throw new Error(`Expected compiled version ${version}, got ${versionOutput}`);
     }
 
+    initSmokeGitRepo(tempDir);
     const quickstartOutput = run(executable, ["quickstart"], { cwd: tempDir });
     assertIncludes(quickstartOutput, "agentplane quickstart", "quickstart");
 


### PR DESCRIPTION
Fixes the compiled CLI smoke test after quickstart route handling started requiring git context. The smoke temp directory is now initialized as a git repo before running quickstart/role checks.\n\nVerified:\n- bun test packages/agentplane/src/commands/release/bun-compiled-cli-smoke-script.test.ts\n- bunx eslint scripts/release/smoke-bun-compiled-cli.mjs\n- node node_modules/prettier/bin/prettier.cjs --check scripts/release/smoke-bun-compiled-cli.mjs