### PR TITLE
🚧 TKMZWV task: Fix upstream issue #4451: finish/task complete can loop on stale quality_review.evaluated_sha... [202606050431-TKMZWV]

### DIFF
--- a/.agentplane/tasks/202606050431-TKMZWV/README.md
+++ b/.agentplane/tasks/202606050431-TKMZWV/README.md
@@ -4,7 +4,7 @@ title: "Fix upstream issue #4451: finish/task complete can loop on stale quality
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 4
+revision: 5
 origin:
   system: "manual"
 depends_on: []
@@ -17,10 +17,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-06-06T16:41:48.030Z"
+  updated_by: "CODER"
+  note: "Verified: fixed direct closeout quality review target selection for existing task-artifact-only commit metadata. Commands: bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts packages/agentplane/src/commands/task/quality-review-gate.unit.test.ts packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts; git diff --check; node .agentplane/policy/check-routing.mjs."
   attempts: 0
 commit: null
 comments:
@@ -35,8 +35,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: investigating upstream issue #4451 in the dedicated branch_pr worktree and preparing the bounded Codex runner handoff."
+  -
+    type: "verify"
+    at: "2026-06-06T16:41:48.030Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: fixed direct closeout quality review target selection for existing task-artifact-only commit metadata. Commands: bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts packages/agentplane/src/commands/task/quality-review-gate.unit.test.ts packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts; git diff --check; node .agentplane/policy/check-routing.mjs."
 doc_version: 3
-doc_updated_at: "2026-06-05T04:33:32.696Z"
+doc_updated_at: "2026-06-06T16:41:49.122Z"
 doc_updated_by: "CODER"
 description: "Resolve https://github.com/basilisk-labs/agentplane/issues/4451"
 sections:
@@ -59,6 +65,36 @@ sections:
     3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-06-06T16:41:48.030Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified: fixed direct closeout quality review target selection for existing task-artifact-only commit metadata. Commands: bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts packages/agentplane/src/commands/task/quality-review-gate.unit.test.ts packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts; git diff --check; node .agentplane/policy/check-routing.mjs.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-06-05T04:33:32.696Z, excerpt_hash=sha256:ffd25d481a7f9d3f97cacaf135e78dbd8c18b1d2f457b10ada75f95c7d59fdb4
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202606050431-TKMZWV/.agentplane/tasks/202606050431-TKMZWV/blueprint/resolved-snapshot.json
+    - old_digest: 9574f5a3ad62e5b13055839429cae1cb6446d9ed9caf4505903ef2f8cb4f1442
+    - current_digest: 9574f5a3ad62e5b13055839429cae1cb6446d9ed9caf4505903ef2f8cb4f1442
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202606050431-TKMZWV
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane pr update 202606050431-TKMZWV
+    - diagnostic_command: agentplane pr check 202606050431-TKMZWV
+    - source_of_truth: route=task_next_action diagnostic=pr_check remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
+    - risks: pr_artifact_freshness_loop, git_hook_side_effect
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -94,6 +130,36 @@ PLANNER fallback scaffold for "Fix upstream issue #4451: finish/task complete ca
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-06-06T16:41:48.030Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: fixed direct closeout quality review target selection for existing task-artifact-only commit metadata. Commands: bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts packages/agentplane/src/commands/task/quality-review-gate.unit.test.ts packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts; git diff --check; node .agentplane/policy/check-routing.mjs.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-06-05T04:33:32.696Z, excerpt_hash=sha256:ffd25d481a7f9d3f97cacaf135e78dbd8c18b1d2f457b10ada75f95c7d59fdb4
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202606050431-TKMZWV/.agentplane/tasks/202606050431-TKMZWV/blueprint/resolved-snapshot.json
+- old_digest: 9574f5a3ad62e5b13055839429cae1cb6446d9ed9caf4505903ef2f8cb4f1442
+- current_digest: 9574f5a3ad62e5b13055839429cae1cb6446d9ed9caf4505903ef2f8cb4f1442
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202606050431-TKMZWV
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane pr update 202606050431-TKMZWV
+- diagnostic_command: agentplane pr check 202606050431-TKMZWV
+- source_of_truth: route=task_next_action diagnostic=pr_check remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
+- risks: pr_artifact_freshness_loop, git_hook_side_effect
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202606050431-TKMZWV/README.md
+++ b/.agentplane/tasks/202606050431-TKMZWV/README.md
@@ -1,0 +1,104 @@
+---
+id: "202606050431-TKMZWV"
+title: "Fix upstream issue #4451: finish/task complete can loop on stale quality_review.evaluated_sha after task-artifact-only commits"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "github-issue"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-06-05T04:32:22.916Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: investigating upstream issue #4451 in the dedicated branch_pr worktree and preparing the bounded Codex runner handoff."
+events:
+  -
+    type: "status"
+    at: "2026-06-05T04:33:32.696Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: investigating upstream issue #4451 in the dedicated branch_pr worktree and preparing the bounded Codex runner handoff."
+doc_version: 3
+doc_updated_at: "2026-06-05T04:33:32.696Z"
+doc_updated_by: "CODER"
+description: "Resolve https://github.com/basilisk-labs/agentplane/issues/4451"
+sections:
+  Summary: |-
+    Fix upstream issue #4451: finish/task complete can loop on stale quality_review.evaluated_sha after task-artifact-only commits
+
+    Resolve https://github.com/basilisk-labs/agentplane/issues/4451
+  Scope: |-
+    - In scope: Resolve https://github.com/basilisk-labs/agentplane/issues/4451.
+    - Out of scope: unrelated refactors not required for "Fix upstream issue #4451: finish/task complete can loop on stale quality_review.evaluated_sha after task-artifact-only commits".
+  Plan: |-
+    1. Reproduce the stale `quality_review.evaluated_sha` closeout loop described in upstream issue #4451 and identify which finish/task-complete validation still binds to outdated evaluation state after task-artifact-only commits.
+    2. Implement the smallest route-safe fix so artifact-only follow-up commits do not force a fresh evaluator run when prior evaluation evidence is still valid for the task closeout path.
+    3. Verify with targeted reproduction coverage and the required policy checks, then prepare branch/PR evidence and upstream closeout notes only if the fix is validated.
+  Verify Steps: |-
+    PLANNER fallback scaffold for "Fix upstream issue #4451: finish/task complete can loop on stale quality_review.evaluated_sha after task-artifact-only commits". Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the requested outcome for "Fix upstream issue #4451: finish/task complete can loop on stale quality_review.evaluated_sha after task-artifact-only commits". Expected: the visible result matches ## Summary and stays inside approved scope.
+    2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+    3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Fix upstream issue #4451: finish/task complete can loop on stale quality_review.evaluated_sha after task-artifact-only commits
+
+Resolve https://github.com/basilisk-labs/agentplane/issues/4451
+
+## Scope
+
+- In scope: Resolve https://github.com/basilisk-labs/agentplane/issues/4451.
+- Out of scope: unrelated refactors not required for "Fix upstream issue #4451: finish/task complete can loop on stale quality_review.evaluated_sha after task-artifact-only commits".
+
+## Plan
+
+1. Reproduce the stale `quality_review.evaluated_sha` closeout loop described in upstream issue #4451 and identify which finish/task-complete validation still binds to outdated evaluation state after task-artifact-only commits.
+2. Implement the smallest route-safe fix so artifact-only follow-up commits do not force a fresh evaluator run when prior evaluation evidence is still valid for the task closeout path.
+3. Verify with targeted reproduction coverage and the required policy checks, then prepare branch/PR evidence and upstream closeout notes only if the fix is validated.
+
+## Verify Steps
+
+PLANNER fallback scaffold for "Fix upstream issue #4451: finish/task complete can loop on stale quality_review.evaluated_sha after task-artifact-only commits". Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the requested outcome for "Fix upstream issue #4451: finish/task complete can loop on stale quality_review.evaluated_sha after task-artifact-only commits". Expected: the visible result matches ## Summary and stays inside approved scope.
+2. Run the most relevant validation step for this task. Expected: it succeeds without unexpected regressions in touched behavior.
+3. Compare the final result against ## Scope and record any residual follow-up in ## Findings. Expected: open edges are explicit rather than implicit.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202606050431-TKMZWV/README.md
+++ b/.agentplane/tasks/202606050431-TKMZWV/README.md
@@ -4,7 +4,7 @@ title: "Fix upstream issue #4451: finish/task complete can loop on stale quality
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -22,6 +22,27 @@ verification:
   updated_by: "CODER"
   note: "Verified: fixed direct closeout quality review target selection for existing task-artifact-only commit metadata. Commands: bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts packages/agentplane/src/commands/task/quality-review-gate.unit.test.ts packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts; git diff --check; node .agentplane/policy/check-routing.mjs."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-06-06T16:43:20.798Z"
+  updated_by: "EVALUATOR"
+  note: "Reviewed the focused finish closeout diff and regression evidence for issue #4451."
+  evaluated_sha: "0e491ed63c0984063d4e7fd4dc6aa467543d603b"
+  blueprint_digest: "9574f5a3ad62e5b13055839429cae1cb6446d9ed9caf4505903ef2f8cb4f1442"
+  evidence_refs:
+    - ".agentplane/tasks/202606050431-TKMZWV/README.md"
+    - ".agentplane/tasks/202606050431-TKMZWV/quality/20260606-164320798-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202606050431-TKMZWV/quality/20260606-164320798-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202606050431-TKMZWV/quality/20260606-164320798-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202606050431-TKMZWV/blueprint/resolved-snapshot.json"
+    - "packages/agentplane/src/commands/task/finish-execute-commit.ts"
+    - "packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts"
+    - "bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts packages/agentplane/src/commands/task/quality-review-gate.unit.test.ts packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts"
+    - "git diff --check"
+    - "node .agentplane/policy/check-routing.mjs"
+  findings:
+    - "resolveImplementationCommitInfo now normalizes existing task.commit artifact-only metadata through quality_review.evaluated_sha when isTaskLocalOnlyAdvance proves the tail is task-local."
+    - "Regression coverage exercises both explicit --commit artifact tails and existing task commit artifact tails without weakening stale-review rejection for non-task-local changes."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202606050431-TKMZWV/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202606050431-TKMZWV/blueprint/resolved-snapshot.json
@@ -1,0 +1,360 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202606050431-TKMZWV",
+    "title": "Fix upstream issue #4451: finish/task complete can loop on stale quality_review.evaluated_sha after task-artifact-only commits",
+    "description": "Resolve https://github.com/basilisk-labs/agentplane/issues/4451",
+    "tags": [
+      "github-issue"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "none",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "analysis.light",
+    "version": 1,
+    "title": "Lightweight analysis",
+    "taskKinds": [
+      "analysis"
+    ],
+    "workflowModes": []
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "analysis.light",
+    "blueprintVersion": 1,
+    "title": "Lightweight analysis",
+    "taskId": "202606050431-TKMZWV",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "none"
+    },
+    "whySelected": [
+      "task kind resolved to analysis",
+      "workflow mode: branch_pr",
+      "mutation scope: none"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "context_manifest",
+          "sources"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "weak_links",
+          "final_output"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "analysis.sources",
+        "kind": "sources",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Sources used for analysis."
+      },
+      {
+        "id": "analysis.assumptions",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Assumptions and constraints."
+      },
+      {
+        "id": "analysis.weak_links",
+        "kind": "weak_links",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Weak links or uncertainty."
+      },
+      {
+        "id": "analysis.final",
+        "kind": "final_output",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Final answer or report."
+      },
+      {
+        "id": "analysis.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      }
+    ],
+    "policyModules": [],
+    "allowedCommands": [],
+    "contextBudget": {
+      "maxPolicyModules": 0,
+      "maxPromptBlocks": 6,
+      "rationale": "Lightweight analysis should load sources and task context without policy modules."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "context_manifest",
+        "sources"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "weak_links",
+        "final_output"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "analysis.sources",
+      "kind": "sources",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Sources used for analysis."
+    },
+    {
+      "id": "analysis.assumptions",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Assumptions and constraints."
+    },
+    {
+      "id": "analysis.weak_links",
+      "kind": "weak_links",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Weak links or uncertainty."
+    },
+    {
+      "id": "analysis.final",
+      "kind": "final_output",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Final answer or report."
+    },
+    {
+      "id": "analysis.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    }
+  ],
+  "policyModules": [],
+  "allowedCommands": [],
+  "contextBudget": {
+    "maxPolicyModules": 0,
+    "maxPromptBlocks": 6,
+    "rationale": "Lightweight analysis should load sources and task context without policy modules."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to analysis",
+    "workflow mode: branch_pr",
+    "mutation scope: none"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "9574f5a3ad62e5b13055839429cae1cb6446d9ed9caf4505903ef2f8cb4f1442"
+  }
+}

--- a/.agentplane/tasks/202606050431-TKMZWV/pr/diffstat.txt
+++ b/.agentplane/tasks/202606050431-TKMZWV/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../src/commands/task/finish-execute-commit.ts     | 13 +++++++---
+ .../task/finish.quality-review-target.unit.test.ts | 28 ++++++++++++++++++++++
+ 2 files changed, 38 insertions(+), 3 deletions(-)

--- a/.agentplane/tasks/202606050431-TKMZWV/pr/github-body.md
+++ b/.agentplane/tasks/202606050431-TKMZWV/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202606050431-TKMZWV`
+Title: Fix upstream issue #4451: finish/task complete can loop on stale quality_review.evaluated_sha after task-artifact-onl...
+Canonical task record: `.agentplane/tasks/202606050431-TKMZWV/README.md`
+
+## Summary
+
+Fix upstream issue #4451: finish/task complete can loop on stale quality_review.evaluated_sha after task-artifact-only commits
+
+Resolve https://github.com/basilisk-labs/agentplane/issues/4451
+
+## Scope
+
+- In scope: Resolve https://github.com/basilisk-labs/agentplane/issues/4451.
+- Out of scope: unrelated refactors not required for "Fix upstream issue #4451: finish/task complete can loop on stale quality_review.evaluated_sha after task-artifact-only commits".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-06-05T04:33:32.789Z
+- Branch: task/202606050431-TKMZWV/fix-upstream-issue-4451-finish-task-complete-can
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202606050431-TKMZWV/pr/github-body.md
+++ b/.agentplane/tasks/202606050431-TKMZWV/pr/github-body.md
@@ -15,8 +15,17 @@ Resolve https://github.com/basilisk-labs/agentplane/issues/4451
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Verified: fixed direct closeout quality review target selection for existing task-artifact-only
+commit metadata. Commands: bunx vitest --config vitest.workspace.ts run --project agentplane
+packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts
+packages/agentplane/src/commands/task/quality-review-gate.unit.test.ts
+packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts; git diff --check; node
+.agentplane/policy/check-routing.mjs.
+```
 - Canonical workflow state lives in the task README.
 
 <details>

--- a/.agentplane/tasks/202606050431-TKMZWV/pr/github-body.md
+++ b/.agentplane/tasks/202606050431-TKMZWV/pr/github-body.md
@@ -36,7 +36,9 @@ packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts; git di
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/commands/task/finish-execute-commit.ts     | 13 +++++++---
+ .../task/finish.quality-review-target.unit.test.ts | 28 ++++++++++++++++++++++
+ 2 files changed, 38 insertions(+), 3 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202606050431-TKMZWV/pr/github-title.txt
+++ b/.agentplane/tasks/202606050431-TKMZWV/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 TKMZWV task: Fix upstream issue #4451: finish/task complete can loop on stale quality_review.evaluated_sha... [202606050431-TKMZWV]

--- a/.agentplane/tasks/202606050431-TKMZWV/pr/meta.json
+++ b/.agentplane/tasks/202606050431-TKMZWV/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202606050431-TKMZWV/fix-upstream-issue-4451-finish-task-complete-can",
   "created_at": "2026-06-05T04:33:32.789Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "diffstat_sha256": "sha256:f4e6658c1efd357f10259580bd25b72dd80d7093a9d20190036d6488806bbadf",
   "last_verified_at": "2026-06-06T16:41:48.030Z",
   "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "schema_version": 1,

--- a/.agentplane/tasks/202606050431-TKMZWV/pr/meta.json
+++ b/.agentplane/tasks/202606050431-TKMZWV/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202606050431-TKMZWV/fix-upstream-issue-4451-finish-task-complete-can",
+  "created_at": "2026-06-05T04:33:32.789Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202606050431-TKMZWV",
+  "updated_at": "2026-06-05T04:33:32.789Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202606050431-TKMZWV/pr/meta.json
+++ b/.agentplane/tasks/202606050431-TKMZWV/pr/meta.json
@@ -3,11 +3,12 @@
   "branch": "task/202606050431-TKMZWV/fix-upstream-issue-4451-finish-task-complete-can",
   "created_at": "2026-06-05T04:33:32.789Z",
   "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "last_verified_at": "2026-06-06T16:41:48.030Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "schema_version": 1,
   "task_id": "202606050431-TKMZWV",
   "updated_at": "2026-06-05T04:33:32.789Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202606050431-TKMZWV/pr/review.md
+++ b/.agentplane/tasks/202606050431-TKMZWV/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-06-05T04:33:32.789Z
+
+## Task
+
+- Task: `202606050431-TKMZWV`
+- Title: Fix upstream issue #4451: finish/task complete can loop on stale quality_review.evaluated_sha after task-artifact-onl...
+- Status: DOING
+- Branch: `task/202606050431-TKMZWV/fix-upstream-issue-4451-finish-task-complete-can`
+- Canonical task record: `.agentplane/tasks/202606050431-TKMZWV/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-06-05T04:33:32.789Z
+- Branch: task/202606050431-TKMZWV/fix-upstream-issue-4451-finish-task-complete-can
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202606050431-TKMZWV/pr/review.md
+++ b/.agentplane/tasks/202606050431-TKMZWV/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-06-05T04:33:32.789Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified: fixed direct closeout quality review target selection for existing task-artifact-only commit metadata. Commands: bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts packages/agentplane/src/commands/task/quality-review-gate.unit.test.ts packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts; git diff --check; node .agentplane/policy/check-routing.mjs.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes

--- a/.agentplane/tasks/202606050431-TKMZWV/pr/review.md
+++ b/.agentplane/tasks/202606050431-TKMZWV/pr/review.md
@@ -29,7 +29,9 @@ Created: 2026-06-05T04:33:32.789Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/commands/task/finish-execute-commit.ts     | 13 +++++++---
+ .../task/finish.quality-review-target.unit.test.ts | 28 ++++++++++++++++++++++
+ 2 files changed, 38 insertions(+), 3 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202606050431-TKMZWV/quality/20260606-164320798-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202606050431-TKMZWV/quality/20260606-164320798-recovery-context/evaluator-opinion.md
@@ -1,0 +1,24 @@
+# EVALUATOR opinion: pass
+
+Reviewed the focused finish closeout diff and regression evidence for issue #4451.
+
+## Findings
+- resolveImplementationCommitInfo now normalizes existing task.commit artifact-only metadata through quality_review.evaluated_sha when isTaskLocalOnlyAdvance proves the tail is task-local.
+- Regression coverage exercises both explicit --commit artifact tails and existing task commit artifact tails without weakening stale-review rejection for non-task-local changes.
+
+## Evidence
+- .agentplane/tasks/202606050431-TKMZWV/README.md
+- packages/agentplane/src/commands/task/finish-execute-commit.ts
+- packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts
+- bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts packages/agentplane/src/commands/task/quality-review-gate.unit.test.ts packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts
+- git diff --check
+- node .agentplane/policy/check-routing.mjs
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202606050431-TKMZWV/quality/20260606-164320798-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202606050431-TKMZWV/quality/20260606-164320798-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202606050431-TKMZWV
+- task_readme: .agentplane/tasks/202606050431-TKMZWV/README.md
+- report_path: .agentplane/tasks/202606050431-TKMZWV/quality/20260606-164320798-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202606050431-TKMZWV/quality/20260606-164320798-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202606050431-TKMZWV/quality/20260606-164320798-recovery-context/quality-report.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "task_id": "202606050431-TKMZWV",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-06-06T16:43:20.798Z",
+  "verdict": "pass",
+  "summary": "Reviewed the focused finish closeout diff and regression evidence for issue #4451.",
+  "evaluated_sha": "0e491ed63c0984063d4e7fd4dc6aa467543d603b",
+  "blueprint_digest": "9574f5a3ad62e5b13055839429cae1cb6446d9ed9caf4505903ef2f8cb4f1442",
+  "findings": [
+    "resolveImplementationCommitInfo now normalizes existing task.commit artifact-only metadata through quality_review.evaluated_sha when isTaskLocalOnlyAdvance proves the tail is task-local.",
+    "Regression coverage exercises both explicit --commit artifact tails and existing task commit artifact tails without weakening stale-review rejection for non-task-local changes."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202606050431-TKMZWV/README.md",
+    "packages/agentplane/src/commands/task/finish-execute-commit.ts",
+    "packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts",
+    "bunx vitest --config vitest.workspace.ts run --project agentplane packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts packages/agentplane/src/commands/task/quality-review-gate.unit.test.ts packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts",
+    "git diff --check",
+    "node .agentplane/policy/check-routing.mjs"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/commands/task/finish-execute-commit.ts
+++ b/packages/agentplane/src/commands/task/finish-execute-commit.ts
@@ -8,7 +8,11 @@ import {
   readCommitInfo,
   runTaskTransitionCommentCommit,
 } from "./shared.js";
-import type { LoadedFinishTask, ResolvedCommitInfo } from "./finish-shared.js";
+import {
+  existingCommitInfo,
+  type LoadedFinishTask,
+  type ResolvedCommitInfo,
+} from "./finish-shared.js";
 import type { FinishExecutionPlan, FinishOptions } from "./finish-types.js";
 
 export async function resolveTaskCommitInfo(opts: {
@@ -118,18 +122,21 @@ export async function resolveImplementationCommitInfo(opts: {
     );
   }
 
-  if (opts.loadedTasks.length !== 1 || !opts.taskCommitInfo) return null;
+  if (opts.loadedTasks.length !== 1) return null;
 
   const loaded = opts.loadedTasks[0];
   const reviewedSha = loaded?.task.quality_review?.evaluated_sha ?? null;
   if (!loaded || !reviewedSha) return null;
+  const candidateCommitInfo = opts.taskCommitInfo ?? existingCommitInfo(loaded.task);
+  if (!candidateCommitInfo) return null;
+
   const taskLocalAdvance = await isTaskLocalOnlyAdvance({
     gitRoot: opts.ctx.resolvedProject.gitRoot,
     workflowDir: opts.ctx.config.paths.workflow_dir,
     taskId: loaded.taskId,
     tasksPath: opts.ctx.config.paths.tasks_path,
     fromRef: reviewedSha,
-    toRef: opts.taskCommitInfo.hash,
+    toRef: candidateCommitInfo.hash,
   }).catch(() => false);
   if (!taskLocalAdvance) return null;
 

--- a/packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts
+++ b/packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts
@@ -100,6 +100,34 @@ describe("finish quality review target selection", () => {
     expect(resolved).toEqual({ hash: "impl-sha", message: "feat: implement T-1" });
   });
 
+  it("auto-resolves quality_review.evaluated_sha when existing task commit is task-artifact-only", async () => {
+    const loaded = mkLoadedTask();
+    loaded.task.commit = {
+      hash: "artifact-sha",
+      message: "✅ T-1 close: task artifacts",
+    };
+    mocks.isTaskLocalOnlyAdvance.mockResolvedValue(true);
+    mocks.readCommitInfo.mockResolvedValue({ hash: "impl-sha", message: "feat: implement T-1" });
+    const { resolveImplementationCommitInfo } = await import("./finish-execute-commit.js");
+
+    const resolved = await resolveImplementationCommitInfo({
+      ctx: mkCtx(),
+      options: { quiet: true } as never,
+      loadedTasks: [loaded],
+      taskCommitInfo: null,
+    });
+
+    expect(mocks.isTaskLocalOnlyAdvance).toHaveBeenCalledWith({
+      gitRoot: "/repo",
+      workflowDir: ".agentplane/tasks",
+      taskId: "T-1",
+      tasksPath: ".agentplane/tasks.json",
+      fromRef: "impl-sha",
+      toRef: "artifact-sha",
+    });
+    expect(resolved).toEqual({ hash: "impl-sha", message: "feat: implement T-1" });
+  });
+
   it("keeps stale-review validation when --commit is not task-local", async () => {
     mocks.isTaskLocalOnlyAdvance.mockResolvedValue(false);
     const { resolveImplementationCommitInfo } = await import("./finish-execute-commit.js");


### PR DESCRIPTION
Task: `202606050431-TKMZWV`
Title: Fix upstream issue #4451: finish/task complete can loop on stale quality_review.evaluated_sha after task-artifact-onl...
Canonical task record: `.agentplane/tasks/202606050431-TKMZWV/README.md`

## Summary

Fix upstream issue #4451: finish/task complete can loop on stale quality_review.evaluated_sha after task-artifact-only commits

Resolve https://github.com/basilisk-labs/agentplane/issues/4451

## Scope

- In scope: Resolve https://github.com/basilisk-labs/agentplane/issues/4451.
- Out of scope: unrelated refactors not required for "Fix upstream issue #4451: finish/task complete can loop on stale quality_review.evaluated_sha after task-artifact-only commits".

## Verification

- State: ok
- Note:

```text
Verified: fixed direct closeout quality review target selection for existing task-artifact-only
commit metadata. Commands: bunx vitest --config vitest.workspace.ts run --project agentplane
packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts
packages/agentplane/src/commands/task/quality-review-gate.unit.test.ts
packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts; git diff --check; node
.agentplane/policy/check-routing.mjs.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-06-05T04:33:32.789Z
- Branch: task/202606050431-TKMZWV/fix-upstream-issue-4451-finish-task-complete-can
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/commands/task/finish-execute-commit.ts     | 13 +++++++---
 .../task/finish.quality-review-target.unit.test.ts | 28 ++++++++++++++++++++++
 2 files changed, 38 insertions(+), 3 deletions(-)
```

</details>
