### PR TITLE
🚧 5DXKKR task: Fix release evidence task attribution [202607111438-5DXKKR]

### DIFF
--- a/.agentplane/tasks/202607030734-6T937A/README.md
+++ b/.agentplane/tasks/202607030734-6T937A/README.md
@@ -21,9 +21,10 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-07-11T14:30:35.714Z"
-  updated_by: "DEUS"
-  note: "Hosted publish confirmed for v0.6.22."
+  updated_at: "2026-07-11T14:17:43.940Z"
+  updated_by: "CURATOR"
+  note: "Included implementation was merged by PR #4543; rebased patch-id matches d53b6cf, current help contract is 14/14 passing, and agentplane typecheck passes."
+  attempts: 0
 quality_review:
   state: "pass"
   updated_at: "2026-07-11T14:17:46.445Z"
@@ -78,8 +79,8 @@ events:
     to: "DONE"
     note: "Verified: PR #4580 merged on GitHub main; hosted closure automation recorded canonical task artifacts."
 doc_version: 3
-doc_updated_at: "2026-07-11T14:30:35.714Z"
-doc_updated_by: "DEUS"
+doc_updated_at: "2026-07-11T14:21:58.873Z"
+doc_updated_by: "INTEGRATOR"
 description: "Fix smoke finding where context migrate and context extraction apply execute but are not discoverable through agentplane help, so users cannot inspect fresh context v2 command syntax reliably."
 sections:
   Summary: |-
@@ -98,19 +99,66 @@ sections:
     3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
-    - State: ok
-    - Note: Hosted publish confirmed for v0.6.22.
-    - Details:
-      - release_sha: bd61ef4982f29cd0909587d0034cf6e35a62a03d
-      - version: 0.6.22
-      - tag: v0.6.22
-      - @agentplaneorg/core: published_in_run
-      - @agentplaneorg/recipes: published_in_run
-      - agentplane: published_in_run
-      - npm_smoke: pass
-      - github_release: created
-      - release_url: https://github.com/basilisk-labs/agentplane/releases/tag/v0.6.22
-      - publish_run: https://github.com/basilisk-labs/agentplane/actions/runs/29156079982
+    ### 2026-07-03T07:38:56.455Z — VERIFY — ok
+
+    By: CURATOR
+
+    Note: Command: bunx vitest run packages/agentplane/src/cli/run-cli.core.help-contract.test.ts; Result: pass; Evidence: explicit help for context migrate and context extraction apply works without --all. Command: repo-local CLI help smoke; Result: pass; Evidence: compact help rendered for both advanced context commands. Scope: nested context command help discoverability.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-03T07:34:58.046Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607030734-7S66KX-context-graph-align-sgr-vocabulary-and-diagnosti/.agentplane/tasks/202607030734-6T937A/blueprint/resolved-snapshot.json
+    - old_digest: b65e4399cbf3ca9ce1d4997993a0684edaf01d841d77bd7e4d6269fe798ea67a
+    - current_digest: b65e4399cbf3ca9ce1d4997993a0684edaf01d841d77bd7e4d6269fe798ea67a
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607030734-6T937A
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane work start 202607030734-6T937A --agent CURATOR --slug context-help-expose-nested-v2-commands --worktree
+    - diagnostic_command: agentplane work resume 202607030734-6T937A
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: true
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: worktree_projection_drift
+
+    ### 2026-07-11T14:17:43.940Z — VERIFY — ok
+
+    By: CURATOR
+
+    Note: Included implementation was merged by PR #4543; rebased patch-id matches d53b6cf, current help contract is 14/14 passing, and agentplane typecheck passes.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-03T07:38:56.559Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607030734-6T937A-post-merge-close-included-context-help/.agentplane/tasks/202607030734-6T937A/blueprint/resolved-snapshot.json
+    - old_digest: b65e4399cbf3ca9ce1d4997993a0684edaf01d841d77bd7e4d6269fe798ea67a
+    - current_digest: b65e4399cbf3ca9ce1d4997993a0684edaf01d841d77bd7e4d6269fe798ea67a
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607030734-6T937A
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane work start 202607030734-6T937A --agent CURATOR --slug context-help-expose-nested-v2-commands --worktree
+    - diagnostic_command: agentplane work resume 202607030734-6T937A
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: true
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: worktree_projection_drift
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -144,19 +192,66 @@ PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLA
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
-- State: ok
-- Note: Hosted publish confirmed for v0.6.22.
-- Details:
-  - release_sha: bd61ef4982f29cd0909587d0034cf6e35a62a03d
-  - version: 0.6.22
-  - tag: v0.6.22
-  - @agentplaneorg/core: published_in_run
-  - @agentplaneorg/recipes: published_in_run
-  - agentplane: published_in_run
-  - npm_smoke: pass
-  - github_release: created
-  - release_url: https://github.com/basilisk-labs/agentplane/releases/tag/v0.6.22
-  - publish_run: https://github.com/basilisk-labs/agentplane/actions/runs/29156079982
+### 2026-07-03T07:38:56.455Z — VERIFY — ok
+
+By: CURATOR
+
+Note: Command: bunx vitest run packages/agentplane/src/cli/run-cli.core.help-contract.test.ts; Result: pass; Evidence: explicit help for context migrate and context extraction apply works without --all. Command: repo-local CLI help smoke; Result: pass; Evidence: compact help rendered for both advanced context commands. Scope: nested context command help discoverability.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-03T07:34:58.046Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607030734-7S66KX-context-graph-align-sgr-vocabulary-and-diagnosti/.agentplane/tasks/202607030734-6T937A/blueprint/resolved-snapshot.json
+- old_digest: b65e4399cbf3ca9ce1d4997993a0684edaf01d841d77bd7e4d6269fe798ea67a
+- current_digest: b65e4399cbf3ca9ce1d4997993a0684edaf01d841d77bd7e4d6269fe798ea67a
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607030734-6T937A
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane work start 202607030734-6T937A --agent CURATOR --slug context-help-expose-nested-v2-commands --worktree
+- diagnostic_command: agentplane work resume 202607030734-6T937A
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: true
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: worktree_projection_drift
+
+### 2026-07-11T14:17:43.940Z — VERIFY — ok
+
+By: CURATOR
+
+Note: Included implementation was merged by PR #4543; rebased patch-id matches d53b6cf, current help contract is 14/14 passing, and agentplane typecheck passes.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-03T07:38:56.559Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607030734-6T937A-post-merge-close-included-context-help/.agentplane/tasks/202607030734-6T937A/blueprint/resolved-snapshot.json
+- old_digest: b65e4399cbf3ca9ce1d4997993a0684edaf01d841d77bd7e4d6269fe798ea67a
+- current_digest: b65e4399cbf3ca9ce1d4997993a0684edaf01d841d77bd7e4d6269fe798ea67a
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607030734-6T937A
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane work start 202607030734-6T937A --agent CURATOR --slug context-help-expose-nested-v2-commands --worktree
+- diagnostic_command: agentplane work resume 202607030734-6T937A
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: true
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: worktree_projection_drift
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202607092209-F33MNN/README.md
+++ b/.agentplane/tasks/202607092209-F33MNN/README.md
@@ -51,10 +51,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-07-11T14:04:06.411Z"
-  updated_by: "INTEGRATOR"
-  note: "Regenerated v0.6.22 README header artifacts; docs:readme-header:check, format:check, release:parity, and ci:contract pass."
-  attempts: 0
+  updated_at: "2026-07-11T14:30:35.714Z"
+  updated_by: "DEUS"
+  note: "Hosted publish confirmed for v0.6.22."
 quality_review:
   state: "pass"
   updated_at: "2026-07-11T14:04:10.012Z"
@@ -131,8 +130,8 @@ events:
     state: "ok"
     note: "Regenerated v0.6.22 README header artifacts; docs:readme-header:check, format:check, release:parity, and ci:contract pass."
 doc_version: 3
-doc_updated_at: "2026-07-11T14:04:08.205Z"
-doc_updated_by: "INTEGRATOR"
+doc_updated_at: "2026-07-11T14:30:35.714Z"
+doc_updated_by: "DEUS"
 description: "Integrate the approved refactor leaves, resolve only release-blocking drift, generate the patch release plan and notes, publish v0.6.22 through the protected main workflow, and verify package/tag parity."
 sections:
   Summary: |-
@@ -241,6 +240,23 @@ sections:
     - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
     - risks: git_hook_side_effect
 
+    <!-- BEGIN HOSTED PUBLISH EVIDENCE -->
+    ### Hosted publish
+
+    - State: ok
+    - Note: Hosted publish confirmed for v0.6.22.
+    - Details:
+      - release_sha: bd61ef4982f29cd0909587d0034cf6e35a62a03d
+      - version: 0.6.22
+      - tag: v0.6.22
+      - @agentplaneorg/core: published_in_run
+      - @agentplaneorg/recipes: published_in_run
+      - agentplane: published_in_run
+      - npm_smoke: pass
+      - github_release: created
+      - release_url: https://github.com/basilisk-labs/agentplane/releases/tag/v0.6.22
+      - publish_run: https://github.com/basilisk-labs/agentplane/actions/runs/29156079982
+    <!-- END HOSTED PUBLISH EVIDENCE -->
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -364,6 +380,23 @@ DecisionContextRef:
 - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
 - risks: git_hook_side_effect
 
+<!-- BEGIN HOSTED PUBLISH EVIDENCE -->
+### Hosted publish
+
+- State: ok
+- Note: Hosted publish confirmed for v0.6.22.
+- Details:
+  - release_sha: bd61ef4982f29cd0909587d0034cf6e35a62a03d
+  - version: 0.6.22
+  - tag: v0.6.22
+  - @agentplaneorg/core: published_in_run
+  - @agentplaneorg/recipes: published_in_run
+  - agentplane: published_in_run
+  - npm_smoke: pass
+  - github_release: created
+  - release_url: https://github.com/basilisk-labs/agentplane/releases/tag/v0.6.22
+  - publish_run: https://github.com/basilisk-labs/agentplane/actions/runs/29156079982
+<!-- END HOSTED PUBLISH EVIDENCE -->
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202607111438-5DXKKR/README.md
+++ b/.agentplane/tasks/202607111438-5DXKKR/README.md
@@ -1,0 +1,101 @@
+---
+id: "202607111438-5DXKKR"
+title: "Fix release evidence task attribution"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "release"
+  - "workflow"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-07-11T14:38:38.675Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: fix deterministic release-task evidence attribution, add regression coverage, and correct v0.6.22 task evidence."
+events:
+  -
+    type: "status"
+    at: "2026-07-11T14:38:57.305Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: fix deterministic release-task evidence attribution, add regression coverage, and correct v0.6.22 task evidence."
+doc_version: 3
+doc_updated_at: "2026-07-11T14:38:57.305Z"
+doc_updated_by: "CODER"
+description: "Resolve hosted publish evidence to the matching release task instead of whichever task README happens to be changed by the exact publish SHA; add regression coverage and correct v0.6.22 evidence attribution."
+sections:
+  Summary: |-
+    Fix release evidence task attribution
+
+    Resolve hosted publish evidence to the matching release task instead of whichever task README happens to be changed by the exact publish SHA; add regression coverage and correct v0.6.22 evidence attribution.
+  Scope: |-
+    - In scope: Resolve hosted publish evidence to the matching release task instead of whichever task README happens to be changed by the exact publish SHA; add regression coverage and correct v0.6.22 evidence attribution.
+    - Out of scope: unrelated refactors not required for "Fix release evidence task attribution".
+  Plan: "1. Reproduce evidence misattribution when the publish SHA changes an unrelated task after the release task merge. 2. Resolve a unique DONE release task matching publish-result version/tag from the task registry before falling back to commit-diff inference. 3. Add regression coverage for unrelated post-release task commits and ambiguity. 4. Correct v0.6.22 hosted publish evidence so it belongs to F33MNN and no longer claims 6T937A as the release task. 5. Run focused release evidence tests, publish workflow contract tests, typecheck, and CI contract; merge through protected main."
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+    3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Fix release evidence task attribution
+
+Resolve hosted publish evidence to the matching release task instead of whichever task README happens to be changed by the exact publish SHA; add regression coverage and correct v0.6.22 evidence attribution.
+
+## Scope
+
+- In scope: Resolve hosted publish evidence to the matching release task instead of whichever task README happens to be changed by the exact publish SHA; add regression coverage and correct v0.6.22 evidence attribution.
+- Out of scope: unrelated refactors not required for "Fix release evidence task attribution".
+
+## Plan
+
+1. Reproduce evidence misattribution when the publish SHA changes an unrelated task after the release task merge. 2. Resolve a unique DONE release task matching publish-result version/tag from the task registry before falling back to commit-diff inference. 3. Add regression coverage for unrelated post-release task commits and ambiguity. 4. Correct v0.6.22 hosted publish evidence so it belongs to F33MNN and no longer claims 6T937A as the release task. 5. Run focused release evidence tests, publish workflow contract tests, typecheck, and CI contract; merge through protected main.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+2. Run the most relevant validation step for the `code` task. Expected: it succeeds without unexpected regressions in touched scope.
+3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202607111438-5DXKKR/README.md
+++ b/.agentplane/tasks/202607111438-5DXKKR/README.md
@@ -4,7 +4,7 @@ title: "Fix release evidence task attribution"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 4
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -19,11 +19,27 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-07-11T14:48:41.280Z"
+  updated_by: "CODER"
+  note: "Version-matched release-task resolver, ambiguity guard, evidence preservation/idempotence, and corrected v0.6.22 attribution verified: 17/17 focused tests, agentplane typecheck, format:check, and full ci:contract pass."
   attempts: 0
+quality_review:
+  state: "pass"
+  updated_at: "2026-07-11T14:48:43.150Z"
+  updated_by: "EVALUATOR"
+  note: "Hosted publish evidence now resolves to the unique DONE release task matching the published version, preserves prior verification history, and corrects v0.6.22 attribution."
+  evaluated_sha: "0e557961a2fa30c79ef75642ebdbfdd4c32f93e2"
+  blueprint_digest: "f0622fc8e731607c3ab0c8967e2e4fce27927ad547feba62bea4439e4fb952f6"
+  evidence_refs:
+    - ".agentplane/tasks/202607111438-5DXKKR/README.md"
+    - ".agentplane/tasks/202607111438-5DXKKR/quality/20260711-144843150-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607111438-5DXKKR/quality/20260711-144843150-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607111438-5DXKKR/quality/20260711-144843150-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607111438-5DXKKR/blueprint/resolved-snapshot.json"
+    - "bunx vitest run packages/agentplane/src/commands/release/release-task-evidence-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts; bun run --filter=agentplane typecheck; bun run format:check; bun run ci:contract"
+  findings:
+    - "Regression covers unrelated task commits and ambiguous release matches; repeated apply is idempotent; 6T937A evidence restored and F33MNN holds v0.6.22 publish proof."
 commit: null
 comments:
   -
@@ -37,8 +53,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: fix deterministic release-task evidence attribution, add regression coverage, and correct v0.6.22 task evidence."
+  -
+    type: "verify"
+    at: "2026-07-11T14:48:41.280Z"
+    author: "CODER"
+    state: "ok"
+    note: "Version-matched release-task resolver, ambiguity guard, evidence preservation/idempotence, and corrected v0.6.22 attribution verified: 17/17 focused tests, agentplane typecheck, format:check, and full ci:contract pass."
 doc_version: 3
-doc_updated_at: "2026-07-11T14:38:57.305Z"
+doc_updated_at: "2026-07-11T14:48:41.476Z"
 doc_updated_by: "CODER"
 description: "Resolve hosted publish evidence to the matching release task instead of whichever task README happens to be changed by the exact publish SHA; add regression coverage and correct v0.6.22 evidence attribution."
 sections:
@@ -58,6 +80,36 @@ sections:
     3. Compare the final result against the task summary and scope. Expected: any remaining follow-up is explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-07-11T14:48:41.280Z — VERIFY — ok
+
+    By: CODER
+
+    Note: Version-matched release-task resolver, ambiguity guard, evidence preservation/idempotence, and corrected v0.6.22 attribution verified: 17/17 focused tests, agentplane typecheck, format:check, and full ci:contract pass.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-11T14:38:57.305Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607111438-5DXKKR-post-release-fix-evidence-attribution/.agentplane/tasks/202607111438-5DXKKR/blueprint/resolved-snapshot.json
+    - old_digest: f0622fc8e731607c3ab0c8967e2e4fce27927ad547feba62bea4439e4fb952f6
+    - current_digest: f0622fc8e731607c3ab0c8967e2e4fce27927ad547feba62bea4439e4fb952f6
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607111438-5DXKKR
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane pr update 202607111438-5DXKKR
+    - diagnostic_command: agentplane pr check 202607111438-5DXKKR
+    - source_of_truth: route=task_next_action diagnostic=pr_check remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
+    - risks: pr_artifact_freshness_loop, git_hook_side_effect
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -91,6 +143,36 @@ PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLA
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-07-11T14:48:41.280Z — VERIFY — ok
+
+By: CODER
+
+Note: Version-matched release-task resolver, ambiguity guard, evidence preservation/idempotence, and corrected v0.6.22 attribution verified: 17/17 focused tests, agentplane typecheck, format:check, and full ci:contract pass.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-11T14:38:57.305Z, excerpt_hash=sha256:4067e6c0d2671944bbb825f93b0ba7363aab826f8b2f3d8fbcbd2a2e4f1204c6
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607111438-5DXKKR-post-release-fix-evidence-attribution/.agentplane/tasks/202607111438-5DXKKR/blueprint/resolved-snapshot.json
+- old_digest: f0622fc8e731607c3ab0c8967e2e4fce27927ad547feba62bea4439e4fb952f6
+- current_digest: f0622fc8e731607c3ab0c8967e2e4fce27927ad547feba62bea4439e4fb952f6
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607111438-5DXKKR
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane pr update 202607111438-5DXKKR
+- diagnostic_command: agentplane pr check 202607111438-5DXKKR
+- source_of_truth: route=task_next_action diagnostic=pr_check remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: if PR check passes but next-action still requests PR artifact update, verify live PR state before rerunning mutation
+- risks: pr_artifact_freshness_loop, git_hook_side_effect
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202607111438-5DXKKR/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202607111438-5DXKKR/blueprint/resolved-snapshot.json
@@ -1,0 +1,455 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607111438-5DXKKR",
+    "title": "Fix release evidence task attribution",
+    "description": "Resolve hosted publish evidence to the matching release task instead of whichever task README happens to be changed by the exact publish SHA; add regression coverage and correct v0.6.22 evidence attribution.",
+    "tags": [
+      "code",
+      "release",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "release",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "release.strict",
+    "version": 1,
+    "title": "Strict release",
+    "taskKinds": [
+      "release"
+    ],
+    "workflowModes": [
+      "direct",
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "release.strict",
+    "blueprintVersion": 1,
+    "title": "Strict release",
+    "taskId": "202607111438-5DXKKR",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "release"
+    },
+    "whySelected": [
+      "task kind resolved to release",
+      "workflow mode: branch_pr",
+      "mutation scope: release"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.release.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "deterministic_check",
+        "kind": "deterministic_check",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "release.approval",
+        "kind": "approval",
+        "producedBy": "approval_gate",
+        "required": true,
+        "description": "Release approval."
+      },
+      {
+        "id": "release.plan",
+        "kind": "artifact",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Release plan or candidate artifact."
+      },
+      {
+        "id": "release.check",
+        "kind": "check_result",
+        "producedBy": "deterministic_check",
+        "required": true,
+        "description": "Release gates."
+      },
+      {
+        "id": "release.publish",
+        "kind": "external_link",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Publish evidence."
+      },
+      {
+        "id": "release.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Release commit."
+      },
+      {
+        "id": "release.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.release.md"
+    ],
+    "allowedCommands": [
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "publish commands after approval",
+      "release gates"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Release work needs strict release policy, approval evidence, and rollback context."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.release.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "deterministic_check",
+      "kind": "deterministic_check",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "release.approval",
+      "kind": "approval",
+      "producedBy": "approval_gate",
+      "required": true,
+      "description": "Release approval."
+    },
+    {
+      "id": "release.plan",
+      "kind": "artifact",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Release plan or candidate artifact."
+    },
+    {
+      "id": "release.check",
+      "kind": "check_result",
+      "producedBy": "deterministic_check",
+      "required": true,
+      "description": "Release gates."
+    },
+    {
+      "id": "release.publish",
+      "kind": "external_link",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Publish evidence."
+    },
+    {
+      "id": "release.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Release commit."
+    },
+    {
+      "id": "release.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.release.md"
+  ],
+  "allowedCommands": [
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "publish commands after approval",
+    "release gates"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Release work needs strict release policy, approval evidence, and rollback context."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to release",
+    "workflow mode: branch_pr",
+    "mutation scope: release"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "f0622fc8e731607c3ab0c8967e2e4fce27927ad547feba62bea4439e4fb952f6"
+  }
+}

--- a/.agentplane/tasks/202607111438-5DXKKR/pr/diffstat.txt
+++ b/.agentplane/tasks/202607111438-5DXKKR/pr/diffstat.txt
@@ -1,0 +1,5 @@
+ .agentplane/tasks/202607030734-6T937A/README.md    | 159 ++++++++++++++++-----
+ .agentplane/tasks/202607092209-F33MNN/README.md    |  47 +++++-
+ .../release/release-task-evidence-script.test.ts   | 124 +++++++++++++++-
+ scripts/release/release-task-evidence.mjs          | 116 ++++++++++++++-
+ 4 files changed, 399 insertions(+), 47 deletions(-)

--- a/.agentplane/tasks/202607111438-5DXKKR/pr/github-body.md
+++ b/.agentplane/tasks/202607111438-5DXKKR/pr/github-body.md
@@ -15,19 +15,29 @@ Resolve hosted publish evidence to the matching release task instead of whicheve
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Version-matched release-task resolver, ambiguity guard, evidence preservation/idempotence, and
+corrected v0.6.22 attribution verified: 17/17 focused tests, agentplane typecheck, format:check, and
+full ci:contract pass.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-11T14:38:57.348Z
+- Updated: 2026-07-11T14:49:13.478Z
 - Branch: task/202607111438-5DXKKR/post-release-fix-evidence-attribution
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .agentplane/tasks/202607030734-6T937A/README.md    | 159 ++++++++++++++++-----
+ .agentplane/tasks/202607092209-F33MNN/README.md    |  47 +++++-
+ .../release/release-task-evidence-script.test.ts   | 124 +++++++++++++++-
+ scripts/release/release-task-evidence.mjs          | 116 ++++++++++++++-
+ 4 files changed, 399 insertions(+), 47 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607111438-5DXKKR/pr/github-body.md
+++ b/.agentplane/tasks/202607111438-5DXKKR/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202607111438-5DXKKR`
+Title: Fix release evidence task attribution
+Canonical task record: `.agentplane/tasks/202607111438-5DXKKR/README.md`
+
+## Summary
+
+Fix release evidence task attribution
+
+Resolve hosted publish evidence to the matching release task instead of whichever task README happens to be changed by the exact publish SHA; add regression coverage and correct v0.6.22 evidence attribution.
+
+## Scope
+
+- In scope: Resolve hosted publish evidence to the matching release task instead of whichever task README happens to be changed by the exact publish SHA; add regression coverage and correct v0.6.22 evidence attribution.
+- Out of scope: unrelated refactors not required for "Fix release evidence task attribution".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-11T14:38:57.348Z
+- Branch: task/202607111438-5DXKKR/post-release-fix-evidence-attribution
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202607111438-5DXKKR/pr/github-title.txt
+++ b/.agentplane/tasks/202607111438-5DXKKR/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 5DXKKR task: Fix release evidence task attribution [202607111438-5DXKKR]

--- a/.agentplane/tasks/202607111438-5DXKKR/pr/meta.json
+++ b/.agentplane/tasks/202607111438-5DXKKR/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202607111438-5DXKKR/post-release-fix-evidence-attribution",
+  "created_at": "2026-07-11T14:38:57.348Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202607111438-5DXKKR",
+  "updated_at": "2026-07-11T14:38:57.348Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202607111438-5DXKKR/pr/meta.json
+++ b/.agentplane/tasks/202607111438-5DXKKR/pr/meta.json
@@ -2,12 +2,16 @@
   "base": "main",
   "branch": "task/202607111438-5DXKKR/post-release-fix-evidence-attribution",
   "created_at": "2026-07-11T14:38:57.348Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:bf30a03c36ed784c29e85db5466fb230feb8f7701abbcaf86f1febbcbbf3dd9b",
+  "last_verified_at": "2026-07-11T14:48:41.280Z",
+  "last_verified_diffstat_sha256": "sha256:bf30a03c36ed784c29e85db5466fb230feb8f7701abbcaf86f1febbcbbf3dd9b",
+  "pr_number": 4583,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4583",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202607111438-5DXKKR",
-  "updated_at": "2026-07-11T14:38:57.348Z",
+  "updated_at": "2026-07-11T14:49:13.478Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202607111438-5DXKKR/pr/review.md
+++ b/.agentplane/tasks/202607111438-5DXKKR/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-07-11T14:38:57.348Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Version-matched release-task resolver, ambiguity guard, evidence preservation/idempotence, and corrected v0.6.22 attribution verified: 17/17 focused tests, agentplane typecheck, format:check, and full ci:contract pass.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,12 +24,16 @@ Created: 2026-07-11T14:38:57.348Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-11T14:38:57.348Z
+- Updated: 2026-07-11T14:49:13.478Z
 - Branch: task/202607111438-5DXKKR/post-release-fix-evidence-attribution
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .agentplane/tasks/202607030734-6T937A/README.md    | 159 ++++++++++++++++-----
+ .agentplane/tasks/202607092209-F33MNN/README.md    |  47 +++++-
+ .../release/release-task-evidence-script.test.ts   | 124 +++++++++++++++-
+ scripts/release/release-task-evidence.mjs          | 116 ++++++++++++++-
+ 4 files changed, 399 insertions(+), 47 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607111438-5DXKKR/pr/review.md
+++ b/.agentplane/tasks/202607111438-5DXKKR/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-07-11T14:38:57.348Z
+
+## Task
+
+- Task: `202607111438-5DXKKR`
+- Title: Fix release evidence task attribution
+- Status: DOING
+- Branch: `task/202607111438-5DXKKR/post-release-fix-evidence-attribution`
+- Canonical task record: `.agentplane/tasks/202607111438-5DXKKR/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-11T14:38:57.348Z
+- Branch: task/202607111438-5DXKKR/post-release-fix-evidence-attribution
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202607111438-5DXKKR/quality/20260711-144843150-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607111438-5DXKKR/quality/20260711-144843150-recovery-context/evaluator-opinion.md
@@ -1,0 +1,19 @@
+# EVALUATOR opinion: pass
+
+Hosted publish evidence now resolves to the unique DONE release task matching the published version, preserves prior verification history, and corrects v0.6.22 attribution.
+
+## Findings
+- Regression covers unrelated task commits and ambiguous release matches; repeated apply is idempotent; 6T937A evidence restored and F33MNN holds v0.6.22 publish proof.
+
+## Evidence
+- .agentplane/tasks/202607111438-5DXKKR/README.md
+- bunx vitest run packages/agentplane/src/commands/release/release-task-evidence-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts; bun run --filter=agentplane typecheck; bun run format:check; bun run ci:contract
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607111438-5DXKKR/quality/20260711-144843150-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607111438-5DXKKR/quality/20260711-144843150-recovery-context/evaluator-prompt.md
@@ -1,0 +1,74 @@
+# AgentPlane EVALUATOR quality review
+
+Use the evaluator module below as binding review procedure.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+Write the final structured review to the report path as JSON matching the requested report shape.
+
+- task_id: 202607111438-5DXKKR
+- task_readme: .agentplane/tasks/202607111438-5DXKKR/README.md
+- report_path: .agentplane/tasks/202607111438-5DXKKR/quality/20260711-144843150-recovery-context/quality-report.json
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id>` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607111438-5DXKKR/quality/20260711-144843150-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607111438-5DXKKR/quality/20260711-144843150-recovery-context/quality-report.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "task_id": "202607111438-5DXKKR",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-11T14:48:43.150Z",
+  "verdict": "pass",
+  "summary": "Hosted publish evidence now resolves to the unique DONE release task matching the published version, preserves prior verification history, and corrects v0.6.22 attribution.",
+  "evaluated_sha": "0e557961a2fa30c79ef75642ebdbfdd4c32f93e2",
+  "blueprint_digest": "f0622fc8e731607c3ab0c8967e2e4fce27927ad547feba62bea4439e4fb952f6",
+  "findings": [
+    "Regression covers unrelated task commits and ambiguous release matches; repeated apply is idempotent; 6T937A evidence restored and F33MNN holds v0.6.22 publish proof."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607111438-5DXKKR/README.md",
+    "bunx vitest run packages/agentplane/src/commands/release/release-task-evidence-script.test.ts packages/agentplane/src/commands/release/publish-workflow-contract.test.ts; bun run --filter=agentplane typecheck; bun run format:check; bun run ci:contract"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/commands/release/release-task-evidence-script.test.ts
+++ b/packages/agentplane/src/commands/release/release-task-evidence-script.test.ts
@@ -46,6 +46,10 @@ async function writeTaskReadme(
     verificationState?: "pending" | "ok" | "needs_rework";
     verificationText?: string;
     docUpdatedAt?: string;
+    title?: string;
+    tags?: string[];
+    taskKind?: string;
+    mutationScope?: string;
   } = {},
 ) {
   const readmePath = path.join(root, ".agentplane", "tasks", taskId, "README.md");
@@ -86,14 +90,16 @@ async function writeTaskReadme(
   const text = renderTaskReadme(
     {
       id: taskId,
-      title: "Release task",
+      title: opts.title ?? "Release task",
       status: "DONE",
       priority: "high",
       owner: "CODER",
       revision: 1,
       origin: { system: "manual" },
       depends_on: [],
-      tags: ["release"],
+      tags: opts.tags ?? ["release"],
+      ...(opts.taskKind ? { task_kind: opts.taskKind } : {}),
+      ...(opts.mutationScope ? { mutation_scope: opts.mutationScope } : {}),
       verify: [],
       plan_approval: {
         state: "approved",
@@ -320,6 +326,83 @@ describe("release-task-evidence script", () => {
     expect(payload.actionable).toBe(true);
     expect(payload.task_id).toBe(taskId);
   }, 60_000);
+
+  it("prefers the unique version-matched release task over an unrelated task changed by the publish SHA", async () => {
+    const root = await initRepo();
+    const releaseTaskId = "202604191130-RELEASE";
+    await writeTaskReadme(root, releaseTaskId, {
+      title: "Prepare and publish patch release v0.3.15",
+      tags: ["patch-0.3.15", "release"],
+      taskKind: "release",
+      mutationScope: "release",
+    });
+    await commitAll(root, "merge release task");
+    await writeTaskReadme(root, "202604191131-UNRELATED", {
+      title: "Close unrelated task",
+      tags: ["maintenance"],
+    });
+    const releaseSha = await commitAll(root, "close unrelated task before publish");
+    const publishResultPath = await writePublishResult(root, buildPublishResult(true));
+
+    const result = await execFileAsync(
+      "bun",
+      [
+        SCRIPT_PATH,
+        "prepare",
+        "--release-sha",
+        releaseSha,
+        "--publish-result",
+        publishResultPath,
+        "--repo",
+        "basilisk-labs/agentplane",
+      ],
+      { cwd: root, env: process.env },
+    );
+
+    const payload = JSON.parse(String(result.stdout ?? "")) as {
+      actionable: boolean;
+      task_id: string;
+    };
+    expect(payload.actionable).toBe(true);
+    expect(payload.task_id).toBe(releaseTaskId);
+  });
+
+  it("refuses ambiguous version-matched release tasks instead of attributing publish evidence", async () => {
+    const root = await initRepo();
+    for (const taskId of ["202604191130-RELEASE", "202604191131-RELEASE"]) {
+      await writeTaskReadme(root, taskId, {
+        title: "Prepare and publish patch release v0.3.15",
+        tags: ["patch-0.3.15", "release"],
+        taskKind: "release",
+      });
+    }
+    const releaseSha = await commitAll(root, "ambiguous release tasks");
+    const publishResultPath = await writePublishResult(root, buildPublishResult(true));
+
+    let stdout = "";
+    try {
+      await execFileAsync(
+        "bun",
+        [
+          SCRIPT_PATH,
+          "prepare",
+          "--release-sha",
+          releaseSha,
+          "--publish-result",
+          publishResultPath,
+          "--repo",
+          "basilisk-labs/agentplane",
+        ],
+        { cwd: root, env: process.env },
+      );
+    } catch (error) {
+      stdout = String((error as { stdout?: string }).stdout ?? "");
+    }
+
+    const payload = JSON.parse(stdout) as { actionable: boolean; reason: string };
+    expect(payload.actionable).toBe(false);
+    expect(payload.reason).toContain("multiple DONE release tasks match v0.3.15");
+  });
 
   it("marks prepare as non-actionable when publish-result is incomplete", async () => {
     const root = await initRepo();

--- a/packages/agentplane/src/commands/release/release-task-evidence-script.test.ts
+++ b/packages/agentplane/src/commands/release/release-task-evidence-script.test.ts
@@ -439,7 +439,16 @@ describe("release-task-evidence script", () => {
   it("writes hosted publish evidence into the release task README", async () => {
     const root = await initRepo();
     const taskId = "202604191130-JWBEB7";
-    const readmePath = await writeTaskReadme(root, taskId);
+    const readmePath = await writeTaskReadme(root, taskId, {
+      verificationText: [
+        "<!-- BEGIN VERIFICATION RESULTS -->",
+        "### Candidate validation",
+        "",
+        "- State: ok",
+        "- Note: Candidate checks passed.",
+        "<!-- END VERIFICATION RESULTS -->",
+      ].join("\n"),
+    });
     await commitAll(root, "seed release task");
     const publishResultPath = await writePublishResult(root, buildPublishResult(true));
 
@@ -466,6 +475,9 @@ describe("release-task-evidence script", () => {
     const updated = await readFile(readmePath, "utf8");
 
     expect(payload.changed).toBe(true);
+    expect(updated).toContain("Candidate checks passed.");
+    expect(updated).toContain("<!-- BEGIN HOSTED PUBLISH EVIDENCE -->");
+    expect(updated).toContain("### Hosted publish");
     expect(updated).toContain("Hosted publish confirmed for v0.3.15.");
     expect(updated).toContain(
       "release_url: https://github.com/basilisk-labs/agentplane/releases/tag/v0.3.15",
@@ -475,6 +487,29 @@ describe("release-task-evidence script", () => {
     );
     expect(updated).toContain('updated_by: "DEUS"');
     expect(updated).toContain('state: "ok"');
+
+    const repeated = await execFileAsync(
+      "bun",
+      [
+        SCRIPT_PATH,
+        "apply",
+        "--task-id",
+        taskId,
+        "--publish-result",
+        publishResultPath,
+        "--repo",
+        "basilisk-labs/agentplane",
+        "--author",
+        "DEUS",
+        "--at",
+        "2026-04-19T12:00:00.000Z",
+      ],
+      { cwd: root, env: process.env },
+    );
+    const repeatedPayload = JSON.parse(String(repeated.stdout ?? "")) as { changed: boolean };
+    const repeatedReadme = await readFile(readmePath, "utf8");
+    expect(repeatedPayload.changed).toBe(false);
+    expect(repeatedReadme.match(/BEGIN HOSTED PUBLISH EVIDENCE/gu)).toHaveLength(2);
   });
 
   it("audits only scoped recent DONE tasks with closure evidence and pending verification", async () => {

--- a/scripts/release/release-task-evidence.mjs
+++ b/scripts/release/release-task-evidence.mjs
@@ -112,7 +112,7 @@ async function resolveReleaseTaskIdsFromCommit(releaseSha) {
 }
 
 function escapeRegExp(value) {
-  return String(value).replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  return String(value).replaceAll(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
 async function resolveReleaseTaskIdsFromRegistry(manifest) {
@@ -429,13 +429,18 @@ async function runPrepare(argv) {
   });
 }
 
-function renderVerificationSection(manifest, repo) {
+const HOSTED_PUBLISH_EVIDENCE_BEGIN = "<!-- BEGIN HOSTED PUBLISH EVIDENCE -->";
+const HOSTED_PUBLISH_EVIDENCE_END = "<!-- END HOSTED PUBLISH EVIDENCE -->";
+
+function renderHostedPublishEvidence(manifest, repo) {
   const releaseUrl = `https://github.com/${repo}/releases/tag/${manifest.tag}`;
   const publishRunUrl = manifest.job.runId
     ? `https://github.com/${repo}/actions/runs/${manifest.job.runId}`
     : null;
   const lines = [
-    "<!-- BEGIN VERIFICATION RESULTS -->",
+    HOSTED_PUBLISH_EVIDENCE_BEGIN,
+    "### Hosted publish",
+    "",
     "- State: ok",
     `- Note: Hosted publish confirmed for ${manifest.tag}.`,
     "- Details:",
@@ -452,8 +457,37 @@ function renderVerificationSection(manifest, repo) {
   if (publishRunUrl) {
     lines.push(`  - publish_run: ${publishRunUrl}`);
   }
-  lines.push("<!-- END VERIFICATION RESULTS -->");
+  lines.push(HOSTED_PUBLISH_EVIDENCE_END);
   return lines.join("\n");
+}
+
+function renderVerificationSection(manifest, repo, existingVerification) {
+  const hostedEvidence = renderHostedPublishEvidence(manifest, repo);
+  const existing = String(existingVerification ?? "")
+    .replaceAll(
+      new RegExp(
+        `${escapeRegExp(HOSTED_PUBLISH_EVIDENCE_BEGIN)}[\\s\\S]*?${escapeRegExp(HOSTED_PUBLISH_EVIDENCE_END)}`,
+        "gu",
+      ),
+      "",
+    )
+    .trim();
+  if (!existing) {
+    return [
+      "<!-- BEGIN VERIFICATION RESULTS -->",
+      hostedEvidence,
+      "<!-- END VERIFICATION RESULTS -->",
+    ].join("\n");
+  }
+  const closingMarker = "<!-- END VERIFICATION RESULTS -->";
+  const closingIndex = existing.indexOf(closingMarker);
+  if (closingIndex !== -1) {
+    const beforeClosing = existing.slice(0, closingIndex).trimEnd();
+    const afterClosing = existing.slice(closingIndex + closingMarker.length).trimStart();
+    const closingSection = afterClosing ? `${closingMarker}\n\n${afterClosing}` : closingMarker;
+    return `${beforeClosing}\n\n${hostedEvidence}\n${closingSection}`;
+  }
+  return `${existing}\n\n${hostedEvidence}`;
 }
 
 async function runApply(argv) {
@@ -470,9 +504,14 @@ async function runApply(argv) {
     throw new Error(`Task README id mismatch at ${readmePath}`);
   }
 
-  const verificationText = renderVerificationSection(manifest, args.repo);
+  const currentSections = taskDocToSectionMap(taskReadmeDocBody(parsed.frontmatter, parsed.body));
+  const verificationText = renderVerificationSection(
+    manifest,
+    args.repo,
+    currentSections.Verification,
+  );
   const sections = {
-    ...taskDocToSectionMap(taskReadmeDocBody(parsed.frontmatter, parsed.body)),
+    ...currentSections,
     Verification: verificationText,
   };
   const body = renderTaskDocFromSections(sections);

--- a/scripts/release/release-task-evidence.mjs
+++ b/scripts/release/release-task-evidence.mjs
@@ -111,6 +111,49 @@ async function resolveReleaseTaskIdsFromCommit(releaseSha) {
   return [...new Set(taskIds)];
 }
 
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+async function resolveReleaseTaskIdsFromRegistry(manifest) {
+  const version = String(manifest.version ?? "").trim();
+  if (!version) return [];
+  const versionPattern = new RegExp(
+    `(^|[^0-9A-Za-z])v?${escapeRegExp(version)}($|[^0-9A-Za-z])`,
+    "iu",
+  );
+  const tasksDir = path.join(process.cwd(), ".agentplane", "tasks");
+  const entries = await readdir(tasksDir, { withFileTypes: true }).catch(() => []);
+  const taskIds = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const readmePath = path.join(tasksDir, entry.name, "README.md");
+    let frontmatter;
+    try {
+      frontmatter = parseTaskReadme(await readFile(readmePath, "utf8")).frontmatter;
+    } catch {
+      continue;
+    }
+    if (String(frontmatter.status ?? "").toUpperCase() !== "DONE") continue;
+    const tags = Array.isArray(frontmatter.tags)
+      ? frontmatter.tags.map((tag) => String(tag).trim()).filter(Boolean)
+      : [];
+    const releaseMarked =
+      String(frontmatter.task_kind ?? "").toLowerCase() === "release" ||
+      String(frontmatter.mutation_scope ?? "").toLowerCase() === "release" ||
+      tags.some((tag) => tag.toLowerCase() === "release");
+    if (!releaseMarked) continue;
+    const releaseRefs = [frontmatter.title, frontmatter.description, ...tags]
+      .map((value) => String(value ?? "").trim())
+      .filter(Boolean);
+    if (!releaseRefs.some((value) => versionPattern.test(value))) continue;
+    taskIds.push(String(frontmatter.id ?? entry.name).trim());
+  }
+
+  return [...new Set(taskIds.filter(Boolean))];
+}
+
 function buildPrepareOutcome({
   actionable,
   reason,
@@ -326,6 +369,30 @@ async function runPrepare(argv) {
       releaseSha: args.releaseSha,
       baseRef: args.baseRef,
       repo: args.repo,
+      taskCloseBranchPrefix,
+    });
+  }
+  const registryTaskIds = await resolveReleaseTaskIdsFromRegistry(manifest);
+  if (registryTaskIds.length > 1) {
+    return buildPrepareOutcome({
+      actionable: false,
+      reason: `multiple DONE release tasks match ${manifest.tag}: ${registryTaskIds.join(", ")}`,
+      manifest,
+      releaseSha: args.releaseSha,
+      baseRef: args.baseRef,
+      repo: args.repo,
+      taskCloseBranchPrefix,
+    });
+  }
+  if (registryTaskIds.length === 1) {
+    return buildPrepareOutcome({
+      actionable: true,
+      reason: null,
+      manifest,
+      releaseSha: args.releaseSha,
+      baseRef: args.baseRef,
+      repo: args.repo,
+      taskId: registryTaskIds[0],
       taskCloseBranchPrefix,
     });
   }


### PR DESCRIPTION
Task: `202607111438-5DXKKR`
Title: Fix release evidence task attribution
Canonical task record: `.agentplane/tasks/202607111438-5DXKKR/README.md`

## Summary

Fix release evidence task attribution

Resolve hosted publish evidence to the matching release task instead of whichever task README happens to be changed by the exact publish SHA; add regression coverage and correct v0.6.22 evidence attribution.

## Scope

- In scope: Resolve hosted publish evidence to the matching release task instead of whichever task README happens to be changed by the exact publish SHA; add regression coverage and correct v0.6.22 evidence attribution.
- Out of scope: unrelated refactors not required for "Fix release evidence task attribution".

## Verification

- State: ok
- Note:

```text
Version-matched release-task resolver, ambiguity guard, evidence preservation/idempotence, and
corrected v0.6.22 attribution verified: 17/17 focused tests, agentplane typecheck, format:check, and
full ci:contract pass.
```
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-07-11T14:38:57.348Z
- Branch: task/202607111438-5DXKKR/post-release-fix-evidence-attribution
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .agentplane/tasks/202607030734-6T937A/README.md    | 159 ++++++++++++++++-----
 .agentplane/tasks/202607092209-F33MNN/README.md    |  47 +++++-
 .../release/release-task-evidence-script.test.ts   | 124 +++++++++++++++-
 scripts/release/release-task-evidence.mjs          | 116 ++++++++++++++-
 4 files changed, 399 insertions(+), 47 deletions(-)
```

</details>
