### PR TITLE
Sync context policy template

### DIFF
--- a/.agentplane/policy/context.must.md
+++ b/.agentplane/policy/context.must.md
@@ -26,7 +26,7 @@ Local context means `context/wiki/**`, `context/capabilities/**`, `context/raw/*
 ap context search "<query>"
 ap context show <ref>
 ap context learn changes
-ap context learn files <path> [--run]
+ap context learn files <path> [--dry-run]
 ap context ingest --changed|--all|--index-only
 ap context reindex --include-raw
 ap context wiki lint <path>

--- a/packages/agentplane/assets/policy/context.must.md
+++ b/packages/agentplane/assets/policy/context.must.md
@@ -26,7 +26,7 @@ Local context means `context/wiki/**`, `context/capabilities/**`, `context/raw/*
 ap context search "<query>"
 ap context show <ref>
 ap context learn changes
-ap context learn files <path> [--run]
+ap context learn files <path> [--dry-run]
 ap context ingest --changed|--all|--index-only
 ap context reindex --include-raw
 ap context wiki lint <path>


### PR DESCRIPTION
## Summary
- update the packaged context policy command contract to use the current `ap context learn files <path> [--dry-run]` form

## Checks
- `rg -n "(ap|agentplane) context learn files .*--run|context learn files <path> \[--run\]" packages/agentplane/assets/policy/context.must.md`
- `bunx prettier --check packages/agentplane/assets/policy/context.must.md`
- `git diff --check`

Note: the historical Agentplane 0.6 blog post is intentionally unchanged because v0.6.0 did support `context learn files --run`. The generated builtin asset table is also intentionally unchanged because it already has unrelated drift on main.