### PR TITLE
Add extraction quality signals for context assimilation

### DIFF
--- a/.agentplane/tasks/202607031338-KHMQAV/README.md
+++ b/.agentplane/tasks/202607031338-KHMQAV/README.md
@@ -4,7 +4,7 @@ title: "Add extraction quality signals for context assimilation"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -23,6 +23,25 @@ verification:
   updated_by: "CODER"
   note: "Extraction quality report implemented and focused context checks passed."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-07-03T13:47:01.144Z"
+  updated_by: "EVALUATOR"
+  note: "Quality review passed."
+  evaluated_sha: "8d8786ca0d310ed76ef7154ce4c17b70b46baac0"
+  blueprint_digest: "9e9c51bde24185e0555b669e64d7e290bbf443efe95ba5e5778309a42586cb93"
+  evidence_refs:
+    - ".agentplane/tasks/202607031338-KHMQAV/README.md"
+    - ".agentplane/tasks/202607031338-KHMQAV/quality/20260703-134701144-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607031338-KHMQAV/quality/20260703-134701144-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607031338-KHMQAV/quality/20260703-134701144-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607031338-KHMQAV/blueprint/resolved-snapshot.json"
+    - "packages/agentplane/src/context/extraction-writer.ts"
+    - "packages/agentplane/src/commands/context/extraction-apply.unit.test.ts"
+    - "bunx vitest run packages/agentplane/src/commands/context/extraction-apply.unit.test.ts packages/agentplane/src/context/extraction-writer.test.ts packages/agentplane/src/context/coverage-validation.test.ts packages/agentplane/src/commands/context/wiki-reports.unit.test.ts"
+    - "bun run typecheck"
+  findings:
+    - "No blocking findings."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202607031338-KHMQAV/README.md
+++ b/.agentplane/tasks/202607031338-KHMQAV/README.md
@@ -4,7 +4,7 @@ title: "Add extraction quality signals for context assimilation"
 status: "DOING"
 priority: "med"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -25,21 +25,21 @@ verification:
   attempts: 0
 quality_review:
   state: "pass"
-  updated_at: "2026-07-03T13:47:01.144Z"
+  updated_at: "2026-07-03T13:56:40.537Z"
   updated_by: "EVALUATOR"
-  note: "Quality review passed."
-  evaluated_sha: "8d8786ca0d310ed76ef7154ce4c17b70b46baac0"
+  note: "Quality review passed after lint fix."
+  evaluated_sha: "c71e2c60c805700429defa41df056a0351227de8"
   blueprint_digest: "9e9c51bde24185e0555b669e64d7e290bbf443efe95ba5e5778309a42586cb93"
   evidence_refs:
     - ".agentplane/tasks/202607031338-KHMQAV/README.md"
-    - ".agentplane/tasks/202607031338-KHMQAV/quality/20260703-134701144-recovery-context/quality-report.json"
-    - ".agentplane/tasks/202607031338-KHMQAV/quality/20260703-134701144-recovery-context/evaluator-prompt.md"
-    - ".agentplane/tasks/202607031338-KHMQAV/quality/20260703-134701144-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607031338-KHMQAV/quality/20260703-135640537-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607031338-KHMQAV/quality/20260703-135640537-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607031338-KHMQAV/quality/20260703-135640537-recovery-context/evaluator-opinion.md"
     - ".agentplane/tasks/202607031338-KHMQAV/blueprint/resolved-snapshot.json"
     - "packages/agentplane/src/context/extraction-writer.ts"
     - "packages/agentplane/src/commands/context/extraction-apply.unit.test.ts"
-    - "bunx vitest run packages/agentplane/src/commands/context/extraction-apply.unit.test.ts packages/agentplane/src/context/extraction-writer.test.ts packages/agentplane/src/context/coverage-validation.test.ts packages/agentplane/src/commands/context/wiki-reports.unit.test.ts"
-    - "bun run typecheck"
+    - "bunx eslint packages/agentplane/src/commands/context/extraction-apply.unit.test.ts packages/agentplane/src/commands/context/extraction.ts packages/agentplane/src/context/extraction-writer.ts"
+    - "bunx vitest run packages/agentplane/src/commands/context/extraction-apply.unit.test.ts"
   findings:
     - "No blocking findings."
 commit: null

--- a/.agentplane/tasks/202607031338-KHMQAV/README.md
+++ b/.agentplane/tasks/202607031338-KHMQAV/README.md
@@ -1,0 +1,185 @@
+---
+id: "202607031338-KHMQAV"
+title: "Add extraction quality signals for context assimilation"
+status: "DOING"
+priority: "med"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "context"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-07-03T13:38:25.266Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "ok"
+  updated_at: "2026-07-03T13:46:24.366Z"
+  updated_by: "CODER"
+  note: "Extraction quality report implemented and focused context checks passed."
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement extraction quality signals in the existing context extraction apply flow with focused unit coverage."
+events:
+  -
+    type: "status"
+    at: "2026-07-03T13:38:55.767Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement extraction quality signals in the existing context extraction apply flow with focused unit coverage."
+  -
+    type: "verify"
+    at: "2026-07-03T13:46:24.366Z"
+    author: "CODER"
+    state: "ok"
+    note: "Extraction quality report implemented and focused context checks passed."
+doc_version: 3
+doc_updated_at: "2026-07-03T13:46:24.880Z"
+doc_updated_by: "CODER"
+description: "Add a derived extraction quality report that flags over-fragmentation, unsupported summaries, and risky normalization before wiki publication."
+sections:
+  Summary: |-
+    Add extraction quality signals for context assimilation
+
+    Add a derived extraction quality report that flags over-fragmentation, unsupported summaries, and risky normalization before wiki publication.
+  Scope: |-
+    - In scope: Add a derived extraction quality report that flags over-fragmentation, unsupported summaries, and risky normalization before wiki publication.
+    - Out of scope: unrelated refactors not required for "Add extraction quality signals for context assimilation".
+  Plan: |-
+    1. Inspect context extraction apply artifact flow and existing tests.
+    2. Add an extraction quality report under .agentplane/context/derived/reports that flags over-fragmentation, unsupported summaries, and risky normalization from existing extracted rows.
+    3. Add focused unit coverage for the new report and ensure existing extraction apply tests still pass.
+    4. Run focused context tests, typecheck/routing checks, record verification, publish PR, and integrate into main.
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-07-03T13:46:24.366Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Extraction quality report implemented and focused context checks passed.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-03T13:38:55.767Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    Command: bun run format:changed; Result: pass; Evidence: all changed files use Prettier style. Scope: extraction writer, extraction command, extraction apply test.
+    Command: bunx vitest run packages/agentplane/src/commands/context/extraction-apply.unit.test.ts packages/agentplane/src/context/extraction-writer.test.ts packages/agentplane/src/context/coverage-validation.test.ts packages/agentplane/src/commands/context/wiki-reports.unit.test.ts; Result: pass; Evidence: 4 files, 17 tests passed. Scope: context extraction/report interactions.
+    Command: bun run typecheck; Result: pass; Evidence: TypeScript build exited 0. Scope: repository TypeScript contracts.
+    Command: node .agentplane/policy/check-routing.mjs; Result: pass; Evidence: policy routing OK. Scope: policy routing.
+    Command: agentplane doctor; Result: pass; Evidence: doctor OK with only pre-existing DONE-task commit-hash warnings. Scope: workspace health.
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607031338-KHMQAV-add-extraction-quality-signals-for-context-assim/.agentplane/tasks/202607031338-KHMQAV/blueprint/resolved-snapshot.json
+    - old_digest: 9e9c51bde24185e0555b669e64d7e290bbf443efe95ba5e5778309a42586cb93
+    - current_digest: 9e9c51bde24185e0555b669e64d7e290bbf443efe95ba5e5778309a42586cb93
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607031338-KHMQAV
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane pr update 202607031338-KHMQAV
+    - diagnostic_command: agentplane pr check 202607031338-KHMQAV
+    - source_of_truth: route=task_next_action diagnostic=pr_check remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
+    - risks: pr_artifact_freshness_loop, git_hook_side_effect
+
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Add extraction quality signals for context assimilation
+
+Add a derived extraction quality report that flags over-fragmentation, unsupported summaries, and risky normalization before wiki publication.
+
+## Scope
+
+- In scope: Add a derived extraction quality report that flags over-fragmentation, unsupported summaries, and risky normalization before wiki publication.
+- Out of scope: unrelated refactors not required for "Add extraction quality signals for context assimilation".
+
+## Plan
+
+1. Inspect context extraction apply artifact flow and existing tests.
+2. Add an extraction quality report under .agentplane/context/derived/reports that flags over-fragmentation, unsupported summaries, and risky normalization from existing extracted rows.
+3. Add focused unit coverage for the new report and ensure existing extraction apply tests still pass.
+4. Run focused context tests, typecheck/routing checks, record verification, publish PR, and integrate into main.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+### 2026-07-03T13:46:24.366Z — VERIFY — ok
+
+By: CODER
+
+Note: Extraction quality report implemented and focused context checks passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-03T13:38:55.767Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+Command: bun run format:changed; Result: pass; Evidence: all changed files use Prettier style. Scope: extraction writer, extraction command, extraction apply test.
+Command: bunx vitest run packages/agentplane/src/commands/context/extraction-apply.unit.test.ts packages/agentplane/src/context/extraction-writer.test.ts packages/agentplane/src/context/coverage-validation.test.ts packages/agentplane/src/commands/context/wiki-reports.unit.test.ts; Result: pass; Evidence: 4 files, 17 tests passed. Scope: context extraction/report interactions.
+Command: bun run typecheck; Result: pass; Evidence: TypeScript build exited 0. Scope: repository TypeScript contracts.
+Command: node .agentplane/policy/check-routing.mjs; Result: pass; Evidence: policy routing OK. Scope: policy routing.
+Command: agentplane doctor; Result: pass; Evidence: doctor OK with only pre-existing DONE-task commit-hash warnings. Scope: workspace health.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607031338-KHMQAV-add-extraction-quality-signals-for-context-assim/.agentplane/tasks/202607031338-KHMQAV/blueprint/resolved-snapshot.json
+- old_digest: 9e9c51bde24185e0555b669e64d7e290bbf443efe95ba5e5778309a42586cb93
+- current_digest: 9e9c51bde24185e0555b669e64d7e290bbf443efe95ba5e5778309a42586cb93
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607031338-KHMQAV
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane pr update 202607031338-KHMQAV
+- diagnostic_command: agentplane pr check 202607031338-KHMQAV
+- source_of_truth: route=task_next_action diagnostic=pr_check remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
+- risks: pr_artifact_freshness_loop, git_hook_side_effect
+
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202607031338-KHMQAV/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202607031338-KHMQAV/blueprint/resolved-snapshot.json
@@ -1,0 +1,571 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607031338-KHMQAV",
+    "title": "Add extraction quality signals for context assimilation",
+    "description": "Add a derived extraction quality report that flags over-fragmentation, unsupported summaries, and risky normalization before wiki publication.",
+    "tags": [
+      "code",
+      "context"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607031338-KHMQAV",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "9e9c51bde24185e0555b669e64d7e290bbf443efe95ba5e5778309a42586cb93"
+  }
+}

--- a/.agentplane/tasks/202607031338-KHMQAV/pr/diffstat.txt
+++ b/.agentplane/tasks/202607031338-KHMQAV/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ .../commands/context/extraction-apply.unit.test.ts |  90 ++++++++++
+ .../agentplane/src/commands/context/extraction.ts  |   1 +
+ .../agentplane/src/context/extraction-writer.ts    | 182 +++++++++++++++++++++
+ 3 files changed, 273 insertions(+)

--- a/.agentplane/tasks/202607031338-KHMQAV/pr/github-body.md
+++ b/.agentplane/tasks/202607031338-KHMQAV/pr/github-body.md
@@ -27,7 +27,10 @@ Add a derived extraction quality report that flags over-fragmentation, unsupport
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../commands/context/extraction-apply.unit.test.ts |  90 ++++++++++
+ .../agentplane/src/commands/context/extraction.ts  |   1 +
+ .../agentplane/src/context/extraction-writer.ts    | 182 +++++++++++++++++++++
+ 3 files changed, 273 insertions(+)
 ```
 
 </details>

--- a/.agentplane/tasks/202607031338-KHMQAV/pr/github-body.md
+++ b/.agentplane/tasks/202607031338-KHMQAV/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202607031338-KHMQAV`
+Title: Add extraction quality signals for context assimilation
+Canonical task record: `.agentplane/tasks/202607031338-KHMQAV/README.md`
+
+## Summary
+
+Add extraction quality signals for context assimilation
+
+Add a derived extraction quality report that flags over-fragmentation, unsupported summaries, and risky normalization before wiki publication.
+
+## Scope
+
+- In scope: Add a derived extraction quality report that flags over-fragmentation, unsupported summaries, and risky normalization before wiki publication.
+- Out of scope: unrelated refactors not required for "Add extraction quality signals for context assimilation".
+
+## Verification
+
+- State: ok
+- Note: Extraction quality report implemented and focused context checks passed.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-03T13:38:55.819Z
+- Branch: task/202607031338-KHMQAV/add-extraction-quality-signals-for-context-assim
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202607031338-KHMQAV/pr/github-title.txt
+++ b/.agentplane/tasks/202607031338-KHMQAV/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 KHMQAV task: Add extraction quality signals for context assimilation [202607031338-KHMQAV]

--- a/.agentplane/tasks/202607031338-KHMQAV/pr/meta.json
+++ b/.agentplane/tasks/202607031338-KHMQAV/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202607031338-KHMQAV/add-extraction-quality-signals-for-context-assim",
   "created_at": "2026-07-03T13:38:55.819Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "diffstat_sha256": "sha256:94ad30d29e2de48673b11851631a01e05df92fd7e4c2b208da2e338c4314251c",
   "last_verified_at": "2026-07-03T13:46:24.366Z",
   "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "schema_version": 1,

--- a/.agentplane/tasks/202607031338-KHMQAV/pr/meta.json
+++ b/.agentplane/tasks/202607031338-KHMQAV/pr/meta.json
@@ -1,0 +1,14 @@
+{
+  "base": "main",
+  "branch": "task/202607031338-KHMQAV/add-extraction-quality-signals-for-context-assim",
+  "created_at": "2026-07-03T13:38:55.819Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": "2026-07-03T13:46:24.366Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "schema_version": 1,
+  "task_id": "202607031338-KHMQAV",
+  "updated_at": "2026-07-03T13:38:55.819Z",
+  "verify": {
+    "status": "pass"
+  }
+}

--- a/.agentplane/tasks/202607031338-KHMQAV/pr/review.md
+++ b/.agentplane/tasks/202607031338-KHMQAV/pr/review.md
@@ -29,7 +29,10 @@ Created: 2026-07-03T13:38:55.819Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../commands/context/extraction-apply.unit.test.ts |  90 ++++++++++
+ .../agentplane/src/commands/context/extraction.ts  |   1 +
+ .../agentplane/src/context/extraction-writer.ts    | 182 +++++++++++++++++++++
+ 3 files changed, 273 insertions(+)
 ```
 
 </details>

--- a/.agentplane/tasks/202607031338-KHMQAV/pr/review.md
+++ b/.agentplane/tasks/202607031338-KHMQAV/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-07-03T13:38:55.819Z
+
+## Task
+
+- Task: `202607031338-KHMQAV`
+- Title: Add extraction quality signals for context assimilation
+- Status: DOING
+- Branch: `task/202607031338-KHMQAV/add-extraction-quality-signals-for-context-assim`
+- Canonical task record: `.agentplane/tasks/202607031338-KHMQAV/README.md`
+
+## Verification
+
+- State: ok
+- Note: Extraction quality report implemented and focused context checks passed.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-03T13:38:55.819Z
+- Branch: task/202607031338-KHMQAV/add-extraction-quality-signals-for-context-assim
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202607031338-KHMQAV/quality/20260703-134701144-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607031338-KHMQAV/quality/20260703-134701144-recovery-context/evaluator-opinion.md
@@ -1,0 +1,22 @@
+# EVALUATOR opinion: pass
+
+Quality review passed.
+
+## Findings
+- No blocking findings.
+
+## Evidence
+- .agentplane/tasks/202607031338-KHMQAV/README.md
+- packages/agentplane/src/context/extraction-writer.ts
+- packages/agentplane/src/commands/context/extraction-apply.unit.test.ts
+- bunx vitest run packages/agentplane/src/commands/context/extraction-apply.unit.test.ts packages/agentplane/src/context/extraction-writer.test.ts packages/agentplane/src/context/coverage-validation.test.ts packages/agentplane/src/commands/context/wiki-reports.unit.test.ts
+- bun run typecheck
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607031338-KHMQAV/quality/20260703-134701144-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607031338-KHMQAV/quality/20260703-134701144-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202607031338-KHMQAV
+- task_readme: .agentplane/tasks/202607031338-KHMQAV/README.md
+- report_path: .agentplane/tasks/202607031338-KHMQAV/quality/20260703-134701144-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607031338-KHMQAV/quality/20260703-134701144-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607031338-KHMQAV/quality/20260703-134701144-recovery-context/quality-report.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "task_id": "202607031338-KHMQAV",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-03T13:47:01.144Z",
+  "verdict": "pass",
+  "summary": "Quality review passed.",
+  "evaluated_sha": "8d8786ca0d310ed76ef7154ce4c17b70b46baac0",
+  "blueprint_digest": "9e9c51bde24185e0555b669e64d7e290bbf443efe95ba5e5778309a42586cb93",
+  "findings": [
+    "No blocking findings."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607031338-KHMQAV/README.md",
+    "packages/agentplane/src/context/extraction-writer.ts",
+    "packages/agentplane/src/commands/context/extraction-apply.unit.test.ts",
+    "bunx vitest run packages/agentplane/src/commands/context/extraction-apply.unit.test.ts packages/agentplane/src/context/extraction-writer.test.ts packages/agentplane/src/context/coverage-validation.test.ts packages/agentplane/src/commands/context/wiki-reports.unit.test.ts",
+    "bun run typecheck"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/.agentplane/tasks/202607031338-KHMQAV/quality/20260703-135640537-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607031338-KHMQAV/quality/20260703-135640537-recovery-context/evaluator-opinion.md
@@ -1,0 +1,22 @@
+# EVALUATOR opinion: pass
+
+Quality review passed after lint fix.
+
+## Findings
+- No blocking findings.
+
+## Evidence
+- .agentplane/tasks/202607031338-KHMQAV/README.md
+- packages/agentplane/src/context/extraction-writer.ts
+- packages/agentplane/src/commands/context/extraction-apply.unit.test.ts
+- bunx eslint packages/agentplane/src/commands/context/extraction-apply.unit.test.ts packages/agentplane/src/commands/context/extraction.ts packages/agentplane/src/context/extraction-writer.ts
+- bunx vitest run packages/agentplane/src/commands/context/extraction-apply.unit.test.ts
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607031338-KHMQAV/quality/20260703-135640537-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607031338-KHMQAV/quality/20260703-135640537-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202607031338-KHMQAV
+- task_readme: .agentplane/tasks/202607031338-KHMQAV/README.md
+- report_path: .agentplane/tasks/202607031338-KHMQAV/quality/20260703-135640537-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607031338-KHMQAV/quality/20260703-135640537-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607031338-KHMQAV/quality/20260703-135640537-recovery-context/quality-report.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "task_id": "202607031338-KHMQAV",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-03T13:56:40.537Z",
+  "verdict": "pass",
+  "summary": "Quality review passed after lint fix.",
+  "evaluated_sha": "c71e2c60c805700429defa41df056a0351227de8",
+  "blueprint_digest": "9e9c51bde24185e0555b669e64d7e290bbf443efe95ba5e5778309a42586cb93",
+  "findings": [
+    "No blocking findings."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607031338-KHMQAV/README.md",
+    "packages/agentplane/src/context/extraction-writer.ts",
+    "packages/agentplane/src/commands/context/extraction-apply.unit.test.ts",
+    "bunx eslint packages/agentplane/src/commands/context/extraction-apply.unit.test.ts packages/agentplane/src/commands/context/extraction.ts packages/agentplane/src/context/extraction-writer.ts",
+    "bunx vitest run packages/agentplane/src/commands/context/extraction-apply.unit.test.ts"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/commands/context/extraction-apply.unit.test.ts
+++ b/packages/agentplane/src/commands/context/extraction-apply.unit.test.ts
@@ -402,6 +402,96 @@ describe("context extraction apply", () => {
     expect(edges).toContain('"relation":"tests"');
   });
 
+  it("writes extraction quality signals for granularity and normalization risks", async () => {
+    const root = await tempRoot();
+    await write(
+      root,
+      "context/extraction-quality.json",
+      JSON.stringify({
+        schema_version: 2,
+        kind: "context_extraction",
+        task_id: "202607031338-KHMQAV",
+        reasoning: [{ label: "qa", summary: "Quality signals expose weak extraction shape." }],
+        source_refs: [
+          { path: "context/raw/research/a.md", lines: "1-20" },
+          { path: "context/raw/research/uncovered.md", lines: "1-20" },
+        ],
+        extracted_items: [
+          {
+            id: "entity.a",
+            kind: "graph_entity",
+            summary: "A is an extracted singleton.",
+            source_refs: [{ path: "context/raw/research/a.md" }],
+            confidence: 0.8,
+            status: "accepted",
+            entity: { id: "entity.a", kind: "concept", label: "A" },
+          },
+          {
+            id: "entity.b",
+            kind: "graph_entity",
+            summary: "B is an extracted singleton.",
+            source_refs: [{ path: "context/raw/research/a.md" }],
+            confidence: 0.8,
+            status: "accepted",
+            entity: { id: "entity.b", kind: "concept", label: "B" },
+          },
+          {
+            id: "entity.c",
+            kind: "graph_entity",
+            summary: "C is an extracted singleton.",
+            source_refs: [{ path: "context/raw/research/a.md" }],
+            confidence: 0.8,
+            status: "accepted",
+            entity: { id: "entity.c", kind: "concept", label: "C" },
+          },
+          {
+            id: "resolution.a",
+            kind: "entity_resolution",
+            summary: "A source term may resolve to entity A.",
+            source_refs: [{ path: "context/raw/research/a.md", lines: "8-9" }],
+            confidence: 0.6,
+            status: "proposed",
+            entity_resolution: {
+              source_term: "alpha",
+              resolution: "alias_of",
+              canonical_entity_id: "entity.a",
+            },
+          },
+        ],
+      }),
+    );
+
+    const out = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    await cmdContextExtractionApply({
+      cwd: root,
+      parsed: {
+        file: "context/extraction-quality.json",
+        taskId: "202607031338-KHMQAV",
+        dryRun: false,
+      },
+    });
+
+    const qualityReportText = await readFile(
+      path.join(root, ".agentplane/context/derived/reports/extraction-quality.jsonl"),
+      "utf8",
+    );
+    const qualityRows = qualityReportText
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(qualityRows.map((row) => row.signal_type)).toEqual(
+      expect.arrayContaining([
+        "source_scope_gap",
+        "source_precision_gap",
+        "normalization_uncertainty",
+        "over_fragmentation_risk",
+      ]),
+    );
+    expect(qualityReportText).toContain("context/raw/research/uncovered.md");
+    expect(qualityReportText).toContain("resolution.a");
+    expect(out.mock.calls.map((call) => String(call[0])).join("")).toContain("quality=4");
+  });
+
   it("surfaces concrete graph validation issue lines", async () => {
     const root = await tempRoot();
     await write(

--- a/packages/agentplane/src/commands/context/extraction.ts
+++ b/packages/agentplane/src/commands/context/extraction.ts
@@ -25,6 +25,7 @@ export async function cmdContextExtractionApply(opts: {
       `ontology=${result.ontology}`,
       `sources=${result.sources}`,
       `wiki=${result.wiki}`,
+      `quality=${result.quality}`,
       result.changed_paths.length > 0 ? `changed=${result.changed_paths.join(",")}` : "",
     ]
       .filter(Boolean)

--- a/packages/agentplane/src/context/extraction-writer.ts
+++ b/packages/agentplane/src/context/extraction-writer.ts
@@ -24,6 +24,7 @@ type ApplyResult = {
   ontology: number;
   sources: number;
   wiki: number;
+  quality: number;
   changed_paths: string[];
 };
 
@@ -181,6 +182,173 @@ function countSourceRefs(result: ContextExtractionSgrResult): {
   return { inputSourcePaths: inputSourcePaths.size, sourcePaths: sourcePaths.size, sourceRefs };
 }
 
+function hasPreciseSourceRef(ref: SgrSourceRef): boolean {
+  return Boolean(ref.lines || typeof ref.line === "number" || ref.section);
+}
+
+function qualityScope(taskId: string | undefined): string {
+  return slugFragment(taskId || "unscoped");
+}
+
+function qualityRow(opts: {
+  taskId?: string;
+  signalType: string;
+  subject: string;
+  severity: "info" | "warning";
+  summary: string;
+  evidenceItemIds?: string[];
+  evidenceSourcePaths?: string[];
+  suggestedAction: string;
+}): Record<string, unknown> {
+  return compactRow({
+    schema_version: 1,
+    id: `quality.${qualityScope(opts.taskId)}.${opts.signalType}.${slugFragment(opts.subject)}`,
+    signal_type: opts.signalType,
+    severity: opts.severity,
+    subject: opts.subject,
+    summary: opts.summary,
+    ...(opts.taskId ? { task_id: opts.taskId } : {}),
+    ...(opts.evidenceItemIds?.length ? { evidence_item_ids: opts.evidenceItemIds } : {}),
+    ...(opts.evidenceSourcePaths?.length
+      ? { evidence_source_paths: opts.evidenceSourcePaths }
+      : {}),
+    suggested_action: opts.suggestedAction,
+  });
+}
+
+function buildExtractionQualityRows(
+  result: ContextExtractionSgrResult,
+  taskId?: string,
+): Record<string, unknown>[] {
+  const rows: Record<string, unknown>[] = [];
+  const extractedSourcePaths = new Set<string>();
+  const coverageSourcePaths = new Set<string>();
+  const entityIds = new Set<string>();
+  const connectedEntityIds = new Set<string>();
+  const pageCreationIds: string[] = [];
+  let topologyDecisions = 0;
+
+  for (const item of result.extracted_items) {
+    for (const ref of item.source_refs) extractedSourcePaths.add(ref.path);
+    if (item.kind === "coverage" && item.coverage)
+      coverageSourcePaths.add(item.coverage.source_path);
+    if (item.kind === "graph_entity" && item.entity) entityIds.add(item.entity.id);
+    if (item.kind === "graph_edge" && item.edge) {
+      connectedEntityIds.add(item.edge.from);
+      connectedEntityIds.add(item.edge.to);
+    }
+    if (item.kind === "page_creation") pageCreationIds.push(item.id);
+    if (item.kind === "topology_decision") topologyDecisions += 1;
+  }
+
+  const uncoveredInputSources = result.source_refs
+    .map((ref) => ref.path)
+    .filter((sourcePath, index, paths) => paths.indexOf(sourcePath) === index)
+    .filter(
+      (sourcePath) => !extractedSourcePaths.has(sourcePath) && !coverageSourcePaths.has(sourcePath),
+    );
+  if (uncoveredInputSources.length > 0) {
+    rows.push(
+      qualityRow({
+        taskId,
+        signalType: "source_scope_gap",
+        subject: "input-sources",
+        severity: "warning",
+        summary:
+          "Some declared input sources produced no extracted rows and no explicit coverage rows.",
+        evidenceSourcePaths: uncoveredInputSources,
+        suggestedAction:
+          "Add coverage rows marking these sources covered, duplicate, out_of_scope, redacted, or unresolved before claiming complete assimilation.",
+      }),
+    );
+  }
+
+  const impreciseItems = result.extracted_items
+    .filter(
+      (item) =>
+        item.source_refs.length === 0 || item.source_refs.every((ref) => !hasPreciseSourceRef(ref)),
+    )
+    .map((item) => item.id);
+  if (impreciseItems.length > 0) {
+    rows.push(
+      qualityRow({
+        taskId,
+        signalType: "source_precision_gap",
+        subject: "source-refs",
+        severity: "warning",
+        summary: "Some extracted items lack line-, section-, or span-addressed source references.",
+        evidenceItemIds: impreciseItems.slice(0, 20),
+        suggestedAction:
+          "Attach line, lines, section, or span references so later wiki summaries can be traced back without semantic drift.",
+      }),
+    );
+  }
+
+  const riskyNormalizationIds = result.extracted_items
+    .filter((item) => item.kind === "entity_resolution")
+    .filter((item) => {
+      const confidence =
+        item.confidence_vector?.entity_resolution ??
+        item.confidence_vector?.extraction ??
+        item.confidence;
+      return item.status !== "accepted" || confidence === undefined || confidence < 0.75;
+    })
+    .map((item) => item.id);
+  if (riskyNormalizationIds.length > 0) {
+    rows.push(
+      qualityRow({
+        taskId,
+        signalType: "normalization_uncertainty",
+        subject: "entity-resolution",
+        severity: "warning",
+        summary:
+          "Some entity-resolution rows are proposed, unresolved, or lack sufficient confidence.",
+        evidenceItemIds: riskyNormalizationIds,
+        suggestedAction:
+          "Keep these rows as candidates or add do-not-merge/open-question evidence before using them to canonicalize wiki terminology.",
+      }),
+    );
+  }
+
+  const singletonEntityIds = [...entityIds].filter((entityId) => !connectedEntityIds.has(entityId));
+  if (
+    singletonEntityIds.length >= 3 &&
+    singletonEntityIds.length / Math.max(entityIds.size, 1) >= 0.6
+  ) {
+    rows.push(
+      qualityRow({
+        taskId,
+        signalType: "over_fragmentation_risk",
+        subject: "graph-entities",
+        severity: "warning",
+        summary:
+          "Most extracted graph entities are singletons, which can indicate excessive fragmentation before topology planning.",
+        evidenceItemIds: singletonEntityIds.slice(0, 20),
+        suggestedAction:
+          "Add graph edges, page clusters, or explicit topology decisions before publishing one page per extracted entity.",
+      }),
+    );
+  }
+
+  if (pageCreationIds.length > 0 && topologyDecisions === 0) {
+    rows.push(
+      qualityRow({
+        taskId,
+        signalType: "topology_without_decision",
+        subject: "page-creation",
+        severity: "info",
+        summary:
+          "Page creation rows exist without a topology_decision row explaining the page family and split/merge rationale.",
+        evidenceItemIds: pageCreationIds.slice(0, 20),
+        suggestedAction:
+          "Add a topology_decision row so wiki publication can distinguish source-shaped structure from default scaffolding.",
+      }),
+    );
+  }
+
+  return rows;
+}
+
 export async function applyContextExtractionResult(opts: {
   root: string;
   raw: unknown;
@@ -199,6 +367,10 @@ export async function applyContextExtractionResult(opts: {
     ".agentplane/context/derived/graph/provenance_edges.jsonl",
   );
   const coveragePath = path.join(opts.root, ".agentplane/context/derived/reports/coverage.jsonl");
+  const extractionQualityPath = path.join(
+    opts.root,
+    ".agentplane/context/derived/reports/extraction-quality.jsonl",
+  );
   const sourceSpansPath = path.join(
     opts.root,
     ".agentplane/context/derived/sources/source-spans.jsonl",
@@ -229,6 +401,7 @@ export async function applyContextExtractionResult(opts: {
   const edges = await readJsonlById(edgesPath);
   const provenance = await readJsonlById(provenancePath);
   const coverage = await readJsonlById(coveragePath);
+  const extractionQuality = await readJsonlById(extractionQualityPath);
   const sourceSpans = await readJsonlById(sourceSpansPath);
   const entityResolution = await readJsonlById(entityResolutionPath);
   const aliases = await readJsonlById(aliasesPath);
@@ -241,6 +414,12 @@ export async function applyContextExtractionResult(opts: {
     claimMaps.set(abs, await readJsonlById(abs));
   }
   let topologyPlan: Record<string, unknown> | null = null;
+  for (const id of [...extractionQuality.keys()]) {
+    if (id.startsWith(`quality.${qualityScope(taskId)}.`)) extractionQuality.delete(id);
+  }
+  for (const row of buildExtractionQualityRows(result, taskId)) {
+    extractionQuality.set(rowId(row), row);
+  }
 
   function addProvenance(item: ContextExtractionItem, artifactPath: string, id = item.id): void {
     for (const row of provenanceRows(
@@ -368,6 +547,8 @@ export async function applyContextExtractionResult(opts: {
     changed.add(toPosix(path.relative(opts.root, provenancePath)));
   if (await writeJsonlById(coveragePath, coverage, dryRun))
     changed.add(toPosix(path.relative(opts.root, coveragePath)));
+  if (await writeJsonlById(extractionQualityPath, extractionQuality, dryRun))
+    changed.add(toPosix(path.relative(opts.root, extractionQualityPath)));
   if (await writeJsonlById(sourceSpansPath, sourceSpans, dryRun))
     changed.add(toPosix(path.relative(opts.root, sourceSpansPath)));
   if (await writeJsonlById(entityResolutionPath, entityResolution, dryRun))
@@ -401,6 +582,7 @@ export async function applyContextExtractionResult(opts: {
     ontology: entityResolution.size + aliases.size + pageCreation.size + topologyChanges.size,
     sources: sourceSpans.size,
     wiki: pageManifests.size + (topologyPlan === null ? 0 : 1),
+    quality: extractionQuality.size,
     changed_paths: [...changed].toSorted(),
   };
 }

--- a/packages/agentplane/src/context/extraction-writer.ts
+++ b/packages/agentplane/src/context/extraction-writer.ts
@@ -183,11 +183,11 @@ function countSourceRefs(result: ContextExtractionSgrResult): {
 }
 
 function hasPreciseSourceRef(ref: SgrSourceRef): boolean {
-  return Boolean(ref.lines || typeof ref.line === "number" || ref.section);
+  return ref.lines !== undefined || typeof ref.line === "number" || ref.section !== undefined;
 }
 
 function qualityScope(taskId: string | undefined): string {
-  return slugFragment(taskId || "unscoped");
+  return slugFragment(taskId ?? "unscoped");
 }
 
 function qualityRow(opts: {
@@ -264,10 +264,7 @@ function buildExtractionQualityRows(
   }
 
   const impreciseItems = result.extracted_items
-    .filter(
-      (item) =>
-        item.source_refs.length === 0 || item.source_refs.every((ref) => !hasPreciseSourceRef(ref)),
-    )
+    .filter((item) => item.source_refs.every((ref) => !hasPreciseSourceRef(ref)))
     .map((item) => item.id);
   if (impreciseItems.length > 0) {
     rows.push(
@@ -414,7 +411,7 @@ export async function applyContextExtractionResult(opts: {
     claimMaps.set(abs, await readJsonlById(abs));
   }
   let topologyPlan: Record<string, unknown> | null = null;
-  for (const id of [...extractionQuality.keys()]) {
+  for (const id of extractionQuality.keys()) {
     if (id.startsWith(`quality.${qualityScope(taskId)}.`)) extractionQuality.delete(id);
   }
   for (const row of buildExtractionQualityRows(result, taskId)) {


### PR DESCRIPTION
Task: `202607031338-KHMQAV`
Title: Add extraction quality signals for context assimilation
Canonical task record: `.agentplane/tasks/202607031338-KHMQAV/README.md`

## Summary

Add extraction quality signals for context assimilation

Add a derived extraction quality report that flags over-fragmentation, unsupported summaries, and risky normalization before wiki publication.

## Scope

- In scope: Add a derived extraction quality report that flags over-fragmentation, unsupported summaries, and risky normalization before wiki publication.
- Out of scope: unrelated refactors not required for "Add extraction quality signals for context assimilation".

## Verification

- State: ok
- Note: Extraction quality report implemented and focused context checks passed.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-07-03T13:38:55.819Z
- Branch: task/202607031338-KHMQAV/add-extraction-quality-signals-for-context-assim
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../commands/context/extraction-apply.unit.test.ts |  90 ++++++++++
 .../agentplane/src/commands/context/extraction.ts  |   1 +
 .../agentplane/src/context/extraction-writer.ts    | 182 +++++++++++++++++++++
 3 files changed, 273 insertions(+)
```

</details>
