### PR TITLE
🚧 MHC3NY task: Clarify non-recipe runner route guidance [202606081631-MHC3NY]

### DIFF
--- a/.agentplane/tasks/202606081631-MHC3NY/README.md
+++ b/.agentplane/tasks/202606081631-MHC3NY/README.md
@@ -4,7 +4,7 @@ title: "Clarify non-recipe runner route guidance"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 9
+revision: 10
 origin:
   system: "manual"
 depends_on: []
@@ -24,6 +24,25 @@ verification:
   updated_by: "CODER"
   note: "Post-commit route guidance verification passed on HEAD 42779867b; PR check reports fresh local artifacts and live task surfaces show current_agent executor semantics."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-06-08T16:45:02.310Z"
+  updated_by: "EVALUATOR"
+  note: "Route guidance now distinguishes ordinary current-agent execution from explicit runner routes."
+  evaluated_sha: "99ba15ec68fa096d59f48f3e0437b6a9db023039"
+  blueprint_digest: "bfda5dea3eba1509d7025de1f7095a7b9e2411e5386d4f010d9ad5b35ca88aac"
+  evidence_refs:
+    - ".agentplane/tasks/202606081631-MHC3NY/README.md"
+    - ".agentplane/tasks/202606081631-MHC3NY/quality/20260608-164502310-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202606081631-MHC3NY/quality/20260608-164502310-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202606081631-MHC3NY/quality/20260608-164502310-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202606081631-MHC3NY/blueprint/resolved-snapshot.json"
+    - "bun test packages/agentplane/src/commands/shared/route-guidance.test.ts"
+    - "bun run --filter=agentplane typecheck"
+    - "node .agentplane/policy/check-routing.mjs"
+    - "ap task next-action 202606081631-MHC3NY --explain"
+  findings:
+    - "Non-runner route surfaces now show executor_context executor=current_agent runner_route_active=false with a warning that the current coding agent must run safe_command itself and must not wait for or retry a runner; explicit wait_runner coverage still preserves runner-owned guidance."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202606081631-MHC3NY/README.md
+++ b/.agentplane/tasks/202606081631-MHC3NY/README.md
@@ -1,0 +1,250 @@
+---
+id: "202606081631-MHC3NY"
+title: "Clarify non-recipe runner route guidance"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 9
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "guidance"
+  - "runner"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-06-08T16:32:13.855Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-06-08T16:38:38.497Z"
+  updated_by: "CODER"
+  note: "Post-commit route guidance verification passed on HEAD 42779867b; PR check reports fresh local artifacts and live task surfaces show current_agent executor semantics."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement focused route guidance fix so ordinary Codex agents execute local work themselves unless explicit task-run, wait_runner, runner_alive, or active runner recipe delegation is present."
+events:
+  -
+    type: "status"
+    at: "2026-06-08T16:32:55.195Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement focused route guidance fix so ordinary Codex agents execute local work themselves unless explicit task-run, wait_runner, runner_alive, or active runner recipe delegation is present."
+  -
+    type: "verify"
+    at: "2026-06-08T16:36:40.245Z"
+    author: "CODER"
+    state: "ok"
+    note: "Route guidance fix verified: non-runner routes now expose executor=current_agent and runner_route_active=false with explicit no runner wait/retry warning; explicit wait_runner route remains runner-owned."
+  -
+    type: "verify"
+    at: "2026-06-08T16:38:38.497Z"
+    author: "CODER"
+    state: "ok"
+    note: "Post-commit route guidance verification passed on HEAD 42779867b; PR check reports fresh local artifacts and live task surfaces show current_agent executor semantics."
+doc_version: 3
+doc_updated_at: "2026-06-08T16:38:38.675Z"
+doc_updated_by: "CODER"
+description: "Fix AgentPlane route/operator guidance so normal Codex agents do not treat runner_context or stale runner attempts as an active runner route unless task run, wait_runner, runner_alive, or an active runner recipe such as parallel-codex explicitly delegates execution."
+sections:
+  Summary: |-
+    Clarify non-recipe runner route guidance
+
+    Fix AgentPlane route/operator guidance so normal Codex agents do not treat runner_context or stale runner attempts as an active runner route unless task run, wait_runner, runner_alive, or an active runner recipe such as parallel-codex explicitly delegates execution.
+  Scope: "Fix AgentPlane route/operator guidance for ordinary Codex-agent execution when no runner recipe is active. Scope includes route guidance code, focused tests, and task lifecycle artifacts only. Out of scope: implementing a new runner, changing parallel-codex behavior, or altering branch_pr lifecycle semantics."
+  Plan: |-
+    1. Reproduce the ambiguity in the current route guidance surfaces around runner_context for non-runner routes.
+    2. Update operator guidance/rendered JSON or prompt surfaces so normal Codex execution states explicitly say the current coding agent is the executor unless an explicit task-run/wait_runner/runner_alive/active runner recipe route is present.
+    3. Add focused regression coverage for non-runner route guidance and explicit runner route preservation.
+    4. Run focused tests plus routing validation and record verification.
+  Verify Steps: |-
+    1. Run `bun test packages/agentplane/src/commands/shared/route-guidance.test.ts`. Expected: non-runner routes report executor semantics that forbid runner retry/wait language, while explicit `wait_runner` routes still surface runner guidance.
+    2. Run focused task rendering tests if present. Expected: rendered task guidance does not expose misleading runner context for ordinary routes; if no focused suites exist, record the absence and rely on route-guidance coverage.
+    3. Run `node .agentplane/policy/check-routing.mjs`. Expected: policy/routing validation passes.
+    4. Inspect changed paths. Expected: scope is limited to route/operator guidance, tests, and task artifacts for `202606081631-MHC3NY`.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-06-08T16:36:40.245Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Route guidance fix verified: non-runner routes now expose executor=current_agent and runner_route_active=false with explicit no runner wait/retry warning; explicit wait_runner route remains runner-owned.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-06-08T16:32:55.195Z, excerpt_hash=sha256:cb5cdbce63d151600bb638100edaaf7fa2bee559e9914aa4614d645201ba7ceb
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202606081631-MHC3NY-clarify-non-recipe-runner-route-guidance/.agentplane/tasks/202606081631-MHC3NY/blueprint/resolved-snapshot.json
+    - old_digest: bfda5dea3eba1509d7025de1f7095a7b9e2411e5386d4f010d9ad5b35ca88aac
+    - current_digest: bfda5dea3eba1509d7025de1f7095a7b9e2411e5386d4f010d9ad5b35ca88aac
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202606081631-MHC3NY
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane pr update 202606081631-MHC3NY
+    - diagnostic_command: agentplane pr check 202606081631-MHC3NY
+    - source_of_truth: route=task_next_action diagnostic=pr_check remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
+    - risks: pr_artifact_freshness_loop, git_hook_side_effect
+
+    ### 2026-06-08T16:38:38.497Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Post-commit route guidance verification passed on HEAD 42779867b; PR check reports fresh local artifacts and live task surfaces show current_agent executor semantics.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-06-08T16:36:40.567Z, excerpt_hash=sha256:cb5cdbce63d151600bb638100edaaf7fa2bee559e9914aa4614d645201ba7ceb
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202606081631-MHC3NY-clarify-non-recipe-runner-route-guidance/.agentplane/tasks/202606081631-MHC3NY/blueprint/resolved-snapshot.json
+    - old_digest: bfda5dea3eba1509d7025de1f7095a7b9e2411e5386d4f010d9ad5b35ca88aac
+    - current_digest: bfda5dea3eba1509d7025de1f7095a7b9e2411e5386d4f010d9ad5b35ca88aac
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202606081631-MHC3NY
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane pr update 202606081631-MHC3NY
+    - diagnostic_command: agentplane pr check 202606081631-MHC3NY
+    - source_of_truth: route=task_next_action diagnostic=pr_check remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
+    - risks: pr_artifact_freshness_loop, git_hook_side_effect
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: |-
+    - Observation: Command: bun test packages/agentplane/src/commands/shared/route-guidance.test.ts; Result: pass; Evidence: 6 pass, 0 fail, 9 expectations. Command: bun run --filter=agentplane typecheck; Result: pass; Evidence: agentplane typecheck exited 0. Command: node .agentplane/policy/check-routing.mjs; Result: pass; Evidence: policy routing OK. Command: ap task next-action 202606081631-MHC3NY --explain and ap task brief 202606081631-MHC3NY after bun run framework:dev:bootstrap; Result: pass; Evidence: executor_context executor=current_agent runner_route_active=false instruction=current_agent_executes_safe_command plus warning not to wait for or retry a runner. Render-test path search found no dedicated next-action/brief/status test files, so coverage is route-guidance test + typecheck + live CLI output.
+      Impact: Ordinary Codex agents should no longer convert non-runner work into a false runner-infra diagnosis when parallel-codex or task-run delegation is not active.
+      Resolution: Added RouteExecutorContext and rendered it in task next-action, task brief, and task status while preserving runnerContext for explicit runner routes.
+
+    - Observation: Command: ap pr check 202606081631-MHC3NY; Result: pass; Evidence: artifact_freshness=fresh branch_head=42779867b verify_status=pass. Command: ap task next-action 202606081631-MHC3NY --explain; Result: pass; Evidence: executor_context executor=current_agent runner_route_active=false instruction=current_agent_executes_safe_command and warning that the current coding agent must run safe_command itself and must not wait for or retry a runner.
+      Impact: Task evidence now reflects the committed branch head rather than the pre-commit working tree.
+      Resolution: Recorded post-commit verification readback before final PR artifact update.
+id_source: "generated"
+---
+## Summary
+
+Clarify non-recipe runner route guidance
+
+Fix AgentPlane route/operator guidance so normal Codex agents do not treat runner_context or stale runner attempts as an active runner route unless task run, wait_runner, runner_alive, or an active runner recipe such as parallel-codex explicitly delegates execution.
+
+## Scope
+
+Fix AgentPlane route/operator guidance for ordinary Codex-agent execution when no runner recipe is active. Scope includes route guidance code, focused tests, and task lifecycle artifacts only. Out of scope: implementing a new runner, changing parallel-codex behavior, or altering branch_pr lifecycle semantics.
+
+## Plan
+
+1. Reproduce the ambiguity in the current route guidance surfaces around runner_context for non-runner routes.
+2. Update operator guidance/rendered JSON or prompt surfaces so normal Codex execution states explicitly say the current coding agent is the executor unless an explicit task-run/wait_runner/runner_alive/active runner recipe route is present.
+3. Add focused regression coverage for non-runner route guidance and explicit runner route preservation.
+4. Run focused tests plus routing validation and record verification.
+
+## Verify Steps
+
+1. Run `bun test packages/agentplane/src/commands/shared/route-guidance.test.ts`. Expected: non-runner routes report executor semantics that forbid runner retry/wait language, while explicit `wait_runner` routes still surface runner guidance.
+2. Run focused task rendering tests if present. Expected: rendered task guidance does not expose misleading runner context for ordinary routes; if no focused suites exist, record the absence and rely on route-guidance coverage.
+3. Run `node .agentplane/policy/check-routing.mjs`. Expected: policy/routing validation passes.
+4. Inspect changed paths. Expected: scope is limited to route/operator guidance, tests, and task artifacts for `202606081631-MHC3NY`.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-06-08T16:36:40.245Z — VERIFY — ok
+
+By: CODER
+
+Note: Route guidance fix verified: non-runner routes now expose executor=current_agent and runner_route_active=false with explicit no runner wait/retry warning; explicit wait_runner route remains runner-owned.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-06-08T16:32:55.195Z, excerpt_hash=sha256:cb5cdbce63d151600bb638100edaaf7fa2bee559e9914aa4614d645201ba7ceb
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202606081631-MHC3NY-clarify-non-recipe-runner-route-guidance/.agentplane/tasks/202606081631-MHC3NY/blueprint/resolved-snapshot.json
+- old_digest: bfda5dea3eba1509d7025de1f7095a7b9e2411e5386d4f010d9ad5b35ca88aac
+- current_digest: bfda5dea3eba1509d7025de1f7095a7b9e2411e5386d4f010d9ad5b35ca88aac
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202606081631-MHC3NY
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane pr update 202606081631-MHC3NY
+- diagnostic_command: agentplane pr check 202606081631-MHC3NY
+- source_of_truth: route=task_next_action diagnostic=pr_check remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
+- risks: pr_artifact_freshness_loop, git_hook_side_effect
+
+### 2026-06-08T16:38:38.497Z — VERIFY — ok
+
+By: CODER
+
+Note: Post-commit route guidance verification passed on HEAD 42779867b; PR check reports fresh local artifacts and live task surfaces show current_agent executor semantics.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-06-08T16:36:40.567Z, excerpt_hash=sha256:cb5cdbce63d151600bb638100edaaf7fa2bee559e9914aa4614d645201ba7ceb
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202606081631-MHC3NY-clarify-non-recipe-runner-route-guidance/.agentplane/tasks/202606081631-MHC3NY/blueprint/resolved-snapshot.json
+- old_digest: bfda5dea3eba1509d7025de1f7095a7b9e2411e5386d4f010d9ad5b35ca88aac
+- current_digest: bfda5dea3eba1509d7025de1f7095a7b9e2411e5386d4f010d9ad5b35ca88aac
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202606081631-MHC3NY
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane pr update 202606081631-MHC3NY
+- diagnostic_command: agentplane pr check 202606081631-MHC3NY
+- source_of_truth: route=task_next_action diagnostic=pr_check remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
+- risks: pr_artifact_freshness_loop, git_hook_side_effect
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings
+
+- Observation: Command: bun test packages/agentplane/src/commands/shared/route-guidance.test.ts; Result: pass; Evidence: 6 pass, 0 fail, 9 expectations. Command: bun run --filter=agentplane typecheck; Result: pass; Evidence: agentplane typecheck exited 0. Command: node .agentplane/policy/check-routing.mjs; Result: pass; Evidence: policy routing OK. Command: ap task next-action 202606081631-MHC3NY --explain and ap task brief 202606081631-MHC3NY after bun run framework:dev:bootstrap; Result: pass; Evidence: executor_context executor=current_agent runner_route_active=false instruction=current_agent_executes_safe_command plus warning not to wait for or retry a runner. Render-test path search found no dedicated next-action/brief/status test files, so coverage is route-guidance test + typecheck + live CLI output.
+  Impact: Ordinary Codex agents should no longer convert non-runner work into a false runner-infra diagnosis when parallel-codex or task-run delegation is not active.
+  Resolution: Added RouteExecutorContext and rendered it in task next-action, task brief, and task status while preserving runnerContext for explicit runner routes.
+
+- Observation: Command: ap pr check 202606081631-MHC3NY; Result: pass; Evidence: artifact_freshness=fresh branch_head=42779867b verify_status=pass. Command: ap task next-action 202606081631-MHC3NY --explain; Result: pass; Evidence: executor_context executor=current_agent runner_route_active=false instruction=current_agent_executes_safe_command and warning that the current coding agent must run safe_command itself and must not wait for or retry a runner.
+  Impact: Task evidence now reflects the committed branch head rather than the pre-commit working tree.
+  Resolution: Recorded post-commit verification readback before final PR artifact update.

--- a/.agentplane/tasks/202606081631-MHC3NY/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202606081631-MHC3NY/blueprint/resolved-snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202606081631-MHC3NY",
+    "title": "Clarify non-recipe runner route guidance",
+    "description": "Fix AgentPlane route/operator guidance so normal Codex agents do not treat runner_context or stale runner attempts as an active runner route unless task run, wait_runner, runner_alive, or an active runner recipe such as parallel-codex explicitly delegates execution.",
+    "tags": [
+      "code",
+      "guidance",
+      "runner"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202606081631-MHC3NY",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "bfda5dea3eba1509d7025de1f7095a7b9e2411e5386d4f010d9ad5b35ca88aac"
+  }
+}

--- a/.agentplane/tasks/202606081631-MHC3NY/pr/diffstat.txt
+++ b/.agentplane/tasks/202606081631-MHC3NY/pr/diffstat.txt
@@ -1,0 +1,6 @@
+ .../src/commands/shared/route-guidance.test.ts     | 14 ++++++
+ .../src/commands/shared/route-guidance.ts          | 55 +++++++++++++++++++++-
+ .../agentplane/src/commands/task/brief-render.ts   | 13 +++++
+ .../src/commands/task/next-action.command.ts       | 21 +++++++++
+ .../agentplane/src/commands/task/status.command.ts | 11 +++++
+ 5 files changed, 113 insertions(+), 1 deletion(-)

--- a/.agentplane/tasks/202606081631-MHC3NY/pr/github-body.md
+++ b/.agentplane/tasks/202606081631-MHC3NY/pr/github-body.md
@@ -1,0 +1,42 @@
+Task: `202606081631-MHC3NY`
+Title: Clarify non-recipe runner route guidance
+Canonical task record: `.agentplane/tasks/202606081631-MHC3NY/README.md`
+
+## Summary
+
+Clarify non-recipe runner route guidance
+
+Fix AgentPlane route/operator guidance so normal Codex agents do not treat runner_context or stale runner attempts as an active runner route unless task run, wait_runner, runner_alive, or an active runner recipe such as parallel-codex explicitly delegates execution.
+
+## Scope
+
+Fix AgentPlane route/operator guidance for ordinary Codex-agent execution when no runner recipe is active. Scope includes route guidance code, focused tests, and task lifecycle artifacts only. Out of scope: implementing a new runner, changing parallel-codex behavior, or altering branch_pr lifecycle semantics.
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Post-commit route guidance verification passed on HEAD 42779867b; PR check reports fresh local
+artifacts and live task surfaces show current_agent executor semantics.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-06-08T16:32:55.363Z
+- Branch: task/202606081631-MHC3NY/clarify-non-recipe-runner-route-guidance
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/commands/shared/route-guidance.test.ts     | 14 ++++++
+ .../src/commands/shared/route-guidance.ts          | 55 +++++++++++++++++++++-
+ .../agentplane/src/commands/task/brief-render.ts   | 13 +++++
+ .../src/commands/task/next-action.command.ts       | 21 +++++++++
+ .../agentplane/src/commands/task/status.command.ts | 11 +++++
+ 5 files changed, 113 insertions(+), 1 deletion(-)
+```
+
+</details>

--- a/.agentplane/tasks/202606081631-MHC3NY/pr/github-title.txt
+++ b/.agentplane/tasks/202606081631-MHC3NY/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 MHC3NY task: Clarify non-recipe runner route guidance [202606081631-MHC3NY]

--- a/.agentplane/tasks/202606081631-MHC3NY/pr/meta.json
+++ b/.agentplane/tasks/202606081631-MHC3NY/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202606081631-MHC3NY/clarify-non-recipe-runner-route-guidance",
+  "created_at": "2026-06-08T16:32:55.363Z",
+  "diffstat_sha256": "sha256:b62fe5e3acc54434f97cf6044167e3a7da5ff13b229c77f0ae3940f43e5fa0a4",
+  "last_verified_at": "2026-06-08T16:38:38.497Z",
+  "last_verified_diffstat_sha256": "sha256:b62fe5e3acc54434f97cf6044167e3a7da5ff13b229c77f0ae3940f43e5fa0a4",
+  "schema_version": 1,
+  "task_id": "202606081631-MHC3NY",
+  "updated_at": "2026-06-08T16:32:55.363Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202606081631-MHC3NY/pr/review.md
+++ b/.agentplane/tasks/202606081631-MHC3NY/pr/review.md
@@ -1,0 +1,41 @@
+# PR Review
+
+Created: 2026-06-08T16:32:55.363Z
+
+## Task
+
+- Task: `202606081631-MHC3NY`
+- Title: Clarify non-recipe runner route guidance
+- Status: DOING
+- Branch: `task/202606081631-MHC3NY/clarify-non-recipe-runner-route-guidance`
+- Canonical task record: `.agentplane/tasks/202606081631-MHC3NY/README.md`
+
+## Verification
+
+- State: ok
+- Note: Post-commit route guidance verification passed on HEAD 42779867b; PR check reports fresh local artifacts and live task surfaces show current_agent executor semantics.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-06-08T16:32:55.363Z
+- Branch: task/202606081631-MHC3NY/clarify-non-recipe-runner-route-guidance
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/commands/shared/route-guidance.test.ts     | 14 ++++++
+ .../src/commands/shared/route-guidance.ts          | 55 +++++++++++++++++++++-
+ .../agentplane/src/commands/task/brief-render.ts   | 13 +++++
+ .../src/commands/task/next-action.command.ts       | 21 +++++++++
+ .../agentplane/src/commands/task/status.command.ts | 11 +++++
+ 5 files changed, 113 insertions(+), 1 deletion(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202606081631-MHC3NY/quality/20260608-164502310-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202606081631-MHC3NY/quality/20260608-164502310-recovery-context/evaluator-opinion.md
@@ -1,0 +1,22 @@
+# EVALUATOR opinion: pass
+
+Route guidance now distinguishes ordinary current-agent execution from explicit runner routes.
+
+## Findings
+- Non-runner route surfaces now show executor_context executor=current_agent runner_route_active=false with a warning that the current coding agent must run safe_command itself and must not wait for or retry a runner; explicit wait_runner coverage still preserves runner-owned guidance.
+
+## Evidence
+- .agentplane/tasks/202606081631-MHC3NY/README.md
+- bun test packages/agentplane/src/commands/shared/route-guidance.test.ts
+- bun run --filter=agentplane typecheck
+- node .agentplane/policy/check-routing.mjs
+- ap task next-action 202606081631-MHC3NY --explain
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202606081631-MHC3NY/quality/20260608-164502310-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202606081631-MHC3NY/quality/20260608-164502310-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202606081631-MHC3NY
+- task_readme: .agentplane/tasks/202606081631-MHC3NY/README.md
+- report_path: .agentplane/tasks/202606081631-MHC3NY/quality/20260608-164502310-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202606081631-MHC3NY/quality/20260608-164502310-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202606081631-MHC3NY/quality/20260608-164502310-recovery-context/quality-report.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "task_id": "202606081631-MHC3NY",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-06-08T16:45:02.310Z",
+  "verdict": "pass",
+  "summary": "Route guidance now distinguishes ordinary current-agent execution from explicit runner routes.",
+  "evaluated_sha": "99ba15ec68fa096d59f48f3e0437b6a9db023039",
+  "blueprint_digest": "bfda5dea3eba1509d7025de1f7095a7b9e2411e5386d4f010d9ad5b35ca88aac",
+  "findings": [
+    "Non-runner route surfaces now show executor_context executor=current_agent runner_route_active=false with a warning that the current coding agent must run safe_command itself and must not wait for or retry a runner; explicit wait_runner coverage still preserves runner-owned guidance."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202606081631-MHC3NY/README.md",
+    "bun test packages/agentplane/src/commands/shared/route-guidance.test.ts",
+    "bun run --filter=agentplane typecheck",
+    "node .agentplane/policy/check-routing.mjs",
+    "ap task next-action 202606081631-MHC3NY --explain"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/commands/shared/route-guidance.test.ts
+++ b/packages/agentplane/src/commands/shared/route-guidance.test.ts
@@ -64,6 +64,14 @@ describe("route operator guidance", () => {
         allowed: true,
         command: "agentplane doctor",
       },
+      executorContext: {
+        executor: "current_agent",
+        runnerRouteActive: false,
+        currentAgentMustExecute: true,
+        instruction: "current_agent_executes_safe_command",
+        warning:
+          "not a runner route; the current coding agent must run safe_command itself and must not wait for or retry a runner",
+      },
       runnerContext: {
         runnerIsRequired: false,
         runnerIsAllowedNow: false,
@@ -176,6 +184,12 @@ describe("route operator guidance", () => {
 
     const guidance = deriveRouteOperatorGuidance(decision);
 
+    expect(guidance.executorContext).toMatchObject({
+      executor: "runner",
+      runnerRouteActive: true,
+      currentAgentMustExecute: false,
+      instruction: "runner_route_follow_runner_lifecycle",
+    });
     expect(guidance.runnerContext).toMatchObject({
       runnerIsRequired: true,
       runnerIsAllowedNow: false,

--- a/packages/agentplane/src/commands/shared/route-guidance.ts
+++ b/packages/agentplane/src/commands/shared/route-guidance.ts
@@ -11,6 +11,7 @@ export type RouteOperatorGuidance = {
   freshness: RouteFreshnessContext;
   repeatPolicy: RouteRepeatPolicy;
   fallback: RouteFallbackContext;
+  executorContext: RouteExecutorContext;
   runnerContext: RouteRunnerContext;
   stopReason: string | null;
   afterCommand: string;
@@ -55,6 +56,17 @@ type RouteFallbackContext = {
   allowed: boolean;
   command: string | null;
   reason: string | null;
+};
+
+type RouteExecutorContext = {
+  executor: "current_agent" | "runner";
+  runnerRouteActive: boolean;
+  currentAgentMustExecute: boolean;
+  instruction:
+    | "current_agent_executes_safe_command"
+    | "runner_route_follow_runner_lifecycle"
+    | "current_agent_waits_for_provider_or_recompute";
+  warning: string;
 };
 
 type RouteRunnerContext = {
@@ -232,6 +244,45 @@ function deriveRunnerContext(decision: TaskRouteDecision): RouteRunnerContext {
   };
 }
 
+function deriveExecutorContext(
+  decision: TaskRouteDecision,
+  runnerContext: RouteRunnerContext,
+): RouteExecutorContext {
+  const runnerRouteActive = runnerContext.runnerIsRequired || runnerContext.runnerIsAllowedNow;
+  const currentAgentMustExecute =
+    !runnerRouteActive &&
+    decision.executionPacket.actionKind === "local_command" &&
+    decision.executionPacket.safeToMutate;
+  if (runnerRouteActive) {
+    return {
+      executor: "runner",
+      runnerRouteActive,
+      currentAgentMustExecute: false,
+      instruction: "runner_route_follow_runner_lifecycle",
+      warning:
+        "runner route is active; inspect runner artifacts/status before local mutation or verification",
+    };
+  }
+  if (currentAgentMustExecute) {
+    return {
+      executor: "current_agent",
+      runnerRouteActive,
+      currentAgentMustExecute,
+      instruction: "current_agent_executes_safe_command",
+      warning:
+        "not a runner route; the current coding agent must run safe_command itself and must not wait for or retry a runner",
+    };
+  }
+  return {
+    executor: "current_agent",
+    runnerRouteActive,
+    currentAgentMustExecute: false,
+    instruction: "current_agent_waits_for_provider_or_recompute",
+    warning:
+      "not a runner route; do not introduce runner retry/wait language unless next-action explicitly delegates to task run or wait_runner",
+  };
+}
+
 export function deriveRouteOperatorGuidance(decision: TaskRouteDecision): RouteOperatorGuidance {
   const risks = [
     artifactFreshnessRisk(decision),
@@ -260,6 +311,7 @@ export function deriveRouteOperatorGuidance(decision: TaskRouteDecision): RouteO
     risks.find((risk) => risk.code === "runner_rail_confusion")?.mitigationCommand ??
     null;
   const repeatAllowed = canExecuteNow && artifactRisk === null;
+  const runnerContext = deriveRunnerContext(decision);
   return {
     schemaVersion: 1,
     canExecuteNow,
@@ -286,7 +338,8 @@ export function deriveRouteOperatorGuidance(decision: TaskRouteDecision): RouteO
       command: hookRisk?.mitigationCommand ?? null,
       reason: hookRisk?.summary ?? null,
     },
-    runnerContext: deriveRunnerContext(decision),
+    executorContext: deriveExecutorContext(decision, runnerContext),
+    runnerContext,
     stopReason: canExecuteNow
       ? null
       : (decision.executionPacket.stopReason ??

--- a/packages/agentplane/src/commands/task/brief-render.ts
+++ b/packages/agentplane/src/commands/task/brief-render.ts
@@ -60,6 +60,19 @@ export function reportTaskBriefText(brief: TaskBrief, taskId: string): void {
           `allowed=${String(brief.decision_context.repeatPolicy.allowed)} ` +
           `recompute=${brief.decision_context.repeatPolicy.recomputeCommand}`,
       },
+      {
+        label: "executor_context",
+        value:
+          `executor=${brief.decision_context.executorContext.executor} ` +
+          `runner_route_active=${String(
+            brief.decision_context.executorContext.runnerRouteActive,
+          )} ` +
+          `instruction=${brief.decision_context.executorContext.instruction}`,
+      },
+      {
+        label: "executor_warning",
+        value: brief.decision_context.executorContext.warning,
+      },
       ...(routeRunnerContextIsRelevant(brief.decision_context)
         ? [
             {

--- a/packages/agentplane/src/commands/task/next-action.command.ts
+++ b/packages/agentplane/src/commands/task/next-action.command.ts
@@ -108,6 +108,16 @@ function operatorGuidanceJson(guidance: RouteOperatorGuidance): Record<string, u
     },
     repeatPolicy: guidance.repeatPolicy,
     fallback: guidance.fallback,
+    executor_context: {
+      executor: guidance.executorContext.executor,
+      runner_route_active: guidance.executorContext.runnerRouteActive,
+      runnerRouteActive: guidance.executorContext.runnerRouteActive,
+      current_agent_must_execute: guidance.executorContext.currentAgentMustExecute,
+      currentAgentMustExecute: guidance.executorContext.currentAgentMustExecute,
+      instruction: guidance.executorContext.instruction,
+      warning: guidance.executorContext.warning,
+    },
+    executorContext: guidance.executorContext,
     runner_context: {
       runner_is_required: guidance.runnerContext.runnerIsRequired,
       runnerIsRequired: guidance.runnerContext.runnerIsRequired,
@@ -196,6 +206,17 @@ export function makeRunTaskNextActionHandler(getCtx: (cmd: string) => Promise<Co
           value:
             `allowed=${String(operatorGuidance.repeatPolicy.allowed)} ` +
             `recompute=${operatorGuidance.repeatPolicy.recomputeCommand}`,
+        },
+        {
+          label: "executor_context",
+          value:
+            `executor=${operatorGuidance.executorContext.executor} ` +
+            `runner_route_active=${String(operatorGuidance.executorContext.runnerRouteActive)} ` +
+            `instruction=${operatorGuidance.executorContext.instruction}`,
+        },
+        {
+          label: "executor_warning",
+          value: operatorGuidance.executorContext.warning,
         },
         {
           label: "fallback",

--- a/packages/agentplane/src/commands/task/status.command.ts
+++ b/packages/agentplane/src/commands/task/status.command.ts
@@ -116,6 +116,17 @@ export function makeRunTaskStatusHandler(getCtx: (cmd: string) => Promise<Comman
             `allowed=${String(operatorGuidance.repeatPolicy.allowed)} ` +
             `recompute=${operatorGuidance.repeatPolicy.recomputeCommand}`,
         },
+        {
+          label: "executor_context",
+          value:
+            `executor=${operatorGuidance.executorContext.executor} ` +
+            `runner_route_active=${String(operatorGuidance.executorContext.runnerRouteActive)} ` +
+            `instruction=${operatorGuidance.executorContext.instruction}`,
+        },
+        {
+          label: "executor_warning",
+          value: operatorGuidance.executorContext.warning,
+        },
         ...(routeRunnerContextIsRelevant(operatorGuidance)
           ? [
               {


### PR DESCRIPTION
Task: `202606081631-MHC3NY`
Title: Clarify non-recipe runner route guidance
Canonical task record: `.agentplane/tasks/202606081631-MHC3NY/README.md`

## Summary

Clarify non-recipe runner route guidance

Fix AgentPlane route/operator guidance so normal Codex agents do not treat runner_context or stale runner attempts as an active runner route unless task run, wait_runner, runner_alive, or an active runner recipe such as parallel-codex explicitly delegates execution.

## Scope

Fix AgentPlane route/operator guidance for ordinary Codex-agent execution when no runner recipe is active. Scope includes route guidance code, focused tests, and task lifecycle artifacts only. Out of scope: implementing a new runner, changing parallel-codex behavior, or altering branch_pr lifecycle semantics.

## Verification

- State: ok
- Note:

```text
Post-commit route guidance verification passed on HEAD 42779867b; PR check reports fresh local
artifacts and live task surfaces show current_agent executor semantics.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-06-08T16:32:55.363Z
- Branch: task/202606081631-MHC3NY/clarify-non-recipe-runner-route-guidance
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/commands/shared/route-guidance.test.ts     | 14 ++++++
 .../src/commands/shared/route-guidance.ts          | 55 +++++++++++++++++++++-
 .../agentplane/src/commands/task/brief-render.ts   | 13 +++++
 .../src/commands/task/next-action.command.ts       | 21 +++++++++
 .../agentplane/src/commands/task/status.command.ts | 11 +++++
 5 files changed, 113 insertions(+), 1 deletion(-)
```

</details>
