### PR TITLE
🚧 KSXT6H task: Split runtime and backend hotspots for v0.6.22 [202607092208-KSXT6H]

### DIFF
--- a/.agentplane/tasks/202607092208-KSXT6H/README.md
+++ b/.agentplane/tasks/202607092208-KSXT6H/README.md
@@ -4,7 +4,7 @@ title: "Split runtime and backend hotspots for v0.6.22"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -27,11 +27,30 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-07-11T11:46:53.934Z"
+  updated_by: "REVIEWER"
+  note: "Public APIs and serialized contracts are preserved; all seven scoped hotspots are decomposed. Focused 33/246 and full 364/2157 tests, build, typecheck, architecture, hotspot, contract, Knip, and coverage checks passed."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-07-11T11:47:03.032Z"
+  updated_by: "EVALUATOR"
+  note: "Scoped hotspot decomposition preserves external contracts and passes the declared verification matrix."
+  evaluated_sha: "d63ebfd6171436ff0c84a8feec6c02fb736e86a2"
+  blueprint_digest: "11a67e840a3589f825ce9d568a614c9f7ee9947d245095dc1808f41ac1aca91d"
+  evidence_refs:
+    - ".agentplane/tasks/202607092208-KSXT6H/README.md"
+    - ".agentplane/tasks/202607092208-KSXT6H/quality/20260711-114703032-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607092208-KSXT6H/quality/20260711-114703032-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607092208-KSXT6H/quality/20260711-114703032-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607092208-KSXT6H/blueprint/resolved-snapshot.json"
+    - "d63ebfd6171436ff0c84a8feec6c02fb736e86a2"
+    - "focused:33-files-246-tests"
+    - "full:364-files-2157-tests"
+    - "build,typecheck,arch,hotspots,ci-contract,knip,coverage:pass"
+  findings:
+    - "No blocking defects found; seven scoped runtime/backend hotspots were decomposed and repository runtime hotspot count is now two."
 commit: null
 comments:
   -
@@ -45,8 +64,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: split runtime and backend hotspots behind existing public APIs and schemas."
+  -
+    type: "verify"
+    at: "2026-07-11T11:46:53.934Z"
+    author: "REVIEWER"
+    state: "ok"
+    note: "Public APIs and serialized contracts are preserved; all seven scoped hotspots are decomposed. Focused 33/246 and full 364/2157 tests, build, typecheck, architecture, hotspot, contract, Knip, and coverage checks passed."
 doc_version: 3
-doc_updated_at: "2026-07-11T11:46:41.305Z"
+doc_updated_at: "2026-07-11T11:46:54.123Z"
 doc_updated_by: "CODER"
 description: "Decompose Hermes command/runtime, result manifest, insights report, SGR contracts, and cloud backend modules into cohesive helpers while retaining public APIs, schemas, and backend behavior."
 sections:
@@ -69,6 +94,36 @@ sections:
     4. Run `bun run typecheck` and `bun run ci:contract`; both pass.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-07-11T11:46:53.934Z — VERIFY — ok
+
+    By: REVIEWER
+
+    Note: Public APIs and serialized contracts are preserved; all seven scoped hotspots are decomposed. Focused 33/246 and full 364/2157 tests, build, typecheck, architecture, hotspot, contract, Knip, and coverage checks passed.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-11T11:46:41.305Z, excerpt_hash=sha256:f90157d4c997166fcfd8652a7373224351fe284d252ab0639a1dc4b8c2aee825
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607092208-KSXT6H-split-runtime-and-backend-hotspots-for-v0-6-22/.agentplane/tasks/202607092208-KSXT6H/blueprint/resolved-snapshot.json
+    - old_digest: 11a67e840a3589f825ce9d568a614c9f7ee9947d245095dc1808f41ac1aca91d
+    - current_digest: 11a67e840a3589f825ce9d568a614c9f7ee9947d245095dc1808f41ac1aca91d
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607092208-KSXT6H
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane pr update 202607092208-KSXT6H
+    - diagnostic_command: agentplane pr check 202607092208-KSXT6H
+    - source_of_truth: route=task_next_action diagnostic=pr_check remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
+    - risks: pr_artifact_freshness_loop, git_hook_side_effect
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -104,6 +159,36 @@ Decompose Hermes command/runtime, result manifest, insights report, SGR contract
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-07-11T11:46:53.934Z — VERIFY — ok
+
+By: REVIEWER
+
+Note: Public APIs and serialized contracts are preserved; all seven scoped hotspots are decomposed. Focused 33/246 and full 364/2157 tests, build, typecheck, architecture, hotspot, contract, Knip, and coverage checks passed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-11T11:46:41.305Z, excerpt_hash=sha256:f90157d4c997166fcfd8652a7373224351fe284d252ab0639a1dc4b8c2aee825
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607092208-KSXT6H-split-runtime-and-backend-hotspots-for-v0-6-22/.agentplane/tasks/202607092208-KSXT6H/blueprint/resolved-snapshot.json
+- old_digest: 11a67e840a3589f825ce9d568a614c9f7ee9947d245095dc1808f41ac1aca91d
+- current_digest: 11a67e840a3589f825ce9d568a614c9f7ee9947d245095dc1808f41ac1aca91d
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607092208-KSXT6H
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane pr update 202607092208-KSXT6H
+- diagnostic_command: agentplane pr check 202607092208-KSXT6H
+- source_of_truth: route=task_next_action diagnostic=pr_check remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
+- risks: pr_artifact_freshness_loop, git_hook_side_effect
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202607092208-KSXT6H/README.md
+++ b/.agentplane/tasks/202607092208-KSXT6H/README.md
@@ -1,10 +1,10 @@
 ---
 id: "202607092208-KSXT6H"
 title: "Split runtime and backend hotspots for v0.6.22"
-status: "TODO"
+status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 4
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -33,11 +33,21 @@ verification:
   note: null
   attempts: 0
 commit: null
-comments: []
-events: []
+comments:
+  -
+    author: "CODER"
+    body: "Start: split runtime and backend hotspots behind existing public APIs and schemas."
+events:
+  -
+    type: "status"
+    at: "2026-07-11T11:31:25.595Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: split runtime and backend hotspots behind existing public APIs and schemas."
 doc_version: 3
-doc_updated_at: "2026-07-09T22:09:46.427Z"
-doc_updated_by: "PLANNER"
+doc_updated_at: "2026-07-11T11:46:41.305Z"
+doc_updated_by: "CODER"
 description: "Decompose Hermes command/runtime, result manifest, insights report, SGR contracts, and cloud backend modules into cohesive helpers while retaining public APIs, schemas, and backend behavior."
 sections:
   Summary: |-
@@ -63,7 +73,7 @@ sections:
   Rollback Plan: |-
     - Revert task-related commit(s).
     - Re-run required checks to confirm rollback safety.
-  Findings: ""
+  Findings: "Extracted cohesive internal modules for Hermes command/runtime, result-manifest artifacts, insights loading/rendering, SGR validation/routing, and cloud configuration overrides. All seven scoped >400-line runtime hotspots are now below the threshold; the repository-wide runtime hotspot count fell from 9 to 2, with the remaining PR flow-status and evaluator command files outside this task scope. Verification passed: focused suites 33 files / 246 tests, full suite 364 files / 2157 tests, build, typecheck, arch:check, hotspots:check, ci:contract, Knip baseline 574/574, and coverage thresholds."
 id_source: "generated"
 ---
 ## Summary
@@ -102,3 +112,5 @@ Decompose Hermes command/runtime, result manifest, insights report, SGR contract
 - Re-run required checks to confirm rollback safety.
 
 ## Findings
+
+Extracted cohesive internal modules for Hermes command/runtime, result-manifest artifacts, insights loading/rendering, SGR validation/routing, and cloud configuration overrides. All seven scoped >400-line runtime hotspots are now below the threshold; the repository-wide runtime hotspot count fell from 9 to 2, with the remaining PR flow-status and evaluator command files outside this task scope. Verification passed: focused suites 33 files / 246 tests, full suite 364 files / 2157 tests, build, typecheck, arch:check, hotspots:check, ci:contract, Knip baseline 574/574, and coverage thresholds.

--- a/.agentplane/tasks/202607092208-KSXT6H/README.md
+++ b/.agentplane/tasks/202607092208-KSXT6H/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202607092208-KSXT6H"
 title: "Split runtime and backend hotspots for v0.6.22"
-status: "DOING"
+result_summary: "Split seven runtime/backend hotspots into cohesive helpers; runtime hotspot count reduced from 9 to 2."
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 8
+revision: 9
 origin:
   system: "manual"
 depends_on: []
@@ -51,11 +52,16 @@ quality_review:
     - "build,typecheck,arch,hotspots,ci-contract,knip,coverage:pass"
   findings:
     - "No blocking defects found; seven scoped runtime/backend hotspots were decomposed and repository runtime hotspot count is now two."
-commit: null
+commit:
+  hash: "d63ebfd6171436ff0c84a8feec6c02fb736e86a2"
+  message: "🚧 KSXT6H task: split runtime and backend hotspots"
 comments:
   -
     author: "CODER"
     body: "Start: split runtime and backend hotspots behind existing public APIs and schemas."
+  -
+    author: "INTEGRATOR"
+    body: "Verified: scoped refactor preserves APIs and all local/hosted checks passed."
 events:
   -
     type: "status"
@@ -70,9 +76,16 @@ events:
     author: "REVIEWER"
     state: "ok"
     note: "Public APIs and serialized contracts are preserved; all seven scoped hotspots are decomposed. Focused 33/246 and full 364/2157 tests, build, typecheck, architecture, hotspot, contract, Knip, and coverage checks passed."
+  -
+    type: "status"
+    at: "2026-07-11T11:54:39.352Z"
+    author: "INTEGRATOR"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: scoped refactor preserves APIs and all local/hosted checks passed."
 doc_version: 3
-doc_updated_at: "2026-07-11T11:46:54.123Z"
-doc_updated_by: "CODER"
+doc_updated_at: "2026-07-11T11:54:39.353Z"
+doc_updated_by: "INTEGRATOR"
 description: "Decompose Hermes command/runtime, result manifest, insights report, SGR contracts, and cloud backend modules into cohesive helpers while retaining public APIs, schemas, and backend behavior."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202607092208-KSXT6H/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202607092208-KSXT6H/blueprint/resolved-snapshot.json
@@ -1,0 +1,580 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607092208-KSXT6H",
+    "title": "Split runtime and backend hotspots for v0.6.22",
+    "description": "Decompose Hermes command/runtime, result manifest, insights report, SGR contracts, and cloud backend modules into cohesive helpers while retaining public APIs, schemas, and backend behavior.",
+    "tags": [
+      "code",
+      "patch-0.6.22",
+      "refactor",
+      "runtime"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607092208-KSXT6H",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "11a67e840a3589f825ce9d568a614c9f7ee9947d245095dc1808f41ac1aca91d"
+  }
+}

--- a/.agentplane/tasks/202607092208-KSXT6H/pr/diffstat.txt
+++ b/.agentplane/tasks/202607092208-KSXT6H/pr/diffstat.txt
@@ -1,0 +1,17 @@
+ .../backends/task-backend/cloud-backend-utils.ts   |  37 +--
+ .../src/backends/task-backend/cloud-backend.ts     |  18 +-
+ .../task-backend/cloud-config-overrides.ts         |  34 +++
+ .../src/commands/hermes/hermes-environment.ts      |  64 ++++++
+ .../src/commands/hermes/hermes-runtime.ts          | 164 +-------------
+ .../agentplane/src/commands/hermes/hermes-specs.ts | 230 +++++++++++++++++++
+ .../agentplane/src/commands/hermes/hermes-state.ts |  93 ++++++++
+ .../src/commands/hermes/hermes.command.ts          | 252 ++-------------------
+ .../commands/insights/insights-report-render.ts    |  69 ++++++
+ .../src/commands/insights/insights-report.ts       |  89 +-------
+ .../src/commands/insights/insights-task-loader.ts  |  19 ++
+ .../src/runner/result-manifest-artifacts.ts        | 149 ++++++++++++
+ packages/agentplane/src/runner/result-manifest.ts  | 165 ++------------
+ .../src/runtime/sgr/contract-evaluator-routing.ts  | 143 ++++++++++++
+ .../src/runtime/sgr/contract-shared-validation.ts  |  37 +++
+ packages/agentplane/src/runtime/sgr/contracts.ts   | 170 +-------------
+ 16 files changed, 901 insertions(+), 832 deletions(-)

--- a/.agentplane/tasks/202607092208-KSXT6H/pr/github-body.md
+++ b/.agentplane/tasks/202607092208-KSXT6H/pr/github-body.md
@@ -15,8 +15,14 @@ Decompose Hermes command/runtime, result manifest, insights report, SGR contract
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Public APIs and serialized contracts are preserved; all seven scoped hotspots are decomposed.
+Focused 33/246 and full 364/2157 tests, build, typecheck, architecture, hotspot, contract, Knip, and
+coverage checks passed.
+```
 - Canonical workflow state lives in the task README.
 
 <details>

--- a/.agentplane/tasks/202607092208-KSXT6H/pr/github-body.md
+++ b/.agentplane/tasks/202607092208-KSXT6H/pr/github-body.md
@@ -1,0 +1,49 @@
+Task: `202607092208-KSXT6H`
+Title: Split runtime and backend hotspots for v0.6.22
+Canonical task record: `.agentplane/tasks/202607092208-KSXT6H/README.md`
+
+## Summary
+
+Split runtime and backend hotspots for v0.6.22
+
+Decompose Hermes command/runtime, result manifest, insights report, SGR contracts, and cloud backend modules into cohesive helpers while retaining public APIs, schemas, and backend behavior.
+
+## Scope
+
+- In scope: Decompose Hermes command/runtime, result manifest, insights report, SGR contracts, and cloud backend modules into cohesive helpers while retaining public APIs, schemas, and backend behavior.
+- Out of scope: unrelated refactors not required for "Split runtime and backend hotspots for v0.6.22".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-11T11:31:25.645Z
+- Branch: task/202607092208-KSXT6H/split-runtime-and-backend-hotspots-for-v0-6-22
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../backends/task-backend/cloud-backend-utils.ts   |  37 +--
+ .../src/backends/task-backend/cloud-backend.ts     |  18 +-
+ .../task-backend/cloud-config-overrides.ts         |  34 +++
+ .../src/commands/hermes/hermes-environment.ts      |  64 ++++++
+ .../src/commands/hermes/hermes-runtime.ts          | 164 +-------------
+ .../agentplane/src/commands/hermes/hermes-specs.ts | 230 +++++++++++++++++++
+ .../agentplane/src/commands/hermes/hermes-state.ts |  93 ++++++++
+ .../src/commands/hermes/hermes.command.ts          | 252 ++-------------------
+ .../commands/insights/insights-report-render.ts    |  69 ++++++
+ .../src/commands/insights/insights-report.ts       |  89 +-------
+ .../src/commands/insights/insights-task-loader.ts  |  19 ++
+ .../src/runner/result-manifest-artifacts.ts        | 149 ++++++++++++
+ packages/agentplane/src/runner/result-manifest.ts  | 165 ++------------
+ .../src/runtime/sgr/contract-evaluator-routing.ts  | 143 ++++++++++++
+ .../src/runtime/sgr/contract-shared-validation.ts  |  37 +++
+ packages/agentplane/src/runtime/sgr/contracts.ts   | 170 +-------------
+ 16 files changed, 901 insertions(+), 832 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202607092208-KSXT6H/pr/github-title.txt
+++ b/.agentplane/tasks/202607092208-KSXT6H/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 KSXT6H task: Split runtime and backend hotspots for v0.6.22 [202607092208-KSXT6H]

--- a/.agentplane/tasks/202607092208-KSXT6H/pr/meta.json
+++ b/.agentplane/tasks/202607092208-KSXT6H/pr/meta.json
@@ -3,11 +3,12 @@
   "branch": "task/202607092208-KSXT6H/split-runtime-and-backend-hotspots-for-v0-6-22",
   "created_at": "2026-07-11T11:31:25.645Z",
   "diffstat_sha256": "sha256:8660cc0ad4190fa3651eaa56e7bf1d354f9745871eeabfcef45717238e0fa3a8",
-  "last_verified_at": null,
+  "last_verified_at": "2026-07-11T11:46:53.934Z",
+  "last_verified_diffstat_sha256": "sha256:8660cc0ad4190fa3651eaa56e7bf1d354f9745871eeabfcef45717238e0fa3a8",
   "schema_version": 1,
   "task_id": "202607092208-KSXT6H",
   "updated_at": "2026-07-11T11:31:25.645Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202607092208-KSXT6H/pr/meta.json
+++ b/.agentplane/tasks/202607092208-KSXT6H/pr/meta.json
@@ -5,9 +5,12 @@
   "diffstat_sha256": "sha256:8660cc0ad4190fa3651eaa56e7bf1d354f9745871eeabfcef45717238e0fa3a8",
   "last_verified_at": "2026-07-11T11:46:53.934Z",
   "last_verified_diffstat_sha256": "sha256:8660cc0ad4190fa3651eaa56e7bf1d354f9745871eeabfcef45717238e0fa3a8",
+  "pr_number": 4575,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4575",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202607092208-KSXT6H",
-  "updated_at": "2026-07-11T11:31:25.645Z",
+  "updated_at": "2026-07-11T11:49:52.647Z",
   "verify": {
     "status": "pass"
   }

--- a/.agentplane/tasks/202607092208-KSXT6H/pr/meta.json
+++ b/.agentplane/tasks/202607092208-KSXT6H/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202607092208-KSXT6H/split-runtime-and-backend-hotspots-for-v0-6-22",
+  "created_at": "2026-07-11T11:31:25.645Z",
+  "diffstat_sha256": "sha256:8660cc0ad4190fa3651eaa56e7bf1d354f9745871eeabfcef45717238e0fa3a8",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202607092208-KSXT6H",
+  "updated_at": "2026-07-11T11:31:25.645Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202607092208-KSXT6H/pr/meta.json
+++ b/.agentplane/tasks/202607092208-KSXT6H/pr/meta.json
@@ -7,6 +7,13 @@
   "last_verified_diffstat_sha256": "sha256:8660cc0ad4190fa3651eaa56e7bf1d354f9745871eeabfcef45717238e0fa3a8",
   "pr_number": 4575,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4575",
+  "pre_merge_closure": {
+    "basis_commit": "81d3c0c4bf1b9ae3da051cf7579c6bbfda8e6c01",
+    "branch": "task/202607092208-KSXT6H/split-runtime-and-backend-hotspots-for-v0-6-22",
+    "pr_number": 4575,
+    "recorded_at": "2026-07-11T11:54:39.391Z",
+    "state": "closed_before_merge"
+  },
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202607092208-KSXT6H",

--- a/.agentplane/tasks/202607092208-KSXT6H/pr/review.md
+++ b/.agentplane/tasks/202607092208-KSXT6H/pr/review.md
@@ -1,0 +1,52 @@
+# PR Review
+
+Created: 2026-07-11T11:31:25.645Z
+
+## Task
+
+- Task: `202607092208-KSXT6H`
+- Title: Split runtime and backend hotspots for v0.6.22
+- Status: DOING
+- Branch: `task/202607092208-KSXT6H/split-runtime-and-backend-hotspots-for-v0-6-22`
+- Canonical task record: `.agentplane/tasks/202607092208-KSXT6H/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-11T11:31:25.645Z
+- Branch: task/202607092208-KSXT6H/split-runtime-and-backend-hotspots-for-v0-6-22
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../backends/task-backend/cloud-backend-utils.ts   |  37 +--
+ .../src/backends/task-backend/cloud-backend.ts     |  18 +-
+ .../task-backend/cloud-config-overrides.ts         |  34 +++
+ .../src/commands/hermes/hermes-environment.ts      |  64 ++++++
+ .../src/commands/hermes/hermes-runtime.ts          | 164 +-------------
+ .../agentplane/src/commands/hermes/hermes-specs.ts | 230 +++++++++++++++++++
+ .../agentplane/src/commands/hermes/hermes-state.ts |  93 ++++++++
+ .../src/commands/hermes/hermes.command.ts          | 252 ++-------------------
+ .../commands/insights/insights-report-render.ts    |  69 ++++++
+ .../src/commands/insights/insights-report.ts       |  89 +-------
+ .../src/commands/insights/insights-task-loader.ts  |  19 ++
+ .../src/runner/result-manifest-artifacts.ts        | 149 ++++++++++++
+ packages/agentplane/src/runner/result-manifest.ts  | 165 ++------------
+ .../src/runtime/sgr/contract-evaluator-routing.ts  | 143 ++++++++++++
+ .../src/runtime/sgr/contract-shared-validation.ts  |  37 +++
+ packages/agentplane/src/runtime/sgr/contracts.ts   | 170 +-------------
+ 16 files changed, 901 insertions(+), 832 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202607092208-KSXT6H/pr/review.md
+++ b/.agentplane/tasks/202607092208-KSXT6H/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-07-11T11:31:25.645Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Public APIs and serialized contracts are preserved; all seven scoped hotspots are decomposed. Focused 33/246 and full 364/2157 tests, build, typecheck, architecture, hotspot, contract, Knip, and coverage checks passed.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes

--- a/.agentplane/tasks/202607092208-KSXT6H/quality/20260711-114703032-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607092208-KSXT6H/quality/20260711-114703032-recovery-context/evaluator-opinion.md
@@ -1,0 +1,22 @@
+# EVALUATOR opinion: pass
+
+Scoped hotspot decomposition preserves external contracts and passes the declared verification matrix.
+
+## Findings
+- No blocking defects found; seven scoped runtime/backend hotspots were decomposed and repository runtime hotspot count is now two.
+
+## Evidence
+- .agentplane/tasks/202607092208-KSXT6H/README.md
+- d63ebfd6171436ff0c84a8feec6c02fb736e86a2
+- focused:33-files-246-tests
+- full:364-files-2157-tests
+- build,typecheck,arch,hotspots,ci-contract,knip,coverage:pass
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607092208-KSXT6H/quality/20260711-114703032-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607092208-KSXT6H/quality/20260711-114703032-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202607092208-KSXT6H
+- task_readme: .agentplane/tasks/202607092208-KSXT6H/README.md
+- report_path: .agentplane/tasks/202607092208-KSXT6H/quality/20260711-114703032-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607092208-KSXT6H/quality/20260711-114703032-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607092208-KSXT6H/quality/20260711-114703032-recovery-context/quality-report.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "task_id": "202607092208-KSXT6H",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-11T11:47:03.032Z",
+  "verdict": "pass",
+  "summary": "Scoped hotspot decomposition preserves external contracts and passes the declared verification matrix.",
+  "evaluated_sha": "d63ebfd6171436ff0c84a8feec6c02fb736e86a2",
+  "blueprint_digest": "11a67e840a3589f825ce9d568a614c9f7ee9947d245095dc1808f41ac1aca91d",
+  "findings": [
+    "No blocking defects found; seven scoped runtime/backend hotspots were decomposed and repository runtime hotspot count is now two."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607092208-KSXT6H/README.md",
+    "d63ebfd6171436ff0c84a8feec6c02fb736e86a2",
+    "focused:33-files-246-tests",
+    "full:364-files-2157-tests",
+    "build,typecheck,arch,hotspots,ci-contract,knip,coverage:pass"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/backends/task-backend/cloud-backend-utils.ts
+++ b/packages/agentplane/src/backends/task-backend/cloud-backend-utils.ts
@@ -1,8 +1,9 @@
 import * as net from "node:net";
 
 import { BackendError, type TaskData } from "./shared.js";
-import { isDotEnvLoadedKey } from "../../shared/env.js";
 import { isRecord } from "../../shared/guards.js";
+
+export { cloudConfigOverrides, type CloudConfigOverride } from "./cloud-config-overrides.js";
 
 export type CloudSyncResponse = {
   data?: unknown;
@@ -46,12 +47,6 @@ export type CloudSyncStateDiagnostics = {
     status: string | null;
     error: string | null;
   } | null;
-};
-
-export type CloudConfigOverride = {
-  key: string;
-  configured: string | null;
-  effective: string;
 };
 
 export class CloudHttpError extends BackendError {
@@ -312,25 +307,6 @@ export function readCloudSyncStateDiagnostics(
   };
 }
 
-export function cloudConfigOverrides(
-  settings: { endpoint?: string; project_id?: string; provider?: string },
-  effective: Record<string, string>,
-): CloudConfigOverride[] {
-  const configured: Record<string, string | null> = {
-    AGENTPLANE_CLOUD_ENDPOINT: normalizeEndpoint(settings.endpoint),
-    AGENTPLANE_CLOUD_PROJECT_ID: normalizedString(settings.project_id),
-    AGENTPLANE_CLOUD_PROVIDER: normalizedString(settings.provider),
-  };
-  const out: CloudConfigOverride[] = [];
-  for (const [key, value] of Object.entries(effective)) {
-    if (!isDotEnvLoadedKey(key)) continue;
-    const configuredValue = configured[key] ?? null;
-    if (configuredValue === value) continue;
-    out.push({ key, configured: configuredValue, effective: value });
-  }
-  return out;
-}
-
 function readLatestCloudSyncJob(
   data: Record<string, unknown>,
 ): CloudSyncStateDiagnostics["latestJob"] {
@@ -361,15 +337,6 @@ function readNumber(input: unknown, key: string): number | null {
   const value = input[key];
   if (typeof value !== "number" || !Number.isFinite(value)) return null;
   return Math.trunc(value);
-}
-
-function normalizedString(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
-}
-
-function normalizeEndpoint(value: unknown): string | null {
-  const normalized = normalizedString(value);
-  return normalized ? normalized.replaceAll(/\/+$/gu, "") : null;
 }
 
 function readString(input: unknown, key: string): string | null {

--- a/packages/agentplane/src/backends/task-backend/cloud-backend.ts
+++ b/packages/agentplane/src/backends/task-backend/cloud-backend.ts
@@ -221,7 +221,7 @@ export class CloudBackend implements TaskBackend {
       autoSyncEnabled: this.autoSyncEnabled,
       autoSyncPullOnStartReady: this.autoSyncPullOnStartReady,
       autoSyncNetworkAllowed: this.autoSyncNetworkAllowed,
-      missingConfigKeys: this.missingConfigKeys.bind(this),
+      missingConfigKeys: () => missingCloudConfigKeys(this.configSnapshot()),
       projectId: this.projectId,
       statePath: this.statePath,
       requestCloudSyncState: this.requestCloudSyncState.bind(this),
@@ -237,7 +237,7 @@ export class CloudBackend implements TaskBackend {
     timeoutMs?: number;
     syncStateTimeoutMs?: number;
   }): Promise<void> {
-    this.assertConfigured();
+    assertCloudBackendConfigured(this.configSnapshot());
     await performCloudBackendSync(
       {
         provider: this.provider,
@@ -304,7 +304,7 @@ export class CloudBackend implements TaskBackend {
         autoSyncPullOnWrite: this.autoSyncPullOnWrite,
         projectId: this.projectId,
         staleAfterSeconds: this.staleAfterSeconds,
-        missingConfigKeys: this.missingConfigKeys.bind(this),
+        missingConfigKeys: () => missingCloudConfigKeys(this.configSnapshot()),
         readState: this.readState.bind(this),
         clearPendingPush: this.clearPendingPush.bind(this),
         maybeAutoPull: this.maybeAutoPull.bind(this),
@@ -319,7 +319,7 @@ export class CloudBackend implements TaskBackend {
     if (opts.mode === "read" && !this.autoSyncPullOnRead) return;
     if (opts.mode === "write" && !this.autoSyncPullOnWrite) return;
     if (!this.autoSyncNetworkAllowed) return;
-    if (this.missingConfigKeys().length > 0) return;
+    if (missingCloudConfigKeys(this.configSnapshot()).length > 0) return;
     const state = await this.readState();
     if (!isStale(state.last_checked_at, this.staleAfterSeconds)) return;
     await this.sync({
@@ -335,7 +335,7 @@ export class CloudBackend implements TaskBackend {
   private async maybeAutoPush(): Promise<void> {
     if (!this.autoSyncEnabled || !this.autoSyncPushOnWrite) return;
     if (!this.autoSyncNetworkAllowed) return;
-    if (this.missingConfigKeys().length > 0) return;
+    if (missingCloudConfigKeys(this.configSnapshot()).length > 0) return;
     try {
       await this.sync({
         direction: "push",
@@ -376,14 +376,6 @@ export class CloudBackend implements TaskBackend {
       last_start_ready_pull_at: state.last_start_ready_pull_at,
       pending_push: null,
     });
-  }
-
-  private assertConfigured(): void {
-    assertCloudBackendConfigured(this.configSnapshot());
-  }
-
-  private missingConfigKeys(): string[] {
-    return missingCloudConfigKeys(this.configSnapshot());
   }
 
   private configSnapshot() {

--- a/packages/agentplane/src/backends/task-backend/cloud-config-overrides.ts
+++ b/packages/agentplane/src/backends/task-backend/cloud-config-overrides.ts
@@ -1,0 +1,34 @@
+import { isDotEnvLoadedKey } from "../../shared/env.js";
+
+export type CloudConfigOverride = {
+  key: string;
+  configured: string | null;
+  effective: string;
+};
+
+function normalizedString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+function normalizeEndpoint(value: unknown): string | null {
+  const normalized = normalizedString(value);
+  return normalized ? normalized.replaceAll(/\/+$/gu, "") : null;
+}
+
+export function cloudConfigOverrides(
+  settings: { endpoint?: string; project_id?: string; provider?: string },
+  effective: Record<string, string>,
+): CloudConfigOverride[] {
+  const configured: Record<string, string | null> = {
+    AGENTPLANE_CLOUD_ENDPOINT: normalizeEndpoint(settings.endpoint),
+    AGENTPLANE_CLOUD_PROJECT_ID: normalizedString(settings.project_id),
+    AGENTPLANE_CLOUD_PROVIDER: normalizedString(settings.provider),
+  };
+  const out: CloudConfigOverride[] = [];
+  for (const [key, value] of Object.entries(effective)) {
+    if (!isDotEnvLoadedKey(key)) continue;
+    const configuredValue = configured[key] ?? null;
+    if (configuredValue === value) continue;
+    out.push({ key, configured: configuredValue, effective: value });
+  }
+  return out;
+}

--- a/packages/agentplane/src/commands/hermes/hermes-environment.ts
+++ b/packages/agentplane/src/commands/hermes/hermes-environment.ts
@@ -1,0 +1,64 @@
+import { readFile } from "node:fs/promises";
+import { isRecord } from "../../shared/guards.js";
+import { resolveAgentplaneBinPath } from "../../shared/package-paths.js";
+
+export function hermesEnvSnapshot() {
+  return {
+    task_id: process.env.HERMES_KANBAN_TASK ?? null,
+    board: process.env.HERMES_KANBAN_BOARD ?? null,
+    db: process.env.HERMES_KANBAN_DB ?? null,
+    run_id: process.env.HERMES_KANBAN_RUN_ID ?? null,
+    workspace: process.env.HERMES_KANBAN_WORKSPACE ?? null,
+    claim_lock_present: Boolean(process.env.HERMES_KANBAN_CLAIM_LOCK),
+  };
+}
+
+export async function loadLaneRegistry() {
+  const rawRegistryPath = process.env.AGENTPLANE_HERMES_LANE_REGISTRY?.trim();
+  const registryPath = rawRegistryPath && rawRegistryPath.length > 0 ? rawRegistryPath : null;
+  if (!registryPath) {
+    return {
+      path: null,
+      loaded: false,
+      error: null,
+      agentplane_lanes: [] as unknown[],
+    };
+  }
+  try {
+    const parsed = JSON.parse(await readFile(registryPath, "utf8")) as unknown;
+    const lanes = isRecord(parsed) ? parsed.lanes : null;
+    const agentplaneLanes = Array.isArray(lanes)
+      ? lanes.filter((lane) => isRecord(lane) && lane.kind === "agentplane")
+      : [];
+    return {
+      path: registryPath,
+      loaded: true,
+      error: null,
+      agentplane_lanes: agentplaneLanes,
+    };
+  } catch (err) {
+    return {
+      path: registryPath,
+      loaded: false,
+      error: err instanceof Error ? err.message : String(err),
+      agentplane_lanes: [] as unknown[],
+    };
+  }
+}
+
+export function currentAgentplaneCommand(): { command: string; argsPrefix: string[] } {
+  const rawAgentplaneBin = process.env.AGENTPLANE_BIN?.trim();
+  const command =
+    rawAgentplaneBin && rawAgentplaneBin.length > 0 ? rawAgentplaneBin : resolveAgentplaneBinPath();
+  const rawArgsPrefix = process.env.AGENTPLANE_BIN_ARGS?.trim();
+  if (!rawArgsPrefix) return { command, argsPrefix: [] };
+  try {
+    const parsed = JSON.parse(rawArgsPrefix) as unknown;
+    const argsPrefix = Array.isArray(parsed)
+      ? parsed.map((entry) => String(entry ?? "").trim()).filter(Boolean)
+      : [];
+    return { command, argsPrefix };
+  } catch {
+    return { command, argsPrefix: [] };
+  }
+}

--- a/packages/agentplane/src/commands/hermes/hermes-runtime.ts
+++ b/packages/agentplane/src/commands/hermes/hermes-runtime.ts
@@ -1,9 +1,6 @@
 import { execFile } from "node:child_process";
-import { readFile } from "node:fs/promises";
 import { promisify } from "node:util";
 
-import { isRecord } from "../../shared/guards.js";
-import { resolveAgentplaneBinPath } from "../../shared/package-paths.js";
 import { loadTaskRunnerInspection } from "../../runner/usecases/task-run-inspect.js";
 import { buildTaskRouteDecision } from "../shared/route-decision.js";
 import {
@@ -12,11 +9,21 @@ import {
 } from "../shared/route-guidance.js";
 import { loadTaskFromContext, type CommandContext } from "../shared/task-backend.js";
 
+import { currentAgentplaneCommand } from "./hermes-environment.js";
+export {
+  currentAgentplaneCommand,
+  hermesEnvSnapshot,
+  loadLaneRegistry,
+} from "./hermes-environment.js";
+export { loadHermesStateSnapshot, reconcileHermesState } from "./hermes-state.js";
+
 const execFileAsync = promisify(execFile);
 
 export const HERMES_LIFECYCLE_ACTIONS = ["comment", "block", "complete", "heartbeat"] as const;
 
 export type HermesLifecycleAction = (typeof HERMES_LIFECYCLE_ACTIONS)[number];
+
+export type HermesLocalProjection = Awaited<ReturnType<typeof routePacket>>;
 
 export type HermesRoutePacketForExecution = {
   task: {
@@ -38,67 +45,6 @@ function taskTerminalForHermesComplete(task: {
   const statusDone = task.status.trim().toUpperCase() === "DONE";
   const verificationState = task.verification?.trim().toLowerCase() ?? "";
   return statusDone && verificationState === "ok";
-}
-
-export function hermesEnvSnapshot() {
-  return {
-    task_id: process.env.HERMES_KANBAN_TASK ?? null,
-    board: process.env.HERMES_KANBAN_BOARD ?? null,
-    db: process.env.HERMES_KANBAN_DB ?? null,
-    run_id: process.env.HERMES_KANBAN_RUN_ID ?? null,
-    workspace: process.env.HERMES_KANBAN_WORKSPACE ?? null,
-    claim_lock_present: Boolean(process.env.HERMES_KANBAN_CLAIM_LOCK),
-  };
-}
-
-export async function loadLaneRegistry() {
-  const rawRegistryPath = process.env.AGENTPLANE_HERMES_LANE_REGISTRY?.trim();
-  const registryPath = rawRegistryPath && rawRegistryPath.length > 0 ? rawRegistryPath : null;
-  if (!registryPath) {
-    return {
-      path: null,
-      loaded: false,
-      error: null,
-      agentplane_lanes: [] as unknown[],
-    };
-  }
-  try {
-    const parsed = JSON.parse(await readFile(registryPath, "utf8")) as unknown;
-    const lanes = isRecord(parsed) ? parsed.lanes : null;
-    const agentplaneLanes = Array.isArray(lanes)
-      ? lanes.filter((lane) => isRecord(lane) && lane.kind === "agentplane")
-      : [];
-    return {
-      path: registryPath,
-      loaded: true,
-      error: null,
-      agentplane_lanes: agentplaneLanes,
-    };
-  } catch (err) {
-    return {
-      path: registryPath,
-      loaded: false,
-      error: err instanceof Error ? err.message : String(err),
-      agentplane_lanes: [] as unknown[],
-    };
-  }
-}
-
-export function currentAgentplaneCommand(): { command: string; argsPrefix: string[] } {
-  const rawAgentplaneBin = process.env.AGENTPLANE_BIN?.trim();
-  const command =
-    rawAgentplaneBin && rawAgentplaneBin.length > 0 ? rawAgentplaneBin : resolveAgentplaneBinPath();
-  const rawArgsPrefix = process.env.AGENTPLANE_BIN_ARGS?.trim();
-  if (!rawArgsPrefix) return { command, argsPrefix: [] };
-  try {
-    const parsed = JSON.parse(rawArgsPrefix) as unknown;
-    const argsPrefix = Array.isArray(parsed)
-      ? parsed.map((entry) => String(entry ?? "").trim()).filter(Boolean)
-      : [];
-    return { command, argsPrefix };
-  } catch {
-    return { command, argsPrefix: [] };
-  }
 }
 
 async function runnerVisibilityPacket(opts: {
@@ -445,94 +391,4 @@ export async function runHermesLifecycle(
   if (opts.dryRun) return { executed: false, command: [hermesCliCommand(), ...args] };
   const result = await execFileAsync(hermesCliCommand(), args, { maxBuffer: 1024 * 1024 });
   return { executed: true, command: [hermesCliCommand(), ...args], stdout: result.stdout };
-}
-
-function hermesCardAgentplaneTaskId(card: Record<string, unknown>): string | null {
-  const direct = card.agentplane_task_id ?? card.agentplaneTaskId;
-  if (typeof direct === "string" && direct.trim().length > 0) return direct.trim();
-  const metadata = isRecord(card.metadata) ? card.metadata : null;
-  const agentplane = metadata && isRecord(metadata.agentplane) ? metadata.agentplane : null;
-  for (const key of ["task_id", "taskId", "id"]) {
-    const value = agentplane?.[key];
-    if (typeof value === "string" && value.trim().length > 0) return value.trim();
-  }
-  return null;
-}
-
-export async function loadHermesStateSnapshot(path: string) {
-  const parsed = JSON.parse(await readFile(path, "utf8")) as unknown;
-  if (Array.isArray(parsed)) return parsed.filter(isRecord);
-  if (isRecord(parsed)) {
-    const cards = parsed.cards ?? parsed.tasks ?? parsed.items;
-    if (Array.isArray(cards)) return cards.filter(isRecord);
-    return [parsed];
-  }
-  return [];
-}
-
-export function reconcileHermesState(
-  localProjection: Awaited<ReturnType<typeof routePacket>> | null,
-  cards: Record<string, unknown>[],
-  taskId: string | null,
-) {
-  const relevantCards = taskId
-    ? cards.filter((card) => hermesCardAgentplaneTaskId(card) === taskId)
-    : cards;
-  const findings: { code: string; severity: "info" | "warn"; message: string }[] = [];
-  if (taskId && relevantCards.length === 0) {
-    findings.push({
-      code: "missing_hermes_card",
-      severity: "warn",
-      message: `No Hermes card in state snapshot maps to Agentplane task ${taskId}.`,
-    });
-  }
-  const duplicateGroups = new Map<string, number>();
-  for (const card of relevantCards) {
-    const cardTaskId = hermesCardAgentplaneTaskId(card);
-    if (!cardTaskId) continue;
-    duplicateGroups.set(cardTaskId, (duplicateGroups.get(cardTaskId) ?? 0) + 1);
-  }
-  for (const [cardTaskId, count] of duplicateGroups) {
-    if (count <= 1) continue;
-    findings.push({
-      code: "duplicate_hermes_cards",
-      severity: "warn",
-      message: `${count} Hermes cards map to Agentplane task ${cardTaskId}.`,
-    });
-  }
-  const first = relevantCards[0];
-  const rawStatus = first?.status ?? first?.state;
-  const status = typeof rawStatus === "string" ? rawStatus.trim().toLowerCase() : "";
-  if (
-    localProjection?.terminal.hermes_root_complete_allowed === true &&
-    status &&
-    !["done", "complete", "completed"].includes(status)
-  ) {
-    findings.push({
-      code: "agentplane_done_hermes_open",
-      severity: "warn",
-      message: "Agentplane is terminal and verified, but the Hermes card is not complete.",
-    });
-  }
-  if (
-    localProjection?.terminal.hermes_root_complete_allowed === false &&
-    ["done", "complete", "completed"].includes(status)
-  ) {
-    findings.push({
-      code: "hermes_complete_agentplane_open",
-      severity: "warn",
-      message: "Hermes card is complete, but Agentplane task truth is not terminal verified.",
-    });
-  }
-  return {
-    state_card_count: cards.length,
-    matched_card_count: relevantCards.length,
-    matched_cards: relevantCards.map((card) => ({
-      id: typeof card.id === "string" ? card.id : null,
-      status: typeof card.status === "string" ? card.status : (card.state ?? null),
-      assignee: typeof card.assignee === "string" ? card.assignee : null,
-      agentplane_task_id: hermesCardAgentplaneTaskId(card),
-    })),
-    findings,
-  };
 }

--- a/packages/agentplane/src/commands/hermes/hermes-specs.ts
+++ b/packages/agentplane/src/commands/hermes/hermes-specs.ts
@@ -1,0 +1,230 @@
+import { parseGroupCommand, type GroupCommandParsed } from "../../cli/group-command.js";
+import type { CommandSpec } from "../../cli/spec/spec.js";
+
+export type HermesEnqueueParsed = {
+  taskId: string;
+  board: string;
+  assignee: string;
+  role: string;
+  workspace: string | null;
+  json: boolean;
+};
+
+export type HermesSuperviseParsed = {
+  taskId: string;
+  json: boolean;
+  executeStep: boolean;
+  dryRun: boolean;
+};
+
+export type HermesReconcileParsed = {
+  taskId?: string;
+  hermesState?: string;
+  json: boolean;
+};
+
+export type HermesLifecycleParsed = {
+  action: string;
+  body: string | null;
+  json: boolean;
+  dryRun: boolean;
+};
+
+export type HermesDoctorParsed = {
+  json: boolean;
+};
+
+export const hermesSpec: CommandSpec<GroupCommandParsed> = {
+  id: ["hermes"],
+  group: "Integrations",
+  summary: "Inspect the Agentplane-owned Hermes adapter contract.",
+  description:
+    "This command group exposes the repo-local Agentplane side of the Hermes Kanban adapter. " +
+    "It does not talk directly to the Hermes SQLite database; Hermes-side plugins should call " +
+    "these commands through the CLI or a typed wrapper.",
+  synopsis: ["agentplane hermes <enqueue|supervise|reconcile|doctor> [args] [options]"],
+  args: [{ name: "cmd", required: false, variadic: true, valueHint: "<cmd>" }],
+  examples: [
+    {
+      cmd: "agentplane hermes enqueue 202605311941-K4FCKS --json",
+      why: "Render the provider-safe Hermes projection for one Agentplane task.",
+    },
+  ],
+  parse: (raw) => parseGroupCommand(raw),
+};
+
+export const hermesEnqueueSpec: CommandSpec<HermesEnqueueParsed> = {
+  id: ["hermes", "enqueue"],
+  group: "Integrations",
+  summary: "Render a provider-safe Hermes Kanban card projection for a task.",
+  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
+  options: [
+    {
+      kind: "string",
+      name: "board",
+      default: "agentplane",
+      valueHint: "<slug>",
+      description: "Hermes board slug for the projected card.",
+    },
+    {
+      kind: "string",
+      name: "assignee",
+      default: "agentplane-supervisor",
+      valueHint: "<lane>",
+      description: "Hermes assignee or lane that should own the projected root card.",
+    },
+    {
+      kind: "string",
+      name: "role",
+      default: "CODER",
+      valueHint: "<ROLE>",
+      description: "Agentplane role represented by the projected Hermes card.",
+    },
+    {
+      kind: "string",
+      name: "workspace",
+      valueHint: "dir:/abs/repo",
+      description: "Hermes workspace spec. Defaults to the Agentplane repository root.",
+    },
+    { kind: "boolean", name: "json", default: false, description: "Emit machine-readable result." },
+  ],
+  examples: [
+    {
+      cmd: "agentplane hermes enqueue 202605311941-K4FCKS --board my-repo --json",
+      why: "Build the card body/metadata a Hermes plugin should create idempotently.",
+    },
+  ],
+  parse: (raw) => ({
+    taskId: String(raw.args["task-id"]),
+    board: typeof raw.opts.board === "string" ? raw.opts.board : "agentplane",
+    assignee: typeof raw.opts.assignee === "string" ? raw.opts.assignee : "agentplane-supervisor",
+    role: typeof raw.opts.role === "string" ? raw.opts.role : "CODER",
+    workspace: typeof raw.opts.workspace === "string" ? raw.opts.workspace : null,
+    json: raw.opts.json === true,
+  }),
+};
+
+export const hermesSuperviseSpec: CommandSpec<HermesSuperviseParsed> = {
+  id: ["hermes", "supervise"],
+  group: "Integrations",
+  summary: "Compute the next safe Agentplane route step for a Hermes supervisor run.",
+  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
+  options: [
+    { kind: "boolean", name: "json", default: false, description: "Emit machine-readable result." },
+    {
+      kind: "boolean",
+      name: "execute-step",
+      default: false,
+      description: "Execute one allowlisted Agentplane route step for this Hermes claim.",
+    },
+    {
+      kind: "boolean",
+      name: "dry-run",
+      default: false,
+      description: "With --execute-step, return the planned command without executing it.",
+    },
+  ],
+  examples: [
+    {
+      cmd: "agentplane hermes supervise 202605311941-K4FCKS --json",
+      why: "Return a route-gated supervisor packet without executing arbitrary shell text.",
+    },
+  ],
+  parse: (raw) => ({
+    taskId: String(raw.args["task-id"]),
+    json: raw.opts.json === true,
+    executeStep: raw.opts["execute-step"] === true,
+    dryRun: raw.opts["dry-run"] === true,
+  }),
+};
+
+export const hermesReconcileSpec: CommandSpec<HermesReconcileParsed> = {
+  id: ["hermes", "reconcile"],
+  group: "Integrations",
+  summary: "Inspect Hermes projection drift without mutating Agentplane task truth.",
+  options: [
+    {
+      kind: "string",
+      name: "task-id",
+      valueHint: "<task-id>",
+      description: "Limit reconcile diagnostics to one Agentplane task id.",
+    },
+    {
+      kind: "string",
+      name: "hermes-state",
+      valueHint: "<path>",
+      description: "Read a Hermes card/task JSON snapshot and compare it with Agentplane truth.",
+    },
+    { kind: "boolean", name: "json", default: false, description: "Emit machine-readable result." },
+  ],
+  examples: [
+    {
+      cmd: "agentplane hermes reconcile --task-id 202605311941-K4FCKS --json",
+      why: "Inspect the local Agentplane side of a Hermes projection.",
+    },
+  ],
+  parse: (raw) => ({
+    taskId: typeof raw.opts["task-id"] === "string" ? raw.opts["task-id"] : undefined,
+    hermesState:
+      typeof raw.opts["hermes-state"] === "string" ? raw.opts["hermes-state"] : undefined,
+    json: raw.opts.json === true,
+  }),
+};
+
+export const hermesLifecycleSpec: CommandSpec<HermesLifecycleParsed> = {
+  id: ["hermes", "lifecycle"],
+  group: "Integrations",
+  summary: "Emit one Hermes Kanban lifecycle callback through the configured Hermes CLI.",
+  description:
+    "This is the Agentplane-side lifecycle client for Hermes worker lanes. It sends comment, block, " +
+    "complete, or heartbeat callbacks through the Hermes CLI and reads task, board, and run identity " +
+    "from the Hermes worker environment.",
+  args: [{ name: "action", required: true, valueHint: "comment|block|complete|heartbeat" }],
+  options: [
+    {
+      kind: "string",
+      name: "body",
+      valueHint: "<text>",
+      description: "Callback body, reason, or summary. Heartbeat uses a default body when omitted.",
+    },
+    { kind: "boolean", name: "json", default: false, description: "Emit machine-readable result." },
+    {
+      kind: "boolean",
+      name: "dry-run",
+      default: false,
+      description: "Return the Hermes CLI command without executing it.",
+    },
+  ],
+  examples: [
+    {
+      cmd: 'agentplane hermes lifecycle comment --body \'{"agentplane_task_id":"202605311941-K4FCKS"}\' --json',
+      why: "Write a structured projection comment for the current Hermes card.",
+    },
+    {
+      cmd: "agentplane hermes lifecycle complete --body 'Agentplane terminal evidence validated' --json",
+      why: "Complete the current Hermes card after Agentplane terminal gates have passed.",
+    },
+  ],
+  parse: (raw) => ({
+    action: String(raw.args.action),
+    body: typeof raw.opts.body === "string" ? raw.opts.body : null,
+    json: raw.opts.json === true,
+    dryRun: raw.opts["dry-run"] === true,
+  }),
+};
+
+export const hermesDoctorSpec: CommandSpec<HermesDoctorParsed> = {
+  id: ["hermes", "doctor"],
+  group: "Integrations",
+  summary: "Check the local Agentplane side of the Hermes adapter contract.",
+  options: [
+    { kind: "boolean", name: "json", default: false, description: "Emit machine-readable result." },
+  ],
+  examples: [
+    {
+      cmd: "agentplane hermes doctor --json",
+      why: "Check workflow mode, repo root, and Hermes Kanban environment variables.",
+    },
+  ],
+  parse: (raw) => ({ json: raw.opts.json === true }),
+};

--- a/packages/agentplane/src/commands/hermes/hermes-state.ts
+++ b/packages/agentplane/src/commands/hermes/hermes-state.ts
@@ -1,0 +1,93 @@
+import { readFile } from "node:fs/promises";
+import { isRecord } from "../../shared/guards.js";
+import type { HermesLocalProjection } from "./hermes-runtime.js";
+
+function hermesCardAgentplaneTaskId(card: Record<string, unknown>): string | null {
+  const direct = card.agentplane_task_id ?? card.agentplaneTaskId;
+  if (typeof direct === "string" && direct.trim().length > 0) return direct.trim();
+  const metadata = isRecord(card.metadata) ? card.metadata : null;
+  const agentplane = metadata && isRecord(metadata.agentplane) ? metadata.agentplane : null;
+  for (const key of ["task_id", "taskId", "id"]) {
+    const value = agentplane?.[key];
+    if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  }
+  return null;
+}
+
+export async function loadHermesStateSnapshot(path: string) {
+  const parsed = JSON.parse(await readFile(path, "utf8")) as unknown;
+  if (Array.isArray(parsed)) return parsed.filter(isRecord);
+  if (isRecord(parsed)) {
+    const cards = parsed.cards ?? parsed.tasks ?? parsed.items;
+    if (Array.isArray(cards)) return cards.filter(isRecord);
+    return [parsed];
+  }
+  return [];
+}
+
+export function reconcileHermesState(
+  localProjection: HermesLocalProjection | null,
+  cards: Record<string, unknown>[],
+  taskId: string | null,
+) {
+  const relevantCards = taskId
+    ? cards.filter((card) => hermesCardAgentplaneTaskId(card) === taskId)
+    : cards;
+  const findings: { code: string; severity: "info" | "warn"; message: string }[] = [];
+  if (taskId && relevantCards.length === 0) {
+    findings.push({
+      code: "missing_hermes_card",
+      severity: "warn",
+      message: `No Hermes card in state snapshot maps to Agentplane task ${taskId}.`,
+    });
+  }
+  const duplicateGroups = new Map<string, number>();
+  for (const card of relevantCards) {
+    const cardTaskId = hermesCardAgentplaneTaskId(card);
+    if (!cardTaskId) continue;
+    duplicateGroups.set(cardTaskId, (duplicateGroups.get(cardTaskId) ?? 0) + 1);
+  }
+  for (const [cardTaskId, count] of duplicateGroups) {
+    if (count <= 1) continue;
+    findings.push({
+      code: "duplicate_hermes_cards",
+      severity: "warn",
+      message: `${count} Hermes cards map to Agentplane task ${cardTaskId}.`,
+    });
+  }
+  const first = relevantCards[0];
+  const rawStatus = first?.status ?? first?.state;
+  const status = typeof rawStatus === "string" ? rawStatus.trim().toLowerCase() : "";
+  if (
+    localProjection?.terminal.hermes_root_complete_allowed === true &&
+    status &&
+    !["done", "complete", "completed"].includes(status)
+  ) {
+    findings.push({
+      code: "agentplane_done_hermes_open",
+      severity: "warn",
+      message: "Agentplane is terminal and verified, but the Hermes card is not complete.",
+    });
+  }
+  if (
+    localProjection?.terminal.hermes_root_complete_allowed === false &&
+    ["done", "complete", "completed"].includes(status)
+  ) {
+    findings.push({
+      code: "hermes_complete_agentplane_open",
+      severity: "warn",
+      message: "Hermes card is complete, but Agentplane task truth is not terminal verified.",
+    });
+  }
+  return {
+    state_card_count: cards.length,
+    matched_card_count: relevantCards.length,
+    matched_cards: relevantCards.map((card) => ({
+      id: typeof card.id === "string" ? card.id : null,
+      status: typeof card.status === "string" ? card.status : (card.state ?? null),
+      assignee: typeof card.assignee === "string" ? card.assignee : null,
+      agentplane_task_id: hermesCardAgentplaneTaskId(card),
+    })),
+    findings,
+  };
+}

--- a/packages/agentplane/src/commands/hermes/hermes.command.ts
+++ b/packages/agentplane/src/commands/hermes/hermes.command.ts
@@ -1,11 +1,10 @@
 import {
   loadDirectSubcommandNames,
-  parseGroupCommand,
   throwGroupCommandUsage,
   type GroupCommandParsed,
 } from "../../cli/group-command.js";
 import { createCliEmitter } from "../../cli/output.js";
-import type { CommandCtx, CommandHandler, CommandSpec } from "../../cli/spec/spec.js";
+import type { CommandCtx, CommandHandler } from "../../cli/spec/spec.js";
 import { CliError } from "../../shared/errors.js";
 import type { CommandContext } from "../shared/task-backend.js";
 import {
@@ -23,236 +22,29 @@ import {
   runHermesLifecycle,
   type HermesLifecycleAction,
 } from "./hermes-runtime.js";
-
-export type HermesEnqueueParsed = {
-  taskId: string;
-  board: string;
-  assignee: string;
-  role: string;
-  workspace: string | null;
-  json: boolean;
-};
-
-export type HermesSuperviseParsed = {
-  taskId: string;
-  json: boolean;
-  executeStep: boolean;
-  dryRun: boolean;
-};
-
-export type HermesReconcileParsed = {
-  taskId?: string;
-  hermesState?: string;
-  json: boolean;
-};
-
-export type HermesLifecycleParsed = {
-  action: string;
-  body: string | null;
-  json: boolean;
-  dryRun: boolean;
-};
-
-export type HermesDoctorParsed = {
-  json: boolean;
-};
+import {
+  hermesSpec,
+  type HermesDoctorParsed,
+  type HermesEnqueueParsed,
+  type HermesLifecycleParsed,
+  type HermesReconcileParsed,
+  type HermesSuperviseParsed,
+} from "./hermes-specs.js";
 
 const output = createCliEmitter();
-
-export const hermesSpec: CommandSpec<GroupCommandParsed> = {
-  id: ["hermes"],
-  group: "Integrations",
-  summary: "Inspect the Agentplane-owned Hermes adapter contract.",
-  description:
-    "This command group exposes the repo-local Agentplane side of the Hermes Kanban adapter. " +
-    "It does not talk directly to the Hermes SQLite database; Hermes-side plugins should call " +
-    "these commands through the CLI or a typed wrapper.",
-  synopsis: ["agentplane hermes <enqueue|supervise|reconcile|doctor> [args] [options]"],
-  args: [{ name: "cmd", required: false, variadic: true, valueHint: "<cmd>" }],
-  examples: [
-    {
-      cmd: "agentplane hermes enqueue 202605311941-K4FCKS --json",
-      why: "Render the provider-safe Hermes projection for one Agentplane task.",
-    },
-  ],
-  parse: (raw) => parseGroupCommand(raw),
-};
-
-export const hermesEnqueueSpec: CommandSpec<HermesEnqueueParsed> = {
-  id: ["hermes", "enqueue"],
-  group: "Integrations",
-  summary: "Render a provider-safe Hermes Kanban card projection for a task.",
-  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
-  options: [
-    {
-      kind: "string",
-      name: "board",
-      default: "agentplane",
-      valueHint: "<slug>",
-      description: "Hermes board slug for the projected card.",
-    },
-    {
-      kind: "string",
-      name: "assignee",
-      default: "agentplane-supervisor",
-      valueHint: "<lane>",
-      description: "Hermes assignee or lane that should own the projected root card.",
-    },
-    {
-      kind: "string",
-      name: "role",
-      default: "CODER",
-      valueHint: "<ROLE>",
-      description: "Agentplane role represented by the projected Hermes card.",
-    },
-    {
-      kind: "string",
-      name: "workspace",
-      valueHint: "dir:/abs/repo",
-      description: "Hermes workspace spec. Defaults to the Agentplane repository root.",
-    },
-    { kind: "boolean", name: "json", default: false, description: "Emit machine-readable result." },
-  ],
-  examples: [
-    {
-      cmd: "agentplane hermes enqueue 202605311941-K4FCKS --board my-repo --json",
-      why: "Build the card body/metadata a Hermes plugin should create idempotently.",
-    },
-  ],
-  parse: (raw) => ({
-    taskId: String(raw.args["task-id"]),
-    board: typeof raw.opts.board === "string" ? raw.opts.board : "agentplane",
-    assignee: typeof raw.opts.assignee === "string" ? raw.opts.assignee : "agentplane-supervisor",
-    role: typeof raw.opts.role === "string" ? raw.opts.role : "CODER",
-    workspace: typeof raw.opts.workspace === "string" ? raw.opts.workspace : null,
-    json: raw.opts.json === true,
-  }),
-};
-
-export const hermesSuperviseSpec: CommandSpec<HermesSuperviseParsed> = {
-  id: ["hermes", "supervise"],
-  group: "Integrations",
-  summary: "Compute the next safe Agentplane route step for a Hermes supervisor run.",
-  args: [{ name: "task-id", required: true, valueHint: "<task-id>" }],
-  options: [
-    { kind: "boolean", name: "json", default: false, description: "Emit machine-readable result." },
-    {
-      kind: "boolean",
-      name: "execute-step",
-      default: false,
-      description: "Execute one allowlisted Agentplane route step for this Hermes claim.",
-    },
-    {
-      kind: "boolean",
-      name: "dry-run",
-      default: false,
-      description: "With --execute-step, return the planned command without executing it.",
-    },
-  ],
-  examples: [
-    {
-      cmd: "agentplane hermes supervise 202605311941-K4FCKS --json",
-      why: "Return a route-gated supervisor packet without executing arbitrary shell text.",
-    },
-  ],
-  parse: (raw) => ({
-    taskId: String(raw.args["task-id"]),
-    json: raw.opts.json === true,
-    executeStep: raw.opts["execute-step"] === true,
-    dryRun: raw.opts["dry-run"] === true,
-  }),
-};
-
-export const hermesReconcileSpec: CommandSpec<HermesReconcileParsed> = {
-  id: ["hermes", "reconcile"],
-  group: "Integrations",
-  summary: "Inspect Hermes projection drift without mutating Agentplane task truth.",
-  options: [
-    {
-      kind: "string",
-      name: "task-id",
-      valueHint: "<task-id>",
-      description: "Limit reconcile diagnostics to one Agentplane task id.",
-    },
-    {
-      kind: "string",
-      name: "hermes-state",
-      valueHint: "<path>",
-      description: "Read a Hermes card/task JSON snapshot and compare it with Agentplane truth.",
-    },
-    { kind: "boolean", name: "json", default: false, description: "Emit machine-readable result." },
-  ],
-  examples: [
-    {
-      cmd: "agentplane hermes reconcile --task-id 202605311941-K4FCKS --json",
-      why: "Inspect the local Agentplane side of a Hermes projection.",
-    },
-  ],
-  parse: (raw) => ({
-    taskId: typeof raw.opts["task-id"] === "string" ? raw.opts["task-id"] : undefined,
-    hermesState:
-      typeof raw.opts["hermes-state"] === "string" ? raw.opts["hermes-state"] : undefined,
-    json: raw.opts.json === true,
-  }),
-};
-
-export const hermesLifecycleSpec: CommandSpec<HermesLifecycleParsed> = {
-  id: ["hermes", "lifecycle"],
-  group: "Integrations",
-  summary: "Emit one Hermes Kanban lifecycle callback through the configured Hermes CLI.",
-  description:
-    "This is the Agentplane-side lifecycle client for Hermes worker lanes. It sends comment, block, " +
-    "complete, or heartbeat callbacks through the Hermes CLI and reads task, board, and run identity " +
-    "from the Hermes worker environment.",
-  args: [{ name: "action", required: true, valueHint: "comment|block|complete|heartbeat" }],
-  options: [
-    {
-      kind: "string",
-      name: "body",
-      valueHint: "<text>",
-      description: "Callback body, reason, or summary. Heartbeat uses a default body when omitted.",
-    },
-    { kind: "boolean", name: "json", default: false, description: "Emit machine-readable result." },
-    {
-      kind: "boolean",
-      name: "dry-run",
-      default: false,
-      description: "Return the Hermes CLI command without executing it.",
-    },
-  ],
-  examples: [
-    {
-      cmd: 'agentplane hermes lifecycle comment --body \'{"agentplane_task_id":"202605311941-K4FCKS"}\' --json',
-      why: "Write a structured projection comment for the current Hermes card.",
-    },
-    {
-      cmd: "agentplane hermes lifecycle complete --body 'Agentplane terminal evidence validated' --json",
-      why: "Complete the current Hermes card after Agentplane terminal gates have passed.",
-    },
-  ],
-  parse: (raw) => ({
-    action: String(raw.args.action),
-    body: typeof raw.opts.body === "string" ? raw.opts.body : null,
-    json: raw.opts.json === true,
-    dryRun: raw.opts["dry-run"] === true,
-  }),
-};
-
-export const hermesDoctorSpec: CommandSpec<HermesDoctorParsed> = {
-  id: ["hermes", "doctor"],
-  group: "Integrations",
-  summary: "Check the local Agentplane side of the Hermes adapter contract.",
-  options: [
-    { kind: "boolean", name: "json", default: false, description: "Emit machine-readable result." },
-  ],
-  examples: [
-    {
-      cmd: "agentplane hermes doctor --json",
-      why: "Check workflow mode, repo root, and Hermes Kanban environment variables.",
-    },
-  ],
-  parse: (raw) => ({ json: raw.opts.json === true }),
-};
+export {
+  hermesDoctorSpec,
+  hermesEnqueueSpec,
+  hermesLifecycleSpec,
+  hermesReconcileSpec,
+  hermesSpec,
+  hermesSuperviseSpec,
+  type HermesDoctorParsed,
+  type HermesEnqueueParsed,
+  type HermesLifecycleParsed,
+  type HermesReconcileParsed,
+  type HermesSuperviseParsed,
+} from "./hermes-specs.js";
 
 export async function runHermesGroup(_ctx: CommandCtx, p: GroupCommandParsed): Promise<number> {
   return throwGroupCommandUsage({

--- a/packages/agentplane/src/commands/insights/insights-report-render.ts
+++ b/packages/agentplane/src/commands/insights/insights-report-render.ts
@@ -1,0 +1,69 @@
+import type { CliReportEntry } from "../../cli/output.js";
+import type { InsightsReport } from "./insights-report.js";
+
+type CountMap = Record<string, number>;
+
+function renderCountMap(map: CountMap, limit?: number): string {
+  let entries = Object.entries(map).filter(([, value]) => value > 0);
+  if (entries.length === 0) return "none";
+  entries = entries.toSorted(([keyA, valueA], [keyB, valueB]) => {
+    if (valueA !== valueB) return valueB - valueA;
+    return keyA.localeCompare(keyB);
+  });
+  if (limit !== undefined && entries.length > limit) {
+    const visible = entries.slice(0, limit);
+    const other = entries.slice(limit).reduce((sum, [, value]) => sum + value, 0);
+    entries = [...visible, ["other", other]];
+  }
+  return entries.map(([key, value]) => `${key}=${value}`).join(", ");
+}
+
+export function renderInsightsReport(report: InsightsReport): CliReportEntry[] {
+  return [
+    { label: "schema", value: report.schema },
+    { label: "generated_at", value: report.generated_at },
+    { label: "local_only", value: report.privacy.local_only },
+    { label: "network", value: report.privacy.network },
+    { label: "upload", value: report.privacy.upload },
+    { label: "failure_error_code", value: report.failure.error_code ?? "unknown" },
+    { label: "failure_command", value: report.failure.command_id ?? "unknown" },
+    { label: "failure_phase", value: report.failure.phase ?? "unknown" },
+    { label: "failure_reason_code", value: report.failure.reason_code ?? "unknown" },
+    { label: "failure_dedupe", value: report.failure.dedupe_signature },
+    { label: "agentplane", value: report.environment.agentplane_version ?? "unknown" },
+    { label: "node_major", value: report.environment.node_major ?? "unknown" },
+    { label: "platform", value: `${report.environment.platform}/${report.environment.arch}` },
+    { label: "workflow_mode", value: report.project.workflow_mode },
+    { label: "backend", value: report.project.backend.id },
+    { label: "backend_cache_configured", value: report.project.backend.cache_configured },
+    { label: "git_branch", value: report.git.branch ?? "unknown" },
+    { label: "git_dirty", value: report.git.dirty },
+    { label: "git_status", value: renderCountMap(report.git.status_counts) },
+    { label: "tasks_total", value: report.tasks.total },
+    { label: "tasks_by_status", value: renderCountMap(report.tasks.by_status) },
+    { label: "tasks_by_owner", value: renderCountMap(report.tasks.by_owner) },
+    { label: "tasks_by_primary_tag", value: renderCountMap(report.tasks.by_primary_tag, 20) },
+    { label: "plan_approval", value: renderCountMap(report.tasks.plan_approval) },
+    { label: "verification", value: renderCountMap(report.tasks.verification) },
+    { label: "verify_steps", value: renderCountMap(report.tasks.verify_steps) },
+    { label: "quality_verify_steps", value: renderCountMap(report.quality.verify_steps) },
+    { label: "quality_intake_manifest", value: renderCountMap(report.quality.intake_manifest) },
+    { label: "quality_runner_repeat", value: renderCountMap(report.quality.runner_repeat) },
+    {
+      label: "quality_runner_failure_fingerprints",
+      value: renderCountMap(report.quality.runner_failure_fingerprints, 5),
+    },
+    { label: "task_event_types", value: renderCountMap(report.tasks.event_types) },
+    { label: "active_task_ids", value: report.tasks.active_task_ids.join(", ") || "none" },
+    { label: "recent_task_ids", value: report.tasks.recent_task_ids.join(", ") || "none" },
+    { label: "runner_tasks", value: report.runner.tasks_with_runner },
+    { label: "runner_status", value: renderCountMap(report.runner.by_status) },
+    { label: "runner_adapters", value: renderCountMap(report.runner.by_adapter) },
+    { label: "runner_modes", value: renderCountMap(report.runner.mode) },
+    { label: "runner_duration", value: renderCountMap(report.runner.duration_ms_buckets) },
+    {
+      label: "excluded_content",
+      value: report.privacy.excludes.join("; "),
+    },
+  ];
+}

--- a/packages/agentplane/src/commands/insights/insights-report.ts
+++ b/packages/agentplane/src/commands/insights/insights-report.ts
@@ -1,13 +1,14 @@
 import { execFile as execFileCb } from "node:child_process";
-import { access, readFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
-import { listTasks, type TaskRecord } from "@agentplaneorg/core/tasks";
+import type { TaskRecord } from "@agentplaneorg/core/tasks";
 
-import type { CliReportEntry } from "../../cli/output.js";
 import type { RunDeps } from "../../cli/run-cli/command-catalog/kernel.js";
+import { listTasksForInsights, pathExists } from "./insights-task-loader.js";
+export { renderInsightsReport } from "./insights-report-render.js";
 import { getVersion } from "../../meta/version.js";
 import { isRecord } from "../../shared/guards.js";
 import {
@@ -177,23 +178,6 @@ async function readGitStatus(root: string): Promise<InsightsReport["git"]> {
 function taskUpdatedAt(task: TaskRecord): string {
   const value = task.frontmatter.doc_updated_at;
   return typeof value === "string" ? value : "";
-}
-
-async function pathExists(filePath: string): Promise<boolean> {
-  try {
-    await access(filePath);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function listTasksForInsights(root: string): Promise<TaskRecord[]> {
-  try {
-    return await listTasks({ cwd: root, rootOverride: root });
-  } catch {
-    return [];
-  }
 }
 
 function summarizeTasks(tasks: TaskRecord[], recentLimit: number): InsightsReport["tasks"] {
@@ -410,69 +394,4 @@ export async function buildInsightsReport(opts: {
     quality: await summarizeQuality(tasks),
     runner: summarizeRunner(tasks),
   };
-}
-
-function renderCountMap(map: CountMap, limit?: number): string {
-  let entries = Object.entries(map).filter(([, value]) => value > 0);
-  if (entries.length === 0) return "none";
-  entries = entries.toSorted(([keyA, valueA], [keyB, valueB]) => {
-    if (valueA !== valueB) return valueB - valueA;
-    return keyA.localeCompare(keyB);
-  });
-  if (limit !== undefined && entries.length > limit) {
-    const visible = entries.slice(0, limit);
-    const other = entries.slice(limit).reduce((sum, [, value]) => sum + value, 0);
-    entries = [...visible, ["other", other]];
-  }
-  return entries.map(([key, value]) => `${key}=${value}`).join(", ");
-}
-
-export function renderInsightsReport(report: InsightsReport): CliReportEntry[] {
-  return [
-    { label: "schema", value: report.schema },
-    { label: "generated_at", value: report.generated_at },
-    { label: "local_only", value: report.privacy.local_only },
-    { label: "network", value: report.privacy.network },
-    { label: "upload", value: report.privacy.upload },
-    { label: "failure_error_code", value: report.failure.error_code ?? "unknown" },
-    { label: "failure_command", value: report.failure.command_id ?? "unknown" },
-    { label: "failure_phase", value: report.failure.phase ?? "unknown" },
-    { label: "failure_reason_code", value: report.failure.reason_code ?? "unknown" },
-    { label: "failure_dedupe", value: report.failure.dedupe_signature },
-    { label: "agentplane", value: report.environment.agentplane_version ?? "unknown" },
-    { label: "node_major", value: report.environment.node_major ?? "unknown" },
-    { label: "platform", value: `${report.environment.platform}/${report.environment.arch}` },
-    { label: "workflow_mode", value: report.project.workflow_mode },
-    { label: "backend", value: report.project.backend.id },
-    { label: "backend_cache_configured", value: report.project.backend.cache_configured },
-    { label: "git_branch", value: report.git.branch ?? "unknown" },
-    { label: "git_dirty", value: report.git.dirty },
-    { label: "git_status", value: renderCountMap(report.git.status_counts) },
-    { label: "tasks_total", value: report.tasks.total },
-    { label: "tasks_by_status", value: renderCountMap(report.tasks.by_status) },
-    { label: "tasks_by_owner", value: renderCountMap(report.tasks.by_owner) },
-    { label: "tasks_by_primary_tag", value: renderCountMap(report.tasks.by_primary_tag, 20) },
-    { label: "plan_approval", value: renderCountMap(report.tasks.plan_approval) },
-    { label: "verification", value: renderCountMap(report.tasks.verification) },
-    { label: "verify_steps", value: renderCountMap(report.tasks.verify_steps) },
-    { label: "quality_verify_steps", value: renderCountMap(report.quality.verify_steps) },
-    { label: "quality_intake_manifest", value: renderCountMap(report.quality.intake_manifest) },
-    { label: "quality_runner_repeat", value: renderCountMap(report.quality.runner_repeat) },
-    {
-      label: "quality_runner_failure_fingerprints",
-      value: renderCountMap(report.quality.runner_failure_fingerprints, 5),
-    },
-    { label: "task_event_types", value: renderCountMap(report.tasks.event_types) },
-    { label: "active_task_ids", value: report.tasks.active_task_ids.join(", ") || "none" },
-    { label: "recent_task_ids", value: report.tasks.recent_task_ids.join(", ") || "none" },
-    { label: "runner_tasks", value: report.runner.tasks_with_runner },
-    { label: "runner_status", value: renderCountMap(report.runner.by_status) },
-    { label: "runner_adapters", value: renderCountMap(report.runner.by_adapter) },
-    { label: "runner_modes", value: renderCountMap(report.runner.mode) },
-    { label: "runner_duration", value: renderCountMap(report.runner.duration_ms_buckets) },
-    {
-      label: "excluded_content",
-      value: report.privacy.excludes.join("; "),
-    },
-  ];
 }

--- a/packages/agentplane/src/commands/insights/insights-task-loader.ts
+++ b/packages/agentplane/src/commands/insights/insights-task-loader.ts
@@ -1,0 +1,19 @@
+import { access } from "node:fs/promises";
+import { listTasks, type TaskRecord } from "@agentplaneorg/core/tasks";
+
+export async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function listTasksForInsights(root: string): Promise<TaskRecord[]> {
+  try {
+    return await listTasks({ cwd: root, rootOverride: root });
+  } catch {
+    return [];
+  }
+}

--- a/packages/agentplane/src/runner/result-manifest-artifacts.ts
+++ b/packages/agentplane/src/runner/result-manifest-artifacts.ts
@@ -1,0 +1,149 @@
+import { mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { atomicWriteFile } from "@agentplaneorg/core/fs";
+import { isRecord } from "../shared/guards.js";
+import type { RunnerResult, RunnerResultManifest } from "./types.js";
+import type { InvalidRunnerResultManifestError } from "./result-manifest.js";
+
+const INVALID_RESULT_MANIFEST_SUFFIX = ".invalid.json";
+const SOURCE_RESULT_MANIFEST_SUFFIX = ".source.json";
+function normalizeStringArraySoft(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out = value
+    .filter((item): item is string => typeof item === "string" && item.trim() !== "")
+    .map((item) => item.trim());
+  return out.length > 0 ? out : undefined;
+}
+function normalizeTrimmedStringSoft(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function invalidRunnerResultManifestPath(resultPath: string): string {
+  const dir = path.dirname(resultPath);
+  const base = path.basename(resultPath, ".json");
+  return path.join(dir, `${base}${INVALID_RESULT_MANIFEST_SUFFIX}`);
+}
+
+export function sourceRunnerResultManifestPath(resultPath: string): string {
+  const dir = path.dirname(resultPath);
+  const base = path.basename(resultPath, ".json");
+  return path.join(dir, `${base}${SOURCE_RESULT_MANIFEST_SUFFIX}`);
+}
+
+export async function preserveInvalidRunnerResultManifest(opts: {
+  result_path: string;
+  error: InvalidRunnerResultManifestError;
+}): Promise<string> {
+  const invalidPath = invalidRunnerResultManifestPath(opts.result_path);
+  await mkdir(path.dirname(invalidPath), { recursive: true });
+  await atomicWriteFile(invalidPath, opts.error.raw_content, "utf8");
+  return invalidPath;
+}
+
+export async function preserveRunnerResultManifestSource(
+  resultPath: string,
+): Promise<string | null> {
+  try {
+    const rawContent = await readFile(resultPath, "utf8");
+    const sourcePath = sourceRunnerResultManifestPath(resultPath);
+    await mkdir(path.dirname(sourcePath), { recursive: true });
+    await atomicWriteFile(sourcePath, rawContent, "utf8");
+    return sourcePath;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | null)?.code;
+    if (code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+export function salvageBlockedRunnerResultManifest(
+  rawContent: string,
+): Pick<RunnerResultManifest, "summary" | "evidence"> | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawContent);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed) || !isRecord(parsed.evidence)) return null;
+  const conflict_paths = normalizeStringArraySoft(parsed.evidence.conflict_paths);
+  const blocked_reason = normalizeTrimmedStringSoft(parsed.evidence.blocked_reason);
+  const recommended_parent_action = normalizeTrimmedStringSoft(
+    parsed.evidence.recommended_parent_action,
+  );
+  if (!conflict_paths || !blocked_reason || !recommended_parent_action) {
+    return null;
+  }
+  const summary = normalizeTrimmedStringSoft(parsed.summary);
+  return {
+    ...(summary ? { summary } : {}),
+    evidence: {
+      conflict_paths,
+      blocked_reason,
+      recommended_parent_action,
+    },
+  };
+}
+
+export async function writeRunnerResultManifest(opts: {
+  result_path: string;
+  manifest: RunnerResultManifest;
+}): Promise<void> {
+  await mkdir(path.dirname(opts.result_path), { recursive: true });
+  await atomicWriteFile(opts.result_path, `${JSON.stringify(opts.manifest, null, 2)}\n`, "utf8");
+}
+
+export function applyRunnerResultManifest(opts: {
+  base: RunnerResult;
+  manifest: RunnerResultManifest | null;
+}): RunnerResult {
+  if (!opts.manifest) return opts.base;
+  const merged: RunnerResult = {
+    ...opts.base,
+    status:
+      opts.base.status === "cancelled" ? "cancelled" : (opts.manifest.status ?? opts.base.status),
+    exit_code:
+      opts.base.status === "cancelled"
+        ? opts.base.exit_code
+        : (opts.manifest.exit_code ?? opts.base.exit_code),
+    summary: opts.manifest.summary ?? opts.base.summary,
+    stdout_summary: opts.manifest.stdout_summary ?? opts.base.stdout_summary,
+    stderr_summary: opts.manifest.stderr_summary ?? opts.base.stderr_summary,
+    timeout_reason: opts.manifest.timeout_reason ?? opts.base.timeout_reason,
+    artifacts: opts.manifest.artifacts ?? opts.base.artifacts,
+    findings: opts.manifest.findings ?? opts.base.findings,
+    verification_hints: opts.manifest.verification_hints ?? opts.base.verification_hints,
+    capabilities_used: opts.manifest.capabilities_used ?? opts.base.capabilities_used,
+    metrics: {
+      ...opts.base.metrics,
+      ...opts.manifest.metrics,
+    },
+    evidence: opts.manifest.evidence ?? opts.base.evidence,
+  };
+  if (merged.artifacts && merged.artifacts.length > 0) {
+    merged.output_paths = merged.artifacts.map((artifact) => artifact.path);
+  }
+  return merged;
+}
+
+export function manifestFromRunnerResult(result: RunnerResult): RunnerResultManifest {
+  return {
+    schema_version: 1,
+    status: result.status,
+    exit_code: result.exit_code,
+    summary: result.summary,
+    stdout_summary: result.stdout_summary,
+    stderr_summary: result.stderr_summary,
+    timeout_reason: result.timeout_reason,
+    artifacts:
+      result.artifacts ??
+      result.output_paths?.map((outputPath) => ({
+        path: outputPath,
+      })),
+    findings: result.findings,
+    verification_hints: result.verification_hints,
+    capabilities_used: result.capabilities_used,
+    metrics: result.metrics,
+    evidence: result.evidence,
+  };
+}

--- a/packages/agentplane/src/runner/result-manifest.ts
+++ b/packages/agentplane/src/runner/result-manifest.ts
@@ -1,12 +1,9 @@
-import { mkdir, readFile } from "node:fs/promises";
-import path from "node:path";
-import { atomicWriteFile } from "@agentplaneorg/core/fs";
+import { readFile } from "node:fs/promises";
 
 import { isRecord } from "../shared/guards.js";
 import type {
   RunnerResultEvidence,
   RunnerExecutionMetrics,
-  RunnerResult,
   RunnerResultArtifact,
   RunnerResultManifest,
   RunnerResultStatus,
@@ -14,8 +11,20 @@ import type {
 } from "./types.js";
 
 export const RUNNER_RESULT_MANIFEST_SCHEMA_VERSION = 1 as const;
-const INVALID_RESULT_MANIFEST_SUFFIX = ".invalid.json";
-const SOURCE_RESULT_MANIFEST_SUFFIX = ".source.json";
+export {
+  applyRunnerResultManifest,
+  invalidRunnerResultManifestPath,
+  manifestFromRunnerResult,
+  preserveInvalidRunnerResultManifest,
+  preserveRunnerResultManifestSource,
+  salvageBlockedRunnerResultManifest,
+  writeRunnerResultManifest,
+} from "./result-manifest-artifacts.js";
+import { sourceRunnerResultManifestPath as resolveSourceRunnerResultManifestPath } from "./result-manifest-artifacts.js";
+
+export function sourceRunnerResultManifestPath(resultPath: string): string {
+  return resolveSourceRunnerResultManifestPath(resultPath);
+}
 
 export class InvalidRunnerResultManifestError extends Error {
   readonly result_path: string;
@@ -55,20 +64,6 @@ function normalizeStringArray(value: unknown): string[] | undefined {
     return normalized;
   });
   return entries.length > 0 ? entries : undefined;
-}
-
-function normalizeStringArraySoft(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) return undefined;
-  const entries = value
-    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
-    .filter((entry) => entry.length > 0);
-  return entries.length > 0 ? entries : undefined;
-}
-
-function normalizeTrimmedStringSoft(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  const normalized = value.trim();
-  return normalized.length > 0 ? normalized : undefined;
 }
 
 function normalizeMachineIdentifier(value: unknown, field: string): string {
@@ -348,134 +343,4 @@ export async function readRunnerResultManifest(
     if (code === "ENOENT") return null;
     throw err;
   }
-}
-
-export function invalidRunnerResultManifestPath(resultPath: string): string {
-  const dir = path.dirname(resultPath);
-  const base = path.basename(resultPath, ".json");
-  return path.join(dir, `${base}${INVALID_RESULT_MANIFEST_SUFFIX}`);
-}
-
-export function sourceRunnerResultManifestPath(resultPath: string): string {
-  const dir = path.dirname(resultPath);
-  const base = path.basename(resultPath, ".json");
-  return path.join(dir, `${base}${SOURCE_RESULT_MANIFEST_SUFFIX}`);
-}
-
-export async function preserveInvalidRunnerResultManifest(opts: {
-  result_path: string;
-  error: InvalidRunnerResultManifestError;
-}): Promise<string> {
-  const invalidPath = invalidRunnerResultManifestPath(opts.result_path);
-  await mkdir(path.dirname(invalidPath), { recursive: true });
-  await atomicWriteFile(invalidPath, opts.error.raw_content, "utf8");
-  return invalidPath;
-}
-
-export async function preserveRunnerResultManifestSource(
-  resultPath: string,
-): Promise<string | null> {
-  try {
-    const rawContent = await readFile(resultPath, "utf8");
-    const sourcePath = sourceRunnerResultManifestPath(resultPath);
-    await mkdir(path.dirname(sourcePath), { recursive: true });
-    await atomicWriteFile(sourcePath, rawContent, "utf8");
-    return sourcePath;
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException | null)?.code;
-    if (code === "ENOENT") return null;
-    throw err;
-  }
-}
-
-export function salvageBlockedRunnerResultManifest(
-  rawContent: string,
-): Pick<RunnerResultManifest, "summary" | "evidence"> | null {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(rawContent);
-  } catch {
-    return null;
-  }
-  if (!isRecord(parsed) || !isRecord(parsed.evidence)) return null;
-  const conflict_paths = normalizeStringArraySoft(parsed.evidence.conflict_paths);
-  const blocked_reason = normalizeTrimmedStringSoft(parsed.evidence.blocked_reason);
-  const recommended_parent_action = normalizeTrimmedStringSoft(
-    parsed.evidence.recommended_parent_action,
-  );
-  if (!conflict_paths || !blocked_reason || !recommended_parent_action) {
-    return null;
-  }
-  const summary = normalizeTrimmedStringSoft(parsed.summary);
-  return {
-    ...(summary ? { summary } : {}),
-    evidence: {
-      conflict_paths,
-      blocked_reason,
-      recommended_parent_action,
-    },
-  };
-}
-
-export async function writeRunnerResultManifest(opts: {
-  result_path: string;
-  manifest: RunnerResultManifest;
-}): Promise<void> {
-  await mkdir(path.dirname(opts.result_path), { recursive: true });
-  await atomicWriteFile(opts.result_path, `${JSON.stringify(opts.manifest, null, 2)}\n`, "utf8");
-}
-
-export function applyRunnerResultManifest(opts: {
-  base: RunnerResult;
-  manifest: RunnerResultManifest | null;
-}): RunnerResult {
-  if (!opts.manifest) return opts.base;
-  const merged: RunnerResult = {
-    ...opts.base,
-    status:
-      opts.base.status === "cancelled" ? "cancelled" : (opts.manifest.status ?? opts.base.status),
-    exit_code:
-      opts.base.status === "cancelled"
-        ? opts.base.exit_code
-        : (opts.manifest.exit_code ?? opts.base.exit_code),
-    summary: opts.manifest.summary ?? opts.base.summary,
-    stdout_summary: opts.manifest.stdout_summary ?? opts.base.stdout_summary,
-    stderr_summary: opts.manifest.stderr_summary ?? opts.base.stderr_summary,
-    timeout_reason: opts.manifest.timeout_reason ?? opts.base.timeout_reason,
-    artifacts: opts.manifest.artifacts ?? opts.base.artifacts,
-    findings: opts.manifest.findings ?? opts.base.findings,
-    verification_hints: opts.manifest.verification_hints ?? opts.base.verification_hints,
-    capabilities_used: opts.manifest.capabilities_used ?? opts.base.capabilities_used,
-    metrics: {
-      ...opts.base.metrics,
-      ...opts.manifest.metrics,
-    },
-    evidence: opts.manifest.evidence ?? opts.base.evidence,
-  };
-  if (merged.artifacts && merged.artifacts.length > 0) {
-    merged.output_paths = merged.artifacts.map((artifact) => artifact.path);
-  }
-  return merged;
-}
-
-export function manifestFromRunnerResult(result: RunnerResult): RunnerResultManifest {
-  return {
-    schema_version: RUNNER_RESULT_MANIFEST_SCHEMA_VERSION,
-    status: result.status,
-    exit_code: result.exit_code,
-    summary: result.summary,
-    stdout_summary: result.stdout_summary,
-    stderr_summary: result.stderr_summary,
-    timeout_reason: result.timeout_reason,
-    artifacts:
-      result.artifacts ??
-      result.output_paths?.map((outputPath) => ({
-        path: outputPath,
-      })),
-    findings: result.findings,
-    verification_hints: result.verification_hints,
-    capabilities_used: result.capabilities_used,
-    metrics: result.metrics,
-    evidence: result.evidence,
-  };
 }

--- a/packages/agentplane/src/runtime/sgr/contract-evaluator-routing.ts
+++ b/packages/agentplane/src/runtime/sgr/contract-evaluator-routing.ts
@@ -1,0 +1,143 @@
+import type { BlueprintRouteDecisionSgrResult, EvaluatorSgrResult } from "./contract-types.js";
+import { SGR_CONTRACT_SCHEMA_VERSION } from "./contract-types.js";
+import {
+  invalid,
+  optionalString,
+  requireArray,
+  requireEnum,
+  requireNonEmptyArray,
+  requireRecord,
+  requireSchemaVersion,
+  requireString,
+  requireStringArray,
+} from "./contract-validators.js";
+import { validateReasoningStep, validateSourceRef } from "./contract-shared-validation.js";
+
+export function validateEvaluatorSgrResult(
+  raw: unknown,
+  field = "evaluator SGR result",
+): EvaluatorSgrResult {
+  const result = requireRecord(raw, field);
+  requireSchemaVersion(result, field);
+  if (result.kind !== "evaluator_result") throw invalid(`${field}.kind`, '"evaluator_result"');
+  const verdict = requireEnum(result.verdict, `${field}.verdict`, ["pass", "rework", "blocked"]);
+  const findings = requireArray(result.findings, `${field}.findings`, (entry, findingField) => {
+    const finding = requireRecord(entry, findingField);
+    return {
+      id: requireString(finding.id, `${findingField}.id`),
+      severity: requireEnum(finding.severity, `${findingField}.severity`, [
+        "low",
+        "medium",
+        "high",
+      ]),
+      summary: requireString(finding.summary, `${findingField}.summary`),
+      broken_invariant: requireString(finding.broken_invariant, `${findingField}.broken_invariant`),
+      evidence_refs: requireNonEmptyArray(
+        finding.evidence_refs,
+        `${findingField}.evidence_refs`,
+        validateSourceRef,
+      ),
+    };
+  });
+  if ((verdict === "rework" || verdict === "blocked") && findings.length === 0) {
+    throw invalid(`${field}.findings`, "non-empty array for rework or blocked verdict");
+  }
+  return {
+    schema_version: SGR_CONTRACT_SCHEMA_VERSION,
+    kind: "evaluator_result",
+    evaluator_id: requireString(result.evaluator_id, `${field}.evaluator_id`),
+    verdict,
+    findings,
+    missing_tests: requireStringArray(result.missing_tests, `${field}.missing_tests`),
+    hidden_assumptions: requireStringArray(
+      result.hidden_assumptions,
+      `${field}.hidden_assumptions`,
+    ),
+    recovery_context: optionalString(result.recovery_context, `${field}.recovery_context`),
+  };
+}
+
+export function validateBlueprintRouteDecisionSgrResult(
+  raw: unknown,
+  field = "blueprint route decision SGR result",
+): BlueprintRouteDecisionSgrResult {
+  const result = requireRecord(raw, field);
+  requireSchemaVersion(result, field);
+  if (result.kind !== "blueprint_route_decision") {
+    throw invalid(`${field}.kind`, '"blueprint_route_decision"');
+  }
+  const selected = requireRecord(result.selected_route, `${field}.selected_route`);
+  return {
+    schema_version: SGR_CONTRACT_SCHEMA_VERSION,
+    kind: "blueprint_route_decision",
+    facts: requireNonEmptyArray(result.facts, `${field}.facts`, validateReasoningStep),
+    inferences: requireNonEmptyArray(
+      result.inferences,
+      `${field}.inferences`,
+      validateReasoningStep,
+    ),
+    rejected_routes: requireArray(
+      result.rejected_routes,
+      `${field}.rejected_routes`,
+      (entry, routeField) => {
+        const route = requireRecord(entry, routeField);
+        return {
+          blueprint_id: requireString(route.blueprint_id, `${routeField}.blueprint_id`),
+          reason: requireString(route.reason, `${routeField}.reason`),
+        };
+      },
+    ),
+    selected_route: {
+      blueprint_id: requireString(selected.blueprint_id, `${field}.selected_route.blueprint_id`),
+      task_kind: requireEnum(selected.task_kind, `${field}.selected_route.task_kind`, [
+        "analysis",
+        "content",
+        "docs",
+        "code",
+        "release",
+        "ops",
+        "context",
+      ]),
+      rationale: requireString(selected.rationale, `${field}.selected_route.rationale`),
+    },
+    required_evidence: requireArray(
+      result.required_evidence,
+      `${field}.required_evidence`,
+      (entry, evidenceField) => {
+        const evidence = requireRecord(entry, evidenceField);
+        return {
+          id: requireString(evidence.id, `${evidenceField}.id`),
+          kind: requireEnum(evidence.kind, `${evidenceField}.kind`, [
+            "sources",
+            "assumptions",
+            "context_manifest",
+            "changed_paths",
+            "check_result",
+            "artifact",
+            "approval",
+            "external_link",
+            "commit",
+            "final_output",
+            "weak_links",
+            "quality_report",
+            "rollback",
+          ]),
+          description: requireString(evidence.description, `${evidenceField}.description`),
+        };
+      },
+    ),
+    stop_rules: requireArray(result.stop_rules, `${field}.stop_rules`, (entry, stopField) => {
+      const stop = requireRecord(entry, stopField);
+      return {
+        id: requireString(stop.id, `${stopField}.id`),
+        severity: requireEnum(stop.severity, `${stopField}.severity`, [
+          "stop",
+          "approval_required",
+          "warn",
+        ]),
+        reason: requireString(stop.reason, `${stopField}.reason`),
+      };
+    }),
+    weak_links: requireStringArray(result.weak_links, `${field}.weak_links`),
+  };
+}

--- a/packages/agentplane/src/runtime/sgr/contract-shared-validation.ts
+++ b/packages/agentplane/src/runtime/sgr/contract-shared-validation.ts
@@ -1,0 +1,37 @@
+import type { SgrReasoningStep, SgrSourceRef } from "./contract-types.js";
+import {
+  invalid,
+  optionalNumber,
+  optionalSourceRefs,
+  optionalString,
+  requireRecord,
+  requireString,
+} from "./contract-validators.js";
+
+export function validateSourceRef(raw: unknown, field = "source ref"): SgrSourceRef {
+  const source = requireRecord(raw, field);
+  const sha256 = optionalString(source.sha256, `${field}.sha256`);
+  if (sha256 !== undefined && !/^sha256:[a-fA-F0-9]{64}$/.test(sha256)) {
+    throw invalid(`${field}.sha256`, "sha256:<64 hex chars>");
+  }
+  return {
+    path: requireString(source.path, `${field}.path`),
+    sha256: sha256 as SgrSourceRef["sha256"],
+    line: optionalNumber(source.line, `${field}.line`),
+    lines: optionalString(source.lines, `${field}.lines`),
+    section: optionalString(source.section, `${field}.section`),
+  };
+}
+
+export function validateReasoningStep(raw: unknown, field = "reasoning step"): SgrReasoningStep {
+  const step = requireRecord(raw, field);
+  return {
+    label: requireString(step.label, `${field}.label`),
+    summary: requireString(step.summary, `${field}.summary`),
+    evidence_refs: optionalSourceRefs(
+      step.evidence_refs,
+      `${field}.evidence_refs`,
+      validateSourceRef,
+    ),
+  };
+}

--- a/packages/agentplane/src/runtime/sgr/contracts.ts
+++ b/packages/agentplane/src/runtime/sgr/contracts.ts
@@ -1,5 +1,4 @@
 import type {
-  BlueprintRouteDecisionSgrResult,
   ContextExtractionCoverage,
   ContextExtractionConfidenceVector,
   ContextExtractionEntityResolutionRow,
@@ -8,9 +7,6 @@ import type {
   ContextExtractionPageCreationRow,
   ContextExtractionSgrResult,
   ContextExtractionTopologyDecisionRow,
-  EvaluatorSgrResult,
-  SgrReasoningStep,
-  SgrSourceRef,
 } from "./contract-types.js";
 import {
   CONTEXT_EXTRACTION_SGR_CONTRACT_SCHEMA_VERSION,
@@ -18,17 +14,13 @@ import {
 } from "./contract-types.js";
 import {
   invalid,
-  optionalNumber,
-  optionalSourceRefs,
   optionalString,
   optionalStringArray,
   requireArray,
   requireEnum,
   requireNonEmptyArray,
   requireRecord,
-  requireSchemaVersion,
   requireString,
-  requireStringArray,
   validateConfidence,
 } from "./contract-validators.js";
 import {
@@ -36,6 +28,11 @@ import {
   validatePageCreationPayload,
   validateTopologyDecisionPayload,
 } from "./context-extraction-payloads.js";
+import { validateReasoningStep, validateSourceRef } from "./contract-shared-validation.js";
+export {
+  validateBlueprintRouteDecisionSgrResult,
+  validateEvaluatorSgrResult,
+} from "./contract-evaluator-routing.js";
 
 export {
   CONTEXT_EXTRACTION_SGR_CONTRACT_SCHEMA_VERSION,
@@ -61,34 +58,6 @@ export {
   type SgrReasoningStep,
   type SgrSourceRef,
 } from "./contract-types.js";
-
-function validateSourceRef(raw: unknown, field = "source ref"): SgrSourceRef {
-  const source = requireRecord(raw, field);
-  const sha256 = optionalString(source.sha256, `${field}.sha256`);
-  if (sha256 !== undefined && !/^sha256:[a-fA-F0-9]{64}$/.test(sha256)) {
-    throw invalid(`${field}.sha256`, "sha256:<64 hex chars>");
-  }
-  return {
-    path: requireString(source.path, `${field}.path`),
-    sha256: sha256 as SgrSourceRef["sha256"],
-    line: optionalNumber(source.line, `${field}.line`),
-    lines: optionalString(source.lines, `${field}.lines`),
-    section: optionalString(source.section, `${field}.section`),
-  };
-}
-
-function validateReasoningStep(raw: unknown, field = "reasoning step"): SgrReasoningStep {
-  const step = requireRecord(raw, field);
-  return {
-    label: requireString(step.label, `${field}.label`),
-    summary: requireString(step.summary, `${field}.summary`),
-    evidence_refs: optionalSourceRefs(
-      step.evidence_refs,
-      `${field}.evidence_refs`,
-      validateSourceRef,
-    ),
-  };
-}
 
 function validateGraphEntity(raw: unknown, field: string): ContextExtractionGraphEntity {
   const entity = requireRecord(raw, field);
@@ -334,134 +303,5 @@ export function validateContextExtractionSgrResult(
         };
       },
     ),
-  };
-}
-
-export function validateEvaluatorSgrResult(
-  raw: unknown,
-  field = "evaluator SGR result",
-): EvaluatorSgrResult {
-  const result = requireRecord(raw, field);
-  requireSchemaVersion(result, field);
-  if (result.kind !== "evaluator_result") throw invalid(`${field}.kind`, '"evaluator_result"');
-  const verdict = requireEnum(result.verdict, `${field}.verdict`, ["pass", "rework", "blocked"]);
-  const findings = requireArray(result.findings, `${field}.findings`, (entry, findingField) => {
-    const finding = requireRecord(entry, findingField);
-    return {
-      id: requireString(finding.id, `${findingField}.id`),
-      severity: requireEnum(finding.severity, `${findingField}.severity`, [
-        "low",
-        "medium",
-        "high",
-      ]),
-      summary: requireString(finding.summary, `${findingField}.summary`),
-      broken_invariant: requireString(finding.broken_invariant, `${findingField}.broken_invariant`),
-      evidence_refs: requireNonEmptyArray(
-        finding.evidence_refs,
-        `${findingField}.evidence_refs`,
-        validateSourceRef,
-      ),
-    };
-  });
-  if ((verdict === "rework" || verdict === "blocked") && findings.length === 0) {
-    throw invalid(`${field}.findings`, "non-empty array for rework or blocked verdict");
-  }
-  return {
-    schema_version: SGR_CONTRACT_SCHEMA_VERSION,
-    kind: "evaluator_result",
-    evaluator_id: requireString(result.evaluator_id, `${field}.evaluator_id`),
-    verdict,
-    findings,
-    missing_tests: requireStringArray(result.missing_tests, `${field}.missing_tests`),
-    hidden_assumptions: requireStringArray(
-      result.hidden_assumptions,
-      `${field}.hidden_assumptions`,
-    ),
-    recovery_context: optionalString(result.recovery_context, `${field}.recovery_context`),
-  };
-}
-
-export function validateBlueprintRouteDecisionSgrResult(
-  raw: unknown,
-  field = "blueprint route decision SGR result",
-): BlueprintRouteDecisionSgrResult {
-  const result = requireRecord(raw, field);
-  requireSchemaVersion(result, field);
-  if (result.kind !== "blueprint_route_decision") {
-    throw invalid(`${field}.kind`, '"blueprint_route_decision"');
-  }
-  const selected = requireRecord(result.selected_route, `${field}.selected_route`);
-  return {
-    schema_version: SGR_CONTRACT_SCHEMA_VERSION,
-    kind: "blueprint_route_decision",
-    facts: requireNonEmptyArray(result.facts, `${field}.facts`, validateReasoningStep),
-    inferences: requireNonEmptyArray(
-      result.inferences,
-      `${field}.inferences`,
-      validateReasoningStep,
-    ),
-    rejected_routes: requireArray(
-      result.rejected_routes,
-      `${field}.rejected_routes`,
-      (entry, routeField) => {
-        const route = requireRecord(entry, routeField);
-        return {
-          blueprint_id: requireString(route.blueprint_id, `${routeField}.blueprint_id`),
-          reason: requireString(route.reason, `${routeField}.reason`),
-        };
-      },
-    ),
-    selected_route: {
-      blueprint_id: requireString(selected.blueprint_id, `${field}.selected_route.blueprint_id`),
-      task_kind: requireEnum(selected.task_kind, `${field}.selected_route.task_kind`, [
-        "analysis",
-        "content",
-        "docs",
-        "code",
-        "release",
-        "ops",
-        "context",
-      ]),
-      rationale: requireString(selected.rationale, `${field}.selected_route.rationale`),
-    },
-    required_evidence: requireArray(
-      result.required_evidence,
-      `${field}.required_evidence`,
-      (entry, evidenceField) => {
-        const evidence = requireRecord(entry, evidenceField);
-        return {
-          id: requireString(evidence.id, `${evidenceField}.id`),
-          kind: requireEnum(evidence.kind, `${evidenceField}.kind`, [
-            "sources",
-            "assumptions",
-            "context_manifest",
-            "changed_paths",
-            "check_result",
-            "artifact",
-            "approval",
-            "external_link",
-            "commit",
-            "final_output",
-            "weak_links",
-            "quality_report",
-            "rollback",
-          ]),
-          description: requireString(evidence.description, `${evidenceField}.description`),
-        };
-      },
-    ),
-    stop_rules: requireArray(result.stop_rules, `${field}.stop_rules`, (entry, stopField) => {
-      const stop = requireRecord(entry, stopField);
-      return {
-        id: requireString(stop.id, `${stopField}.id`),
-        severity: requireEnum(stop.severity, `${stopField}.severity`, [
-          "stop",
-          "approval_required",
-          "warn",
-        ]),
-        reason: requireString(stop.reason, `${stopField}.reason`),
-      };
-    }),
-    weak_links: requireStringArray(result.weak_links, `${field}.weak_links`),
   };
 }


### PR DESCRIPTION
Task: `202607092208-KSXT6H`
Title: Split runtime and backend hotspots for v0.6.22
Canonical task record: `.agentplane/tasks/202607092208-KSXT6H/README.md`

## Summary

Split runtime and backend hotspots for v0.6.22

Decompose Hermes command/runtime, result manifest, insights report, SGR contracts, and cloud backend modules into cohesive helpers while retaining public APIs, schemas, and backend behavior.

## Scope

- In scope: Decompose Hermes command/runtime, result manifest, insights report, SGR contracts, and cloud backend modules into cohesive helpers while retaining public APIs, schemas, and backend behavior.
- Out of scope: unrelated refactors not required for "Split runtime and backend hotspots for v0.6.22".

## Verification

- State: ok
- Note:

```text
Public APIs and serialized contracts are preserved; all seven scoped hotspots are decomposed.
Focused 33/246 and full 364/2157 tests, build, typecheck, architecture, hotspot, contract, Knip, and
coverage checks passed.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-07-11T11:31:25.645Z
- Branch: task/202607092208-KSXT6H/split-runtime-and-backend-hotspots-for-v0-6-22
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../backends/task-backend/cloud-backend-utils.ts   |  37 +--
 .../src/backends/task-backend/cloud-backend.ts     |  18 +-
 .../task-backend/cloud-config-overrides.ts         |  34 +++
 .../src/commands/hermes/hermes-environment.ts      |  64 ++++++
 .../src/commands/hermes/hermes-runtime.ts          | 164 +-------------
 .../agentplane/src/commands/hermes/hermes-specs.ts | 230 +++++++++++++++++++
 .../agentplane/src/commands/hermes/hermes-state.ts |  93 ++++++++
 .../src/commands/hermes/hermes.command.ts          | 252 ++-------------------
 .../commands/insights/insights-report-render.ts    |  69 ++++++
 .../src/commands/insights/insights-report.ts       |  89 +-------
 .../src/commands/insights/insights-task-loader.ts  |  19 ++
 .../src/runner/result-manifest-artifacts.ts        | 149 ++++++++++++
 packages/agentplane/src/runner/result-manifest.ts  | 165 ++------------
 .../src/runtime/sgr/contract-evaluator-routing.ts  | 143 ++++++++++++
 .../src/runtime/sgr/contract-shared-validation.ts  |  37 +++
 packages/agentplane/src/runtime/sgr/contracts.ts   | 170 +-------------
 16 files changed, 901 insertions(+), 832 deletions(-)
```

</details>
