### PR TITLE
🧩 96WEYY task: Make RF-04 replay cleanup retry-safe on macOS [202607250037-96WEYY]

### DIFF
--- a/.agentplane/tasks/202607250037-96WEYY/README.md
+++ b/.agentplane/tasks/202607250037-96WEYY/README.md
@@ -4,7 +4,7 @@ title: "Make RF-04 replay cleanup retry-safe on macOS"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 7
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -24,11 +24,11 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: "Approved under the existing AgentPlane 0.7 authorization as a narrow release-reliability fix for a reproduced cleanup-only failure."
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
-  attempts: 0
+  state: "needs_rework"
+  updated_at: "2026-07-25T00:44:48.440Z"
+  updated_by: "TESTER"
+  note: "No implementation diff exists yet; the branch contains only lifecycle artifacts."
+  attempts: 1
 commit: null
 comments:
   -
@@ -42,8 +42,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: make RF-04 replay cleanup retry-safe without changing frozen evidence."
+  -
+    type: "verify"
+    at: "2026-07-25T00:44:48.440Z"
+    author: "TESTER"
+    state: "needs_rework"
+    note: "No implementation diff exists yet; the branch contains only lifecycle artifacts."
 doc_version: 3
-doc_updated_at: "2026-07-25T00:43:04.222Z"
+doc_updated_at: "2026-07-25T00:44:48.777Z"
 doc_updated_by: "CODER"
 description: "Prevent Finder-created .DS_Store files from turning successful RF-04 offline replay assertions into cleanup-only ENOTEMPTY failures. Keep the frozen 50-run/55-provider-episode evidence unchanged and add deterministic cleanup regression coverage."
 sections:
@@ -62,11 +68,44 @@ sections:
     4. Run `bun run test:critical`, `bun run typecheck`, scoped ESLint, Prettier, routing, hotspot, and task-lint gates. Expected: all product assertions pass; no provider/model calls are made.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-07-25T00:44:48.440Z — VERIFY — needs_rework
+
+    By: TESTER
+
+    Note: No implementation diff exists yet; the branch contains only lifecycle artifacts.
+    Attempts: 1
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-25T00:43:04.222Z, excerpt_hash=sha256:ce52142cae84398119276adf38634f5a5ab92fdbf2f92e6d361d2053deb7f271
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607250037-96WEYY-make-rf-04-replay-cleanup-retry-safe-on-macos/.agentplane/tasks/202607250037-96WEYY/blueprint/resolved-snapshot.json
+    - old_digest: 877eb9a360741e407588402f2d2ef75b4a50f1a2059aad710594c155f5e99e21
+    - current_digest: 877eb9a360741e407588402f2d2ef75b4a50f1a2059aad710594c155f5e99e21
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607250037-96WEYY
+
+    DecisionContextRef:
+    - operator_action: stop
+    - can_execute_now: false
+    - safe_command: none
+    - diagnostic_command: agentplane task verify-show 202607250037-96WEYY
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: none
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
     - Re-run required checks to confirm rollback safety.
-  Findings: ""
+  Findings: |-
+    - Observation: The published branch changes only task and PR metadata, so none of the four Verify Steps can be exercised.
+      Impact: Accepting this state would allow an empty PR to advance as if RF-04 cleanup reliability were implemented.
+      Resolution: Return the task to CODER, implement bounded retry cleanup plus deterministic late-entry and persistent-failure coverage, then rerun the declared gates.
 id_source: "generated"
 ---
 ## Summary
@@ -94,6 +133,36 @@ Prevent Finder-created .DS_Store files from turning successful RF-04 offline rep
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-07-25T00:44:48.440Z — VERIFY — needs_rework
+
+By: TESTER
+
+Note: No implementation diff exists yet; the branch contains only lifecycle artifacts.
+Attempts: 1
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-25T00:43:04.222Z, excerpt_hash=sha256:ce52142cae84398119276adf38634f5a5ab92fdbf2f92e6d361d2053deb7f271
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607250037-96WEYY-make-rf-04-replay-cleanup-retry-safe-on-macos/.agentplane/tasks/202607250037-96WEYY/blueprint/resolved-snapshot.json
+- old_digest: 877eb9a360741e407588402f2d2ef75b4a50f1a2059aad710594c155f5e99e21
+- current_digest: 877eb9a360741e407588402f2d2ef75b4a50f1a2059aad710594c155f5e99e21
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607250037-96WEYY
+
+DecisionContextRef:
+- operator_action: stop
+- can_execute_now: false
+- safe_command: none
+- diagnostic_command: agentplane task verify-show 202607250037-96WEYY
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: none
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -102,3 +171,7 @@ Prevent Finder-created .DS_Store files from turning successful RF-04 offline rep
 - Re-run required checks to confirm rollback safety.
 
 ## Findings
+
+- Observation: The published branch changes only task and PR metadata, so none of the four Verify Steps can be exercised.
+  Impact: Accepting this state would allow an empty PR to advance as if RF-04 cleanup reliability were implemented.
+  Resolution: Return the task to CODER, implement bounded retry cleanup plus deterministic late-entry and persistent-failure coverage, then rerun the declared gates.

--- a/.agentplane/tasks/202607250037-96WEYY/README.md
+++ b/.agentplane/tasks/202607250037-96WEYY/README.md
@@ -1,10 +1,10 @@
 ---
 id: "202607250037-96WEYY"
 title: "Make RF-04 replay cleanup retry-safe on macOS"
-status: "TODO"
+status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -30,11 +30,21 @@ verification:
   note: null
   attempts: 0
 commit: null
-comments: []
-events: []
+comments:
+  -
+    author: "CODER"
+    body: "Start: make RF-04 replay cleanup retry-safe without changing frozen evidence."
+events:
+  -
+    type: "status"
+    at: "2026-07-25T00:43:04.222Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: make RF-04 replay cleanup retry-safe without changing frozen evidence."
 doc_version: 3
-doc_updated_at: "2026-07-25T00:39:06.635Z"
-doc_updated_by: "ORCHESTRATOR"
+doc_updated_at: "2026-07-25T00:43:04.222Z"
+doc_updated_by: "CODER"
 description: "Prevent Finder-created .DS_Store files from turning successful RF-04 offline replay assertions into cleanup-only ENOTEMPTY failures. Keep the frozen 50-run/55-provider-episode evidence unchanged and add deterministic cleanup regression coverage."
 sections:
   Summary: |-

--- a/.agentplane/tasks/202607250037-96WEYY/README.md
+++ b/.agentplane/tasks/202607250037-96WEYY/README.md
@@ -4,7 +4,7 @@ title: "Make RF-04 replay cleanup retry-safe on macOS"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 8
+revision: 9
 origin:
   system: "manual"
 depends_on: []
@@ -24,11 +24,11 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: "Approved under the existing AgentPlane 0.7 authorization as a narrow release-reliability fix for a reproduced cleanup-only failure."
 verification:
-  state: "needs_rework"
-  updated_at: "2026-07-25T00:44:48.440Z"
+  state: "ok"
+  updated_at: "2026-07-25T01:13:14.872Z"
   updated_by: "TESTER"
-  note: "No implementation diff exists yet; the branch contains only lifecycle artifacts."
-  attempts: 1
+  note: "Independent review PASS at e1ed542204ff. Focused RF-04 test passed three consecutive final runs (10/10 each) with unchanged 50 runs, 70/70 outcomes, 27/27 provider token cells, 170/170 scalar cells, and structural SHA 006ddc...9ee4; test:critical passed all 11 chunks; typecheck, scoped ESLint, Prettier, routing, hotspots, task lint, and diff-check passed; no provider/model calls were made."
+  attempts: 0
 commit: null
 comments:
   -
@@ -48,8 +48,14 @@ events:
     author: "TESTER"
     state: "needs_rework"
     note: "No implementation diff exists yet; the branch contains only lifecycle artifacts."
+  -
+    type: "verify"
+    at: "2026-07-25T01:13:14.872Z"
+    author: "TESTER"
+    state: "ok"
+    note: "Independent review PASS at e1ed542204ff. Focused RF-04 test passed three consecutive final runs (10/10 each) with unchanged 50 runs, 70/70 outcomes, 27/27 provider token cells, 170/170 scalar cells, and structural SHA 006ddc...9ee4; test:critical passed all 11 chunks; typecheck, scoped ESLint, Prettier, routing, hotspots, task lint, and diff-check passed; no provider/model calls were made."
 doc_version: 3
-doc_updated_at: "2026-07-25T00:44:48.777Z"
+doc_updated_at: "2026-07-25T01:13:15.170Z"
 doc_updated_by: "CODER"
 description: "Prevent Finder-created .DS_Store files from turning successful RF-04 offline replay assertions into cleanup-only ENOTEMPTY failures. Keep the frozen 50-run/55-provider-episode evidence unchanged and add deterministic cleanup regression coverage."
 sections:
@@ -98,6 +104,36 @@ sections:
     - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
     - risks: none
 
+    ### 2026-07-25T01:13:14.872Z — VERIFY — ok
+
+    By: TESTER
+
+    Note: Independent review PASS at e1ed542204ff. Focused RF-04 test passed three consecutive final runs (10/10 each) with unchanged 50 runs, 70/70 outcomes, 27/27 provider token cells, 170/170 scalar cells, and structural SHA 006ddc...9ee4; test:critical passed all 11 chunks; typecheck, scoped ESLint, Prettier, routing, hotspots, task lint, and diff-check passed; no provider/model calls were made.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-25T00:44:48.777Z, excerpt_hash=sha256:ce52142cae84398119276adf38634f5a5ab92fdbf2f92e6d361d2053deb7f271
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607250037-96WEYY-make-rf-04-replay-cleanup-retry-safe-on-macos/.agentplane/tasks/202607250037-96WEYY/blueprint/resolved-snapshot.json
+    - old_digest: 877eb9a360741e407588402f2d2ef75b4a50f1a2059aad710594c155f5e99e21
+    - current_digest: 877eb9a360741e407588402f2d2ef75b4a50f1a2059aad710594c155f5e99e21
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607250037-96WEYY
+
+    DecisionContextRef:
+    - operator_action: stop
+    - can_execute_now: false
+    - safe_command: none
+    - diagnostic_command: none
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: none
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -106,6 +142,10 @@ sections:
     - Observation: The published branch changes only task and PR metadata, so none of the four Verify Steps can be exercised.
       Impact: Accepting this state would allow an empty PR to advance as if RF-04 cleanup reliability were implemented.
       Resolution: Return the task to CODER, implement bounded retry cleanup plus deterministic late-entry and persistent-failure coverage, then rerun the declared gates.
+
+    - Observation: Finder can race temporary replay cleanup and emit retryable ENOTEMPTY after the semantic assertion has already completed.
+      Impact: A cleanup-only race can mask the real replay result and create a false release-gate failure without changing provider evidence.
+      Resolution: Use a four-attempt test-boundary cleanup/replay wrapper that deletes only capture roots created by the current test, preserves the first persistent cleanup error, and immediately surfaces non-retryable errors; production harness bytes remain frozen.
 id_source: "generated"
 ---
 ## Summary
@@ -163,6 +203,36 @@ DecisionContextRef:
 - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
 - risks: none
 
+### 2026-07-25T01:13:14.872Z — VERIFY — ok
+
+By: TESTER
+
+Note: Independent review PASS at e1ed542204ff. Focused RF-04 test passed three consecutive final runs (10/10 each) with unchanged 50 runs, 70/70 outcomes, 27/27 provider token cells, 170/170 scalar cells, and structural SHA 006ddc...9ee4; test:critical passed all 11 chunks; typecheck, scoped ESLint, Prettier, routing, hotspots, task lint, and diff-check passed; no provider/model calls were made.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-25T00:44:48.777Z, excerpt_hash=sha256:ce52142cae84398119276adf38634f5a5ab92fdbf2f92e6d361d2053deb7f271
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607250037-96WEYY-make-rf-04-replay-cleanup-retry-safe-on-macos/.agentplane/tasks/202607250037-96WEYY/blueprint/resolved-snapshot.json
+- old_digest: 877eb9a360741e407588402f2d2ef75b4a50f1a2059aad710594c155f5e99e21
+- current_digest: 877eb9a360741e407588402f2d2ef75b4a50f1a2059aad710594c155f5e99e21
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607250037-96WEYY
+
+DecisionContextRef:
+- operator_action: stop
+- can_execute_now: false
+- safe_command: none
+- diagnostic_command: none
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: none
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -175,3 +245,7 @@ DecisionContextRef:
 - Observation: The published branch changes only task and PR metadata, so none of the four Verify Steps can be exercised.
   Impact: Accepting this state would allow an empty PR to advance as if RF-04 cleanup reliability were implemented.
   Resolution: Return the task to CODER, implement bounded retry cleanup plus deterministic late-entry and persistent-failure coverage, then rerun the declared gates.
+
+- Observation: Finder can race temporary replay cleanup and emit retryable ENOTEMPTY after the semantic assertion has already completed.
+  Impact: A cleanup-only race can mask the real replay result and create a false release-gate failure without changing provider evidence.
+  Resolution: Use a four-attempt test-boundary cleanup/replay wrapper that deletes only capture roots created by the current test, preserves the first persistent cleanup error, and immediately surfaces non-retryable errors; production harness bytes remain frozen.

--- a/.agentplane/tasks/202607250037-96WEYY/README.md
+++ b/.agentplane/tasks/202607250037-96WEYY/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202607250037-96WEYY"
 title: "Make RF-04 replay cleanup retry-safe on macOS"
-status: "DOING"
+result_summary: "pre-merge closure"
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 10
+revision: 11
 origin:
   system: "manual"
 depends_on: []
@@ -49,11 +50,16 @@ quality_review:
   findings:
     - "Cleanup retries are capped at four attempts, retain the first persistent retryable error, and surface non-retryable errors immediately; deterministic tests distinguish first-vs-last error identity and one-call EIO behavior."
     - "Capture retry cleanup deletes only newly created rf04-replay roots and preserves pre-existing roots; three repeated focused runs and the full 11-chunk critical suite passed with the same 50/70/27/170 evidence and structural digest."
-commit: null
+commit:
+  hash: "18c0d75004c7cb5486266753d5e782ab09e71521"
+  message: "🧭 96WEYY task: record independent quality pass"
 comments:
   -
     author: "CODER"
     body: "Start: make RF-04 replay cleanup retry-safe without changing frozen evidence."
+  -
+    author: "CODER"
+    body: "Verified: pre-merge closure packet is ready for the task PR."
 events:
   -
     type: "status"
@@ -74,8 +80,15 @@ events:
     author: "TESTER"
     state: "ok"
     note: "Independent review PASS at e1ed542204ff. Focused RF-04 test passed three consecutive final runs (10/10 each) with unchanged 50 runs, 70/70 outcomes, 27/27 provider token cells, 170/170 scalar cells, and structural SHA 006ddc...9ee4; test:critical passed all 11 chunks; typecheck, scoped ESLint, Prettier, routing, hotspots, task lint, and diff-check passed; no provider/model calls were made."
+  -
+    type: "status"
+    at: "2026-07-25T01:14:44.308Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-25T01:13:15.170Z"
+doc_updated_at: "2026-07-25T01:14:44.308Z"
 doc_updated_by: "CODER"
 description: "Prevent Finder-created .DS_Store files from turning successful RF-04 offline replay assertions into cleanup-only ENOTEMPTY failures. Keep the frozen 50-run/55-provider-episode evidence unchanged and add deterministic cleanup regression coverage."
 sections:
@@ -166,6 +179,10 @@ sections:
     - Observation: Finder can race temporary replay cleanup and emit retryable ENOTEMPTY after the semantic assertion has already completed.
       Impact: A cleanup-only race can mask the real replay result and create a false release-gate failure without changing provider evidence.
       Resolution: Use a four-attempt test-boundary cleanup/replay wrapper that deletes only capture roots created by the current test, preserves the first persistent cleanup error, and immediately surfaces non-retryable errors; production harness bytes remain frozen.
+extensions:
+  implementation_commit:
+    hash: "e1ed542204ffdf66d142c0689c76af3e863a2631"
+    message: "🛠️ 96WEYY task: retry replay cleanup at test boundary"
 id_source: "generated"
 ---
 ## Summary

--- a/.agentplane/tasks/202607250037-96WEYY/README.md
+++ b/.agentplane/tasks/202607250037-96WEYY/README.md
@@ -4,7 +4,7 @@ title: "Make RF-04 replay cleanup retry-safe on macOS"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 9
+revision: 10
 origin:
   system: "manual"
 depends_on: []
@@ -29,6 +29,26 @@ verification:
   updated_by: "TESTER"
   note: "Independent review PASS at e1ed542204ff. Focused RF-04 test passed three consecutive final runs (10/10 each) with unchanged 50 runs, 70/70 outcomes, 27/27 provider token cells, 170/170 scalar cells, and structural SHA 006ddc...9ee4; test:critical passed all 11 chunks; typecheck, scoped ESLint, Prettier, routing, hotspots, task lint, and diff-check passed; no provider/model calls were made."
   attempts: 0
+quality_review:
+  state: "pass"
+  provenance: "human_supplied"
+  updated_at: "2026-07-25T01:14:02.383Z"
+  updated_by: "HUMAN"
+  note: "Independent review confirms the RF-04 cleanup-only macOS race is bounded at the test boundary without mutating the frozen replay harness or provider evidence."
+  evaluated_sha: "e1ed542204ffdf66d142c0689c76af3e863a2631"
+  blueprint_digest: "877eb9a360741e407588402f2d2ef75b4a50f1a2059aad710594c155f5e99e21"
+  evidence_refs:
+    - ".agentplane/tasks/202607250037-96WEYY/README.md"
+    - ".agentplane/tasks/202607250037-96WEYY/quality/20260725-011402383-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607250037-96WEYY/quality/20260725-011402383-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607250037-96WEYY/quality/20260725-011402383-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607250037-96WEYY/blueprint/resolved-snapshot.json"
+    - "packages/agentplane/src/cli/run-cli.critical.agent-efficiency-replay-hardening.test.ts"
+    - "e1ed542204ff"
+    - "bun run test:critical: 11/11 chunks PASS; focused RF-04: 3 consecutive 10/10 PASS with unchanged structural SHA 006ddc...9ee4"
+  findings:
+    - "Cleanup retries are capped at four attempts, retain the first persistent retryable error, and surface non-retryable errors immediately; deterministic tests distinguish first-vs-last error identity and one-call EIO behavior."
+    - "Capture retry cleanup deletes only newly created rf04-replay roots and preserves pre-existing roots; three repeated focused runs and the full 11-chunk critical suite passed with the same 50/70/27/170 evidence and structural digest."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202607250037-96WEYY/README.md
+++ b/.agentplane/tasks/202607250037-96WEYY/README.md
@@ -1,0 +1,94 @@
+---
+id: "202607250037-96WEYY"
+title: "Make RF-04 replay cleanup retry-safe on macOS"
+status: "TODO"
+priority: "high"
+owner: "CODER"
+revision: 6
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "milestone-alpha2"
+  - "reliability"
+  - "rf-04"
+  - "v0.7"
+verify:
+  - "bunx vitest run packages/agentplane/src/cli/run-cli.critical.agent-efficiency-replay-hardening.test.ts"
+  - "bun run test:critical"
+  - "bun run typecheck"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-07-25T00:38:13.292Z"
+  updated_by: "ORCHESTRATOR"
+  note: "Approved under the existing AgentPlane 0.7 authorization as a narrow release-reliability fix for a reproduced cleanup-only failure."
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments: []
+events: []
+doc_version: 3
+doc_updated_at: "2026-07-25T00:39:06.635Z"
+doc_updated_by: "ORCHESTRATOR"
+description: "Prevent Finder-created .DS_Store files from turning successful RF-04 offline replay assertions into cleanup-only ENOTEMPTY failures. Keep the frozen 50-run/55-provider-episode evidence unchanged and add deterministic cleanup regression coverage."
+sections:
+  Summary: |-
+    Make RF-04 replay cleanup retry-safe on macOS
+
+    Prevent Finder-created .DS_Store files from turning successful RF-04 offline replay assertions into cleanup-only ENOTEMPTY failures. Keep the frozen 50-run/55-provider-episode evidence unchanged and add deterministic cleanup regression coverage.
+  Scope: |-
+    - In scope: Prevent Finder-created .DS_Store files from turning successful RF-04 offline replay assertions into cleanup-only ENOTEMPTY failures. Keep the frozen 50-run/55-provider-episode evidence unchanged and add deterministic cleanup regression coverage.
+    - Out of scope: unrelated refactors not required for "Make RF-04 replay cleanup retry-safe on macOS".
+  Plan: "1. Reproduce the cleanup-only ENOTEMPTY path without changing RF-04 replay assertions or frozen provider evidence. 2. Replace one-shot recursive cleanup with the smallest bounded retry-safe helper at the test boundary. 3. Add deterministic regression coverage that injects a late .DS_Store-style entry and proves bounded cleanup succeeds while real cleanup errors still surface. 4. Run the focused RF-04 hardening test repeatedly, test:critical, typecheck, scoped lint, format, and task gates."
+  Verify Steps: |-
+    1. Inject a late `.DS_Store`-style entry during temporary-root cleanup. Expected: bounded retry cleanup removes the tree without hiding the successful replay assertions.
+    2. Inject a persistent cleanup failure. Expected: cleanup stops after the configured bound and surfaces the original error.
+    3. Run the RF-04 replay-hardening test repeatedly. Expected: every run preserves the frozen 50 runs, 70 outcomes, 27 provider token cells, and 170 scalar cells.
+    4. Run `bun run test:critical`, `bun run typecheck`, scoped ESLint, Prettier, routing, hotspot, and task-lint gates. Expected: all product assertions pass; no provider/model calls are made.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Make RF-04 replay cleanup retry-safe on macOS
+
+Prevent Finder-created .DS_Store files from turning successful RF-04 offline replay assertions into cleanup-only ENOTEMPTY failures. Keep the frozen 50-run/55-provider-episode evidence unchanged and add deterministic cleanup regression coverage.
+
+## Scope
+
+- In scope: Prevent Finder-created .DS_Store files from turning successful RF-04 offline replay assertions into cleanup-only ENOTEMPTY failures. Keep the frozen 50-run/55-provider-episode evidence unchanged and add deterministic cleanup regression coverage.
+- Out of scope: unrelated refactors not required for "Make RF-04 replay cleanup retry-safe on macOS".
+
+## Plan
+
+1. Reproduce the cleanup-only ENOTEMPTY path without changing RF-04 replay assertions or frozen provider evidence. 2. Replace one-shot recursive cleanup with the smallest bounded retry-safe helper at the test boundary. 3. Add deterministic regression coverage that injects a late .DS_Store-style entry and proves bounded cleanup succeeds while real cleanup errors still surface. 4. Run the focused RF-04 hardening test repeatedly, test:critical, typecheck, scoped lint, format, and task gates.
+
+## Verify Steps
+
+1. Inject a late `.DS_Store`-style entry during temporary-root cleanup. Expected: bounded retry cleanup removes the tree without hiding the successful replay assertions.
+2. Inject a persistent cleanup failure. Expected: cleanup stops after the configured bound and surfaces the original error.
+3. Run the RF-04 replay-hardening test repeatedly. Expected: every run preserves the frozen 50 runs, 70 outcomes, 27 provider token cells, and 170 scalar cells.
+4. Run `bun run test:critical`, `bun run typecheck`, scoped ESLint, Prettier, routing, hotspot, and task-lint gates. Expected: all product assertions pass; no provider/model calls are made.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202607250037-96WEYY/README.md
+++ b/.agentplane/tasks/202607250037-96WEYY/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 11
+revision: 12
 origin:
   system: "manual"
 depends_on: []
@@ -51,8 +51,8 @@ quality_review:
     - "Cleanup retries are capped at four attempts, retain the first persistent retryable error, and surface non-retryable errors immediately; deterministic tests distinguish first-vs-last error identity and one-call EIO behavior."
     - "Capture retry cleanup deletes only newly created rf04-replay roots and preserves pre-existing roots; three repeated focused runs and the full 11-chunk critical suite passed with the same 50/70/27/170 evidence and structural digest."
 commit:
-  hash: "18c0d75004c7cb5486266753d5e782ab09e71521"
-  message: "🧭 96WEYY task: record independent quality pass"
+  hash: "c09a9cca0e5ba2bb78e4a302f8d7bd0bf0c56ef0"
+  message: "🧩 96WEYY task: refresh task artifacts after commit"
 comments:
   -
     author: "CODER"
@@ -60,6 +60,9 @@ comments:
   -
     author: "CODER"
     body: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    author: "CODER"
+    body: "Verified: refreshed pre-merge closure packet is ready for the task PR."
 events:
   -
     type: "status"
@@ -87,8 +90,15 @@ events:
     from: "DOING"
     to: "DONE"
     note: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    type: "status"
+    at: "2026-07-25T03:24:33.112Z"
+    author: "CODER"
+    from: "DONE"
+    to: "DONE"
+    note: "Verified: refreshed pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-25T01:14:44.308Z"
+doc_updated_at: "2026-07-25T03:24:33.113Z"
 doc_updated_by: "CODER"
 description: "Prevent Finder-created .DS_Store files from turning successful RF-04 offline replay assertions into cleanup-only ENOTEMPTY failures. Keep the frozen 50-run/55-provider-episode evidence unchanged and add deterministic cleanup regression coverage."
 sections:

--- a/.agentplane/tasks/202607250037-96WEYY/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202607250037-96WEYY/blueprint/resolved-snapshot.json
@@ -1,0 +1,600 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607250037-96WEYY",
+    "title": "Make RF-04 replay cleanup retry-safe on macOS",
+    "description": "Prevent Finder-created .DS_Store files from turning successful RF-04 offline replay assertions into cleanup-only ENOTEMPTY failures. Keep the frozen 50-run/55-provider-episode evidence unchanged and add deterministic cleanup regression coverage.",
+    "tags": [
+      "code",
+      "milestone-alpha2",
+      "reliability",
+      "rf-04",
+      "v0.7"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "quality.regression",
+    "version": 1,
+    "title": "Quality regression",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "quality.regression",
+    "blueprintVersion": 1,
+    "title": "Quality regression",
+    "taskId": "202607250037-96WEYY",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "code"
+    },
+    "whySelected": [
+      "specialized code domain resolved to quality.regression",
+      "workflow mode: branch_pr",
+      "mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest",
+          "artifact"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths",
+          "check_result"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "weak_links"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "regression.original_failure",
+        "kind": "artifact",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Original failure log or check output."
+      },
+      {
+        "id": "regression.reproduction",
+        "kind": "check_result",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Local reproduction or explicit non-reproduction result."
+      },
+      {
+        "id": "regression.focused_check",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Focused regression check."
+      },
+      {
+        "id": "regression.matrix_or_scope",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Affected test/check matrix or bounded scope."
+      },
+      {
+        "id": "regression.full_gate",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Full relevant gate or hosted check evidence."
+      },
+      {
+        "id": "regression.flake_classification",
+        "kind": "weak_links",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Flake classification or residual risk."
+      },
+      {
+        "id": "regression.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "regression.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "affected matrix or full relevant gate",
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "failure reproduction command",
+      "focused regression check",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 16,
+      "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest",
+        "artifact"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths",
+        "check_result"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "weak_links"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "regression.original_failure",
+      "kind": "artifact",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Original failure log or check output."
+    },
+    {
+      "id": "regression.reproduction",
+      "kind": "check_result",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Local reproduction or explicit non-reproduction result."
+    },
+    {
+      "id": "regression.focused_check",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Focused regression check."
+    },
+    {
+      "id": "regression.matrix_or_scope",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Affected test/check matrix or bounded scope."
+    },
+    {
+      "id": "regression.full_gate",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Full relevant gate or hosted check evidence."
+    },
+    {
+      "id": "regression.flake_classification",
+      "kind": "weak_links",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Flake classification or residual risk."
+    },
+    {
+      "id": "regression.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "regression.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "affected matrix or full relevant gate",
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "failure reproduction command",
+    "focused regression check",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 16,
+    "rationale": "Regression work needs failure evidence, focused reproduction, and the relevant quality gate."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "specialized code domain resolved to quality.regression",
+    "workflow mode: branch_pr",
+    "mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "877eb9a360741e407588402f2d2ef75b4a50f1a2059aad710594c155f5e99e21"
+  }
+}

--- a/.agentplane/tasks/202607250037-96WEYY/pr/diffstat.txt
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/diffstat.txt
@@ -1,2 +1,2 @@
- ...tical.agent-efficiency-replay-hardening.test.ts | 74 +++++++++++++++++++++-
- 1 file changed, 73 insertions(+), 1 deletion(-)
+ ...tical.agent-efficiency-replay-hardening.test.ts | 94 +++++++++++++++++++++-
+ 1 file changed, 93 insertions(+), 1 deletion(-)

--- a/.agentplane/tasks/202607250037-96WEYY/pr/diffstat.txt
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/diffstat.txt
@@ -1,2 +1,2 @@
- ...tical.agent-efficiency-replay-hardening.test.ts | 94 +++++++++++++++++++++-
- 1 file changed, 93 insertions(+), 1 deletion(-)
+ ...tical.agent-efficiency-replay-hardening.test.ts | 170 +++++++++++++++++++--
+ 1 file changed, 157 insertions(+), 13 deletions(-)

--- a/.agentplane/tasks/202607250037-96WEYY/pr/diffstat.txt
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/diffstat.txt
@@ -1,0 +1,2 @@
+ ...tical.agent-efficiency-replay-hardening.test.ts | 74 +++++++++++++++++++++-
+ 1 file changed, 73 insertions(+), 1 deletion(-)

--- a/.agentplane/tasks/202607250037-96WEYY/pr/github-body.md
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/github-body.md
@@ -27,7 +27,8 @@ Prevent Finder-created .DS_Store files from turning successful RF-04 offline rep
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ ...tical.agent-efficiency-replay-hardening.test.ts | 74 +++++++++++++++++++++-
+ 1 file changed, 73 insertions(+), 1 deletion(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607250037-96WEYY/pr/github-body.md
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/github-body.md
@@ -27,8 +27,8 @@ Prevent Finder-created .DS_Store files from turning successful RF-04 offline rep
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
- ...tical.agent-efficiency-replay-hardening.test.ts | 74 +++++++++++++++++++++-
- 1 file changed, 73 insertions(+), 1 deletion(-)
+ ...tical.agent-efficiency-replay-hardening.test.ts | 94 +++++++++++++++++++++-
+ 1 file changed, 93 insertions(+), 1 deletion(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607250037-96WEYY/pr/github-body.md
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/github-body.md
@@ -15,8 +15,8 @@ Prevent Finder-created .DS_Store files from turning successful RF-04 offline rep
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: needs_rework
+- Note: No implementation diff exists yet; the branch contains only lifecycle artifacts.
 - Canonical workflow state lives in the task README.
 
 <details>

--- a/.agentplane/tasks/202607250037-96WEYY/pr/github-body.md
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/github-body.md
@@ -27,8 +27,8 @@ Prevent Finder-created .DS_Store files from turning successful RF-04 offline rep
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
- ...tical.agent-efficiency-replay-hardening.test.ts | 94 +++++++++++++++++++++-
- 1 file changed, 93 insertions(+), 1 deletion(-)
+ ...tical.agent-efficiency-replay-hardening.test.ts | 170 +++++++++++++++++++--
+ 1 file changed, 157 insertions(+), 13 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607250037-96WEYY/pr/github-body.md
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202607250037-96WEYY`
+Title: Make RF-04 replay cleanup retry-safe on macOS
+Canonical task record: `.agentplane/tasks/202607250037-96WEYY/README.md`
+
+## Summary
+
+Make RF-04 replay cleanup retry-safe on macOS
+
+Prevent Finder-created .DS_Store files from turning successful RF-04 offline replay assertions into cleanup-only ENOTEMPTY failures. Keep the frozen 50-run/55-provider-episode evidence unchanged and add deterministic cleanup regression coverage.
+
+## Scope
+
+- In scope: Prevent Finder-created .DS_Store files from turning successful RF-04 offline replay assertions into cleanup-only ENOTEMPTY failures. Keep the frozen 50-run/55-provider-episode evidence unchanged and add deterministic cleanup regression coverage.
+- Out of scope: unrelated refactors not required for "Make RF-04 replay cleanup retry-safe on macOS".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-25T00:39:52.775Z
+- Branch: task/202607250037-96WEYY/make-rf-04-replay-cleanup-retry-safe-on-macos
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202607250037-96WEYY/pr/github-body.md
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/github-body.md
@@ -15,8 +15,16 @@ Prevent Finder-created .DS_Store files from turning successful RF-04 offline rep
 
 ## Verification
 
-- State: needs_rework
-- Note: No implementation diff exists yet; the branch contains only lifecycle artifacts.
+- State: ok
+- Note:
+
+```text
+Independent review PASS at e1ed542204ff. Focused RF-04 test passed three consecutive final runs
+(10/10 each) with unchanged 50 runs, 70/70 outcomes, 27/27 provider token cells, 170/170 scalar
+cells, and structural SHA 006ddc...9ee4; test:critical passed all 11 chunks; typecheck, scoped
+ESLint, Prettier, routing, hotspots, task lint, and diff-check passed; no provider/model calls were
+made.
+```
 - Canonical workflow state lives in the task README.
 
 <details>

--- a/.agentplane/tasks/202607250037-96WEYY/pr/github-body.md
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/github-body.md
@@ -22,7 +22,7 @@ Prevent Finder-created .DS_Store files from turning successful RF-04 offline rep
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-25T00:39:52.775Z
+- Updated: 2026-07-25T00:39:56.590Z
 - Branch: task/202607250037-96WEYY/make-rf-04-replay-cleanup-retry-safe-on-macos
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 

--- a/.agentplane/tasks/202607250037-96WEYY/pr/github-title.txt
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/github-title.txt
@@ -1,0 +1,1 @@
+🧩 96WEYY task: Make RF-04 replay cleanup retry-safe on macOS [202607250037-96WEYY]

--- a/.agentplane/tasks/202607250037-96WEYY/pr/github-title.txt
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/github-title.txt
@@ -1,1 +1,1 @@
-🧩 96WEYY task: Make RF-04 replay cleanup retry-safe on macOS [202607250037-96WEYY]
+🚧 96WEYY task: Make RF-04 replay cleanup retry-safe on macOS [202607250037-96WEYY]

--- a/.agentplane/tasks/202607250037-96WEYY/pr/github-title.txt
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/github-title.txt
@@ -1,1 +1,1 @@
-🚧 96WEYY task: Make RF-04 replay cleanup retry-safe on macOS [202607250037-96WEYY]
+✅ 96WEYY task: Make RF-04 replay cleanup retry-safe on macOS [202607250037-96WEYY]

--- a/.agentplane/tasks/202607250037-96WEYY/pr/meta.json
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202607250037-96WEYY/make-rf-04-replay-cleanup-retry-safe-on-macos",
   "created_at": "2026-07-25T00:39:52.775Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "diffstat_sha256": "sha256:be0b50ca855cb3f03659fa091abb3ef60f938f45f08fd3e3fb4daeb322f712af",
   "last_verified_at": "2026-07-25T00:44:48.440Z",
   "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "pr_number": 4615,

--- a/.agentplane/tasks/202607250037-96WEYY/pr/meta.json
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/meta.json
@@ -3,7 +3,8 @@
   "branch": "task/202607250037-96WEYY/make-rf-04-replay-cleanup-retry-safe-on-macos",
   "created_at": "2026-07-25T00:39:52.775Z",
   "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "last_verified_at": null,
+  "last_verified_at": "2026-07-25T00:44:48.440Z",
+  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "pr_number": 4615,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4615",
   "schema_version": 1,
@@ -11,6 +12,6 @@
   "task_id": "202607250037-96WEYY",
   "updated_at": "2026-07-25T00:39:56.590Z",
   "verify": {
-    "status": "skipped"
+    "status": "fail"
   }
 }

--- a/.agentplane/tasks/202607250037-96WEYY/pr/meta.json
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/meta.json
@@ -3,8 +3,8 @@
   "branch": "task/202607250037-96WEYY/make-rf-04-replay-cleanup-retry-safe-on-macos",
   "created_at": "2026-07-25T00:39:52.775Z",
   "diffstat_sha256": "sha256:4d0488c75d2ec6040c489a7b8676eb90334c8be8ee2deb850899c675492acde4",
-  "last_verified_at": "2026-07-25T00:44:48.440Z",
-  "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": "2026-07-25T01:13:14.872Z",
+  "last_verified_diffstat_sha256": "sha256:4d0488c75d2ec6040c489a7b8676eb90334c8be8ee2deb850899c675492acde4",
   "pr_number": 4615,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4615",
   "schema_version": 1,
@@ -12,6 +12,6 @@
   "task_id": "202607250037-96WEYY",
   "updated_at": "2026-07-25T00:39:56.590Z",
   "verify": {
-    "status": "fail"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202607250037-96WEYY/pr/meta.json
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/meta.json
@@ -4,9 +4,12 @@
   "created_at": "2026-07-25T00:39:52.775Z",
   "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "last_verified_at": null,
+  "pr_number": 4615,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4615",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202607250037-96WEYY",
-  "updated_at": "2026-07-25T00:39:52.775Z",
+  "updated_at": "2026-07-25T00:39:56.590Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202607250037-96WEYY/pr/meta.json
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/meta.json
@@ -8,10 +8,10 @@
   "pr_number": 4615,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4615",
   "pre_merge_closure": {
-    "basis_commit": "18c0d75004c7cb5486266753d5e782ab09e71521",
+    "basis_commit": "c09a9cca0e5ba2bb78e4a302f8d7bd0bf0c56ef0",
     "branch": "task/202607250037-96WEYY/make-rf-04-replay-cleanup-retry-safe-on-macos",
     "pr_number": 4615,
-    "recorded_at": "2026-07-25T01:14:44.360Z",
+    "recorded_at": "2026-07-25T03:24:33.179Z",
     "state": "closed_before_merge"
   },
   "schema_version": 1,

--- a/.agentplane/tasks/202607250037-96WEYY/pr/meta.json
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202607250037-96WEYY/make-rf-04-replay-cleanup-retry-safe-on-macos",
+  "created_at": "2026-07-25T00:39:52.775Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202607250037-96WEYY",
+  "updated_at": "2026-07-25T00:39:52.775Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202607250037-96WEYY/pr/meta.json
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202607250037-96WEYY/make-rf-04-replay-cleanup-retry-safe-on-macos",
   "created_at": "2026-07-25T00:39:52.775Z",
-  "diffstat_sha256": "sha256:fdf8a55a78702a87d3919b5b940be39ba99818a45e6a47b874796e123b065c20",
+  "diffstat_sha256": "sha256:4d0488c75d2ec6040c489a7b8676eb90334c8be8ee2deb850899c675492acde4",
   "last_verified_at": "2026-07-25T00:44:48.440Z",
   "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "pr_number": 4615,

--- a/.agentplane/tasks/202607250037-96WEYY/pr/meta.json
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202607250037-96WEYY/make-rf-04-replay-cleanup-retry-safe-on-macos",
   "created_at": "2026-07-25T00:39:52.775Z",
-  "diffstat_sha256": "sha256:be0b50ca855cb3f03659fa091abb3ef60f938f45f08fd3e3fb4daeb322f712af",
+  "diffstat_sha256": "sha256:fdf8a55a78702a87d3919b5b940be39ba99818a45e6a47b874796e123b065c20",
   "last_verified_at": "2026-07-25T00:44:48.440Z",
   "last_verified_diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "pr_number": 4615,

--- a/.agentplane/tasks/202607250037-96WEYY/pr/meta.json
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/meta.json
@@ -7,6 +7,13 @@
   "last_verified_diffstat_sha256": "sha256:4d0488c75d2ec6040c489a7b8676eb90334c8be8ee2deb850899c675492acde4",
   "pr_number": 4615,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4615",
+  "pre_merge_closure": {
+    "basis_commit": "18c0d75004c7cb5486266753d5e782ab09e71521",
+    "branch": "task/202607250037-96WEYY/make-rf-04-replay-cleanup-retry-safe-on-macos",
+    "pr_number": 4615,
+    "recorded_at": "2026-07-25T01:14:44.360Z",
+    "state": "closed_before_merge"
+  },
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202607250037-96WEYY",

--- a/.agentplane/tasks/202607250037-96WEYY/pr/review.md
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-07-25T00:39:52.775Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: needs_rework
+- Note: No implementation diff exists yet; the branch contains only lifecycle artifacts.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes

--- a/.agentplane/tasks/202607250037-96WEYY/pr/review.md
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/review.md
@@ -6,7 +6,7 @@ Created: 2026-07-25T00:39:52.775Z
 
 - Task: `202607250037-96WEYY`
 - Title: Make RF-04 replay cleanup retry-safe on macOS
-- Status: TODO
+- Status: DOING
 - Branch: `task/202607250037-96WEYY/make-rf-04-replay-cleanup-retry-safe-on-macos`
 - Canonical task record: `.agentplane/tasks/202607250037-96WEYY/README.md`
 

--- a/.agentplane/tasks/202607250037-96WEYY/pr/review.md
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-07-25T00:39:52.775Z
+
+## Task
+
+- Task: `202607250037-96WEYY`
+- Title: Make RF-04 replay cleanup retry-safe on macOS
+- Status: TODO
+- Branch: `task/202607250037-96WEYY/make-rf-04-replay-cleanup-retry-safe-on-macos`
+- Canonical task record: `.agentplane/tasks/202607250037-96WEYY/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-25T00:39:52.775Z
+- Branch: task/202607250037-96WEYY/make-rf-04-replay-cleanup-retry-safe-on-macos
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202607250037-96WEYY/pr/review.md
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/review.md
@@ -29,8 +29,8 @@ Created: 2026-07-25T00:39:52.775Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
- ...tical.agent-efficiency-replay-hardening.test.ts | 74 +++++++++++++++++++++-
- 1 file changed, 73 insertions(+), 1 deletion(-)
+ ...tical.agent-efficiency-replay-hardening.test.ts | 94 +++++++++++++++++++++-
+ 1 file changed, 93 insertions(+), 1 deletion(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607250037-96WEYY/pr/review.md
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/review.md
@@ -29,8 +29,8 @@ Created: 2026-07-25T00:39:52.775Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
- ...tical.agent-efficiency-replay-hardening.test.ts | 94 +++++++++++++++++++++-
- 1 file changed, 93 insertions(+), 1 deletion(-)
+ ...tical.agent-efficiency-replay-hardening.test.ts | 170 +++++++++++++++++++--
+ 1 file changed, 157 insertions(+), 13 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607250037-96WEYY/pr/review.md
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/review.md
@@ -29,7 +29,8 @@ Created: 2026-07-25T00:39:52.775Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ ...tical.agent-efficiency-replay-hardening.test.ts | 74 +++++++++++++++++++++-
+ 1 file changed, 73 insertions(+), 1 deletion(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607250037-96WEYY/pr/review.md
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-07-25T00:39:52.775Z
 
 ## Verification
 
-- State: needs_rework
-- Note: No implementation diff exists yet; the branch contains only lifecycle artifacts.
+- State: ok
+- Note: Independent review PASS at e1ed542204ff. Focused RF-04 test passed three consecutive final runs (10/10 each) with unchanged 50 runs, 70/70 outcomes, 27/27 provider token cells, 170/170 scalar cells, and structural SHA 006ddc...9ee4; test:critical passed all 11 chunks; typecheck, scoped ESLint, Prettier, routing, hotspots, task lint, and diff-check passed; no provider/model calls were made.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes

--- a/.agentplane/tasks/202607250037-96WEYY/pr/review.md
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/review.md
@@ -24,7 +24,7 @@ Created: 2026-07-25T00:39:52.775Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-25T00:39:52.775Z
+- Updated: 2026-07-25T00:39:56.590Z
 - Branch: task/202607250037-96WEYY/make-rf-04-replay-cleanup-retry-safe-on-macos
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 

--- a/.agentplane/tasks/202607250037-96WEYY/pr/review.md
+++ b/.agentplane/tasks/202607250037-96WEYY/pr/review.md
@@ -6,7 +6,7 @@ Created: 2026-07-25T00:39:52.775Z
 
 - Task: `202607250037-96WEYY`
 - Title: Make RF-04 replay cleanup retry-safe on macOS
-- Status: DOING
+- Status: DONE
 - Branch: `task/202607250037-96WEYY/make-rf-04-replay-cleanup-retry-safe-on-macos`
 - Canonical task record: `.agentplane/tasks/202607250037-96WEYY/README.md`
 

--- a/.agentplane/tasks/202607250037-96WEYY/quality/20260725-011402383-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607250037-96WEYY/quality/20260725-011402383-recovery-context/evaluator-opinion.md
@@ -1,0 +1,24 @@
+# Semantic quality review: pass
+
+Provenance: human_supplied
+
+Independent review confirms the RF-04 cleanup-only macOS race is bounded at the test boundary without mutating the frozen replay harness or provider evidence.
+
+## Findings
+- Cleanup retries are capped at four attempts, retain the first persistent retryable error, and surface non-retryable errors immediately; deterministic tests distinguish first-vs-last error identity and one-call EIO behavior.
+- Capture retry cleanup deletes only newly created rf04-replay roots and preserves pre-existing roots; three repeated focused runs and the full 11-chunk critical suite passed with the same 50/70/27/170 evidence and structural digest.
+
+## Evidence
+- .agentplane/tasks/202607250037-96WEYY/README.md
+- packages/agentplane/src/cli/run-cli.critical.agent-efficiency-replay-hardening.test.ts
+- e1ed542204ff
+- bun run test:critical: 11/11 chunks PASS; focused RF-04: 3 consecutive 10/10 PASS with unchanged structural SHA 006ddc...9ee4
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- The frozen production capture harness retains one-shot internal cleanup; changing those bytes would invalidate the approved provider evidence, so this task intentionally hardens only the offline test boundary.

--- a/.agentplane/tasks/202607250037-96WEYY/quality/20260725-011402383-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607250037-96WEYY/quality/20260725-011402383-recovery-context/evaluator-prompt.md
@@ -1,0 +1,75 @@
+# AgentPlane semantic quality review record
+
+AgentPlane records supplied review values here; this command does not execute an evaluator.
+Use the evaluator module below as the review procedure before supplying a result.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+
+- task_id: 202607250037-96WEYY
+- task_readme: .agentplane/tasks/202607250037-96WEYY/README.md
+- report_path: .agentplane/tasks/202607250037-96WEYY/quality/20260725-011402383-recovery-context/quality-report.json
+- provenance: human_supplied
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607250037-96WEYY/quality/20260725-011402383-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607250037-96WEYY/quality/20260725-011402383-recovery-context/quality-report.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "task_id": "202607250037-96WEYY",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-25T01:14:02.383Z",
+  "provenance": "human_supplied",
+  "verdict": "pass",
+  "summary": "Independent review confirms the RF-04 cleanup-only macOS race is bounded at the test boundary without mutating the frozen replay harness or provider evidence.",
+  "evaluated_sha": "e1ed542204ffdf66d142c0689c76af3e863a2631",
+  "blueprint_digest": "877eb9a360741e407588402f2d2ef75b4a50f1a2059aad710594c155f5e99e21",
+  "findings": [
+    "Cleanup retries are capped at four attempts, retain the first persistent retryable error, and surface non-retryable errors immediately; deterministic tests distinguish first-vs-last error identity and one-call EIO behavior.",
+    "Capture retry cleanup deletes only newly created rf04-replay roots and preserves pre-existing roots; three repeated focused runs and the full 11-chunk critical suite passed with the same 50/70/27/170 evidence and structural digest."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607250037-96WEYY/README.md",
+    "packages/agentplane/src/cli/run-cli.critical.agent-efficiency-replay-hardening.test.ts",
+    "e1ed542204ff",
+    "bun run test:critical: 11/11 chunks PASS; focused RF-04: 3 consecutive 10/10 PASS with unchanged structural SHA 006ddc...9ee4"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": [
+    "The frozen production capture harness retains one-shot internal cleanup; changing those bytes would invalidate the approved provider evidence, so this task intentionally hardens only the offline test boundary."
+  ]
+}

--- a/packages/agentplane/src/cli/run-cli.critical.agent-efficiency-replay-hardening.test.ts
+++ b/packages/agentplane/src/cli/run-cli.critical.agent-efficiency-replay-hardening.test.ts
@@ -80,7 +80,7 @@ afterEach(() => {
 });
 
 describeCritical("critical: RF-04 replay hardening boundaries", () => {
-  it("retries late temporary-root entries and preserves persistent cleanup errors", () => {
+  it("retries late entries and preserves retryable and non-retryable cleanup errors", () => {
     const lateEntryRoot = temporaryRoot();
     let lateEntryAttempts = 0;
     cleanupTemporaryRoot(lateEntryRoot, (root) => {
@@ -97,13 +97,16 @@ describeCritical("critical: RF-04 replay hardening boundaries", () => {
     expect(existsSync(lateEntryRoot)).toBe(false);
 
     const persistentRoot = temporaryRoot();
-    const persistentError = Object.assign(new Error("persistent cleanup failure"), {
-      code: "ENOTEMPTY",
-    });
+    const persistentErrors = Array.from({ length: TEMPORARY_ROOT_CLEANUP_ATTEMPTS }, (_, index) =>
+      Object.assign(new Error(`persistent cleanup failure ${index + 1}`), {
+        code: "ENOTEMPTY",
+      }),
+    );
     let persistentAttempts = 0;
     let surfacedError: unknown;
     try {
       cleanupTemporaryRoot(persistentRoot, () => {
+        const persistentError = persistentErrors[persistentAttempts];
         persistentAttempts += 1;
         throw persistentError;
       });
@@ -111,7 +114,24 @@ describeCritical("critical: RF-04 replay hardening boundaries", () => {
       surfacedError = error;
     }
     expect(persistentAttempts).toBe(TEMPORARY_ROOT_CLEANUP_ATTEMPTS);
-    expect(surfacedError).toBe(persistentError);
+    expect(surfacedError).toBe(persistentErrors[0]);
+
+    const nonRetryableRoot = temporaryRoot();
+    const nonRetryableError = Object.assign(new Error("non-retryable cleanup failure"), {
+      code: "EIO",
+    });
+    let nonRetryableAttempts = 0;
+    let surfacedNonRetryableError: unknown;
+    try {
+      cleanupTemporaryRoot(nonRetryableRoot, () => {
+        nonRetryableAttempts += 1;
+        throw nonRetryableError;
+      });
+    } catch (error) {
+      surfacedNonRetryableError = error;
+    }
+    expect(nonRetryableAttempts).toBe(1);
+    expect(surfacedNonRetryableError).toBe(nonRetryableError);
   });
 
   it("surfaces only a whole bounded UTF-8 replay driver diagnostic code", async () => {

--- a/packages/agentplane/src/cli/run-cli.critical.agent-efficiency-replay-hardening.test.ts
+++ b/packages/agentplane/src/cli/run-cli.critical.agent-efficiency-replay-hardening.test.ts
@@ -21,6 +21,44 @@ import { describeCritical } from "@agentplane/testkit";
 const REPO_ROOT = process.cwd();
 const TEST_ROOT = path.join(REPO_ROOT, ".agentplane/cache/rf04-test-targets");
 const temporaryRoots: string[] = [];
+const TEMPORARY_ROOT_CLEANUP_ATTEMPTS = 4;
+const RETRYABLE_CLEANUP_CODES = new Set(["EBUSY", "ENOTEMPTY", "EPERM"]);
+
+type TemporaryRootRemover = (root: string) => void;
+
+function isRetryableCleanupError(error: unknown): error is NodeJS.ErrnoException {
+  return (
+    error instanceof Error &&
+    typeof (error as NodeJS.ErrnoException).code === "string" &&
+    RETRYABLE_CLEANUP_CODES.has((error as NodeJS.ErrnoException).code ?? "")
+  );
+}
+
+function removeTemporaryRootAttempt(root: string): void {
+  rmSync(root, {
+    force: true,
+    maxRetries: 2,
+    recursive: true,
+    retryDelay: 25,
+  });
+}
+
+function cleanupTemporaryRoot(
+  root: string,
+  remove: TemporaryRootRemover = removeTemporaryRootAttempt,
+): void {
+  let firstRetryableError: unknown;
+  for (let attempt = 0; attempt < TEMPORARY_ROOT_CLEANUP_ATTEMPTS; attempt += 1) {
+    try {
+      remove(root);
+      return;
+    } catch (error) {
+      if (!isRetryableCleanupError(error)) throw error;
+      firstRetryableError ??= error;
+      if (attempt === TEMPORARY_ROOT_CLEANUP_ATTEMPTS - 1) throw firstRetryableError;
+    }
+  }
+}
 
 function temporaryRoot(): string {
   mkdirSync(TEST_ROOT, { recursive: true });
@@ -38,10 +76,44 @@ async function importModule<T>(relativePath: string): Promise<T> {
 }
 
 afterEach(() => {
-  for (const root of temporaryRoots.splice(0)) rmSync(root, { force: true, recursive: true });
+  for (const root of temporaryRoots.splice(0)) cleanupTemporaryRoot(root);
 });
 
 describeCritical("critical: RF-04 replay hardening boundaries", () => {
+  it("retries late temporary-root entries and preserves persistent cleanup errors", () => {
+    const lateEntryRoot = temporaryRoot();
+    let lateEntryAttempts = 0;
+    cleanupTemporaryRoot(lateEntryRoot, (root) => {
+      lateEntryAttempts += 1;
+      if (lateEntryAttempts === 1) {
+        writeFileSync(path.join(root, ".DS_Store"), "late entry\n");
+        throw Object.assign(new Error("simulated late temporary-root entry"), {
+          code: "ENOTEMPTY",
+        });
+      }
+      rmSync(root, { force: true, recursive: true });
+    });
+    expect(lateEntryAttempts).toBe(2);
+    expect(existsSync(lateEntryRoot)).toBe(false);
+
+    const persistentRoot = temporaryRoot();
+    const persistentError = Object.assign(new Error("persistent cleanup failure"), {
+      code: "ENOTEMPTY",
+    });
+    let persistentAttempts = 0;
+    let surfacedError: unknown;
+    try {
+      cleanupTemporaryRoot(persistentRoot, () => {
+        persistentAttempts += 1;
+        throw persistentError;
+      });
+    } catch (error) {
+      surfacedError = error;
+    }
+    expect(persistentAttempts).toBe(TEMPORARY_ROOT_CLEANUP_ATTEMPTS);
+    expect(surfacedError).toBe(persistentError);
+  });
+
   it("surfaces only a whole bounded UTF-8 replay driver diagnostic code", async () => {
     const safety = await importModule<{
       replayDriverDiagnosticCode(stderr: Uint8Array): string | null;

--- a/packages/agentplane/src/cli/run-cli.critical.agent-efficiency-replay-hardening.test.ts
+++ b/packages/agentplane/src/cli/run-cli.critical.agent-efficiency-replay-hardening.test.ts
@@ -60,6 +60,21 @@ function cleanupTemporaryRoot(
   }
 }
 
+function runWithReplayCleanupRetry<T>(run: () => T, cleanup: () => void): T {
+  let firstRetryableError: unknown;
+  for (let attempt = 0; attempt < TEMPORARY_ROOT_CLEANUP_ATTEMPTS; attempt += 1) {
+    try {
+      return run();
+    } catch (error) {
+      if (!isRetryableCleanupError(error)) throw error;
+      firstRetryableError ??= error;
+      cleanup();
+      if (attempt === TEMPORARY_ROOT_CLEANUP_ATTEMPTS - 1) throw firstRetryableError;
+    }
+  }
+  throw firstRetryableError;
+}
+
 function temporaryRoot(): string {
   mkdirSync(TEST_ROOT, { recursive: true });
   const root = mkdtempSync(path.join(TEST_ROOT, "hardening-"));
@@ -132,6 +147,31 @@ describeCritical("critical: RF-04 replay hardening boundaries", () => {
     }
     expect(nonRetryableAttempts).toBe(1);
     expect(surfacedNonRetryableError).toBe(nonRetryableError);
+
+    const transientRunCleanupError = Object.assign(new Error("transient replay cleanup failure"), {
+      code: "ENOTEMPTY",
+    });
+    const replayFailure = new Error("replay driver failure");
+    let runAttempts = 0;
+    let runCleanupAttempts = 0;
+    let surfacedReplayFailure: unknown;
+    try {
+      runWithReplayCleanupRetry(
+        () => {
+          runAttempts += 1;
+          if (runAttempts === 1) throw transientRunCleanupError;
+          throw replayFailure;
+        },
+        () => {
+          runCleanupAttempts += 1;
+        },
+      );
+    } catch (error) {
+      surfacedReplayFailure = error;
+    }
+    expect(runAttempts).toBe(2);
+    expect(runCleanupAttempts).toBe(1);
+    expect(surfacedReplayFailure).toBe(replayFailure);
   });
 
   it("surfaces only a whole bounded UTF-8 replay driver diagnostic code", async () => {
@@ -216,24 +256,36 @@ describeCritical("critical: RF-04 replay hardening boundaries", () => {
     const replayCacheBefore = readdirSync(cacheRoot)
       .filter((name) => name.startsWith("rf04-replay-"))
       .toSorted();
+    const replayCacheBeforeSet = new Set(replayCacheBefore);
+    const cleanupFailedReplayCaptures = () => {
+      for (const name of readdirSync(cacheRoot)) {
+        if (name.startsWith("rf04-replay-") && !replayCacheBeforeSet.has(name)) {
+          cleanupTemporaryRoot(path.join(cacheRoot, name));
+        }
+      }
+    };
     writeFileSync(
       driverPath,
       'process.stderr.write("RF04_DRIVER_ERROR:CODEX_EXIT\\n");\nprocess.exitCode = 1;\n',
     );
     try {
       expect(() =>
-        capture.captureAgentEfficiencyReplay({
-          allowTestTargets: true,
-          anchor: replay.REPLAY_ANCHOR_COMMIT,
-          driverPath,
-          evidenceDirectory,
-          outputPath,
-          pilot: true,
-          registryPath: path.join(REPO_ROOT, "scripts/bench/agent-efficiency-fixtures.json"),
-          replace: false,
-          runs: replay.MINIMUM_REPLAY_RUNS,
-          sourceDirectory,
-        }),
+        runWithReplayCleanupRetry(
+          () =>
+            capture.captureAgentEfficiencyReplay({
+              allowTestTargets: true,
+              anchor: replay.REPLAY_ANCHOR_COMMIT,
+              driverPath,
+              evidenceDirectory,
+              outputPath,
+              pilot: true,
+              registryPath: path.join(REPO_ROOT, "scripts/bench/agent-efficiency-fixtures.json"),
+              replace: false,
+              runs: replay.MINIMUM_REPLAY_RUNS,
+              sourceDirectory,
+            }),
+          cleanupFailedReplayCaptures,
+        ),
       ).toThrow("direct/run-01 replay driver failed with exit 1; diagnostic=CODEX_EXIT");
     } finally {
       rmSync(driverPath, { force: true });


### PR DESCRIPTION
Task: `202607250037-96WEYY`
Title: Make RF-04 replay cleanup retry-safe on macOS
Canonical task record: `.agentplane/tasks/202607250037-96WEYY/README.md`

## Summary

Make RF-04 replay cleanup retry-safe on macOS

Prevent Finder-created .DS_Store files from turning successful RF-04 offline replay assertions into cleanup-only ENOTEMPTY failures. Keep the frozen 50-run/55-provider-episode evidence unchanged and add deterministic cleanup regression coverage.

## Scope

- In scope: Prevent Finder-created .DS_Store files from turning successful RF-04 offline replay assertions into cleanup-only ENOTEMPTY failures. Keep the frozen 50-run/55-provider-episode evidence unchanged and add deterministic cleanup regression coverage.
- Out of scope: unrelated refactors not required for "Make RF-04 replay cleanup retry-safe on macOS".

## Verification

- State: pending
- Note: Not recorded yet.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-07-25T00:39:52.775Z
- Branch: task/202607250037-96WEYY/make-rf-04-replay-cleanup-retry-safe-on-macos
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
No changes detected.
```

</details>
