### PR TITLE
🚧 BC11BT task: Enforce maximum-assimilation structural validators [202607021729-BC11BT]

### DIFF
--- a/.agentplane/tasks/202607021729-BC11BT/README.md
+++ b/.agentplane/tasks/202607021729-BC11BT/README.md
@@ -1,10 +1,10 @@
 ---
 id: "202607021729-BC11BT"
 title: "Enforce maximum-assimilation structural validators"
-status: "TODO"
+status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 1
+revision: 5
 origin:
   system: "manual"
 depends_on:
@@ -19,20 +19,52 @@ verify:
   - "bun test packages/agentplane/src/context/coverage-validation.test.ts packages/agentplane/src/context/maximum-assimilation-artifacts-validation.test.ts packages/agentplane/src/context/verify-task.test.ts"
   - "node .agentplane/policy/check-routing.mjs"
 plan_approval:
-  state: "pending"
-  updated_at: null
-  updated_by: null
+  state: "approved"
+  updated_at: "2026-07-02T19:16:57.371Z"
+  updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-07-02T19:25:18.567Z"
+  updated_by: "CODER"
+  note: "Verified maximum-assimilation structural validators."
   attempts: 0
-comments: []
-events: []
+quality_review:
+  state: "pass"
+  updated_at: "2026-07-02T19:25:38.094Z"
+  updated_by: "EVALUATOR"
+  note: "Quality review passed."
+  evaluated_sha: "5a0884d3658a756e8536acd53cde6e08842281a7"
+  blueprint_digest: "25e215a9317034cd61e9fe293212cae9681cb701e1ba5ede19c4027908c1a7b3"
+  evidence_refs:
+    - ".agentplane/tasks/202607021729-BC11BT/README.md"
+    - ".agentplane/tasks/202607021729-BC11BT/quality/20260702-192538094-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607021729-BC11BT/quality/20260702-192538094-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607021729-BC11BT/quality/20260702-192538094-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607021729-BC11BT/blueprint/resolved-snapshot.json"
+  findings:
+    - "No blocking findings."
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implementing maximum-assimilation structural validators in the dedicated task worktree."
+events:
+  -
+    type: "status"
+    at: "2026-07-02T19:17:35.071Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implementing maximum-assimilation structural validators in the dedicated task worktree."
+  -
+    type: "verify"
+    at: "2026-07-02T19:25:18.567Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified maximum-assimilation structural validators."
 doc_version: 3
-doc_updated_at: "2026-07-02T17:29:49.786Z"
+doc_updated_at: "2026-07-02T19:25:18.683Z"
 doc_updated_by: "CODER"
 description: "Phase 3 from the Context Maximum Assimilation PRD. Add validators for span-level coverage, entity-resolution ledger, page-creation ledger, structured topology.plan.json, wiki/graph coherence, and wiki archetypes. Wire them into context verify-task with failure fixtures for missing rows, regex-only topology, no graph refs, and incomplete span coverage."
 sections:
@@ -57,6 +89,38 @@ sections:
     5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-07-02T19:25:18.567Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified maximum-assimilation structural validators.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-02T19:17:35.071Z, excerpt_hash=sha256:29a2e116cf869f01ff5e471b1de922310a9c4272617a659ffec6ab633bb38068
+
+    Details:
+
+    Passed declared validator tests: bun test packages/agentplane/src/context/coverage-validation.test.ts packages/agentplane/src/context/maximum-assimilation-artifacts-validation.test.ts packages/agentplane/src/context/verify-task.test.ts. Passed command-level maximum-assimilation verify-task tests, eslint for touched files, format:changed, policy routing, and ap doctor. Validators now enforce span coverage, structured topology, entity-resolution/page-creation ledgers, and wiki graph coherence.
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607021729-BC11BT-enforce-maximum-assimilation-structural-validato/.agentplane/tasks/202607021729-BC11BT/blueprint/resolved-snapshot.json
+    - old_digest: 25e215a9317034cd61e9fe293212cae9681cb701e1ba5ede19c4027908c1a7b3
+    - current_digest: 25e215a9317034cd61e9fe293212cae9681cb701e1ba5ede19c4027908c1a7b3
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607021729-BC11BT
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane pr update 202607021729-BC11BT
+    - diagnostic_command: agentplane pr check 202607021729-BC11BT
+    - source_of_truth: route=task_next_action diagnostic=pr_check remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
+    - risks: pr_artifact_freshness_loop, git_hook_side_effect
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -94,6 +158,38 @@ PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLA
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-07-02T19:25:18.567Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified maximum-assimilation structural validators.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-02T19:17:35.071Z, excerpt_hash=sha256:29a2e116cf869f01ff5e471b1de922310a9c4272617a659ffec6ab633bb38068
+
+Details:
+
+Passed declared validator tests: bun test packages/agentplane/src/context/coverage-validation.test.ts packages/agentplane/src/context/maximum-assimilation-artifacts-validation.test.ts packages/agentplane/src/context/verify-task.test.ts. Passed command-level maximum-assimilation verify-task tests, eslint for touched files, format:changed, policy routing, and ap doctor. Validators now enforce span coverage, structured topology, entity-resolution/page-creation ledgers, and wiki graph coherence.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607021729-BC11BT-enforce-maximum-assimilation-structural-validato/.agentplane/tasks/202607021729-BC11BT/blueprint/resolved-snapshot.json
+- old_digest: 25e215a9317034cd61e9fe293212cae9681cb701e1ba5ede19c4027908c1a7b3
+- current_digest: 25e215a9317034cd61e9fe293212cae9681cb701e1ba5ede19c4027908c1a7b3
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607021729-BC11BT
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane pr update 202607021729-BC11BT
+- diagnostic_command: agentplane pr check 202607021729-BC11BT
+- source_of_truth: route=task_next_action diagnostic=pr_check remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
+- risks: pr_artifact_freshness_loop, git_hook_side_effect
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202607021729-BC11BT/README.md
+++ b/.agentplane/tasks/202607021729-BC11BT/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202607021729-BC11BT"
 title: "Enforce maximum-assimilation structural validators"
-status: "DOING"
+result_summary: "pre-merge closure"
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on:
@@ -44,11 +45,16 @@ quality_review:
     - ".agentplane/tasks/202607021729-BC11BT/blueprint/resolved-snapshot.json"
   findings:
     - "No blocking findings."
-commit: null
+commit:
+  hash: "65d025a74730c6b5034eaec6a61285d3ce86f668"
+  message: "🚧 BC11BT task: record PR metadata"
 comments:
   -
     author: "CODER"
     body: "Start: implementing maximum-assimilation structural validators in the dedicated task worktree."
+  -
+    author: "CODER"
+    body: "Verified: pre-merge closure packet is ready for the task PR."
 events:
   -
     type: "status"
@@ -63,8 +69,15 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified maximum-assimilation structural validators."
+  -
+    type: "status"
+    at: "2026-07-02T19:30:23.391Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-02T19:25:18.683Z"
+doc_updated_at: "2026-07-02T19:30:23.391Z"
 doc_updated_by: "CODER"
 description: "Phase 3 from the Context Maximum Assimilation PRD. Add validators for span-level coverage, entity-resolution ledger, page-creation ledger, structured topology.plan.json, wiki/graph coherence, and wiki archetypes. Wire them into context verify-task with failure fixtures for missing rows, regex-only topology, no graph refs, and incomplete span coverage."
 sections:
@@ -126,6 +139,10 @@ sections:
     - Revert task-related commit(s).
     - Re-run required checks to confirm rollback safety.
   Findings: ""
+extensions:
+  implementation_commit:
+    hash: "bea2e5d7e757cb4bce4f7ed4a2c2f316f4e3d93b"
+    message: "🚧 BC11BT task: enforce maximum-assimilation validators"
 id_source: "generated"
 ---
 ## Summary

--- a/.agentplane/tasks/202607021729-BC11BT/README.md
+++ b/.agentplane/tasks/202607021729-BC11BT/README.md
@@ -4,7 +4,7 @@ title: "Enforce maximum-assimilation structural validators"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on:
@@ -31,16 +31,16 @@ verification:
   attempts: 0
 quality_review:
   state: "pass"
-  updated_at: "2026-07-02T19:25:38.094Z"
+  updated_at: "2026-07-02T19:26:19.990Z"
   updated_by: "EVALUATOR"
   note: "Quality review passed."
-  evaluated_sha: "5a0884d3658a756e8536acd53cde6e08842281a7"
+  evaluated_sha: "bea2e5d7e757cb4bce4f7ed4a2c2f316f4e3d93b"
   blueprint_digest: "25e215a9317034cd61e9fe293212cae9681cb701e1ba5ede19c4027908c1a7b3"
   evidence_refs:
     - ".agentplane/tasks/202607021729-BC11BT/README.md"
-    - ".agentplane/tasks/202607021729-BC11BT/quality/20260702-192538094-recovery-context/quality-report.json"
-    - ".agentplane/tasks/202607021729-BC11BT/quality/20260702-192538094-recovery-context/evaluator-prompt.md"
-    - ".agentplane/tasks/202607021729-BC11BT/quality/20260702-192538094-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607021729-BC11BT/quality/20260702-192619990-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607021729-BC11BT/quality/20260702-192619990-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607021729-BC11BT/quality/20260702-192619990-recovery-context/evaluator-opinion.md"
     - ".agentplane/tasks/202607021729-BC11BT/blueprint/resolved-snapshot.json"
   findings:
     - "No blocking findings."

--- a/.agentplane/tasks/202607021729-BC11BT/README.md
+++ b/.agentplane/tasks/202607021729-BC11BT/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 7
+revision: 9
 origin:
   system: "manual"
 depends_on:
@@ -26,25 +26,28 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-07-02T19:25:18.567Z"
+  updated_at: "2026-07-02T19:36:55.250Z"
   updated_by: "CODER"
-  note: "Verified maximum-assimilation structural validators."
+  note: "Verified review fixes for maximum-assimilation validators."
   attempts: 0
 quality_review:
   state: "pass"
-  updated_at: "2026-07-02T19:26:19.990Z"
+  updated_at: "2026-07-02T19:37:05.578Z"
   updated_by: "EVALUATOR"
-  note: "Quality review passed."
-  evaluated_sha: "bea2e5d7e757cb4bce4f7ed4a2c2f316f4e3d93b"
+  note: "Review fixes verified on current HEAD: allowed output roots, topology family path boundaries, and non-text empty skeleton handling are covered by regression tests."
+  evaluated_sha: "1be5721e6efaa9b71adf04778314c280540f19ef"
   blueprint_digest: "25e215a9317034cd61e9fe293212cae9681cb701e1ba5ede19c4027908c1a7b3"
   evidence_refs:
     - ".agentplane/tasks/202607021729-BC11BT/README.md"
-    - ".agentplane/tasks/202607021729-BC11BT/quality/20260702-192619990-recovery-context/quality-report.json"
-    - ".agentplane/tasks/202607021729-BC11BT/quality/20260702-192619990-recovery-context/evaluator-prompt.md"
-    - ".agentplane/tasks/202607021729-BC11BT/quality/20260702-192619990-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607021729-BC11BT/quality/20260702-193705578-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607021729-BC11BT/quality/20260702-193705578-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607021729-BC11BT/quality/20260702-193705578-recovery-context/evaluator-opinion.md"
     - ".agentplane/tasks/202607021729-BC11BT/blueprint/resolved-snapshot.json"
+    - "packages/agentplane/src/context/verify-task-policy.test.ts"
+    - "packages/agentplane/src/context/coverage-validation.test.ts"
+    - "packages/agentplane/src/context/maximum-assimilation-artifacts-validation.test.ts"
   findings:
-    - "No blocking findings."
+    - "Passed: focused maximum-assimilation validator tests, ingest pack test, ESLint, format:changed, knip:check, policy routing, and ap doctor."
 commit:
   hash: "65d025a74730c6b5034eaec6a61285d3ce86f668"
   message: "🚧 BC11BT task: record PR metadata"
@@ -76,8 +79,14 @@ events:
     from: "DOING"
     to: "DONE"
     note: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    type: "verify"
+    at: "2026-07-02T19:36:55.250Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified review fixes for maximum-assimilation validators."
 doc_version: 3
-doc_updated_at: "2026-07-02T19:30:23.391Z"
+doc_updated_at: "2026-07-02T19:36:56.163Z"
 doc_updated_by: "CODER"
 description: "Phase 3 from the Context Maximum Assimilation PRD. Add validators for span-level coverage, entity-resolution ledger, page-creation ledger, structured topology.plan.json, wiki/graph coherence, and wiki archetypes. Wire them into context verify-task with failure fixtures for missing rows, regex-only topology, no graph refs, and incomplete span coverage."
 sections:
@@ -134,11 +143,44 @@ sections:
     - repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
     - risks: pr_artifact_freshness_loop, git_hook_side_effect
 
+    ### 2026-07-02T19:36:55.250Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified review fixes for maximum-assimilation validators.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-02T19:30:23.391Z, excerpt_hash=sha256:29a2e116cf869f01ff5e471b1de922310a9c4272617a659ffec6ab633bb38068
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607021729-BC11BT-enforce-maximum-assimilation-structural-validato/.agentplane/tasks/202607021729-BC11BT/blueprint/resolved-snapshot.json
+    - old_digest: 25e215a9317034cd61e9fe293212cae9681cb701e1ba5ede19c4027908c1a7b3
+    - current_digest: 25e215a9317034cd61e9fe293212cae9681cb701e1ba5ede19c4027908c1a7b3
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607021729-BC11BT
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane integrate queue enqueue 202607021729-BC11BT --branch task/202607021729-BC11BT/enforce-maximum-assimilation-structural-validato
+    - diagnostic_command: agentplane pr check 202607021729-BC11BT
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: true
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: git_hook_side_effect
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
     - Re-run required checks to confirm rollback safety.
-  Findings: ""
+  Findings: |-
+    - Observation: Review found missing allowed output roots, unsafe topology path-prefix matching, and empty skeleton rejection for unsupported non-text source sets.
+      Impact: Valid maximum-assimilation tasks could fail verification or let sibling wiki paths bypass topology coverage.
+      Resolution: Allowed required derived roots, preserved page-family directory boundaries, and permits existing empty skeletons only for non-span-producing source sets.
 extensions:
   implementation_commit:
     hash: "bea2e5d7e757cb4bce4f7ed4a2c2f316f4e3d93b"
@@ -207,6 +249,36 @@ DecisionContextRef:
 - repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
 - risks: pr_artifact_freshness_loop, git_hook_side_effect
 
+### 2026-07-02T19:36:55.250Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified review fixes for maximum-assimilation validators.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-02T19:30:23.391Z, excerpt_hash=sha256:29a2e116cf869f01ff5e471b1de922310a9c4272617a659ffec6ab633bb38068
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607021729-BC11BT-enforce-maximum-assimilation-structural-validato/.agentplane/tasks/202607021729-BC11BT/blueprint/resolved-snapshot.json
+- old_digest: 25e215a9317034cd61e9fe293212cae9681cb701e1ba5ede19c4027908c1a7b3
+- current_digest: 25e215a9317034cd61e9fe293212cae9681cb701e1ba5ede19c4027908c1a7b3
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607021729-BC11BT
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane integrate queue enqueue 202607021729-BC11BT --branch task/202607021729-BC11BT/enforce-maximum-assimilation-structural-validato
+- diagnostic_command: agentplane pr check 202607021729-BC11BT
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: true
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: git_hook_side_effect
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -215,3 +287,7 @@ DecisionContextRef:
 - Re-run required checks to confirm rollback safety.
 
 ## Findings
+
+- Observation: Review found missing allowed output roots, unsafe topology path-prefix matching, and empty skeleton rejection for unsupported non-text source sets.
+  Impact: Valid maximum-assimilation tasks could fail verification or let sibling wiki paths bypass topology coverage.
+  Resolution: Allowed required derived roots, preserved page-family directory boundaries, and permits existing empty skeletons only for non-span-producing source sets.

--- a/.agentplane/tasks/202607021729-BC11BT/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202607021729-BC11BT/blueprint/resolved-snapshot.json
@@ -1,0 +1,577 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607021729-BC11BT",
+    "title": "Enforce maximum-assimilation structural validators",
+    "description": "Phase 3 from the Context Maximum Assimilation PRD. Add validators for span-level coverage, entity-resolution ledger, page-creation ledger, structured topology.plan.json, wiki/graph coherence, and wiki archetypes. Wire them into context verify-task with failure fixtures for missing rows, regex-only topology, no graph refs, and incomplete span coverage.",
+    "tags": [
+      "code"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607021729-BC11BT",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "25e215a9317034cd61e9fe293212cae9681cb701e1ba5ede19c4027908c1a7b3"
+  }
+}

--- a/.agentplane/tasks/202607021729-BC11BT/pr/diffstat.txt
+++ b/.agentplane/tasks/202607021729-BC11BT/pr/diffstat.txt
@@ -1,9 +1,14 @@
- .../verify-task.maximum-assimilation.test.ts       |  97 ++++++++++
+ .../verify-task.maximum-assimilation.test.ts       |  97 +++++++++
  .../verify-task.maximum-assimilation.unit.test.ts  |  90 +++++++++
- .../src/context/coverage-validation.test.ts        | 120 ++++++++++++
- .../agentplane/src/context/coverage-validation.ts  |  68 ++++++-
- ...ximum-assimilation-artifacts-validation.test.ts | 110 +++++++++++
- .../maximum-assimilation-artifacts-validation.ts   | 214 +++++++++++++++++++++
+ .../src/context/coverage-validation.test.ts        | 199 +++++++++++++++++++
+ .../agentplane/src/context/coverage-validation.ts  |  98 ++++++++-
+ .../src/context/ingest-task-pack.test.ts           |  12 ++
+ .../agentplane/src/context/ingest-task-pack.ts     |   8 +
+ packages/agentplane/src/context/ingest-task.ts     |   4 +
+ ...ximum-assimilation-artifacts-validation.test.ts | 145 ++++++++++++++
+ .../maximum-assimilation-artifacts-validation.ts   | 218 +++++++++++++++++++++
  .../src/context/verify-task-artifacts.ts           |  82 +++++++-
+ .../src/context/verify-task-policy.test.ts         |  27 +++
+ .../agentplane/src/context/verify-task-policy.ts   |   4 +
  .../agentplane/src/context/verify-task.test.ts     |  72 +++++++
- 8 files changed, 843 insertions(+), 10 deletions(-)
+ 13 files changed, 1045 insertions(+), 11 deletions(-)

--- a/.agentplane/tasks/202607021729-BC11BT/pr/diffstat.txt
+++ b/.agentplane/tasks/202607021729-BC11BT/pr/diffstat.txt
@@ -1,0 +1,9 @@
+ .../verify-task.maximum-assimilation.test.ts       |  97 ++++++++++
+ .../verify-task.maximum-assimilation.unit.test.ts  |  90 +++++++++
+ .../src/context/coverage-validation.test.ts        | 120 ++++++++++++
+ .../agentplane/src/context/coverage-validation.ts  |  68 ++++++-
+ ...ximum-assimilation-artifacts-validation.test.ts | 110 +++++++++++
+ .../maximum-assimilation-artifacts-validation.ts   | 214 +++++++++++++++++++++
+ .../src/context/verify-task-artifacts.ts           |  82 +++++++-
+ .../agentplane/src/context/verify-task.test.ts     |  72 +++++++
+ 8 files changed, 843 insertions(+), 10 deletions(-)

--- a/.agentplane/tasks/202607021729-BC11BT/pr/github-body.md
+++ b/.agentplane/tasks/202607021729-BC11BT/pr/github-body.md
@@ -1,0 +1,41 @@
+Task: `202607021729-BC11BT`
+Title: Enforce maximum-assimilation structural validators
+Canonical task record: `.agentplane/tasks/202607021729-BC11BT/README.md`
+
+## Summary
+
+Enforce maximum-assimilation structural validators
+
+Phase 3 from the Context Maximum Assimilation PRD. Add validators for span-level coverage, entity-resolution ledger, page-creation ledger, structured topology.plan.json, wiki/graph coherence, and wiki archetypes. Wire them into context verify-task with failure fixtures for missing rows, regex-only topology, no graph refs, and incomplete span coverage.
+
+## Scope
+
+- In scope: Phase 3 from the Context Maximum Assimilation PRD. Add validators for span-level coverage, entity-resolution ledger, page-creation ledger, structured topology.plan.json, wiki/graph coherence, and wiki archetypes. Wire them into context verify-task with failure fixtures for missing rows, regex-only topology, no graph refs, and incomplete span coverage.
+- Out of scope: unrelated refactors not required for "Enforce maximum-assimilation structural validators".
+
+## Verification
+
+- State: ok
+- Note: Verified maximum-assimilation structural validators.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-02T19:17:35.140Z
+- Branch: task/202607021729-BC11BT/enforce-maximum-assimilation-structural-validato
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../verify-task.maximum-assimilation.test.ts       |  97 ++++++++++
+ .../verify-task.maximum-assimilation.unit.test.ts  |  90 +++++++++
+ .../src/context/coverage-validation.test.ts        | 120 ++++++++++++
+ .../agentplane/src/context/coverage-validation.ts  |  68 ++++++-
+ ...ximum-assimilation-artifacts-validation.test.ts | 110 +++++++++++
+ .../maximum-assimilation-artifacts-validation.ts   | 214 +++++++++++++++++++++
+ .../src/context/verify-task-artifacts.ts           |  82 +++++++-
+ .../agentplane/src/context/verify-task.test.ts     |  72 +++++++
+ 8 files changed, 843 insertions(+), 10 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202607021729-BC11BT/pr/github-body.md
+++ b/.agentplane/tasks/202607021729-BC11BT/pr/github-body.md
@@ -16,26 +16,31 @@ Phase 3 from the Context Maximum Assimilation PRD. Add validators for span-level
 ## Verification
 
 - State: ok
-- Note: Verified maximum-assimilation structural validators.
+- Note: Verified review fixes for maximum-assimilation validators.
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-02T19:17:35.140Z
+- Updated: 2026-07-02T19:28:11.515Z
 - Branch: task/202607021729-BC11BT/enforce-maximum-assimilation-structural-validato
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
- .../verify-task.maximum-assimilation.test.ts       |  97 ++++++++++
+ .../verify-task.maximum-assimilation.test.ts       |  97 +++++++++
  .../verify-task.maximum-assimilation.unit.test.ts  |  90 +++++++++
- .../src/context/coverage-validation.test.ts        | 120 ++++++++++++
- .../agentplane/src/context/coverage-validation.ts  |  68 ++++++-
- ...ximum-assimilation-artifacts-validation.test.ts | 110 +++++++++++
- .../maximum-assimilation-artifacts-validation.ts   | 214 +++++++++++++++++++++
+ .../src/context/coverage-validation.test.ts        | 199 +++++++++++++++++++
+ .../agentplane/src/context/coverage-validation.ts  |  98 ++++++++-
+ .../src/context/ingest-task-pack.test.ts           |  12 ++
+ .../agentplane/src/context/ingest-task-pack.ts     |   8 +
+ packages/agentplane/src/context/ingest-task.ts     |   4 +
+ ...ximum-assimilation-artifacts-validation.test.ts | 145 ++++++++++++++
+ .../maximum-assimilation-artifacts-validation.ts   | 218 +++++++++++++++++++++
  .../src/context/verify-task-artifacts.ts           |  82 +++++++-
+ .../src/context/verify-task-policy.test.ts         |  27 +++
+ .../agentplane/src/context/verify-task-policy.ts   |   4 +
  .../agentplane/src/context/verify-task.test.ts     |  72 +++++++
- 8 files changed, 843 insertions(+), 10 deletions(-)
+ 13 files changed, 1045 insertions(+), 11 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607021729-BC11BT/pr/github-title.txt
+++ b/.agentplane/tasks/202607021729-BC11BT/pr/github-title.txt
@@ -1,1 +1,1 @@
-🚧 BC11BT task: Enforce maximum-assimilation structural validators [202607021729-BC11BT]
+✅ BC11BT task: Enforce maximum-assimilation structural validators [202607021729-BC11BT]

--- a/.agentplane/tasks/202607021729-BC11BT/pr/github-title.txt
+++ b/.agentplane/tasks/202607021729-BC11BT/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 BC11BT task: Enforce maximum-assimilation structural validators [202607021729-BC11BT]

--- a/.agentplane/tasks/202607021729-BC11BT/pr/meta.json
+++ b/.agentplane/tasks/202607021729-BC11BT/pr/meta.json
@@ -2,9 +2,9 @@
   "base": "main",
   "branch": "task/202607021729-BC11BT/enforce-maximum-assimilation-structural-validato",
   "created_at": "2026-07-02T19:17:35.140Z",
-  "diffstat_sha256": "sha256:c6a5d945b2d4695a4336615227613eb14fecfa0e104198e1acf46ca30efac629",
-  "last_verified_at": "2026-07-02T19:25:18.567Z",
-  "last_verified_diffstat_sha256": "sha256:c6a5d945b2d4695a4336615227613eb14fecfa0e104198e1acf46ca30efac629",
+  "diffstat_sha256": "sha256:e4b99d0161cd60edf99dab718d5a07bfb9d80f3cbdc0efd0d718a08b77c8ced4",
+  "last_verified_at": "2026-07-02T19:36:55.250Z",
+  "last_verified_diffstat_sha256": "sha256:e4b99d0161cd60edf99dab718d5a07bfb9d80f3cbdc0efd0d718a08b77c8ced4",
   "pr_number": 4540,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4540",
   "pre_merge_closure": {

--- a/.agentplane/tasks/202607021729-BC11BT/pr/meta.json
+++ b/.agentplane/tasks/202607021729-BC11BT/pr/meta.json
@@ -7,6 +7,13 @@
   "last_verified_diffstat_sha256": "sha256:c6a5d945b2d4695a4336615227613eb14fecfa0e104198e1acf46ca30efac629",
   "pr_number": 4540,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4540",
+  "pre_merge_closure": {
+    "basis_commit": "65d025a74730c6b5034eaec6a61285d3ce86f668",
+    "branch": "task/202607021729-BC11BT/enforce-maximum-assimilation-structural-validato",
+    "pr_number": 4540,
+    "recorded_at": "2026-07-02T19:30:23.419Z",
+    "state": "closed_before_merge"
+  },
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202607021729-BC11BT",

--- a/.agentplane/tasks/202607021729-BC11BT/pr/meta.json
+++ b/.agentplane/tasks/202607021729-BC11BT/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202607021729-BC11BT/enforce-maximum-assimilation-structural-validato",
+  "created_at": "2026-07-02T19:17:35.140Z",
+  "diffstat_sha256": "sha256:c6a5d945b2d4695a4336615227613eb14fecfa0e104198e1acf46ca30efac629",
+  "last_verified_at": "2026-07-02T19:25:18.567Z",
+  "last_verified_diffstat_sha256": "sha256:c6a5d945b2d4695a4336615227613eb14fecfa0e104198e1acf46ca30efac629",
+  "schema_version": 1,
+  "task_id": "202607021729-BC11BT",
+  "updated_at": "2026-07-02T19:17:35.140Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202607021729-BC11BT/pr/meta.json
+++ b/.agentplane/tasks/202607021729-BC11BT/pr/meta.json
@@ -5,9 +5,12 @@
   "diffstat_sha256": "sha256:c6a5d945b2d4695a4336615227613eb14fecfa0e104198e1acf46ca30efac629",
   "last_verified_at": "2026-07-02T19:25:18.567Z",
   "last_verified_diffstat_sha256": "sha256:c6a5d945b2d4695a4336615227613eb14fecfa0e104198e1acf46ca30efac629",
+  "pr_number": 4540,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4540",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202607021729-BC11BT",
-  "updated_at": "2026-07-02T19:17:35.140Z",
+  "updated_at": "2026-07-02T19:28:11.515Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202607021729-BC11BT/pr/review.md
+++ b/.agentplane/tasks/202607021729-BC11BT/pr/review.md
@@ -1,0 +1,44 @@
+# PR Review
+
+Created: 2026-07-02T19:17:35.140Z
+
+## Task
+
+- Task: `202607021729-BC11BT`
+- Title: Enforce maximum-assimilation structural validators
+- Status: DOING
+- Branch: `task/202607021729-BC11BT/enforce-maximum-assimilation-structural-validato`
+- Canonical task record: `.agentplane/tasks/202607021729-BC11BT/README.md`
+
+## Verification
+
+- State: ok
+- Note: Verified maximum-assimilation structural validators.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-02T19:17:35.140Z
+- Branch: task/202607021729-BC11BT/enforce-maximum-assimilation-structural-validato
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../verify-task.maximum-assimilation.test.ts       |  97 ++++++++++
+ .../verify-task.maximum-assimilation.unit.test.ts  |  90 +++++++++
+ .../src/context/coverage-validation.test.ts        | 120 ++++++++++++
+ .../agentplane/src/context/coverage-validation.ts  |  68 ++++++-
+ ...ximum-assimilation-artifacts-validation.test.ts | 110 +++++++++++
+ .../maximum-assimilation-artifacts-validation.ts   | 214 +++++++++++++++++++++
+ .../src/context/verify-task-artifacts.ts           |  82 +++++++-
+ .../agentplane/src/context/verify-task.test.ts     |  72 +++++++
+ 8 files changed, 843 insertions(+), 10 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202607021729-BC11BT/pr/review.md
+++ b/.agentplane/tasks/202607021729-BC11BT/pr/review.md
@@ -6,14 +6,14 @@ Created: 2026-07-02T19:17:35.140Z
 
 - Task: `202607021729-BC11BT`
 - Title: Enforce maximum-assimilation structural validators
-- Status: DOING
+- Status: DONE
 - Branch: `task/202607021729-BC11BT/enforce-maximum-assimilation-structural-validato`
 - Canonical task record: `.agentplane/tasks/202607021729-BC11BT/README.md`
 
 ## Verification
 
 - State: ok
-- Note: Verified maximum-assimilation structural validators.
+- Note: Verified review fixes for maximum-assimilation validators.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,20 +24,25 @@ Created: 2026-07-02T19:17:35.140Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-02T19:17:35.140Z
+- Updated: 2026-07-02T19:28:11.515Z
 - Branch: task/202607021729-BC11BT/enforce-maximum-assimilation-structural-validato
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
- .../verify-task.maximum-assimilation.test.ts       |  97 ++++++++++
+ .../verify-task.maximum-assimilation.test.ts       |  97 +++++++++
  .../verify-task.maximum-assimilation.unit.test.ts  |  90 +++++++++
- .../src/context/coverage-validation.test.ts        | 120 ++++++++++++
- .../agentplane/src/context/coverage-validation.ts  |  68 ++++++-
- ...ximum-assimilation-artifacts-validation.test.ts | 110 +++++++++++
- .../maximum-assimilation-artifacts-validation.ts   | 214 +++++++++++++++++++++
+ .../src/context/coverage-validation.test.ts        | 199 +++++++++++++++++++
+ .../agentplane/src/context/coverage-validation.ts  |  98 ++++++++-
+ .../src/context/ingest-task-pack.test.ts           |  12 ++
+ .../agentplane/src/context/ingest-task-pack.ts     |   8 +
+ packages/agentplane/src/context/ingest-task.ts     |   4 +
+ ...ximum-assimilation-artifacts-validation.test.ts | 145 ++++++++++++++
+ .../maximum-assimilation-artifacts-validation.ts   | 218 +++++++++++++++++++++
  .../src/context/verify-task-artifacts.ts           |  82 +++++++-
+ .../src/context/verify-task-policy.test.ts         |  27 +++
+ .../agentplane/src/context/verify-task-policy.ts   |   4 +
  .../agentplane/src/context/verify-task.test.ts     |  72 +++++++
- 8 files changed, 843 insertions(+), 10 deletions(-)
+ 13 files changed, 1045 insertions(+), 11 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607021729-BC11BT/quality/20260702-192619990-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607021729-BC11BT/quality/20260702-192619990-recovery-context/evaluator-opinion.md
@@ -1,0 +1,18 @@
+# EVALUATOR opinion: pass
+
+Quality review passed.
+
+## Findings
+- No blocking findings.
+
+## Evidence
+- .agentplane/tasks/202607021729-BC11BT/README.md
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607021729-BC11BT/quality/20260702-192619990-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607021729-BC11BT/quality/20260702-192619990-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202607021729-BC11BT
+- task_readme: .agentplane/tasks/202607021729-BC11BT/README.md
+- report_path: .agentplane/tasks/202607021729-BC11BT/quality/20260702-192619990-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607021729-BC11BT/quality/20260702-192619990-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607021729-BC11BT/quality/20260702-192619990-recovery-context/quality-report.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "task_id": "202607021729-BC11BT",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-02T19:26:19.990Z",
+  "verdict": "pass",
+  "summary": "Quality review passed.",
+  "evaluated_sha": "bea2e5d7e757cb4bce4f7ed4a2c2f316f4e3d93b",
+  "blueprint_digest": "25e215a9317034cd61e9fe293212cae9681cb701e1ba5ede19c4027908c1a7b3",
+  "findings": [
+    "No blocking findings."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607021729-BC11BT/README.md"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/.agentplane/tasks/202607021729-BC11BT/quality/20260702-193705578-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607021729-BC11BT/quality/20260702-193705578-recovery-context/evaluator-opinion.md
@@ -1,0 +1,21 @@
+# EVALUATOR opinion: pass
+
+Review fixes verified on current HEAD: allowed output roots, topology family path boundaries, and non-text empty skeleton handling are covered by regression tests.
+
+## Findings
+- Passed: focused maximum-assimilation validator tests, ingest pack test, ESLint, format:changed, knip:check, policy routing, and ap doctor.
+
+## Evidence
+- .agentplane/tasks/202607021729-BC11BT/README.md
+- packages/agentplane/src/context/verify-task-policy.test.ts
+- packages/agentplane/src/context/coverage-validation.test.ts
+- packages/agentplane/src/context/maximum-assimilation-artifacts-validation.test.ts
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607021729-BC11BT/quality/20260702-193705578-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607021729-BC11BT/quality/20260702-193705578-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202607021729-BC11BT
+- task_readme: .agentplane/tasks/202607021729-BC11BT/README.md
+- report_path: .agentplane/tasks/202607021729-BC11BT/quality/20260702-193705578-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607021729-BC11BT/quality/20260702-193705578-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607021729-BC11BT/quality/20260702-193705578-recovery-context/quality-report.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "task_id": "202607021729-BC11BT",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-02T19:37:05.578Z",
+  "verdict": "pass",
+  "summary": "Review fixes verified on current HEAD: allowed output roots, topology family path boundaries, and non-text empty skeleton handling are covered by regression tests.",
+  "evaluated_sha": "1be5721e6efaa9b71adf04778314c280540f19ef",
+  "blueprint_digest": "25e215a9317034cd61e9fe293212cae9681cb701e1ba5ede19c4027908c1a7b3",
+  "findings": [
+    "Passed: focused maximum-assimilation validator tests, ingest pack test, ESLint, format:changed, knip:check, policy routing, and ap doctor."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607021729-BC11BT/README.md",
+    "packages/agentplane/src/context/verify-task-policy.test.ts",
+    "packages/agentplane/src/context/coverage-validation.test.ts",
+    "packages/agentplane/src/context/maximum-assimilation-artifacts-validation.test.ts"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/commands/context/verify-task.maximum-assimilation.test.ts
+++ b/packages/agentplane/src/commands/context/verify-task.maximum-assimilation.test.ts
@@ -85,6 +85,9 @@ async function writeMaximumAssimilationArtifacts(root: string, opts?: { glossary
       "epistemic_status: draft",
       "source_refs:",
       '  - "[Payment API](../../raw/specs/payment-api.md#lines=1-6)"',
+      "graph_refs:",
+      "  entities:",
+      '    - "entity.payment_api"',
       "---",
       "# Payment API",
       "",
@@ -117,11 +120,13 @@ async function writeMaximumAssimilationArtifacts(root: string, opts?: { glossary
       {
         id: "entity.payment_api",
         label: "Payment API",
+        target_path: "context/wiki/entities/payment-api.md",
         source_refs: ["context/raw/specs/payment-api.md#lines=1-3"],
       },
       {
         id: "entity.payment_workflow",
         label: "Payment Workflow",
+        no_page_reason: "Covered on the Payment API page.",
         source_refs: ["context/raw/specs/payment-api.md#L4-L6"],
       },
     ]
@@ -165,6 +170,7 @@ async function writeMaximumAssimilationArtifacts(root: string, opts?: { glossary
     JSON.stringify({
       id: "coverage.payment_api",
       source_path: "context/raw/specs/payment-api.md",
+      span_id: "span.payment-api.0001",
       coverage_status: "covered",
       reason: "Payment API semantics are represented by wiki, fact, and graph artifacts.",
       covered_item_ids: [
@@ -172,8 +178,99 @@ async function writeMaximumAssimilationArtifacts(root: string, opts?: { glossary
         "entity.payment_workflow",
         "fact.payment_api.public_source",
       ],
+      target_paths: ["context/wiki/entities/payment-api.md"],
       source_refs: ["context/raw/specs/payment-api.md#lines=1-6"],
     }) + "\n",
+  );
+  await write(
+    root,
+    ".agentplane/tasks/202605191451-CTXMAX/source-spans.skeleton.jsonl",
+    JSON.stringify({
+      span_id: "span.payment-api.0001",
+      source_path: "context/raw/specs/payment-api.md",
+      line_start: 1,
+      line_end: 6,
+      text_hash: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    }) + "\n",
+  );
+  await write(
+    root,
+    ".agentplane/context/derived/ontology/entity-resolution.jsonl",
+    [
+      {
+        id: "resolution.payment_api",
+        source_term: "Payment API",
+        resolution: "new_entity_proposal",
+        proposed_entity_id: "entity.payment_api",
+        candidate_entities_checked: [{ entity_id: "entity.payment_workflow" }],
+        why_not_existing: "Payment API is the canonical source entity.",
+        source_refs: ["context/raw/specs/payment-api.md#lines=1-3"],
+      },
+      {
+        id: "resolution.payment_workflow",
+        source_term: "Payment Workflow",
+        resolution: "new_entity_proposal",
+        proposed_entity_id: "entity.payment_workflow",
+        candidate_entities_checked: [{ entity_id: "entity.payment_api" }],
+        why_not_existing: "Payment Workflow is a separate workflow concept.",
+        source_refs: ["context/raw/specs/payment-api.md#L4-L6"],
+      },
+    ]
+      .map((row) => JSON.stringify(row))
+      .join("\n") + "\n",
+  );
+  await write(
+    root,
+    ".agentplane/context/derived/ontology/page-creation.jsonl",
+    JSON.stringify({
+      id: "page.payment-api",
+      path: "context/wiki/entities/payment-api.md",
+      page_type: "concept",
+      family_id: "family.entities",
+      canonical_entity_ids: ["entity.payment_api"],
+      decision: "create_new_page",
+      span_refs: ["span.payment-api.0001"],
+      source_refs: ["context/raw/specs/payment-api.md#lines=1-6"],
+    }) + "\n",
+  );
+  await write(
+    root,
+    ".agentplane/context/derived/wiki/topology.plan.json",
+    JSON.stringify(
+      {
+        schema_version: 1,
+        mode: "maximum_assimilation",
+        topology_version: 1,
+        generated_by_task_id: "202605191451-CTXMAX",
+        source_shape: {
+          primary: "product_docs",
+          rationale: "Payment API source is product documentation.",
+          evidence_span_ids: ["span.payment-api.0001"],
+        },
+        canonical_page_families: [
+          {
+            family_id: "family.entities",
+            path_template: "context/wiki/entities/{slug}.md",
+            page_type: "concept",
+            creation_rule: "Create pages for reusable product entities.",
+            page_vs_heading_rule: "Keep local details as headings.",
+            source_evidence_span_ids: ["span.payment-api.0001"],
+          },
+        ],
+        canonical_pages: [
+          {
+            path: "context/wiki/entities/payment-api.md",
+            page_type: "concept",
+            canonical_entity_ids: ["entity.payment_api"],
+            required_sections: ["Sources"],
+            source_evidence_span_ids: ["span.payment-api.0001"],
+          },
+        ],
+        forbidden_creation_patterns: ["one page per minor fact"],
+      },
+      null,
+      2,
+    ) + "\n",
   );
 }
 

--- a/packages/agentplane/src/commands/context/verify-task.maximum-assimilation.unit.test.ts
+++ b/packages/agentplane/src/commands/context/verify-task.maximum-assimilation.unit.test.ts
@@ -193,6 +193,7 @@ agentplane_context:
         id: "entity.payment-api",
         kind: "concept",
         label: "Payment API",
+        target_path: "context/wiki/glossary.md",
         source_refs: ["context/raw/specs/payment-api.md#L1-L10"],
         confidence: 0.9,
         status: "accepted",
@@ -200,6 +201,7 @@ agentplane_context:
         id: "entity.payment-api-doc",
         kind: "source",
         label: "Payment API source",
+        no_page_reason: "Source entity is represented by glossary provenance.",
         source_refs: ["context/raw/specs/payment-api.md#L1-L10"],
         confidence: 0.9,
         status: "accepted",
@@ -269,6 +271,7 @@ agentplane_context:
         id: "coverage.payment-api",
         summary: "Payment API source was structurally extracted.",
         source_path: "context/raw/specs/payment-api.md",
+        span_id: "span.payment-api.0001",
         coverage_status: "covered",
         reason: "Reusable fact, entity, edge, and provenance rows were extracted.",
         covered_item_ids: [
@@ -276,9 +279,96 @@ agentplane_context:
           "entity.payment-api",
           "edge.payment-api.mentions.source",
         ],
+        target_paths: ["context/wiki/glossary.md"],
         source_refs: ["context/raw/specs/payment-api.md#L1-L10"],
         confidence: 0.9,
         status: "accepted",
+      })}\n`,
+    );
+    await write(
+      root,
+      ".agentplane/tasks/202605191451-CTXGLO/source-spans.skeleton.jsonl",
+      `${JSON.stringify({
+        span_id: "span.payment-api.0001",
+        source_path: "context/raw/specs/payment-api.md",
+        line_start: 1,
+        line_end: 10,
+        text_hash: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      })}\n`,
+    );
+    await write(
+      root,
+      ".agentplane/context/derived/ontology/entity-resolution.jsonl",
+      [
+        {
+          id: "resolution.payment-api",
+          source_term: "Payment API",
+          resolution: "new_entity_proposal",
+          proposed_entity_id: "entity.payment-api",
+          candidate_entities_checked: [{ entity_id: "entity.payment-api-doc" }],
+          why_not_existing: "Payment API is the canonical concept.",
+          source_refs: ["context/raw/specs/payment-api.md#L1-L10"],
+        },
+        {
+          id: "resolution.payment-api-doc",
+          source_term: "Payment API source",
+          resolution: "new_entity_proposal",
+          proposed_entity_id: "entity.payment-api-doc",
+          candidate_entities_checked: [{ entity_id: "entity.payment-api" }],
+          why_not_existing: "Source record tracks provenance rather than the API concept.",
+          source_refs: ["context/raw/specs/payment-api.md#L1-L10"],
+        },
+      ]
+        .map((row) => JSON.stringify(row))
+        .join("\n") + "\n",
+    );
+    await write(
+      root,
+      ".agentplane/context/derived/ontology/page-creation.jsonl",
+      `${JSON.stringify({
+        id: "page.glossary-payment-api",
+        path: "context/wiki/glossary.md",
+        page_type: "reference",
+        family_id: "family.root",
+        canonical_entity_ids: ["entity.payment-api"],
+        decision: "update_existing_page",
+        span_refs: ["span.payment-api.0001"],
+        source_refs: ["context/raw/specs/payment-api.md#L1-L10"],
+      })}\n`,
+    );
+    await write(
+      root,
+      ".agentplane/context/derived/wiki/topology.plan.json",
+      `${JSON.stringify({
+        schema_version: 1,
+        mode: "maximum_assimilation",
+        topology_version: 1,
+        generated_by_task_id: "202605191451-CTXGLO",
+        source_shape: {
+          primary: "product_docs",
+          rationale: "Payment API source is product documentation.",
+          evidence_span_ids: ["span.payment-api.0001"],
+        },
+        canonical_page_families: [
+          {
+            family_id: "family.root",
+            path_template: "context/wiki/{slug}.md",
+            page_type: "reference",
+            creation_rule: "Maintain root navigation and glossary pages.",
+            page_vs_heading_rule: "Use glossary entries for simple canonical terms.",
+            source_evidence_span_ids: ["span.payment-api.0001"],
+          },
+        ],
+        canonical_pages: [
+          {
+            path: "context/wiki/glossary.md",
+            page_type: "reference",
+            canonical_entity_ids: ["entity.payment-api"],
+            required_sections: ["Glossary"],
+            source_evidence_span_ids: ["span.payment-api.0001"],
+          },
+        ],
+        forbidden_creation_patterns: ["one page per minor fact"],
       })}\n`,
     );
 

--- a/packages/agentplane/src/context/coverage-validation.test.ts
+++ b/packages/agentplane/src/context/coverage-validation.test.ts
@@ -117,4 +117,83 @@ describe("maximum-assimilation coverage validation", () => {
       ".agentplane/context/derived/reports/coverage.jsonl#coverage.conflict: conflict coverage rows must reference a contradiction record",
     );
   });
+
+  it("allows an existing empty source span skeleton for non-text source sets", async () => {
+    const root = await tempRoot();
+    await write(root, ".agentplane/tasks/202605191451-CTXMAX/source-spans.skeleton.jsonl", "");
+    await write(
+      root,
+      ".agentplane/context/derived/reports/coverage.jsonl",
+      JSON.stringify({
+        id: "coverage.binary",
+        source_path: "context/raw/screens/payment-flow.png",
+        coverage_status: "out_of_scope",
+        reason: "Binary source does not produce line-addressable text spans.",
+        source_refs: ["context/raw/screens/payment-flow.png"],
+      }) + "\n",
+    );
+
+    const errors: string[] = [];
+    await validateMaximumAssimilationCoverage(
+      root,
+      {
+        mode: "maximum_assimilation",
+        task_type: "context_assimilation",
+        source_set: {
+          files: [
+            {
+              path: "context/raw/screens/payment-flow.png",
+              status: "unsupported",
+              content_type: "image/png",
+            },
+          ],
+        },
+      },
+      errors,
+      "202605191451-CTXMAX",
+    );
+
+    expect(errors).not.toContain(
+      ".agentplane/tasks/202605191451-CTXMAX/source-spans.skeleton.jsonl: maximum-assimilation requires source span skeleton rows",
+    );
+  });
+
+  it("still rejects a missing source span skeleton", async () => {
+    const root = await tempRoot();
+    await write(
+      root,
+      ".agentplane/context/derived/reports/coverage.jsonl",
+      JSON.stringify({
+        id: "coverage.binary",
+        source_path: "context/raw/screens/payment-flow.png",
+        coverage_status: "out_of_scope",
+        reason: "Binary source does not produce line-addressable text spans.",
+        source_refs: ["context/raw/screens/payment-flow.png"],
+      }) + "\n",
+    );
+
+    const errors: string[] = [];
+    await validateMaximumAssimilationCoverage(
+      root,
+      {
+        mode: "maximum_assimilation",
+        task_type: "context_assimilation",
+        source_set: {
+          files: [
+            {
+              path: "context/raw/screens/payment-flow.png",
+              status: "unsupported",
+              content_type: "image/png",
+            },
+          ],
+        },
+      },
+      errors,
+      "202605191451-CTXMAX",
+    );
+
+    expect(errors).toContain(
+      ".agentplane/tasks/202605191451-CTXMAX/source-spans.skeleton.jsonl: maximum-assimilation requires source span skeleton rows",
+    );
+  });
 });

--- a/packages/agentplane/src/context/coverage-validation.test.ts
+++ b/packages/agentplane/src/context/coverage-validation.test.ts
@@ -1,0 +1,120 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { validateMaximumAssimilationCoverage } from "./coverage-validation.js";
+
+let tempRoots: string[] = [];
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "agentplane-coverage-validation-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  for (const root of tempRoots) await rm(root, { recursive: true, force: true });
+  tempRoots = [];
+});
+
+async function write(root: string, rel: string, text: string): Promise<void> {
+  const target = path.join(root, rel);
+  await mkdir(path.dirname(target), { recursive: true });
+  await writeFile(target, text, "utf8");
+}
+
+const context = {
+  mode: "maximum_assimilation",
+  task_type: "context_assimilation",
+  source_set: {
+    files: [{ path: "context/raw/specs/payment-api.md" }],
+  },
+};
+
+describe("maximum-assimilation coverage validation", () => {
+  it("rejects source-level-only coverage when source span skeleton has uncovered spans", async () => {
+    const root = await tempRoot();
+    await write(
+      root,
+      ".agentplane/tasks/202605191451-CTXMAX/source-spans.skeleton.jsonl",
+      [
+        { span_id: "span.payment-api.0001", source_path: "context/raw/specs/payment-api.md" },
+        { span_id: "span.payment-api.0002", source_path: "context/raw/specs/payment-api.md" },
+      ]
+        .map((row) => JSON.stringify(row))
+        .join("\n") + "\n",
+    );
+    await write(
+      root,
+      ".agentplane/context/derived/reports/coverage.jsonl",
+      JSON.stringify({
+        id: "coverage.payment-api",
+        source_path: "context/raw/specs/payment-api.md",
+        span_id: "span.payment-api.0001",
+        coverage_status: "covered",
+        reason: "First span was covered.",
+        covered_item_ids: ["fact.payment-api"],
+        target_paths: ["context/wiki/entities/payment-api.md"],
+        source_refs: ["context/raw/specs/payment-api.md#lines=1-3"],
+      }) + "\n",
+    );
+
+    const errors: string[] = [];
+    await validateMaximumAssimilationCoverage(root, context, errors, "202605191451-CTXMAX");
+
+    expect(errors).toContain(
+      ".agentplane/context/derived/reports/coverage.jsonl: missing coverage row for source span span.payment-api.0002",
+    );
+  });
+
+  it("requires target paths for covered spans and contradiction rows for conflict spans", async () => {
+    const root = await tempRoot();
+    await write(
+      root,
+      ".agentplane/tasks/202605191451-CTXMAX/source-spans.skeleton.jsonl",
+      [
+        { span_id: "span.payment-api.0001", source_path: "context/raw/specs/payment-api.md" },
+        { span_id: "span.payment-api.0002", source_path: "context/raw/specs/payment-api.md" },
+      ]
+        .map((row) => JSON.stringify(row))
+        .join("\n") + "\n",
+    );
+    await write(
+      root,
+      ".agentplane/context/derived/reports/coverage.jsonl",
+      [
+        {
+          id: "coverage.covered",
+          source_path: "context/raw/specs/payment-api.md",
+          span_id: "span.payment-api.0001",
+          coverage_status: "covered",
+          reason: "Covered but missing target path.",
+          covered_item_ids: ["fact.payment-api"],
+          source_refs: ["context/raw/specs/payment-api.md#lines=1-3"],
+        },
+        {
+          id: "coverage.conflict",
+          source_path: "context/raw/specs/payment-api.md",
+          span_id: "span.payment-api.0002",
+          coverage_status: "conflict",
+          reason: "Conflict requires contradiction row.",
+          covered_item_ids: ["contradiction.payment-api"],
+          source_refs: ["context/raw/specs/payment-api.md#lines=4-6"],
+        },
+      ]
+        .map((row) => JSON.stringify(row))
+        .join("\n") + "\n",
+    );
+
+    const errors: string[] = [];
+    await validateMaximumAssimilationCoverage(root, context, errors, "202605191451-CTXMAX");
+
+    expect(errors).toContain(
+      ".agentplane/context/derived/reports/coverage.jsonl#coverage.covered: covered coverage rows must include target_paths",
+    );
+    expect(errors).toContain(
+      ".agentplane/context/derived/reports/coverage.jsonl#coverage.conflict: conflict coverage rows must reference a contradiction record",
+    );
+  });
+});

--- a/packages/agentplane/src/context/coverage-validation.ts
+++ b/packages/agentplane/src/context/coverage-validation.ts
@@ -6,7 +6,7 @@ type ContextExtension = {
   mode?: string;
   task_type?: string;
   source_set?: {
-    files?: { path?: unknown }[];
+    files?: { path?: unknown; status?: unknown; content_type?: unknown }[];
   };
 };
 
@@ -50,6 +50,25 @@ function rowStringArray(row: Record<string, unknown>, field: string): string[] {
 function rowIds(rows: Record<string, unknown>[]): Set<string> {
   return new Set(
     rows.map((row) => (typeof row.id === "string" ? row.id.trim() : "")).filter((id) => id !== ""),
+  );
+}
+
+function sourceMayProduceSpans(file: {
+  path?: unknown;
+  status?: unknown;
+  content_type?: unknown;
+}): boolean {
+  if (file.status === "deleted" || file.status === "unsupported") return false;
+  const sourcePath = typeof file.path === "string" ? file.path.toLowerCase() : "";
+  const contentType = typeof file.content_type === "string" ? file.content_type.toLowerCase() : "";
+  return (
+    contentType.startsWith("text/") ||
+    contentType === "application/json" ||
+    sourcePath.endsWith(".jsonl") ||
+    sourcePath.endsWith(".json") ||
+    sourcePath.endsWith(".md") ||
+    sourcePath.endsWith(".mdx") ||
+    sourcePath.endsWith(".txt")
   );
 }
 
@@ -119,9 +138,18 @@ export async function validateMaximumAssimilationCoverage(
 
   if (taskId) {
     const skeletonRel = `.agentplane/tasks/${taskId}/source-spans.skeleton.jsonl`;
-    const skeletonRows = await loadJsonlRows(path.join(root, skeletonRel));
+    const skeletonPath = path.join(root, skeletonRel);
+    const skeletonExists = await fileExists(skeletonPath);
+    const skeletonRows = skeletonExists ? await loadJsonlRows(skeletonPath) : [];
     if (skeletonRows.length === 0) {
-      errors.push(`${skeletonRel}: maximum-assimilation requires source span skeleton rows`);
+      const sourceFiles = Array.isArray(context.source_set?.files) ? context.source_set.files : [];
+      const requiresSpanRows =
+        !skeletonExists ||
+        sourceFiles.length === 0 ||
+        sourceFiles.some((file) => sourceMayProduceSpans(file));
+      if (requiresSpanRows) {
+        errors.push(`${skeletonRel}: maximum-assimilation requires source span skeleton rows`);
+      }
     } else {
       const coveredSpanIds = new Set(
         rows

--- a/packages/agentplane/src/context/coverage-validation.ts
+++ b/packages/agentplane/src/context/coverage-validation.ts
@@ -41,10 +41,23 @@ async function loadJsonlRows(filePath: string): Promise<Record<string, unknown>[
   return parseJsonlLines(await readText(filePath)) as Record<string, unknown>[];
 }
 
+function rowStringArray(row: Record<string, unknown>, field: string): string[] {
+  const value = row[field];
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === "string" && entry.trim() !== "");
+}
+
+function rowIds(rows: Record<string, unknown>[]): Set<string> {
+  return new Set(
+    rows.map((row) => (typeof row.id === "string" ? row.id.trim() : "")).filter((id) => id !== ""),
+  );
+}
+
 export async function validateMaximumAssimilationCoverage(
   root: string,
   context: ContextExtension,
   errors: string[],
+  taskId?: string,
 ): Promise<void> {
   if (context.mode !== "maximum_assimilation" || isProfileSwitchContextTask(context)) return;
 
@@ -72,15 +85,60 @@ export async function validateMaximumAssimilationCoverage(
       errors.push(`${rel}#${id}: coverage row has no source_ref/source_refs`);
     }
     if (status === "covered") {
-      const coveredItemIds = Array.isArray(row.covered_item_ids) ? row.covered_item_ids : [];
-      if (
-        coveredItemIds.length === 0 ||
-        coveredItemIds.some((value) => typeof value !== "string" || !value.trim())
-      ) {
+      const coveredItemIds = rowStringArray(row, "covered_item_ids");
+      if (coveredItemIds.length === 0) {
         errors.push(`${rel}#${id}: covered coverage rows must include covered_item_ids`);
       }
+      if (rowStringArray(row, "target_paths").length === 0) {
+        errors.push(`${rel}#${id}: covered coverage rows must include target_paths`);
+      }
+    }
+    if (status === "duplicate" && typeof row.duplicate_of_span_id !== "string") {
+      errors.push(`${rel}#${id}: duplicate coverage rows must include duplicate_of_span_id`);
     }
     if (sourcePath) coveredSourcePaths.add(sourcePath);
+  }
+
+  const contradictionIds = rowIds(
+    await loadJsonlRows(path.join(root, ".agentplane/context/derived/claims/contradictions.jsonl")),
+  );
+  const openQuestionIds = rowIds(
+    await loadJsonlRows(path.join(root, ".agentplane/context/derived/claims/open_questions.jsonl")),
+  );
+  for (const row of rows) {
+    const id = typeof row.id === "string" && row.id.trim() ? row.id : "<unknown>";
+    const status = typeof row.coverage_status === "string" ? row.coverage_status.trim() : "";
+    const coveredItemIds = rowStringArray(row, "covered_item_ids");
+    if (status === "conflict" && !coveredItemIds.some((itemId) => contradictionIds.has(itemId))) {
+      errors.push(`${rel}#${id}: conflict coverage rows must reference a contradiction record`);
+    }
+    if (status === "unresolved" && !coveredItemIds.some((itemId) => openQuestionIds.has(itemId))) {
+      errors.push(`${rel}#${id}: unresolved coverage rows must reference an open_question record`);
+    }
+  }
+
+  if (taskId) {
+    const skeletonRel = `.agentplane/tasks/${taskId}/source-spans.skeleton.jsonl`;
+    const skeletonRows = await loadJsonlRows(path.join(root, skeletonRel));
+    if (skeletonRows.length === 0) {
+      errors.push(`${skeletonRel}: maximum-assimilation requires source span skeleton rows`);
+    } else {
+      const coveredSpanIds = new Set(
+        rows
+          .map((row) => (typeof row.span_id === "string" ? row.span_id.trim() : ""))
+          .filter((spanId) => spanId !== ""),
+      );
+      for (const span of skeletonRows) {
+        const spanId = typeof span.span_id === "string" ? span.span_id.trim() : "";
+        if (!spanId) {
+          errors.push(`${skeletonRel}: source span row missing span_id`);
+          continue;
+        }
+        if (!coveredSpanIds.has(spanId)) {
+          errors.push(`${rel}: missing coverage row for source span ${spanId}`);
+        }
+      }
+    }
   }
 
   const sourceFiles = Array.isArray(context.source_set?.files) ? context.source_set.files : [];

--- a/packages/agentplane/src/context/ingest-task-pack.test.ts
+++ b/packages/agentplane/src/context/ingest-task-pack.test.ts
@@ -86,8 +86,20 @@ describe("context ingest task pack", () => {
     expect(spans[0]?.span_id).toMatch(/^span\.[a-f0-9]{12}\.[a-f0-9]{12}\.1$/u);
     expect(contextPack).toContain("Generated spans: 1.");
     expect(expectedArtifacts.required).toContain(`${taskRoot}/source-spans.skeleton.jsonl`);
+    expect(expectedArtifacts.required).toEqual(
+      expect.arrayContaining([
+        ".agentplane/context/derived/ontology/entity-resolution.jsonl",
+        ".agentplane/context/derived/ontology/page-creation.jsonl",
+        ".agentplane/context/derived/sources/source-spans.jsonl",
+        ".agentplane/context/derived/wiki/topology.plan.json",
+      ]),
+    );
     expect(parsedAllowedOutputs).toEqual(
       expect.arrayContaining([
+        ".agentplane/context/derived/claims/**",
+        ".agentplane/context/derived/ontology/**",
+        ".agentplane/context/derived/sources/**",
+        ".agentplane/context/derived/wiki/**",
         ".agentplane/tasks/${taskId}/context-pack.md",
         ".agentplane/tasks/${taskId}/canonical-snapshot.json",
         ".agentplane/tasks/${taskId}/source-set.lock.json",

--- a/packages/agentplane/src/context/ingest-task-pack.ts
+++ b/packages/agentplane/src/context/ingest-task-pack.ts
@@ -37,6 +37,10 @@ function buildExpectedArtifacts(taskId: string): Record<string, unknown> {
       ".agentplane/context/derived/facts/facts.jsonl",
       ".agentplane/context/derived/graph/entities.jsonl",
       ".agentplane/context/derived/graph/edges.jsonl",
+      ".agentplane/context/derived/ontology/entity-resolution.jsonl",
+      ".agentplane/context/derived/ontology/page-creation.jsonl",
+      ".agentplane/context/derived/sources/source-spans.jsonl",
+      ".agentplane/context/derived/wiki/topology.plan.json",
       ".agentplane/context/derived/reports/coverage.jsonl",
     ],
     notes: [
@@ -107,6 +111,10 @@ export async function writeContextTaskPack(opts: {
       facts: ".agentplane/context/derived/facts/facts.jsonl",
       graph_entities: ".agentplane/context/derived/graph/entities.jsonl",
       graph_edges: ".agentplane/context/derived/graph/edges.jsonl",
+      entity_resolution: ".agentplane/context/derived/ontology/entity-resolution.jsonl",
+      page_creation: ".agentplane/context/derived/ontology/page-creation.jsonl",
+      source_spans: ".agentplane/context/derived/sources/source-spans.jsonl",
+      topology_plan: ".agentplane/context/derived/wiki/topology.plan.json",
       coverage: ".agentplane/context/derived/reports/coverage.jsonl",
     },
   });

--- a/packages/agentplane/src/context/ingest-task.ts
+++ b/packages/agentplane/src/context/ingest-task.ts
@@ -140,9 +140,13 @@ export function createTaskNewParsed(
     MAXIMUM_ASSIMILATION_BLUEPRINT;
   const allowedOutputs = [
     "context/wiki/**",
+    ".agentplane/context/derived/claims/**",
     ".agentplane/context/derived/facts/**",
     ".agentplane/context/derived/graph/**",
+    ".agentplane/context/derived/ontology/**",
     ".agentplane/context/derived/reports/**",
+    ".agentplane/context/derived/sources/**",
+    ".agentplane/context/derived/wiki/**",
     ".agentplane/tasks/${taskId}/README.md",
     ".agentplane/tasks/${taskId}/acr.json",
     ".agentplane/tasks/${taskId}/context-pack.md",

--- a/packages/agentplane/src/context/maximum-assimilation-artifacts-validation.test.ts
+++ b/packages/agentplane/src/context/maximum-assimilation-artifacts-validation.test.ts
@@ -107,4 +107,39 @@ describe("maximum-assimilation artifact validation", () => {
       "context/wiki/foo/payment-api.md: wiki page is not covered by topology plan page families",
     );
   });
+
+  it("does not treat sibling path prefixes as declared topology page families", async () => {
+    const root = await tempRoot();
+    await writeMinimalReadableArtifacts(root);
+    await write(
+      root,
+      ".agentplane/context/derived/wiki/topology.plan.json",
+      JSON.stringify({
+        schema_version: 1,
+        mode: "maximum_assimilation",
+        source_shape: {
+          primary: "product_docs",
+          rationale: "Payment API source is product documentation.",
+          evidence_span_ids: ["span.payment-api.0001"],
+        },
+        canonical_page_families: [
+          {
+            family_id: "family.entities",
+            path_template: "context/wiki/entities/{slug}.md",
+            page_type: "concept",
+            source_evidence_span_ids: ["span.payment-api.0001"],
+          },
+        ],
+      }) + "\n",
+    );
+
+    const errors = await validateMaximumAssimilationArtifacts({
+      root,
+      changedPaths: ["context/wiki/entities-extra/payment-api.md"],
+    });
+
+    expect(errors).toContain(
+      "context/wiki/entities-extra/payment-api.md: wiki page is not covered by topology plan page families",
+    );
+  });
 });

--- a/packages/agentplane/src/context/maximum-assimilation-artifacts-validation.test.ts
+++ b/packages/agentplane/src/context/maximum-assimilation-artifacts-validation.test.ts
@@ -1,0 +1,110 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { validateMaximumAssimilationArtifacts } from "./maximum-assimilation-artifacts-validation.js";
+
+let tempRoots: string[] = [];
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "agentplane-max-artifacts-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  for (const root of tempRoots) await rm(root, { recursive: true, force: true });
+  tempRoots = [];
+});
+
+async function write(root: string, rel: string, text: string): Promise<void> {
+  const target = path.join(root, rel);
+  await mkdir(path.dirname(target), { recursive: true });
+  await writeFile(target, text, "utf8");
+}
+
+async function writeMinimalReadableArtifacts(root: string): Promise<void> {
+  await write(
+    root,
+    "context/wiki/glossary.md",
+    "# Glossary\n\n- [[Payment API]]\nsource_refs: x\n",
+  );
+  await write(
+    root,
+    "context/wiki/reports/topology.md",
+    "source_shape: product_docs\ncanonical_families: entities\npage_vs_heading: pages\nsource_refs: x\n",
+  );
+  await write(
+    root,
+    "context/wiki/reports/coverage.md",
+    "coverage: covered; omitted; redacted; duplicate; unresolved; conflict; out_of_scope; source_refs: x\n",
+  );
+  await write(
+    root,
+    ".agentplane/context/derived/graph/entities.jsonl",
+    JSON.stringify({
+      id: "entity.payment_api",
+      source_refs: ["context/raw/specs/payment-api.md#lines=1-3"],
+    }) + "\n",
+  );
+  await write(
+    root,
+    ".agentplane/context/derived/graph/edges.jsonl",
+    JSON.stringify({
+      id: "edge.payment_api.workflow",
+      source_refs: ["context/raw/specs/payment-api.md#lines=1-3"],
+    }) + "\n",
+  );
+}
+
+describe("maximum-assimilation artifact validation", () => {
+  it("rejects regex-only topology prose without a structured topology plan", async () => {
+    const root = await tempRoot();
+    await writeMinimalReadableArtifacts(root);
+
+    const errors = await validateMaximumAssimilationArtifacts({ root, changedPaths: [] });
+
+    expect(errors).toContain(
+      ".agentplane/context/derived/wiki/topology.plan.json: maximum-assimilation requires a structured topology plan",
+    );
+  });
+
+  it("rejects changed wiki pages outside declared topology page families", async () => {
+    const root = await tempRoot();
+    await writeMinimalReadableArtifacts(root);
+    await write(
+      root,
+      ".agentplane/context/derived/wiki/topology.plan.json",
+      JSON.stringify({
+        schema_version: 1,
+        mode: "maximum_assimilation",
+        topology_version: 1,
+        source_shape: {
+          primary: "product_docs",
+          rationale: "Payment API source is product documentation.",
+          evidence_span_ids: ["span.payment-api.0001"],
+        },
+        canonical_page_families: [
+          {
+            family_id: "family.entities",
+            path_template: "context/wiki/entities/{slug}.md",
+            page_type: "concept",
+            creation_rule: "Create pages for reusable entities.",
+            page_vs_heading_rule: "Use headings for local details.",
+            source_evidence_span_ids: ["span.payment-api.0001"],
+          },
+        ],
+      }) + "\n",
+    );
+
+    const errors = await validateMaximumAssimilationArtifacts({
+      root,
+      changedPaths: ["context/wiki/foo/payment-api.md"],
+    });
+
+    expect(errors).toContain(
+      "context/wiki/foo/payment-api.md: wiki page is not covered by topology plan page families",
+    );
+  });
+});

--- a/packages/agentplane/src/context/maximum-assimilation-artifacts-validation.ts
+++ b/packages/agentplane/src/context/maximum-assimilation-artifacts-validation.ts
@@ -43,6 +43,217 @@ async function readExistingText(root: string, rel: string): Promise<string> {
   return (await fileExists(abs)) ? await readText(abs) : "";
 }
 
+async function readJsonFile(root: string, rel: string): Promise<Record<string, unknown> | null> {
+  const abs = path.join(root, rel);
+  if (!(await fileExists(abs))) return null;
+  try {
+    const parsed = JSON.parse(await readText(abs)) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function stringField(row: Record<string, unknown>, field: string): string {
+  const value = row[field];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function stringArray(row: Record<string, unknown>, field: string): string[] {
+  const value = row[field];
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === "string" && entry.trim() !== "");
+}
+
+function hasRecordArray(row: Record<string, unknown>, field: string): boolean {
+  const value = row[field];
+  return Array.isArray(value) && value.some((entry) => entry && typeof entry === "object");
+}
+
+function pathTemplatePrefix(pathTemplate: string): string {
+  const marker = pathTemplate.indexOf("{");
+  const prefix = marker === -1 ? pathTemplate : pathTemplate.slice(0, marker);
+  return toPosix(prefix).replace(/\/?$/u, "");
+}
+
+function pageFamilyAllowsPath(family: Record<string, unknown>, rel: string): boolean {
+  const pathTemplate = stringField(family, "path_template");
+  const prefix = pathTemplatePrefix(pathTemplate);
+  return prefix !== "" && rel.startsWith(prefix);
+}
+
+function isExemptWikiPage(rel: string): boolean {
+  return (
+    rel === "context/wiki/index.md" ||
+    rel === "context/wiki/glossary.md" ||
+    rel.includes("/reports/") ||
+    rel.includes("/maps/")
+  );
+}
+
+async function validateEntityResolution(root: string, errors: string[]): Promise<void> {
+  const rel = ".agentplane/context/derived/ontology/entity-resolution.jsonl";
+  const rows = await loadJsonlRows(path.join(root, rel));
+  if (rows.length === 0) {
+    errors.push(`${rel}: maximum-assimilation requires entity-resolution rows`);
+    return;
+  }
+  const resolvedEntityIds = new Set<string>();
+  for (const row of rows) {
+    const id = stringField(row, "id") || "<unknown>";
+    const resolution = stringField(row, "resolution");
+    const sourceTerm = stringField(row, "source_term");
+    const canonicalEntityId = stringField(row, "canonical_entity_id");
+    const proposedEntityId = stringField(row, "proposed_entity_id");
+    if (!sourceTerm) errors.push(`${rel}#${id}: entity-resolution row missing source_term`);
+    if (!resolution) errors.push(`${rel}#${id}: entity-resolution row missing resolution`);
+    if (rowSourceRefs(row).length === 0) {
+      errors.push(`${rel}#${id}: entity-resolution row has no source_ref/source_refs`);
+    }
+    if (resolution === "new_entity_proposal") {
+      if (!proposedEntityId) {
+        errors.push(`${rel}#${id}: new_entity_proposal requires proposed_entity_id`);
+      }
+      if (!hasRecordArray(row, "candidate_entities_checked")) {
+        errors.push(`${rel}#${id}: new_entity_proposal requires candidate_entities_checked`);
+      }
+      if (!stringField(row, "why_not_existing") && !stringField(row, "why_not_alias_of_existing")) {
+        errors.push(`${rel}#${id}: new_entity_proposal requires why_not_existing`);
+      }
+    }
+    if (canonicalEntityId) resolvedEntityIds.add(canonicalEntityId);
+    if (proposedEntityId) resolvedEntityIds.add(proposedEntityId);
+  }
+
+  for (const row of await loadJsonlRows(
+    path.join(root, ".agentplane/context/derived/graph/entities.jsonl"),
+  )) {
+    const entityId = stringField(row, "id");
+    if (entityId && !resolvedEntityIds.has(entityId)) {
+      errors.push(`${rel}: missing entity-resolution row for graph entity ${entityId}`);
+    }
+  }
+
+  const aliasTargets = new Map<string, Set<string>>();
+  for (const row of await loadJsonlRows(
+    path.join(root, ".agentplane/context/derived/ontology/aliases.jsonl"),
+  )) {
+    const alias = stringField(row, "alias").toLowerCase();
+    const canonicalEntityId = stringField(row, "canonical_entity_id");
+    if (!alias || !canonicalEntityId) continue;
+    const targets = aliasTargets.get(alias) ?? new Set<string>();
+    targets.add(canonicalEntityId);
+    aliasTargets.set(alias, targets);
+  }
+  for (const [alias, targets] of aliasTargets) {
+    if (targets.size > 1) {
+      errors.push(`${rel}: alias ${alias} points to multiple canonical entities`);
+    }
+  }
+}
+
+async function validateTopologyPlan(
+  root: string,
+  changedPaths: string[],
+  errors: string[],
+): Promise<void> {
+  const rel = ".agentplane/context/derived/wiki/topology.plan.json";
+  const plan = await readJsonFile(root, rel);
+  if (!plan) {
+    errors.push(`${rel}: maximum-assimilation requires a structured topology plan`);
+    return;
+  }
+  if (plan.schema_version !== 1) errors.push(`${rel}: topology plan schema_version must be 1`);
+  if (plan.mode !== "maximum_assimilation") {
+    errors.push(`${rel}: topology plan mode must be maximum_assimilation`);
+  }
+  const sourceShape = plan.source_shape;
+  if (!sourceShape || typeof sourceShape !== "object" || Array.isArray(sourceShape)) {
+    errors.push(`${rel}: topology plan missing source_shape`);
+  } else {
+    const shape = sourceShape as Record<string, unknown>;
+    if (!stringField(shape, "primary")) errors.push(`${rel}: source_shape.primary is required`);
+    if (!stringField(shape, "rationale")) errors.push(`${rel}: source_shape.rationale is required`);
+    if (stringArray(shape, "evidence_span_ids").length === 0) {
+      errors.push(`${rel}: source_shape.evidence_span_ids is required`);
+    }
+  }
+  const families = Array.isArray(plan.canonical_page_families)
+    ? plan.canonical_page_families.filter(
+        (entry): entry is Record<string, unknown> =>
+          Boolean(entry) && typeof entry === "object" && !Array.isArray(entry),
+      )
+    : [];
+  if (families.length === 0) errors.push(`${rel}: canonical_page_families is required`);
+  for (const family of families) {
+    const familyId = stringField(family, "family_id") || "<unknown>";
+    if (!stringField(family, "path_template")) {
+      errors.push(`${rel}#${familyId}: page family requires path_template`);
+    }
+    if (!stringField(family, "page_type")) {
+      errors.push(`${rel}#${familyId}: page family requires page_type`);
+    }
+    if (stringArray(family, "source_evidence_span_ids").length === 0) {
+      errors.push(`${rel}#${familyId}: page family requires source_evidence_span_ids`);
+    }
+  }
+
+  const changedWikiPages = changedPaths.filter(
+    (changed) =>
+      changed.startsWith("context/wiki/") &&
+      (changed.endsWith(".md") || changed.endsWith(".mdx")) &&
+      !isExemptWikiPage(changed),
+  );
+  for (const changed of changedWikiPages) {
+    if (!families.some((family) => pageFamilyAllowsPath(family, changed))) {
+      errors.push(`${changed}: wiki page is not covered by topology plan page families`);
+    }
+  }
+}
+
+async function validatePageCreation(
+  root: string,
+  changedPaths: string[],
+  errors: string[],
+): Promise<void> {
+  const rel = ".agentplane/context/derived/ontology/page-creation.jsonl";
+  const rows = await loadJsonlRows(path.join(root, rel));
+  if (rows.length === 0) {
+    errors.push(`${rel}: maximum-assimilation requires page-creation rows`);
+    return;
+  }
+  const pageRows = new Map<string, Record<string, unknown>>();
+  for (const row of rows) {
+    const id = stringField(row, "id") || "<unknown>";
+    const pagePath = stringField(row, "path") || stringField(row, "target_path");
+    if (!pagePath) errors.push(`${rel}#${id}: page-creation row missing path`);
+    if (!stringField(row, "page_type"))
+      errors.push(`${rel}#${id}: page-creation row missing page_type`);
+    if (!stringField(row, "family_id"))
+      errors.push(`${rel}#${id}: page-creation row missing family_id`);
+    if (rowSourceRefs(row).length === 0) {
+      errors.push(`${rel}#${id}: page-creation row has no source_ref/source_refs`);
+    }
+    if (stringArray(row, "span_refs").length === 0) {
+      errors.push(`${rel}#${id}: page-creation row requires span_refs`);
+    }
+    if (pagePath) pageRows.set(pagePath, row);
+  }
+  const changedWikiPages = changedPaths.filter(
+    (changed) =>
+      changed.startsWith("context/wiki/") &&
+      (changed.endsWith(".md") || changed.endsWith(".mdx")) &&
+      !isExemptWikiPage(changed),
+  );
+  for (const changed of changedWikiPages) {
+    if (!pageRows.has(changed)) {
+      errors.push(`${changed}: new or changed wiki page requires page-creation row`);
+    }
+  }
+}
+
 export async function validateMaximumAssimilationArtifacts(opts: {
   root: string;
   changedPaths: string[];
@@ -97,6 +308,9 @@ export async function validateMaximumAssimilationArtifacts(opts: {
       "maximum-assimilation requires a source-shaped topology artifact with source_shape, canonical_families, page-vs-heading granularity, and source refs",
     );
   }
+  await validateTopologyPlan(opts.root, opts.changedPaths, errors);
+  await validateEntityResolution(opts.root, errors);
+  await validatePageCreation(opts.root, opts.changedPaths, errors);
 
   const coverageTexts = await Promise.all(
     [

--- a/packages/agentplane/src/context/maximum-assimilation-artifacts-validation.ts
+++ b/packages/agentplane/src/context/maximum-assimilation-artifacts-validation.ts
@@ -75,13 +75,17 @@ function hasRecordArray(row: Record<string, unknown>, field: string): boolean {
 function pathTemplatePrefix(pathTemplate: string): string {
   const marker = pathTemplate.indexOf("{");
   const prefix = marker === -1 ? pathTemplate : pathTemplate.slice(0, marker);
-  return toPosix(prefix).replace(/\/?$/u, "");
+  return toPosix(prefix);
 }
 
 function pageFamilyAllowsPath(family: Record<string, unknown>, rel: string): boolean {
   const pathTemplate = stringField(family, "path_template");
   const prefix = pathTemplatePrefix(pathTemplate);
-  return prefix !== "" && rel.startsWith(prefix);
+  if (prefix === "") return false;
+  if (!pathTemplate.includes("{"))
+    return rel === prefix || rel.startsWith(`${prefix.replace(/\/+$/u, "")}/`);
+  if (prefix.endsWith("/")) return rel.startsWith(prefix);
+  return rel === prefix || rel.startsWith(`${prefix}/`);
 }
 
 function isExemptWikiPage(rel: string): boolean {

--- a/packages/agentplane/src/context/verify-task-artifacts.ts
+++ b/packages/agentplane/src/context/verify-task-artifacts.ts
@@ -125,12 +125,40 @@ function hasNonEmptyGraphRefs(text: string): boolean {
   const frontmatter = frontmatterMatch?.[1] ?? "";
   if (!frontmatter) return false;
   const parsed = parseYaml(frontmatter) as unknown;
-  if (!isRecord(parsed) || !isRecord(parsed.agentplane_context)) return false;
-  const graphRefs = parsed.agentplane_context.graph_refs;
+  if (!isRecord(parsed)) return false;
+  const graphRefs = isRecord(parsed.agentplane_context)
+    ? parsed.agentplane_context.graph_refs
+    : parsed.graph_refs;
   if (!isRecord(graphRefs)) return false;
   return (
     (Array.isArray(graphRefs.entities) && graphRefs.entities.length > 0) ||
     (Array.isArray(graphRefs.edges) && graphRefs.edges.length > 0)
+  );
+}
+
+function wikiFrontmatterRecord(text: string): Record<string, unknown> | null {
+  const frontmatterMatch = /^---\n([\s\S]*?)\n---/u.exec(text.replaceAll("\r\n", "\n"));
+  const frontmatter = frontmatterMatch?.[1] ?? "";
+  if (!frontmatter) return null;
+  const parsed = parseYaml(frontmatter) as unknown;
+  return isRecord(parsed) ? parsed : null;
+}
+
+function hasNoGraphRefReason(text: string): boolean {
+  const frontmatter = wikiFrontmatterRecord(text);
+  if (!frontmatter) return false;
+  const reason = isRecord(frontmatter.agentplane_context)
+    ? frontmatter.agentplane_context.no_graph_ref_reason
+    : frontmatter.no_graph_ref_reason;
+  return typeof reason === "string" && reason.trim() !== "";
+}
+
+function isGraphRefExemptWikiPage(rel: string): boolean {
+  return (
+    rel === "context/wiki/index.md" ||
+    rel === "context/wiki/glossary.md" ||
+    rel.includes("/reports/") ||
+    rel.includes("/maps/")
   );
 }
 
@@ -179,10 +207,54 @@ async function validateMaximumAssimilationDerivedConsistency(
   }
   await walk(wikiRoot);
   let pagesWithGraphRefs = 0;
+  let pagesRequiringGraphRefs = 0;
   for (const page of wikiPages) {
-    if (hasNonEmptyGraphRefs(await readText(page))) pagesWithGraphRefs += 1;
+    const rel = toPosix(path.relative(root, page));
+    const text = await readText(page);
+    const isExempt = isGraphRefExemptWikiPage(rel);
+    if (!isExempt) pagesRequiringGraphRefs += 1;
+    if (hasNonEmptyGraphRefs(text)) {
+      pagesWithGraphRefs += 1;
+      continue;
+    }
+    if (!isExempt && !hasNoGraphRefReason(text)) {
+      errors.push(
+        `${rel}: maximum-assimilation wiki pages require graph_refs or no_graph_ref_reason`,
+      );
+    }
   }
-  if (pagesWithGraphRefs === 0) return;
+  if (pagesRequiringGraphRefs > 0 && pagesWithGraphRefs === 0) {
+    errors.push("maximum-assimilation requires at least one wiki page with graph_refs");
+  }
+
+  const openQuestionRows = await loadJsonlRows(
+    path.join(root, ".agentplane/context/derived/claims/open_questions.jsonl"),
+  );
+  const openQuestionRefs = new Set<string>();
+  for (const row of openQuestionRows) {
+    for (const ref of [
+      ...rowSourceRefs(row),
+      ...String(row.summary ?? "")
+        .split(/\s+/u)
+        .filter(Boolean),
+    ]) {
+      openQuestionRefs.add(ref);
+    }
+  }
+  for (const row of entities) {
+    const id = String(row.id ?? "");
+    if (!id) continue;
+    const status = typeof row.status === "string" ? row.status : "active";
+    if (status !== "active" && status !== "accepted") continue;
+    const hasPage = typeof row.target_path === "string" && row.target_path.trim() !== "";
+    const hasNoPageReason =
+      typeof row.no_page_reason === "string" && row.no_page_reason.trim() !== "";
+    if (!hasPage && !hasNoPageReason && !openQuestionRefs.has(id)) {
+      errors.push(
+        `.agentplane/context/derived/graph/entities.jsonl#${id}: active entity requires target_path, no_page_reason, or open question`,
+      );
+    }
+  }
 }
 
 async function validateCapabilityArtifact(filePath: string, errors: string[]): Promise<void> {
@@ -291,7 +363,7 @@ export async function validateContextArtifacts(opts: {
     await validateMaximumAssimilationGlossary(opts.root, errors);
   }
   await validateGraph(opts.root, errors);
-  await validateMaximumAssimilationCoverage(opts.root, opts.context, errors);
+  await validateMaximumAssimilationCoverage(opts.root, opts.context, errors, opts.task.id);
   await validateMaximumAssimilationDerivedConsistency(opts.root, opts.context, errors);
   if (
     isMaximumAssimilationTask(opts.task, opts.context) &&

--- a/packages/agentplane/src/context/verify-task-policy.test.ts
+++ b/packages/agentplane/src/context/verify-task-policy.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { isTaskPathMatch, readAllowed } from "./verify-task-policy.js";
+
+describe("context verify-task policy", () => {
+  it("allows maximum-assimilation derived roots required by structural validators", () => {
+    const taskId = "202605191451-CTXMAX";
+    const allowed = readAllowed({ mode: "maximum_assimilation" }, taskId);
+
+    expect(
+      isTaskPathMatch(".agentplane/context/derived/claims/decisions.jsonl", allowed, taskId),
+    ).toBe(true);
+    expect(
+      isTaskPathMatch(
+        ".agentplane/context/derived/ontology/entity-resolution.jsonl",
+        allowed,
+        taskId,
+      ),
+    ).toBe(true);
+    expect(
+      isTaskPathMatch(".agentplane/context/derived/sources/source-spans.jsonl", allowed, taskId),
+    ).toBe(true);
+    expect(
+      isTaskPathMatch(".agentplane/context/derived/wiki/topology.plan.json", allowed, taskId),
+    ).toBe(true);
+  });
+});

--- a/packages/agentplane/src/context/verify-task-policy.ts
+++ b/packages/agentplane/src/context/verify-task-policy.ts
@@ -42,10 +42,14 @@ export type VerificationInput = {
 
 const DEFAULT_ALLOWED = [
   "context/wiki/",
+  ".agentplane/context/derived/claims/",
   ".agentplane/context/derived/facts/facts.jsonl",
   ".agentplane/context/derived/graph/entities.jsonl",
   ".agentplane/context/derived/graph/edges.jsonl",
   ".agentplane/context/derived/graph/provenance_edges.jsonl",
+  ".agentplane/context/derived/ontology/",
+  ".agentplane/context/derived/sources/",
+  ".agentplane/context/derived/wiki/",
   ".agentplane/context/derived/capabilities/capabilities.jsonl",
   ".agentplane/context/derived/reports/assimilation-events.jsonl",
   ".agentplane/context/derived/reports/coverage.jsonl",

--- a/packages/agentplane/src/context/verify-task.test.ts
+++ b/packages/agentplane/src/context/verify-task.test.ts
@@ -1,0 +1,72 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { validateContextArtifacts } from "./verify-task-artifacts.js";
+
+let tempRoots: string[] = [];
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "agentplane-verify-task-artifacts-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  for (const root of tempRoots) await rm(root, { recursive: true, force: true });
+  tempRoots = [];
+});
+
+async function write(root: string, rel: string, text: string): Promise<void> {
+  const target = path.join(root, rel);
+  await mkdir(path.dirname(target), { recursive: true });
+  await writeFile(target, text, "utf8");
+}
+
+describe("context verify-task artifact gates", () => {
+  it("requires graph refs or an explicit no-graph reason on maximum-assimilation wiki pages", async () => {
+    const root = await tempRoot();
+    await write(
+      root,
+      "context/wiki/entities/payment-api.md",
+      [
+        "---",
+        "agentplane_context:",
+        "  source_refs:",
+        "    - context/raw/specs/payment-api.md#lines=1-3",
+        "---",
+        "# Payment API",
+        "",
+        "The [[Payment API]] is documented.",
+      ].join("\n"),
+    );
+
+    const errors = await validateContextArtifacts({
+      root,
+      task: {
+        id: "202605191451-CTXMAX",
+        status: "DOING",
+        task_kind: "context",
+        blueprint_request: "context.maximum_assimilation",
+      },
+      context: {
+        task_type: "context_assimilation",
+        mode: "maximum_assimilation",
+        source_set: {
+          files: [
+            {
+              path: "context/raw/specs/payment-api.md",
+              sha256: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+            },
+          ],
+        },
+      },
+      changedPaths: ["context/wiki/entities/payment-api.md"],
+    });
+
+    expect(errors).toContain(
+      "context/wiki/entities/payment-api.md: maximum-assimilation wiki pages require graph_refs or no_graph_ref_reason",
+    );
+  });
+});


### PR DESCRIPTION
Task: `202607021729-BC11BT`
Title: Enforce maximum-assimilation structural validators
Canonical task record: `.agentplane/tasks/202607021729-BC11BT/README.md`

## Summary

Enforce maximum-assimilation structural validators

Phase 3 from the Context Maximum Assimilation PRD. Add validators for span-level coverage, entity-resolution ledger, page-creation ledger, structured topology.plan.json, wiki/graph coherence, and wiki archetypes. Wire them into context verify-task with failure fixtures for missing rows, regex-only topology, no graph refs, and incomplete span coverage.

## Scope

- In scope: Phase 3 from the Context Maximum Assimilation PRD. Add validators for span-level coverage, entity-resolution ledger, page-creation ledger, structured topology.plan.json, wiki/graph coherence, and wiki archetypes. Wire them into context verify-task with failure fixtures for missing rows, regex-only topology, no graph refs, and incomplete span coverage.
- Out of scope: unrelated refactors not required for "Enforce maximum-assimilation structural validators".

## Verification

- State: ok
- Note: Verified maximum-assimilation structural validators.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-07-02T19:17:35.140Z
- Branch: task/202607021729-BC11BT/enforce-maximum-assimilation-structural-validato
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../verify-task.maximum-assimilation.test.ts       |  97 ++++++++++
 .../verify-task.maximum-assimilation.unit.test.ts  |  90 +++++++++
 .../src/context/coverage-validation.test.ts        | 120 ++++++++++++
 .../agentplane/src/context/coverage-validation.ts  |  68 ++++++-
 ...ximum-assimilation-artifacts-validation.test.ts | 110 +++++++++++
 .../maximum-assimilation-artifacts-validation.ts   | 214 +++++++++++++++++++++
 .../src/context/verify-task-artifacts.ts           |  82 +++++++-
 .../agentplane/src/context/verify-task.test.ts     |  72 +++++++
 8 files changed, 843 insertions(+), 10 deletions(-)
```

</details>
