### PR TITLE
🚧 15G7ZE task: Add task-level human input blockers [202606101735-15G7ZE]

### DIFF
--- a/.agentplane/tasks/202606101735-15G7ZE/README.md
+++ b/.agentplane/tasks/202606101735-15G7ZE/README.md
@@ -1,0 +1,174 @@
+---
+id: "202606101735-15G7ZE"
+title: "Add task-level human input blockers"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "cli"
+  - "code"
+  - "task-lifecycle"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-06-10T17:36:53.579Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-06-10T17:55:00.382Z"
+  updated_by: "CODER"
+  note: "Command: bunx vitest run packages/agentplane/src/cli/run-cli.core.tasks.lifecycle.test.ts packages/agentplane/src/cli/run-cli.core.tasks.active.test.ts packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts. Result: pass, 3 files / 19 tests. Command: bun run --filter=agentplane build. Result: pass, tsup build succeeded. Command: node .agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Command: git diff --check. Result: pass."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: Implement task-scoped human input blockers, expose waiting-on-user tasks in active and route guidance, and verify with focused CLI tests plus routing validation."
+events:
+  -
+    type: "status"
+    at: "2026-06-10T17:38:34.227Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: Implement task-scoped human input blockers, expose waiting-on-user tasks in active and route guidance, and verify with focused CLI tests plus routing validation."
+  -
+    type: "verify"
+    at: "2026-06-10T17:55:00.382Z"
+    author: "CODER"
+    state: "ok"
+    note: "Command: bunx vitest run packages/agentplane/src/cli/run-cli.core.tasks.lifecycle.test.ts packages/agentplane/src/cli/run-cli.core.tasks.active.test.ts packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts. Result: pass, 3 files / 19 tests. Command: bun run --filter=agentplane build. Result: pass, tsup build succeeded. Command: node .agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Command: git diff --check. Result: pass."
+doc_version: 3
+doc_updated_at: "2026-06-10T17:55:00.963Z"
+doc_updated_by: "CODER"
+description: "Add explicit task-scoped human input blocker support so agents can record a blocking question, ap task active surfaces waiting-on-user tasks with the exact question and answer command, and route guidance treats unresolved user input as a first-class blocker."
+sections:
+  Summary: |-
+    Add task-level human input blockers
+
+    Add explicit task-scoped human input blocker support so agents can record a blocking question, ap task active surfaces waiting-on-user tasks with the exact question and answer command, and route guidance treats unresolved user input as a first-class blocker.
+  Scope: |-
+    - In scope: Add explicit task-scoped human input blocker support so agents can record a blocking question, ap task active surfaces waiting-on-user tasks with the exact question and answer command, and route guidance treats unresolved user input as a first-class blocker.
+    - Out of scope: unrelated refactors not required for "Add task-level human input blockers".
+  Plan: |-
+    1. Inspect existing task state, comments, active-list, and route-oracle code paths.
+    2. Add task-scoped human input blocker storage and commands for asking and answering a blocking question.
+    3. Surface waiting-on-user tasks in ap task active, ap task brief, and ap task next-action with the exact question and answer command.
+    4. Add focused CLI/unit coverage for ask/answer, active listing, and route guidance.
+    5. Run targeted tests plus routing validation, record verification, and prepare branch_pr artifacts.
+  Verify Steps: |-
+    1. Run focused CLI/unit tests for task human-input blockers. Expected: ask/answer behavior, unresolved blocker visibility, and route guidance pass.
+    2. Run `ap task active` coverage for waiting-on-user tasks. Expected: active output lists the exact question and answer command without hiding ready tasks.
+    3. Run route-oracle coverage for unresolved user input. Expected: `ap task brief` and `ap task next-action --explain` report the blocker and prevent unsafe progression until answered.
+    4. Run `node .agentplane/policy/check-routing.mjs`. Expected: routing policy validation passes.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-06-10T17:55:00.382Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Command: bunx vitest run packages/agentplane/src/cli/run-cli.core.tasks.lifecycle.test.ts packages/agentplane/src/cli/run-cli.core.tasks.active.test.ts packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts. Result: pass, 3 files / 19 tests. Command: bun run --filter=agentplane build. Result: pass, tsup build succeeded. Command: node .agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Command: git diff --check. Result: pass.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-06-10T17:38:34.227Z, excerpt_hash=sha256:b2dc1ef05e9ce7d9c6f61070e028327e71034a842665fed4730ed88938eab70c
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202606101735-15G7ZE-add-task-level-human-input-blockers/.agentplane/tasks/202606101735-15G7ZE/blueprint/resolved-snapshot.json
+    - old_digest: 4e19c83fcadf1f3c322caf9fddc13399e598bed72373a6bce4f34167612bbfab
+    - current_digest: 4e19c83fcadf1f3c322caf9fddc13399e598bed72373a6bce4f34167612bbfab
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202606101735-15G7ZE
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane pr update 202606101735-15G7ZE
+    - diagnostic_command: agentplane pr check 202606101735-15G7ZE
+    - source_of_truth: route=task_next_action diagnostic=pr_check remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
+    - risks: pr_artifact_freshness_loop, git_hook_side_effect
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add task-level human input blockers
+
+Add explicit task-scoped human input blocker support so agents can record a blocking question, ap task active surfaces waiting-on-user tasks with the exact question and answer command, and route guidance treats unresolved user input as a first-class blocker.
+
+## Scope
+
+- In scope: Add explicit task-scoped human input blocker support so agents can record a blocking question, ap task active surfaces waiting-on-user tasks with the exact question and answer command, and route guidance treats unresolved user input as a first-class blocker.
+- Out of scope: unrelated refactors not required for "Add task-level human input blockers".
+
+## Plan
+
+1. Inspect existing task state, comments, active-list, and route-oracle code paths.
+2. Add task-scoped human input blocker storage and commands for asking and answering a blocking question.
+3. Surface waiting-on-user tasks in ap task active, ap task brief, and ap task next-action with the exact question and answer command.
+4. Add focused CLI/unit coverage for ask/answer, active listing, and route guidance.
+5. Run targeted tests plus routing validation, record verification, and prepare branch_pr artifacts.
+
+## Verify Steps
+
+1. Run focused CLI/unit tests for task human-input blockers. Expected: ask/answer behavior, unresolved blocker visibility, and route guidance pass.
+2. Run `ap task active` coverage for waiting-on-user tasks. Expected: active output lists the exact question and answer command without hiding ready tasks.
+3. Run route-oracle coverage for unresolved user input. Expected: `ap task brief` and `ap task next-action --explain` report the blocker and prevent unsafe progression until answered.
+4. Run `node .agentplane/policy/check-routing.mjs`. Expected: routing policy validation passes.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-06-10T17:55:00.382Z — VERIFY — ok
+
+By: CODER
+
+Note: Command: bunx vitest run packages/agentplane/src/cli/run-cli.core.tasks.lifecycle.test.ts packages/agentplane/src/cli/run-cli.core.tasks.active.test.ts packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts. Result: pass, 3 files / 19 tests. Command: bun run --filter=agentplane build. Result: pass, tsup build succeeded. Command: node .agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Command: git diff --check. Result: pass.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-06-10T17:38:34.227Z, excerpt_hash=sha256:b2dc1ef05e9ce7d9c6f61070e028327e71034a842665fed4730ed88938eab70c
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/202606101735-15G7ZE-add-task-level-human-input-blockers/.agentplane/tasks/202606101735-15G7ZE/blueprint/resolved-snapshot.json
+- old_digest: 4e19c83fcadf1f3c322caf9fddc13399e598bed72373a6bce4f34167612bbfab
+- current_digest: 4e19c83fcadf1f3c322caf9fddc13399e598bed72373a6bce4f34167612bbfab
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202606101735-15G7ZE
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane pr update 202606101735-15G7ZE
+- diagnostic_command: agentplane pr check 202606101735-15G7ZE
+- source_of_truth: route=task_next_action diagnostic=pr_check remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
+- risks: pr_artifact_freshness_loop, git_hook_side_effect
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202606101735-15G7ZE/README.md
+++ b/.agentplane/tasks/202606101735-15G7ZE/README.md
@@ -4,7 +4,7 @@ title: "Add task-level human input blockers"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -24,6 +24,24 @@ verification:
   updated_by: "CODER"
   note: "Command: bunx vitest run packages/agentplane/src/cli/run-cli.core.tasks.lifecycle.test.ts packages/agentplane/src/cli/run-cli.core.tasks.active.test.ts packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts. Result: pass, 3 files / 19 tests. Command: bun run --filter=agentplane build. Result: pass, tsup build succeeded. Command: node .agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Command: git diff --check. Result: pass."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-06-10T17:58:42.646Z"
+  updated_by: "EVALUATOR"
+  note: "Human input blocker implementation is task-scoped and covered by focused CLI tests."
+  evaluated_sha: "a08513d863411d967cf8c86287e26b4942c81361"
+  blueprint_digest: "4e19c83fcadf1f3c322caf9fddc13399e598bed72373a6bce4f34167612bbfab"
+  evidence_refs:
+    - ".agentplane/tasks/202606101735-15G7ZE/README.md"
+    - ".agentplane/tasks/202606101735-15G7ZE/quality/20260610-175842646-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202606101735-15G7ZE/quality/20260610-175842646-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202606101735-15G7ZE/quality/20260610-175842646-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202606101735-15G7ZE/blueprint/resolved-snapshot.json"
+    - "bunx vitest run packages/agentplane/src/cli/run-cli.core.tasks.lifecycle.test.ts packages/agentplane/src/cli/run-cli.core.tasks.active.test.ts packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts"
+    - "bun run --filter=agentplane build"
+    - "node .agentplane/policy/check-routing.mjs"
+  findings:
+    - "task ask/answer stores an explicit user-input blocker, active listing exposes the question and answer command, and route next-action blocks progression until answered."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202606101735-15G7ZE/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202606101735-15G7ZE/blueprint/resolved-snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202606101735-15G7ZE",
+    "title": "Add task-level human input blockers",
+    "description": "Add explicit task-scoped human input blocker support so agents can record a blocking question, ap task active surfaces waiting-on-user tasks with the exact question and answer command, and route guidance treats unresolved user input as a first-class blocker.",
+    "tags": [
+      "cli",
+      "code",
+      "task-lifecycle"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202606101735-15G7ZE",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "4e19c83fcadf1f3c322caf9fddc13399e598bed72373a6bce4f34167612bbfab"
+  }
+}

--- a/.agentplane/tasks/202606101735-15G7ZE/pr/diffstat.txt
+++ b/.agentplane/tasks/202606101735-15G7ZE/pr/diffstat.txt
@@ -1,0 +1,13 @@
+ .../cli/run-cli.core.task-next-action-json.test.ts |  69 ++++++++++++
+ .../src/cli/run-cli.core.tasks.active.test.ts      |  74 +++++++++++++
+ .../src/cli/run-cli.core.tasks.lifecycle.test.ts   |  89 +++++++++++++++
+ .../src/cli/run-cli/command-catalog/task.ts        |   6 ++
+ .../src/cli/run-cli/command-loaders/task.ts        |   8 ++
+ .../src/commands/shared/route-decision-blockers.ts |   9 ++
+ .../commands/shared/route-decision-next-action.ts  |  10 ++
+ .../src/commands/shared/route-decision.ts          |   9 ++
+ .../agentplane/src/commands/task/active.command.ts |  19 ++++
+ .../agentplane/src/commands/task/answer.command.ts | 107 ++++++++++++++++++
+ .../agentplane/src/commands/task/ask.command.ts    | 119 +++++++++++++++++++++
+ .../agentplane/src/commands/task/human-input.ts    |  94 ++++++++++++++++
+ 12 files changed, 613 insertions(+)

--- a/.agentplane/tasks/202606101735-15G7ZE/pr/github-body.md
+++ b/.agentplane/tasks/202606101735-15G7ZE/pr/github-body.md
@@ -1,0 +1,54 @@
+Task: `202606101735-15G7ZE`
+Title: Add task-level human input blockers
+Canonical task record: `.agentplane/tasks/202606101735-15G7ZE/README.md`
+
+## Summary
+
+Add task-level human input blockers
+
+Add explicit task-scoped human input blocker support so agents can record a blocking question, ap task active surfaces waiting-on-user tasks with the exact question and answer command, and route guidance treats unresolved user input as a first-class blocker.
+
+## Scope
+
+- In scope: Add explicit task-scoped human input blocker support so agents can record a blocking question, ap task active surfaces waiting-on-user tasks with the exact question and answer command, and route guidance treats unresolved user input as a first-class blocker.
+- Out of scope: unrelated refactors not required for "Add task-level human input blockers".
+
+## Verification
+
+- State: ok
+- Note:
+
+```text
+Command: bunx vitest run packages/agentplane/src/cli/run-cli.core.tasks.lifecycle.test.ts
+packages/agentplane/src/cli/run-cli.core.tasks.active.test.ts
+packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts. Result: pass, 3 files / 19
+tests. Command: bun run --filter=agentplane build. Result: pass, tsup build succeeded. Command: node
+.agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Command: git diff --check.
+Result: pass.
+```
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-06-10T17:38:34.588Z
+- Branch: task/202606101735-15G7ZE/add-task-level-human-input-blockers
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../cli/run-cli.core.task-next-action-json.test.ts |  69 ++++++++++++
+ .../src/cli/run-cli.core.tasks.active.test.ts      |  74 +++++++++++++
+ .../src/cli/run-cli.core.tasks.lifecycle.test.ts   |  89 +++++++++++++++
+ .../src/cli/run-cli/command-catalog/task.ts        |   6 ++
+ .../src/cli/run-cli/command-loaders/task.ts        |   8 ++
+ .../src/commands/shared/route-decision-blockers.ts |   9 ++
+ .../commands/shared/route-decision-next-action.ts  |  10 ++
+ .../src/commands/shared/route-decision.ts          |   9 ++
+ .../agentplane/src/commands/task/active.command.ts |  19 ++++
+ .../agentplane/src/commands/task/answer.command.ts | 107 ++++++++++++++++++
+ .../agentplane/src/commands/task/ask.command.ts    | 119 +++++++++++++++++++++
+ .../agentplane/src/commands/task/human-input.ts    |  94 ++++++++++++++++
+ 12 files changed, 613 insertions(+)
+```
+
+</details>

--- a/.agentplane/tasks/202606101735-15G7ZE/pr/github-title.txt
+++ b/.agentplane/tasks/202606101735-15G7ZE/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 15G7ZE task: Add task-level human input blockers [202606101735-15G7ZE]

--- a/.agentplane/tasks/202606101735-15G7ZE/pr/meta.json
+++ b/.agentplane/tasks/202606101735-15G7ZE/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202606101735-15G7ZE/add-task-level-human-input-blockers",
+  "created_at": "2026-06-10T17:38:34.588Z",
+  "diffstat_sha256": "sha256:8d3b9ecca822b799a3cdb8a7929eda27bc3370942d880f92cf5e78e7e5529577",
+  "last_verified_at": "2026-06-10T17:55:00.382Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202606101735-15G7ZE",
+  "updated_at": "2026-06-10T17:38:34.588Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202606101735-15G7ZE/pr/review.md
+++ b/.agentplane/tasks/202606101735-15G7ZE/pr/review.md
@@ -1,0 +1,48 @@
+# PR Review
+
+Created: 2026-06-10T17:38:34.588Z
+
+## Task
+
+- Task: `202606101735-15G7ZE`
+- Title: Add task-level human input blockers
+- Status: DOING
+- Branch: `task/202606101735-15G7ZE/add-task-level-human-input-blockers`
+- Canonical task record: `.agentplane/tasks/202606101735-15G7ZE/README.md`
+
+## Verification
+
+- State: ok
+- Note: Command: bunx vitest run packages/agentplane/src/cli/run-cli.core.tasks.lifecycle.test.ts packages/agentplane/src/cli/run-cli.core.tasks.active.test.ts packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts. Result: pass, 3 files / 19 tests. Command: bun run --filter=agentplane build. Result: pass, tsup build succeeded. Command: node .agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Command: git diff --check. Result: pass.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-06-10T17:38:34.588Z
+- Branch: task/202606101735-15G7ZE/add-task-level-human-input-blockers
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../cli/run-cli.core.task-next-action-json.test.ts |  69 ++++++++++++
+ .../src/cli/run-cli.core.tasks.active.test.ts      |  74 +++++++++++++
+ .../src/cli/run-cli.core.tasks.lifecycle.test.ts   |  89 +++++++++++++++
+ .../src/cli/run-cli/command-catalog/task.ts        |   6 ++
+ .../src/cli/run-cli/command-loaders/task.ts        |   8 ++
+ .../src/commands/shared/route-decision-blockers.ts |   9 ++
+ .../commands/shared/route-decision-next-action.ts  |  10 ++
+ .../src/commands/shared/route-decision.ts          |   9 ++
+ .../agentplane/src/commands/task/active.command.ts |  19 ++++
+ .../agentplane/src/commands/task/answer.command.ts | 107 ++++++++++++++++++
+ .../agentplane/src/commands/task/ask.command.ts    | 119 +++++++++++++++++++++
+ .../agentplane/src/commands/task/human-input.ts    |  94 ++++++++++++++++
+ 12 files changed, 613 insertions(+)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202606101735-15G7ZE/quality/20260610-175842646-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202606101735-15G7ZE/quality/20260610-175842646-recovery-context/evaluator-opinion.md
@@ -1,0 +1,21 @@
+# EVALUATOR opinion: pass
+
+Human input blocker implementation is task-scoped and covered by focused CLI tests.
+
+## Findings
+- task ask/answer stores an explicit user-input blocker, active listing exposes the question and answer command, and route next-action blocks progression until answered.
+
+## Evidence
+- .agentplane/tasks/202606101735-15G7ZE/README.md
+- bunx vitest run packages/agentplane/src/cli/run-cli.core.tasks.lifecycle.test.ts packages/agentplane/src/cli/run-cli.core.tasks.active.test.ts packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts
+- bun run --filter=agentplane build
+- node .agentplane/policy/check-routing.mjs
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202606101735-15G7ZE/quality/20260610-175842646-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202606101735-15G7ZE/quality/20260610-175842646-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202606101735-15G7ZE
+- task_readme: .agentplane/tasks/202606101735-15G7ZE/README.md
+- report_path: .agentplane/tasks/202606101735-15G7ZE/quality/20260610-175842646-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202606101735-15G7ZE/quality/20260610-175842646-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202606101735-15G7ZE/quality/20260610-175842646-recovery-context/quality-report.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "task_id": "202606101735-15G7ZE",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-06-10T17:58:42.646Z",
+  "verdict": "pass",
+  "summary": "Human input blocker implementation is task-scoped and covered by focused CLI tests.",
+  "evaluated_sha": "a08513d863411d967cf8c86287e26b4942c81361",
+  "blueprint_digest": "4e19c83fcadf1f3c322caf9fddc13399e598bed72373a6bce4f34167612bbfab",
+  "findings": [
+    "task ask/answer stores an explicit user-input blocker, active listing exposes the question and answer command, and route next-action blocks progression until answered."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202606101735-15G7ZE/README.md",
+    "bunx vitest run packages/agentplane/src/cli/run-cli.core.tasks.lifecycle.test.ts packages/agentplane/src/cli/run-cli.core.tasks.active.test.ts packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts",
+    "bun run --filter=agentplane build",
+    "node .agentplane/policy/check-routing.mjs"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -14,6 +14,8 @@ This page is generated from the CLI command specs. Do not edit it by hand; edit 
 - Task
   - [ready](#ready)
   - [task active](#task-active)
+  - [task answer](#task-answer)
+  - [task ask](#task-ask)
   - [task begin](#task-begin)
   - [task brief](#task-brief)
   - [task comment](#task-comment)
@@ -392,6 +394,52 @@ agentplane task active --json
 ```
 
 - Emit machine-readable active work state.
+
+### task answer
+
+Answer and close a task user-input blocker.
+
+Usage:
+
+```text
+agentplane task answer <task-id> [options]
+```
+
+Options:
+
+- `--by <USER>`: Answer author.
+- `--body <text>`: Answer body.
+
+Examples:
+
+```sh
+agentplane task answer 202602030608-F1Q8AB --by USER --body "Use the existing REST API."
+```
+
+- Close the open user-input blocker.
+
+### task ask
+
+Record a blocking user question for a task.
+
+Usage:
+
+```text
+agentplane task ask <task-id> [options]
+```
+
+Options:
+
+- `--author <ROLE>`: Question author.
+- `--body <text>`: Blocking question.
+
+Examples:
+
+```sh
+agentplane task ask 202602030608-F1Q8AB --author CODER --body "Which API should this use?"
+```
+
+- Block the task until the user answers.
 
 ### task begin
 

--- a/packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts
@@ -106,7 +106,7 @@ describe("task next-action JSON", () => {
     }
   });
 
-  it("routes open user questions to task answer before task progression", async () => {
+  it("routes open user questions to task answer before plan approval", async () => {
     const root = await mkGitRepoRootWithBranch("main");
     const config = defaultConfig();
     config.workflow_mode = "branch_pr";
@@ -126,7 +126,6 @@ describe("task next-action JSON", () => {
       "--root",
       root,
     ]);
-    await runCliSilent(["task", "plan", "approve", taskId, "--by", "ORCHESTRATOR", "--root", root]);
     await runCliSilent([
       "task",
       "ask",

--- a/packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts
@@ -164,12 +164,8 @@ describe("task next-action JSON", () => {
       expect(parsed.execution_packet.human_provider_action).toContain(
         "Which implementation path should this use?",
       );
-      expect(parsed.blockers[0]).toEqual(
-        expect.objectContaining({
-          code: "human_input_required",
-          summary: expect.stringContaining("Which implementation path should this use?"),
-        }),
-      );
+      expect(parsed.blockers[0]?.code).toBe("human_input_required");
+      expect(parsed.blockers[0]?.summary).toContain("Which implementation path should this use?");
     } finally {
       io.restore();
     }

--- a/packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts
@@ -105,4 +105,73 @@ describe("task next-action JSON", () => {
       io.restore();
     }
   });
+
+  it("routes open user questions to task answer before task progression", async () => {
+    const root = await mkGitRepoRootWithBranch("main");
+    const config = defaultConfig();
+    config.workflow_mode = "branch_pr";
+    await writeConfig(root, config);
+    await runCliSilent(["branch", "base", "set", "main", "--root", root]);
+
+    const taskId = await createBranchPrTask(root);
+    await runCliSilent([
+      "task",
+      "plan",
+      "set",
+      taskId,
+      "--text",
+      "Exercise user input route blocker.",
+      "--updated-by",
+      "ORCHESTRATOR",
+      "--root",
+      root,
+    ]);
+    await runCliSilent(["task", "plan", "approve", taskId, "--by", "ORCHESTRATOR", "--root", root]);
+    await runCliSilent([
+      "task",
+      "ask",
+      taskId,
+      "--author",
+      "CODER",
+      "--body",
+      "Which implementation path should this use?",
+      "--root",
+      root,
+    ]);
+
+    const io = captureStdIO();
+    try {
+      const code = await runCli(["task", "next-action", taskId, "--json", "--root", root]);
+      expect(code).toBe(0);
+      const parsed = JSON.parse(io.stdout) as {
+        next_action: { code: string; command: string; requiresApproval: boolean };
+        execution_packet: {
+          action_kind: string;
+          recommended_role: string;
+          human_provider_action: string;
+        };
+        blockers: { code: string; summary: string }[];
+      };
+      expect(parsed.next_action).toEqual(
+        expect.objectContaining({
+          code: "answer_user_question",
+          command: `agentplane task answer ${taskId} --by USER --body "..."`,
+          requiresApproval: true,
+        }),
+      );
+      expect(parsed.execution_packet.action_kind).toBe("provider_action");
+      expect(parsed.execution_packet.recommended_role).toBe("USER");
+      expect(parsed.execution_packet.human_provider_action).toContain(
+        "Which implementation path should this use?",
+      );
+      expect(parsed.blockers[0]).toEqual(
+        expect.objectContaining({
+          code: "human_input_required",
+          summary: expect.stringContaining("Which implementation path should this use?"),
+        }),
+      );
+    } finally {
+      io.restore();
+    }
+  });
 });

--- a/packages/agentplane/src/cli/run-cli.core.tasks.active.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.tasks.active.test.ts
@@ -176,6 +176,80 @@ describe("runCli task active", { timeout: TASKS_QUERY_CLI_TIMEOUT_MS }, () => {
     }
   });
 
+  it("surfaces waiting-on-user questions with answer commands", async () => {
+    const root = await mkGitRepoRootWithBranch("main");
+    const blockedTaskId = "202603010157-ASKSER";
+    await seedTaskQueryFixture(root, [
+      {
+        id: blockedTaskId,
+        title: "Waiting on user",
+        description: "Needs a user decision",
+        status: "BLOCKED",
+        priority: "high",
+        owner: "CODER",
+        depends_on: [],
+        tags: ["code"],
+        verify: [],
+        plan_approval: {
+          state: "approved",
+          updated_at: "2026-03-01T02:00:00.000Z",
+          updated_by: "ORCHESTRATOR",
+          note: null,
+        },
+        extensions: {
+          "agentplane.human_input": {
+            openQuestion: {
+              id: "question-20260301020000000",
+              question: "Should this use the REST or CLI path?",
+              askedAt: "2026-03-01T02:00:00.000Z",
+              askedBy: "CODER",
+              previousStatus: "DOING",
+            },
+            history: [],
+          },
+        },
+      },
+    ]);
+    const config = defaultConfig();
+    config.workflow_mode = "branch_pr";
+    await writeConfig(root, config);
+    await runCliSilent(["branch", "base", "set", "main", "--root", root]);
+
+    const textIo = captureStdIO();
+    try {
+      const code = await runCli(["task", "active", "--owner", "CODER", "--root", root]);
+      expect(code).toBe(0);
+      expect(textIo.stdout).toContain(blockedTaskId);
+      expect(textIo.stdout).toContain("waiting_on_user=true");
+      expect(textIo.stdout).toContain("Should this use the REST or CLI path?");
+      expect(textIo.stdout).toContain(`agentplane task answer ${blockedTaskId}`);
+    } finally {
+      textIo.restore();
+    }
+
+    const jsonIo = captureStdIO();
+    try {
+      const code = await runCli(["task", "active", "--owner", "CODER", "--json", "--root", root]);
+      expect(code).toBe(0);
+      const parsed = JSON.parse(jsonIo.stdout) as {
+        items: {
+          human_input: {
+            waiting_on_user: boolean;
+            question: string | null;
+            answer_command: string | null;
+          };
+        }[];
+      };
+      expect(parsed.items[0]?.human_input).toEqual({
+        waiting_on_user: true,
+        question: "Should this use the REST or CLI path?",
+        answer_command: `agentplane task answer ${blockedTaskId} --by USER --body "..."`,
+      });
+    } finally {
+      jsonIo.restore();
+    }
+  });
+
   it("prints a concrete next step when no active work matches", async () => {
     const root = await mkGitRepoRootWithBranch("main");
     const doneTaskId = "202603010159-ZZZZZZ";

--- a/packages/agentplane/src/cli/run-cli.core.tasks.human-input.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.tasks.human-input.test.ts
@@ -1,0 +1,108 @@
+import { readTask } from "@agentplaneorg/core/tasks";
+import { describe, expect, it } from "vitest";
+
+import { captureStdIO, installRunCliIntegrationHarness, mkGitRepoRoot } from "@agentplane/testkit";
+
+import { runCli } from "./run-cli.js";
+
+installRunCliIntegrationHarness();
+
+type HumanInputTestExtensions = {
+  "agentplane.human_input"?: {
+    openQuestion?: { question?: string; previousStatus?: string } | null;
+    history?: { answer?: string }[];
+  };
+};
+
+describe("runCli task human input", { timeout: 300_000 }, () => {
+  it("task ask and answer manage a task-scoped user-input blocker", async () => {
+    const root = await mkGitRepoRoot();
+    let taskId = "";
+    {
+      const io = captureStdIO();
+      try {
+        const code = await runCli([
+          "task",
+          "new",
+          "--title",
+          "Needs user input",
+          "--description",
+          "Exercise human input blockers",
+          "--priority",
+          "med",
+          "--owner",
+          "CODER",
+          "--tag",
+          "code",
+          "--root",
+          root,
+        ]);
+        expect(code).toBe(0);
+        taskId = io.stdout.trim();
+      } finally {
+        io.restore();
+      }
+    }
+
+    {
+      const io = captureStdIO();
+      try {
+        const code = await runCli([
+          "task",
+          "ask",
+          taskId,
+          "--author",
+          "CODER",
+          "--body",
+          "Which endpoint should this use?",
+          "--root",
+          root,
+        ]);
+        expect(code).toBe(0);
+        expect(io.stdout).toContain("question-opened");
+      } finally {
+        io.restore();
+      }
+    }
+
+    const blocked = await readTask({ cwd: root, rootOverride: root, taskId });
+    expect(blocked.frontmatter.status).toBe("BLOCKED");
+    const blockedExtensions = blocked.frontmatter.extensions as
+      | HumanInputTestExtensions
+      | undefined;
+    const blockerState = blockedExtensions?.["agentplane.human_input"];
+    expect(blockerState?.openQuestion?.question).toBe("Which endpoint should this use?");
+    expect(blockerState?.openQuestion?.previousStatus).toBe("TODO");
+
+    {
+      const io = captureStdIO();
+      try {
+        const code = await runCli([
+          "task",
+          "answer",
+          taskId,
+          "--by",
+          "USER",
+          "--body",
+          "Use the existing internal API.",
+          "--root",
+          root,
+        ]);
+        expect(code).toBe(0);
+        expect(io.stdout).toContain("question-answered");
+      } finally {
+        io.restore();
+      }
+    }
+
+    const answered = await readTask({ cwd: root, rootOverride: root, taskId });
+    expect(answered.frontmatter.status).toBe("TODO");
+    const answeredExtensions = answered.frontmatter.extensions as
+      | HumanInputTestExtensions
+      | undefined;
+    const answeredState = answeredExtensions?.["agentplane.human_input"];
+    expect(answeredState?.openQuestion).toBeNull();
+    expect(answeredState?.history?.at(-1)?.answer).toBe("Use the existing internal API.");
+    expect(answered.frontmatter.comments?.at(-1)?.body).toContain("Use the existing internal API.");
+  });
+});

--- a/packages/agentplane/src/cli/run-cli.core.tasks.lifecycle.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.tasks.lifecycle.test.ts
@@ -50,6 +50,12 @@ import * as prompts from "./prompts.js";
 
 installRunCliIntegrationHarness();
 const TASKS_CLI_TIMEOUT_MS = 300_000;
+type HumanInputTestExtensions = {
+  "agentplane.human_input"?: {
+    openQuestion?: { question?: string; previousStatus?: string } | null;
+    history?: { answer?: string }[];
+  };
+};
 
 describe("runCli", { timeout: TASKS_CLI_TIMEOUT_MS }, () => {
   it("task comment validates flags and appends comments", async () => {
@@ -193,9 +199,10 @@ describe("runCli", { timeout: TASKS_CLI_TIMEOUT_MS }, () => {
 
     const blocked = await readTask({ cwd: root, rootOverride: root, taskId });
     expect(blocked.frontmatter.status).toBe("BLOCKED");
-    const blockerState = blocked.frontmatter.extensions?.["agentplane.human_input"] as
-      | { openQuestion?: { question?: string; previousStatus?: string } }
+    const blockedExtensions = blocked.frontmatter.extensions as
+      | HumanInputTestExtensions
       | undefined;
+    const blockerState = blockedExtensions?.["agentplane.human_input"];
     expect(blockerState?.openQuestion?.question).toBe("Which endpoint should this use?");
     expect(blockerState?.openQuestion?.previousStatus).toBe("TODO");
 
@@ -222,9 +229,10 @@ describe("runCli", { timeout: TASKS_CLI_TIMEOUT_MS }, () => {
 
     const answered = await readTask({ cwd: root, rootOverride: root, taskId });
     expect(answered.frontmatter.status).toBe("TODO");
-    const answeredState = answered.frontmatter.extensions?.["agentplane.human_input"] as
-      | { openQuestion?: unknown; history?: { answer?: string }[] }
+    const answeredExtensions = answered.frontmatter.extensions as
+      | HumanInputTestExtensions
       | undefined;
+    const answeredState = answeredExtensions?.["agentplane.human_input"];
     expect(answeredState?.openQuestion).toBeNull();
     expect(answeredState?.history?.at(-1)?.answer).toBe("Use the existing internal API.");
     expect(answered.frontmatter.comments?.at(-1)?.body).toContain("Use the existing internal API.");

--- a/packages/agentplane/src/cli/run-cli.core.tasks.lifecycle.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.tasks.lifecycle.test.ts
@@ -50,12 +50,6 @@ import * as prompts from "./prompts.js";
 
 installRunCliIntegrationHarness();
 const TASKS_CLI_TIMEOUT_MS = 300_000;
-type HumanInputTestExtensions = {
-  "agentplane.human_input"?: {
-    openQuestion?: { question?: string; previousStatus?: string } | null;
-    history?: { answer?: string }[];
-  };
-};
 
 describe("runCli", { timeout: TASKS_CLI_TIMEOUT_MS }, () => {
   it("task comment validates flags and appends comments", async () => {
@@ -145,97 +139,6 @@ describe("runCli", { timeout: TASKS_CLI_TIMEOUT_MS }, () => {
     const task = await readTask({ cwd: root, rootOverride: root, taskId });
     expect(task.frontmatter.comments?.length).toBe(1);
     expect(task.frontmatter.comments?.[0]?.body).toContain("All good");
-  });
-
-  it("task ask and answer manage a task-scoped user-input blocker", async () => {
-    const root = await mkGitRepoRoot();
-    let taskId = "";
-    {
-      const io = captureStdIO();
-      try {
-        const code = await runCli([
-          "task",
-          "new",
-          "--title",
-          "Needs user input",
-          "--description",
-          "Exercise human input blockers",
-          "--priority",
-          "med",
-          "--owner",
-          "CODER",
-          "--tag",
-          "code",
-          "--root",
-          root,
-        ]);
-        expect(code).toBe(0);
-        taskId = io.stdout.trim();
-      } finally {
-        io.restore();
-      }
-    }
-
-    {
-      const io = captureStdIO();
-      try {
-        const code = await runCli([
-          "task",
-          "ask",
-          taskId,
-          "--author",
-          "CODER",
-          "--body",
-          "Which endpoint should this use?",
-          "--root",
-          root,
-        ]);
-        expect(code).toBe(0);
-        expect(io.stdout).toContain("question-opened");
-      } finally {
-        io.restore();
-      }
-    }
-
-    const blocked = await readTask({ cwd: root, rootOverride: root, taskId });
-    expect(blocked.frontmatter.status).toBe("BLOCKED");
-    const blockedExtensions = blocked.frontmatter.extensions as
-      | HumanInputTestExtensions
-      | undefined;
-    const blockerState = blockedExtensions?.["agentplane.human_input"];
-    expect(blockerState?.openQuestion?.question).toBe("Which endpoint should this use?");
-    expect(blockerState?.openQuestion?.previousStatus).toBe("TODO");
-
-    {
-      const io = captureStdIO();
-      try {
-        const code = await runCli([
-          "task",
-          "answer",
-          taskId,
-          "--by",
-          "USER",
-          "--body",
-          "Use the existing internal API.",
-          "--root",
-          root,
-        ]);
-        expect(code).toBe(0);
-        expect(io.stdout).toContain("question-answered");
-      } finally {
-        io.restore();
-      }
-    }
-
-    const answered = await readTask({ cwd: root, rootOverride: root, taskId });
-    expect(answered.frontmatter.status).toBe("TODO");
-    const answeredExtensions = answered.frontmatter.extensions as
-      | HumanInputTestExtensions
-      | undefined;
-    const answeredState = answeredExtensions?.["agentplane.human_input"];
-    expect(answeredState?.openQuestion).toBeNull();
-    expect(answeredState?.history?.at(-1)?.answer).toBe("Use the existing internal API.");
-    expect(answered.frontmatter.comments?.at(-1)?.body).toContain("Use the existing internal API.");
   });
 
   it("task close-duplicate closes duplicate task in one command", async () => {

--- a/packages/agentplane/src/cli/run-cli.core.tasks.lifecycle.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.tasks.lifecycle.test.ts
@@ -141,6 +141,95 @@ describe("runCli", { timeout: TASKS_CLI_TIMEOUT_MS }, () => {
     expect(task.frontmatter.comments?.[0]?.body).toContain("All good");
   });
 
+  it("task ask and answer manage a task-scoped user-input blocker", async () => {
+    const root = await mkGitRepoRoot();
+    let taskId = "";
+    {
+      const io = captureStdIO();
+      try {
+        const code = await runCli([
+          "task",
+          "new",
+          "--title",
+          "Needs user input",
+          "--description",
+          "Exercise human input blockers",
+          "--priority",
+          "med",
+          "--owner",
+          "CODER",
+          "--tag",
+          "code",
+          "--root",
+          root,
+        ]);
+        expect(code).toBe(0);
+        taskId = io.stdout.trim();
+      } finally {
+        io.restore();
+      }
+    }
+
+    {
+      const io = captureStdIO();
+      try {
+        const code = await runCli([
+          "task",
+          "ask",
+          taskId,
+          "--author",
+          "CODER",
+          "--body",
+          "Which endpoint should this use?",
+          "--root",
+          root,
+        ]);
+        expect(code).toBe(0);
+        expect(io.stdout).toContain("question-opened");
+      } finally {
+        io.restore();
+      }
+    }
+
+    const blocked = await readTask({ cwd: root, rootOverride: root, taskId });
+    expect(blocked.frontmatter.status).toBe("BLOCKED");
+    const blockerState = blocked.frontmatter.extensions?.["agentplane.human_input"] as
+      | { openQuestion?: { question?: string; previousStatus?: string } }
+      | undefined;
+    expect(blockerState?.openQuestion?.question).toBe("Which endpoint should this use?");
+    expect(blockerState?.openQuestion?.previousStatus).toBe("TODO");
+
+    {
+      const io = captureStdIO();
+      try {
+        const code = await runCli([
+          "task",
+          "answer",
+          taskId,
+          "--by",
+          "USER",
+          "--body",
+          "Use the existing internal API.",
+          "--root",
+          root,
+        ]);
+        expect(code).toBe(0);
+        expect(io.stdout).toContain("question-answered");
+      } finally {
+        io.restore();
+      }
+    }
+
+    const answered = await readTask({ cwd: root, rootOverride: root, taskId });
+    expect(answered.frontmatter.status).toBe("TODO");
+    const answeredState = answered.frontmatter.extensions?.["agentplane.human_input"] as
+      | { openQuestion?: unknown; history?: { answer?: string }[] }
+      | undefined;
+    expect(answeredState?.openQuestion).toBeNull();
+    expect(answeredState?.history?.at(-1)?.answer).toBe("Use the existing internal API.");
+    expect(answered.frontmatter.comments?.at(-1)?.body).toContain("Use the existing internal API.");
+  });
+
   it("task close-duplicate closes duplicate task in one command", async () => {
     const root = await mkGitRepoRoot();
     const ids: string[] = [];

--- a/packages/agentplane/src/cli/run-cli/command-catalog/task.ts
+++ b/packages/agentplane/src/cli/run-cli/command-catalog/task.ts
@@ -1,5 +1,7 @@
 import { taskAddSpec } from "../../../commands/task/add.command.js";
 import { taskActiveSpec } from "../../../commands/task/active.command.js";
+import { taskAnswerSpec } from "../../../commands/task/answer.command.js";
+import { taskAskSpec } from "../../../commands/task/ask.command.js";
 import { taskCloseDuplicateSpec } from "../../../commands/task/close-duplicate.command.js";
 import { taskCloseNoopSpec } from "../../../commands/task/close-noop.command.js";
 import { taskCommentSpec } from "../../../commands/task/comment.command.js";
@@ -82,6 +84,8 @@ import {
   loadTaskHostedCloseSpec,
   loadTaskHostedClosePrSpec,
   loadTaskActiveSpec,
+  loadTaskAnswerSpec,
+  loadTaskAskSpec,
   loadTaskListSpec,
   loadTaskNextSpec,
   loadTaskSearchSpec,
@@ -156,6 +160,8 @@ export const TASK_COMMANDS = [
     helpGroup: "Advanced",
   }),
   declareCommand(taskActiveSpec, { load: loadTaskActiveSpec }),
+  declareCommand(taskAskSpec, { load: loadTaskAskSpec }),
+  declareCommand(taskAnswerSpec, { load: loadTaskAnswerSpec }),
   declareCommand(taskListSpec, {
     load: loadTaskListSpec,
     invocation: requireCanonicalCommandInvocation(["task", "list"]),

--- a/packages/agentplane/src/cli/run-cli/command-loaders/task.ts
+++ b/packages/agentplane/src/cli/run-cli/command-loaders/task.ts
@@ -46,9 +46,7 @@ export const loadTaskActiveSpec = (deps: RunDeps) =>
     m.makeRunTaskActiveHandler(deps.getCtx),
   );
 export const loadTaskAskSpec = (deps: RunDeps) =>
-  import("../../../commands/task/ask.command.js").then((m) =>
-    m.makeRunTaskAskHandler(deps.getCtx),
-  );
+  import("../../../commands/task/ask.command.js").then((m) => m.makeRunTaskAskHandler(deps.getCtx));
 export const loadTaskAnswerSpec = (deps: RunDeps) =>
   import("../../../commands/task/answer.command.js").then((m) =>
     m.makeRunTaskAnswerHandler(deps.getCtx),

--- a/packages/agentplane/src/cli/run-cli/command-loaders/task.ts
+++ b/packages/agentplane/src/cli/run-cli/command-loaders/task.ts
@@ -45,6 +45,14 @@ export const loadTaskActiveSpec = (deps: RunDeps) =>
   import("../../../commands/task/active.command.js").then((m) =>
     m.makeRunTaskActiveHandler(deps.getCtx),
   );
+export const loadTaskAskSpec = (deps: RunDeps) =>
+  import("../../../commands/task/ask.command.js").then((m) =>
+    m.makeRunTaskAskHandler(deps.getCtx),
+  );
+export const loadTaskAnswerSpec = (deps: RunDeps) =>
+  import("../../../commands/task/answer.command.js").then((m) =>
+    m.makeRunTaskAnswerHandler(deps.getCtx),
+  );
 export const loadTaskListSpec = (deps: RunDeps) =>
   import("../../../commands/task/list.run.js").then((m) => m.makeRunTaskListHandler(deps.getCtx));
 export const loadTaskNextSpec = (deps: RunDeps) =>

--- a/packages/agentplane/src/commands/shared/route-decision-blockers.ts
+++ b/packages/agentplane/src/commands/shared/route-decision-blockers.ts
@@ -6,6 +6,7 @@ import type { RouteBlocker } from "./route-oracle.js";
 import { isTaskLocalOnlyAdvance } from "./task-local-freshness.js";
 import type { CommandContext } from "./task-backend.js";
 import { isRecord } from "../../shared/guards.js";
+import { getHumanInputState } from "../task/human-input.js";
 
 function addBlocker(blockers: RouteBlocker[], code: string, summary: string): void {
   if (blockers.some((blocker) => blocker.code === code)) return;
@@ -96,6 +97,14 @@ export async function deriveBlockers(opts: {
       }
     }
     return blockers;
+  }
+  const humanInput = getHumanInputState(opts.task);
+  if (humanInput.openQuestion) {
+    addBlocker(
+      blockers,
+      "human_input_required",
+      `waiting on user answer to: ${humanInput.openQuestion.question}`,
+    );
   }
   if (opts.task.plan_approval?.state !== "approved") {
     addBlocker(blockers, "plan_not_approved", "task plan is not approved");

--- a/packages/agentplane/src/commands/shared/route-decision-next-action.ts
+++ b/packages/agentplane/src/commands/shared/route-decision-next-action.ts
@@ -125,20 +125,20 @@ export function deriveNextAction(opts: {
       requiresApproval: false,
     };
   }
-  if (opts.task.plan_approval?.state !== "approved") {
-    return {
-      code: "approve_plan",
-      command: `agentplane task plan approve ${id} --by ORCHESTRATOR`,
-      summary: "approve the task plan before owner-scoped execution",
-      requiresApproval: true,
-    };
-  }
   const humanInput = getHumanInputState(opts.task);
   if (humanInput.openQuestion) {
     return {
       code: "answer_user_question",
       command: humanInputAnswerCommand(id),
       summary: `answer the open user question before continuing: ${humanInput.openQuestion.question}`,
+      requiresApproval: true,
+    };
+  }
+  if (opts.task.plan_approval?.state !== "approved") {
+    return {
+      code: "approve_plan",
+      command: `agentplane task plan approve ${id} --by ORCHESTRATOR`,
+      summary: "approve the task plan before owner-scoped execution",
       requiresApproval: true,
     };
   }

--- a/packages/agentplane/src/commands/shared/route-decision-next-action.ts
+++ b/packages/agentplane/src/commands/shared/route-decision-next-action.ts
@@ -6,6 +6,7 @@ import type { RouteNextAction } from "./route-decision-types.js";
 import type { RouteBlocker } from "./route-oracle.js";
 import { workStartCommand } from "./work-start-command.js";
 import { isRecord } from "../../shared/guards.js";
+import { getHumanInputState, humanInputAnswerCommand } from "../task/human-input.js";
 
 function verifiedIncludedClosureCandidate(task: TaskData): boolean {
   if (task.verification?.state !== "ok") return false;
@@ -129,6 +130,15 @@ export function deriveNextAction(opts: {
       code: "approve_plan",
       command: `agentplane task plan approve ${id} --by ORCHESTRATOR`,
       summary: "approve the task plan before owner-scoped execution",
+      requiresApproval: true,
+    };
+  }
+  const humanInput = getHumanInputState(opts.task);
+  if (humanInput.openQuestion) {
+    return {
+      code: "answer_user_question",
+      command: humanInputAnswerCommand(id),
+      summary: `answer the open user question before continuing: ${humanInput.openQuestion.question}`,
       requiresApproval: true,
     };
   }

--- a/packages/agentplane/src/commands/shared/route-decision.ts
+++ b/packages/agentplane/src/commands/shared/route-decision.ts
@@ -22,6 +22,7 @@ import { loadBackendTask, loadCommandContext, type CommandContext } from "./task
 import { buildRouteSourceConfidenceBase } from "./source-confidence.js";
 import { hasClosedPreMergeClosureMarker, parsePrMeta } from "./pr-meta.js";
 import { taskCloseAlreadyRecordedOnBase } from "../task/close-tail-state.js";
+import { humanInputAnswerCommand } from "../task/human-input.js";
 
 function isCliUsageOrIo(err: unknown): boolean {
   return err instanceof CliError && (err.code === "E_USAGE" || err.code === "E_IO");
@@ -170,6 +171,14 @@ function deriveRepairPlan(
         code: "approve_plan",
         command: `agentplane task plan approve ${id} --by ORCHESTRATOR`,
         summary: "approve the task plan before owner-scoped execution",
+        mutates: true,
+      });
+    }
+    if (blocker.code === "human_input_required") {
+      steps.push({
+        code: "answer_user_question",
+        command: humanInputAnswerCommand(id),
+        summary: "answer the open user question before continuing task execution",
         mutates: true,
       });
     }

--- a/packages/agentplane/src/commands/task/active.command.ts
+++ b/packages/agentplane/src/commands/task/active.command.ts
@@ -13,6 +13,7 @@ import {
   taskListStatusLabel,
 } from "./shared/branch-pr-list-state.js";
 import type { DependencyState } from "./shared/dependencies.js";
+import { getHumanInputState, humanInputAnswerCommand } from "./human-input.js";
 
 export type TaskActiveParsed = {
   filters: TaskListFilters;
@@ -41,6 +42,11 @@ type ActiveWorkItem = {
   };
   blocker_count: number;
   blockers: { code: string; summary: string }[];
+  human_input: {
+    waiting_on_user: boolean;
+    question: string | null;
+    answer_command: string | null;
+  };
   source_freshness: "live_local";
   rank: {
     bucket: number;
@@ -221,6 +227,13 @@ function formatActiveWorkLine(item: ActiveWorkItem): string {
     ...(item.task.priority ? [`prio=${item.task.priority}`] : []),
     `deps=${formatDependencyState(item.dependency_readiness)}`,
     `next=${item.next_action.code}`,
+    ...(item.human_input.waiting_on_user
+      ? [
+          "waiting_on_user=true",
+          `question=${JSON.stringify(item.human_input.question)}`,
+          `answer=${item.human_input.answer_command}`,
+        ]
+      : []),
     `blockers=${item.blocker_count}`,
     `source_freshness=${item.source_freshness}`,
   ];
@@ -261,6 +274,7 @@ async function buildActiveWorkItems(opts: {
       const status = taskListStatusLabel(task);
       const blockerCount = route.blockers.length;
       const priority = normalizePriority(task.priority);
+      const humanInput = getHumanInputState(task);
       return {
         task: {
           id: task.id,
@@ -278,6 +292,11 @@ async function buildActiveWorkItems(opts: {
         },
         blocker_count: blockerCount,
         blockers: route.blockers.map((blocker) => ({ ...blocker })),
+        human_input: {
+          waiting_on_user: humanInput.openQuestion !== null,
+          question: humanInput.openQuestion?.question ?? null,
+          answer_command: humanInput.openQuestion ? humanInputAnswerCommand(task.id) : null,
+        },
         source_freshness: "live_local" as const,
         rank: {
           bucket: actionRank({

--- a/packages/agentplane/src/commands/task/answer.command.ts
+++ b/packages/agentplane/src/commands/task/answer.command.ts
@@ -1,0 +1,107 @@
+import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
+import { usageError } from "../../cli/spec/errors.js";
+import { createCliEmitter, emitCommandResult } from "../../cli/output.js";
+import type { CommandContext } from "../shared/task-backend.js";
+import { applyTaskMutation } from "../shared/task-mutation.js";
+import { appendTaskEvent, normalizeTaskDocVersion, nowIso } from "./shared.js";
+import { getHumanInputState, setHumanInputState } from "./human-input.js";
+
+export type TaskAnswerParsed = {
+  taskId: string;
+  by: string;
+  body: string;
+};
+
+export const taskAnswerSpec: CommandSpec<TaskAnswerParsed> = {
+  id: ["task", "answer"],
+  group: "Task",
+  summary: "Answer and close a task user-input blocker.",
+  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
+  options: [
+    { kind: "string", name: "by", valueHint: "<USER>", description: "Answer author." },
+    { kind: "string", name: "body", valueHint: "<text>", description: "Answer body." },
+  ],
+  examples: [
+    {
+      cmd: 'agentplane task answer 202602030608-F1Q8AB --by USER --body "Use the existing REST API."',
+      why: "Close the open user-input blocker.",
+    },
+  ],
+  validateRaw: (raw) => {
+    for (const key of ["by", "body"] as const) {
+      const value = raw.opts[key];
+      if (typeof value !== "string" || value.trim() === "") {
+        throw usageError({ spec: taskAnswerSpec, message: `Missing required --${key}.` });
+      }
+    }
+  },
+  parse: (raw) => ({
+    taskId: String(raw.args["task-id"]),
+    by: String(raw.opts.by).trim(),
+    body: String(raw.opts.body).trim(),
+  }),
+};
+
+export function makeRunTaskAnswerHandler(getCtx: (cmd: string) => Promise<CommandContext>) {
+  return async (ctx: CommandCtx, parsed: TaskAnswerParsed): Promise<number> => {
+    const commandCtx = await getCtx("task answer");
+    const at = nowIso();
+    await applyTaskMutation({
+      ctx: commandCtx,
+      taskId: parsed.taskId,
+      build: (task) => {
+        const state = getHumanInputState(task);
+        const open = state.openQuestion;
+        if (!open) {
+          throw usageError({
+            spec: taskAnswerSpec,
+            message: "Task has no open user question.",
+          });
+        }
+        const nextStatus =
+          String(task.status).toUpperCase() === "BLOCKED" ? open.previousStatus : task.status;
+        const extensions = setHumanInputState(task, {
+          openQuestion: null,
+          history: [
+            ...state.history,
+            {
+              id: open.id,
+              question: open.question,
+              askedAt: open.askedAt,
+              askedBy: open.askedBy,
+              answeredAt: at,
+              answeredBy: parsed.by,
+              answer: parsed.body,
+              previousStatus: open.previousStatus,
+            },
+          ],
+        });
+        const commentBody = `User answer: ${parsed.body}`;
+        return {
+          nextTask: {
+            ...task,
+            status: nextStatus,
+            extensions,
+            comments: [...(task.comments ?? []), { author: parsed.by, body: commentBody }],
+            events: appendTaskEvent(task, {
+              type: "comment",
+              at,
+              author: parsed.by,
+              body: commentBody,
+            }),
+            doc_version: normalizeTaskDocVersion(task.doc_version),
+            doc_updated_at: at,
+            doc_updated_by: parsed.by,
+          },
+        };
+      },
+    });
+    emitCommandResult(createCliEmitter(), {
+      kind: "success",
+      action: "question-answered",
+      target: parsed.taskId,
+    });
+    return 0;
+  };
+}
+

--- a/packages/agentplane/src/commands/task/answer.command.ts
+++ b/packages/agentplane/src/commands/task/answer.command.ts
@@ -104,4 +104,3 @@ export function makeRunTaskAnswerHandler(getCtx: (cmd: string) => Promise<Comman
     return 0;
   };
 }
-

--- a/packages/agentplane/src/commands/task/ask.command.ts
+++ b/packages/agentplane/src/commands/task/ask.command.ts
@@ -116,4 +116,3 @@ export function makeRunTaskAskHandler(getCtx: (cmd: string) => Promise<CommandCo
     return 0;
   };
 }
-

--- a/packages/agentplane/src/commands/task/ask.command.ts
+++ b/packages/agentplane/src/commands/task/ask.command.ts
@@ -1,0 +1,119 @@
+import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
+import { usageError } from "../../cli/spec/errors.js";
+import { createCliEmitter, emitCommandResult } from "../../cli/output.js";
+import type { CommandContext } from "../shared/task-backend.js";
+import { applyTaskMutation } from "../shared/task-mutation.js";
+import {
+  appendTaskCommentIntent,
+  appendTaskEventIntent,
+  setTaskFieldsIntent,
+  touchTaskDocMetaIntent,
+} from "../shared/task-store.js";
+import { appendTaskEvent, normalizeTaskDocVersion, nowIso } from "./shared.js";
+import { getHumanInputState, setHumanInputState } from "./human-input.js";
+
+export type TaskAskParsed = {
+  taskId: string;
+  author: string;
+  body: string;
+};
+
+export const taskAskSpec: CommandSpec<TaskAskParsed> = {
+  id: ["task", "ask"],
+  group: "Task",
+  summary: "Record a blocking user question for a task.",
+  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
+  options: [
+    { kind: "string", name: "author", valueHint: "<ROLE>", description: "Question author." },
+    { kind: "string", name: "body", valueHint: "<text>", description: "Blocking question." },
+  ],
+  examples: [
+    {
+      cmd: 'agentplane task ask 202602030608-F1Q8AB --author CODER --body "Which API should this use?"',
+      why: "Block the task until the user answers.",
+    },
+  ],
+  validateRaw: (raw) => {
+    for (const key of ["author", "body"] as const) {
+      const value = raw.opts[key];
+      if (typeof value !== "string" || value.trim() === "") {
+        throw usageError({ spec: taskAskSpec, message: `Missing required --${key}.` });
+      }
+    }
+  },
+  parse: (raw) => ({
+    taskId: String(raw.args["task-id"]),
+    author: String(raw.opts.author).trim(),
+    body: String(raw.opts.body).trim(),
+  }),
+};
+
+export function makeRunTaskAskHandler(getCtx: (cmd: string) => Promise<CommandContext>) {
+  return async (ctx: CommandCtx, parsed: TaskAskParsed): Promise<number> => {
+    const commandCtx = await getCtx("task ask");
+    const at = nowIso();
+    await applyTaskMutation({
+      ctx: commandCtx,
+      taskId: parsed.taskId,
+      build: (task) => {
+        const state = getHumanInputState(task);
+        if (state.openQuestion) {
+          throw usageError({
+            spec: taskAskSpec,
+            message: `Task already has an open user question: ${state.openQuestion.id}`,
+          });
+        }
+        const question = {
+          id: `question-${at.replaceAll(/[^0-9]/gu, "")}`,
+          question: parsed.body,
+          askedAt: at,
+          askedBy: parsed.author,
+          previousStatus: String(task.status || "TODO"),
+        };
+        const extensions = setHumanInputState(task, {
+          openQuestion: question,
+          history: state.history,
+        });
+        const commentBody = `Question for user: ${parsed.body}`;
+        return {
+          intents: [
+            setTaskFieldsIntent({ status: "BLOCKED", extensions }),
+            appendTaskCommentIntent({ author: parsed.author, body: commentBody }),
+            appendTaskEventIntent({
+              type: "comment",
+              at,
+              author: parsed.author,
+              body: commentBody,
+            }),
+            touchTaskDocMetaIntent({
+              updatedBy: parsed.author,
+              version: normalizeTaskDocVersion(task.doc_version),
+            }),
+          ],
+          nextTask: {
+            ...task,
+            status: "BLOCKED",
+            extensions,
+            comments: [...(task.comments ?? []), { author: parsed.author, body: commentBody }],
+            events: appendTaskEvent(task, {
+              type: "comment",
+              at,
+              author: parsed.author,
+              body: commentBody,
+            }),
+            doc_version: normalizeTaskDocVersion(task.doc_version),
+            doc_updated_at: at,
+            doc_updated_by: parsed.author,
+          },
+        };
+      },
+    });
+    emitCommandResult(createCliEmitter(), {
+      kind: "success",
+      action: "question-opened",
+      target: parsed.taskId,
+    });
+    return 0;
+  };
+}
+

--- a/packages/agentplane/src/commands/task/human-input.ts
+++ b/packages/agentplane/src/commands/task/human-input.ts
@@ -91,4 +91,3 @@ export function setHumanInputState(
 export function humanInputAnswerCommand(taskId: string): string {
   return `agentplane task answer ${taskId} --by USER --body "..."`;
 }
-

--- a/packages/agentplane/src/commands/task/human-input.ts
+++ b/packages/agentplane/src/commands/task/human-input.ts
@@ -1,0 +1,94 @@
+import type { TaskData } from "../../backends/task-backend.js";
+import { isRecord } from "../../shared/guards.js";
+
+const HUMAN_INPUT_EXTENSION_KEY = "agentplane.human_input";
+
+export type HumanInputQuestion = {
+  id: string;
+  question: string;
+  askedAt: string;
+  askedBy: string;
+  previousStatus: string;
+};
+
+export type HumanInputState = {
+  openQuestion: HumanInputQuestion | null;
+  history: {
+    id: string;
+    question: string;
+    askedAt: string;
+    askedBy: string;
+    answeredAt: string;
+    answeredBy: string;
+    answer: string;
+    previousStatus: string;
+  }[];
+};
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function normalizeHistory(value: unknown): HumanInputState["history"] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => {
+      if (!isRecord(item)) return null;
+      const id = readString(item.id);
+      const question = readString(item.question);
+      const askedAt = readString(item.askedAt);
+      const askedBy = readString(item.askedBy);
+      const answeredAt = readString(item.answeredAt);
+      const answeredBy = readString(item.answeredBy);
+      const answer = readString(item.answer);
+      const previousStatus = readString(item.previousStatus);
+      if (
+        !id ||
+        !question ||
+        !askedAt ||
+        !askedBy ||
+        !answeredAt ||
+        !answeredBy ||
+        !answer ||
+        !previousStatus
+      ) {
+        return null;
+      }
+      return { id, question, askedAt, askedBy, answeredAt, answeredBy, answer, previousStatus };
+    })
+    .filter((item): item is HumanInputState["history"][number] => item !== null);
+}
+
+export function getHumanInputState(task: Pick<TaskData, "extensions">): HumanInputState {
+  const raw = isRecord(task.extensions?.[HUMAN_INPUT_EXTENSION_KEY])
+    ? task.extensions[HUMAN_INPUT_EXTENSION_KEY]
+    : null;
+  const openRaw = isRecord(raw?.openQuestion) ? raw.openQuestion : null;
+  const id = readString(openRaw?.id);
+  const question = readString(openRaw?.question);
+  const askedAt = readString(openRaw?.askedAt);
+  const askedBy = readString(openRaw?.askedBy);
+  const previousStatus = readString(openRaw?.previousStatus);
+  return {
+    openQuestion:
+      id && question && askedAt && askedBy && previousStatus
+        ? { id, question, askedAt, askedBy, previousStatus }
+        : null,
+    history: normalizeHistory(raw?.history),
+  };
+}
+
+export function setHumanInputState(
+  task: TaskData,
+  state: HumanInputState,
+): NonNullable<TaskData["extensions"]> {
+  return {
+    ...(isRecord(task.extensions) ? task.extensions : {}),
+    [HUMAN_INPUT_EXTENSION_KEY]: state,
+  };
+}
+
+export function humanInputAnswerCommand(taskId: string): string {
+  return `agentplane task answer ${taskId} --by USER --body "..."`;
+}
+

--- a/packages/agentplane/src/commands/task/human-input.ts
+++ b/packages/agentplane/src/commands/task/human-input.ts
@@ -3,7 +3,7 @@ import { isRecord } from "../../shared/guards.js";
 
 const HUMAN_INPUT_EXTENSION_KEY = "agentplane.human_input";
 
-export type HumanInputQuestion = {
+type HumanInputQuestion = {
   id: string;
   question: string;
   askedAt: string;


### PR DESCRIPTION
Task: `202606101735-15G7ZE`
Title: Add task-level human input blockers
Canonical task record: `.agentplane/tasks/202606101735-15G7ZE/README.md`

## Summary

Add task-level human input blockers

Add explicit task-scoped human input blocker support so agents can record a blocking question, ap task active surfaces waiting-on-user tasks with the exact question and answer command, and route guidance treats unresolved user input as a first-class blocker.

## Scope

- In scope: Add explicit task-scoped human input blocker support so agents can record a blocking question, ap task active surfaces waiting-on-user tasks with the exact question and answer command, and route guidance treats unresolved user input as a first-class blocker.
- Out of scope: unrelated refactors not required for "Add task-level human input blockers".

## Verification

- State: ok
- Note:

```text
Command: bunx vitest run packages/agentplane/src/cli/run-cli.core.tasks.lifecycle.test.ts
packages/agentplane/src/cli/run-cli.core.tasks.active.test.ts
packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts. Result: pass, 3 files / 19
tests. Command: bun run --filter=agentplane build. Result: pass, tsup build succeeded. Command: node
.agentplane/policy/check-routing.mjs. Result: pass, policy routing OK. Command: git diff --check.
Result: pass.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-06-10T17:38:34.588Z
- Branch: task/202606101735-15G7ZE/add-task-level-human-input-blockers
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../cli/run-cli.core.task-next-action-json.test.ts |  69 ++++++++++++
 .../src/cli/run-cli.core.tasks.active.test.ts      |  74 +++++++++++++
 .../src/cli/run-cli.core.tasks.lifecycle.test.ts   |  89 +++++++++++++++
 .../src/cli/run-cli/command-catalog/task.ts        |   6 ++
 .../src/cli/run-cli/command-loaders/task.ts        |   8 ++
 .../src/commands/shared/route-decision-blockers.ts |   9 ++
 .../commands/shared/route-decision-next-action.ts  |  10 ++
 .../src/commands/shared/route-decision.ts          |   9 ++
 .../agentplane/src/commands/task/active.command.ts |  19 ++++
 .../agentplane/src/commands/task/answer.command.ts | 107 ++++++++++++++++++
 .../agentplane/src/commands/task/ask.command.ts    | 119 +++++++++++++++++++++
 .../agentplane/src/commands/task/human-input.ts    |  94 ++++++++++++++++
 12 files changed, 613 insertions(+)
```

</details>
