### PR TITLE
🚧 D7QB76 task: Anchor evaluator reviews for metadata-only tasks [202607100436-D7QB76]

### DIFF
--- a/.agentplane/tasks/202607100436-D7QB76/README.md
+++ b/.agentplane/tasks/202607100436-D7QB76/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 11
+revision: 12
 origin:
   system: "manual"
 depends_on: []
@@ -51,8 +51,8 @@ quality_review:
   findings:
     - "Two-pass regression proves a repeated review remains anchored to the original metadata work unit; explicit new work still supersedes the prior target."
 commit:
-  hash: "612b12171d5c9cb942fcd573e79795d8eb0d9f4a"
-  message: "📝 D7QB76 task: record pull request metadata"
+  hash: "6b28d0fc5273bd6f22e6b502ebc393fb463dbfca"
+  message: "🧪 D7QB76 task: verify stable evaluator reruns"
 comments:
   -
     author: "CODER"
@@ -60,6 +60,9 @@ comments:
   -
     author: "CODER"
     body: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    author: "CODER"
+    body: "Verified: refreshed pre-merge closure after rebase and review fix."
 events:
   -
     type: "status"
@@ -87,8 +90,15 @@ events:
     author: "REVIEWER"
     state: "ok"
     note: "Evaluator reruns now preserve an ancestral reviewed SHA across managed quality, PR, blueprint, and README advances while still selecting new task-local or code work. Focused 2/12, targeted 10/133, typecheck, lint, ci:contract, test:fast 364/2157, policy routing, and doctor passed."
+  -
+    type: "status"
+    at: "2026-07-10T12:47:50.847Z"
+    author: "CODER"
+    from: "DONE"
+    to: "DONE"
+    note: "Verified: refreshed pre-merge closure after rebase and review fix."
 doc_version: 3
-doc_updated_at: "2026-07-10T12:46:25.777Z"
+doc_updated_at: "2026-07-10T12:47:50.848Z"
 doc_updated_by: "CODER"
 description: "For v0.6.22, give metadata-only docs and task-closure changes a fresh auditable evaluator target instead of walking past all workflow artifacts to an unrelated older code commit."
 sections:
@@ -187,8 +197,8 @@ sections:
     Review follow-up: added a two-pass evaluator regression that commits the first quality report and a later PR metadata refresh, then proves the second report remains anchored to the original metadata work unit. Focused suites pass 2 files / 12 tests; typecheck and lint pass.
 extensions:
   implementation_commit:
-    hash: "f6f17a1f6f44a2247a62dbf3b6fe2dd668c54804"
-    message: "🐛 D7QB76 task: anchor metadata-only evaluator targets"
+    hash: "0b817152a8da33505a18974d6a3c069141345e21"
+    message: "🐛 D7QB76 task: preserve evaluator rerun targets"
 id_source: "generated"
 ---
 ## Summary

--- a/.agentplane/tasks/202607100436-D7QB76/README.md
+++ b/.agentplane/tasks/202607100436-D7QB76/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 9
+revision: 11
 origin:
   system: "manual"
 depends_on: []
@@ -30,30 +30,26 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-07-10T10:47:38.387Z"
+  updated_at: "2026-07-10T12:46:22.248Z"
   updated_by: "REVIEWER"
-  note: "Focused evaluator/finish regressions pass (2 files, 11 tests); typecheck, lint:core, ci:contract, test:fast (364 files/2153 tests), policy routing, and doctor pass. The evaluator keeps code targets, anchors the current pure metadata work unit, and rejects unrelated task artifacts."
+  note: "Evaluator reruns now preserve an ancestral reviewed SHA across managed quality, PR, blueprint, and README advances while still selecting new task-local or code work. Focused 2/12, targeted 10/133, typecheck, lint, ci:contract, test:fast 364/2157, policy routing, and doctor passed."
   attempts: 0
 quality_review:
   state: "pass"
-  updated_at: "2026-07-10T10:47:40.192Z"
+  updated_at: "2026-07-10T12:46:28.705Z"
   updated_by: "EVALUATOR"
-  note: "Metadata-only evaluator targets are now current, auditable, and bounded without weakening code-task freshness."
-  evaluated_sha: "f6f17a1f6f44a2247a62dbf3b6fe2dd668c54804"
+  note: "Metadata-only evaluator targets remain stable across committed review and PR artifacts after rebase."
+  evaluated_sha: "0b817152a8da33505a18974d6a3c069141345e21"
   blueprint_digest: "4723f7ad08c4985149e8fc1af430e49b65e5909aed7ca3d13ff9a45b7d5a656f"
   evidence_refs:
     - ".agentplane/tasks/202607100436-D7QB76/README.md"
-    - ".agentplane/tasks/202607100436-D7QB76/quality/20260710-104740192-recovery-context/quality-report.json"
-    - ".agentplane/tasks/202607100436-D7QB76/quality/20260710-104740192-recovery-context/evaluator-prompt.md"
-    - ".agentplane/tasks/202607100436-D7QB76/quality/20260710-104740192-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607100436-D7QB76/quality/20260710-124628705-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607100436-D7QB76/quality/20260710-124628705-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607100436-D7QB76/quality/20260710-124628705-recovery-context/evaluator-opinion.md"
     - ".agentplane/tasks/202607100436-D7QB76/blueprint/resolved-snapshot.json"
-    - "commit f6f17a1f6f44"
-    - "focused vitest 2 files/11 tests; typecheck; lint:core; ci:contract; test:fast 364 files/2153 tests"
-    - "node .agentplane/policy/check-routing.mjs; ap doctor"
+    - "packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts"
   findings:
-    - "Code-bearing branches still resolve to the last non-workflow implementation commit after current-task evidence commits."
-    - "Pure current-task metadata work stops at the first unrelated workflow-history boundary and uses its own latest committed work unit; a branch with only unrelated task artifacts receives no evaluated SHA."
-    - "Finish preserves the reviewed metadata SHA across later evaluator artifacts through the existing task-local-only advance check."
+    - "Two-pass regression proves a repeated review remains anchored to the original metadata work unit; explicit new work still supersedes the prior target."
 commit:
   hash: "612b12171d5c9cb942fcd573e79795d8eb0d9f4a"
   message: "📝 D7QB76 task: record pull request metadata"
@@ -85,8 +81,14 @@ events:
     from: "DOING"
     to: "DONE"
     note: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    type: "verify"
+    at: "2026-07-10T12:46:22.248Z"
+    author: "REVIEWER"
+    state: "ok"
+    note: "Evaluator reruns now preserve an ancestral reviewed SHA across managed quality, PR, blueprint, and README advances while still selecting new task-local or code work. Focused 2/12, targeted 10/133, typecheck, lint, ci:contract, test:fast 364/2157, policy routing, and doctor passed."
 doc_version: 3
-doc_updated_at: "2026-07-10T12:40:28.157Z"
+doc_updated_at: "2026-07-10T12:46:25.777Z"
 doc_updated_by: "CODER"
 description: "For v0.6.22, give metadata-only docs and task-closure changes a fresh auditable evaluator target instead of walking past all workflow artifacts to an unrelated older code commit."
 sections:
@@ -142,6 +144,36 @@ sections:
     - repeat_allowed: false
     - repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
     - risks: pr_artifact_freshness_loop, git_hook_side_effect
+
+    ### 2026-07-10T12:46:22.248Z — VERIFY — ok
+
+    By: REVIEWER
+
+    Note: Evaluator reruns now preserve an ancestral reviewed SHA across managed quality, PR, blueprint, and README advances while still selecting new task-local or code work. Focused 2/12, targeted 10/133, typecheck, lint, ci:contract, test:fast 364/2157, policy routing, and doctor passed.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-10T12:40:28.157Z, excerpt_hash=sha256:229aa2370d990d8dc394c6783bbe065b2f3598019ed3ef2a58d73d0b7af5c382
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607100436-D7QB76-anchor-evaluator-reviews-for-metadata-only-tasks/.agentplane/tasks/202607100436-D7QB76/blueprint/resolved-snapshot.json
+    - old_digest: 4723f7ad08c4985149e8fc1af430e49b65e5909aed7ca3d13ff9a45b7d5a656f
+    - current_digest: 4723f7ad08c4985149e8fc1af430e49b65e5909aed7ca3d13ff9a45b7d5a656f
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607100436-D7QB76
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane integrate queue enqueue 202607100436-D7QB76 --branch task/202607100436-D7QB76/anchor-evaluator-reviews-for-metadata-only-tasks
+    - diagnostic_command: agentplane pr check 202607100436-D7QB76
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: true
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: git_hook_side_effect
 
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
@@ -220,6 +252,36 @@ DecisionContextRef:
 - repeat_allowed: false
 - repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
 - risks: pr_artifact_freshness_loop, git_hook_side_effect
+
+### 2026-07-10T12:46:22.248Z — VERIFY — ok
+
+By: REVIEWER
+
+Note: Evaluator reruns now preserve an ancestral reviewed SHA across managed quality, PR, blueprint, and README advances while still selecting new task-local or code work. Focused 2/12, targeted 10/133, typecheck, lint, ci:contract, test:fast 364/2157, policy routing, and doctor passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-10T12:40:28.157Z, excerpt_hash=sha256:229aa2370d990d8dc394c6783bbe065b2f3598019ed3ef2a58d73d0b7af5c382
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607100436-D7QB76-anchor-evaluator-reviews-for-metadata-only-tasks/.agentplane/tasks/202607100436-D7QB76/blueprint/resolved-snapshot.json
+- old_digest: 4723f7ad08c4985149e8fc1af430e49b65e5909aed7ca3d13ff9a45b7d5a656f
+- current_digest: 4723f7ad08c4985149e8fc1af430e49b65e5909aed7ca3d13ff9a45b7d5a656f
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607100436-D7QB76
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane integrate queue enqueue 202607100436-D7QB76 --branch task/202607100436-D7QB76/anchor-evaluator-reviews-for-metadata-only-tasks
+- diagnostic_command: agentplane pr check 202607100436-D7QB76
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: true
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: git_hook_side_effect
 
 <!-- END VERIFICATION RESULTS -->
 

--- a/.agentplane/tasks/202607100436-D7QB76/README.md
+++ b/.agentplane/tasks/202607100436-D7QB76/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 8
+revision: 9
 origin:
   system: "manual"
 depends_on: []
@@ -86,7 +86,7 @@ events:
     to: "DONE"
     note: "Verified: pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-10T10:53:10.995Z"
+doc_updated_at: "2026-07-10T12:40:28.157Z"
 doc_updated_by: "CODER"
 description: "For v0.6.22, give metadata-only docs and task-closure changes a fresh auditable evaluator target instead of walking past all workflow artifacts to an unrelated older code commit."
 sections:
@@ -147,7 +147,12 @@ sections:
   Rollback Plan: |-
     - Revert task-related commit(s).
     - Re-run required checks to confirm rollback safety.
-  Findings: ""
+  Findings: |-
+    Root cause: metadata-only evaluator resolution skipped all task artifacts and could fall through to unrelated workflow history. The first fix retained the latest current-task artifact commit, but a repeated evaluator run could then mistake its own committed quality artifacts or refreshed PR metadata for newly reviewed work.
+
+    Implementation: retain the previous evaluated SHA when it is still an ancestor of HEAD and intervening current-task commits contain only managed quality, PR, blueprint, or README artifacts. A new task-local work unit outside those managed derived paths still supersedes the previous target, and code commits continue to target their implementation SHA.
+
+    Review follow-up: added a two-pass evaluator regression that commits the first quality report and a later PR metadata refresh, then proves the second report remains anchored to the original metadata work unit. Focused suites pass 2 files / 12 tests; typecheck and lint pass.
 extensions:
   implementation_commit:
     hash: "f6f17a1f6f44a2247a62dbf3b6fe2dd668c54804"
@@ -224,3 +229,9 @@ DecisionContextRef:
 - Re-run required checks to confirm rollback safety.
 
 ## Findings
+
+Root cause: metadata-only evaluator resolution skipped all task artifacts and could fall through to unrelated workflow history. The first fix retained the latest current-task artifact commit, but a repeated evaluator run could then mistake its own committed quality artifacts or refreshed PR metadata for newly reviewed work.
+
+Implementation: retain the previous evaluated SHA when it is still an ancestor of HEAD and intervening current-task commits contain only managed quality, PR, blueprint, or README artifacts. A new task-local work unit outside those managed derived paths still supersedes the previous target, and code commits continue to target their implementation SHA.
+
+Review follow-up: added a two-pass evaluator regression that commits the first quality report and a later PR metadata refresh, then proves the second report remains anchored to the original metadata work unit. Focused suites pass 2 files / 12 tests; typecheck and lint pass.

--- a/.agentplane/tasks/202607100436-D7QB76/README.md
+++ b/.agentplane/tasks/202607100436-D7QB76/README.md
@@ -4,7 +4,7 @@ title: "Anchor evaluator reviews for metadata-only tasks"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 5
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -28,11 +28,31 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-07-10T10:47:38.387Z"
+  updated_by: "REVIEWER"
+  note: "Focused evaluator/finish regressions pass (2 files, 11 tests); typecheck, lint:core, ci:contract, test:fast (364 files/2153 tests), policy routing, and doctor pass. The evaluator keeps code targets, anchors the current pure metadata work unit, and rejects unrelated task artifacts."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-07-10T10:47:40.192Z"
+  updated_by: "EVALUATOR"
+  note: "Metadata-only evaluator targets are now current, auditable, and bounded without weakening code-task freshness."
+  evaluated_sha: "f6f17a1f6f44a2247a62dbf3b6fe2dd668c54804"
+  blueprint_digest: "4723f7ad08c4985149e8fc1af430e49b65e5909aed7ca3d13ff9a45b7d5a656f"
+  evidence_refs:
+    - ".agentplane/tasks/202607100436-D7QB76/README.md"
+    - ".agentplane/tasks/202607100436-D7QB76/quality/20260710-104740192-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607100436-D7QB76/quality/20260710-104740192-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607100436-D7QB76/quality/20260710-104740192-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607100436-D7QB76/blueprint/resolved-snapshot.json"
+    - "commit f6f17a1f6f44"
+    - "focused vitest 2 files/11 tests; typecheck; lint:core; ci:contract; test:fast 364 files/2153 tests"
+    - "node .agentplane/policy/check-routing.mjs; ap doctor"
+  findings:
+    - "Code-bearing branches still resolve to the last non-workflow implementation commit after current-task evidence commits."
+    - "Pure current-task metadata work stops at the first unrelated workflow-history boundary and uses its own latest committed work unit; a branch with only unrelated task artifacts receives no evaluated SHA."
+    - "Finish preserves the reviewed metadata SHA across later evaluator artifacts through the existing task-local-only advance check."
 commit: null
 comments:
   -
@@ -46,8 +66,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: implement and verify a strict evaluator target for metadata-only task and documentation commits."
+  -
+    type: "verify"
+    at: "2026-07-10T10:47:38.387Z"
+    author: "REVIEWER"
+    state: "ok"
+    note: "Focused evaluator/finish regressions pass (2 files, 11 tests); typecheck, lint:core, ci:contract, test:fast (364 files/2153 tests), policy routing, and doctor pass. The evaluator keeps code targets, anchors the current pure metadata work unit, and rejects unrelated task artifacts."
 doc_version: 3
-doc_updated_at: "2026-07-10T10:42:25.725Z"
+doc_updated_at: "2026-07-10T10:47:38.540Z"
 doc_updated_by: "CODER"
 description: "For v0.6.22, give metadata-only docs and task-closure changes a fresh auditable evaluator target instead of walking past all workflow artifacts to an unrelated older code commit."
 sections:
@@ -74,6 +100,36 @@ sections:
     7. Merge through the integration queue, complete Hosted Close, pull `main`, and inspect `ap integrate queue list --json`. Expected: task `202607100435-A932SP` is automatically released from `handoff` by its valid merged pre-merge closure evidence before this task is claimed.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-07-10T10:47:38.387Z — VERIFY — ok
+
+    By: REVIEWER
+
+    Note: Focused evaluator/finish regressions pass (2 files, 11 tests); typecheck, lint:core, ci:contract, test:fast (364 files/2153 tests), policy routing, and doctor pass. The evaluator keeps code targets, anchors the current pure metadata work unit, and rejects unrelated task artifacts.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-10T10:42:25.725Z, excerpt_hash=sha256:229aa2370d990d8dc394c6783bbe065b2f3598019ed3ef2a58d73d0b7af5c382
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607100436-D7QB76-anchor-evaluator-reviews-for-metadata-only-tasks/.agentplane/tasks/202607100436-D7QB76/blueprint/resolved-snapshot.json
+    - old_digest: 4723f7ad08c4985149e8fc1af430e49b65e5909aed7ca3d13ff9a45b7d5a656f
+    - current_digest: 4723f7ad08c4985149e8fc1af430e49b65e5909aed7ca3d13ff9a45b7d5a656f
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607100436-D7QB76
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane pr update 202607100436-D7QB76
+    - diagnostic_command: agentplane pr check 202607100436-D7QB76
+    - source_of_truth: route=task_next_action diagnostic=pr_check remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
+    - risks: pr_artifact_freshness_loop, git_hook_side_effect
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -113,6 +169,36 @@ For v0.6.22, give metadata-only docs and task-closure changes a fresh auditable 
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-07-10T10:47:38.387Z — VERIFY — ok
+
+By: REVIEWER
+
+Note: Focused evaluator/finish regressions pass (2 files, 11 tests); typecheck, lint:core, ci:contract, test:fast (364 files/2153 tests), policy routing, and doctor pass. The evaluator keeps code targets, anchors the current pure metadata work unit, and rejects unrelated task artifacts.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-10T10:42:25.725Z, excerpt_hash=sha256:229aa2370d990d8dc394c6783bbe065b2f3598019ed3ef2a58d73d0b7af5c382
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607100436-D7QB76-anchor-evaluator-reviews-for-metadata-only-tasks/.agentplane/tasks/202607100436-D7QB76/blueprint/resolved-snapshot.json
+- old_digest: 4723f7ad08c4985149e8fc1af430e49b65e5909aed7ca3d13ff9a45b7d5a656f
+- current_digest: 4723f7ad08c4985149e8fc1af430e49b65e5909aed7ca3d13ff9a45b7d5a656f
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607100436-D7QB76
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane pr update 202607100436-D7QB76
+- diagnostic_command: agentplane pr check 202607100436-D7QB76
+- source_of_truth: route=task_next_action diagnostic=pr_check remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
+- risks: pr_artifact_freshness_loop, git_hook_side_effect
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202607100436-D7QB76/README.md
+++ b/.agentplane/tasks/202607100436-D7QB76/README.md
@@ -1,0 +1,123 @@
+---
+id: "202607100436-D7QB76"
+title: "Anchor evaluator reviews for metadata-only tasks"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "branch-pr"
+  - "code"
+  - "evaluator"
+  - "quality"
+  - "release-0.6.22"
+verify:
+  - "bunx vitest run packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts"
+  - "bun run typecheck"
+  - "bun run lint:core"
+  - "bun run ci:contract"
+  - "bun run test:fast"
+  - "node .agentplane/policy/check-routing.mjs"
+  - "ap doctor"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-07-10T04:36:16.223Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: implement and verify a strict evaluator target for metadata-only task and documentation commits."
+events:
+  -
+    type: "status"
+    at: "2026-07-10T10:34:39.295Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: implement and verify a strict evaluator target for metadata-only task and documentation commits."
+doc_version: 3
+doc_updated_at: "2026-07-10T10:42:25.725Z"
+doc_updated_by: "CODER"
+description: "For v0.6.22, give metadata-only docs and task-closure changes a fresh auditable evaluator target instead of walking past all workflow artifacts to an unrelated older code commit."
+sections:
+  Summary: |-
+    Anchor evaluator reviews for metadata-only tasks
+
+    For v0.6.22, give metadata-only docs and task-closure changes a fresh auditable evaluator target instead of walking past all workflow artifacts to an unrelated older code commit.
+  Scope: |-
+    - In scope: For v0.6.22, give metadata-only docs and task-closure changes a fresh auditable evaluator target instead of walking past all workflow artifacts to an unrelated older code commit.
+    - Out of scope: unrelated refactors not required for "Anchor evaluator reviews for metadata-only tasks".
+  Plan: |-
+    1. Add a metadata-only evaluator regression that changes task/docs artifacts without an implementation-code commit.
+    2. Define an auditable evaluated SHA rule that remains strict for implementation tasks but does not skip the current metadata-only work unit.
+    3. Preserve finish freshness and unrelated-artifact rejection.
+    4. Replace the matching evaluator follow-up placeholder in the v0.6.22 plan and keep the release task dependent on it.
+    5. Run focused evaluator/finish tests, typecheck, lint:core, ci:contract, and full fast.
+  Verify Steps: |-
+    1. Run `bunx vitest run packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts`. Expected: code tasks still target their implementation commit, pure current-task metadata work targets its own latest committed work unit, unrelated workflow artifacts are rejected, and later evaluator artifacts preserve the reviewed metadata SHA.
+    2. Run `bun run typecheck`. Expected: TypeScript contracts remain valid.
+    3. Run `bun run lint:core`. Expected: core lint passes.
+    4. Run `bun run ci:contract`. Expected: public CLI, architecture, Knip, clone, and coverage contracts remain unchanged.
+    5. Run `bun run test:fast`. Expected: the full fast regression suite passes.
+    6. Run `node .agentplane/policy/check-routing.mjs` and `ap doctor`. Expected: policy routing passes and no new release-blocking diagnostics appear.
+    7. Merge through the integration queue, complete Hosted Close, pull `main`, and inspect `ap integrate queue list --json`. Expected: task `202607100435-A932SP` is automatically released from `handoff` by its valid merged pre-merge closure evidence before this task is claimed.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Anchor evaluator reviews for metadata-only tasks
+
+For v0.6.22, give metadata-only docs and task-closure changes a fresh auditable evaluator target instead of walking past all workflow artifacts to an unrelated older code commit.
+
+## Scope
+
+- In scope: For v0.6.22, give metadata-only docs and task-closure changes a fresh auditable evaluator target instead of walking past all workflow artifacts to an unrelated older code commit.
+- Out of scope: unrelated refactors not required for "Anchor evaluator reviews for metadata-only tasks".
+
+## Plan
+
+1. Add a metadata-only evaluator regression that changes task/docs artifacts without an implementation-code commit.
+2. Define an auditable evaluated SHA rule that remains strict for implementation tasks but does not skip the current metadata-only work unit.
+3. Preserve finish freshness and unrelated-artifact rejection.
+4. Replace the matching evaluator follow-up placeholder in the v0.6.22 plan and keep the release task dependent on it.
+5. Run focused evaluator/finish tests, typecheck, lint:core, ci:contract, and full fast.
+
+## Verify Steps
+
+1. Run `bunx vitest run packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts`. Expected: code tasks still target their implementation commit, pure current-task metadata work targets its own latest committed work unit, unrelated workflow artifacts are rejected, and later evaluator artifacts preserve the reviewed metadata SHA.
+2. Run `bun run typecheck`. Expected: TypeScript contracts remain valid.
+3. Run `bun run lint:core`. Expected: core lint passes.
+4. Run `bun run ci:contract`. Expected: public CLI, architecture, Knip, clone, and coverage contracts remain unchanged.
+5. Run `bun run test:fast`. Expected: the full fast regression suite passes.
+6. Run `node .agentplane/policy/check-routing.mjs` and `ap doctor`. Expected: policy routing passes and no new release-blocking diagnostics appear.
+7. Merge through the integration queue, complete Hosted Close, pull `main`, and inspect `ap integrate queue list --json`. Expected: task `202607100435-A932SP` is automatically released from `handoff` by its valid merged pre-merge closure evidence before this task is claimed.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202607100436-D7QB76/README.md
+++ b/.agentplane/tasks/202607100436-D7QB76/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202607100436-D7QB76"
 title: "Anchor evaluator reviews for metadata-only tasks"
-status: "DOING"
+result_summary: "pre-merge closure"
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 7
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -53,11 +54,16 @@ quality_review:
     - "Code-bearing branches still resolve to the last non-workflow implementation commit after current-task evidence commits."
     - "Pure current-task metadata work stops at the first unrelated workflow-history boundary and uses its own latest committed work unit; a branch with only unrelated task artifacts receives no evaluated SHA."
     - "Finish preserves the reviewed metadata SHA across later evaluator artifacts through the existing task-local-only advance check."
-commit: null
+commit:
+  hash: "612b12171d5c9cb942fcd573e79795d8eb0d9f4a"
+  message: "📝 D7QB76 task: record pull request metadata"
 comments:
   -
     author: "CODER"
     body: "Start: implement and verify a strict evaluator target for metadata-only task and documentation commits."
+  -
+    author: "CODER"
+    body: "Verified: pre-merge closure packet is ready for the task PR."
 events:
   -
     type: "status"
@@ -72,8 +78,15 @@ events:
     author: "REVIEWER"
     state: "ok"
     note: "Focused evaluator/finish regressions pass (2 files, 11 tests); typecheck, lint:core, ci:contract, test:fast (364 files/2153 tests), policy routing, and doctor pass. The evaluator keeps code targets, anchors the current pure metadata work unit, and rejects unrelated task artifacts."
+  -
+    type: "status"
+    at: "2026-07-10T10:53:10.994Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-10T10:47:38.540Z"
+doc_updated_at: "2026-07-10T10:53:10.995Z"
 doc_updated_by: "CODER"
 description: "For v0.6.22, give metadata-only docs and task-closure changes a fresh auditable evaluator target instead of walking past all workflow artifacts to an unrelated older code commit."
 sections:
@@ -135,6 +148,10 @@ sections:
     - Revert task-related commit(s).
     - Re-run required checks to confirm rollback safety.
   Findings: ""
+extensions:
+  implementation_commit:
+    hash: "f6f17a1f6f44a2247a62dbf3b6fe2dd668c54804"
+    message: "🐛 D7QB76 task: anchor metadata-only evaluator targets"
 id_source: "generated"
 ---
 ## Summary

--- a/.agentplane/tasks/202607100436-D7QB76/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202607100436-D7QB76/blueprint/resolved-snapshot.json
@@ -1,0 +1,574 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607100436-D7QB76",
+    "title": "Anchor evaluator reviews for metadata-only tasks",
+    "description": "For v0.6.22, give metadata-only docs and task-closure changes a fresh auditable evaluator target instead of walking past all workflow artifacts to an unrelated older code commit.",
+    "tags": [
+      "branch-pr",
+      "code",
+      "evaluator",
+      "quality",
+      "release-0.6.22"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607100436-D7QB76",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "task kind resolved to code",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to code",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "4723f7ad08c4985149e8fc1af430e49b65e5909aed7ca3d13ff9a45b7d5a656f"
+  }
+}

--- a/.agentplane/tasks/202607100436-D7QB76/pr/diffstat.txt
+++ b/.agentplane/tasks/202607100436-D7QB76/pr/diffstat.txt
@@ -1,0 +1,4 @@
+ .../evaluator/evaluator-run.command.test.ts        | 96 +++++++++++++++++++---
+ .../src/commands/evaluator/evaluator.command.ts    | 14 +++-
+ .../task/finish.quality-review-target.unit.test.ts | 33 ++++++++
+ 3 files changed, 131 insertions(+), 12 deletions(-)

--- a/.agentplane/tasks/202607100436-D7QB76/pr/diffstat.txt
+++ b/.agentplane/tasks/202607100436-D7QB76/pr/diffstat.txt
@@ -1,4 +1,4 @@
- .../evaluator/evaluator-run.command.test.ts        | 96 +++++++++++++++++++---
- .../src/commands/evaluator/evaluator.command.ts    | 14 +++-
- .../task/finish.quality-review-target.unit.test.ts | 33 ++++++++
- 3 files changed, 131 insertions(+), 12 deletions(-)
+ .../evaluator/evaluator-run.command.test.ts        | 154 +++++++++++++++++++--
+ .../src/commands/evaluator/evaluator.command.ts    |  44 +++++-
+ .../task/finish.quality-review-target.unit.test.ts |  33 +++++
+ 3 files changed, 219 insertions(+), 12 deletions(-)

--- a/.agentplane/tasks/202607100436-D7QB76/pr/github-body.md
+++ b/.agentplane/tasks/202607100436-D7QB76/pr/github-body.md
@@ -15,8 +15,14 @@ For v0.6.22, give metadata-only docs and task-closure changes a fresh auditable 
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Focused evaluator/finish regressions pass (2 files, 11 tests); typecheck, lint:core, ci:contract,
+test:fast (364 files/2153 tests), policy routing, and doctor pass. The evaluator keeps code targets,
+anchors the current pure metadata work unit, and rejects unrelated task artifacts.
+```
 - Canonical workflow state lives in the task README.
 
 <details>

--- a/.agentplane/tasks/202607100436-D7QB76/pr/github-body.md
+++ b/.agentplane/tasks/202607100436-D7QB76/pr/github-body.md
@@ -19,24 +19,24 @@ For v0.6.22, give metadata-only docs and task-closure changes a fresh auditable 
 - Note:
 
 ```text
-Focused evaluator/finish regressions pass (2 files, 11 tests); typecheck, lint:core, ci:contract,
-test:fast (364 files/2153 tests), policy routing, and doctor pass. The evaluator keeps code targets,
-anchors the current pure metadata work unit, and rejects unrelated task artifacts.
+Evaluator reruns now preserve an ancestral reviewed SHA across managed quality, PR, blueprint, and
+README advances while still selecting new task-local or code work. Focused 2/12, targeted 10/133,
+typecheck, lint, ci:contract, test:fast 364/2157, policy routing, and doctor passed.
 ```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-10T10:34:39.342Z
+- Updated: 2026-07-10T10:49:25.932Z
 - Branch: task/202607100436-D7QB76/anchor-evaluator-reviews-for-metadata-only-tasks
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
- .../evaluator/evaluator-run.command.test.ts        | 96 +++++++++++++++++++---
- .../src/commands/evaluator/evaluator.command.ts    | 14 +++-
- .../task/finish.quality-review-target.unit.test.ts | 33 ++++++++
- 3 files changed, 131 insertions(+), 12 deletions(-)
+ .../evaluator/evaluator-run.command.test.ts        | 154 +++++++++++++++++++--
+ .../src/commands/evaluator/evaluator.command.ts    |  44 +++++-
+ .../task/finish.quality-review-target.unit.test.ts |  33 +++++
+ 3 files changed, 219 insertions(+), 12 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607100436-D7QB76/pr/github-body.md
+++ b/.agentplane/tasks/202607100436-D7QB76/pr/github-body.md
@@ -1,0 +1,36 @@
+Task: `202607100436-D7QB76`
+Title: Anchor evaluator reviews for metadata-only tasks
+Canonical task record: `.agentplane/tasks/202607100436-D7QB76/README.md`
+
+## Summary
+
+Anchor evaluator reviews for metadata-only tasks
+
+For v0.6.22, give metadata-only docs and task-closure changes a fresh auditable evaluator target instead of walking past all workflow artifacts to an unrelated older code commit.
+
+## Scope
+
+- In scope: For v0.6.22, give metadata-only docs and task-closure changes a fresh auditable evaluator target instead of walking past all workflow artifacts to an unrelated older code commit.
+- Out of scope: unrelated refactors not required for "Anchor evaluator reviews for metadata-only tasks".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-10T10:34:39.342Z
+- Branch: task/202607100436-D7QB76/anchor-evaluator-reviews-for-metadata-only-tasks
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../evaluator/evaluator-run.command.test.ts        | 96 +++++++++++++++++++---
+ .../src/commands/evaluator/evaluator.command.ts    | 14 +++-
+ .../task/finish.quality-review-target.unit.test.ts | 33 ++++++++
+ 3 files changed, 131 insertions(+), 12 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202607100436-D7QB76/pr/github-title.txt
+++ b/.agentplane/tasks/202607100436-D7QB76/pr/github-title.txt
@@ -1,1 +1,1 @@
-🚧 D7QB76 task: Anchor evaluator reviews for metadata-only tasks [202607100436-D7QB76]
+✅ D7QB76 task: Anchor evaluator reviews for metadata-only tasks [202607100436-D7QB76]

--- a/.agentplane/tasks/202607100436-D7QB76/pr/github-title.txt
+++ b/.agentplane/tasks/202607100436-D7QB76/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 D7QB76 task: Anchor evaluator reviews for metadata-only tasks [202607100436-D7QB76]

--- a/.agentplane/tasks/202607100436-D7QB76/pr/meta.json
+++ b/.agentplane/tasks/202607100436-D7QB76/pr/meta.json
@@ -2,9 +2,9 @@
   "base": "main",
   "branch": "task/202607100436-D7QB76/anchor-evaluator-reviews-for-metadata-only-tasks",
   "created_at": "2026-07-10T10:34:39.342Z",
-  "diffstat_sha256": "sha256:bf8622c0551e4d010e29b1e08bb751fdc0f1675e16efb0c07eb1b62e164db441",
-  "last_verified_at": "2026-07-10T10:47:38.387Z",
-  "last_verified_diffstat_sha256": "sha256:bf8622c0551e4d010e29b1e08bb751fdc0f1675e16efb0c07eb1b62e164db441",
+  "diffstat_sha256": "sha256:9577609c4993bb2f4393505ddb2d95b402074a161964f59334a29e4184ed778e",
+  "last_verified_at": "2026-07-10T12:46:22.248Z",
+  "last_verified_diffstat_sha256": "sha256:9577609c4993bb2f4393505ddb2d95b402074a161964f59334a29e4184ed778e",
   "pr_number": 4570,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4570",
   "pre_merge_closure": {

--- a/.agentplane/tasks/202607100436-D7QB76/pr/meta.json
+++ b/.agentplane/tasks/202607100436-D7QB76/pr/meta.json
@@ -7,6 +7,13 @@
   "last_verified_diffstat_sha256": "sha256:bf8622c0551e4d010e29b1e08bb751fdc0f1675e16efb0c07eb1b62e164db441",
   "pr_number": 4570,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4570",
+  "pre_merge_closure": {
+    "basis_commit": "612b12171d5c9cb942fcd573e79795d8eb0d9f4a",
+    "branch": "task/202607100436-D7QB76/anchor-evaluator-reviews-for-metadata-only-tasks",
+    "pr_number": 4570,
+    "recorded_at": "2026-07-10T10:53:11.016Z",
+    "state": "closed_before_merge"
+  },
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202607100436-D7QB76",

--- a/.agentplane/tasks/202607100436-D7QB76/pr/meta.json
+++ b/.agentplane/tasks/202607100436-D7QB76/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202607100436-D7QB76/anchor-evaluator-reviews-for-metadata-only-tasks",
+  "created_at": "2026-07-10T10:34:39.342Z",
+  "diffstat_sha256": "sha256:bf8622c0551e4d010e29b1e08bb751fdc0f1675e16efb0c07eb1b62e164db441",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202607100436-D7QB76",
+  "updated_at": "2026-07-10T10:34:39.342Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202607100436-D7QB76/pr/meta.json
+++ b/.agentplane/tasks/202607100436-D7QB76/pr/meta.json
@@ -3,11 +3,12 @@
   "branch": "task/202607100436-D7QB76/anchor-evaluator-reviews-for-metadata-only-tasks",
   "created_at": "2026-07-10T10:34:39.342Z",
   "diffstat_sha256": "sha256:bf8622c0551e4d010e29b1e08bb751fdc0f1675e16efb0c07eb1b62e164db441",
-  "last_verified_at": null,
+  "last_verified_at": "2026-07-10T10:47:38.387Z",
+  "last_verified_diffstat_sha256": "sha256:bf8622c0551e4d010e29b1e08bb751fdc0f1675e16efb0c07eb1b62e164db441",
   "schema_version": 1,
   "task_id": "202607100436-D7QB76",
   "updated_at": "2026-07-10T10:34:39.342Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202607100436-D7QB76/pr/meta.json
+++ b/.agentplane/tasks/202607100436-D7QB76/pr/meta.json
@@ -5,9 +5,12 @@
   "diffstat_sha256": "sha256:bf8622c0551e4d010e29b1e08bb751fdc0f1675e16efb0c07eb1b62e164db441",
   "last_verified_at": "2026-07-10T10:47:38.387Z",
   "last_verified_diffstat_sha256": "sha256:bf8622c0551e4d010e29b1e08bb751fdc0f1675e16efb0c07eb1b62e164db441",
+  "pr_number": 4570,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4570",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202607100436-D7QB76",
-  "updated_at": "2026-07-10T10:34:39.342Z",
+  "updated_at": "2026-07-10T10:49:25.932Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202607100436-D7QB76/pr/meta.json
+++ b/.agentplane/tasks/202607100436-D7QB76/pr/meta.json
@@ -8,10 +8,10 @@
   "pr_number": 4570,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4570",
   "pre_merge_closure": {
-    "basis_commit": "612b12171d5c9cb942fcd573e79795d8eb0d9f4a",
+    "basis_commit": "6b28d0fc5273bd6f22e6b502ebc393fb463dbfca",
     "branch": "task/202607100436-D7QB76/anchor-evaluator-reviews-for-metadata-only-tasks",
     "pr_number": 4570,
-    "recorded_at": "2026-07-10T10:53:11.016Z",
+    "recorded_at": "2026-07-10T12:47:50.893Z",
     "state": "closed_before_merge"
   },
   "schema_version": 1,

--- a/.agentplane/tasks/202607100436-D7QB76/pr/review.md
+++ b/.agentplane/tasks/202607100436-D7QB76/pr/review.md
@@ -6,14 +6,14 @@ Created: 2026-07-10T10:34:39.342Z
 
 - Task: `202607100436-D7QB76`
 - Title: Anchor evaluator reviews for metadata-only tasks
-- Status: DOING
+- Status: DONE
 - Branch: `task/202607100436-D7QB76/anchor-evaluator-reviews-for-metadata-only-tasks`
 - Canonical task record: `.agentplane/tasks/202607100436-D7QB76/README.md`
 
 ## Verification
 
 - State: ok
-- Note: Focused evaluator/finish regressions pass (2 files, 11 tests); typecheck, lint:core, ci:contract, test:fast (364 files/2153 tests), policy routing, and doctor pass. The evaluator keeps code targets, anchors the current pure metadata work unit, and rejects unrelated task artifacts.
+- Note: Evaluator reruns now preserve an ancestral reviewed SHA across managed quality, PR, blueprint, and README advances while still selecting new task-local or code work. Focused 2/12, targeted 10/133, typecheck, lint, ci:contract, test:fast 364/2157, policy routing, and doctor passed.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,15 +24,15 @@ Created: 2026-07-10T10:34:39.342Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-10T10:34:39.342Z
+- Updated: 2026-07-10T10:49:25.932Z
 - Branch: task/202607100436-D7QB76/anchor-evaluator-reviews-for-metadata-only-tasks
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
- .../evaluator/evaluator-run.command.test.ts        | 96 +++++++++++++++++++---
- .../src/commands/evaluator/evaluator.command.ts    | 14 +++-
- .../task/finish.quality-review-target.unit.test.ts | 33 ++++++++
- 3 files changed, 131 insertions(+), 12 deletions(-)
+ .../evaluator/evaluator-run.command.test.ts        | 154 +++++++++++++++++++--
+ .../src/commands/evaluator/evaluator.command.ts    |  44 +++++-
+ .../task/finish.quality-review-target.unit.test.ts |  33 +++++
+ 3 files changed, 219 insertions(+), 12 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607100436-D7QB76/pr/review.md
+++ b/.agentplane/tasks/202607100436-D7QB76/pr/review.md
@@ -1,0 +1,39 @@
+# PR Review
+
+Created: 2026-07-10T10:34:39.342Z
+
+## Task
+
+- Task: `202607100436-D7QB76`
+- Title: Anchor evaluator reviews for metadata-only tasks
+- Status: DOING
+- Branch: `task/202607100436-D7QB76/anchor-evaluator-reviews-for-metadata-only-tasks`
+- Canonical task record: `.agentplane/tasks/202607100436-D7QB76/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-10T10:34:39.342Z
+- Branch: task/202607100436-D7QB76/anchor-evaluator-reviews-for-metadata-only-tasks
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../evaluator/evaluator-run.command.test.ts        | 96 +++++++++++++++++++---
+ .../src/commands/evaluator/evaluator.command.ts    | 14 +++-
+ .../task/finish.quality-review-target.unit.test.ts | 33 ++++++++
+ 3 files changed, 131 insertions(+), 12 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202607100436-D7QB76/pr/review.md
+++ b/.agentplane/tasks/202607100436-D7QB76/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-07-10T10:34:39.342Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Focused evaluator/finish regressions pass (2 files, 11 tests); typecheck, lint:core, ci:contract, test:fast (364 files/2153 tests), policy routing, and doctor pass. The evaluator keeps code targets, anchors the current pure metadata work unit, and rejects unrelated task artifacts.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes

--- a/.agentplane/tasks/202607100436-D7QB76/quality/20260710-104740192-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607100436-D7QB76/quality/20260710-104740192-recovery-context/evaluator-opinion.md
@@ -1,0 +1,23 @@
+# EVALUATOR opinion: pass
+
+Metadata-only evaluator targets are now current, auditable, and bounded without weakening code-task freshness.
+
+## Findings
+- Code-bearing branches still resolve to the last non-workflow implementation commit after current-task evidence commits.
+- Pure current-task metadata work stops at the first unrelated workflow-history boundary and uses its own latest committed work unit; a branch with only unrelated task artifacts receives no evaluated SHA.
+- Finish preserves the reviewed metadata SHA across later evaluator artifacts through the existing task-local-only advance check.
+
+## Evidence
+- .agentplane/tasks/202607100436-D7QB76/README.md
+- commit f6f17a1f6f44
+- focused vitest 2 files/11 tests; typecheck; lint:core; ci:contract; test:fast 364 files/2153 tests
+- node .agentplane/policy/check-routing.mjs; ap doctor
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- The bounded 20-commit walk remains unchanged; extremely long current-task artifact chains retain the existing depth cap.

--- a/.agentplane/tasks/202607100436-D7QB76/quality/20260710-104740192-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607100436-D7QB76/quality/20260710-104740192-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202607100436-D7QB76
+- task_readme: .agentplane/tasks/202607100436-D7QB76/README.md
+- report_path: .agentplane/tasks/202607100436-D7QB76/quality/20260710-104740192-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607100436-D7QB76/quality/20260710-104740192-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607100436-D7QB76/quality/20260710-104740192-recovery-context/quality-report.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "task_id": "202607100436-D7QB76",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-10T10:47:40.192Z",
+  "verdict": "pass",
+  "summary": "Metadata-only evaluator targets are now current, auditable, and bounded without weakening code-task freshness.",
+  "evaluated_sha": "f6f17a1f6f44a2247a62dbf3b6fe2dd668c54804",
+  "blueprint_digest": "4723f7ad08c4985149e8fc1af430e49b65e5909aed7ca3d13ff9a45b7d5a656f",
+  "findings": [
+    "Code-bearing branches still resolve to the last non-workflow implementation commit after current-task evidence commits.",
+    "Pure current-task metadata work stops at the first unrelated workflow-history boundary and uses its own latest committed work unit; a branch with only unrelated task artifacts receives no evaluated SHA.",
+    "Finish preserves the reviewed metadata SHA across later evaluator artifacts through the existing task-local-only advance check."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607100436-D7QB76/README.md",
+    "commit f6f17a1f6f44",
+    "focused vitest 2 files/11 tests; typecheck; lint:core; ci:contract; test:fast 364 files/2153 tests",
+    "node .agentplane/policy/check-routing.mjs; ap doctor"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": [
+    "The bounded 20-commit walk remains unchanged; extremely long current-task artifact chains retain the existing depth cap."
+  ]
+}

--- a/.agentplane/tasks/202607100436-D7QB76/quality/20260710-124628705-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607100436-D7QB76/quality/20260710-124628705-recovery-context/evaluator-opinion.md
@@ -1,0 +1,19 @@
+# EVALUATOR opinion: pass
+
+Metadata-only evaluator targets remain stable across committed review and PR artifacts after rebase.
+
+## Findings
+- Two-pass regression proves a repeated review remains anchored to the original metadata work unit; explicit new work still supersedes the prior target.
+
+## Evidence
+- .agentplane/tasks/202607100436-D7QB76/README.md
+- packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607100436-D7QB76/quality/20260710-124628705-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607100436-D7QB76/quality/20260710-124628705-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202607100436-D7QB76
+- task_readme: .agentplane/tasks/202607100436-D7QB76/README.md
+- report_path: .agentplane/tasks/202607100436-D7QB76/quality/20260710-124628705-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607100436-D7QB76/quality/20260710-124628705-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607100436-D7QB76/quality/20260710-124628705-recovery-context/quality-report.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "task_id": "202607100436-D7QB76",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-10T12:46:28.705Z",
+  "verdict": "pass",
+  "summary": "Metadata-only evaluator targets remain stable across committed review and PR artifacts after rebase.",
+  "evaluated_sha": "0b817152a8da33505a18974d6a3c069141345e21",
+  "blueprint_digest": "4723f7ad08c4985149e8fc1af430e49b65e5909aed7ca3d13ff9a45b7d5a656f",
+  "findings": [
+    "Two-pass regression proves a repeated review remains anchored to the original metadata work unit; explicit new work still supersedes the prior target."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607100436-D7QB76/README.md",
+    "packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts
+++ b/packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts
@@ -45,6 +45,20 @@ async function commitPath(
   return stdout.trim();
 }
 
+async function readEvaluatedSha(root: string, taskId: string): Promise<string | null> {
+  const { stdout } = await execFileAsync(
+    "find",
+    [`.agentplane/tasks/${taskId}/quality`, "-name", "quality-report.json", "-print"],
+    { cwd: root },
+  );
+  const reportPaths = stdout.trim().split("\n");
+  expect(reportPaths).toHaveLength(1);
+  const report = JSON.parse(await readFile(path.join(root, reportPaths[0] ?? ""), "utf8")) as {
+    evaluated_sha: string | null;
+  };
+  return report.evaluated_sha;
+}
+
 describe("evaluator run command", () => {
   it("parses structured review evidence and findings as repeatable fields", () => {
     const { parsed } = parseCommandArgv(evaluatorRunSpec, [
@@ -127,16 +141,78 @@ describe("evaluator run command", () => {
       },
     );
 
-    const { stdout: findStdout } = await execFileAsync(
-      "find",
-      [`.agentplane/tasks/${taskId}/quality`, "-name", "quality-report.json", "-print"],
-      { cwd: root },
+    expect(await readEvaluatedSha(root, taskId)).toBe(implementationSha);
+  });
+
+  it("anchors a task-artifact-only work unit before unrelated workflow history", async () => {
+    const root = await mkGitRepoRoot();
+    await writeDefaultConfig(root);
+    const taskId = "202605240900-EV02";
+    await addTask(root, taskId);
+    await commitPath(root, "src/older-feature.txt", "older implementation", "feat: older work");
+    await commitPath(
+      root,
+      ".agentplane/tasks/202605240900-OTHER/manual-note.md",
+      "unrelated task artifact",
+      "chore: unrelated task artifact",
     );
-    const reportPaths = findStdout.trim().split("\n");
-    expect(reportPaths).toHaveLength(1);
-    const report = JSON.parse(await readFile(path.join(root, reportPaths[0] ?? ""), "utf8")) as {
-      evaluated_sha: string | null;
-    };
-    expect(report.evaluated_sha).toBe(implementationSha);
+    const metadataSha = await commitPath(
+      root,
+      `.agentplane/tasks/${taskId}/manual-note.md`,
+      "current metadata work unit",
+      "docs: record metadata-only work unit",
+    );
+
+    await runEvaluatorRun(
+      { cwd: root, rootOverride: undefined },
+      {
+        taskId,
+        evaluator: "recovery-context",
+        verdict: "pass",
+        summary: "Metadata work unit reviewed",
+        findings: ["Current task metadata is the auditable review target."],
+        evidenceRefs: [`.agentplane/tasks/${taskId}/manual-note.md`],
+        missingTests: [],
+        hiddenAssumptions: [],
+        residualRisks: [],
+        json: false,
+        record: true,
+      },
+    );
+
+    expect(await readEvaluatedSha(root, taskId)).toBe(metadataSha);
+  });
+
+  it("does not anchor an unrelated task artifact when the current task has no committed work", async () => {
+    const root = await mkGitRepoRoot();
+    await writeDefaultConfig(root);
+    const taskId = "202605240900-EV03";
+    await addTask(root, taskId);
+    await commitPath(root, "src/older-feature.txt", "older implementation", "feat: older work");
+    await commitPath(
+      root,
+      ".agentplane/tasks/202605240900-OTHER/manual-note.md",
+      "unrelated task artifact",
+      "chore: unrelated task artifact",
+    );
+
+    await runEvaluatorRun(
+      { cwd: root, rootOverride: undefined },
+      {
+        taskId,
+        evaluator: "recovery-context",
+        verdict: "pass",
+        summary: "No current committed work unit",
+        findings: ["Unrelated workflow history is not a valid review target."],
+        evidenceRefs: [`.agentplane/tasks/${taskId}/README.md`],
+        missingTests: [],
+        hiddenAssumptions: [],
+        residualRisks: [],
+        json: false,
+        record: true,
+      },
+    );
+
+    expect(await readEvaluatedSha(root, taskId)).toBeNull();
   });
 });

--- a/packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts
+++ b/packages/agentplane/src/commands/evaluator/evaluator-run.command.test.ts
@@ -45,15 +45,19 @@ async function commitPath(
   return stdout.trim();
 }
 
-async function readEvaluatedSha(root: string, taskId: string): Promise<string | null> {
+async function readEvaluatedSha(
+  root: string,
+  taskId: string,
+  expectedReports = 1,
+): Promise<string | null> {
   const { stdout } = await execFileAsync(
     "find",
     [`.agentplane/tasks/${taskId}/quality`, "-name", "quality-report.json", "-print"],
     { cwd: root },
   );
-  const reportPaths = stdout.trim().split("\n");
-  expect(reportPaths).toHaveLength(1);
-  const report = JSON.parse(await readFile(path.join(root, reportPaths[0] ?? ""), "utf8")) as {
+  const reportPaths = stdout.trim().split("\n").toSorted();
+  expect(reportPaths).toHaveLength(expectedReports);
+  const report = JSON.parse(await readFile(path.join(root, reportPaths.at(-1) ?? ""), "utf8")) as {
     evaluated_sha: string | null;
   };
   return report.evaluated_sha;
@@ -181,6 +185,62 @@ describe("evaluator run command", () => {
     );
 
     expect(await readEvaluatedSha(root, taskId)).toBe(metadataSha);
+  });
+
+  it("keeps evaluator reruns anchored across committed review and PR artifacts", async () => {
+    const root = await mkGitRepoRoot();
+    await writeDefaultConfig(root);
+    const taskId = "202605240900-EV04";
+    await addTask(root, taskId);
+    await commitPath(root, "src/older-feature.txt", "older implementation", "feat: older work");
+    await commitPath(
+      root,
+      ".agentplane/tasks/202605240900-OTHER/manual-note.md",
+      "unrelated task artifact",
+      "chore: unrelated task artifact",
+    );
+    const metadataSha = await commitPath(
+      root,
+      `.agentplane/tasks/${taskId}/manual-note.md`,
+      "current metadata work unit",
+      "docs: record metadata-only work unit",
+    );
+
+    const runReview = async (summary: string): Promise<void> => {
+      await runEvaluatorRun(
+        { cwd: root, rootOverride: undefined },
+        {
+          taskId,
+          evaluator: "recovery-context",
+          verdict: "pass",
+          summary,
+          findings: ["Current task metadata is the auditable review target."],
+          evidenceRefs: [`.agentplane/tasks/${taskId}/manual-note.md`],
+          missingTests: [],
+          hiddenAssumptions: [],
+          residualRisks: [],
+          json: false,
+          record: true,
+        },
+      );
+    };
+
+    await runReview("Initial metadata review");
+    expect(await readEvaluatedSha(root, taskId)).toBe(metadataSha);
+    await execFileAsync("git", ["add", "--", `.agentplane/tasks/${taskId}`], { cwd: root });
+    await execFileAsync("git", ["commit", "-m", "test: record evaluator artifacts"], {
+      cwd: root,
+    });
+    await commitPath(
+      root,
+      `.agentplane/tasks/${taskId}/pr/meta.json`,
+      "{}\n",
+      "test: refresh PR metadata",
+    );
+
+    await runReview("Repeated metadata review");
+
+    expect(await readEvaluatedSha(root, taskId, 2)).toBe(metadataSha);
   });
 
   it("does not anchor an unrelated task artifact when the current task has no committed work", async () => {

--- a/packages/agentplane/src/commands/evaluator/evaluator.command.ts
+++ b/packages/agentplane/src/commands/evaluator/evaluator.command.ts
@@ -116,6 +116,7 @@ async function resolveEvaluatedSha(opts: {
   const taskArtifactPrefix = `${normalizedWorkflowDir}/${opts.taskId}/`;
   const workflowArtifactPrefix = `${normalizedWorkflowDir}/`;
   let current = head;
+  let currentTaskArtifactHead: string | null = null;
 
   for (let depth = 0; depth < 20; depth += 1) {
     let parent: string;
@@ -129,6 +130,7 @@ async function resolveEvaluatedSha(opts: {
     if (changed.length === 0) {
       return current;
     }
+    const touchesCurrentTask = changed.some((name) => name.startsWith(taskArtifactPrefix));
     const touchesOnlyCurrentTask = changed.every((name) => name.startsWith(taskArtifactPrefix));
     const touchesOnlyWorkflowArtifacts = changed.every((name) =>
       name.startsWith(workflowArtifactPrefix),
@@ -136,10 +138,18 @@ async function resolveEvaluatedSha(opts: {
     if (!touchesOnlyCurrentTask && !touchesOnlyWorkflowArtifacts) {
       return current;
     }
-    current = parent;
+    if (touchesOnlyCurrentTask) {
+      currentTaskArtifactHead ??= current;
+      current = parent;
+      continue;
+    }
+    if (touchesCurrentTask) {
+      return currentTaskArtifactHead ?? current;
+    }
+    return currentTaskArtifactHead;
   }
 
-  return current;
+  return currentTaskArtifactHead ?? current;
 }
 
 function assertRunnableReviewInput(parsed: EvaluatorRunParsed): void {

--- a/packages/agentplane/src/commands/evaluator/evaluator.command.ts
+++ b/packages/agentplane/src/commands/evaluator/evaluator.command.ts
@@ -11,7 +11,7 @@ import type { CommandCtx, CommandHandler } from "../../cli/spec/spec.js";
 import { CliError, GitError } from "../../shared/errors.js";
 import { loadEvaluatorCatalog, type EvaluatorModule } from "../../evaluators/catalog.js";
 import { checkTaskBlueprintSnapshotDrift } from "../blueprint/snapshot-artifact.js";
-import { gitDiffNames, gitRevParse } from "@agentplaneorg/core/git";
+import { gitDiffNames, gitIsAncestor, gitRevParse } from "@agentplaneorg/core/git";
 import { loadCommandContext, loadTaskFromContext } from "../shared/task-backend.js";
 import { applyTaskMutation } from "../shared/task-mutation.js";
 import { setTaskFieldsIntent } from "../shared/task-store.js";
@@ -108,6 +108,7 @@ async function resolveEvaluatedSha(opts: {
   gitRoot: string;
   workflowDir: string;
   taskId: string;
+  previousEvaluatedSha?: string | null;
 }): Promise<string | null> {
   const head = await gitRevParse(opts.gitRoot, ["HEAD"]).catch(() => null);
   if (!head) return null;
@@ -115,10 +116,20 @@ async function resolveEvaluatedSha(opts: {
   const normalizedWorkflowDir = opts.workflowDir.replaceAll("\\", "/").replaceAll(/\/+$/g, "");
   const taskArtifactPrefix = `${normalizedWorkflowDir}/${opts.taskId}/`;
   const workflowArtifactPrefix = `${normalizedWorkflowDir}/`;
+  const previousEvaluatedSha = await (async (): Promise<string | null> => {
+    const candidate = opts.previousEvaluatedSha?.trim();
+    if (!candidate) return null;
+    const resolved = await gitRevParse(opts.gitRoot, [`${candidate}^{commit}`]).catch(() => null);
+    if (!resolved) return null;
+    return (await gitIsAncestor(opts.gitRoot, resolved, head)) ? resolved : null;
+  })();
   let current = head;
   let currentTaskArtifactHead: string | null = null;
 
   for (let depth = 0; depth < 20; depth += 1) {
+    if (current === previousEvaluatedSha) {
+      return currentTaskArtifactHead ?? current;
+    }
     let parent: string;
     try {
       parent = await gitRevParse(opts.gitRoot, [`${current}^`]);
@@ -139,6 +150,22 @@ async function resolveEvaluatedSha(opts: {
       return current;
     }
     if (touchesOnlyCurrentTask) {
+      const taskRelativePaths = changed.map((name) => name.slice(taskArtifactPrefix.length));
+      const touchesDerivedArtifacts = taskRelativePaths.some(
+        (name) =>
+          name.startsWith("quality/") || name.startsWith("pr/") || name.startsWith("blueprint/"),
+      );
+      const touchesOnlyManagedArtifacts = taskRelativePaths.every(
+        (name) =>
+          name === "README.md" ||
+          name.startsWith("quality/") ||
+          name.startsWith("pr/") ||
+          name.startsWith("blueprint/"),
+      );
+      if (previousEvaluatedSha && touchesDerivedArtifacts && touchesOnlyManagedArtifacts) {
+        current = parent;
+        continue;
+      }
       currentTaskArtifactHead ??= current;
       current = parent;
       continue;
@@ -280,6 +307,7 @@ export const runEvaluatorRun: CommandHandler<EvaluatorRunParsed> = async (ctx, p
     gitRoot,
     workflowDir: command.config.paths.workflow_dir,
     taskId: p.taskId,
+    previousEvaluatedSha: task.quality_review?.evaluated_sha ?? null,
   });
   const snapshot = await checkTaskBlueprintSnapshotDrift({ ctx: command, task }).catch(() => null);
   const reportPath = path.join(reviewDir, QUALITY_REPORT_FILE);

--- a/packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts
+++ b/packages/agentplane/src/commands/task/finish.quality-review-target.unit.test.ts
@@ -103,6 +103,39 @@ describe("finish quality review target selection", () => {
     expect(resolved).toEqual({ hash: "impl-sha", message: "feat: implement T-1" });
   });
 
+  it("preserves a metadata-only reviewed SHA across later evaluator artifacts", async () => {
+    const artifactCommit: ResolvedCommitInfo = {
+      hash: "review-artifacts-sha",
+      message: "🧪 T-1 task: record evaluator evidence",
+    };
+    mocks.isTaskLocalOnlyAdvance.mockResolvedValue(true);
+    mocks.readCommitInfo.mockResolvedValue({
+      hash: "metadata-sha",
+      message: "📝 T-1 docs: record metadata-only work unit",
+    });
+    const { resolveImplementationCommitInfo } = await import("./finish-execute-commit.js");
+
+    const resolved = await resolveImplementationCommitInfo({
+      ctx: mkCtx(),
+      options: { quiet: true } as never,
+      loadedTasks: [mkLoadedTask("metadata-sha")],
+      taskCommitInfo: artifactCommit,
+    });
+
+    expect(mocks.isTaskLocalOnlyAdvance).toHaveBeenCalledWith({
+      gitRoot: "/repo",
+      workflowDir: ".agentplane/tasks",
+      taskId: "T-1",
+      tasksPath: ".agentplane/tasks.json",
+      fromRef: "metadata-sha",
+      toRef: "review-artifacts-sha",
+    });
+    expect(resolved).toEqual({
+      hash: "metadata-sha",
+      message: "📝 T-1 docs: record metadata-only work unit",
+    });
+  });
+
   it("auto-resolves quality_review.evaluated_sha when existing task commit is task-artifact-only", async () => {
     const loaded = mkLoadedTask();
     loaded.task.commit = {


### PR DESCRIPTION
Task: `202607100436-D7QB76`
Title: Anchor evaluator reviews for metadata-only tasks
Canonical task record: `.agentplane/tasks/202607100436-D7QB76/README.md`

## Summary

Anchor evaluator reviews for metadata-only tasks

For v0.6.22, give metadata-only docs and task-closure changes a fresh auditable evaluator target instead of walking past all workflow artifacts to an unrelated older code commit.

## Scope

- In scope: For v0.6.22, give metadata-only docs and task-closure changes a fresh auditable evaluator target instead of walking past all workflow artifacts to an unrelated older code commit.
- Out of scope: unrelated refactors not required for "Anchor evaluator reviews for metadata-only tasks".

## Verification

- State: ok
- Note:

```text
Evaluator reruns now preserve an ancestral reviewed SHA across managed quality, PR, blueprint, and
README advances while still selecting new task-local or code work. Focused 2/12, targeted 10/133,
typecheck, lint, ci:contract, test:fast 364/2157, policy routing, and doctor passed.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-07-10T10:49:25.932Z
- Branch: task/202607100436-D7QB76/anchor-evaluator-reviews-for-metadata-only-tasks
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../evaluator/evaluator-run.command.test.ts        | 154 +++++++++++++++++++--
 .../src/commands/evaluator/evaluator.command.ts    |  44 +++++-
 .../task/finish.quality-review-target.unit.test.ts |  33 +++++
 3 files changed, 219 insertions(+), 12 deletions(-)
```

</details>
