### PR TITLE
🚧 ABG7SD task: Align CLI error, exit-code, and Node support contracts [202607221848-ABG7SD]

### DIFF
--- a/.agentplane/tasks/202607221848-ABG7SD/README.md
+++ b/.agentplane/tasks/202607221848-ABG7SD/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202607221848-ABG7SD"
 title: "Align CLI error, exit-code, and Node support contracts"
-status: "DOING"
+result_summary: "pre-merge closure"
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 7
+revision: 11
 origin:
   system: "manual"
 depends_on:
@@ -32,16 +33,40 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-07-24T10:06:16.421Z"
+  updated_by: "TESTER"
+  note: "Implementation rework verified at 8bf0104e: runtime-derived CLI/error docs, exact installed-tarball envelopes, mandatory core/recipes Node matrix, focused 9/9, docs check, typecheck, critical, ci:contract and RF04 offline replay 50/70/27/170 pass; independent semantic review PASS. Hosted Node 20 cells remain a PR integration gate."
   attempts: 0
-commit: null
+quality_review:
+  state: "pass"
+  provenance: "evaluator_supplied"
+  updated_at: "2026-07-24T10:07:09.959Z"
+  updated_by: "EVALUATOR"
+  note: "Runtime CLI/error documentation, installed-tarball behavior, compatibility provenance, and Node support gates align at DCO head 8bf0104e."
+  evaluated_sha: "8bf0104e2379a265002107bd24096f686e87d280"
+  blueprint_digest: "dfad433ba50ff6e3a4d8424a251f191246002efb1b357c5a99e3caf407fe5bf5"
+  evidence_refs:
+    - ".agentplane/tasks/202607221848-ABG7SD/README.md"
+    - ".agentplane/tasks/202607221848-ABG7SD/quality/20260724-100709959-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607221848-ABG7SD/quality/20260724-100709959-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607221848-ABG7SD/quality/20260724-100709959-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607221848-ABG7SD/blueprint/resolved-snapshot.json"
+    - ".github/workflows/ci.yml"
+    - "scripts/release/check-local-tarball-install-smoke.mjs"
+    - "commit:8bf0104e2379a265002107bd24096f686e87d280"
+  findings:
+    - "Independent semantic review found no code blocker: exact JSON projections prevent field leakage; the 4-cell core/recipes Node matrix is a direct mandatory PR verification dependency; RF04 offline replay remains 50/70/27/170."
+commit:
+  hash: "8bf0104e2379a265002107bd24096f686e87d280"
+  message: "🧩 ABG7SD cli: align runtime contracts"
 comments:
   -
     author: "CODER"
     body: "Start: align generated CLI error, exit-code, installed-tarball, and Node support contracts."
+  -
+    author: "CODER"
+    body: "Verified: pre-merge closure packet is ready for the task PR."
 events:
   -
     type: "status"
@@ -50,8 +75,27 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: align generated CLI error, exit-code, installed-tarball, and Node support contracts."
+  -
+    type: "verify"
+    at: "2026-07-24T09:13:52.072Z"
+    author: "TESTER"
+    state: "needs_rework"
+    note: "Implementation is not present yet; the branch contains only generated task, PR, and blueprint artifacts."
+  -
+    type: "verify"
+    at: "2026-07-24T10:06:16.421Z"
+    author: "TESTER"
+    state: "ok"
+    note: "Implementation rework verified at 8bf0104e: runtime-derived CLI/error docs, exact installed-tarball envelopes, mandatory core/recipes Node matrix, focused 9/9, docs check, typecheck, critical, ci:contract and RF04 offline replay 50/70/27/170 pass; independent semantic review PASS. Hosted Node 20 cells remain a PR integration gate."
+  -
+    type: "status"
+    at: "2026-07-24T10:07:51.065Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-24T09:04:19.991Z"
+doc_updated_at: "2026-07-24T10:07:51.066Z"
 doc_updated_by: "CODER"
 description: "Correct the verified drift between documented and runtime exit/error shapes, structured remediation fields, package engine ranges, and the CI support matrix before 0.7 compatibility is frozen."
 sections:
@@ -75,12 +119,75 @@ sections:
     4. Run `bun run docs:cli:check`, `bun run test:critical`, `bun run typecheck`, and `bun run ci:contract`.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-07-24T09:13:52.072Z — VERIFY — needs_rework
+
+    By: TESTER
+
+    Note: Implementation is not present yet; the branch contains only generated task, PR, and blueprint artifacts.
+    Attempts: 1
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-24T09:04:19.991Z, excerpt_hash=sha256:d7b0d6bc97e263826e6a452e3c2bea485bca5677a941b298dcf1a6f7a42c0c4d
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607221848-ABG7SD-align-cli-error-exit-code-and-node-support-contr/.agentplane/tasks/202607221848-ABG7SD/blueprint/resolved-snapshot.json
+    - old_digest: dfad433ba50ff6e3a4d8424a251f191246002efb1b357c5a99e3caf407fe5bf5
+    - current_digest: dfad433ba50ff6e3a4d8424a251f191246002efb1b357c5a99e3caf407fe5bf5
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607221848-ABG7SD
+
+    DecisionContextRef:
+    - operator_action: stop
+    - can_execute_now: false
+    - safe_command: none
+    - diagnostic_command: agentplane task verify-show 202607221848-ABG7SD
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: none
+
+    ### 2026-07-24T10:06:16.421Z — VERIFY — ok
+
+    By: TESTER
+
+    Note: Implementation rework verified at 8bf0104e: runtime-derived CLI/error docs, exact installed-tarball envelopes, mandatory core/recipes Node matrix, focused 9/9, docs check, typecheck, critical, ci:contract and RF04 offline replay 50/70/27/170 pass; independent semantic review PASS. Hosted Node 20 cells remain a PR integration gate.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-24T09:13:52.511Z, excerpt_hash=sha256:d7b0d6bc97e263826e6a452e3c2bea485bca5677a941b298dcf1a6f7a42c0c4d
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607221848-ABG7SD-align-cli-error-exit-code-and-node-support-contr/.agentplane/tasks/202607221848-ABG7SD/blueprint/resolved-snapshot.json
+    - old_digest: dfad433ba50ff6e3a4d8424a251f191246002efb1b357c5a99e3caf407fe5bf5
+    - current_digest: dfad433ba50ff6e3a4d8424a251f191246002efb1b357c5a99e3caf407fe5bf5
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607221848-ABG7SD
+
+    DecisionContextRef:
+    - operator_action: stop
+    - can_execute_now: false
+    - safe_command: none
+    - diagnostic_command: none
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: none
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert the task implementation commit(s) while preserving unrelated task and migration state.
     - Restore the previous compatibility view or persisted contract version.
     - Re-run focused contract, migration, and type checks.
-  Findings: ""
+  Findings: |-
+    - Observation: HEAD changes only lifecycle metadata and the resolved blueprint snapshot; no CLI error/exit-code contract, generated reference, Node support alignment, or tests exist.
+      Impact: The approved Verify Steps cannot be executed and the task cannot pass verification.
+      Resolution: Return control to CODER to implement the runtime-derived CLI contract, installed-tarball coverage, Node support alignment, and declared checks before re-verification.
 id_source: "generated"
 ---
 ## Summary
@@ -112,6 +219,66 @@ Correct the verified drift between documented and runtime exit/error shapes, str
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-07-24T09:13:52.072Z — VERIFY — needs_rework
+
+By: TESTER
+
+Note: Implementation is not present yet; the branch contains only generated task, PR, and blueprint artifacts.
+Attempts: 1
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-24T09:04:19.991Z, excerpt_hash=sha256:d7b0d6bc97e263826e6a452e3c2bea485bca5677a941b298dcf1a6f7a42c0c4d
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607221848-ABG7SD-align-cli-error-exit-code-and-node-support-contr/.agentplane/tasks/202607221848-ABG7SD/blueprint/resolved-snapshot.json
+- old_digest: dfad433ba50ff6e3a4d8424a251f191246002efb1b357c5a99e3caf407fe5bf5
+- current_digest: dfad433ba50ff6e3a4d8424a251f191246002efb1b357c5a99e3caf407fe5bf5
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607221848-ABG7SD
+
+DecisionContextRef:
+- operator_action: stop
+- can_execute_now: false
+- safe_command: none
+- diagnostic_command: agentplane task verify-show 202607221848-ABG7SD
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: none
+
+### 2026-07-24T10:06:16.421Z — VERIFY — ok
+
+By: TESTER
+
+Note: Implementation rework verified at 8bf0104e: runtime-derived CLI/error docs, exact installed-tarball envelopes, mandatory core/recipes Node matrix, focused 9/9, docs check, typecheck, critical, ci:contract and RF04 offline replay 50/70/27/170 pass; independent semantic review PASS. Hosted Node 20 cells remain a PR integration gate.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-24T09:13:52.511Z, excerpt_hash=sha256:d7b0d6bc97e263826e6a452e3c2bea485bca5677a941b298dcf1a6f7a42c0c4d
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607221848-ABG7SD-align-cli-error-exit-code-and-node-support-contr/.agentplane/tasks/202607221848-ABG7SD/blueprint/resolved-snapshot.json
+- old_digest: dfad433ba50ff6e3a4d8424a251f191246002efb1b357c5a99e3caf407fe5bf5
+- current_digest: dfad433ba50ff6e3a4d8424a251f191246002efb1b357c5a99e3caf407fe5bf5
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607221848-ABG7SD
+
+DecisionContextRef:
+- operator_action: stop
+- can_execute_now: false
+- safe_command: none
+- diagnostic_command: none
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: none
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -121,3 +288,7 @@ Correct the verified drift between documented and runtime exit/error shapes, str
 - Re-run focused contract, migration, and type checks.
 
 ## Findings
+
+- Observation: HEAD changes only lifecycle metadata and the resolved blueprint snapshot; no CLI error/exit-code contract, generated reference, Node support alignment, or tests exist.
+  Impact: The approved Verify Steps cannot be executed and the task cannot pass verification.
+  Resolution: Return control to CODER to implement the runtime-derived CLI contract, installed-tarball coverage, Node support alignment, and declared checks before re-verification.

--- a/.agentplane/tasks/202607221848-ABG7SD/README.md
+++ b/.agentplane/tasks/202607221848-ABG7SD/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 11
+revision: 12
 origin:
   system: "manual"
 depends_on:
@@ -41,22 +41,22 @@ verification:
 quality_review:
   state: "pass"
   provenance: "evaluator_supplied"
-  updated_at: "2026-07-24T10:07:09.959Z"
+  updated_at: "2026-07-24T10:18:02.890Z"
   updated_by: "EVALUATOR"
-  note: "Runtime CLI/error documentation, installed-tarball behavior, compatibility provenance, and Node support gates align at DCO head 8bf0104e."
-  evaluated_sha: "8bf0104e2379a265002107bd24096f686e87d280"
+  note: "Hosted verify-unit regression is corrected at DCO head 3ff89179 without weakening the release-ready contract."
+  evaluated_sha: "3ff891791141db79b8679742d903d72e066198b3"
   blueprint_digest: "dfad433ba50ff6e3a4d8424a251f191246002efb1b357c5a99e3caf407fe5bf5"
   evidence_refs:
     - ".agentplane/tasks/202607221848-ABG7SD/README.md"
-    - ".agentplane/tasks/202607221848-ABG7SD/quality/20260724-100709959-recovery-context/quality-report.json"
-    - ".agentplane/tasks/202607221848-ABG7SD/quality/20260724-100709959-recovery-context/evaluator-prompt.md"
-    - ".agentplane/tasks/202607221848-ABG7SD/quality/20260724-100709959-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607221848-ABG7SD/quality/20260724-101802890-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607221848-ABG7SD/quality/20260724-101802890-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607221848-ABG7SD/quality/20260724-101802890-recovery-context/evaluator-opinion.md"
     - ".agentplane/tasks/202607221848-ABG7SD/blueprint/resolved-snapshot.json"
-    - ".github/workflows/ci.yml"
-    - "scripts/release/check-local-tarball-install-smoke.mjs"
-    - "commit:8bf0104e2379a265002107bd24096f686e87d280"
+    - "packages/agentplane/src/commands/release/ci-workflow-contract.test.ts"
+    - "https://github.com/basilisk-labs/agentplane/actions/runs/30085162677/job/89455569371"
+    - "bun run test:fast: 427/427 files, 2679/2679 tests"
   findings:
-    - "Independent semantic review found no code blocker: exact JSON projections prevent field leakage; the 4-cell core/recipes Node matrix is a direct mandatory PR verification dependency; RF04 offline replay remains 50/70/27/170."
+    - "Independent review confirmed the one-line expectation now explicitly requires verify-package-node-runtime success; it does not broaden alternatives or remove assertions. Exact local test:fast passes 427 files and 2679 tests."
 commit:
   hash: "8bf0104e2379a265002107bd24096f686e87d280"
   message: "🧩 ABG7SD cli: align runtime contracts"

--- a/.agentplane/tasks/202607221848-ABG7SD/README.md
+++ b/.agentplane/tasks/202607221848-ABG7SD/README.md
@@ -1,10 +1,10 @@
 ---
 id: "202607221848-ABG7SD"
 title: "Align CLI error, exit-code, and Node support contracts"
-status: "TODO"
+status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 5
+revision: 7
 origin:
   system: "manual"
 depends_on:
@@ -27,9 +27,9 @@ verify:
   - "bun run test:critical"
   - "bun run typecheck"
 plan_approval:
-  state: "pending"
-  updated_at: null
-  updated_by: null
+  state: "approved"
+  updated_at: "2026-07-24T09:03:13.942Z"
+  updated_by: "ORCHESTRATOR"
   note: null
 verification:
   state: "pending"
@@ -38,11 +38,21 @@ verification:
   note: null
   attempts: 0
 commit: null
-comments: []
-events: []
+comments:
+  -
+    author: "CODER"
+    body: "Start: align generated CLI error, exit-code, installed-tarball, and Node support contracts."
+events:
+  -
+    type: "status"
+    at: "2026-07-24T09:04:19.991Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: align generated CLI error, exit-code, installed-tarball, and Node support contracts."
 doc_version: 3
-doc_updated_at: "2026-07-22T18:48:42.500Z"
-doc_updated_by: "PLANNER"
+doc_updated_at: "2026-07-24T09:04:19.991Z"
+doc_updated_by: "CODER"
 description: "Correct the verified drift between documented and runtime exit/error shapes, structured remediation fields, package engine ranges, and the CI support matrix before 0.7 compatibility is frozen."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202607221848-ABG7SD/README.md
+++ b/.agentplane/tasks/202607221848-ABG7SD/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 12
+revision: 13
 origin:
   system: "manual"
 depends_on:
@@ -58,8 +58,8 @@ quality_review:
   findings:
     - "Independent review confirmed the one-line expectation now explicitly requires verify-package-node-runtime success; it does not broaden alternatives or remove assertions. Exact local test:fast passes 427 files and 2679 tests."
 commit:
-  hash: "8bf0104e2379a265002107bd24096f686e87d280"
-  message: "🧩 ABG7SD cli: align runtime contracts"
+  hash: "70c4256abe977cdf41fea3547fa852c5e4c04070"
+  message: "🧩 ABG7SD task: record follow-up quality review"
 comments:
   -
     author: "CODER"
@@ -67,6 +67,9 @@ comments:
   -
     author: "CODER"
     body: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    author: "CODER"
+    body: "Verified: refreshed pre-merge closure packet is ready for the task PR."
 events:
   -
     type: "status"
@@ -94,8 +97,15 @@ events:
     from: "DOING"
     to: "DONE"
     note: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    type: "status"
+    at: "2026-07-24T10:19:12.761Z"
+    author: "CODER"
+    from: "DONE"
+    to: "DONE"
+    note: "Verified: refreshed pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-24T10:07:51.066Z"
+doc_updated_at: "2026-07-24T10:19:12.761Z"
 doc_updated_by: "CODER"
 description: "Correct the verified drift between documented and runtime exit/error shapes, structured remediation fields, package engine ranges, and the CI support matrix before 0.7 compatibility is frozen."
 sections:
@@ -188,6 +198,10 @@ sections:
     - Observation: HEAD changes only lifecycle metadata and the resolved blueprint snapshot; no CLI error/exit-code contract, generated reference, Node support alignment, or tests exist.
       Impact: The approved Verify Steps cannot be executed and the task cannot pass verification.
       Resolution: Return control to CODER to implement the runtime-derived CLI contract, installed-tarball coverage, Node support alignment, and declared checks before re-verification.
+extensions:
+  implementation_commit:
+    hash: "3ff891791141db79b8679742d903d72e066198b3"
+    message: "🧪 ABG7SD cli: align release-ready contract"
 id_source: "generated"
 ---
 ## Summary

--- a/.agentplane/tasks/202607221848-ABG7SD/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202607221848-ABG7SD/blueprint/resolved-snapshot.json
@@ -1,0 +1,584 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607221848-ABG7SD",
+    "title": "Align CLI error, exit-code, and Node support contracts",
+    "description": "Correct the verified drift between documented and runtime exit/error shapes, structured remediation fields, package engine ranges, and the CI support matrix before 0.7 compatibility is frozen.",
+    "tags": [
+      "cli",
+      "contract-drift",
+      "docs",
+      "milestone-alpha2",
+      "node",
+      "refactor",
+      "v0.7",
+      "wave-contracts"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607221848-ABG7SD",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "dfad433ba50ff6e3a4d8424a251f191246002efb1b357c5a99e3caf407fe5bf5"
+  }
+}

--- a/.agentplane/tasks/202607221848-ABG7SD/pr/diffstat.txt
+++ b/.agentplane/tasks/202607221848-ABG7SD/pr/diffstat.txt
@@ -1,0 +1,17 @@
+ .github/workflows/ci.yml                           |  57 +++++
+ docs/developer/cli-contract.mdx                    |  37 +--
+ docs/user/cli-reference.generated.mdx              |  51 +++-
+ packages/agentplane/src/cli/cli-contract.test.ts   |  66 ++++-
+ packages/agentplane/src/cli/exit-codes.ts          |  21 ++
+ .../src/cli/run-cli.core.docs-cli.test.ts          |   3 +
+ ...-cli.critical.agent-efficiency-baseline.test.ts |   6 +-
+ .../agentplane/src/cli/spec/docs-render.test.ts    |  19 ++
+ packages/agentplane/src/cli/spec/docs-render.ts    |  57 ++++-
+ .../release/workflow-node-version-contract.test.ts | 120 ++++++++-
+ packages/agentplane/src/shared/errors.test.ts      |  58 +++++
+ packages/agentplane/src/shared/errors.ts           |  69 +++++-
+ .../baselines/v0.7-compatibility-candidate.json    |  28 ++-
+ .../check-compatibility-contract-baseline.mjs      |  42 +++-
+ .../release/check-local-tarball-install-smoke.mjs  | 267 ++++++++++++++++++++-
+ scripts/release/check-package-node-runtime.mjs     | 164 +++++++++++++
+ 16 files changed, 1024 insertions(+), 41 deletions(-)

--- a/.agentplane/tasks/202607221848-ABG7SD/pr/diffstat.txt
+++ b/.agentplane/tasks/202607221848-ABG7SD/pr/diffstat.txt
@@ -7,6 +7,7 @@
  ...-cli.critical.agent-efficiency-baseline.test.ts |   6 +-
  .../agentplane/src/cli/spec/docs-render.test.ts    |  19 ++
  packages/agentplane/src/cli/spec/docs-render.ts    |  57 ++++-
+ .../commands/release/ci-workflow-contract.test.ts  |   2 +-
  .../release/workflow-node-version-contract.test.ts | 120 ++++++++-
  packages/agentplane/src/shared/errors.test.ts      |  58 +++++
  packages/agentplane/src/shared/errors.ts           |  69 +++++-
@@ -14,4 +15,4 @@
  .../check-compatibility-contract-baseline.mjs      |  42 +++-
  .../release/check-local-tarball-install-smoke.mjs  | 267 ++++++++++++++++++++-
  scripts/release/check-package-node-runtime.mjs     | 164 +++++++++++++
- 16 files changed, 1024 insertions(+), 41 deletions(-)
+ 17 files changed, 1025 insertions(+), 42 deletions(-)

--- a/.agentplane/tasks/202607221848-ABG7SD/pr/github-body.md
+++ b/.agentplane/tasks/202607221848-ABG7SD/pr/github-body.md
@@ -22,7 +22,7 @@ Correct the verified drift between documented and runtime exit/error shapes, str
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-24T09:04:20.081Z
+- Updated: 2026-07-24T09:06:11.144Z
 - Branch: task/202607221848-ABG7SD/align-cli-error-exit-code-and-node-support-contr
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 

--- a/.agentplane/tasks/202607221848-ABG7SD/pr/github-body.md
+++ b/.agentplane/tasks/202607221848-ABG7SD/pr/github-body.md
@@ -43,6 +43,7 @@ ci:contract and RF04 offline replay 50/70/27/170 pass; independent semantic revi
  ...-cli.critical.agent-efficiency-baseline.test.ts |   6 +-
  .../agentplane/src/cli/spec/docs-render.test.ts    |  19 ++
  packages/agentplane/src/cli/spec/docs-render.ts    |  57 ++++-
+ .../commands/release/ci-workflow-contract.test.ts  |   2 +-
  .../release/workflow-node-version-contract.test.ts | 120 ++++++++-
  packages/agentplane/src/shared/errors.test.ts      |  58 +++++
  packages/agentplane/src/shared/errors.ts           |  69 +++++-
@@ -50,7 +51,7 @@ ci:contract and RF04 offline replay 50/70/27/170 pass; independent semantic revi
  .../check-compatibility-contract-baseline.mjs      |  42 +++-
  .../release/check-local-tarball-install-smoke.mjs  | 267 ++++++++++++++++++++-
  scripts/release/check-package-node-runtime.mjs     | 164 +++++++++++++
- 16 files changed, 1024 insertions(+), 41 deletions(-)
+ 17 files changed, 1025 insertions(+), 42 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607221848-ABG7SD/pr/github-body.md
+++ b/.agentplane/tasks/202607221848-ABG7SD/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202607221848-ABG7SD`
+Title: Align CLI error, exit-code, and Node support contracts
+Canonical task record: `.agentplane/tasks/202607221848-ABG7SD/README.md`
+
+## Summary
+
+Align CLI error, exit-code, and Node support contracts
+
+Correct the verified drift between documented and runtime exit/error shapes, structured remediation fields, package engine ranges, and the CI support matrix before 0.7 compatibility is frozen.
+
+## Scope
+
+- In scope: one generated source for CLI exit codes and error payload documentation, guidance/remediation compatibility, installed-tarball fixtures, aligned Node engine declarations or an explicit tested matrix, and CI coverage for every supported runtime.
+- Out of scope: changing unrelated command semantics or removing an existing error field without migration evidence.
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-24T09:04:20.081Z
+- Branch: task/202607221848-ABG7SD/align-cli-error-exit-code-and-node-support-contr
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202607221848-ABG7SD/pr/github-body.md
+++ b/.agentplane/tasks/202607221848-ABG7SD/pr/github-body.md
@@ -15,8 +15,15 @@ Correct the verified drift between documented and runtime exit/error shapes, str
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Implementation rework verified at 8bf0104e: runtime-derived CLI/error docs, exact installed-tarball
+envelopes, mandatory core/recipes Node matrix, focused 9/9, docs check, typecheck, critical,
+ci:contract and RF04 offline replay 50/70/27/170 pass; independent semantic review PASS. Hosted Node
+20 cells remain a PR integration gate.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
@@ -27,7 +34,23 @@ Correct the verified drift between documented and runtime exit/error shapes, str
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .github/workflows/ci.yml                           |  57 +++++
+ docs/developer/cli-contract.mdx                    |  37 +--
+ docs/user/cli-reference.generated.mdx              |  51 +++-
+ packages/agentplane/src/cli/cli-contract.test.ts   |  66 ++++-
+ packages/agentplane/src/cli/exit-codes.ts          |  21 ++
+ .../src/cli/run-cli.core.docs-cli.test.ts          |   3 +
+ ...-cli.critical.agent-efficiency-baseline.test.ts |   6 +-
+ .../agentplane/src/cli/spec/docs-render.test.ts    |  19 ++
+ packages/agentplane/src/cli/spec/docs-render.ts    |  57 ++++-
+ .../release/workflow-node-version-contract.test.ts | 120 ++++++++-
+ packages/agentplane/src/shared/errors.test.ts      |  58 +++++
+ packages/agentplane/src/shared/errors.ts           |  69 +++++-
+ .../baselines/v0.7-compatibility-candidate.json    |  28 ++-
+ .../check-compatibility-contract-baseline.mjs      |  42 +++-
+ .../release/check-local-tarball-install-smoke.mjs  | 267 ++++++++++++++++++++-
+ scripts/release/check-package-node-runtime.mjs     | 164 +++++++++++++
+ 16 files changed, 1024 insertions(+), 41 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607221848-ABG7SD/pr/github-title.txt
+++ b/.agentplane/tasks/202607221848-ABG7SD/pr/github-title.txt
@@ -1,1 +1,1 @@
-🚧 ABG7SD task: Align CLI error, exit-code, and Node support contracts [202607221848-ABG7SD]
+✅ ABG7SD task: Align CLI error, exit-code, and Node support contracts [202607221848-ABG7SD]

--- a/.agentplane/tasks/202607221848-ABG7SD/pr/github-title.txt
+++ b/.agentplane/tasks/202607221848-ABG7SD/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 ABG7SD task: Align CLI error, exit-code, and Node support contracts [202607221848-ABG7SD]

--- a/.agentplane/tasks/202607221848-ABG7SD/pr/meta.json
+++ b/.agentplane/tasks/202607221848-ABG7SD/pr/meta.json
@@ -8,10 +8,10 @@
   "pr_number": 4611,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4611",
   "pre_merge_closure": {
-    "basis_commit": "8bf0104e2379a265002107bd24096f686e87d280",
+    "basis_commit": "70c4256abe977cdf41fea3547fa852c5e4c04070",
     "branch": "task/202607221848-ABG7SD/align-cli-error-exit-code-and-node-support-contr",
     "pr_number": 4611,
-    "recorded_at": "2026-07-24T10:07:51.125Z",
+    "recorded_at": "2026-07-24T10:19:12.813Z",
     "state": "closed_before_merge"
   },
   "schema_version": 1,

--- a/.agentplane/tasks/202607221848-ABG7SD/pr/meta.json
+++ b/.agentplane/tasks/202607221848-ABG7SD/pr/meta.json
@@ -4,9 +4,12 @@
   "created_at": "2026-07-24T09:04:20.081Z",
   "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "last_verified_at": null,
+  "pr_number": 4611,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4611",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202607221848-ABG7SD",
-  "updated_at": "2026-07-24T09:04:20.081Z",
+  "updated_at": "2026-07-24T09:06:11.144Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202607221848-ABG7SD/pr/meta.json
+++ b/.agentplane/tasks/202607221848-ABG7SD/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202607221848-ABG7SD/align-cli-error-exit-code-and-node-support-contr",
+  "created_at": "2026-07-24T09:04:20.081Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202607221848-ABG7SD",
+  "updated_at": "2026-07-24T09:04:20.081Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202607221848-ABG7SD/pr/meta.json
+++ b/.agentplane/tasks/202607221848-ABG7SD/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202607221848-ABG7SD/align-cli-error-exit-code-and-node-support-contr",
   "created_at": "2026-07-24T09:04:20.081Z",
-  "diffstat_sha256": "sha256:f2497022096a4c78f7ec90b510b0107987d6ea7efd58bf14247e4da9cf5b72cf",
+  "diffstat_sha256": "sha256:6550d3939542a0542f5613a9ad77149d7dc7ecdc7015ea8cf1e60dc2a6e1c26e",
   "last_verified_at": "2026-07-24T10:06:16.421Z",
   "last_verified_diffstat_sha256": "sha256:f2497022096a4c78f7ec90b510b0107987d6ea7efd58bf14247e4da9cf5b72cf",
   "pr_number": 4611,

--- a/.agentplane/tasks/202607221848-ABG7SD/pr/meta.json
+++ b/.agentplane/tasks/202607221848-ABG7SD/pr/meta.json
@@ -2,15 +2,23 @@
   "base": "main",
   "branch": "task/202607221848-ABG7SD/align-cli-error-exit-code-and-node-support-contr",
   "created_at": "2026-07-24T09:04:20.081Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:f2497022096a4c78f7ec90b510b0107987d6ea7efd58bf14247e4da9cf5b72cf",
+  "last_verified_at": "2026-07-24T10:06:16.421Z",
+  "last_verified_diffstat_sha256": "sha256:f2497022096a4c78f7ec90b510b0107987d6ea7efd58bf14247e4da9cf5b72cf",
   "pr_number": 4611,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4611",
+  "pre_merge_closure": {
+    "basis_commit": "8bf0104e2379a265002107bd24096f686e87d280",
+    "branch": "task/202607221848-ABG7SD/align-cli-error-exit-code-and-node-support-contr",
+    "pr_number": 4611,
+    "recorded_at": "2026-07-24T10:07:51.125Z",
+    "state": "closed_before_merge"
+  },
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202607221848-ABG7SD",
   "updated_at": "2026-07-24T09:06:11.144Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202607221848-ABG7SD/pr/review.md
+++ b/.agentplane/tasks/202607221848-ABG7SD/pr/review.md
@@ -38,6 +38,7 @@ Created: 2026-07-24T09:04:20.081Z
  ...-cli.critical.agent-efficiency-baseline.test.ts |   6 +-
  .../agentplane/src/cli/spec/docs-render.test.ts    |  19 ++
  packages/agentplane/src/cli/spec/docs-render.ts    |  57 ++++-
+ .../commands/release/ci-workflow-contract.test.ts  |   2 +-
  .../release/workflow-node-version-contract.test.ts | 120 ++++++++-
  packages/agentplane/src/shared/errors.test.ts      |  58 +++++
  packages/agentplane/src/shared/errors.ts           |  69 +++++-
@@ -45,7 +46,7 @@ Created: 2026-07-24T09:04:20.081Z
  .../check-compatibility-contract-baseline.mjs      |  42 +++-
  .../release/check-local-tarball-install-smoke.mjs  | 267 ++++++++++++++++++++-
  scripts/release/check-package-node-runtime.mjs     | 164 +++++++++++++
- 16 files changed, 1024 insertions(+), 41 deletions(-)
+ 17 files changed, 1025 insertions(+), 42 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607221848-ABG7SD/pr/review.md
+++ b/.agentplane/tasks/202607221848-ABG7SD/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-07-24T09:04:20.081Z
+
+## Task
+
+- Task: `202607221848-ABG7SD`
+- Title: Align CLI error, exit-code, and Node support contracts
+- Status: DOING
+- Branch: `task/202607221848-ABG7SD/align-cli-error-exit-code-and-node-support-contr`
+- Canonical task record: `.agentplane/tasks/202607221848-ABG7SD/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-24T09:04:20.081Z
+- Branch: task/202607221848-ABG7SD/align-cli-error-exit-code-and-node-support-contr
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202607221848-ABG7SD/pr/review.md
+++ b/.agentplane/tasks/202607221848-ABG7SD/pr/review.md
@@ -6,14 +6,14 @@ Created: 2026-07-24T09:04:20.081Z
 
 - Task: `202607221848-ABG7SD`
 - Title: Align CLI error, exit-code, and Node support contracts
-- Status: DOING
+- Status: DONE
 - Branch: `task/202607221848-ABG7SD/align-cli-error-exit-code-and-node-support-contr`
 - Canonical task record: `.agentplane/tasks/202607221848-ABG7SD/README.md`
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Implementation rework verified at 8bf0104e: runtime-derived CLI/error docs, exact installed-tarball envelopes, mandatory core/recipes Node matrix, focused 9/9, docs check, typecheck, critical, ci:contract and RF04 offline replay 50/70/27/170 pass; independent semantic review PASS. Hosted Node 20 cells remain a PR integration gate.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -29,7 +29,23 @@ Created: 2026-07-24T09:04:20.081Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .github/workflows/ci.yml                           |  57 +++++
+ docs/developer/cli-contract.mdx                    |  37 +--
+ docs/user/cli-reference.generated.mdx              |  51 +++-
+ packages/agentplane/src/cli/cli-contract.test.ts   |  66 ++++-
+ packages/agentplane/src/cli/exit-codes.ts          |  21 ++
+ .../src/cli/run-cli.core.docs-cli.test.ts          |   3 +
+ ...-cli.critical.agent-efficiency-baseline.test.ts |   6 +-
+ .../agentplane/src/cli/spec/docs-render.test.ts    |  19 ++
+ packages/agentplane/src/cli/spec/docs-render.ts    |  57 ++++-
+ .../release/workflow-node-version-contract.test.ts | 120 ++++++++-
+ packages/agentplane/src/shared/errors.test.ts      |  58 +++++
+ packages/agentplane/src/shared/errors.ts           |  69 +++++-
+ .../baselines/v0.7-compatibility-candidate.json    |  28 ++-
+ .../check-compatibility-contract-baseline.mjs      |  42 +++-
+ .../release/check-local-tarball-install-smoke.mjs  | 267 ++++++++++++++++++++-
+ scripts/release/check-package-node-runtime.mjs     | 164 +++++++++++++
+ 16 files changed, 1024 insertions(+), 41 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607221848-ABG7SD/pr/review.md
+++ b/.agentplane/tasks/202607221848-ABG7SD/pr/review.md
@@ -24,7 +24,7 @@ Created: 2026-07-24T09:04:20.081Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-24T09:04:20.081Z
+- Updated: 2026-07-24T09:06:11.144Z
 - Branch: task/202607221848-ABG7SD/align-cli-error-exit-code-and-node-support-contr
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 

--- a/.agentplane/tasks/202607221848-ABG7SD/quality/20260724-100709959-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607221848-ABG7SD/quality/20260724-100709959-recovery-context/evaluator-opinion.md
@@ -1,0 +1,23 @@
+# Semantic quality review: pass
+
+Provenance: evaluator_supplied
+
+Runtime CLI/error documentation, installed-tarball behavior, compatibility provenance, and Node support gates align at DCO head 8bf0104e.
+
+## Findings
+- Independent semantic review found no code blocker: exact JSON projections prevent field leakage; the 4-cell core/recipes Node matrix is a direct mandatory PR verification dependency; RF04 offline replay remains 50/70/27/170.
+
+## Evidence
+- .agentplane/tasks/202607221848-ABG7SD/README.md
+- .github/workflows/ci.yml
+- scripts/release/check-local-tarball-install-smoke.mjs
+- commit:8bf0104e2379a265002107bd24096f686e87d280
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- Node 20.0 and 20.5 execution is only authoritative after the new GitHub-hosted matrix cells pass on the published head.

--- a/.agentplane/tasks/202607221848-ABG7SD/quality/20260724-100709959-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607221848-ABG7SD/quality/20260724-100709959-recovery-context/evaluator-prompt.md
@@ -1,0 +1,75 @@
+# AgentPlane semantic quality review record
+
+AgentPlane records supplied review values here; this command does not execute an evaluator.
+Use the evaluator module below as the review procedure before supplying a result.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+
+- task_id: 202607221848-ABG7SD
+- task_readme: .agentplane/tasks/202607221848-ABG7SD/README.md
+- report_path: .agentplane/tasks/202607221848-ABG7SD/quality/20260724-100709959-recovery-context/quality-report.json
+- provenance: evaluator_supplied
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607221848-ABG7SD/quality/20260724-100709959-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607221848-ABG7SD/quality/20260724-100709959-recovery-context/quality-report.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "task_id": "202607221848-ABG7SD",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-24T10:07:09.959Z",
+  "provenance": "evaluator_supplied",
+  "verdict": "pass",
+  "summary": "Runtime CLI/error documentation, installed-tarball behavior, compatibility provenance, and Node support gates align at DCO head 8bf0104e.",
+  "evaluated_sha": "8bf0104e2379a265002107bd24096f686e87d280",
+  "blueprint_digest": "dfad433ba50ff6e3a4d8424a251f191246002efb1b357c5a99e3caf407fe5bf5",
+  "findings": [
+    "Independent semantic review found no code blocker: exact JSON projections prevent field leakage; the 4-cell core/recipes Node matrix is a direct mandatory PR verification dependency; RF04 offline replay remains 50/70/27/170."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607221848-ABG7SD/README.md",
+    ".github/workflows/ci.yml",
+    "scripts/release/check-local-tarball-install-smoke.mjs",
+    "commit:8bf0104e2379a265002107bd24096f686e87d280"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": [
+    "Node 20.0 and 20.5 execution is only authoritative after the new GitHub-hosted matrix cells pass on the published head."
+  ]
+}

--- a/.agentplane/tasks/202607221848-ABG7SD/quality/20260724-101802890-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607221848-ABG7SD/quality/20260724-101802890-recovery-context/evaluator-opinion.md
@@ -1,0 +1,23 @@
+# Semantic quality review: pass
+
+Provenance: evaluator_supplied
+
+Hosted verify-unit regression is corrected at DCO head 3ff89179 without weakening the release-ready contract.
+
+## Findings
+- Independent review confirmed the one-line expectation now explicitly requires verify-package-node-runtime success; it does not broaden alternatives or remove assertions. Exact local test:fast passes 427 files and 2679 tests.
+
+## Evidence
+- .agentplane/tasks/202607221848-ABG7SD/README.md
+- packages/agentplane/src/commands/release/ci-workflow-contract.test.ts
+- https://github.com/basilisk-labs/agentplane/actions/runs/30085162677/job/89455569371
+- bun run test:fast: 427/427 files, 2679/2679 tests
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- The new published head must rerun GitHub PR verification before integration.

--- a/.agentplane/tasks/202607221848-ABG7SD/quality/20260724-101802890-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607221848-ABG7SD/quality/20260724-101802890-recovery-context/evaluator-prompt.md
@@ -1,0 +1,75 @@
+# AgentPlane semantic quality review record
+
+AgentPlane records supplied review values here; this command does not execute an evaluator.
+Use the evaluator module below as the review procedure before supplying a result.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+
+- task_id: 202607221848-ABG7SD
+- task_readme: .agentplane/tasks/202607221848-ABG7SD/README.md
+- report_path: .agentplane/tasks/202607221848-ABG7SD/quality/20260724-101802890-recovery-context/quality-report.json
+- provenance: evaluator_supplied
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607221848-ABG7SD/quality/20260724-101802890-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607221848-ABG7SD/quality/20260724-101802890-recovery-context/quality-report.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "task_id": "202607221848-ABG7SD",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-24T10:18:02.890Z",
+  "provenance": "evaluator_supplied",
+  "verdict": "pass",
+  "summary": "Hosted verify-unit regression is corrected at DCO head 3ff89179 without weakening the release-ready contract.",
+  "evaluated_sha": "3ff891791141db79b8679742d903d72e066198b3",
+  "blueprint_digest": "dfad433ba50ff6e3a4d8424a251f191246002efb1b357c5a99e3caf407fe5bf5",
+  "findings": [
+    "Independent review confirmed the one-line expectation now explicitly requires verify-package-node-runtime success; it does not broaden alternatives or remove assertions. Exact local test:fast passes 427 files and 2679 tests."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607221848-ABG7SD/README.md",
+    "packages/agentplane/src/commands/release/ci-workflow-contract.test.ts",
+    "https://github.com/basilisk-labs/agentplane/actions/runs/30085162677/job/89455569371",
+    "bun run test:fast: 427/427 files, 2679/2679 tests"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": [
+    "The new published head must rerun GitHub PR verification before integration."
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,56 @@ jobs:
       - name: Hotspot Threshold (check)
         run: bun run hotspots:check
 
+  verify-package-node-runtime:
+    name: Package runtime (${{ matrix.package_name }}, Node ${{ matrix.node_version }})
+    needs: plan
+    if: >-
+      needs.plan.outputs.core == 'true' &&
+      !(github.event_name == 'workflow_dispatch' && github.event.inputs.sha != '')
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package_name: core
+            package_dir: packages/core
+            node_version: "20.5.0"
+          - package_name: core
+            package_dir: packages/core
+            node_version: "24"
+          - package_name: recipes
+            package_dir: packages/recipes
+            node_version: "20.0.0"
+          - package_name: recipes
+            package_dir: packages/recipes
+            node_version: "24"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.AGENTPLANE_CI_REF }}
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.6"
+      - name: Use supported build runtime
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - run: bun install --frozen-lockfile --ignore-scripts
+      - name: Build and pack ${{ matrix.package_name }}
+        working-directory: ${{ matrix.package_dir }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/package-node-runtime"
+          npm pack --json --pack-destination "$RUNNER_TEMP/package-node-runtime"
+      - name: Use declared package runtime
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node_version }}
+      - name: Install packed artifact and exercise public API
+        run: >-
+          node scripts/release/check-package-node-runtime.mjs
+          --package-dir ${{ matrix.package_dir }}
+          --tarball-dir "$RUNNER_TEMP/package-node-runtime"
+
   verify-static:
     needs: plan
     if: >-
@@ -460,6 +510,7 @@ jobs:
       - plan
       - verify-routed
       - verify-contract
+      - verify-package-node-runtime
       - verify-static
       - verify-unit
       - verify-cli-critical
@@ -493,6 +544,7 @@ jobs:
           (
             (
               needs.plan.outputs.core == 'true' &&
+              needs.verify-package-node-runtime.result == 'success' &&
               (
                 needs.verify-routed.result == 'success' ||
                 (
@@ -570,6 +622,7 @@ jobs:
       - plan
       - verify-routed
       - verify-contract
+      - verify-package-node-runtime
       - verify-static
       - verify-unit
       - verify-cli-critical
@@ -595,6 +648,7 @@ jobs:
           echo "changed_files_count=${{ needs.plan.outputs.changed_files_count }}"
           echo "verify-routed=${{ needs.verify-routed.result }}"
           echo "verify-contract=${{ needs.verify-contract.result }}"
+          echo "verify-package-node-runtime=${{ needs.verify-package-node-runtime.result }}"
           echo "verify-static=${{ needs.verify-static.result }}"
           echo "verify-unit=${{ needs.verify-unit.result }}"
           echo "verify-cli-critical=${{ needs.verify-cli-critical.result }}"
@@ -617,6 +671,7 @@ jobs:
             echo
             echo "- verify-routed: ${{ needs.verify-routed.result }}"
             echo "- verify-contract: ${{ needs.verify-contract.result }}"
+            echo "- verify-package-node-runtime: ${{ needs.verify-package-node-runtime.result }}"
             echo "- verify-static: ${{ needs.verify-static.result }}"
             echo "- verify-unit: ${{ needs.verify-unit.result }}"
             echo "- verify-cli-critical: ${{ needs.verify-cli-critical.result }}"
@@ -646,6 +701,8 @@ jobs:
           if [ "${{ needs.plan.outputs.core }}" != "true" ]; then
             exit 0
           fi
+
+          [ "${{ needs.verify-package-node-runtime.result }}" = "success" ]
 
           if [ "${{ needs.verify-routed.result }}" = "success" ]; then
             exit 0

--- a/docs/developer/cli-contract.mdx
+++ b/docs/developer/cli-contract.mdx
@@ -29,20 +29,22 @@ Scoped global flags (`--json-errors`, `--allow-network`) are recognized only bef
 - `agentplane help --json` emits JSON help output and does not enable JSON error mode.
 - `agentplane task list --json-errors` treats `--json-errors` as a command flag candidate, not global mode.
 
+### 1.2 Node runtime support
+
+The `agentplane` CLI requires Node.js 24 or newer. The separately published library packages retain
+their wider runtime contracts: `@agentplaneorg/core` requires Node.js 20.5.0 or newer, and
+`@agentplaneorg/recipes` requires Node.js 20 or newer.
+
+CI builds and packs both library artifacts on Node.js 24, then installs and exercises every public
+export from those tarballs on both the declared minimum runtime and Node.js 24. Package manifests
+remain the source of truth for the engine ranges.
+
 ## 2) Exit codes
 
-The CLI uses stable exit codes for common failure classes:
-
-| Code | Meaning                                                         |
-| ---: | --------------------------------------------------------------- |
-|    0 | Success                                                         |
-|    2 | Usage error (invalid args, missing required args)               |
-|    3 | Validation error (schema/invariants)                            |
-|    4 | Filesystem / IO error                                           |
-|    5 | Git / workflow guardrail error                                  |
-|    6 | Backend error (local or remote backend)                         |
-|    7 | Network error (only for commands that explicitly allow network) |
-|    1 | Any other error (unexpected/unclassified)                       |
+The CLI uses stable exit codes for success and every classified failure family. The exhaustive
+code list and error-code mapping are generated from runtime metadata in the
+[CLI reference](../user/cli-reference.generated#runtime-error-contract). Do not maintain a second
+handwritten mapping in documentation.
 
 ## 3) `--json-errors` format
 
@@ -64,9 +66,10 @@ When `--json-errors` is provided and a command fails, the CLI prints one JSON ob
 Rules:
 
 - JSON errors are written to stdout; human-readable diagnostics go to stderr only when `--json-errors` is not set.
-- `error.code` is a stable string enum (`E_USAGE`, `E_VALIDATION`, `E_IO`, `E_GIT`, `E_BACKEND`, `E_NETWORK`, `E_INTERNAL`).
+- `error.code` is a stable string enum; the exhaustive enum and exit-code mapping are generated in the [CLI reference](../user/cli-reference.generated#error-codes).
 - `context` is optional and must not include secrets.
-- No additional keys are emitted; the schema is exact.
+- State, remediation, next-action, and reason-decoding fields are optional and omitted when unavailable.
+- Field names, nesting, and casing are exact. The generated [JSON error envelope reference](../user/cli-reference.generated#json-error-envelope) is canonical.
 
 ## 4) `--output json` success envelope (`agent_json_v1`)
 
@@ -139,6 +142,12 @@ This split keeps `agentplane help` fast and reduces accidental startup cost from
 
 - Parser and global flags:
   - `packages/agentplane/src/cli/run-cli.ts`
+- Error codes and JSON error envelope metadata:
+  - `packages/agentplane/src/shared/errors.ts`
+- Exit-code metadata and error mapping:
+  - `packages/agentplane/src/cli/exit-codes.ts`
+- Generated runtime and command reference renderer:
+  - `packages/agentplane/src/cli/spec/docs-render.ts`
 - Help/role guide text:
   - `packages/agentplane/src/cli/command-guide.ts`
 - Startup guide source:

--- a/docs/user/cli-reference.generated.mdx
+++ b/docs/user/cli-reference.generated.mdx
@@ -1,6 +1,55 @@
 # CLI Reference (Generated)
 
-This page is generated from the CLI command specs. Do not edit it by hand; edit the specs instead.
+This page is generated from CLI command specs and runtime error metadata. Do not edit it by hand; edit those sources instead.
+
+## Runtime error contract
+
+The following reference is generated from the runtime error and exit-code metadata.
+
+### Exit codes
+
+- `0` — Success: Command completed successfully.
+- `1` — Internal: Unexpected or unclassified failure.
+- `2` — Usage: Invalid or incomplete command invocation.
+- `3` — Validation: Input, schema, or repository invariant validation failed.
+- `4` — IO: Filesystem or other local IO operation failed.
+- `5` — Git: Git operation or workflow guardrail failed.
+- `6` — Backend: Configured task backend failed.
+- `7` — Network: Explicitly requested network operation failed.
+- `8` — Runtime: Selected runtime or provider failed.
+- `9` — Handoff: Task or agent handoff failed.
+
+### JSON error envelope
+
+- Root field: `error`.
+- Required error fields: `code`, `message`.
+- Optional error fields: `context`, `state`, `likely_cause`, `hint`, `remediation`, `next_action`, `reason_decode`.
+- `remediation` required fields: `code`, `why`, `fix`, `safe_command`, `stop_condition`.
+- `next_action` required fields: `command`, `reason`; optional fields: `reasonCode`.
+- `reason_decode` required fields: `code`, `category`, `summary`, `action`.
+
+Field names and casing are exact. Optional fields are omitted when no value is available.
+
+### Error codes
+
+- `E_USAGE` → exit `2`: Command invocation is incomplete or invalid.
+- `E_DEPRECATED_FLAG` → exit `2`: A deprecated or disabled flag was used.
+- `E_VALIDATION` → exit `3`: Input, schema, or repository invariants failed validation.
+- `E_IO` → exit `4`: A filesystem or other local IO operation failed.
+- `E_COMMIT_ALLOW_EMPTY` → exit `2`: A commit path override did not select any paths.
+- `E_COMMIT_ALLOW_NO_MATCH` → exit `2`: A commit path override matched no eligible paths.
+- `E_COMMIT_ALLOW_TASK_ARTIFACT_DENIED` → exit `2`: A commit attempted to include a protected task artifact without authorization.
+- `E_PHASE_POLICY` → exit `2`: The requested lifecycle transition is blocked by policy.
+- `E_GIT` → exit `5`: A Git operation or workflow guardrail failed.
+- `E_GIT_LOCKED` → exit `5`: Git state is locked by another operation.
+- `E_GIT_PERMISSION` → exit `5`: Git could not access a required path or repository resource.
+- `E_GIT_RACE` → exit `5`: Git state changed while the command was executing.
+- `E_GIT_STAGE_FAILED` → exit `5`: Git could not stage the requested paths.
+- `E_BACKEND` → exit `6`: The configured task backend failed.
+- `E_NETWORK` → exit `7`: An explicitly requested network operation failed.
+- `E_RUNTIME` → exit `8`: The selected runtime or provider failed.
+- `E_HANDOFF` → exit `9`: A task or agent handoff failed.
+- `E_INTERNAL` → exit `1`: An unexpected or unclassified AgentPlane failure occurred.
 
 ## Index
 

--- a/packages/agentplane/src/cli/cli-contract.test.ts
+++ b/packages/agentplane/src/cli/cli-contract.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { ERROR_TO_EXIT, ExitCode, exitCodeForError } from "./exit-codes.js";
+import { ERROR_CODE_SUMMARIES } from "../shared/errors.js";
+import { ERROR_TO_EXIT, EXIT_CODE_CONTRACT, ExitCode, exitCodeForError } from "./exit-codes.js";
 
 describe("cli contract exit codes", () => {
   it("maps error codes to documented exit codes", () => {
@@ -26,5 +27,68 @@ describe("cli contract exit codes", () => {
     });
     expect(exitCodeForError("E_USAGE")).toBe(ExitCode.Usage);
     expect(exitCodeForError("E_INTERNAL")).toBe(ExitCode.Internal);
+  });
+
+  it("publishes one exhaustive runtime metadata inventory", () => {
+    expect(EXIT_CODE_CONTRACT).toEqual([
+      { code: 0, name: "Success", meaning: "Command completed successfully." },
+      {
+        code: ExitCode.Internal,
+        name: "Internal",
+        meaning: "Unexpected or unclassified failure.",
+      },
+      {
+        code: ExitCode.Usage,
+        name: "Usage",
+        meaning: "Invalid or incomplete command invocation.",
+      },
+      {
+        code: ExitCode.Validation,
+        name: "Validation",
+        meaning: "Input, schema, or repository invariant validation failed.",
+      },
+      {
+        code: ExitCode.Io,
+        name: "IO",
+        meaning: "Filesystem or other local IO operation failed.",
+      },
+      {
+        code: ExitCode.Git,
+        name: "Git",
+        meaning: "Git operation or workflow guardrail failed.",
+      },
+      {
+        code: ExitCode.Backend,
+        name: "Backend",
+        meaning: "Configured task backend failed.",
+      },
+      {
+        code: ExitCode.Network,
+        name: "Network",
+        meaning: "Explicitly requested network operation failed.",
+      },
+      {
+        code: ExitCode.Runtime,
+        name: "Runtime",
+        meaning: "Selected runtime or provider failed.",
+      },
+      {
+        code: ExitCode.Handoff,
+        name: "Handoff",
+        meaning: "Task or agent handoff failed.",
+      },
+    ]);
+    expect(Object.keys(ERROR_CODE_SUMMARIES)).toEqual(Object.keys(ERROR_TO_EXIT));
+    expect([...new Set(Object.values(ERROR_TO_EXIT))].toSorted()).toEqual([
+      ExitCode.Internal,
+      ExitCode.Usage,
+      ExitCode.Validation,
+      ExitCode.Io,
+      ExitCode.Git,
+      ExitCode.Backend,
+      ExitCode.Network,
+      ExitCode.Runtime,
+      ExitCode.Handoff,
+    ]);
   });
 });

--- a/packages/agentplane/src/cli/exit-codes.ts
+++ b/packages/agentplane/src/cli/exit-codes.ts
@@ -12,6 +12,27 @@ export enum ExitCode {
   Handoff = 9,
 }
 
+export const EXIT_CODE_CONTRACT = [
+  { code: 0, name: "Success", meaning: "Command completed successfully." },
+  { code: ExitCode.Internal, name: "Internal", meaning: "Unexpected or unclassified failure." },
+  { code: ExitCode.Usage, name: "Usage", meaning: "Invalid or incomplete command invocation." },
+  {
+    code: ExitCode.Validation,
+    name: "Validation",
+    meaning: "Input, schema, or repository invariant validation failed.",
+  },
+  { code: ExitCode.Io, name: "IO", meaning: "Filesystem or other local IO operation failed." },
+  { code: ExitCode.Git, name: "Git", meaning: "Git operation or workflow guardrail failed." },
+  { code: ExitCode.Backend, name: "Backend", meaning: "Configured task backend failed." },
+  {
+    code: ExitCode.Network,
+    name: "Network",
+    meaning: "Explicitly requested network operation failed.",
+  },
+  { code: ExitCode.Runtime, name: "Runtime", meaning: "Selected runtime or provider failed." },
+  { code: ExitCode.Handoff, name: "Handoff", meaning: "Task or agent handoff failed." },
+] as const;
+
 export const ERROR_TO_EXIT: Readonly<Record<ErrorCode, ExitCode>> = {
   E_USAGE: DEFAULT_ERROR_EXIT_CODES.E_USAGE,
   E_DEPRECATED_FLAG: DEFAULT_ERROR_EXIT_CODES.E_DEPRECATED_FLAG,

--- a/packages/agentplane/src/cli/run-cli.core.docs-cli.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.docs-cli.test.ts
@@ -50,6 +50,9 @@ describe("runCli docs cli", () => {
 
       const text = await readFile(outPath, "utf8");
       expect(text).toContain("# CLI Reference (Generated)");
+      expect(text).toContain("## Runtime error contract");
+      expect(text).toContain("`E_RUNTIME` → exit `8`");
+      expect(text).toContain("`E_HANDOFF` → exit `9`");
       expect(text).toContain("## Task");
       expect(text).toContain("### task new");
       expect(text).toContain("### task begin");

--- a/packages/agentplane/src/cli/run-cli.critical.agent-efficiency-baseline.test.ts
+++ b/packages/agentplane/src/cli/run-cli.critical.agent-efficiency-baseline.test.ts
@@ -166,11 +166,15 @@ describeCritical("critical: v0.7 compatibility and agent-efficiency baselines", 
           "202607221846-YGWMA2",
           "202607230554-YFYT83",
           "202607221846-9XC1H0",
+          "202607221848-ABG7SD",
         ],
         candidate: {
-          surface_sha256: "174782f185b73b4356df5e8e33ce722af7fb33b3e023d6460e1d498db3751dbd",
+          surface_sha256: "57b789caa3dcaf39a6e0d0fa8afd7dbd2bd3aa75304ebe80617f59aa2b49eb40",
           section_digests: {
             cli_topology: "ba9b2aa5ec996c1cab5ccc64ecc0796a2381157442d44f73b6472a5406c75cda",
+            machine_output_contract:
+              "dbff2a7806819a57a7d036fd087be05af0e0f35cdb4506226b8a38fcad75b6d1",
+            package_manifests: "2a2e2668620dd74fe0f79818798434b89b80253f86c1a3d48f8ca8307fbfc76a",
           },
         },
         contract_artifacts: {

--- a/packages/agentplane/src/cli/spec/docs-render.test.ts
+++ b/packages/agentplane/src/cli/spec/docs-render.test.ts
@@ -25,4 +25,23 @@ describe("renderCliDocsMdx", () => {
     expect(mdx).toContain("### task doc show");
     expect(mdx).toContain("### task doc set");
   });
+
+  it("renders the runtime error contract from canonical metadata", () => {
+    const mdx = renderCliDocsMdx([spec(["task", "show"])]);
+
+    expect(mdx).toContain("## Runtime error contract");
+    expect(mdx).toContain("`0` — Success");
+    expect(mdx).toContain("`8` — Runtime");
+    expect(mdx).toContain("`9` — Handoff");
+    expect(mdx).toContain("Required error fields: `code`, `message`.");
+    expect(mdx).toContain(
+      "Optional error fields: `context`, `state`, `likely_cause`, `hint`, `remediation`, `next_action`, `reason_decode`.",
+    );
+    expect(mdx).toContain(
+      "`next_action` required fields: `command`, `reason`; optional fields: `reasonCode`.",
+    );
+    expect(mdx).toContain("`E_RUNTIME` → exit `8`");
+    expect(mdx).toContain("`E_HANDOFF` → exit `9`");
+    expect(mdx).toContain("`E_COMMIT_ALLOW_TASK_ARTIFACT_DENIED` → exit `2`");
+  });
 });

--- a/packages/agentplane/src/cli/spec/docs-render.ts
+++ b/packages/agentplane/src/cli/spec/docs-render.ts
@@ -1,4 +1,11 @@
 import type { HelpJson } from "./help-render.js";
+import {
+  DEFAULT_ERROR_EXIT_CODES,
+  ERROR_CODE_SUMMARIES,
+  JSON_ERROR_CONTRACT,
+  type ErrorCode,
+} from "../../shared/errors.js";
+import { EXIT_CODE_CONTRACT } from "../exit-codes.js";
 
 const DOCS_GROUP_ORDER = new Map<string, number>([
   ["Core", 10],
@@ -96,6 +103,52 @@ function isVisibleOption(option: NonNullable<HelpJson["options"]>[number]): bool
   return option.hidden !== true && option.deprecated !== "disabled";
 }
 
+function codeList(values: readonly string[]): string {
+  return values.map((value) => `\`${value}\``).join(", ");
+}
+
+function renderRuntimeErrorContract(): string[] {
+  const exitCodeLines = EXIT_CODE_CONTRACT.map(
+    ({ code, name, meaning }) => `- \`${code}\` — ${name}: ${meaning}`,
+  );
+  const errorCodeLines = (Object.keys(ERROR_CODE_SUMMARIES) as ErrorCode[]).map(
+    (code) =>
+      `- \`${code}\` → exit \`${DEFAULT_ERROR_EXIT_CODES[code]}\`: ${ERROR_CODE_SUMMARIES[code]}`,
+  );
+  const nestedObjectLines = Object.entries(JSON_ERROR_CONTRACT.nestedObjects).map(
+    ([field, contract]) => {
+      const optional =
+        contract.optionalFields.length === 0
+          ? ""
+          : `; optional fields: ${codeList(contract.optionalFields)}`;
+      return `- \`${field}\` required fields: ${codeList(contract.requiredFields)}${optional}.`;
+    },
+  );
+
+  return [
+    "## Runtime error contract",
+    "",
+    "The following reference is generated from the runtime error and exit-code metadata.",
+    "",
+    "### Exit codes",
+    "",
+    ...exitCodeLines,
+    "",
+    "### JSON error envelope",
+    "",
+    `- Root field: \`${JSON_ERROR_CONTRACT.rootField}\`.`,
+    `- Required error fields: ${codeList(JSON_ERROR_CONTRACT.error.requiredFields)}.`,
+    `- Optional error fields: ${codeList(JSON_ERROR_CONTRACT.error.optionalFields)}.`,
+    ...nestedObjectLines,
+    "",
+    "Field names and casing are exact. Optional fields are omitted when no value is available.",
+    "",
+    "### Error codes",
+    "",
+    ...errorCodeLines,
+  ];
+}
+
 export function renderCliDocsMdx(specs: readonly HelpJson[]): string {
   const actionableSpecs = specs.filter((spec) => !isGroupOnlyCommand(spec, specs));
   const byGroup = new Map<string, readonly HelpJson[]>();
@@ -189,7 +242,9 @@ export function renderCliDocsMdx(specs: readonly HelpJson[]): string {
   const lines = [
     "# CLI Reference (Generated)",
     "",
-    "This page is generated from the CLI command specs. Do not edit it by hand; edit the specs instead.",
+    "This page is generated from CLI command specs and runtime error metadata. Do not edit it by hand; edit those sources instead.",
+    "",
+    ...renderRuntimeErrorContract(),
     "",
     "## Index",
     "",

--- a/packages/agentplane/src/commands/release/ci-workflow-contract.test.ts
+++ b/packages/agentplane/src/commands/release/ci-workflow-contract.test.ts
@@ -121,7 +121,7 @@ describe("Core CI workflow contract", () => {
     const workflow = await readFile(CI_WORKFLOW_PATH, "utf8");
 
     expect(workflow).toContain(
-      "(\n              needs.plan.outputs.core == 'true' &&\n              (\n                needs.verify-routed.result == 'success' ||\n                (\n                  needs.verify-contract.result == 'success' &&\n                  needs.verify-static.result == 'success' &&\n                  needs.verify-unit.result == 'success' &&\n                  needs.verify-cli-critical.result == 'success' &&\n                  needs.verify-workflow.result == 'success' &&\n                  needs.verify-coverage.result == 'success' &&\n                  needs.test-windows.result == 'success'\n                )\n              )\n            ) ||\n            needs.plan.outputs.core != 'true'",
+      "(\n              needs.plan.outputs.core == 'true' &&\n              needs.verify-package-node-runtime.result == 'success' &&\n              (\n                needs.verify-routed.result == 'success' ||\n                (\n                  needs.verify-contract.result == 'success' &&\n                  needs.verify-static.result == 'success' &&\n                  needs.verify-unit.result == 'success' &&\n                  needs.verify-cli-critical.result == 'success' &&\n                  needs.verify-workflow.result == 'success' &&\n                  needs.verify-coverage.result == 'success' &&\n                  needs.test-windows.result == 'success'\n                )\n              )\n            ) ||\n            needs.plan.outputs.core != 'true'",
     );
   });
 });

--- a/packages/agentplane/src/commands/release/workflow-node-version-contract.test.ts
+++ b/packages/agentplane/src/commands/release/workflow-node-version-contract.test.ts
@@ -2,10 +2,39 @@ import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
 
 const WORKFLOWS_DIR = path.resolve(process.cwd(), ".github/workflows");
-const ROOT_PACKAGE_PATH = path.resolve(process.cwd(), "package.json");
+const CI_WORKFLOW_PATH = path.join(WORKFLOWS_DIR, "ci.yml");
+const NODE_ENGINE_CONTRACTS = {
+  "package.json": ">=24",
+  "packages/agentplane/package.json": ">=24",
+  "packages/core/package.json": ">=20.5.0",
+  "packages/recipes/package.json": ">=20",
+  "website/package.json": ">=24",
+} as const;
 const DEPCRUISE_SCRIPT_PATH = path.resolve(process.cwd(), "scripts/checks/run-depcruise-arch.mjs");
+
+type WorkflowStep = {
+  name?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+  run?: string;
+};
+
+type WorkflowJob = {
+  needs?: string[];
+  steps?: WorkflowStep[];
+  strategy?: {
+    matrix?: {
+      include?: Record<string, unknown>[];
+    };
+  };
+};
+
+type WorkflowDocument = {
+  jobs?: Record<string, WorkflowJob>;
+};
 
 async function listWorkflowFiles(dir: string): Promise<string[]> {
   const entries = await readdir(dir, { withFileTypes: true });
@@ -24,27 +53,94 @@ async function listWorkflowFiles(dir: string): Promise<string[]> {
 }
 
 describe("workflow Node runtime contract", () => {
-  it("keeps actions/setup-node pinned to Node 24 across repository workflows", async () => {
+  it("keeps Node 20 selection isolated to the explicit package compatibility matrix", async () => {
     const workflowFiles = await listWorkflowFiles(WORKFLOWS_DIR);
     expect(workflowFiles.length).toBeGreaterThan(0);
+    let setupNodeSteps = 0;
 
     for (const workflowPath of workflowFiles) {
-      const workflow = await readFile(workflowPath, "utf8");
-      if (!workflow.includes("actions/setup-node@")) {
-        continue;
+      const workflow = parseYaml(await readFile(workflowPath, "utf8")) as WorkflowDocument;
+      for (const [jobId, job] of Object.entries(workflow.jobs ?? {})) {
+        for (const [stepIndex, step] of (job.steps ?? []).entries()) {
+          if (!step.uses?.startsWith("actions/setup-node@")) continue;
+          setupNodeSteps += 1;
+          const label = `${workflowPath} jobs.${jobId}.steps[${stepIndex}]`;
+          const nodeVersion = step.with?.["node-version"];
+          if (workflowPath === CI_WORKFLOW_PATH && jobId === "verify-package-node-runtime") {
+            expect(["24", "${{ matrix.node_version }}"], label).toContain(nodeVersion);
+          } else {
+            expect(nodeVersion, label).toBe("24");
+          }
+        }
       }
-      expect(workflow, workflowPath).toContain('node-version: "24"');
-      expect(workflow, workflowPath).not.toContain('node-version: "20"');
     }
+    expect(setupNodeSteps).toBeGreaterThan(0);
   });
 
-  it("allows the architecture gate on every runtime supported by the root engines contract", async () => {
-    const rootPackage = JSON.parse(await readFile(ROOT_PACKAGE_PATH, "utf8")) as {
-      engines?: { node?: string };
-    };
+  it("backs every advertised package range with packed-artifact runtime checks", async () => {
+    for (const [relativePath, expectedEngine] of Object.entries(NODE_ENGINE_CONTRACTS)) {
+      const packagePath = path.resolve(process.cwd(), relativePath);
+      const packageJson = JSON.parse(await readFile(packagePath, "utf8")) as {
+        engines?: { node?: string };
+      };
+      expect(packageJson.engines?.node, packagePath).toBe(expectedEngine);
+    }
+
+    const workflow = parseYaml(await readFile(CI_WORKFLOW_PATH, "utf8")) as WorkflowDocument;
+    const compatibilityJob = workflow.jobs?.["verify-package-node-runtime"];
+    expect(compatibilityJob?.strategy?.matrix?.include).toEqual([
+      {
+        package_name: "core",
+        package_dir: "packages/core",
+        node_version: "20.5.0",
+      },
+      {
+        package_name: "core",
+        package_dir: "packages/core",
+        node_version: "24",
+      },
+      {
+        package_name: "recipes",
+        package_dir: "packages/recipes",
+        node_version: "20.0.0",
+      },
+      {
+        package_name: "recipes",
+        package_dir: "packages/recipes",
+        node_version: "24",
+      },
+    ]);
+    const setupNodeVersions = (compatibilityJob?.steps ?? [])
+      .filter((step) => step.uses?.startsWith("actions/setup-node@"))
+      .map((step) => step.with?.["node-version"]);
+    expect(setupNodeVersions).toEqual(["24", "${{ matrix.node_version }}"]);
+    const commands = (compatibilityJob?.steps ?? []).map((step) => step.run ?? "").join("\n");
+    expect(commands).toContain("npm pack --json");
+    expect(commands).toContain("check-package-node-runtime.mjs");
+
+    const aggregateJob = workflow.jobs?.["pr-verification"];
+    expect(aggregateJob?.needs).toContain("verify-package-node-runtime");
+    const aggregateRun =
+      aggregateJob?.steps?.find((step) => step.name === "Evaluate aggregate verification")?.run ??
+      "";
+    const coreBypassIndex = aggregateRun.indexOf(
+      'if [ "${{ needs.plan.outputs.core }}" != "true" ]; then',
+    );
+    const packageRuntimeGateIndex = aggregateRun.indexOf(
+      '[ "${{ needs.verify-package-node-runtime.result }}" = "success" ]',
+    );
+    const routedEarlyExitIndex = aggregateRun.indexOf(
+      'if [ "${{ needs.verify-routed.result }}" = "success" ]; then',
+    );
+    expect(coreBypassIndex).toBeGreaterThanOrEqual(0);
+    expect(packageRuntimeGateIndex).toBeGreaterThan(coreBypassIndex);
+    expect(routedEarlyExitIndex).toBeGreaterThan(packageRuntimeGateIndex);
+    expect(aggregateRun).toContain(
+      'echo "- verify-package-node-runtime: ${{ needs.verify-package-node-runtime.result }}"',
+    );
+
     const depcruiseScript = await readFile(DEPCRUISE_SCRIPT_PATH, "utf8");
 
-    expect(rootPackage.engines?.node).toBe(">=24");
     expect(depcruiseScript).toContain("major < 24");
     expect(depcruiseScript).not.toContain("major !== 24");
     expect(depcruiseScript).toContain("requires Node >=24");

--- a/packages/agentplane/src/shared/errors.test.ts
+++ b/packages/agentplane/src/shared/errors.test.ts
@@ -11,6 +11,7 @@ import {
   RuntimeError,
   UsageError,
   ValidationError,
+  JSON_ERROR_CONTRACT,
   formatJsonError,
 } from "./errors.js";
 
@@ -106,5 +107,62 @@ describe("errors", () => {
     expect(json.error?.state).toBe("release apply cannot start from a dirty tracked tree");
     expect(json.error?.likely_cause).toBe("tracked edits already exist in the workspace");
     expect(json.error?.next_action?.command).toBe("git status --short --untracked-files=no");
+  });
+
+  it("keeps runtime JSON metadata aligned with the fully populated envelope", () => {
+    const json = JSON.parse(
+      formatJsonError(
+        new CliError({
+          code: "E_GIT",
+          message: "Git failed",
+          context: { command: "work start" },
+        }),
+        {
+          state: "base branch is stale",
+          likelyCause: "origin/main advanced",
+          hint: "Refresh the base branch.",
+          remediation: {
+            code: "stale_base",
+            why: "Starting from stale state can produce an invalid PR.",
+            fix: "Fast-forward the base branch.",
+            safeCommand: "git pull --ff-only",
+            stopCondition: "Stop if the pull is not a fast-forward.",
+          },
+          nextAction: Object.assign(
+            {
+              command: "git pull --ff-only",
+              reason: "refresh the base branch",
+              reasonCode: "stale_base",
+            },
+            { unexpected: "must not leak" },
+          ),
+          reasonDecode: Object.assign(
+            {
+              code: "stale_base",
+              category: "git",
+              summary: "base branch is behind its upstream",
+              action: "refresh the base branch",
+            },
+            { unexpected: "must not leak" },
+          ),
+        },
+      ),
+    ) as {
+      error: Record<string, unknown> & {
+        remediation: Record<string, unknown>;
+        next_action: Record<string, unknown>;
+        reason_decode: Record<string, unknown>;
+      };
+    };
+
+    expect(Object.keys(json)).toEqual([JSON_ERROR_CONTRACT.rootField]);
+    expect(Object.keys(json.error)).toEqual([
+      ...JSON_ERROR_CONTRACT.error.requiredFields,
+      ...JSON_ERROR_CONTRACT.error.optionalFields,
+    ]);
+    for (const [field, contract] of Object.entries(JSON_ERROR_CONTRACT.nestedObjects)) {
+      const nested = json.error[field] as Record<string, unknown>;
+      expect(Object.keys(nested)).toEqual([...contract.requiredFields, ...contract.optionalFields]);
+    }
   });
 });

--- a/packages/agentplane/src/shared/errors.ts
+++ b/packages/agentplane/src/shared/errors.ts
@@ -52,6 +52,58 @@ export const DEFAULT_ERROR_EXIT_CODES: Readonly<Record<ErrorCode, number>> = {
   E_INTERNAL: 1,
 };
 
+export const ERROR_CODE_SUMMARIES = {
+  E_USAGE: "Command invocation is incomplete or invalid.",
+  E_DEPRECATED_FLAG: "A deprecated or disabled flag was used.",
+  E_VALIDATION: "Input, schema, or repository invariants failed validation.",
+  E_IO: "A filesystem or other local IO operation failed.",
+  E_COMMIT_ALLOW_EMPTY: "A commit path override did not select any paths.",
+  E_COMMIT_ALLOW_NO_MATCH: "A commit path override matched no eligible paths.",
+  E_COMMIT_ALLOW_TASK_ARTIFACT_DENIED:
+    "A commit attempted to include a protected task artifact without authorization.",
+  E_PHASE_POLICY: "The requested lifecycle transition is blocked by policy.",
+  E_GIT: "A Git operation or workflow guardrail failed.",
+  E_GIT_LOCKED: "Git state is locked by another operation.",
+  E_GIT_PERMISSION: "Git could not access a required path or repository resource.",
+  E_GIT_RACE: "Git state changed while the command was executing.",
+  E_GIT_STAGE_FAILED: "Git could not stage the requested paths.",
+  E_BACKEND: "The configured task backend failed.",
+  E_NETWORK: "An explicitly requested network operation failed.",
+  E_RUNTIME: "The selected runtime or provider failed.",
+  E_HANDOFF: "A task or agent handoff failed.",
+  E_INTERNAL: "An unexpected or unclassified AgentPlane failure occurred.",
+} as const satisfies Readonly<Record<ErrorCode, string>>;
+
+export const JSON_ERROR_CONTRACT = {
+  rootField: "error",
+  error: {
+    requiredFields: ["code", "message"],
+    optionalFields: [
+      "context",
+      "state",
+      "likely_cause",
+      "hint",
+      "remediation",
+      "next_action",
+      "reason_decode",
+    ],
+  },
+  nestedObjects: {
+    remediation: {
+      requiredFields: ["code", "why", "fix", "safe_command", "stop_condition"],
+      optionalFields: [],
+    },
+    next_action: {
+      requiredFields: ["command", "reason"],
+      optionalFields: ["reasonCode"],
+    },
+    reason_decode: {
+      requiredFields: ["code", "category", "summary", "action"],
+      optionalFields: [],
+    },
+  },
+} as const;
+
 type AgentplaneErrorOptions = {
   message: string;
   exitCode?: number;
@@ -186,8 +238,21 @@ export function formatJsonError(err: CliError, guidance?: JsonErrorGuidance): st
               stop_condition: guidance.remediation.stopCondition,
             }
           : undefined,
-        next_action: guidance?.nextAction,
-        reason_decode: guidance?.reasonDecode,
+        next_action: guidance?.nextAction
+          ? {
+              command: guidance.nextAction.command,
+              reason: guidance.nextAction.reason,
+              reasonCode: guidance.nextAction.reasonCode,
+            }
+          : undefined,
+        reason_decode: guidance?.reasonDecode
+          ? {
+              code: guidance.reasonDecode.code,
+              category: guidance.reasonDecode.category,
+              summary: guidance.reasonDecode.summary,
+              action: guidance.reasonDecode.action,
+            }
+          : undefined,
       },
     },
     null,

--- a/scripts/baselines/v0.7-compatibility-candidate.json
+++ b/scripts/baselines/v0.7-compatibility-candidate.json
@@ -5,7 +5,8 @@
     "202607221846-4VB97J",
     "202607221846-YGWMA2",
     "202607230554-YFYT83",
-    "202607221846-9XC1H0"
+    "202607221846-9XC1H0",
+    "202607221848-ABG7SD"
   ],
   "base": {
     "baseline_id": "agentplane.compatibility.v0.6.24",
@@ -14,11 +15,11 @@
     "surface_sha256": "79d9462b114a65e0a5897ab1e40dbec424e6a79940e875b8e40c832805766839"
   },
   "candidate": {
-    "surface_sha256": "174782f185b73b4356df5e8e33ce722af7fb33b3e023d6460e1d498db3751dbd",
+    "surface_sha256": "57b789caa3dcaf39a6e0d0fa8afd7dbd2bd3aa75304ebe80617f59aa2b49eb40",
     "section_digests": {
       "cli_topology": "ba9b2aa5ec996c1cab5ccc64ecc0796a2381157442d44f73b6472a5406c75cda",
       "exit_error_contract": "ff4cae2b7920fe6c226a578dcb7463fdaf1fd3abe7fa55a111984c2fedf51653",
-      "machine_output_contract": "4b5a62135ada227eca13961e1ef3fbaaae269eea082375539a5c9fa085b9a613",
+      "machine_output_contract": "dbff2a7806819a57a7d036fd087be05af0e0f35cdb4506226b8a38fcad75b6d1",
       "workflow_schema": "41efbc04ff954b8a1bfc163235fe885068a837e7d55b4179da79126a9717e788",
       "agent_facing_context_contracts": "3dd1740625fb68fc6038d323a9320af5945a42ceb9fa2a6e2575e98e7f8182bf",
       "package_manifests": "2a2e2668620dd74fe0f79818798434b89b80253f86c1a3d48f8ca8307fbfc76a",
@@ -313,6 +314,27 @@
         "schema_id": "https://agentplane.dev/schemas/workflow.schema.json",
         "title": "Agentplane Workflow Contract",
         "supported_input_versions": [1, 2]
+      }
+    },
+    {
+      "section": "machine_output_contract",
+      "source_tasks": ["202607221848-ABG7SD"],
+      "from_sha256": "4b5a62135ada227eca13961e1ef3fbaaae269eea082375539a5c9fa085b9a613",
+      "to_sha256": "dbff2a7806819a57a7d036fd087be05af0e0f35cdb4506226b8a38fcad75b6d1",
+      "classification": "behavior_preserving_hardening",
+      "summary": "Projects next_action and reason_decode onto their documented keys so structurally compatible objects cannot leak undeclared fields; the published envelope schema and current payloads are unchanged.",
+      "evidence": {
+        "envelope_contract_unchanged": true,
+        "source_contract": {
+          "path": "packages/agentplane/src/shared/errors.ts",
+          "marker": "formatJsonError",
+          "from_sha256": "21224231c4b7e84e69432130463e188c960e1b0ae26a51f0305833b01de60562",
+          "to_sha256": "a8283f4bfb97f5c6333294c5ef36f8ff5209a786907b2c3871eeeea37854120a"
+        },
+        "projected_nested_fields": {
+          "next_action": ["command", "reason", "reasonCode"],
+          "reason_decode": ["code", "category", "summary", "action"]
+        }
       }
     },
     {

--- a/scripts/checks/check-compatibility-contract-baseline.mjs
+++ b/scripts/checks/check-compatibility-contract-baseline.mjs
@@ -309,12 +309,13 @@ function validateReviewedCandidate({
     candidate.candidate_id === "agentplane.compatibility.v0.7.cumulative",
     "compatibility candidate id drift",
   );
-  const expectedSourceTasks = [
+  const cliSourceTasks = [
     "202607221846-4VB97J",
     "202607221846-YGWMA2",
     "202607230554-YFYT83",
     "202607221846-9XC1H0",
   ];
+  const expectedSourceTasks = [...cliSourceTasks, "202607221848-ABG7SD"];
   assert(
     hashJson(candidate.source_tasks) === hashJson(expectedSourceTasks),
     "compatibility source task inventory drift",
@@ -481,7 +482,8 @@ function validateReviewedCandidate({
     );
   }
   const expectedDeltaSources = {
-    cli_topology: expectedSourceTasks,
+    cli_topology: cliSourceTasks,
+    machine_output_contract: ["202607221848-ABG7SD"],
     workflow_schema: ["202607221846-4VB97J"],
     tarball_policy: ["202607221846-4VB97J"],
   };
@@ -682,6 +684,42 @@ function validateReviewedCandidate({
   );
   assert(cliTopologyDelta.removed_options.length === 0, "candidate removes an existing CLI option");
   assert(cliTopologyDelta.mutated_options.length === 0, "candidate mutates an existing CLI option");
+
+  const machineOutputDelta = candidate.deltas.find(
+    (delta) => delta.section === "machine_output_contract",
+  );
+  const beforeJsonErrorSource = exactMainSurface.machine_output_contract.source_contracts.find(
+    (contract) => contract.marker === "formatJsonError",
+  );
+  const afterJsonErrorSource = currentSurface.machine_output_contract.source_contracts.find(
+    (contract) => contract.marker === "formatJsonError",
+  );
+  assert(beforeJsonErrorSource && afterJsonErrorSource, "formatJsonError source contract missing");
+  assert(
+    machineOutputDelta?.classification === "behavior_preserving_hardening",
+    "machine output candidate classification drift",
+  );
+  assert(
+    hashJson(machineOutputDelta.evidence) ===
+      hashJson({
+        envelope_contract_unchanged:
+          hashJson(exactMainSurface.machine_output_contract.error_envelope) ===
+            hashJson(currentSurface.machine_output_contract.error_envelope) &&
+          hashJson(exactMainSurface.machine_output_contract.success_envelope) ===
+            hashJson(currentSurface.machine_output_contract.success_envelope),
+        source_contract: {
+          path: afterJsonErrorSource.path,
+          marker: afterJsonErrorSource.marker,
+          from_sha256: beforeJsonErrorSource.normalized_sha256,
+          to_sha256: afterJsonErrorSource.normalized_sha256,
+        },
+        projected_nested_fields: {
+          next_action: ["command", "reason", "reasonCode"],
+          reason_decode: ["code", "category", "summary", "action"],
+        },
+      }),
+    "machine output candidate evidence drift",
+  );
 
   const schemaDelta = candidate.deltas.find((delta) => delta.section === "workflow_schema");
   const workflowSchema = JSON.parse(

--- a/scripts/release/check-local-tarball-install-smoke.mjs
+++ b/scripts/release/check-local-tarball-install-smoke.mjs
@@ -1,5 +1,6 @@
-import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -11,9 +12,120 @@ function run(command, args, opts = {}) {
   return execFileSync(command, args, {
     cwd: opts.cwd ?? process.cwd(),
     encoding: "utf8",
-    env: opts.env ?? process.env,
+    env: {
+      ...process.env,
+      AGENTPLANE_NO_UPDATE_CHECK: "1",
+      ...(opts.env ?? {}),
+    },
     stdio: opts.stdio ?? ["ignore", "pipe", "pipe"],
   });
+}
+
+function runFailure(command, args, opts = {}) {
+  const result = spawnSync(command, args, {
+    cwd: opts.cwd ?? process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      AGENTPLANE_NO_UPDATE_CHECK: "1",
+      ...(opts.env ?? {}),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) throw result.error;
+  assert.notEqual(result.status, 0, `${command} ${args.join(" ")} unexpectedly succeeded`);
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function assertOnlyContractFields(value, contract, label) {
+  assert.ok(
+    value && typeof value === "object" && !Array.isArray(value),
+    `${label} must be an object`,
+  );
+  const required = new Set(contract.requiredFields);
+  const allowed = new Set([...contract.requiredFields, ...contract.optionalFields]);
+  for (const field of required) {
+    assert.ok(Object.hasOwn(value, field), `${label}.${field} is required`);
+  }
+  for (const field of Object.keys(value)) {
+    assert.ok(
+      allowed.has(field),
+      `${label}.${field} is not part of the installed runtime contract`,
+    );
+  }
+}
+
+function assertJsonFailure(result, expected, contract) {
+  assert.equal(result.status, expected.exitCode, result.stderr || result.stdout);
+  assert.equal(result.stderr.trim(), "", "JSON error mode must not emit human diagnostics");
+
+  const envelope = JSON.parse(result.stdout);
+  assert.deepEqual(Object.keys(envelope), [contract.rootField]);
+  const error = envelope[contract.rootField];
+  assertOnlyContractFields(error, contract.error, contract.rootField);
+  assert.equal(error.code, expected.code);
+  assert.equal(typeof error.message, "string");
+  if (expected.messageIncludes) {
+    assert.match(error.message, new RegExp(expected.messageIncludes, "u"));
+  }
+  if (expected.fields) {
+    assert.deepEqual(
+      Object.keys(error),
+      expected.fields,
+      `${expected.code} emitted an unexpected JSON field set`,
+    );
+  }
+  for (const [field, nestedContract] of Object.entries(contract.nestedObjects)) {
+    if (error[field] !== undefined) {
+      assertOnlyContractFields(error[field], nestedContract, `${contract.rootField}.${field}`);
+    }
+  }
+  for (const [field, expectedFields] of Object.entries(expected.nestedFields ?? {})) {
+    assert.deepEqual(
+      Object.keys(error[field] ?? {}),
+      expectedFields,
+      `${expected.code}.${field} emitted an unexpected field set`,
+    );
+  }
+}
+
+function parseCodeList(value) {
+  return [...value.matchAll(/`([^`]+)`/gu)].map((match) => match[1]);
+}
+
+function parseInstalledJsonErrorContract(reference) {
+  const root = /^- Root field: `([^`]+)`\.$/mu.exec(reference);
+  const required = /^- Required error fields: (.+)\.$/mu.exec(reference);
+  const optional = /^- Optional error fields: (.+)\.$/mu.exec(reference);
+  assert.ok(root, "installed reference omits the JSON error root field");
+  assert.ok(required, "installed reference omits required JSON error fields");
+  assert.ok(optional, "installed reference omits optional JSON error fields");
+
+  const nestedObjects = {};
+  const nestedPattern = /^- `([^`]+)` required fields: (.+?)(?:; optional fields: (.+?))?\.$/gmu;
+  for (const match of reference.matchAll(nestedPattern)) {
+    nestedObjects[match[1]] = {
+      requiredFields: parseCodeList(match[2]),
+      optionalFields: match[3] ? parseCodeList(match[3]) : [],
+    };
+  }
+  assert.ok(
+    Object.keys(nestedObjects).length > 0,
+    "installed reference omits nested error objects",
+  );
+
+  return {
+    rootField: root[1],
+    error: {
+      requiredFields: parseCodeList(required[1]),
+      optionalFields: parseCodeList(optional[1]),
+    },
+    nestedObjects,
+  };
 }
 
 function npmPack(packageDir, outDir, cacheDir) {
@@ -68,6 +180,14 @@ const main = defineScript({
       run(agentplane, ["--help"]);
       run(ap, ["--version"]);
       run(ap, ["help"]);
+      const installedReference = path.join(tempRoot, "installed-cli-reference.mdx");
+      run(agentplane, ["docs", "cli", "--out", installedReference]);
+      const installedReferenceText = readFileSync(installedReference, "utf8");
+      assert.match(installedReferenceText, /## Runtime error contract/u);
+      assert.match(installedReferenceText, /`E_RUNTIME` → exit `8`/u);
+      assert.match(installedReferenceText, /`E_HANDOFF` → exit `9`/u);
+      assert.match(installedReferenceText, /Required error fields: `code`, `message`\./u);
+      const installedJsonErrorContract = parseInstalledJsonErrorContract(installedReferenceText);
 
       run("git", ["init", "-q", "-b", "main", repo]);
       run("git", ["config", "user.name", "AgentPlane Smoke"], { cwd: repo });
@@ -75,7 +195,24 @@ const main = defineScript({
       writeFileSync(path.join(repo, "README.md"), "# Smoke\n", "utf8");
       run("git", ["add", "README.md"], { cwd: repo });
       run("git", ["commit", "-m", "seed"], { cwd: repo });
-      run(agentplane, ["init", "--yes"], { cwd: repo });
+      run(
+        agentplane,
+        [
+          "init",
+          "--yes",
+          "--setup-profile",
+          "light",
+          "--workflow",
+          "branch_pr",
+          "--backend",
+          "local",
+          "--hooks",
+          "false",
+          "--require-plan-approval",
+          "true",
+        ],
+        { cwd: repo },
+      );
       run(agentplane, ["context", "init"], { cwd: repo });
       mkdirSync(path.join(repo, "context", "raw", "smoke"), { recursive: true });
       writeFileSync(
@@ -88,6 +225,22 @@ const main = defineScript({
       });
       run(agentplane, ["context", "reindex", "--include-raw"], { cwd: repo });
       run(agentplane, ["context", "search", "Packaged", "--format", "json"], { cwd: repo });
+
+      assertJsonFailure(
+        runFailure(agentplane, ["--json-errors", "task", "show"], { cwd: repo }),
+        {
+          exitCode: 2,
+          code: "E_USAGE",
+          messageIncludes: "Missing required argument",
+          fields: ["code", "message", "context", "hint", "next_action", "reason_decode"],
+          nestedFields: {
+            next_action: ["command", "reason", "reasonCode"],
+            reason_decode: ["code", "category", "summary", "action"],
+          },
+        },
+        installedJsonErrorContract,
+      );
+
       const taskId = run(
         agentplane,
         [
@@ -108,6 +261,112 @@ const main = defineScript({
       ).trim();
       run(agentplane, ["task", "list"], { cwd: repo });
       run(agentplane, ["task", "show", taskId], { cwd: repo });
+
+      assertJsonFailure(
+        runFailure(
+          agentplane,
+          [
+            "--json-errors",
+            "task",
+            "start-ready",
+            taskId,
+            "--author",
+            "CODER",
+            "--body",
+            "Start: exercise installed tarball policy failure behavior.",
+          ],
+          { cwd: repo },
+        ),
+        {
+          exitCode: 2,
+          code: "E_PHASE_POLICY",
+          messageIncludes: "cannot start implementation before plan approval",
+          fields: ["code", "message"],
+        },
+        installedJsonErrorContract,
+      );
+
+      run(
+        agentplane,
+        [
+          "task",
+          "plan",
+          "set",
+          taskId,
+          "--text",
+          "1) Exercise installed contract failures\n2) Verify JSON envelopes and exit codes",
+          "--updated-by",
+          "ORCHESTRATOR",
+        ],
+        { cwd: repo },
+      );
+      run(
+        agentplane,
+        ["task", "plan", "approve", taskId, "--by", "ORCHESTRATOR", "--note", "Smoke plan"],
+        { cwd: repo },
+      );
+
+      run("git", ["remote", "add", "origin", "."], { cwd: repo });
+      run("git", ["config", "branch.main.remote", "origin"], { cwd: repo });
+      run("git", ["config", "branch.main.merge", "refs/heads/main"], { cwd: repo });
+      const baseTree = run("git", ["rev-parse", "HEAD^{tree}"], { cwd: repo }).trim();
+      const baseCommit = run("git", ["rev-parse", "HEAD"], { cwd: repo }).trim();
+      const upstreamCommit = run(
+        "git",
+        ["commit-tree", baseTree, "-p", baseCommit, "-m", "upstream smoke advance"],
+        { cwd: repo },
+      ).trim();
+      run("git", ["update-ref", "refs/remotes/origin/main", upstreamCommit], { cwd: repo });
+
+      assertJsonFailure(
+        runFailure(
+          agentplane,
+          [
+            "--json-errors",
+            "work",
+            "start",
+            taskId,
+            "--agent",
+            "CODER",
+            "--slug",
+            "stale-base",
+            "--worktree",
+          ],
+          { cwd: repo },
+        ),
+        {
+          exitCode: 5,
+          code: "E_GIT",
+          messageIncludes: "behind its upstream origin/main",
+          fields: ["code", "message", "hint", "next_action", "reason_decode"],
+          nestedFields: {
+            next_action: ["command", "reason", "reasonCode"],
+            reason_decode: ["code", "category", "summary", "action"],
+          },
+        },
+        installedJsonErrorContract,
+      );
+
+      assertJsonFailure(
+        runFailure(
+          agentplane,
+          [
+            "--json-errors",
+            "workflow",
+            "migrate",
+            "--rollback",
+            ".agentplane/workflows/migrations/missing-smoke-receipt.json",
+          ],
+          { cwd: repo },
+        ),
+        {
+          exitCode: 1,
+          code: "E_INTERNAL",
+          messageIncludes: "ENOENT",
+          fields: ["code", "message", "context"],
+        },
+        installedJsonErrorContract,
+      );
 
       process.stdout.write(`local tarball install smoke OK (${taskId})\n`);
     } finally {

--- a/scripts/release/check-package-node-runtime.mjs
+++ b/scripts/release/check-package-node-runtime.mjs
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { defineCheck, parseScriptArgs, runScriptMain } from "../lib/script-runtime.mjs";
+
+const SUPPORTED_PACKAGES = new Set(["packages/core", "packages/recipes"]);
+
+function parseArgs(argv) {
+  const { flags, positionals } = parseScriptArgs(argv, {
+    valueFlags: ["package-dir", "tarball-dir"],
+  });
+  if (positionals.length > 0) {
+    throw new Error(`unexpected positional arguments: ${positionals.join(" ")}`);
+  }
+  if (!flags["package-dir"] || !flags["tarball-dir"]) {
+    throw new Error("--package-dir and --tarball-dir are required");
+  }
+  if (!SUPPORTED_PACKAGES.has(flags["package-dir"])) {
+    throw new Error(`unsupported package directory: ${flags["package-dir"]}`);
+  }
+  return {
+    packageDir: flags["package-dir"],
+    tarballDir: path.resolve(flags["tarball-dir"]),
+  };
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function minimumNodeVersion(engine) {
+  const match = /^>=\s*(\d+)(?:\.(\d+))?(?:\.(\d+))?$/u.exec(engine);
+  if (!match) throw new Error(`unsupported Node engine contract: ${engine}`);
+  return match.slice(1, 4).map((value) => Number.parseInt(value ?? "0", 10));
+}
+
+function compareVersions(left, right) {
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] !== right[index]) return left[index] - right[index];
+  }
+  return 0;
+}
+
+function importTarget(value) {
+  if (typeof value === "string") return value;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return typeof value.import === "string"
+    ? value.import
+    : typeof value.default === "string"
+      ? value.default
+      : null;
+}
+
+async function importPublicExports(packageRoot, manifest) {
+  const imported = new Map();
+  for (const [subpath, value] of Object.entries(manifest.exports ?? {})) {
+    if (subpath === "./package.json") continue;
+    const target = importTarget(value);
+    assert.ok(target, `${manifest.name} ${subpath} omits an importable ESM target`);
+    const modulePath = path.resolve(packageRoot, target);
+    const namespace = await import(pathToFileURL(modulePath).href);
+    assert.ok(Object.keys(namespace).length > 0, `${manifest.name} ${subpath} exports nothing`);
+    imported.set(subpath, namespace);
+  }
+  assert.ok(imported.has("."), `${manifest.name} package root export is missing`);
+  return imported;
+}
+
+function exercisePublicApi(name, rootModule) {
+  if (name === "@agentplaneorg/core") {
+    assert.equal(typeof rootModule.defaultConfig, "function");
+    assert.equal(typeof rootModule.renderExecutionReceiptSchemaJson, "function");
+    const config = rootModule.defaultConfig();
+    assert.ok(
+      config.workflow_mode === "direct" || config.workflow_mode === "branch_pr",
+      "core defaultConfig returned an unsupported workflow mode",
+    );
+    const executionReceiptSchema = JSON.parse(rootModule.renderExecutionReceiptSchemaJson());
+    assert.equal(
+      executionReceiptSchema.$id,
+      "https://agentplane.org/schemas/execution-receipt.schema.json",
+    );
+    assert.equal(executionReceiptSchema.oneOf?.length, 2);
+    return;
+  }
+
+  assert.equal(name, "@agentplaneorg/recipes");
+  assert.equal(typeof rootModule.normalizeRecipeId, "function");
+  assert.equal(rootModule.normalizeRecipeId("  node-runtime-smoke  "), "node-runtime-smoke");
+  assert.equal(typeof rootModule.RECIPES_VERSION, "string");
+  assert.ok(rootModule.RECIPES_VERSION.length > 0, "recipes version is empty");
+}
+
+const main = defineCheck({
+  name: "check-package-node-runtime.mjs",
+  parseArgs,
+  async check({ cwd, options, stdout }) {
+    const sourceManifest = readJson(path.resolve(cwd, options.packageDir, "package.json"));
+    const engine = sourceManifest.engines?.node;
+    assert.equal(typeof engine, "string", `${sourceManifest.name} does not declare engines.node`);
+
+    const runtimeVersion = process.versions.node
+      .split(".")
+      .map((value) => Number.parseInt(value, 10));
+    assert.ok(
+      compareVersions(runtimeVersion, minimumNodeVersion(engine)) >= 0,
+      `Node ${process.versions.node} does not satisfy ${sourceManifest.name} engines.node=${engine}`,
+    );
+
+    const tarballs = readdirSync(options.tarballDir)
+      .filter((entry) => entry.endsWith(".tgz"))
+      .toSorted();
+    assert.equal(tarballs.length, 1, "tarball directory must contain exactly one .tgz artifact");
+    const tarballPath = path.join(options.tarballDir, tarballs[0]);
+    const installRoot = mkdtempSync(path.join(os.tmpdir(), "agentplane-node-runtime-"));
+
+    try {
+      writeFileSync(
+        path.join(installRoot, "package.json"),
+        `${JSON.stringify({ name: "agentplane-node-runtime-smoke", private: true }, null, 2)}\n`,
+        "utf8",
+      );
+      const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+      execFileSync(
+        npmCommand,
+        ["install", "--ignore-scripts", "--engine-strict", "--no-audit", "--no-fund", tarballPath],
+        {
+          cwd: installRoot,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            NPM_CONFIG_CACHE: path.join(installRoot, "npm-cache"),
+          },
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+
+      const packageRoot = path.join(
+        installRoot,
+        "node_modules",
+        ...String(sourceManifest.name).split("/"),
+      );
+      const installedManifest = readJson(path.join(packageRoot, "package.json"));
+      assert.equal(installedManifest.name, sourceManifest.name);
+      assert.equal(installedManifest.version, sourceManifest.version);
+      assert.equal(installedManifest.engines?.node, engine);
+
+      const publicExports = await importPublicExports(packageRoot, installedManifest);
+      exercisePublicApi(installedManifest.name, publicExports.get("."));
+      stdout.write(
+        `package Node runtime smoke OK (${installedManifest.name}@${installedManifest.version}; ` +
+          `node=${process.versions.node}; exports=${publicExports.size})\n`,
+      );
+    } finally {
+      rmSync(installRoot, { recursive: true, force: true });
+    }
+  },
+});
+
+runScriptMain(main);


### PR DESCRIPTION
Task: `202607221848-ABG7SD`
Title: Align CLI error, exit-code, and Node support contracts
Canonical task record: `.agentplane/tasks/202607221848-ABG7SD/README.md`

## Summary

Align CLI error, exit-code, and Node support contracts

Correct the verified drift between documented and runtime exit/error shapes, structured remediation fields, package engine ranges, and the CI support matrix before 0.7 compatibility is frozen.

## Scope

- In scope: one generated source for CLI exit codes and error payload documentation, guidance/remediation compatibility, installed-tarball fixtures, aligned Node engine declarations or an explicit tested matrix, and CI coverage for every supported runtime.
- Out of scope: changing unrelated command semantics or removing an existing error field without migration evidence.

## Verification

- State: pending
- Note: Not recorded yet.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-07-24T09:04:20.081Z
- Branch: task/202607221848-ABG7SD/align-cli-error-exit-code-and-node-support-contr
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
No changes detected.
```

</details>
