### PR TITLE
🚧 XN7G9D task: Hide runner guidance outside parallel-codex context [202606050513-XN7G9D]

### DIFF
--- a/.agentplane/agents/EVALUATOR.json
+++ b/.agentplane/agents/EVALUATOR.json
@@ -1,26 +1,26 @@
 {
   "id": "EVALUATOR",
-  "role": "Evaluate completed runner/task attempts against documented quality criteria and return pass, rework, or blocked verdicts.",
-  "description": "Acts as an independent quality phase for task, recipe, prompt, and eval runs by comparing documented intent, Verify Steps, result manifests, traces, artifacts, and evidence before closure or promotion.",
+  "role": "Evaluate completed task attempts against documented quality criteria and return pass, rework, or blocked verdicts.",
+  "description": "Acts as an independent quality phase for task, recipe, prompt, and eval work by comparing documented intent, Verify Steps, changed behavior, artifacts, and evidence before closure or promotion.",
   "inputs": {
     "task.context": "Task ID, README sections, Verify Steps, comments, events, dependency state, and approved scope.",
-    "runner.evidence": "Runner result manifest, trace summaries, artifacts, changed paths, tests run, and verification candidates.",
+    "optional.runner.evidence": "Runner result manifests, traces, and run artifacts only when the reviewed task already contains runner evidence or a recipe such as parallel-codex explicitly made runner execution part of scope.",
     "reference.behavior": "Optional reference behavior for prompt/module/recipe evals, including expected outputs, hard gates, scoring rubric, and promotion policy."
   },
   "outputs": {
     "verdict": "One of pass, rework, blocked, or human_review, with the criteria and evidence that determined the result.",
-    "rework.context": "Focused instructions for the next runner pass when criteria are not yet satisfied.",
+    "rework.context": "Focused instructions for the next owner pass when criteria are not yet satisfied.",
     "quality.report": "Structured `ap evaluator run` report with findings, evidence_refs, missing_tests, hidden_assumptions, residual_risks, evaluated_sha, and promotion/finish recommendation."
   },
   "permissions": {
-    "review.artifacts": "Read task documentation, runner artifacts, diffs, reports, and eval outputs.",
+    "review.artifacts": "Read task documentation, diffs, reports, eval outputs, and optional runner artifacts only when they already exist in the task evidence.",
     "task.verification": "Record evaluator-scoped quality_review through `ap evaluator run`; use ordinary `agentplane verify --by EVALUATOR` only for legacy/manual records that are not sufficient for finish/integrate gates."
   },
   "workflow": {
-    "goal": "Goal: decide whether the latest task or eval attempt satisfies the documented quality contract without relying on the runner's self-claim alone.",
+    "goal": "Goal: decide whether the latest task or eval attempt satisfies the documented quality contract without relying on the implementer's self-claim alone.",
     "success.criteria": "Success criteria: required task sections and Verify Steps are mapped to concrete evidence; result manifest and artifacts are structurally valid; hard policy/security/lifecycle gates pass; pass reviews include non-empty findings and a quality-report.json evidence ref written by `ap evaluator run`; LLM quality scoring is used only where the approved rubric asks for judgement; context.maximum_assimilation work is checked for source-shaped wiki topology, useful Obsidian-compatible wikilinks, page granularity, line-addressed provenance, coverage gaps, glossary alias safety, raw-deletion resilience, and leakage risk; the final verdict is reproducible from cited evidence.",
-    "constraints": "Constraints: use loaded gateway and policy modules as binding constraints; separate deterministic gates from LLM judgement; do not edit implementation files; do not finish or integrate tasks unless the approved plan explicitly assigns evaluator closure; preserve raw trace/artifact paths instead of copying assistant prose into task docs.",
+    "constraints": "Constraints: use loaded gateway and policy modules as binding constraints; separate deterministic gates from LLM judgement; do not edit implementation files; do not finish or integrate tasks unless the approved plan explicitly assigns evaluator closure; preserve raw artifact paths instead of copying assistant prose into task docs; do not introduce runner execution guidance unless the task already has runner evidence or an active recipe such as parallel-codex explicitly requires it.",
     "stop.rules": "Stop rules: mark blocked when evidence is missing, stale, unverifiable, policy-sensitive, outside approved scope, or cannot be tied to the reviewed commit; mark rework when criteria are testable but unmet; require human approval before changing pass criteria, promotion thresholds, or security-sensitive interpretation.",
-    "output": "Output: run `ap evaluator run <task-id> --verdict <pass|rework|blocked|human_review> --summary \"...\" --finding \"...\" --evidence <path-or-check>` or provide the exact equivalent command; include failed or satisfied criteria, evidence paths, missing tests, hidden assumptions, residual risks, rework context for the next runner pass, and finish/promote recommendation."
+    "output": "Output: run `ap evaluator run <task-id> --verdict <pass|rework|blocked|human_review> --summary \"...\" --finding \"...\" --evidence <path-or-check>` or provide the exact equivalent command; include failed or satisfied criteria, evidence paths, missing tests, hidden assumptions, residual risks, rework context for the next owner pass, and finish/promote recommendation."
   }
 }

--- a/.agentplane/tasks/202606050513-XN7G9D/README.md
+++ b/.agentplane/tasks/202606050513-XN7G9D/README.md
@@ -4,7 +4,7 @@ title: "Hide runner guidance outside parallel-codex context"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 7
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -24,6 +24,24 @@ verification:
   updated_by: "CODER"
   note: "Verified prompt and route context hide default runner-only guidance for ordinary tasks; explicit runner routes remain covered by tests."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-06-05T05:44:18.783Z"
+  updated_by: "EVALUATOR"
+  note: "Prompt and route surfaces now hide default runner guidance outside explicit runner contexts; hosted PR checks passed on PR #4452."
+  evaluated_sha: "0c99d0953f4a2a4ca4f5ad203d1b2e4c7738a5ba"
+  blueprint_digest: "a00f707b51bb3c661393c8cf056c882304ac8dbc5704344e0a33c4a102e6fe26"
+  evidence_refs:
+    - ".agentplane/tasks/202606050513-XN7G9D/README.md"
+    - ".agentplane/tasks/202606050513-XN7G9D/quality/20260605-054418783-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202606050513-XN7G9D/quality/20260605-054418783-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202606050513-XN7G9D/quality/20260605-054418783-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202606050513-XN7G9D/blueprint/resolved-snapshot.json"
+    - "gh pr checks 4452"
+    - "bun run ci:local:fast"
+    - "/tmp/agentplane-XN7G9D-brief.txt"
+  findings:
+    - "Default task brief/status/next-action output no longer emits runner-only context fields for ordinary tasks; Hermes projection no longer includes runner commands unless a runner route or task runner evidence exists."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202606050513-XN7G9D/README.md
+++ b/.agentplane/tasks/202606050513-XN7G9D/README.md
@@ -1,0 +1,174 @@
+---
+id: "202606050513-XN7G9D"
+title: "Hide runner guidance outside parallel-codex context"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 7
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "cli"
+  - "code"
+  - "prompt"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-06-05T05:13:56.089Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-06-05T05:23:39.883Z"
+  updated_by: "CODER"
+  note: "Verified prompt and route context hide default runner-only guidance for ordinary tasks; explicit runner routes remain covered by tests."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: hide default runner guidance from ordinary agent prompt and route surfaces while preserving explicit runner routes and parallel-codex recipe behavior."
+events:
+  -
+    type: "status"
+    at: "2026-06-05T05:13:56.331Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: hide default runner guidance from ordinary agent prompt and route surfaces while preserving explicit runner routes and parallel-codex recipe behavior."
+  -
+    type: "verify"
+    at: "2026-06-05T05:23:39.883Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified prompt and route context hide default runner-only guidance for ordinary tasks; explicit runner routes remain covered by tests."
+doc_version: 3
+doc_updated_at: "2026-06-05T05:23:39.982Z"
+doc_updated_by: "CODER"
+description: "Default agent prompt and route surfaces must not introduce runner execution guidance unless the route is already a real runner wait/run state or the active recipe is parallel-codex. Ordinary agents should execute tasks themselves via normal AgentPlane lifecycle."
+sections:
+  Summary: |-
+    Hide runner guidance outside parallel-codex context
+
+    Default agent prompt and route surfaces must not introduce runner execution guidance unless the route is already a real runner wait/run state or the active recipe is parallel-codex. Ordinary agents should execute tasks themselves via normal AgentPlane lifecycle.
+  Scope: |-
+    - In scope: Default agent prompt and route surfaces must not introduce runner execution guidance unless the route is already a real runner wait/run state or the active recipe is parallel-codex. Ordinary agents should execute tasks themselves via normal AgentPlane lifecycle.
+    - Out of scope: unrelated refactors not required for "Hide runner guidance outside parallel-codex context".
+  Plan: "1. Audit prompt and route-context surfaces that mention runner execution outside recipe-owned parallel-codex assets. 2. Remove default runner_context output from task brief/status/next-action when the current route is not runner-required or runner-allowed. 3. Reword evaluator prompt so default quality review covers task attempts and treats runner artifacts as optional evidence only when present. 4. Verify targeted tests and command output show no runner context for ordinary tasks while preserving actual runner route handling."
+  Verify Steps: |-
+    1. Run `bun run --filter=agentplane typecheck`. Expected: exits 0.
+    2. Run `bun run --filter=agentplane build`. Expected: exits 0 and refreshes the repo-local CLI bundle.
+    3. Run `bun test packages/agentplane/src/commands/shared/route-guidance.test.ts packages/agentplane/src/commands/hermes/hermes.command.test.ts packages/agentplane/src/cli/run-cli.core.route-decision.test.ts packages/agentplane/src/runner/usecases/task-run-blueprint.test.ts`. Expected: all tests pass.
+    4. Run `ap task brief 202606050513-XN7G9D`, `ap task status 202606050513-XN7G9D --route`, and `ap task next-action 202606050513-XN7G9D --explain`; inspect stdout for default runner-only context fields. Expected: ordinary task output contains none of those fields.
+    5. Review `.agentplane/agents/EVALUATOR.json` and Hermes route projection behavior. Expected: runner evidence is optional and only appears when existing task runner evidence or an explicit runner route exists; ordinary agents are directed to continue owner task execution.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-06-05T05:23:39.883Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified prompt and route context hide default runner-only guidance for ordinary tasks; explicit runner routes remain covered by tests.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-06-05T05:23:17.081Z, excerpt_hash=sha256:52d884883f58714c73f6f206b3252c203a809d982035fd433c3fdc497106a960
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202606050513-XN7G9D-hide-runner-guidance/.agentplane/tasks/202606050513-XN7G9D/blueprint/resolved-snapshot.json
+    - old_digest: a00f707b51bb3c661393c8cf056c882304ac8dbc5704344e0a33c4a102e6fe26
+    - current_digest: a00f707b51bb3c661393c8cf056c882304ac8dbc5704344e0a33c4a102e6fe26
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202606050513-XN7G9D
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane work start 202606050513-XN7G9D --agent CODER --slug hide-runner-guidance-outside-parallel-codex-cont --worktree
+    - diagnostic_command: none
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: true
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: none
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: typecheck, build, route CLI tests, Hermes projection tests, runner bootstrap guard tests, and live task brief/status/next-action grep all passed.
+      Impact: Ordinary agents receive direct owner-task route context; runner evidence appears only when existing task runner evidence or an explicit runner route is present.
+      Resolution: Added relevance gating for runner context, removed default runner references from evaluator wording, and made Hermes runner projection conditional.
+id_source: "generated"
+---
+## Summary
+
+Hide runner guidance outside parallel-codex context
+
+Default agent prompt and route surfaces must not introduce runner execution guidance unless the route is already a real runner wait/run state or the active recipe is parallel-codex. Ordinary agents should execute tasks themselves via normal AgentPlane lifecycle.
+
+## Scope
+
+- In scope: Default agent prompt and route surfaces must not introduce runner execution guidance unless the route is already a real runner wait/run state or the active recipe is parallel-codex. Ordinary agents should execute tasks themselves via normal AgentPlane lifecycle.
+- Out of scope: unrelated refactors not required for "Hide runner guidance outside parallel-codex context".
+
+## Plan
+
+1. Audit prompt and route-context surfaces that mention runner execution outside recipe-owned parallel-codex assets. 2. Remove default runner_context output from task brief/status/next-action when the current route is not runner-required or runner-allowed. 3. Reword evaluator prompt so default quality review covers task attempts and treats runner artifacts as optional evidence only when present. 4. Verify targeted tests and command output show no runner context for ordinary tasks while preserving actual runner route handling.
+
+## Verify Steps
+
+1. Run `bun run --filter=agentplane typecheck`. Expected: exits 0.
+2. Run `bun run --filter=agentplane build`. Expected: exits 0 and refreshes the repo-local CLI bundle.
+3. Run `bun test packages/agentplane/src/commands/shared/route-guidance.test.ts packages/agentplane/src/commands/hermes/hermes.command.test.ts packages/agentplane/src/cli/run-cli.core.route-decision.test.ts packages/agentplane/src/runner/usecases/task-run-blueprint.test.ts`. Expected: all tests pass.
+4. Run `ap task brief 202606050513-XN7G9D`, `ap task status 202606050513-XN7G9D --route`, and `ap task next-action 202606050513-XN7G9D --explain`; inspect stdout for default runner-only context fields. Expected: ordinary task output contains none of those fields.
+5. Review `.agentplane/agents/EVALUATOR.json` and Hermes route projection behavior. Expected: runner evidence is optional and only appears when existing task runner evidence or an explicit runner route exists; ordinary agents are directed to continue owner task execution.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-06-05T05:23:39.883Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified prompt and route context hide default runner-only guidance for ordinary tasks; explicit runner routes remain covered by tests.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-06-05T05:23:17.081Z, excerpt_hash=sha256:52d884883f58714c73f6f206b3252c203a809d982035fd433c3fdc497106a960
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202606050513-XN7G9D-hide-runner-guidance/.agentplane/tasks/202606050513-XN7G9D/blueprint/resolved-snapshot.json
+- old_digest: a00f707b51bb3c661393c8cf056c882304ac8dbc5704344e0a33c4a102e6fe26
+- current_digest: a00f707b51bb3c661393c8cf056c882304ac8dbc5704344e0a33c4a102e6fe26
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202606050513-XN7G9D
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane work start 202606050513-XN7G9D --agent CODER --slug hide-runner-guidance-outside-parallel-codex-cont --worktree
+- diagnostic_command: none
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: true
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: none
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: typecheck, build, route CLI tests, Hermes projection tests, runner bootstrap guard tests, and live task brief/status/next-action grep all passed.
+  Impact: Ordinary agents receive direct owner-task route context; runner evidence appears only when existing task runner evidence or an explicit runner route is present.
+  Resolution: Added relevance gating for runner context, removed default runner references from evaluator wording, and made Hermes runner projection conditional.

--- a/.agentplane/tasks/202606050513-XN7G9D/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202606050513-XN7G9D/blueprint/resolved-snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202606050513-XN7G9D",
+    "title": "Hide runner guidance outside parallel-codex context",
+    "description": "Default agent prompt and route surfaces must not introduce runner execution guidance unless the route is already a real runner wait/run state or the active recipe is parallel-codex. Ordinary agents should execute tasks themselves via normal AgentPlane lifecycle.",
+    "tags": [
+      "cli",
+      "code",
+      "prompt"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202606050513-XN7G9D",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "a00f707b51bb3c661393c8cf056c882304ac8dbc5704344e0a33c4a102e6fe26"
+  }
+}

--- a/.agentplane/tasks/202606050513-XN7G9D/pr/diffstat.txt
+++ b/.agentplane/tasks/202606050513-XN7G9D/pr/diffstat.txt
@@ -1,0 +1,11 @@
+ .agentplane/agents/EVALUATOR.json                  | 16 +++----
+ .../src/commands/evaluator/evaluator.spec.ts       |  2 +-
+ .../src/commands/hermes/hermes-runtime.ts          | 36 ++++++++++----
+ .../src/commands/hermes/hermes.command.test.ts     | 42 +++++++----------
+ .../src/commands/shared/route-guidance.test.ts     | 55 +++++++++++++++++++++-
+ .../src/commands/shared/route-guidance.ts          | 11 +++++
+ .../agentplane/src/commands/task/brief-render.ts   | 19 +++++---
+ .../src/commands/task/next-action.command.ts       | 23 +++++----
+ .../agentplane/src/commands/task/status.command.ts | 23 +++++----
+ .../src/commands/task/verify-record-execute.ts     | 14 ++++--
+ 10 files changed, 168 insertions(+), 73 deletions(-)

--- a/.agentplane/tasks/202606050513-XN7G9D/pr/github-body.md
+++ b/.agentplane/tasks/202606050513-XN7G9D/pr/github-body.md
@@ -1,0 +1,48 @@
+Task: `202606050513-XN7G9D`
+Title: Hide runner guidance outside parallel-codex context
+Canonical task record: `.agentplane/tasks/202606050513-XN7G9D/README.md`
+
+## Summary
+
+Hide runner guidance outside parallel-codex context
+
+Default agent prompt and route surfaces must not introduce runner execution guidance unless the route is already a real runner wait/run state or the active recipe is parallel-codex. Ordinary agents should execute tasks themselves via normal AgentPlane lifecycle.
+
+## Scope
+
+- In scope: Default agent prompt and route surfaces must not introduce runner execution guidance unless the route is already a real runner wait/run state or the active recipe is parallel-codex. Ordinary agents should execute tasks themselves via normal AgentPlane lifecycle.
+- Out of scope: unrelated refactors not required for "Hide runner guidance outside parallel-codex context".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Verified prompt and route context hide default runner-only guidance for ordinary tasks; explicit
+runner routes remain covered by tests.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-06-05T05:23:40.008Z
+- Branch: task/202606050513-XN7G9D/hide-runner-guidance
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .agentplane/agents/EVALUATOR.json                  | 16 +++----
+ .../src/commands/evaluator/evaluator.spec.ts       |  2 +-
+ .../src/commands/hermes/hermes-runtime.ts          | 36 ++++++++++----
+ .../src/commands/hermes/hermes.command.test.ts     | 42 +++++++----------
+ .../src/commands/shared/route-guidance.test.ts     | 55 +++++++++++++++++++++-
+ .../src/commands/shared/route-guidance.ts          | 11 +++++
+ .../agentplane/src/commands/task/brief-render.ts   | 19 +++++---
+ .../src/commands/task/next-action.command.ts       | 23 +++++----
+ .../agentplane/src/commands/task/status.command.ts | 23 +++++----
+ .../src/commands/task/verify-record-execute.ts     | 14 ++++--
+ 10 files changed, 168 insertions(+), 73 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202606050513-XN7G9D/pr/github-title.txt
+++ b/.agentplane/tasks/202606050513-XN7G9D/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 XN7G9D task: Hide runner guidance outside parallel-codex context [202606050513-XN7G9D]

--- a/.agentplane/tasks/202606050513-XN7G9D/pr/meta.json
+++ b/.agentplane/tasks/202606050513-XN7G9D/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202606050513-XN7G9D/hide-runner-guidance",
+  "created_at": "2026-06-05T05:23:40.008Z",
+  "diffstat_sha256": "sha256:6583fe76a4bbdbc9abb2d1fc2680c92d57064271e5ae87be1784016b2ebf55aa",
+  "last_verified_at": "2026-06-05T05:23:39.883Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202606050513-XN7G9D",
+  "updated_at": "2026-06-05T05:23:40.008Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202606050513-XN7G9D/pr/review.md
+++ b/.agentplane/tasks/202606050513-XN7G9D/pr/review.md
@@ -1,0 +1,46 @@
+# PR Review
+
+Created: 2026-06-05T05:23:40.008Z
+
+## Task
+
+- Task: `202606050513-XN7G9D`
+- Title: Hide runner guidance outside parallel-codex context
+- Status: DOING
+- Branch: `task/202606050513-XN7G9D/hide-runner-guidance`
+- Canonical task record: `.agentplane/tasks/202606050513-XN7G9D/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified prompt and route context hide default runner-only guidance for ordinary tasks; explicit runner routes remain covered by tests.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-06-05T05:23:40.008Z
+- Branch: task/202606050513-XN7G9D/hide-runner-guidance
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .agentplane/agents/EVALUATOR.json                  | 16 +++----
+ .../src/commands/evaluator/evaluator.spec.ts       |  2 +-
+ .../src/commands/hermes/hermes-runtime.ts          | 36 ++++++++++----
+ .../src/commands/hermes/hermes.command.test.ts     | 42 +++++++----------
+ .../src/commands/shared/route-guidance.test.ts     | 55 +++++++++++++++++++++-
+ .../src/commands/shared/route-guidance.ts          | 11 +++++
+ .../agentplane/src/commands/task/brief-render.ts   | 19 +++++---
+ .../src/commands/task/next-action.command.ts       | 23 +++++----
+ .../agentplane/src/commands/task/status.command.ts | 23 +++++----
+ .../src/commands/task/verify-record-execute.ts     | 14 ++++--
+ 10 files changed, 168 insertions(+), 73 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202606050513-XN7G9D/quality/20260605-054418783-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202606050513-XN7G9D/quality/20260605-054418783-recovery-context/evaluator-opinion.md
@@ -1,0 +1,21 @@
+# EVALUATOR opinion: pass
+
+Prompt and route surfaces now hide default runner guidance outside explicit runner contexts; hosted PR checks passed on PR #4452.
+
+## Findings
+- Default task brief/status/next-action output no longer emits runner-only context fields for ordinary tasks; Hermes projection no longer includes runner commands unless a runner route or task runner evidence exists.
+
+## Evidence
+- .agentplane/tasks/202606050513-XN7G9D/README.md
+- gh pr checks 4452
+- bun run ci:local:fast
+- /tmp/agentplane-XN7G9D-brief.txt
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202606050513-XN7G9D/quality/20260605-054418783-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202606050513-XN7G9D/quality/20260605-054418783-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202606050513-XN7G9D
+- task_readme: .agentplane/tasks/202606050513-XN7G9D/README.md
+- report_path: .agentplane/tasks/202606050513-XN7G9D/quality/20260605-054418783-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202606050513-XN7G9D/quality/20260605-054418783-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202606050513-XN7G9D/quality/20260605-054418783-recovery-context/quality-report.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "task_id": "202606050513-XN7G9D",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-06-05T05:44:18.783Z",
+  "verdict": "pass",
+  "summary": "Prompt and route surfaces now hide default runner guidance outside explicit runner contexts; hosted PR checks passed on PR #4452.",
+  "evaluated_sha": "0c99d0953f4a2a4ca4f5ad203d1b2e4c7738a5ba",
+  "blueprint_digest": "a00f707b51bb3c661393c8cf056c882304ac8dbc5704344e0a33c4a102e6fe26",
+  "findings": [
+    "Default task brief/status/next-action output no longer emits runner-only context fields for ordinary tasks; Hermes projection no longer includes runner commands unless a runner route or task runner evidence exists."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202606050513-XN7G9D/README.md",
+    "gh pr checks 4452",
+    "bun run ci:local:fast",
+    "/tmp/agentplane-XN7G9D-brief.txt"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -3869,7 +3869,7 @@ Options:
 - `--missing-test <text>`: Missing test or check. May be repeated. (repeatable)
 - `--hidden-assumption <text>`: Hidden assumption found during review. May be repeated. (repeatable)
 - `--residual-risk <text>`: Residual risk after review. May be repeated. (repeatable)
-- `--rework-context <text>`: Machine-readable rework instruction for the next runner pass. May be repeated. (repeatable)
+- `--rework-context <text>`: Machine-readable rework instruction for the next owner pass. May be repeated. (repeatable)
 - `--no-record`: Write evaluator artifacts without updating task quality_review. (default=false)
 - `--json`: Emit JSON. (default=false)
 

--- a/packages/agentplane/assets/agents/EVALUATOR.json
+++ b/packages/agentplane/assets/agents/EVALUATOR.json
@@ -1,26 +1,26 @@
 {
   "id": "EVALUATOR",
-  "role": "Evaluate completed runner/task attempts against documented quality criteria and return pass, rework, or blocked verdicts.",
-  "description": "Acts as an independent quality phase for task, recipe, prompt, and eval runs by comparing documented intent, Verify Steps, result manifests, traces, artifacts, and evidence before closure or promotion.",
+  "role": "Evaluate completed task attempts against documented quality criteria and return pass, rework, or blocked verdicts.",
+  "description": "Acts as an independent quality phase for task, recipe, prompt, and eval work by comparing documented intent, Verify Steps, changed behavior, artifacts, and evidence before closure or promotion.",
   "inputs": {
     "task.context": "Task ID, README sections, Verify Steps, comments, events, dependency state, and approved scope.",
-    "runner.evidence": "Runner result manifest, trace summaries, artifacts, changed paths, tests run, and verification candidates.",
+    "optional.runner.evidence": "Runner result manifests, traces, and run artifacts only when the reviewed task already contains runner evidence or a recipe such as parallel-codex explicitly made runner execution part of scope.",
     "reference.behavior": "Optional reference behavior for prompt/module/recipe evals, including expected outputs, hard gates, scoring rubric, and promotion policy."
   },
   "outputs": {
     "verdict": "One of pass, rework, blocked, or human_review, with the criteria and evidence that determined the result.",
-    "rework.context": "Focused instructions for the next runner pass when criteria are not yet satisfied.",
+    "rework.context": "Focused instructions for the next owner pass when criteria are not yet satisfied.",
     "quality.report": "Structured `ap evaluator run` report with findings, evidence_refs, missing_tests, hidden_assumptions, residual_risks, evaluated_sha, and promotion/finish recommendation."
   },
   "permissions": {
-    "review.artifacts": "Read task documentation, runner artifacts, diffs, reports, and eval outputs.",
+    "review.artifacts": "Read task documentation, diffs, reports, eval outputs, and optional runner artifacts only when they already exist in the task evidence.",
     "task.verification": "Record evaluator-scoped quality_review through `ap evaluator run`; use ordinary `agentplane verify --by EVALUATOR` only for legacy/manual records that are not sufficient for finish/integrate gates."
   },
   "workflow": {
-    "goal": "Goal: decide whether the latest task or eval attempt satisfies the documented quality contract without relying on the runner's self-claim alone.",
+    "goal": "Goal: decide whether the latest task or eval attempt satisfies the documented quality contract without relying on the implementer's self-claim alone.",
     "success.criteria": "Success criteria: required task sections and Verify Steps are mapped to concrete evidence; result manifest and artifacts are structurally valid; hard policy/security/lifecycle gates pass; pass reviews include non-empty findings and a quality-report.json evidence ref written by `ap evaluator run`; LLM quality scoring is used only where the approved rubric asks for judgement; context.maximum_assimilation work is checked for source-shaped wiki topology, useful Obsidian-compatible wikilinks, page granularity, line-addressed provenance, coverage gaps, glossary alias safety, raw-deletion resilience, and leakage risk; the final verdict is reproducible from cited evidence.",
-    "constraints": "Constraints: use loaded gateway and policy modules as binding constraints; separate deterministic gates from LLM judgement; do not edit implementation files; do not finish or integrate tasks unless the approved plan explicitly assigns evaluator closure; preserve raw trace/artifact paths instead of copying assistant prose into task docs.",
+    "constraints": "Constraints: use loaded gateway and policy modules as binding constraints; separate deterministic gates from LLM judgement; do not edit implementation files; do not finish or integrate tasks unless the approved plan explicitly assigns evaluator closure; preserve raw artifact paths instead of copying assistant prose into task docs; do not introduce runner execution guidance unless the task already has runner evidence or an active recipe such as parallel-codex explicitly requires it.",
     "stop.rules": "Stop rules: mark blocked when evidence is missing, stale, unverifiable, policy-sensitive, outside approved scope, or cannot be tied to the reviewed commit; mark rework when criteria are testable but unmet; require human approval before changing pass criteria, promotion thresholds, or security-sensitive interpretation.",
-    "output": "Output: run `ap evaluator run <task-id> --verdict <pass|rework|blocked|human_review> --summary \"...\" --finding \"...\" --evidence <path-or-check>` or provide the exact equivalent command; include failed or satisfied criteria, evidence paths, missing tests, hidden assumptions, residual risks, rework context for the next runner pass, and finish/promote recommendation."
+    "output": "Output: run `ap evaluator run <task-id> --verdict <pass|rework|blocked|human_review> --summary \"...\" --finding \"...\" --evidence <path-or-check>` or provide the exact equivalent command; include failed or satisfied criteria, evidence paths, missing tests, hidden assumptions, residual risks, rework context for the next owner pass, and finish/promote recommendation."
   }
 }

--- a/packages/agentplane/src/commands/evaluator/evaluator.spec.ts
+++ b/packages/agentplane/src/commands/evaluator/evaluator.spec.ts
@@ -130,7 +130,7 @@ export const evaluatorRunSpec: CommandSpec<EvaluatorRunParsed> = {
       name: "rework-context",
       valueHint: "<text>",
       repeatable: true,
-      description: "Machine-readable rework instruction for the next runner pass. May be repeated.",
+      description: "Machine-readable rework instruction for the next owner pass. May be repeated.",
     },
     {
       kind: "boolean",

--- a/packages/agentplane/src/commands/hermes/hermes-runtime.ts
+++ b/packages/agentplane/src/commands/hermes/hermes-runtime.ts
@@ -154,6 +154,15 @@ async function runnerVisibilityPacket(opts: {
   }
 }
 
+function routeNeedsRunnerProjection(
+  decision: Awaited<ReturnType<typeof buildTaskRouteDecision>>,
+): boolean {
+  return (
+    decision.nextAction.code === "wait_runner" ||
+    (decision.blockers ?? []).some((blocker) => blocker.code === "runner_alive")
+  );
+}
+
 export async function routePacket(opts: {
   ctx: CommandContext;
   cwd: string;
@@ -169,12 +178,15 @@ export async function routePacket(opts: {
     taskId: opts.taskId,
     includeRemote: opts.includeRemote,
   });
-  const runner = await runnerVisibilityPacket({
-    ctx: opts.ctx,
-    cwd: opts.cwd,
-    rootOverride: opts.rootOverride,
-    taskId: opts.taskId,
-  });
+  const shouldProjectRunner = routeNeedsRunnerProjection(decision) || Boolean(fullTask.runner);
+  const runner = shouldProjectRunner
+    ? await runnerVisibilityPacket({
+        ctx: opts.ctx,
+        cwd: opts.cwd,
+        rootOverride: opts.rootOverride,
+        taskId: opts.taskId,
+      })
+    : null;
   const terminal = {
     hermes_root_complete_allowed: taskTerminalForHermesComplete(decision.task),
     required_gate:
@@ -220,9 +232,13 @@ export async function routePacket(opts: {
       evidence_refs: {
         task_readme: `.agentplane/tasks/${decision.task.id}/README.md`,
         acr: `.agentplane/tasks/${decision.task.id}/acr.json`,
-        runner_status: runner.commands.status,
-        runner_inspect: runner.commands.inspect,
-        runner_event_logs: runner.commands.event_logs,
+        ...(runner
+          ? {
+              runner_status: runner.commands.status,
+              runner_inspect: runner.commands.inspect,
+              runner_event_logs: runner.commands.event_logs,
+            }
+          : {}),
       },
       terminal,
       authority: projectionBoundary,
@@ -260,7 +276,7 @@ export function buildHermesLifecycleRecommendation(
   return {
     action: "comment",
     command: `${base} comment --body ${JSON.stringify(body)}`,
-    reason: "Agentplane task is non-terminal; project the latest route and runner evidence.",
+    reason: "Agentplane task is non-terminal; project the latest route evidence.",
     body,
   };
 }

--- a/packages/agentplane/src/commands/hermes/hermes-runtime.ts
+++ b/packages/agentplane/src/commands/hermes/hermes-runtime.ts
@@ -6,6 +6,10 @@ import { isRecord } from "../../shared/guards.js";
 import { resolveAgentplaneBinPath } from "../../shared/package-paths.js";
 import { loadTaskRunnerInspection } from "../../runner/usecases/task-run-inspect.js";
 import { buildTaskRouteDecision } from "../shared/route-decision.js";
+import {
+  deriveRouteOperatorGuidance,
+  routeRunnerContextIsRelevant,
+} from "../shared/route-guidance.js";
 import { loadTaskFromContext, type CommandContext } from "../shared/task-backend.js";
 
 const execFileAsync = promisify(execFile);
@@ -154,13 +158,10 @@ async function runnerVisibilityPacket(opts: {
   }
 }
 
-function routeNeedsRunnerProjection(
+export function routeNeedsRunnerProjection(
   decision: Awaited<ReturnType<typeof buildTaskRouteDecision>>,
 ): boolean {
-  return (
-    decision.nextAction.code === "wait_runner" ||
-    (decision.blockers ?? []).some((blocker) => blocker.code === "runner_alive")
-  );
+  return routeRunnerContextIsRelevant(deriveRouteOperatorGuidance(decision));
 }
 
 export async function routePacket(opts: {

--- a/packages/agentplane/src/commands/hermes/hermes.command.test.ts
+++ b/packages/agentplane/src/commands/hermes/hermes.command.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import { runCli } from "../../cli/run-cli.js";
-import { executableStepFor, runAgentplaneStep } from "./hermes-runtime.js";
+import {
+  executableStepFor,
+  routeNeedsRunnerProjection,
+  runAgentplaneStep,
+} from "./hermes-runtime.js";
+import type { TaskRouteDecision } from "../shared/route-decision-types.js";
 import { captureStdIO, mkGitRepoRoot, runCliSilent } from "@agentplane/testkit";
 import { chmod, mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
@@ -312,6 +317,48 @@ describe("hermes adapter commands", () => {
       args: ["task", "run", "202606010530-BEYQXA"],
       reason: null,
     });
+  });
+
+  it("keeps Hermes runner projection for explicit task run routes", () => {
+    const taskId = "202606010530-BEYQXA";
+    const decision = {
+      task: {
+        id: taskId,
+        title: "Hermes task launch",
+        status: "DOING",
+        owner: "CODER",
+        planApproval: "approved",
+        verification: "pending",
+        commit: null,
+      },
+      nextAction: {
+        code: "run",
+        command: `agentplane task run ${taskId}`,
+        summary: "continue the direct-mode task from the current checkout",
+        requiresApproval: false,
+      },
+      oracle: {
+        phase: "direct_execute",
+        authoritativeCheckout: "current_checkout",
+        authoritativeCheckoutPath: "/repo",
+        mutationPathHint: "/repo",
+        blocker: null,
+        nextCommand: `agentplane task run ${taskId}`,
+        summary: "continue the direct-mode task from the current checkout",
+      },
+      blockers: [],
+      executionPacket: {
+        actionKind: "local_command",
+        safeToMutate: true,
+        exactArgv: ["agentplane", "task", "run", taskId],
+        stopReason: null,
+        returnControlWhen: "after the exact command exits; recompute task next-action",
+        staleStateCheck: `agentplane task next-action ${taskId} --explain`,
+        verificationCandidate: null,
+      },
+    } as TaskRouteDecision;
+
+    expect(routeNeedsRunnerProjection(decision)).toBe(true);
   });
 
   it("rejects task run route steps for a different task id", () => {

--- a/packages/agentplane/src/commands/hermes/hermes.command.test.ts
+++ b/packages/agentplane/src/commands/hermes/hermes.command.test.ts
@@ -167,11 +167,12 @@ describe("hermes adapter commands", () => {
                 returnControlWhen: string;
                 mustNot: string[];
               };
-              evidence_refs: { runner_status: string; runner_inspect: string };
+              evidence_refs: Record<string, string>;
+              runner: null;
             };
           };
         };
-        evidence_refs: { runner_event_logs: string };
+        evidence_refs: Record<string, string>;
         sync_field_policies: { status: { authority: string } };
       };
       expect(payload.idempotency_key).toContain(`agentplane:${root}:${taskId}:CODER`);
@@ -191,15 +192,14 @@ describe("hermes adapter commands", () => {
       expect(payload.metadata.agentplane.comment_projection.execution_packet.mustNot).toContain(
         "do not reconstruct branch/worktree/PR state from prose",
       );
-      expect(payload.metadata.agentplane.comment_projection.evidence_refs.runner_status).toBe(
-        `agentplane task run status ${taskId} --json`,
+      expect(payload.metadata.agentplane.comment_projection.runner).toBeNull();
+      expect(payload.metadata.agentplane.comment_projection.evidence_refs).not.toHaveProperty(
+        "runner_status",
       );
-      expect(payload.metadata.agentplane.comment_projection.evidence_refs.runner_inspect).toBe(
-        `agentplane task run inspect ${taskId} --json`,
+      expect(payload.metadata.agentplane.comment_projection.evidence_refs).not.toHaveProperty(
+        "runner_inspect",
       );
-      expect(payload.evidence_refs.runner_event_logs).toBe(
-        `agentplane task run logs ${taskId} --stream events`,
-      );
+      expect(payload.evidence_refs).not.toHaveProperty("runner_event_logs");
       expect(payload.sync_field_policies.status.authority).toBe("agentplane");
     } finally {
       io.restore();
@@ -221,17 +221,14 @@ describe("hermes adapter commands", () => {
           execute_raw_shell_from_route: boolean;
           max_route_steps_per_claim: number;
         };
-        runner: {
-          latest_available: boolean;
-          commands: { status: string; inspect: string; event_logs: string };
-        };
+        runner: null;
         hermes_comment_projection: {
           schema: string;
           execution_packet: {
             staleStateCheck: string;
             returnControlWhen: string;
           };
-          evidence_refs: { runner_status: string };
+          evidence_refs: Record<string, string>;
         };
         terminal: { hermes_root_complete_allowed: boolean };
         lifecycle_recommendation: { action: string; command: string; reason: string };
@@ -241,12 +238,7 @@ describe("hermes adapter commands", () => {
       expect(payload.projection_boundary.hermes_authority).toBe("dispatch_run_lifecycle");
       expect(payload.supervisor_policy.execute_raw_shell_from_route).toBe(false);
       expect(payload.supervisor_policy.max_route_steps_per_claim).toBe(1);
-      expect(payload.runner.latest_available).toBe(false);
-      expect(payload.runner.commands.status).toBe(`agentplane task run status ${taskId} --json`);
-      expect(payload.runner.commands.inspect).toBe(`agentplane task run inspect ${taskId} --json`);
-      expect(payload.runner.commands.event_logs).toBe(
-        `agentplane task run logs ${taskId} --stream events`,
-      );
+      expect(payload.runner).toBeNull();
       expect(payload.hermes_comment_projection.schema).toBe(
         "agentplane.hermes.lifecycle-comment.v1",
       );
@@ -256,9 +248,7 @@ describe("hermes adapter commands", () => {
       expect(payload.hermes_comment_projection.execution_packet.returnControlWhen).toContain(
         "after the provider or human action completes",
       );
-      expect(payload.hermes_comment_projection.evidence_refs.runner_status).toBe(
-        payload.runner.commands.status,
-      );
+      expect(payload.hermes_comment_projection.evidence_refs).not.toHaveProperty("runner_status");
       expect(payload.terminal.hermes_root_complete_allowed).toBe(false);
       expect(payload.lifecycle_recommendation.action).toBe("block");
       expect(payload.lifecycle_recommendation.command).toContain("hermes lifecycle block");
@@ -482,7 +472,7 @@ describe("hermes adapter commands", () => {
           task: { id: string };
           hermes_comment_projection: {
             agentplane_task_id: string;
-            evidence_refs: { runner_status: string };
+            evidence_refs: Record<string, string>;
           };
         };
         plugin_contract: { remote_board_reads_required: boolean };
@@ -490,8 +480,8 @@ describe("hermes adapter commands", () => {
       expect(payload.mode).toBe("read_only");
       expect(payload.local_projection.task.id).toBe(taskId);
       expect(payload.local_projection.hermes_comment_projection.agentplane_task_id).toBe(taskId);
-      expect(payload.local_projection.hermes_comment_projection.evidence_refs.runner_status).toBe(
-        `agentplane task run status ${taskId} --json`,
+      expect(payload.local_projection.hermes_comment_projection.evidence_refs).not.toHaveProperty(
+        "runner_status",
       );
       expect(payload.plugin_contract.remote_board_reads_required).toBe(true);
     } finally {

--- a/packages/agentplane/src/commands/shared/route-guidance.test.ts
+++ b/packages/agentplane/src/commands/shared/route-guidance.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { TaskRouteDecision } from "./route-decision-types.js";
-import { deriveRouteOperatorGuidance } from "./route-guidance.js";
+import { deriveRouteOperatorGuidance, routeRunnerContextIsRelevant } from "./route-guidance.js";
 
 describe("route operator guidance", () => {
   it("surfaces PR artifact freshness loops separately from executable route commands", () => {
@@ -42,7 +42,8 @@ describe("route operator guidance", () => {
       },
     } as TaskRouteDecision;
 
-    expect(deriveRouteOperatorGuidance(decision)).toMatchObject({
+    const guidance = deriveRouteOperatorGuidance(decision);
+    expect(guidance).toMatchObject({
       canExecuteNow: true,
       shouldRunNextCommand: true,
       operatorAction: "run_exact_argv",
@@ -80,6 +81,7 @@ describe("route operator guidance", () => {
         },
       ],
     });
+    expect(routeRunnerContextIsRelevant(guidance)).toBe(false);
   });
 
   it("points hybrid PR update route diagnostics at PR check", () => {
@@ -131,5 +133,54 @@ describe("route operator guidance", () => {
         allowed: false,
       },
     });
+  });
+
+  it("keeps runner context visible only for an active runner route", () => {
+    const decision = {
+      task: {
+        id: "202606050513-RUNNER",
+        title: "Wait for runner",
+        status: "DOING",
+        owner: "CODER",
+        planApproval: "approved",
+        verification: "pending",
+        commit: null,
+      },
+      nextAction: {
+        code: "wait_runner",
+        command: null,
+        summary: "wait for the active runner or reclaim with explicit force if it is orphaned",
+        requiresApproval: false,
+      },
+      oracle: {
+        phase: "runner_wait",
+        authoritativeCheckout: "task_worktree",
+        authoritativeCheckoutPath: "/repo/.agentplane/worktrees/task",
+        mutationPathHint: null,
+        blocker: { code: "runner_alive", summary: "latest runner still appears alive" },
+        nextCommand: null,
+        summary: "wait for the active runner or reclaim with explicit force if it is orphaned",
+      },
+      blockers: [{ code: "runner_alive", summary: "latest runner still appears alive" }],
+      executionPacket: {
+        actionKind: "wait",
+        safeToMutate: false,
+        exactArgv: null,
+        stopReason: "wait for the active runner or reclaim with explicit force if it is orphaned",
+        returnControlWhen:
+          "after the waited condition changes or the parent supervisor grants reclaim/escalation",
+        staleStateCheck: "agentplane task next-action 202606050513-RUNNER --explain",
+        verificationCandidate: null,
+      },
+    } as TaskRouteDecision;
+
+    const guidance = deriveRouteOperatorGuidance(decision);
+
+    expect(guidance.runnerContext).toMatchObject({
+      runnerIsRequired: true,
+      runnerIsAllowedNow: false,
+      runnerFailureMeans: "inspect_runner_artifacts",
+    });
+    expect(routeRunnerContextIsRelevant(guidance)).toBe(true);
   });
 });

--- a/packages/agentplane/src/commands/shared/route-guidance.ts
+++ b/packages/agentplane/src/commands/shared/route-guidance.ts
@@ -230,3 +230,14 @@ export function deriveRouteOperatorGuidance(decision: TaskRouteDecision): RouteO
     risks,
   };
 }
+
+export function routeRunnerContextIsRelevant(
+  guidance: Pick<RouteOperatorGuidance, "runnerContext">,
+): boolean {
+  const context = guidance.runnerContext;
+  return (
+    context.runnerIsRequired ||
+    context.runnerIsAllowedNow ||
+    context.runnerFailureMeans !== "not_runner_route"
+  );
+}

--- a/packages/agentplane/src/commands/task/brief-render.ts
+++ b/packages/agentplane/src/commands/task/brief-render.ts
@@ -1,4 +1,5 @@
 import { createCliEmitter, infoMessage } from "../../cli/output.js";
+import { routeRunnerContextIsRelevant } from "../shared/route-guidance.js";
 import type { TaskBrief } from "./brief-model.js";
 
 function splitNonEmptyLines(text: string): string[] {
@@ -59,13 +60,17 @@ export function reportTaskBriefText(brief: TaskBrief, taskId: string): void {
           `allowed=${String(brief.decision_context.repeatPolicy.allowed)} ` +
           `recompute=${brief.decision_context.repeatPolicy.recomputeCommand}`,
       },
-      {
-        label: "runner_context",
-        value:
-          `required=${String(brief.decision_context.runnerContext.runnerIsRequired)} ` +
-          `allowed_now=${String(brief.decision_context.runnerContext.runnerIsAllowedNow)} ` +
-          `failure_means=${brief.decision_context.runnerContext.runnerFailureMeans}`,
-      },
+      ...(routeRunnerContextIsRelevant(brief.decision_context)
+        ? [
+            {
+              label: "runner_context",
+              value:
+                `required=${String(brief.decision_context.runnerContext.runnerIsRequired)} ` +
+                `allowed_now=${String(brief.decision_context.runnerContext.runnerIsAllowedNow)} ` +
+                `failure_means=${brief.decision_context.runnerContext.runnerFailureMeans}`,
+            },
+          ]
+        : []),
       {
         label: "safe_to_mutate",
         value: String(brief.execution_packet.safe_to_mutate),

--- a/packages/agentplane/src/commands/task/next-action.command.ts
+++ b/packages/agentplane/src/commands/task/next-action.command.ts
@@ -2,7 +2,10 @@ import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
 import { createCliEmitter, infoMessage } from "../../cli/output.js";
 import type { CommandContext } from "../shared/task-backend.js";
 import { buildTaskRouteDecision } from "../shared/route-decision.js";
-import { deriveRouteOperatorGuidance } from "../shared/route-guidance.js";
+import {
+  deriveRouteOperatorGuidance,
+  routeRunnerContextIsRelevant,
+} from "../shared/route-guidance.js";
 
 export type TaskNextActionParsed = {
   taskId: string;
@@ -106,13 +109,17 @@ export function makeRunTaskNextActionHandler(getCtx: (cmd: string) => Promise<Co
               ? `${operatorGuidance.fallback.command}: ${operatorGuidance.fallback.reason ?? ""}`
               : "none",
         },
-        {
-          label: "runner_context",
-          value:
-            `required=${String(operatorGuidance.runnerContext.runnerIsRequired)} ` +
-            `allowed_now=${String(operatorGuidance.runnerContext.runnerIsAllowedNow)} ` +
-            `failure_means=${operatorGuidance.runnerContext.runnerFailureMeans}`,
-        },
+        ...(routeRunnerContextIsRelevant(operatorGuidance)
+          ? [
+              {
+                label: "runner_context",
+                value:
+                  `required=${String(operatorGuidance.runnerContext.runnerIsRequired)} ` +
+                  `allowed_now=${String(operatorGuidance.runnerContext.runnerIsAllowedNow)} ` +
+                  `failure_means=${operatorGuidance.runnerContext.runnerFailureMeans}`,
+              },
+            ]
+          : []),
         { label: "code", value: decision.nextAction.code },
         { label: "summary", value: decision.nextAction.summary },
         { label: "requires_approval", value: decision.nextAction.requiresApproval },

--- a/packages/agentplane/src/commands/task/status.command.ts
+++ b/packages/agentplane/src/commands/task/status.command.ts
@@ -2,7 +2,10 @@ import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
 import { createCliEmitter, infoMessage } from "../../cli/output.js";
 import type { CommandContext } from "../shared/task-backend.js";
 import { buildTaskRouteDecision } from "../shared/route-decision.js";
-import { deriveRouteOperatorGuidance } from "../shared/route-guidance.js";
+import {
+  deriveRouteOperatorGuidance,
+  routeRunnerContextIsRelevant,
+} from "../shared/route-guidance.js";
 
 export type TaskStatusParsed = {
   taskId: string;
@@ -113,13 +116,17 @@ export function makeRunTaskStatusHandler(getCtx: (cmd: string) => Promise<Comman
             `allowed=${String(operatorGuidance.repeatPolicy.allowed)} ` +
             `recompute=${operatorGuidance.repeatPolicy.recomputeCommand}`,
         },
-        {
-          label: "runner_context",
-          value:
-            `required=${String(operatorGuidance.runnerContext.runnerIsRequired)} ` +
-            `allowed_now=${String(operatorGuidance.runnerContext.runnerIsAllowedNow)} ` +
-            `failure_means=${operatorGuidance.runnerContext.runnerFailureMeans}`,
-        },
+        ...(routeRunnerContextIsRelevant(operatorGuidance)
+          ? [
+              {
+                label: "runner_context",
+                value:
+                  `required=${String(operatorGuidance.runnerContext.runnerIsRequired)} ` +
+                  `allowed_now=${String(operatorGuidance.runnerContext.runnerIsAllowedNow)} ` +
+                  `failure_means=${operatorGuidance.runnerContext.runnerFailureMeans}`,
+              },
+            ]
+          : []),
         { label: "safe_command", value: operatorGuidance.safeCommand ?? "none" },
         { label: "diagnostic_command", value: operatorGuidance.diagnosticCommand ?? "none" },
         {

--- a/packages/agentplane/src/commands/task/verify-record-execute.ts
+++ b/packages/agentplane/src/commands/task/verify-record-execute.ts
@@ -13,7 +13,10 @@ import {
 import { ensurePrArtifactsSynced } from "../pr/internal/sync.js";
 import { checkTaskBlueprintSnapshotDrift } from "../blueprint/snapshot-artifact.js";
 import { buildTaskRouteDecision } from "../shared/route-decision.js";
-import { deriveRouteOperatorGuidance } from "../shared/route-guidance.js";
+import {
+  deriveRouteOperatorGuidance,
+  routeRunnerContextIsRelevant,
+} from "../shared/route-guidance.js";
 import { buildVerifiedPrMeta, parsePrMeta } from "../shared/pr-meta.js";
 import { resolvePrPaths } from "../pr/internal/pr-paths.js";
 import { gitRevParse } from "../shared/git-ops.js";
@@ -96,6 +99,12 @@ async function appendDecisionContextReference(
       taskId: opts.taskId,
     });
     const guidance = deriveRouteOperatorGuidance(decision);
+    const runnerLines = routeRunnerContextIsRelevant(guidance)
+      ? [
+          `- runner_required: ${String(guidance.runnerContext.runnerIsRequired)}`,
+          `- runner_failure_means: ${guidance.runnerContext.runnerFailureMeans}`,
+        ]
+      : [];
     return appendDetailsBlock(details, [
       "DecisionContextRef:",
       `- operator_action: ${guidance.operatorAction}`,
@@ -106,8 +115,7 @@ async function appendDecisionContextReference(
       `- freshness: route=${guidance.freshness.route} remote=${guidance.freshness.remote}`,
       `- repeat_allowed: ${String(guidance.repeatPolicy.allowed)}`,
       `- repeat_stop_condition: ${guidance.repeatPolicy.stopCondition}`,
-      `- runner_required: ${String(guidance.runnerContext.runnerIsRequired)}`,
-      `- runner_failure_means: ${guidance.runnerContext.runnerFailureMeans}`,
+      ...runnerLines,
       `- risks: ${guidance.risks.map((risk) => risk.code).join(", ") || "none"}`,
     ]);
   } catch (err) {


### PR DESCRIPTION
Task: `202606050513-XN7G9D`
Title: Hide runner guidance outside parallel-codex context
Canonical task record: `.agentplane/tasks/202606050513-XN7G9D/README.md`

## Summary

Hide runner guidance outside parallel-codex context

Default agent prompt and route surfaces must not introduce runner execution guidance unless the route is already a real runner wait/run state or the active recipe is parallel-codex. Ordinary agents should execute tasks themselves via normal AgentPlane lifecycle.

## Scope

- In scope: Default agent prompt and route surfaces must not introduce runner execution guidance unless the route is already a real runner wait/run state or the active recipe is parallel-codex. Ordinary agents should execute tasks themselves via normal AgentPlane lifecycle.
- Out of scope: unrelated refactors not required for "Hide runner guidance outside parallel-codex context".

## Verification

- State: ok
- Note:

```text
Verified prompt and route context hide default runner-only guidance for ordinary tasks; explicit
runner routes remain covered by tests.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-06-05T05:23:40.008Z
- Branch: task/202606050513-XN7G9D/hide-runner-guidance
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .agentplane/agents/EVALUATOR.json                  | 16 +++----
 .../src/commands/evaluator/evaluator.spec.ts       |  2 +-
 .../src/commands/hermes/hermes-runtime.ts          | 36 ++++++++++----
 .../src/commands/hermes/hermes.command.test.ts     | 42 +++++++----------
 .../src/commands/shared/route-guidance.test.ts     | 55 +++++++++++++++++++++-
 .../src/commands/shared/route-guidance.ts          | 11 +++++
 .../agentplane/src/commands/task/brief-render.ts   | 19 +++++---
 .../src/commands/task/next-action.command.ts       | 23 +++++----
 .../agentplane/src/commands/task/status.command.ts | 23 +++++----
 .../src/commands/task/verify-record-execute.ts     | 14 ++++--
 10 files changed, 168 insertions(+), 73 deletions(-)
```

</details>
