### PR TITLE
🚧 AHYFCS task: Enforce cross-surface context integrity for v0.6.22 [202607092342-AHYFCS]

### DIFF
--- a/.agentplane/tasks/202607092342-AHYFCS/README.md
+++ b/.agentplane/tasks/202607092342-AHYFCS/README.md
@@ -1,0 +1,115 @@
+---
+id: "202607092342-AHYFCS"
+title: "Enforce cross-surface context integrity for v0.6.22"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 7
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "context"
+  - "patch-0.6.22"
+  - "quality"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "bun run ci:contract"
+  - "bun run typecheck"
+  - "bunx vitest run packages/agentplane/src/commands/context/check.unit.test.ts packages/agentplane/src/commands/context/wiki-reports.unit.test.ts packages/agentplane/src/commands/context/verify-task.maximum-assimilation.unit.test.ts"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-07-09T23:43:16.688Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement global cross-surface context integrity checks and regression coverage for v0.6.22."
+events:
+  -
+    type: "status"
+    at: "2026-07-09T23:43:35.553Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement global cross-surface context integrity checks and regression coverage for v0.6.22."
+doc_version: 3
+doc_updated_at: "2026-07-09T23:43:35.553Z"
+doc_updated_by: "CODER"
+description: "Make global context checks validate wiki graph references, entity page policy, manifest/source coverage, and freshness of derived wiki reports so structurally valid but semantically disconnected context cannot pass."
+sections:
+  Summary: |-
+    Enforce cross-surface context integrity for v0.6.22
+
+    Make global context checks validate wiki graph references, entity page policy, manifest/source coverage, and freshness of derived wiki reports so structurally valid but semantically disconnected context cannot pass.
+  Scope: |-
+    - In scope: global read-only integrity validation across wiki, graph, manifest/raw source inventory, and derived link/orphan reports.
+    - In scope: actionable diagnostics and regression tests.
+    - Out of scope: rewriting existing repository wiki content, changing public context schemas, or implementing semantic search ranking.
+  Plan: |-
+    1. Add one reusable global integrity validator for wiki graph references, active entity page policy, manifest/raw source coverage, and freshness markers for link/orphan reports.
+    2. Wire the validator into context check and doctor without weakening task-scoped maximum-assimilation verification.
+    3. Add fixtures covering missing graph entities, stale reports, and untracked raw sources, while preserving valid legacy/minimal workspaces.
+    4. Run focused tests, typecheck, and ci:contract.
+  Verify Steps: |-
+    1. Run bunx vitest run packages/agentplane/src/commands/context/check.unit.test.ts packages/agentplane/src/commands/context/wiki-reports.unit.test.ts packages/agentplane/src/commands/context/verify-task.maximum-assimilation.unit.test.ts; broken graph refs, stale reports, and untracked raw source fixtures fail while valid fixtures pass.
+    2. Run bun run typecheck; it passes.
+    3. Run bun run ci:contract; it passes.
+    4. Run git diff --check; it passes.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert the task commits.
+    - Re-run the focused context checks and ci:contract to confirm the previous validation behavior is restored.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Enforce cross-surface context integrity for v0.6.22
+
+Make global context checks validate wiki graph references, entity page policy, manifest/source coverage, and freshness of derived wiki reports so structurally valid but semantically disconnected context cannot pass.
+
+## Scope
+
+- In scope: global read-only integrity validation across wiki, graph, manifest/raw source inventory, and derived link/orphan reports.
+- In scope: actionable diagnostics and regression tests.
+- Out of scope: rewriting existing repository wiki content, changing public context schemas, or implementing semantic search ranking.
+
+## Plan
+
+1. Add one reusable global integrity validator for wiki graph references, active entity page policy, manifest/raw source coverage, and freshness markers for link/orphan reports.
+2. Wire the validator into context check and doctor without weakening task-scoped maximum-assimilation verification.
+3. Add fixtures covering missing graph entities, stale reports, and untracked raw sources, while preserving valid legacy/minimal workspaces.
+4. Run focused tests, typecheck, and ci:contract.
+
+## Verify Steps
+
+1. Run bunx vitest run packages/agentplane/src/commands/context/check.unit.test.ts packages/agentplane/src/commands/context/wiki-reports.unit.test.ts packages/agentplane/src/commands/context/verify-task.maximum-assimilation.unit.test.ts; broken graph refs, stale reports, and untracked raw source fixtures fail while valid fixtures pass.
+2. Run bun run typecheck; it passes.
+3. Run bun run ci:contract; it passes.
+4. Run git diff --check; it passes.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert the task commits.
+- Re-run the focused context checks and ci:contract to confirm the previous validation behavior is restored.
+
+## Findings

--- a/.agentplane/tasks/202607092342-AHYFCS/README.md
+++ b/.agentplane/tasks/202607092342-AHYFCS/README.md
@@ -2,10 +2,10 @@
 id: "202607092342-AHYFCS"
 title: "Enforce cross-surface context integrity for v0.6.22"
 result_summary: "pre-merge closure"
-status: "DONE"
+status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 11
+revision: 14
 origin:
   system: "manual"
 depends_on: []
@@ -28,29 +28,27 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-07-10T00:08:14.065Z"
+  updated_at: "2026-07-10T00:13:21.353Z"
   updated_by: "CODER"
-  note: "Verified: current main-targeting PR head preserves the passing integrity tests, 2,132-test full fast suite, critical CLI suite, typecheck, lint, and ci:contract evidence."
+  note: "Verified: review fix ignores hidden .obsidian and raw archive directories; 10 focused tests, typecheck, lint, diff check, prior full ci:contract, 2,132-test fast suite, and critical CLI remain green."
   attempts: 0
 quality_review:
   state: "pass"
-  updated_at: "2026-07-09T23:53:43.150Z"
+  updated_at: "2026-07-10T00:13:23.689Z"
   updated_by: "EVALUATOR"
-  note: "Global context integrity now rejects disconnected or stale maximum-assimilation artifacts."
-  evaluated_sha: "1ac42ed68fef6764b464e114614fb99b02f102de"
+  note: "Cross-surface integrity is strict for managed context while preserving ignored hidden directories."
+  evaluated_sha: "0c828f95913c21997368cbd31741a99dd22ed834"
   blueprint_digest: "a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2"
   evidence_refs:
     - ".agentplane/tasks/202607092342-AHYFCS/README.md"
-    - ".agentplane/tasks/202607092342-AHYFCS/quality/20260709-235343150-recovery-context/quality-report.json"
-    - ".agentplane/tasks/202607092342-AHYFCS/quality/20260709-235343150-recovery-context/evaluator-prompt.md"
-    - ".agentplane/tasks/202607092342-AHYFCS/quality/20260709-235343150-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607092342-AHYFCS/quality/20260710-001323689-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607092342-AHYFCS/quality/20260710-001323689-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607092342-AHYFCS/quality/20260710-001323689-recovery-context/evaluator-opinion.md"
     - ".agentplane/tasks/202607092342-AHYFCS/blueprint/resolved-snapshot.json"
     - "packages/agentplane/src/commands/context/check.unit.test.ts"
   findings:
-    - "The validator resolves wiki graph references, enforces active entity page policy, checks raw source registration, and fingerprints connectivity reports with focused regression coverage."
-commit:
-  hash: "994ea841af950ac2bf9eb93e8556627e07754595"
-  message: "✅ AHYFCS context: record integrity verification"
+    - "The final collector skips hidden and service directories consistently with ingest and wiki report traversal; focused regression coverage verifies ignored vault/plugin and raw archive paths."
+commit: null
 comments:
   -
     author: "CODER"
@@ -85,8 +83,20 @@ events:
     from: "DOING"
     to: "DONE"
     note: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    type: "verify"
+    at: "2026-07-10T00:12:59.924Z"
+    author: "CODER"
+    state: "needs_rework"
+    note: "Rework: PR review identified hidden .obsidian and raw archive directories must follow existing ingest/report exclusions before merge."
+  -
+    type: "verify"
+    at: "2026-07-10T00:13:21.353Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: review fix ignores hidden .obsidian and raw archive directories; 10 focused tests, typecheck, lint, diff check, prior full ci:contract, 2,132-test fast suite, and critical CLI remain green."
 doc_version: 3
-doc_updated_at: "2026-07-10T00:08:38.184Z"
+doc_updated_at: "2026-07-10T00:13:21.657Z"
 doc_updated_by: "CODER"
 description: "Make global context checks validate wiki graph references, entity page policy, manifest/source coverage, and freshness of derived wiki reports so structurally valid but semantically disconnected context cannot pass."
 sections:
@@ -164,6 +174,66 @@ sections:
     - can_execute_now: true
     - safe_command: agentplane finish 202607092342-AHYFCS --author CODER --body Verified: pre-merge closure packet is ready for the task PR. --result pre-merge closure --commit d68187dbcaedd4e35412aec44b18c62ddc9f3e78 --pre-merge-closure
     - diagnostic_command: none
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: true
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: git_hook_side_effect
+
+    ### 2026-07-10T00:12:59.924Z — VERIFY — needs_rework
+
+    By: CODER
+
+    Note: Rework: PR review identified hidden .obsidian and raw archive directories must follow existing ingest/report exclusions before merge.
+    Attempts: 1
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-10T00:08:38.184Z, excerpt_hash=sha256:a048fab14dab3ec0b1cb44ac4e5067eb124319bc5f3d6256e3cd5dfb73d8b3d8
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607092342-AHYFCS-enforce-cross-surface-context-integrity-for-v0-6/.agentplane/tasks/202607092342-AHYFCS/blueprint/resolved-snapshot.json
+    - old_digest: a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2
+    - current_digest: a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607092342-AHYFCS
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane integrate queue enqueue 202607092342-AHYFCS --branch task/202607092342-AHYFCS/enforce-cross-surface-context-integrity-for-v0-6
+    - diagnostic_command: agentplane pr check 202607092342-AHYFCS
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: true
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: git_hook_side_effect
+
+    ### 2026-07-10T00:13:21.353Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified: review fix ignores hidden .obsidian and raw archive directories; 10 focused tests, typecheck, lint, diff check, prior full ci:contract, 2,132-test fast suite, and critical CLI remain green.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-10T00:13:02.669Z, excerpt_hash=sha256:a048fab14dab3ec0b1cb44ac4e5067eb124319bc5f3d6256e3cd5dfb73d8b3d8
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607092342-AHYFCS-enforce-cross-surface-context-integrity-for-v0-6/.agentplane/tasks/202607092342-AHYFCS/blueprint/resolved-snapshot.json
+    - old_digest: a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2
+    - current_digest: a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607092342-AHYFCS
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane integrate queue enqueue 202607092342-AHYFCS --branch task/202607092342-AHYFCS/enforce-cross-surface-context-integrity-for-v0-6
+    - diagnostic_command: agentplane pr check 202607092342-AHYFCS
     - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
     - freshness: route=computed_local remote=remote_skipped
     - repeat_allowed: true
@@ -264,6 +334,66 @@ DecisionContextRef:
 - can_execute_now: true
 - safe_command: agentplane finish 202607092342-AHYFCS --author CODER --body Verified: pre-merge closure packet is ready for the task PR. --result pre-merge closure --commit d68187dbcaedd4e35412aec44b18c62ddc9f3e78 --pre-merge-closure
 - diagnostic_command: none
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: true
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: git_hook_side_effect
+
+### 2026-07-10T00:12:59.924Z — VERIFY — needs_rework
+
+By: CODER
+
+Note: Rework: PR review identified hidden .obsidian and raw archive directories must follow existing ingest/report exclusions before merge.
+Attempts: 1
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-10T00:08:38.184Z, excerpt_hash=sha256:a048fab14dab3ec0b1cb44ac4e5067eb124319bc5f3d6256e3cd5dfb73d8b3d8
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607092342-AHYFCS-enforce-cross-surface-context-integrity-for-v0-6/.agentplane/tasks/202607092342-AHYFCS/blueprint/resolved-snapshot.json
+- old_digest: a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2
+- current_digest: a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607092342-AHYFCS
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane integrate queue enqueue 202607092342-AHYFCS --branch task/202607092342-AHYFCS/enforce-cross-surface-context-integrity-for-v0-6
+- diagnostic_command: agentplane pr check 202607092342-AHYFCS
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: true
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: git_hook_side_effect
+
+### 2026-07-10T00:13:21.353Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: review fix ignores hidden .obsidian and raw archive directories; 10 focused tests, typecheck, lint, diff check, prior full ci:contract, 2,132-test fast suite, and critical CLI remain green.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-10T00:13:02.669Z, excerpt_hash=sha256:a048fab14dab3ec0b1cb44ac4e5067eb124319bc5f3d6256e3cd5dfb73d8b3d8
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607092342-AHYFCS-enforce-cross-surface-context-integrity-for-v0-6/.agentplane/tasks/202607092342-AHYFCS/blueprint/resolved-snapshot.json
+- old_digest: a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2
+- current_digest: a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607092342-AHYFCS
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane integrate queue enqueue 202607092342-AHYFCS --branch task/202607092342-AHYFCS/enforce-cross-surface-context-integrity-for-v0-6
+- diagnostic_command: agentplane pr check 202607092342-AHYFCS
 - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
 - freshness: route=computed_local remote=remote_skipped
 - repeat_allowed: true

--- a/.agentplane/tasks/202607092342-AHYFCS/README.md
+++ b/.agentplane/tasks/202607092342-AHYFCS/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202607092342-AHYFCS"
 title: "Enforce cross-surface context integrity for v0.6.22"
-status: "DOING"
+result_summary: "pre-merge closure"
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 10
+revision: 11
 origin:
   system: "manual"
 depends_on: []
@@ -47,11 +48,16 @@ quality_review:
     - "packages/agentplane/src/commands/context/check.unit.test.ts"
   findings:
     - "The validator resolves wiki graph references, enforces active entity page policy, checks raw source registration, and fingerprints connectivity reports with focused regression coverage."
-commit: null
+commit:
+  hash: "994ea841af950ac2bf9eb93e8556627e07754595"
+  message: "✅ AHYFCS context: record integrity verification"
 comments:
   -
     author: "CODER"
     body: "Start: implement global cross-surface context integrity checks and regression coverage for v0.6.22."
+  -
+    author: "CODER"
+    body: "Verified: pre-merge closure packet is ready for the task PR."
 events:
   -
     type: "status"
@@ -72,8 +78,15 @@ events:
     author: "CODER"
     state: "ok"
     note: "Verified: current main-targeting PR head preserves the passing integrity tests, 2,132-test full fast suite, critical CLI suite, typecheck, lint, and ci:contract evidence."
+  -
+    type: "status"
+    at: "2026-07-10T00:08:38.183Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-10T00:08:14.302Z"
+doc_updated_at: "2026-07-10T00:08:38.184Z"
 doc_updated_by: "CODER"
 description: "Make global context checks validate wiki graph references, entity page policy, manifest/source coverage, and freshness of derived wiki reports so structurally valid but semantically disconnected context cannot pass."
 sections:
@@ -162,6 +175,10 @@ sections:
     - Revert the task commits.
     - Re-run the focused context checks and ci:contract to confirm the previous validation behavior is restored.
   Findings: ""
+extensions:
+  implementation_commit:
+    hash: "1ac42ed68fef6764b464e114614fb99b02f102de"
+    message: "🛡️ AHYFCS context: enforce cross-surface integrity"
 id_source: "generated"
 ---
 ## Summary

--- a/.agentplane/tasks/202607092342-AHYFCS/README.md
+++ b/.agentplane/tasks/202607092342-AHYFCS/README.md
@@ -4,7 +4,7 @@ title: "Enforce cross-surface context integrity for v0.6.22"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 7
+revision: 10
 origin:
   system: "manual"
 depends_on: []
@@ -26,11 +26,27 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-07-10T00:08:14.065Z"
+  updated_by: "CODER"
+  note: "Verified: current main-targeting PR head preserves the passing integrity tests, 2,132-test full fast suite, critical CLI suite, typecheck, lint, and ci:contract evidence."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-07-09T23:53:43.150Z"
+  updated_by: "EVALUATOR"
+  note: "Global context integrity now rejects disconnected or stale maximum-assimilation artifacts."
+  evaluated_sha: "1ac42ed68fef6764b464e114614fb99b02f102de"
+  blueprint_digest: "a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2"
+  evidence_refs:
+    - ".agentplane/tasks/202607092342-AHYFCS/README.md"
+    - ".agentplane/tasks/202607092342-AHYFCS/quality/20260709-235343150-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607092342-AHYFCS/quality/20260709-235343150-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607092342-AHYFCS/quality/20260709-235343150-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607092342-AHYFCS/blueprint/resolved-snapshot.json"
+    - "packages/agentplane/src/commands/context/check.unit.test.ts"
+  findings:
+    - "The validator resolves wiki graph references, enforces active entity page policy, checks raw source registration, and fingerprints connectivity reports with focused regression coverage."
 commit: null
 comments:
   -
@@ -44,8 +60,20 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: implement global cross-surface context integrity checks and regression coverage for v0.6.22."
+  -
+    type: "verify"
+    at: "2026-07-09T23:53:41.766Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: cross-surface graph, entity page policy, raw manifest coverage, and report freshness gates pass 40 focused tests, typecheck, lint, diff check, and ci:contract."
+  -
+    type: "verify"
+    at: "2026-07-10T00:08:14.065Z"
+    author: "CODER"
+    state: "ok"
+    note: "Verified: current main-targeting PR head preserves the passing integrity tests, 2,132-test full fast suite, critical CLI suite, typecheck, lint, and ci:contract evidence."
 doc_version: 3
-doc_updated_at: "2026-07-09T23:43:35.553Z"
+doc_updated_at: "2026-07-10T00:08:14.302Z"
 doc_updated_by: "CODER"
 description: "Make global context checks validate wiki graph references, entity page policy, manifest/source coverage, and freshness of derived wiki reports so structurally valid but semantically disconnected context cannot pass."
 sections:
@@ -69,6 +97,66 @@ sections:
     4. Run git diff --check; it passes.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-07-09T23:53:41.766Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified: cross-surface graph, entity page policy, raw manifest coverage, and report freshness gates pass 40 focused tests, typecheck, lint, diff check, and ci:contract.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-09T23:43:35.553Z, excerpt_hash=sha256:a048fab14dab3ec0b1cb44ac4e5067eb124319bc5f3d6256e3cd5dfb73d8b3d8
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607092342-AHYFCS-enforce-cross-surface-context-integrity-for-v0-6/.agentplane/tasks/202607092342-AHYFCS/blueprint/resolved-snapshot.json
+    - old_digest: a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2
+    - current_digest: a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607092342-AHYFCS
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane pr update 202607092342-AHYFCS
+    - diagnostic_command: agentplane pr check 202607092342-AHYFCS
+    - source_of_truth: route=task_next_action diagnostic=pr_check remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
+    - risks: pr_artifact_freshness_loop, git_hook_side_effect
+
+    ### 2026-07-10T00:08:14.065Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Verified: current main-targeting PR head preserves the passing integrity tests, 2,132-test full fast suite, critical CLI suite, typecheck, lint, and ci:contract evidence.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-09T23:53:41.875Z, excerpt_hash=sha256:a048fab14dab3ec0b1cb44ac4e5067eb124319bc5f3d6256e3cd5dfb73d8b3d8
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607092342-AHYFCS-enforce-cross-surface-context-integrity-for-v0-6/.agentplane/tasks/202607092342-AHYFCS/blueprint/resolved-snapshot.json
+    - old_digest: a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2
+    - current_digest: a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607092342-AHYFCS
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane finish 202607092342-AHYFCS --author CODER --body Verified: pre-merge closure packet is ready for the task PR. --result pre-merge closure --commit d68187dbcaedd4e35412aec44b18c62ddc9f3e78 --pre-merge-closure
+    - diagnostic_command: none
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: true
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: git_hook_side_effect
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert the task commits.
@@ -105,6 +193,66 @@ Make global context checks validate wiki graph references, entity page policy, m
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-07-09T23:53:41.766Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: cross-surface graph, entity page policy, raw manifest coverage, and report freshness gates pass 40 focused tests, typecheck, lint, diff check, and ci:contract.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-09T23:43:35.553Z, excerpt_hash=sha256:a048fab14dab3ec0b1cb44ac4e5067eb124319bc5f3d6256e3cd5dfb73d8b3d8
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607092342-AHYFCS-enforce-cross-surface-context-integrity-for-v0-6/.agentplane/tasks/202607092342-AHYFCS/blueprint/resolved-snapshot.json
+- old_digest: a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2
+- current_digest: a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607092342-AHYFCS
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane pr update 202607092342-AHYFCS
+- diagnostic_command: agentplane pr check 202607092342-AHYFCS
+- source_of_truth: route=task_next_action diagnostic=pr_check remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
+- risks: pr_artifact_freshness_loop, git_hook_side_effect
+
+### 2026-07-10T00:08:14.065Z — VERIFY — ok
+
+By: CODER
+
+Note: Verified: current main-targeting PR head preserves the passing integrity tests, 2,132-test full fast suite, critical CLI suite, typecheck, lint, and ci:contract evidence.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-09T23:53:41.875Z, excerpt_hash=sha256:a048fab14dab3ec0b1cb44ac4e5067eb124319bc5f3d6256e3cd5dfb73d8b3d8
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607092342-AHYFCS-enforce-cross-surface-context-integrity-for-v0-6/.agentplane/tasks/202607092342-AHYFCS/blueprint/resolved-snapshot.json
+- old_digest: a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2
+- current_digest: a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607092342-AHYFCS
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane finish 202607092342-AHYFCS --author CODER --body Verified: pre-merge closure packet is ready for the task PR. --result pre-merge closure --commit d68187dbcaedd4e35412aec44b18c62ddc9f3e78 --pre-merge-closure
+- diagnostic_command: none
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: true
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: git_hook_side_effect
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202607092342-AHYFCS/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202607092342-AHYFCS/blueprint/resolved-snapshot.json
@@ -1,0 +1,580 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607092342-AHYFCS",
+    "title": "Enforce cross-surface context integrity for v0.6.22",
+    "description": "Make global context checks validate wiki graph references, entity page policy, manifest/source coverage, and freshness of derived wiki reports so structurally valid but semantically disconnected context cannot pass.",
+    "tags": [
+      "code",
+      "context",
+      "patch-0.6.22",
+      "quality"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607092342-AHYFCS",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2"
+  }
+}

--- a/.agentplane/tasks/202607092342-AHYFCS/pr/diffstat.txt
+++ b/.agentplane/tasks/202607092342-AHYFCS/pr/diffstat.txt
@@ -1,0 +1,6 @@
+ .../src/commands/context/check.unit.test.ts        | 118 +++++++++++++
+ .../src/commands/context/wiki-reports.ts           |  21 ++-
+ .../src/commands/context/wiki-reports.unit.test.ts |   9 +
+ packages/agentplane/src/context/doctor.ts          |   2 +
+ packages/agentplane/src/context/integrity.ts       | 186 +++++++++++++++++++++
+ 5 files changed, 334 insertions(+), 2 deletions(-)

--- a/.agentplane/tasks/202607092342-AHYFCS/pr/diffstat.txt
+++ b/.agentplane/tasks/202607092342-AHYFCS/pr/diffstat.txt
@@ -1,6 +1,6 @@
- .../src/commands/context/check.unit.test.ts        | 118 +++++++++++++
+ .../src/commands/context/check.unit.test.ts        | 129 ++++++++++++++
  .../src/commands/context/wiki-reports.ts           |  21 ++-
  .../src/commands/context/wiki-reports.unit.test.ts |   9 +
  packages/agentplane/src/context/doctor.ts          |   2 +
- packages/agentplane/src/context/integrity.ts       | 186 +++++++++++++++++++++
- 5 files changed, 334 insertions(+), 2 deletions(-)
+ packages/agentplane/src/context/integrity.ts       | 188 +++++++++++++++++++++
+ 5 files changed, 347 insertions(+), 2 deletions(-)

--- a/.agentplane/tasks/202607092342-AHYFCS/pr/github-body.md
+++ b/.agentplane/tasks/202607092342-AHYFCS/pr/github-body.md
@@ -1,0 +1,34 @@
+Task: `202607092342-AHYFCS`
+Title: Enforce cross-surface context integrity for v0.6.22
+Canonical task record: `.agentplane/tasks/202607092342-AHYFCS/README.md`
+
+## Summary
+
+Enforce cross-surface context integrity for v0.6.22
+
+Make global context checks validate wiki graph references, entity page policy, manifest/source coverage, and freshness of derived wiki reports so structurally valid but semantically disconnected context cannot pass.
+
+## Scope
+
+- In scope: global read-only integrity validation across wiki, graph, manifest/raw source inventory, and derived link/orphan reports.
+- In scope: actionable diagnostics and regression tests.
+- Out of scope: rewriting existing repository wiki content, changing public context schemas, or implementing semantic search ranking.
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-09T23:43:35.604Z
+- Branch: task/202607092342-AHYFCS/enforce-cross-surface-context-integrity-for-v0-6
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202607092342-AHYFCS/pr/github-body.md
+++ b/.agentplane/tasks/202607092342-AHYFCS/pr/github-body.md
@@ -20,8 +20,9 @@ Make global context checks validate wiki graph references, entity page policy, m
 - Note:
 
 ```text
-Verified: current main-targeting PR head preserves the passing integrity tests, 2,132-test full fast
-suite, critical CLI suite, typecheck, lint, and ci:contract evidence.
+Verified: review fix ignores hidden .obsidian and raw archive directories; 10 focused tests,
+typecheck, lint, diff check, prior full ci:contract, 2,132-test fast suite, and critical CLI remain
+green.
 ```
 - Canonical workflow state lives in the task README.
 
@@ -33,12 +34,12 @@ suite, critical CLI suite, typecheck, lint, and ci:contract evidence.
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
- .../src/commands/context/check.unit.test.ts        | 118 +++++++++++++
+ .../src/commands/context/check.unit.test.ts        | 129 ++++++++++++++
  .../src/commands/context/wiki-reports.ts           |  21 ++-
  .../src/commands/context/wiki-reports.unit.test.ts |   9 +
  packages/agentplane/src/context/doctor.ts          |   2 +
- packages/agentplane/src/context/integrity.ts       | 186 +++++++++++++++++++++
- 5 files changed, 334 insertions(+), 2 deletions(-)
+ packages/agentplane/src/context/integrity.ts       | 188 +++++++++++++++++++++
+ 5 files changed, 347 insertions(+), 2 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607092342-AHYFCS/pr/github-body.md
+++ b/.agentplane/tasks/202607092342-AHYFCS/pr/github-body.md
@@ -16,19 +16,29 @@ Make global context checks validate wiki graph references, entity page policy, m
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Verified: current main-targeting PR head preserves the passing integrity tests, 2,132-test full fast
+suite, critical CLI suite, typecheck, lint, and ci:contract evidence.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-09T23:43:35.604Z
+- Updated: 2026-07-09T23:57:04.928Z
 - Branch: task/202607092342-AHYFCS/enforce-cross-surface-context-integrity-for-v0-6
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/commands/context/check.unit.test.ts        | 118 +++++++++++++
+ .../src/commands/context/wiki-reports.ts           |  21 ++-
+ .../src/commands/context/wiki-reports.unit.test.ts |   9 +
+ packages/agentplane/src/context/doctor.ts          |   2 +
+ packages/agentplane/src/context/integrity.ts       | 186 +++++++++++++++++++++
+ 5 files changed, 334 insertions(+), 2 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607092342-AHYFCS/pr/github-title.txt
+++ b/.agentplane/tasks/202607092342-AHYFCS/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 AHYFCS task: Enforce cross-surface context integrity for v0.6.22 [202607092342-AHYFCS]

--- a/.agentplane/tasks/202607092342-AHYFCS/pr/meta.json
+++ b/.agentplane/tasks/202607092342-AHYFCS/pr/meta.json
@@ -2,12 +2,16 @@
   "base": "main",
   "branch": "task/202607092342-AHYFCS/enforce-cross-surface-context-integrity-for-v0-6",
   "created_at": "2026-07-09T23:43:35.604Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:a84dc6ce765daedfeb02e95d919e1aa3c4eaabe7dafbbcb5989ee530127036ed",
+  "last_verified_at": "2026-07-10T00:08:14.065Z",
+  "last_verified_diffstat_sha256": "sha256:a84dc6ce765daedfeb02e95d919e1aa3c4eaabe7dafbbcb5989ee530127036ed",
+  "pr_number": 4556,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4556",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202607092342-AHYFCS",
-  "updated_at": "2026-07-09T23:43:35.604Z",
+  "updated_at": "2026-07-09T23:57:04.928Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202607092342-AHYFCS/pr/meta.json
+++ b/.agentplane/tasks/202607092342-AHYFCS/pr/meta.json
@@ -7,6 +7,13 @@
   "last_verified_diffstat_sha256": "sha256:a84dc6ce765daedfeb02e95d919e1aa3c4eaabe7dafbbcb5989ee530127036ed",
   "pr_number": 4556,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4556",
+  "pre_merge_closure": {
+    "basis_commit": "994ea841af950ac2bf9eb93e8556627e07754595",
+    "branch": "task/202607092342-AHYFCS/enforce-cross-surface-context-integrity-for-v0-6",
+    "pr_number": 4556,
+    "recorded_at": "2026-07-10T00:08:38.228Z",
+    "state": "closed_before_merge"
+  },
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202607092342-AHYFCS",

--- a/.agentplane/tasks/202607092342-AHYFCS/pr/meta.json
+++ b/.agentplane/tasks/202607092342-AHYFCS/pr/meta.json
@@ -2,9 +2,9 @@
   "base": "main",
   "branch": "task/202607092342-AHYFCS/enforce-cross-surface-context-integrity-for-v0-6",
   "created_at": "2026-07-09T23:43:35.604Z",
-  "diffstat_sha256": "sha256:a84dc6ce765daedfeb02e95d919e1aa3c4eaabe7dafbbcb5989ee530127036ed",
-  "last_verified_at": "2026-07-10T00:08:14.065Z",
-  "last_verified_diffstat_sha256": "sha256:a84dc6ce765daedfeb02e95d919e1aa3c4eaabe7dafbbcb5989ee530127036ed",
+  "diffstat_sha256": "sha256:c957b3428ef88405fac8c26326c39d41b8040c6ffa4879836bb9eac40dd377c8",
+  "last_verified_at": "2026-07-10T00:13:21.353Z",
+  "last_verified_diffstat_sha256": "sha256:c957b3428ef88405fac8c26326c39d41b8040c6ffa4879836bb9eac40dd377c8",
   "pr_number": 4556,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4556",
   "pre_merge_closure": {

--- a/.agentplane/tasks/202607092342-AHYFCS/pr/meta.json
+++ b/.agentplane/tasks/202607092342-AHYFCS/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202607092342-AHYFCS/enforce-cross-surface-context-integrity-for-v0-6",
+  "created_at": "2026-07-09T23:43:35.604Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202607092342-AHYFCS",
+  "updated_at": "2026-07-09T23:43:35.604Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202607092342-AHYFCS/pr/review.md
+++ b/.agentplane/tasks/202607092342-AHYFCS/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-07-09T23:43:35.604Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified: current main-targeting PR head preserves the passing integrity tests, 2,132-test full fast suite, critical CLI suite, typecheck, lint, and ci:contract evidence.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,12 +24,17 @@ Created: 2026-07-09T23:43:35.604Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-09T23:43:35.604Z
+- Updated: 2026-07-09T23:57:04.928Z
 - Branch: task/202607092342-AHYFCS/enforce-cross-surface-context-integrity-for-v0-6
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/commands/context/check.unit.test.ts        | 118 +++++++++++++
+ .../src/commands/context/wiki-reports.ts           |  21 ++-
+ .../src/commands/context/wiki-reports.unit.test.ts |   9 +
+ packages/agentplane/src/context/doctor.ts          |   2 +
+ packages/agentplane/src/context/integrity.ts       | 186 +++++++++++++++++++++
+ 5 files changed, 334 insertions(+), 2 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607092342-AHYFCS/pr/review.md
+++ b/.agentplane/tasks/202607092342-AHYFCS/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-07-09T23:43:35.604Z
+
+## Task
+
+- Task: `202607092342-AHYFCS`
+- Title: Enforce cross-surface context integrity for v0.6.22
+- Status: DOING
+- Branch: `task/202607092342-AHYFCS/enforce-cross-surface-context-integrity-for-v0-6`
+- Canonical task record: `.agentplane/tasks/202607092342-AHYFCS/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-09T23:43:35.604Z
+- Branch: task/202607092342-AHYFCS/enforce-cross-surface-context-integrity-for-v0-6
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202607092342-AHYFCS/pr/review.md
+++ b/.agentplane/tasks/202607092342-AHYFCS/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-07-09T23:43:35.604Z
 ## Verification
 
 - State: ok
-- Note: Verified: current main-targeting PR head preserves the passing integrity tests, 2,132-test full fast suite, critical CLI suite, typecheck, lint, and ci:contract evidence.
+- Note: Verified: review fix ignores hidden .obsidian and raw archive directories; 10 focused tests, typecheck, lint, diff check, prior full ci:contract, 2,132-test fast suite, and critical CLI remain green.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -29,12 +29,12 @@ Created: 2026-07-09T23:43:35.604Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
- .../src/commands/context/check.unit.test.ts        | 118 +++++++++++++
+ .../src/commands/context/check.unit.test.ts        | 129 ++++++++++++++
  .../src/commands/context/wiki-reports.ts           |  21 ++-
  .../src/commands/context/wiki-reports.unit.test.ts |   9 +
  packages/agentplane/src/context/doctor.ts          |   2 +
- packages/agentplane/src/context/integrity.ts       | 186 +++++++++++++++++++++
- 5 files changed, 334 insertions(+), 2 deletions(-)
+ packages/agentplane/src/context/integrity.ts       | 188 +++++++++++++++++++++
+ 5 files changed, 347 insertions(+), 2 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607092342-AHYFCS/quality/20260709-235343150-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607092342-AHYFCS/quality/20260709-235343150-recovery-context/evaluator-opinion.md
@@ -1,0 +1,19 @@
+# EVALUATOR opinion: pass
+
+Global context integrity now rejects disconnected or stale maximum-assimilation artifacts.
+
+## Findings
+- The validator resolves wiki graph references, enforces active entity page policy, checks raw source registration, and fingerprints connectivity reports with focused regression coverage.
+
+## Evidence
+- .agentplane/tasks/202607092342-AHYFCS/README.md
+- packages/agentplane/src/commands/context/check.unit.test.ts
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607092342-AHYFCS/quality/20260709-235343150-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607092342-AHYFCS/quality/20260709-235343150-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202607092342-AHYFCS
+- task_readme: .agentplane/tasks/202607092342-AHYFCS/README.md
+- report_path: .agentplane/tasks/202607092342-AHYFCS/quality/20260709-235343150-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607092342-AHYFCS/quality/20260709-235343150-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607092342-AHYFCS/quality/20260709-235343150-recovery-context/quality-report.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "task_id": "202607092342-AHYFCS",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-09T23:53:43.150Z",
+  "verdict": "pass",
+  "summary": "Global context integrity now rejects disconnected or stale maximum-assimilation artifacts.",
+  "evaluated_sha": "1ac42ed68fef6764b464e114614fb99b02f102de",
+  "blueprint_digest": "a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2",
+  "findings": [
+    "The validator resolves wiki graph references, enforces active entity page policy, checks raw source registration, and fingerprints connectivity reports with focused regression coverage."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607092342-AHYFCS/README.md",
+    "packages/agentplane/src/commands/context/check.unit.test.ts"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/.agentplane/tasks/202607092342-AHYFCS/quality/20260710-001323689-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607092342-AHYFCS/quality/20260710-001323689-recovery-context/evaluator-opinion.md
@@ -1,0 +1,19 @@
+# EVALUATOR opinion: pass
+
+Cross-surface integrity is strict for managed context while preserving ignored hidden directories.
+
+## Findings
+- The final collector skips hidden and service directories consistently with ingest and wiki report traversal; focused regression coverage verifies ignored vault/plugin and raw archive paths.
+
+## Evidence
+- .agentplane/tasks/202607092342-AHYFCS/README.md
+- packages/agentplane/src/commands/context/check.unit.test.ts
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607092342-AHYFCS/quality/20260710-001323689-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607092342-AHYFCS/quality/20260710-001323689-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202607092342-AHYFCS
+- task_readme: .agentplane/tasks/202607092342-AHYFCS/README.md
+- report_path: .agentplane/tasks/202607092342-AHYFCS/quality/20260710-001323689-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607092342-AHYFCS/quality/20260710-001323689-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607092342-AHYFCS/quality/20260710-001323689-recovery-context/quality-report.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "task_id": "202607092342-AHYFCS",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-10T00:13:23.689Z",
+  "verdict": "pass",
+  "summary": "Cross-surface integrity is strict for managed context while preserving ignored hidden directories.",
+  "evaluated_sha": "0c828f95913c21997368cbd31741a99dd22ed834",
+  "blueprint_digest": "a8361a32f0a7051b16c3aab0dd86d3e3de499bf7cfbbd6ecedff558e63c892a2",
+  "findings": [
+    "The final collector skips hidden and service directories consistently with ingest and wiki report traversal; focused regression coverage verifies ignored vault/plugin and raw archive paths."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607092342-AHYFCS/README.md",
+    "packages/agentplane/src/commands/context/check.unit.test.ts"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/commands/context/check.unit.test.ts
+++ b/packages/agentplane/src/commands/context/check.unit.test.ts
@@ -1,0 +1,118 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { CommandContext } from "../shared/task-backend.js";
+import { cmdContextDoctor } from "./doctor.js";
+import { cmdContextInit } from "./init.js";
+import { cmdContextWikiReport } from "./wiki-reports.js";
+
+let tempRoots: string[] = [];
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "agentplane-context-cross-surface-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  for (const root of tempRoots) await rm(root, { recursive: true, force: true });
+  tempRoots = [];
+});
+
+async function write(root: string, rel: string, text: string): Promise<void> {
+  const target = path.join(root, rel);
+  await mkdir(path.dirname(target), { recursive: true });
+  await writeFile(target, text, "utf8");
+}
+
+async function initMaximum(root: string): Promise<void> {
+  vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  await cmdContextInit({
+    ctx: { resolvedProject: { gitRoot: root } } as CommandContext,
+    cwd: root,
+    parsed: {
+      profile: "maximum-assimilation",
+      rawGitignore: "none",
+      derivedGitignore: "none",
+      repair: false,
+      force: false,
+    },
+  });
+}
+
+function wikiPage(id: string, graphEntity = ""): string {
+  return [
+    "---",
+    "agentplane_context:",
+    "  schema_version: 1",
+    "  artifact_type: wiki_page",
+    `  canonical_id: "wiki.${id}"`,
+    `  title: "${id}"`,
+    "  modality: definition",
+    "  epistemic_status: sourced_claim",
+    "  source_refs: []",
+    "  graph_refs:",
+    `    entities: ${graphEntity ? `["${graphEntity}"]` : "[]"}`,
+    "    edges: []",
+    "---",
+    "",
+    `# ${id}`,
+    "",
+    "Body.",
+    "",
+    "## Sources",
+    "",
+    "- no-source: test fixture",
+    "",
+  ].join("\n");
+}
+
+describe("context cross-surface integrity", () => {
+  it("rejects raw files missing from the manifest and unresolved wiki graph refs", async () => {
+    const root = await tempRoot();
+    await initMaximum(root);
+    await write(root, "context/raw/untracked.md", "# Untracked\n");
+    await write(root, "context/wiki/unresolved.md", wikiPage("unresolved", "entity.missing"));
+
+    await expect(
+      cmdContextDoctor({ cwd: root, parsed: { fix: false, label: "check" } }),
+    ).rejects.toThrow(
+      /raw source missing from manifest lock[\s\S]*wiki graph entity ref does not resolve|wiki graph entity ref does not resolve[\s\S]*raw source missing from manifest lock/u,
+    );
+  });
+
+  it("requires page policy for active maximum-assimilation entities", async () => {
+    const root = await tempRoot();
+    await initMaximum(root);
+    await write(
+      root,
+      ".agentplane/context/derived/graph/entities.jsonl",
+      `${JSON.stringify({ id: "entity.unpaged", kind: "concept", status: "active" })}\n`,
+    );
+
+    await expect(
+      cmdContextDoctor({ cwd: root, parsed: { fix: false, label: "check" } }),
+    ).rejects.toThrow(/active graph entity requires target_path or no_page_reason/u);
+  });
+
+  it("detects connectivity reports that became stale after wiki changes", async () => {
+    const root = await tempRoot();
+    await initMaximum(root);
+    for (const id of ["alpha", "beta", "gamma"]) {
+      await write(root, `context/wiki/entities/${id}.md`, wikiPage(id));
+    }
+    await cmdContextWikiReport({ cwd: root, parsed: { path: "context/wiki" } });
+    const reportState = JSON.parse(
+      await readFile(path.join(root, ".agentplane/context/derived/wiki/report-state.json"), "utf8"),
+    ) as { source_digest: string };
+    expect(reportState.source_digest).toMatch(/^sha256:/u);
+
+    await write(root, "context/wiki/entities/alpha.md", wikiPage("alpha-updated"));
+    await expect(
+      cmdContextDoctor({ cwd: root, parsed: { fix: false, label: "check" } }),
+    ).rejects.toThrow(/wiki connectivity reports are stale/u);
+  });
+});

--- a/packages/agentplane/src/commands/context/check.unit.test.ts
+++ b/packages/agentplane/src/commands/context/check.unit.test.ts
@@ -71,6 +71,17 @@ function wikiPage(id: string, graphEntity = ""): string {
 }
 
 describe("context cross-surface integrity", () => {
+  it("ignores hidden vault and raw archive directories", async () => {
+    const root = await tempRoot();
+    await initMaximum(root);
+    await write(root, "context/wiki/.obsidian/plugins/local.md", "not a wiki page");
+    await write(root, "context/raw/.archive/legacy.md", "# Archived\n");
+
+    await expect(
+      cmdContextDoctor({ cwd: root, parsed: { fix: false, label: "check" } }),
+    ).resolves.toBe(0);
+  });
+
   it("rejects raw files missing from the manifest and unresolved wiki graph refs", async () => {
     const root = await tempRoot();
     await initMaximum(root);

--- a/packages/agentplane/src/commands/context/wiki-reports.ts
+++ b/packages/agentplane/src/commands/context/wiki-reports.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import { fileExists, parseJsonlLines, readText, toPosix } from "./context-utils.js";
 import { collectWikiFiles, extractFrontmatter, normalizeExistingWikiTarget } from "./wiki-lint.js";
+import { computeWikiReportSourceDigest, WIKI_REPORT_STATE_PATH } from "../../context/integrity.js";
 
 type JsonRow = Record<string, unknown>;
 
@@ -138,8 +139,9 @@ async function loadJsonl(root: string, rel: string): Promise<JsonRow[]> {
 
 async function writeTextIfChanged(root: string, rel: string, text: string): Promise<boolean> {
   const abs = path.join(root, rel);
-  const existing = (await fileExists(abs)) ? await readFile(abs, "utf8") : "";
-  if (existing === text) return false;
+  const exists = await fileExists(abs);
+  const existing = exists ? await readFile(abs, "utf8") : "";
+  if (exists && existing === text) return false;
   await mkdir(path.dirname(abs), { recursive: true });
   await writeFile(abs, text, "utf8");
   return true;
@@ -435,9 +437,24 @@ async function buildMaximumAssimilationWikiReports(
     }));
 
   const changed: string[] = [];
+  const sourceDigest = await computeWikiReportSourceDigest(root);
   const outputs: [string, string][] = [
     [".agentplane/context/derived/wiki/link-index.jsonl", jsonl(linkRows)],
     [".agentplane/context/derived/wiki/orphan-report.jsonl", jsonl(orphanRows)],
+    [
+      WIKI_REPORT_STATE_PATH,
+      `${JSON.stringify(
+        {
+          schema_version: 1,
+          target,
+          source_digest: sourceDigest,
+          link_rows: linkRows.length,
+          orphan_rows: orphanRows.length,
+        },
+        null,
+        2,
+      )}\n`,
+    ],
   ];
 
   const conflictsRel = ".agentplane/context/derived/claims/contradictions.jsonl";

--- a/packages/agentplane/src/commands/context/wiki-reports.unit.test.ts
+++ b/packages/agentplane/src/commands/context/wiki-reports.unit.test.ts
@@ -103,6 +103,15 @@ describe("context wiki report", () => {
     expect(
       await readFile(path.join(root, "context/wiki/reports/open-questions.md"), "utf8"),
     ).toContain("question.payment");
+    const reportState = JSON.parse(
+      await readFile(path.join(root, ".agentplane/context/derived/wiki/report-state.json"), "utf8"),
+    ) as { target: string; link_rows: number; orphan_rows: number; source_digest: string };
+    expect(reportState).toMatchObject({
+      target: "context/wiki",
+      link_rows: 1,
+      orphan_rows: 1,
+    });
+    expect(reportState.source_digest).toMatch(/^sha256:/u);
   });
 
   it("honors the requested wiki report path", async () => {

--- a/packages/agentplane/src/context/doctor.ts
+++ b/packages/agentplane/src/context/doctor.ts
@@ -12,6 +12,7 @@ import { parseJsonlLines, fileExists, parseSourceRef, readText, toPosix } from "
 import { readHarvestReport } from "./harvest-tasks-artifacts.js";
 import { readContextProjection } from "./reindex.js";
 import { checkSqliteProjection } from "./sqlite.js";
+import { validateContextCrossSurfaceIntegrity } from "./integrity.js";
 
 export async function cmdContextDoctor(opts: {
   cwd: string;
@@ -154,6 +155,7 @@ export async function cmdContextDoctor(opts: {
     await checkSourceRefs(path.join(root, file), manifestSources, root, warnings);
   }
   await checkHarvestReports(root, issues, warnings);
+  issues.push(...(await validateContextCrossSurfaceIntegrity(root)));
 
   if (issues.length > 0) {
     process.stderr.write(

--- a/packages/agentplane/src/context/integrity.ts
+++ b/packages/agentplane/src/context/integrity.ts
@@ -22,8 +22,10 @@ async function collectFiles(root: string, rel: string): Promise<string[]> {
     }
     for (const entry of entries) {
       const child = toPosix(path.join(current, entry.name));
-      if (entry.isDirectory()) await walk(child);
-      else if (entry.isFile()) out.push(child);
+      if (entry.isDirectory()) {
+        if (entry.name.startsWith(".") || entry.name === "service") continue;
+        await walk(child);
+      } else if (entry.isFile()) out.push(child);
     }
   }
   await walk(rel);

--- a/packages/agentplane/src/context/integrity.ts
+++ b/packages/agentplane/src/context/integrity.ts
@@ -1,0 +1,186 @@
+import { createHash } from "node:crypto";
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
+
+import { isRecord } from "../shared/guards.js";
+import { fileExists, parseJsonlLines, toPosix } from "./context-utils.js";
+import { isUnsupportedPath, readContextWorkspaceMode, readManifest } from "./ingest-manifest.js";
+
+export const WIKI_REPORT_STATE_PATH = ".agentplane/context/derived/wiki/report-state.json";
+
+type JsonRow = Record<string, unknown>;
+
+async function collectFiles(root: string, rel: string): Promise<string[]> {
+  const out: string[] = [];
+  async function walk(current: string): Promise<void> {
+    let entries;
+    try {
+      entries = await readdir(path.join(root, current), { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const child = toPosix(path.join(current, entry.name));
+      if (entry.isDirectory()) await walk(child);
+      else if (entry.isFile()) out.push(child);
+    }
+  }
+  await walk(rel);
+  return out.toSorted();
+}
+
+async function readJsonl(root: string, rel: string): Promise<JsonRow[]> {
+  const abs = path.join(root, rel);
+  if (!(await fileExists(abs))) return [];
+  return parseJsonlLines(await readFile(abs, "utf8")) as JsonRow[];
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string" && entry.trim() !== "")
+    : [];
+}
+
+function stringValue(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function wikiGraphRefs(text: string): { entities: string[]; edges: string[] } {
+  const frontmatter = /^---\n([\s\S]*?)\n---/u.exec(text.replaceAll("\r\n", "\n"))?.[1];
+  if (!frontmatter) return { entities: [], edges: [] };
+  const parsed = parseYaml(frontmatter) as unknown;
+  if (!isRecord(parsed)) return { entities: [], edges: [] };
+  const context = isRecord(parsed.agentplane_context) ? parsed.agentplane_context : parsed;
+  if (!isRecord(context.graph_refs)) return { entities: [], edges: [] };
+  return {
+    entities: stringArray(context.graph_refs.entities),
+    edges: stringArray(context.graph_refs.edges),
+  };
+}
+
+function isSemanticWikiPage(rel: string): boolean {
+  return (
+    rel.endsWith(".md") &&
+    rel !== "context/wiki/AGENTS.md" &&
+    rel !== "context/wiki/index.md" &&
+    rel !== "context/wiki/glossary.md" &&
+    !rel.endsWith("/index.md") &&
+    !rel.includes("/reports/")
+  );
+}
+
+export async function computeWikiReportSourceDigest(root: string): Promise<string> {
+  const collectedWikiFiles = await collectFiles(root, "context/wiki");
+  const wikiFiles = collectedWikiFiles.filter(
+    (rel) => rel.endsWith(".md") && !rel.includes("/reports/") && rel !== "context/wiki/AGENTS.md",
+  );
+  const inputs = [
+    ...wikiFiles,
+    ".agentplane/context/derived/graph/entities.jsonl",
+    ".agentplane/context/derived/graph/edges.jsonl",
+  ].toSorted();
+  const hash = createHash("sha256");
+  for (const rel of inputs) {
+    const abs = path.join(root, rel);
+    if (!(await fileExists(abs))) continue;
+    hash.update(rel);
+    hash.update("\0");
+    hash.update(await readFile(abs));
+    hash.update("\0");
+  }
+  return `sha256:${hash.digest("hex")}`;
+}
+
+async function validateWikiGraphRefs(root: string, issues: string[]): Promise<void> {
+  const entities = await readJsonl(root, ".agentplane/context/derived/graph/entities.jsonl");
+  const entityIds = new Set(entities.map((row) => stringValue(row.id)).filter(Boolean));
+  const edges = await readJsonl(root, ".agentplane/context/derived/graph/edges.jsonl");
+  const edgeIds = new Set(edges.map((row) => stringValue(row.id)).filter(Boolean));
+  const collectedWikiFiles = await collectFiles(root, "context/wiki");
+  for (const rel of collectedWikiFiles.filter((file) => file.endsWith(".md"))) {
+    const refs = wikiGraphRefs(await readFile(path.join(root, rel), "utf8"));
+    for (const entityId of refs.entities) {
+      if (!entityIds.has(entityId))
+        issues.push(`wiki graph entity ref does not resolve: ${entityId} (${rel})`);
+    }
+    for (const edgeId of refs.edges) {
+      if (!edgeIds.has(edgeId))
+        issues.push(`wiki graph edge ref does not resolve: ${edgeId} (${rel})`);
+    }
+  }
+}
+
+async function validateEntityPagePolicy(root: string, issues: string[]): Promise<void> {
+  if ((await readContextWorkspaceMode(root)) !== "maximum-assimilation") return;
+  for (const row of await readJsonl(root, ".agentplane/context/derived/graph/entities.jsonl")) {
+    const id = stringValue(row.id, "<unknown>");
+    const status = typeof row.status === "string" ? row.status : "active";
+    if (status !== "active" && status !== "accepted") continue;
+    const targetPath = typeof row.target_path === "string" ? row.target_path.trim() : "";
+    const noPageReason = typeof row.no_page_reason === "string" ? row.no_page_reason.trim() : "";
+    if (!targetPath && !noPageReason) {
+      issues.push(`active graph entity requires target_path or no_page_reason: ${id}`);
+      continue;
+    }
+    if (targetPath && !(await fileExists(path.join(root, targetPath)))) {
+      issues.push(`active graph entity target_path does not exist: ${id} -> ${targetPath}`);
+    }
+  }
+}
+
+async function validateRawManifestCoverage(root: string, issues: string[]): Promise<void> {
+  const manifest = await readManifest(root);
+  const manifestPaths = new Set(manifest.sources.map((source) => source.path));
+  const collectedRawFiles = await collectFiles(root, "context/raw");
+  const rawFiles = collectedRawFiles.filter((rel) => !isUnsupportedPath(rel));
+  for (const rel of rawFiles) {
+    if (!manifestPaths.has(rel)) issues.push(`raw source missing from manifest lock: ${rel}`);
+  }
+}
+
+async function validateWikiReportFreshness(root: string, issues: string[]): Promise<void> {
+  if ((await readContextWorkspaceMode(root)) !== "maximum-assimilation") return;
+  const collectedWikiFiles = await collectFiles(root, "context/wiki");
+  const semanticWikiPages = collectedWikiFiles.filter((rel) => isSemanticWikiPage(rel));
+  if (semanticWikiPages.length < 3) return;
+  const stateAbs = path.join(root, WIKI_REPORT_STATE_PATH);
+  if (!(await fileExists(stateAbs))) {
+    issues.push(`wiki connectivity report state missing: ${WIKI_REPORT_STATE_PATH}`);
+    return;
+  }
+  let state: JsonRow;
+  try {
+    state = JSON.parse(await readFile(stateAbs, "utf8")) as JsonRow;
+  } catch {
+    issues.push(`wiki connectivity report state is unreadable: ${WIKI_REPORT_STATE_PATH}`);
+    return;
+  }
+  if (state.target !== "context/wiki") {
+    issues.push(
+      `wiki connectivity reports cover only ${stringValue(state.target, "<unknown>")}; refresh context/wiki`,
+    );
+  }
+  const currentDigest = await computeWikiReportSourceDigest(root);
+  if (state.source_digest !== currentDigest) {
+    issues.push(
+      "wiki connectivity reports are stale; run agentplane context wiki report context/wiki",
+    );
+  }
+  for (const rel of [
+    ".agentplane/context/derived/wiki/link-index.jsonl",
+    ".agentplane/context/derived/wiki/orphan-report.jsonl",
+  ]) {
+    if (!(await fileExists(path.join(root, rel))))
+      issues.push(`wiki connectivity report missing: ${rel}`);
+  }
+}
+
+export async function validateContextCrossSurfaceIntegrity(root: string): Promise<string[]> {
+  const issues: string[] = [];
+  await validateWikiGraphRefs(root, issues);
+  await validateEntityPagePolicy(root, issues);
+  await validateRawManifestCoverage(root, issues);
+  await validateWikiReportFreshness(root, issues);
+  return issues;
+}


### PR DESCRIPTION
Task: `202607092342-AHYFCS`
Title: Enforce cross-surface context integrity for v0.6.22
Canonical task record: `.agentplane/tasks/202607092342-AHYFCS/README.md`

## Summary

Enforce cross-surface context integrity for v0.6.22

Make global context checks validate wiki graph references, entity page policy, manifest/source coverage, and freshness of derived wiki reports so structurally valid but semantically disconnected context cannot pass.

## Scope

- In scope: global read-only integrity validation across wiki, graph, manifest/raw source inventory, and derived link/orphan reports.
- In scope: actionable diagnostics and regression tests.
- Out of scope: rewriting existing repository wiki content, changing public context schemas, or implementing semantic search ranking.

## Verification

- State: ok
- Note:

```text
Verified: cross-surface graph, entity page policy, raw manifest coverage, and report freshness gates
pass 40 focused tests, typecheck, lint, diff check, and ci:contract.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-07-09T23:56:26.210Z
- Branch: task/202607092342-AHYFCS/enforce-cross-surface-context-integrity-for-v0-6
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/commands/context/check.unit.test.ts        | 118 +++++++++++++
 .../src/commands/context/wiki-reports.ts           |  21 ++-
 .../src/commands/context/wiki-reports.unit.test.ts |   9 +
 packages/agentplane/src/context/doctor.ts          |   2 +
 packages/agentplane/src/context/integrity.ts       | 186 +++++++++++++++++++++
 5 files changed, 334 insertions(+), 2 deletions(-)
```

</details>
