### PR TITLE
🚧 D9HW3D task: Preserve compact incident registry formatting [202607251715-D9HW3D]

### DIFF
--- a/.agentplane/tasks/202607251715-D9HW3D/README.md
+++ b/.agentplane/tasks/202607251715-D9HW3D/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 10
+revision: 11
 origin:
   system: "manual"
 depends_on: []
@@ -50,7 +50,7 @@ quality_review:
   findings:
     - "packages/agentplane/src/commands/incidents/shared.test.ts now asserts the same required compact header prefix through String.prototype.startsWith, preserving the regression invariant."
 commit:
-  hash: "8ea6b5c28a7220a2dafde63d08573954ea4ead2c"
+  hash: "c53d2f86db555e6034b6858e974e41b0992a6ff4"
   message: "🧪 D9HW3D task: pre-merge closure"
 comments:
   -
@@ -59,6 +59,9 @@ comments:
   -
     author: "CODER"
     body: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    author: "CODER"
+    body: "Verified: refreshed pre-merge closure packet is ready for the task PR."
   -
     author: "CODER"
     body: "Verified: refreshed pre-merge closure packet is ready for the task PR."
@@ -96,8 +99,15 @@ events:
     from: "DONE"
     to: "DONE"
     note: "Verified: refreshed pre-merge closure packet is ready for the task PR."
+  -
+    type: "status"
+    at: "2026-07-25T17:49:46.464Z"
+    author: "CODER"
+    from: "DONE"
+    to: "DONE"
+    note: "Verified: refreshed pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-25T17:38:37.584Z"
+doc_updated_at: "2026-07-25T17:49:46.466Z"
 doc_updated_by: "CODER"
 description: "Repair the incident-registry renderer so compact rewrites retain the required blank line after the heading, keep the canonical and asset mirrors byte-identical, and add regression coverage. This unblocks the hosted format check for task 202607251433-75Q4J6 without manually editing a policy log in that task."
 sections:
@@ -186,8 +196,8 @@ sections:
   Findings: ""
 extensions:
   implementation_commit:
-    hash: "b0b3c38440851f91f9d80b90f6c2e5733ccbcce1"
-    message: "🧪 D9HW3D incidents: retain legacy compact fixture"
+    hash: "4e126a1325db4136601f15643bc03fa23418c8be"
+    message: "🧪 D9HW3D incidents: type-safe mirror prefix check"
 id_source: "generated"
 ---
 ## Summary

--- a/.agentplane/tasks/202607251715-D9HW3D/README.md
+++ b/.agentplane/tasks/202607251715-D9HW3D/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202607251715-D9HW3D"
 title: "Preserve compact incident registry formatting"
-status: "DOING"
+result_summary: "pre-merge closure"
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 4
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -26,16 +27,38 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-07-25T17:28:30.085Z"
+  updated_by: "TESTER"
+  note: "Verified published head 57da81c6: runtime incidents 10/10, mirror 1/1, CLI incidents 10/10, format, templates, TypeScript, targeted lint, policy routing, and doctor pass. Legacy compact input is normalized to the Prettier-compatible header and mirrors remain byte-identical."
   attempts: 0
-commit: null
+quality_review:
+  state: "pass"
+  provenance: "evaluator_supplied"
+  updated_at: "2026-07-25T17:33:30.155Z"
+  updated_by: "EVALUATOR"
+  note: "Compact incident registry rendering preserves the required heading blank line while retaining legacy compact parsing and byte-identical canonical/asset mirrors."
+  evaluated_sha: "b0b3c38440851f91f9d80b90f6c2e5733ccbcce1"
+  blueprint_digest: "afe0e20728b15b8d9b47cd281b4d34e77988acc95fdf57bf46b0a1fa306c4424"
+  evidence_refs:
+    - ".agentplane/tasks/202607251715-D9HW3D/README.md"
+    - ".agentplane/tasks/202607251715-D9HW3D/quality/20260725-173330155-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607251715-D9HW3D/quality/20260725-173330155-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607251715-D9HW3D/quality/20260725-173330155-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607251715-D9HW3D/blueprint/resolved-snapshot.json"
+    - "b0b3c3844; focused incidents suite 21/21; format:check pass; agents:check pass; boundary probe 95+1=100 and 96+1=101"
+  findings:
+    - "The new blank line intentionally consumes one physical policy-budget line; the exact boundary remains 95 existing compact entries plus one promotion at 100 lines, while 96 plus one is rejected."
+commit:
+  hash: "b0b3c38440851f91f9d80b90f6c2e5733ccbcce1"
+  message: "🧪 D9HW3D incidents: retain legacy compact fixture"
 comments:
   -
     author: "ORCHESTRATOR"
     body: "Start: approved narrow repair for compact incident registry rendering and regression coverage; it unblocks the verified hosted formatting failure without altering the active incident content manually."
+  -
+    author: "CODER"
+    body: "Verified: pre-merge closure packet is ready for the task PR."
 events:
   -
     type: "status"
@@ -44,9 +67,22 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: approved narrow repair for compact incident registry rendering and regression coverage; it unblocks the verified hosted formatting failure without altering the active incident content manually."
+  -
+    type: "verify"
+    at: "2026-07-25T17:28:30.085Z"
+    author: "TESTER"
+    state: "ok"
+    note: "Verified published head 57da81c6: runtime incidents 10/10, mirror 1/1, CLI incidents 10/10, format, templates, TypeScript, targeted lint, policy routing, and doctor pass. Legacy compact input is normalized to the Prettier-compatible header and mirrors remain byte-identical."
+  -
+    type: "status"
+    at: "2026-07-25T17:33:55.438Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-25T17:15:18.391Z"
-doc_updated_by: "ORCHESTRATOR"
+doc_updated_at: "2026-07-25T17:33:55.439Z"
+doc_updated_by: "CODER"
 description: "Repair the incident-registry renderer so compact rewrites retain the required blank line after the heading, keep the canonical and asset mirrors byte-identical, and add regression coverage. This unblocks the hosted format check for task 202607251433-75Q4J6 without manually editing a policy log in that task."
 sections:
   Summary: |-
@@ -67,6 +103,36 @@ sections:
     5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-07-25T17:28:30.085Z — VERIFY — ok
+
+    By: TESTER
+
+    Note: Verified published head 57da81c6: runtime incidents 10/10, mirror 1/1, CLI incidents 10/10, format, templates, TypeScript, targeted lint, policy routing, and doctor pass. Legacy compact input is normalized to the Prettier-compatible header and mirrors remain byte-identical.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-25T17:15:18.391Z, excerpt_hash=sha256:2d03d77e36376633d6a26412923e23091dde0230ad77269c736c2def2f69eb01
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607251715-D9HW3D-preserve-compact-incident-registry-formatting/.agentplane/tasks/202607251715-D9HW3D/blueprint/resolved-snapshot.json
+    - old_digest: afe0e20728b15b8d9b47cd281b4d34e77988acc95fdf57bf46b0a1fa306c4424
+    - current_digest: afe0e20728b15b8d9b47cd281b4d34e77988acc95fdf57bf46b0a1fa306c4424
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607251715-D9HW3D
+
+    DecisionContextRef:
+    - operator_action: stop
+    - can_execute_now: false
+    - safe_command: none
+    - diagnostic_command: agentplane task verify-show 202607251715-D9HW3D
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: none
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -102,6 +168,36 @@ PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLA
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-07-25T17:28:30.085Z — VERIFY — ok
+
+By: TESTER
+
+Note: Verified published head 57da81c6: runtime incidents 10/10, mirror 1/1, CLI incidents 10/10, format, templates, TypeScript, targeted lint, policy routing, and doctor pass. Legacy compact input is normalized to the Prettier-compatible header and mirrors remain byte-identical.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-25T17:15:18.391Z, excerpt_hash=sha256:2d03d77e36376633d6a26412923e23091dde0230ad77269c736c2def2f69eb01
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607251715-D9HW3D-preserve-compact-incident-registry-formatting/.agentplane/tasks/202607251715-D9HW3D/blueprint/resolved-snapshot.json
+- old_digest: afe0e20728b15b8d9b47cd281b4d34e77988acc95fdf57bf46b0a1fa306c4424
+- current_digest: afe0e20728b15b8d9b47cd281b4d34e77988acc95fdf57bf46b0a1fa306c4424
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607251715-D9HW3D
+
+DecisionContextRef:
+- operator_action: stop
+- can_execute_now: false
+- safe_command: none
+- diagnostic_command: agentplane task verify-show 202607251715-D9HW3D
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: none
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202607251715-D9HW3D/README.md
+++ b/.agentplane/tasks/202607251715-D9HW3D/README.md
@@ -1,0 +1,112 @@
+---
+id: "202607251715-D9HW3D"
+title: "Preserve compact incident registry formatting"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 4
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "code"
+  - "incidents"
+  - "reliability"
+  - "v0.7"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "bun run agents:check"
+  - "bun run format:check"
+  - "bun test packages/agentplane/src/runtime/incidents/resolve.test.ts"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-07-25T17:15:18.004Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "ORCHESTRATOR"
+    body: "Start: approved narrow repair for compact incident registry rendering and regression coverage; it unblocks the verified hosted formatting failure without altering the active incident content manually."
+events:
+  -
+    type: "status"
+    at: "2026-07-25T17:15:18.391Z"
+    author: "ORCHESTRATOR"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: approved narrow repair for compact incident registry rendering and regression coverage; it unblocks the verified hosted formatting failure without altering the active incident content manually."
+doc_version: 3
+doc_updated_at: "2026-07-25T17:15:18.391Z"
+doc_updated_by: "ORCHESTRATOR"
+description: "Repair the incident-registry renderer so compact rewrites retain the required blank line after the heading, keep the canonical and asset mirrors byte-identical, and add regression coverage. This unblocks the hosted format check for task 202607251433-75Q4J6 without manually editing a policy log in that task."
+sections:
+  Summary: |-
+    Preserve compact incident registry formatting
+
+    Repair the incident-registry renderer so compact rewrites retain the required blank line after the heading, keep the canonical and asset mirrors byte-identical, and add regression coverage. This unblocks the hosted format check for task 202607251433-75Q4J6 without manually editing a policy log in that task.
+  Scope: |-
+    - In scope: Repair the incident-registry renderer so compact rewrites retain the required blank line after the heading, keep the canonical and asset mirrors byte-identical, and add regression coverage. This unblocks the hosted format check for task 202607251433-75Q4J6 without manually editing a policy log in that task.
+    - Out of scope: unrelated refactors not required for "Preserve compact incident registry formatting".
+  Plan: "1. Trace compact incident rendering and preserve the Markdown blank line after the heading without changing registry semantics. 2. Add focused regression coverage for compact append output and canonical/asset mirror compatibility. 3. Run focused incident tests, format, agents sync validation, and targeted type/lint checks; publish a branch PR and integrate only after hosted checks pass."
+  Verify Steps: |-
+    PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+    1. Run `bun test packages/agentplane/src/runtime/incidents/resolve.test.ts`. Expected: it succeeds and confirms the requested outcome for this task.
+    2. Run `bun run format:check`. Expected: it succeeds and confirms the requested outcome for this task.
+    3. Run `bun run agents:check`. Expected: it succeeds and confirms the requested outcome for this task.
+    4. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+    5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+id_source: "generated"
+---
+## Summary
+
+Preserve compact incident registry formatting
+
+Repair the incident-registry renderer so compact rewrites retain the required blank line after the heading, keep the canonical and asset mirrors byte-identical, and add regression coverage. This unblocks the hosted format check for task 202607251433-75Q4J6 without manually editing a policy log in that task.
+
+## Scope
+
+- In scope: Repair the incident-registry renderer so compact rewrites retain the required blank line after the heading, keep the canonical and asset mirrors byte-identical, and add regression coverage. This unblocks the hosted format check for task 202607251433-75Q4J6 without manually editing a policy log in that task.
+- Out of scope: unrelated refactors not required for "Preserve compact incident registry formatting".
+
+## Plan
+
+1. Trace compact incident rendering and preserve the Markdown blank line after the heading without changing registry semantics. 2. Add focused regression coverage for compact append output and canonical/asset mirror compatibility. 3. Run focused incident tests, format, agents sync validation, and targeted type/lint checks; publish a branch PR and integrate only after hosted checks pass.
+
+## Verify Steps
+
+PLANNER fallback scaffold. Replace with task-specific acceptance checks when PLANNER context is available.
+
+1. Run `bun test packages/agentplane/src/runtime/incidents/resolve.test.ts`. Expected: it succeeds and confirms the requested outcome for this task.
+2. Run `bun run format:check`. Expected: it succeeds and confirms the requested outcome for this task.
+3. Run `bun run agents:check`. Expected: it succeeds and confirms the requested outcome for this task.
+4. Review the changed artifact or behavior for the `code` task. Expected: the requested outcome is visible and matches the approved scope.
+5. Compare the final result against the task summary and touched scope. Expected: remaining follow-up is either resolved or explicit in ## Findings.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202607251715-D9HW3D/README.md
+++ b/.agentplane/tasks/202607251715-D9HW3D/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 8
+revision: 9
 origin:
   system: "manual"
 depends_on: []
@@ -50,8 +50,8 @@ quality_review:
   findings:
     - "The new blank line intentionally consumes one physical policy-budget line; the exact boundary remains 95 existing compact entries plus one promotion at 100 lines, while 96 plus one is rejected."
 commit:
-  hash: "b0b3c38440851f91f9d80b90f6c2e5733ccbcce1"
-  message: "🧪 D9HW3D incidents: retain legacy compact fixture"
+  hash: "8ea6b5c28a7220a2dafde63d08573954ea4ead2c"
+  message: "🧪 D9HW3D task: pre-merge closure"
 comments:
   -
     author: "ORCHESTRATOR"
@@ -59,6 +59,9 @@ comments:
   -
     author: "CODER"
     body: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    author: "CODER"
+    body: "Verified: refreshed pre-merge closure packet is ready for the task PR."
 events:
   -
     type: "status"
@@ -86,8 +89,15 @@ events:
     author: "TESTER"
     state: "ok"
     note: "Verified final implementation b0b3c384: focused incident suites 21/21, format, templates, TypeScript, targeted lint, policy routing, doctor, and hotspot baseline pass. The closure commit only records lifecycle evidence; compact rendering and mirror behavior are unchanged."
+  -
+    type: "status"
+    at: "2026-07-25T17:38:37.583Z"
+    author: "CODER"
+    from: "DONE"
+    to: "DONE"
+    note: "Verified: refreshed pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-25T17:36:52.429Z"
+doc_updated_at: "2026-07-25T17:38:37.584Z"
 doc_updated_by: "CODER"
 description: "Repair the incident-registry renderer so compact rewrites retain the required blank line after the heading, keep the canonical and asset mirrors byte-identical, and add regression coverage. This unblocks the hosted format check for task 202607251433-75Q4J6 without manually editing a policy log in that task."
 sections:
@@ -174,6 +184,10 @@ sections:
     - Revert task-related commit(s).
     - Re-run required checks to confirm rollback safety.
   Findings: ""
+extensions:
+  implementation_commit:
+    hash: "b0b3c38440851f91f9d80b90f6c2e5733ccbcce1"
+    message: "🧪 D9HW3D incidents: retain legacy compact fixture"
 id_source: "generated"
 ---
 ## Summary

--- a/.agentplane/tasks/202607251715-D9HW3D/README.md
+++ b/.agentplane/tasks/202607251715-D9HW3D/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 7
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -28,9 +28,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-07-25T17:28:30.085Z"
+  updated_at: "2026-07-25T17:36:52.020Z"
   updated_by: "TESTER"
-  note: "Verified published head 57da81c6: runtime incidents 10/10, mirror 1/1, CLI incidents 10/10, format, templates, TypeScript, targeted lint, policy routing, and doctor pass. Legacy compact input is normalized to the Prettier-compatible header and mirrors remain byte-identical."
+  note: "Verified final implementation b0b3c384: focused incident suites 21/21, format, templates, TypeScript, targeted lint, policy routing, doctor, and hotspot baseline pass. The closure commit only records lifecycle evidence; compact rendering and mirror behavior are unchanged."
   attempts: 0
 quality_review:
   state: "pass"
@@ -80,8 +80,14 @@ events:
     from: "DOING"
     to: "DONE"
     note: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    type: "verify"
+    at: "2026-07-25T17:36:52.020Z"
+    author: "TESTER"
+    state: "ok"
+    note: "Verified final implementation b0b3c384: focused incident suites 21/21, format, templates, TypeScript, targeted lint, policy routing, doctor, and hotspot baseline pass. The closure commit only records lifecycle evidence; compact rendering and mirror behavior are unchanged."
 doc_version: 3
-doc_updated_at: "2026-07-25T17:33:55.439Z"
+doc_updated_at: "2026-07-25T17:36:52.429Z"
 doc_updated_by: "CODER"
 description: "Repair the incident-registry renderer so compact rewrites retain the required blank line after the heading, keep the canonical and asset mirrors byte-identical, and add regression coverage. This unblocks the hosted format check for task 202607251433-75Q4J6 without manually editing a policy log in that task."
 sections:
@@ -130,6 +136,36 @@ sections:
     - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
     - freshness: route=computed_local remote=remote_skipped
     - repeat_allowed: false
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: none
+
+    ### 2026-07-25T17:36:52.020Z — VERIFY — ok
+
+    By: TESTER
+
+    Note: Verified final implementation b0b3c384: focused incident suites 21/21, format, templates, TypeScript, targeted lint, policy routing, doctor, and hotspot baseline pass. The closure commit only records lifecycle evidence; compact rendering and mirror behavior are unchanged.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-25T17:33:55.439Z, excerpt_hash=sha256:2d03d77e36376633d6a26412923e23091dde0230ad77269c736c2def2f69eb01
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607251715-D9HW3D-preserve-compact-incident-registry-formatting/.agentplane/tasks/202607251715-D9HW3D/blueprint/resolved-snapshot.json
+    - old_digest: afe0e20728b15b8d9b47cd281b4d34e77988acc95fdf57bf46b0a1fa306c4424
+    - current_digest: afe0e20728b15b8d9b47cd281b4d34e77988acc95fdf57bf46b0a1fa306c4424
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607251715-D9HW3D
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane task next-action 202607251715-D9HW3D --remote --explain
+    - diagnostic_command: agentplane task next-action 202607251715-D9HW3D --remote --explain
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: true
     - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
     - risks: none
 
@@ -195,6 +231,36 @@ DecisionContextRef:
 - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
 - freshness: route=computed_local remote=remote_skipped
 - repeat_allowed: false
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: none
+
+### 2026-07-25T17:36:52.020Z — VERIFY — ok
+
+By: TESTER
+
+Note: Verified final implementation b0b3c384: focused incident suites 21/21, format, templates, TypeScript, targeted lint, policy routing, doctor, and hotspot baseline pass. The closure commit only records lifecycle evidence; compact rendering and mirror behavior are unchanged.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-25T17:33:55.439Z, excerpt_hash=sha256:2d03d77e36376633d6a26412923e23091dde0230ad77269c736c2def2f69eb01
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/worktrees/base-main-for-XS41ZV/.agentplane/worktrees/202607251715-D9HW3D-preserve-compact-incident-registry-formatting/.agentplane/tasks/202607251715-D9HW3D/blueprint/resolved-snapshot.json
+- old_digest: afe0e20728b15b8d9b47cd281b4d34e77988acc95fdf57bf46b0a1fa306c4424
+- current_digest: afe0e20728b15b8d9b47cd281b4d34e77988acc95fdf57bf46b0a1fa306c4424
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607251715-D9HW3D
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane task next-action 202607251715-D9HW3D --remote --explain
+- diagnostic_command: agentplane task next-action 202607251715-D9HW3D --remote --explain
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: true
 - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
 - risks: none
 

--- a/.agentplane/tasks/202607251715-D9HW3D/README.md
+++ b/.agentplane/tasks/202607251715-D9HW3D/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 9
+revision: 10
 origin:
   system: "manual"
 depends_on: []
@@ -35,20 +35,20 @@ verification:
 quality_review:
   state: "pass"
   provenance: "evaluator_supplied"
-  updated_at: "2026-07-25T17:33:30.155Z"
+  updated_at: "2026-07-25T17:46:43.329Z"
   updated_by: "EVALUATOR"
-  note: "Compact incident registry rendering preserves the required heading blank line while retaining legacy compact parsing and byte-identical canonical/asset mirrors."
-  evaluated_sha: "b0b3c38440851f91f9d80b90f6c2e5733ccbcce1"
+  note: "Lint-compatible prefix assertion is semantically equivalent for the UTF-8 string returned by readFile; no incident-registry behavior changed."
+  evaluated_sha: "4e126a1325db4136601f15643bc03fa23418c8be"
   blueprint_digest: "afe0e20728b15b8d9b47cd281b4d34e77988acc95fdf57bf46b0a1fa306c4424"
   evidence_refs:
     - ".agentplane/tasks/202607251715-D9HW3D/README.md"
-    - ".agentplane/tasks/202607251715-D9HW3D/quality/20260725-173330155-recovery-context/quality-report.json"
-    - ".agentplane/tasks/202607251715-D9HW3D/quality/20260725-173330155-recovery-context/evaluator-prompt.md"
-    - ".agentplane/tasks/202607251715-D9HW3D/quality/20260725-173330155-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607251715-D9HW3D/quality/20260725-174643329-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607251715-D9HW3D/quality/20260725-174643329-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607251715-D9HW3D/quality/20260725-174643329-recovery-context/evaluator-opinion.md"
     - ".agentplane/tasks/202607251715-D9HW3D/blueprint/resolved-snapshot.json"
-    - "b0b3c3844; focused incidents suite 21/21; format:check pass; agents:check pass; boundary probe 95+1=100 and 96+1=101"
+    - "4e126a132^..4e126a132; packages/agentplane/src/commands/incidents/shared.test.ts:126-139; git diff --check b0b3c3844..4e126a132"
   findings:
-    - "The new blank line intentionally consumes one physical policy-budget line; the exact boundary remains 95 existing compact entries plus one promotion at 100 lines, while 96 plus one is rejected."
+    - "packages/agentplane/src/commands/incidents/shared.test.ts now asserts the same required compact header prefix through String.prototype.startsWith, preserving the regression invariant."
 commit:
   hash: "8ea6b5c28a7220a2dafde63d08573954ea4ead2c"
   message: "🧪 D9HW3D task: pre-merge closure"

--- a/.agentplane/tasks/202607251715-D9HW3D/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202607251715-D9HW3D/blueprint/resolved-snapshot.json
@@ -1,0 +1,580 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607251715-D9HW3D",
+    "title": "Preserve compact incident registry formatting",
+    "description": "Repair the incident-registry renderer so compact rewrites retain the required blank line after the heading, keep the canonical and asset mirrors byte-identical, and add regression coverage. This unblocks the hosted format check for task 202607251433-75Q4J6 without manually editing a policy log in that task.",
+    "tags": [
+      "code",
+      "incidents",
+      "reliability",
+      "v0.7"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607251715-D9HW3D",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "afe0e20728b15b8d9b47cd281b4d34e77988acc95fdf57bf46b0a1fa306c4424"
+  }
+}

--- a/.agentplane/tasks/202607251715-D9HW3D/pr/diffstat.txt
+++ b/.agentplane/tasks/202607251715-D9HW3D/pr/diffstat.txt
@@ -1,5 +1,4 @@
- packages/agentplane/src/cli/run-cli.core.incidents.test.ts |  1 +
- packages/agentplane/src/commands/incidents/shared.test.ts  | 10 ++++++++--
- packages/agentplane/src/runtime/incidents/resolve.test.ts  | 14 +++++++++++---
- packages/agentplane/src/runtime/incidents/shared.ts        |  1 +
- 4 files changed, 21 insertions(+), 5 deletions(-)
+ packages/agentplane/src/commands/incidents/shared.test.ts | 10 ++++++++--
+ packages/agentplane/src/runtime/incidents/resolve.test.ts | 14 +++++++++++---
+ packages/agentplane/src/runtime/incidents/shared.ts       |  1 +
+ 3 files changed, 20 insertions(+), 5 deletions(-)

--- a/.agentplane/tasks/202607251715-D9HW3D/pr/diffstat.txt
+++ b/.agentplane/tasks/202607251715-D9HW3D/pr/diffstat.txt
@@ -1,0 +1,5 @@
+ packages/agentplane/src/cli/run-cli.core.incidents.test.ts |  1 +
+ packages/agentplane/src/commands/incidents/shared.test.ts  | 10 ++++++++--
+ packages/agentplane/src/runtime/incidents/resolve.test.ts  | 14 +++++++++++---
+ packages/agentplane/src/runtime/incidents/shared.ts        |  1 +
+ 4 files changed, 21 insertions(+), 5 deletions(-)

--- a/.agentplane/tasks/202607251715-D9HW3D/pr/github-body.md
+++ b/.agentplane/tasks/202607251715-D9HW3D/pr/github-body.md
@@ -22,12 +22,16 @@ Repair the incident-registry renderer so compact rewrites retain the required bl
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-25T17:16:51.010Z
+- Updated: 2026-07-25T17:18:50.186Z
 - Branch: task/202607251715-D9HW3D/preserve-compact-incident-registry-formatting
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ packages/agentplane/src/cli/run-cli.core.incidents.test.ts |  1 +
+ packages/agentplane/src/commands/incidents/shared.test.ts  | 10 ++++++++--
+ packages/agentplane/src/runtime/incidents/resolve.test.ts  | 14 +++++++++++---
+ packages/agentplane/src/runtime/incidents/shared.ts        |  1 +
+ 4 files changed, 21 insertions(+), 5 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607251715-D9HW3D/pr/github-body.md
+++ b/.agentplane/tasks/202607251715-D9HW3D/pr/github-body.md
@@ -19,9 +19,9 @@ Repair the incident-registry renderer so compact rewrites retain the required bl
 - Note:
 
 ```text
-Verified published head 57da81c6: runtime incidents 10/10, mirror 1/1, CLI incidents 10/10, format,
-templates, TypeScript, targeted lint, policy routing, and doctor pass. Legacy compact input is
-normalized to the Prettier-compatible header and mirrors remain byte-identical.
+Verified final implementation b0b3c384: focused incident suites 21/21, format, templates,
+TypeScript, targeted lint, policy routing, doctor, and hotspot baseline pass. The closure commit
+only records lifecycle evidence; compact rendering and mirror behavior are unchanged.
 ```
 - Canonical workflow state lives in the task README.
 

--- a/.agentplane/tasks/202607251715-D9HW3D/pr/github-body.md
+++ b/.agentplane/tasks/202607251715-D9HW3D/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202607251715-D9HW3D`
+Title: Preserve compact incident registry formatting
+Canonical task record: `.agentplane/tasks/202607251715-D9HW3D/README.md`
+
+## Summary
+
+Preserve compact incident registry formatting
+
+Repair the incident-registry renderer so compact rewrites retain the required blank line after the heading, keep the canonical and asset mirrors byte-identical, and add regression coverage. This unblocks the hosted format check for task 202607251433-75Q4J6 without manually editing a policy log in that task.
+
+## Scope
+
+- In scope: Repair the incident-registry renderer so compact rewrites retain the required blank line after the heading, keep the canonical and asset mirrors byte-identical, and add regression coverage. This unblocks the hosted format check for task 202607251433-75Q4J6 without manually editing a policy log in that task.
+- Out of scope: unrelated refactors not required for "Preserve compact incident registry formatting".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-25T17:16:51.010Z
+- Branch: task/202607251715-D9HW3D/preserve-compact-incident-registry-formatting
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202607251715-D9HW3D/pr/github-body.md
+++ b/.agentplane/tasks/202607251715-D9HW3D/pr/github-body.md
@@ -15,8 +15,14 @@ Repair the incident-registry renderer so compact rewrites retain the required bl
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Verified published head 57da81c6: runtime incidents 10/10, mirror 1/1, CLI incidents 10/10, format,
+templates, TypeScript, targeted lint, policy routing, and doctor pass. Legacy compact input is
+normalized to the Prettier-compatible header and mirrors remain byte-identical.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
@@ -27,11 +33,10 @@ Repair the incident-registry renderer so compact rewrites retain the required bl
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
- packages/agentplane/src/cli/run-cli.core.incidents.test.ts |  1 +
- packages/agentplane/src/commands/incidents/shared.test.ts  | 10 ++++++++--
- packages/agentplane/src/runtime/incidents/resolve.test.ts  | 14 +++++++++++---
- packages/agentplane/src/runtime/incidents/shared.ts        |  1 +
- 4 files changed, 21 insertions(+), 5 deletions(-)
+ packages/agentplane/src/commands/incidents/shared.test.ts | 10 ++++++++--
+ packages/agentplane/src/runtime/incidents/resolve.test.ts | 14 +++++++++++---
+ packages/agentplane/src/runtime/incidents/shared.ts       |  1 +
+ 3 files changed, 20 insertions(+), 5 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607251715-D9HW3D/pr/github-title.txt
+++ b/.agentplane/tasks/202607251715-D9HW3D/pr/github-title.txt
@@ -1,1 +1,1 @@
-🚧 D9HW3D task: Preserve compact incident registry formatting [202607251715-D9HW3D]
+✅ D9HW3D task: Preserve compact incident registry formatting [202607251715-D9HW3D]

--- a/.agentplane/tasks/202607251715-D9HW3D/pr/github-title.txt
+++ b/.agentplane/tasks/202607251715-D9HW3D/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 D9HW3D task: Preserve compact incident registry formatting [202607251715-D9HW3D]

--- a/.agentplane/tasks/202607251715-D9HW3D/pr/meta.json
+++ b/.agentplane/tasks/202607251715-D9HW3D/pr/meta.json
@@ -8,10 +8,10 @@
   "pr_number": 4620,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4620",
   "pre_merge_closure": {
-    "basis_commit": "8ea6b5c28a7220a2dafde63d08573954ea4ead2c",
+    "basis_commit": "c53d2f86db555e6034b6858e974e41b0992a6ff4",
     "branch": "task/202607251715-D9HW3D/preserve-compact-incident-registry-formatting",
     "pr_number": 4620,
-    "recorded_at": "2026-07-25T17:38:37.641Z",
+    "recorded_at": "2026-07-25T17:49:46.601Z",
     "state": "closed_before_merge"
   },
   "schema_version": 1,

--- a/.agentplane/tasks/202607251715-D9HW3D/pr/meta.json
+++ b/.agentplane/tasks/202607251715-D9HW3D/pr/meta.json
@@ -2,11 +2,14 @@
   "base": "main",
   "branch": "task/202607251715-D9HW3D/preserve-compact-incident-registry-formatting",
   "created_at": "2026-07-25T17:16:51.010Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "diffstat_sha256": "sha256:1cc71fc825426b53edba1938c2e757c564f20f38d9caf027d08f5edf2c46255b",
   "last_verified_at": null,
+  "pr_number": 4620,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4620",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202607251715-D9HW3D",
-  "updated_at": "2026-07-25T17:16:51.010Z",
+  "updated_at": "2026-07-25T17:18:50.186Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202607251715-D9HW3D/pr/meta.json
+++ b/.agentplane/tasks/202607251715-D9HW3D/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202607251715-D9HW3D/preserve-compact-incident-registry-formatting",
+  "created_at": "2026-07-25T17:16:51.010Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202607251715-D9HW3D",
+  "updated_at": "2026-07-25T17:16:51.010Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202607251715-D9HW3D/pr/meta.json
+++ b/.agentplane/tasks/202607251715-D9HW3D/pr/meta.json
@@ -3,8 +3,8 @@
   "branch": "task/202607251715-D9HW3D/preserve-compact-incident-registry-formatting",
   "created_at": "2026-07-25T17:16:51.010Z",
   "diffstat_sha256": "sha256:9211f690b6daf226716ae44d44632f4218418e2483a65866abab81ef83bf84f0",
-  "last_verified_at": "2026-07-25T17:28:30.085Z",
-  "last_verified_diffstat_sha256": "sha256:1cc71fc825426b53edba1938c2e757c564f20f38d9caf027d08f5edf2c46255b",
+  "last_verified_at": "2026-07-25T17:36:52.020Z",
+  "last_verified_diffstat_sha256": "sha256:9211f690b6daf226716ae44d44632f4218418e2483a65866abab81ef83bf84f0",
   "pr_number": 4620,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4620",
   "pre_merge_closure": {

--- a/.agentplane/tasks/202607251715-D9HW3D/pr/meta.json
+++ b/.agentplane/tasks/202607251715-D9HW3D/pr/meta.json
@@ -2,15 +2,23 @@
   "base": "main",
   "branch": "task/202607251715-D9HW3D/preserve-compact-incident-registry-formatting",
   "created_at": "2026-07-25T17:16:51.010Z",
-  "diffstat_sha256": "sha256:1cc71fc825426b53edba1938c2e757c564f20f38d9caf027d08f5edf2c46255b",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:9211f690b6daf226716ae44d44632f4218418e2483a65866abab81ef83bf84f0",
+  "last_verified_at": "2026-07-25T17:28:30.085Z",
+  "last_verified_diffstat_sha256": "sha256:1cc71fc825426b53edba1938c2e757c564f20f38d9caf027d08f5edf2c46255b",
   "pr_number": 4620,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4620",
+  "pre_merge_closure": {
+    "basis_commit": "b0b3c38440851f91f9d80b90f6c2e5733ccbcce1",
+    "branch": "task/202607251715-D9HW3D/preserve-compact-incident-registry-formatting",
+    "pr_number": 4620,
+    "recorded_at": "2026-07-25T17:33:55.493Z",
+    "state": "closed_before_merge"
+  },
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202607251715-D9HW3D",
   "updated_at": "2026-07-25T17:18:50.186Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202607251715-D9HW3D/pr/meta.json
+++ b/.agentplane/tasks/202607251715-D9HW3D/pr/meta.json
@@ -8,10 +8,10 @@
   "pr_number": 4620,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4620",
   "pre_merge_closure": {
-    "basis_commit": "b0b3c38440851f91f9d80b90f6c2e5733ccbcce1",
+    "basis_commit": "8ea6b5c28a7220a2dafde63d08573954ea4ead2c",
     "branch": "task/202607251715-D9HW3D/preserve-compact-incident-registry-formatting",
     "pr_number": 4620,
-    "recorded_at": "2026-07-25T17:33:55.493Z",
+    "recorded_at": "2026-07-25T17:38:37.641Z",
     "state": "closed_before_merge"
   },
   "schema_version": 1,

--- a/.agentplane/tasks/202607251715-D9HW3D/pr/review.md
+++ b/.agentplane/tasks/202607251715-D9HW3D/pr/review.md
@@ -6,14 +6,14 @@ Created: 2026-07-25T17:16:51.010Z
 
 - Task: `202607251715-D9HW3D`
 - Title: Preserve compact incident registry formatting
-- Status: DOING
+- Status: DONE
 - Branch: `task/202607251715-D9HW3D/preserve-compact-incident-registry-formatting`
 - Canonical task record: `.agentplane/tasks/202607251715-D9HW3D/README.md`
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified published head 57da81c6: runtime incidents 10/10, mirror 1/1, CLI incidents 10/10, format, templates, TypeScript, targeted lint, policy routing, and doctor pass. Legacy compact input is normalized to the Prettier-compatible header and mirrors remain byte-identical.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -29,11 +29,10 @@ Created: 2026-07-25T17:16:51.010Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
- packages/agentplane/src/cli/run-cli.core.incidents.test.ts |  1 +
- packages/agentplane/src/commands/incidents/shared.test.ts  | 10 ++++++++--
- packages/agentplane/src/runtime/incidents/resolve.test.ts  | 14 +++++++++++---
- packages/agentplane/src/runtime/incidents/shared.ts        |  1 +
- 4 files changed, 21 insertions(+), 5 deletions(-)
+ packages/agentplane/src/commands/incidents/shared.test.ts | 10 ++++++++--
+ packages/agentplane/src/runtime/incidents/resolve.test.ts | 14 +++++++++++---
+ packages/agentplane/src/runtime/incidents/shared.ts       |  1 +
+ 3 files changed, 20 insertions(+), 5 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607251715-D9HW3D/pr/review.md
+++ b/.agentplane/tasks/202607251715-D9HW3D/pr/review.md
@@ -24,12 +24,16 @@ Created: 2026-07-25T17:16:51.010Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-25T17:16:51.010Z
+- Updated: 2026-07-25T17:18:50.186Z
 - Branch: task/202607251715-D9HW3D/preserve-compact-incident-registry-formatting
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ packages/agentplane/src/cli/run-cli.core.incidents.test.ts |  1 +
+ packages/agentplane/src/commands/incidents/shared.test.ts  | 10 ++++++++--
+ packages/agentplane/src/runtime/incidents/resolve.test.ts  | 14 +++++++++++---
+ packages/agentplane/src/runtime/incidents/shared.ts        |  1 +
+ 4 files changed, 21 insertions(+), 5 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607251715-D9HW3D/pr/review.md
+++ b/.agentplane/tasks/202607251715-D9HW3D/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-07-25T17:16:51.010Z
+
+## Task
+
+- Task: `202607251715-D9HW3D`
+- Title: Preserve compact incident registry formatting
+- Status: DOING
+- Branch: `task/202607251715-D9HW3D/preserve-compact-incident-registry-formatting`
+- Canonical task record: `.agentplane/tasks/202607251715-D9HW3D/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-25T17:16:51.010Z
+- Branch: task/202607251715-D9HW3D/preserve-compact-incident-registry-formatting
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202607251715-D9HW3D/pr/review.md
+++ b/.agentplane/tasks/202607251715-D9HW3D/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-07-25T17:16:51.010Z
 ## Verification
 
 - State: ok
-- Note: Verified published head 57da81c6: runtime incidents 10/10, mirror 1/1, CLI incidents 10/10, format, templates, TypeScript, targeted lint, policy routing, and doctor pass. Legacy compact input is normalized to the Prettier-compatible header and mirrors remain byte-identical.
+- Note: Verified final implementation b0b3c384: focused incident suites 21/21, format, templates, TypeScript, targeted lint, policy routing, doctor, and hotspot baseline pass. The closure commit only records lifecycle evidence; compact rendering and mirror behavior are unchanged.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes

--- a/.agentplane/tasks/202607251715-D9HW3D/quality/20260725-173330155-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607251715-D9HW3D/quality/20260725-173330155-recovery-context/evaluator-opinion.md
@@ -1,0 +1,21 @@
+# Semantic quality review: pass
+
+Provenance: evaluator_supplied
+
+Compact incident registry rendering preserves the required heading blank line while retaining legacy compact parsing and byte-identical canonical/asset mirrors.
+
+## Findings
+- The new blank line intentionally consumes one physical policy-budget line; the exact boundary remains 95 existing compact entries plus one promotion at 100 lines, while 96 plus one is rejected.
+
+## Evidence
+- .agentplane/tasks/202607251715-D9HW3D/README.md
+- b0b3c3844; focused incidents suite 21/21; format:check pass; agents:check pass; boundary probe 95+1=100 and 96+1=101
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607251715-D9HW3D/quality/20260725-173330155-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607251715-D9HW3D/quality/20260725-173330155-recovery-context/evaluator-prompt.md
@@ -1,0 +1,75 @@
+# AgentPlane semantic quality review record
+
+AgentPlane records supplied review values here; this command does not execute an evaluator.
+Use the evaluator module below as the review procedure before supplying a result.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+
+- task_id: 202607251715-D9HW3D
+- task_readme: .agentplane/tasks/202607251715-D9HW3D/README.md
+- report_path: .agentplane/tasks/202607251715-D9HW3D/quality/20260725-173330155-recovery-context/quality-report.json
+- provenance: evaluator_supplied
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607251715-D9HW3D/quality/20260725-173330155-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607251715-D9HW3D/quality/20260725-173330155-recovery-context/quality-report.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "task_id": "202607251715-D9HW3D",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-25T17:33:30.155Z",
+  "provenance": "evaluator_supplied",
+  "verdict": "pass",
+  "summary": "Compact incident registry rendering preserves the required heading blank line while retaining legacy compact parsing and byte-identical canonical/asset mirrors.",
+  "evaluated_sha": "b0b3c38440851f91f9d80b90f6c2e5733ccbcce1",
+  "blueprint_digest": "afe0e20728b15b8d9b47cd281b4d34e77988acc95fdf57bf46b0a1fa306c4424",
+  "findings": [
+    "The new blank line intentionally consumes one physical policy-budget line; the exact boundary remains 95 existing compact entries plus one promotion at 100 lines, while 96 plus one is rejected."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607251715-D9HW3D/README.md",
+    "b0b3c3844; focused incidents suite 21/21; format:check pass; agents:check pass; boundary probe 95+1=100 and 96+1=101"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/.agentplane/tasks/202607251715-D9HW3D/quality/20260725-174643329-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607251715-D9HW3D/quality/20260725-174643329-recovery-context/evaluator-opinion.md
@@ -1,0 +1,21 @@
+# Semantic quality review: pass
+
+Provenance: evaluator_supplied
+
+Lint-compatible prefix assertion is semantically equivalent for the UTF-8 string returned by readFile; no incident-registry behavior changed.
+
+## Findings
+- packages/agentplane/src/commands/incidents/shared.test.ts now asserts the same required compact header prefix through String.prototype.startsWith, preserving the regression invariant.
+
+## Evidence
+- .agentplane/tasks/202607251715-D9HW3D/README.md
+- 4e126a132^..4e126a132; packages/agentplane/src/commands/incidents/shared.test.ts:126-139; git diff --check b0b3c3844..4e126a132
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607251715-D9HW3D/quality/20260725-174643329-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607251715-D9HW3D/quality/20260725-174643329-recovery-context/evaluator-prompt.md
@@ -1,0 +1,75 @@
+# AgentPlane semantic quality review record
+
+AgentPlane records supplied review values here; this command does not execute an evaluator.
+Use the evaluator module below as the review procedure before supplying a result.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+
+- task_id: 202607251715-D9HW3D
+- task_readme: .agentplane/tasks/202607251715-D9HW3D/README.md
+- report_path: .agentplane/tasks/202607251715-D9HW3D/quality/20260725-174643329-recovery-context/quality-report.json
+- provenance: evaluator_supplied
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607251715-D9HW3D/quality/20260725-174643329-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607251715-D9HW3D/quality/20260725-174643329-recovery-context/quality-report.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "task_id": "202607251715-D9HW3D",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-25T17:46:43.329Z",
+  "provenance": "evaluator_supplied",
+  "verdict": "pass",
+  "summary": "Lint-compatible prefix assertion is semantically equivalent for the UTF-8 string returned by readFile; no incident-registry behavior changed.",
+  "evaluated_sha": "4e126a1325db4136601f15643bc03fa23418c8be",
+  "blueprint_digest": "afe0e20728b15b8d9b47cd281b4d34e77988acc95fdf57bf46b0a1fa306c4424",
+  "findings": [
+    "packages/agentplane/src/commands/incidents/shared.test.ts now asserts the same required compact header prefix through String.prototype.startsWith, preserving the regression invariant."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607251715-D9HW3D/README.md",
+    "4e126a132^..4e126a132; packages/agentplane/src/commands/incidents/shared.test.ts:126-139; git diff --check b0b3c3844..4e126a132"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/cli/run-cli.core.incidents.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.incidents.test.ts
@@ -21,7 +21,6 @@ const INCIDENTS_CLI_TIMEOUT_MS = 120_000;
 
 const compactRegistryHeader = [
   "# Policy Incidents Log",
-  "",
   "- Append-only. Required fields: `id`, `date`, `scope`, `failure`, `rule`, `evidence`, `enforcement`, `state`; optional: `tags`, `match`, `advice`, `source_task`, `fixability`.",
 ].join("\n");
 

--- a/packages/agentplane/src/cli/run-cli.core.incidents.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.incidents.test.ts
@@ -21,6 +21,7 @@ const INCIDENTS_CLI_TIMEOUT_MS = 120_000;
 
 const compactRegistryHeader = [
   "# Policy Incidents Log",
+  "",
   "- Append-only. Required fields: `id`, `date`, `scope`, `failure`, `rule`, `evidence`, `enforcement`, `state`; optional: `tags`, `match`, `advice`, `source_task`, `fixability`.",
 ].join("\n");
 

--- a/packages/agentplane/src/commands/incidents/shared.test.ts
+++ b/packages/agentplane/src/commands/incidents/shared.test.ts
@@ -8,11 +8,16 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { TaskBackend, TaskData } from "../../backends/task-backend.js";
 import { GitContext } from "@agentplaneorg/core/git";
 import type { CommandContext } from "../shared/task-backend.js";
-import { createIncidentRegistrySkeleton } from "../../runtime/incidents/index.js";
 
 import { collectTaskIncidents } from "./shared.js";
 
 const tempRoots: string[] = [];
+
+const compactRegistryHeader = [
+  "# Policy Incidents Log",
+  "",
+  "- Append-only. Required fields: `id`, `date`, `scope`, `failure`, `rule`, `evidence`, `enforcement`, `state`; optional: `tags`, `match`, `advice`, `source_task`, `fixability`.",
+].join("\n");
 
 function mkTask(): TaskData {
   return {
@@ -95,7 +100,7 @@ describe("incident registry mirror writes", () => {
     await mkdir(path.join(root, "packages", "agentplane", "assets", "policy"), {
       recursive: true,
     });
-    const registryText = createIncidentRegistrySkeleton();
+    const registryText = `${compactRegistryHeader}\n`;
     await writeFile(path.join(root, ".agentplane", "policy", "incidents.md"), registryText, "utf8");
     await writeFile(
       path.join(root, "packages", "agentplane", "assets", "policy", "incidents.md"),
@@ -128,6 +133,7 @@ describe("incident registry mirror writes", () => {
     );
 
     expect(mirrored).toBe(canonical);
+    expect(mirrored).toStartWith(`${compactRegistryHeader}\n- id:`);
     expect(mirrored).toContain("incident promotion left hidden policy drift");
     expect(mirrored.endsWith("\n")).toBe(true);
   });

--- a/packages/agentplane/src/commands/incidents/shared.test.ts
+++ b/packages/agentplane/src/commands/incidents/shared.test.ts
@@ -133,7 +133,7 @@ describe("incident registry mirror writes", () => {
     );
 
     expect(mirrored).toBe(canonical);
-    expect(mirrored).toStartWith(`${compactRegistryHeader}\n- id:`);
+    expect(mirrored.startsWith(`${compactRegistryHeader}\n- id:`)).toBe(true);
     expect(mirrored).toContain("incident promotion left hidden policy drift");
     expect(mirrored.endsWith("\n")).toBe(true);
   });

--- a/packages/agentplane/src/runtime/incidents/resolve.test.ts
+++ b/packages/agentplane/src/runtime/incidents/resolve.test.ts
@@ -12,6 +12,12 @@ import {
 
 const compactRegistryHeader = [
   "# Policy Incidents Log",
+  "",
+  "- Append-only. Required fields: `id`, `date`, `scope`, `failure`, `rule`, `evidence`, `enforcement`, `state`; optional: `tags`, `match`, `advice`, `source_task`, `fixability`.",
+].join("\n");
+
+const legacyCompactRegistryHeader = [
+  "# Policy Incidents Log",
   "- Append-only. Required fields: `id`, `date`, `scope`, `failure`, `rule`, `evidence`, `enforcement`, `state`; optional: `tags`, `match`, `advice`, `source_task`, `fixability`.",
 ].join("\n");
 
@@ -336,7 +342,7 @@ describe("incidents runtime", () => {
 
   it("normalizes compact registry writes by removing duplicate fingerprints and preserving unique ids", () => {
     const current = [
-      compactRegistryHeader,
+      legacyCompactRegistryHeader,
       "- id: INC-20260407-01 | date: 2026-04-07 | scope: branch_pr GitHub transport helpers | tags: workflow, github, transport, retries | match: github, gh, graphQL, EOF, TLS, SSL_ERROR_SYSCALL, remote-checks | failure: GitHub transport intermittently failed with GraphQL EOF, TLS handshake errors, and SSL_ERROR_SYSCALL during PR creation, remote-check waiting, and reconcile helpers | advice: treat transient GitHub transport failures as retriable | rule: GitHub-dependent workflow helpers MUST classify EOF/TLS/SSL transport failures as transient and retry with bounded backoff. | evidence: task 202604062309-EXTXG1 | enforcement: test + workflow helper | source_task: 202604062309-EXTXG1 | fixability: external | state: open",
       "- id: INC-20260407-04 | date: 2026-04-07 | scope: task normalize hosted reconcile target selection | tags: workflow, github, transport, normalize | match: task normalize, sync-hosted-merges, gh api EOF, GraphQL EOF | failure: GitHub EOF or TLS transport failures during hosted branch_pr reconcile could abort task normalize before it reached the known stale task because the command scanned every candidate task. | advice: When GitHub transport is flaky, reconcile only the known task ids instead of scanning the full branch_pr history. | rule: Hosted reconcile commands MUST support explicit task-id scoping so known drift can be resolved without depending on unrelated GitHub lookups. | evidence: task 202604071853-XGX2YJ | enforcement: manual | fixability: external | state: open",
       "- id: INC-20260407-01 | date: 2026-04-07 | scope: task normalize hosted reconcile target selection | tags: workflow, github, transport, normalize | match: task normalize, sync-hosted-merges, gh api EOF, GraphQL EOF | failure: GitHub EOF or TLS transport failures during hosted branch_pr reconcile could abort task normalize before it reached the known stale task because the command scanned every candidate task. | advice: When GitHub transport is flaky, reconcile only the known task ids instead of scanning the full branch_pr history. | rule: Hosted reconcile commands MUST support explicit task-id scoping so known drift can be resolved without depending on unrelated GitHub lookups. | evidence: task 202604071853-XGX2YJ; commit 5fd312cceb20 | enforcement: manual | source_task: 202604071853-XGX2YJ | fixability: external | state: open",
@@ -364,7 +370,8 @@ describe("incidents runtime", () => {
     const reparsed = parseIncidentRegistry(next);
 
     expect(next.startsWith(compactRegistryHeader)).toBe(true);
-    expect(next).not.toContain("\n\n- id:");
+    expect(next).toContain(`${compactRegistryHeader}\n- id: INC-20260407-01`);
+    expect(next).not.toContain("state: open\n\n- id:");
     expect(next).not.toContain("source_task: 202604071853-XGX2YJ |");
     expect(reparsed.entries.map((entry) => entry.id)).toEqual([
       "INC-20260407-01",
@@ -401,7 +408,8 @@ describe("incidents runtime", () => {
     ]);
 
     expect(next.startsWith(compactRegistryHeader)).toBe(true);
-    expect(next).not.toContain("\n\n- id:");
+    expect(next).toContain(`${compactRegistryHeader}\n- id: INC-20260409-01`);
+    expect(next).not.toContain("state: open\n\n- id:");
     expect(next).not.toContain("source_task:");
     expect(parseIncidentRegistry(next).entries.map((entry) => entry.sourceTask)).toEqual([
       "202604081931-77V6J5",

--- a/packages/agentplane/src/runtime/incidents/shared.ts
+++ b/packages/agentplane/src/runtime/incidents/shared.ts
@@ -13,6 +13,7 @@ export const STRUCTURED_INCIDENTS_HEADER = [
 
 export const COMPACT_INCIDENTS_HEADER = [
   "# Policy Incidents Log",
+  "",
   "- Append-only. Required fields: `id`, `date`, `scope`, `failure`, `rule`, `evidence`, `enforcement`, `state`; optional: `tags`, `match`, `advice`, `source_task`, `fixability`.",
 ].join("\n");
 


### PR DESCRIPTION
Task: `202607251715-D9HW3D`
Title: Preserve compact incident registry formatting
Canonical task record: `.agentplane/tasks/202607251715-D9HW3D/README.md`

## Summary

Preserve compact incident registry formatting

Repair the incident-registry renderer so compact rewrites retain the required blank line after the heading, keep the canonical and asset mirrors byte-identical, and add regression coverage. This unblocks the hosted format check for task 202607251433-75Q4J6 without manually editing a policy log in that task.

## Scope

- In scope: Repair the incident-registry renderer so compact rewrites retain the required blank line after the heading, keep the canonical and asset mirrors byte-identical, and add regression coverage. This unblocks the hosted format check for task 202607251433-75Q4J6 without manually editing a policy log in that task.
- Out of scope: unrelated refactors not required for "Preserve compact incident registry formatting".

## Verification

- State: pending
- Note: Not recorded yet.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-07-25T17:16:51.010Z
- Branch: task/202607251715-D9HW3D/preserve-compact-incident-registry-formatting
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
No changes detected.
```

</details>
