### PR TITLE
🚧 GRJSV6 task: Preserve authority-only tails during merged cleanup [202607270107-GRJSV6]

### DIFF
--- a/.agentplane/tasks/202607270107-GRJSV6/README.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/README.md
@@ -4,7 +4,7 @@ title: "Preserve authority-only tails during merged cleanup"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 7
 origin:
   system: "manual"
 depends_on: []
@@ -76,6 +76,19 @@ extensions:
         schemaVersion: 1
         sequence: 1
         stateFingerprintDigest: "sha256:447625bb985641e8e1e4b9a726a083688bcf78081d00ed1860a1ce1e7b127f05"
+      -
+        actor: "USER"
+        at: "2026-07-27T01:22:50.144Z"
+        authorityDigest: "sha256:e8f1b5d0de585df21375c33ad416a6c9973f035250a488de8b15f3f63e03f17d"
+        digest: "sha256:e6836bb260632ae81a12e17153dd47a1ffb31c581c12a8c7ee387394f3e31989"
+        operationDigest: "sha256:457693dd75dab26a5967c46a9a5cbaed57cb8134a5955c165cc7a37fd1633032"
+        operationId: "pr.open"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:9ec49f000de2e8ff95112a6b97e4021284871adb8250a18f93de09d3c5520780"
+        schemaVersion: 1
+        sequence: 2
+        stateFingerprintDigest: "sha256:6adc15105a5ca7cab4e1a6cf157632ec94ad5b38c20351d8dad04fb2348af97c"
     grants:
       -
         actor: "USER"
@@ -90,6 +103,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:447625bb985641e8e1e4b9a726a083688bcf78081d00ed1860a1ce1e7b127f05"
         stateScopeDigest: "sha256:7315243d9bcacad97144422ba77090892cebb6d15843c223b6acfd376e355a88"
+      -
+        actor: "USER"
+        digest: "sha256:e8f1b5d0de585df21375c33ad416a6c9973f035250a488de8b15f3f63e03f17d"
+        expiresAt: "2026-07-27T01:37:50.144Z"
+        id: "authority-78a995b3-6277-410b-8436-61abd66a4372"
+        issuedAt: "2026-07-27T01:22:50.144Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:457693dd75dab26a5967c46a9a5cbaed57cb8134a5955c165cc7a37fd1633032"
+        operationId: "pr.open"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:6adc15105a5ca7cab4e1a6cf157632ec94ad5b38c20351d8dad04fb2348af97c"
+        stateScopeDigest: "sha256:6fa573bf1fd13a3ea19d43fff269594334175df6b47472ca032305ebcb9cf95c"
     schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "518f9f4a62e09016262af2cbbeb89947550be2e0"

--- a/.agentplane/tasks/202607270107-GRJSV6/README.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 16
+revision: 17
 origin:
   system: "manual"
 depends_on: []
@@ -240,6 +240,19 @@ extensions:
         schemaVersion: 1
         sequence: 8
         stateFingerprintDigest: "sha256:6a70c9fa012364acc32f80c43421995b625dfb879e50ba9538e475eb221c214c"
+      -
+        actor: "USER"
+        at: "2026-07-27T01:57:41.767Z"
+        authorityDigest: "sha256:7a1e3a2a5420457f27952aa51c77fb707d8243404aed87c934a9707b7d2d454a"
+        digest: "sha256:1b690111a33986e08a60cebd5ac2ba45a549dddc4f11675b36322f5149335458"
+        operationDigest: "sha256:32cd8038dd66f1689375293f198abb6f965d6a7768bd945fb924d67bd194605e"
+        operationId: "integration.enqueue"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:9e0ce92f3afd4ad8147384b40281c13c28cc562aaef5cd3881351f6e02d80b5e"
+        schemaVersion: 1
+        sequence: 9
+        stateFingerprintDigest: "sha256:1caebdb18c9b8e7ae42001dd098bf286940008ad1d420006367a3d8a4a99dfb3"
     grants:
       -
         actor: "USER"
@@ -345,6 +358,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:6a70c9fa012364acc32f80c43421995b625dfb879e50ba9538e475eb221c214c"
         stateScopeDigest: "sha256:483bd3a46c969d458889c1d0d819660f14797b21d2f630017269f44d94881551"
+      -
+        actor: "USER"
+        digest: "sha256:7a1e3a2a5420457f27952aa51c77fb707d8243404aed87c934a9707b7d2d454a"
+        expiresAt: "2026-07-27T02:12:41.767Z"
+        id: "authority-68ca091b-ed30-409f-9e9b-ec296a8f0e94"
+        issuedAt: "2026-07-27T01:57:41.767Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:32cd8038dd66f1689375293f198abb6f965d6a7768bd945fb924d67bd194605e"
+        operationId: "integration.enqueue"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:1caebdb18c9b8e7ae42001dd098bf286940008ad1d420006367a3d8a4a99dfb3"
+        stateScopeDigest: "sha256:38a8d0eee649f4209cdc805612e217ea6c9cb1f1823230cd8730f2fc149c122d"
     schemaVersion: 1
   implementation_commit:
     hash: "d97c8521e502c765af00ebe5b4cc467edf812aa2"

--- a/.agentplane/tasks/202607270107-GRJSV6/README.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/README.md
@@ -4,7 +4,7 @@ title: "Preserve authority-only tails during merged cleanup"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 11
+revision: 12
 origin:
   system: "manual"
 depends_on: []
@@ -150,6 +150,19 @@ extensions:
         schemaVersion: 1
         sequence: 5
         stateFingerprintDigest: "sha256:2d1b5b30d7d48cb4087a9960d1105ae3e09c32fe55ce8c99cee1b5028c02d2ab"
+      -
+        actor: "USER"
+        at: "2026-07-27T01:40:59.877Z"
+        authorityDigest: "sha256:848cc16f52970cb9a2c996bdbcb7c46c1947d9926dbef4d5e96a7682540a5d49"
+        digest: "sha256:6908f895757a3252b3725a93834a867d4c5e6546871221fdcc6e9eaea055202e"
+        operationDigest: "sha256:32cd8038dd66f1689375293f198abb6f965d6a7768bd945fb924d67bd194605e"
+        operationId: "integration.enqueue"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:4fd0902dc52b347552d1aa49e73f9a6d9abc5fb6e0658c114c1d83b82ec91f38"
+        schemaVersion: 1
+        sequence: 6
+        stateFingerprintDigest: "sha256:8b1215e3b4524f9b7a6eb95ff5ebd620ba50f1385ed2746600e2f5a4e74d3734"
     grants:
       -
         actor: "USER"
@@ -216,6 +229,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:2d1b5b30d7d48cb4087a9960d1105ae3e09c32fe55ce8c99cee1b5028c02d2ab"
         stateScopeDigest: "sha256:df50ff8a0a0763ca68cfc749918f0fdb621c412cc87f99fcfc9aa7e8e67b4868"
+      -
+        actor: "USER"
+        digest: "sha256:848cc16f52970cb9a2c996bdbcb7c46c1947d9926dbef4d5e96a7682540a5d49"
+        expiresAt: "2026-07-27T01:55:59.877Z"
+        id: "authority-ccf1ba4f-6dcb-4f5c-a7eb-71b2e156296b"
+        issuedAt: "2026-07-27T01:40:59.877Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:32cd8038dd66f1689375293f198abb6f965d6a7768bd945fb924d67bd194605e"
+        operationId: "integration.enqueue"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:8b1215e3b4524f9b7a6eb95ff5ebd620ba50f1385ed2746600e2f5a4e74d3734"
+        stateScopeDigest: "sha256:d1a46e29d8d2c996b0c810fb88df46ca23ab66c7ff6b3bacc72719f55be5e7cb"
     schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "518f9f4a62e09016262af2cbbeb89947550be2e0"

--- a/.agentplane/tasks/202607270107-GRJSV6/README.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 15
+revision: 16
 origin:
   system: "manual"
 depends_on: []
@@ -227,6 +227,19 @@ extensions:
         schemaVersion: 1
         sequence: 7
         stateFingerprintDigest: "sha256:443c314eed9460d32d629a5525d34e7224621db9fafb475f5525eb785dc41bc0"
+      -
+        actor: "USER"
+        at: "2026-07-27T01:50:58.739Z"
+        authorityDigest: "sha256:35c5d57a958f061b7d88ef867c43ced5c9f9e4e9dedb01488e84736bf2a68391"
+        digest: "sha256:9e0ce92f3afd4ad8147384b40281c13c28cc562aaef5cd3881351f6e02d80b5e"
+        operationDigest: "sha256:be6044036047203402ecf8652ec2bbb35b7818eb33cd08789d4498ed30691cd9"
+        operationId: "pr.head.publish"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:67c5558e8b23ada8fd264da3e015d18b03958e781c9678207bf61b7a49aa32e4"
+        schemaVersion: 1
+        sequence: 8
+        stateFingerprintDigest: "sha256:6a70c9fa012364acc32f80c43421995b625dfb879e50ba9538e475eb221c214c"
     grants:
       -
         actor: "USER"
@@ -319,6 +332,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:443c314eed9460d32d629a5525d34e7224621db9fafb475f5525eb785dc41bc0"
         stateScopeDigest: "sha256:fa192646b5c515733d0c408fc0327f7dbea15462bbf3e55f848a47aba477e088"
+      -
+        actor: "USER"
+        digest: "sha256:35c5d57a958f061b7d88ef867c43ced5c9f9e4e9dedb01488e84736bf2a68391"
+        expiresAt: "2026-07-27T02:05:58.739Z"
+        id: "authority-6406ba7a-ced3-430a-9ec7-153b0d3aa189"
+        issuedAt: "2026-07-27T01:50:58.739Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:be6044036047203402ecf8652ec2bbb35b7818eb33cd08789d4498ed30691cd9"
+        operationId: "pr.head.publish"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:6a70c9fa012364acc32f80c43421995b625dfb879e50ba9538e475eb221c214c"
+        stateScopeDigest: "sha256:483bd3a46c969d458889c1d0d819660f14797b21d2f630017269f44d94881551"
     schemaVersion: 1
   implementation_commit:
     hash: "d97c8521e502c765af00ebe5b4cc467edf812aa2"

--- a/.agentplane/tasks/202607270107-GRJSV6/README.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202607270107-GRJSV6"
 title: "Preserve authority-only tails during merged cleanup"
-status: "DOING"
+result_summary: "pre-merge closure"
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 14
+revision: 15
 origin:
   system: "manual"
 depends_on: []
@@ -44,11 +45,16 @@ quality_review:
     - "Accepted path is covered by a targeted provider-receipt fixture with an authority-only descendant chain."
     - "Rejected path is covered by a semantic post-merge tail fixture; no non-authority changes are accepted."
     - "Hosted-close finalization is local reversible only after protected merge and pre-merge closure evidence are already durable."
-commit: null
+commit:
+  hash: "9af398bb45bbfcb5b9898c13612a4d14e9776c83"
+  message: "🔐 GRJSV6 task: authorize pre-merge closure"
 comments:
   -
     author: "ORCHESTRATOR"
     body: "Start: approved post-merge cleanup authority follow-up."
+  -
+    author: "CODER"
+    body: "Verified: pre-merge closure packet is ready for the task PR."
 events:
   -
     type: "status"
@@ -63,9 +69,16 @@ events:
     author: "TESTER"
     state: "ok"
     note: "Verified targeted cleanup acceptance, authority classification, ci:contract, and the complete hosted PR #4636 gate."
+  -
+    type: "status"
+    at: "2026-07-27T01:50:22.277Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-27T01:49:26.850Z"
-doc_updated_by: "ORCHESTRATOR"
+doc_updated_at: "2026-07-27T01:50:22.277Z"
+doc_updated_by: "CODER"
 description: "Follow up RF13: permit targeted merged cleanup only when a local post-merge tail is proven authority-only against the provider-merged head, and classify hosted close finalization as local reversible after the merge and pre-merge closure are already durable."
 sections:
   Summary: |-
@@ -307,6 +320,9 @@ extensions:
         stateFingerprintDigest: "sha256:443c314eed9460d32d629a5525d34e7224621db9fafb475f5525eb785dc41bc0"
         stateScopeDigest: "sha256:fa192646b5c515733d0c408fc0327f7dbea15462bbf3e55f848a47aba477e088"
     schemaVersion: 1
+  implementation_commit:
+    hash: "d97c8521e502c765af00ebe5b4cc467edf812aa2"
+    message: "🐛 GRJSV6 task: preserve authority-only cleanup tails"
   workflow_route_baseline:
     start_head_sha: "518f9f4a62e09016262af2cbbeb89947550be2e0"
     version: 1

--- a/.agentplane/tasks/202607270107-GRJSV6/README.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/README.md
@@ -4,7 +4,7 @@ title: "Preserve authority-only tails during merged cleanup"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 7
+revision: 8
 origin:
   system: "manual"
 depends_on: []
@@ -89,6 +89,19 @@ extensions:
         schemaVersion: 1
         sequence: 2
         stateFingerprintDigest: "sha256:6adc15105a5ca7cab4e1a6cf157632ec94ad5b38c20351d8dad04fb2348af97c"
+      -
+        actor: "USER"
+        at: "2026-07-27T01:29:56.339Z"
+        authorityDigest: "sha256:c391b26e96ec28c8d4696eac2748f3d71f3c3616dd167722a569a9bab7c42702"
+        digest: "sha256:536c88ed614377b316116b8693cdce0042259911630687c63fcb7138b5a54f95"
+        operationDigest: "sha256:32cd8038dd66f1689375293f198abb6f965d6a7768bd945fb924d67bd194605e"
+        operationId: "integration.enqueue"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:e6836bb260632ae81a12e17153dd47a1ffb31c581c12a8c7ee387394f3e31989"
+        schemaVersion: 1
+        sequence: 3
+        stateFingerprintDigest: "sha256:91137e2815b5968a5d5e8cc1860c60ef50c7deb79fd0a36a57ad445af3635d31"
     grants:
       -
         actor: "USER"
@@ -116,6 +129,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:6adc15105a5ca7cab4e1a6cf157632ec94ad5b38c20351d8dad04fb2348af97c"
         stateScopeDigest: "sha256:6fa573bf1fd13a3ea19d43fff269594334175df6b47472ca032305ebcb9cf95c"
+      -
+        actor: "USER"
+        digest: "sha256:c391b26e96ec28c8d4696eac2748f3d71f3c3616dd167722a569a9bab7c42702"
+        expiresAt: "2026-07-27T01:44:56.339Z"
+        id: "authority-1abddddc-39f0-421b-9fa2-159049b8025d"
+        issuedAt: "2026-07-27T01:29:56.339Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:32cd8038dd66f1689375293f198abb6f965d6a7768bd945fb924d67bd194605e"
+        operationId: "integration.enqueue"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:91137e2815b5968a5d5e8cc1860c60ef50c7deb79fd0a36a57ad445af3635d31"
+        stateScopeDigest: "sha256:e661950fb0e988c9efab7a8915a176e8e2b8ef44102f9450758c92c12dea7c16"
     schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "518f9f4a62e09016262af2cbbeb89947550be2e0"

--- a/.agentplane/tasks/202607270107-GRJSV6/README.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/README.md
@@ -4,7 +4,7 @@ title: "Preserve authority-only tails during merged cleanup"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 13
+revision: 14
 origin:
   system: "manual"
 depends_on: []
@@ -201,6 +201,19 @@ extensions:
         schemaVersion: 1
         sequence: 6
         stateFingerprintDigest: "sha256:8b1215e3b4524f9b7a6eb95ff5ebd620ba50f1385ed2746600e2f5a4e74d3734"
+      -
+        actor: "USER"
+        at: "2026-07-27T01:50:04.692Z"
+        authorityDigest: "sha256:c3dbebd1e09b6c7cef7c08491247f61f2ff50cbc49bca8cbbf1d9268a82a1ab9"
+        digest: "sha256:67c5558e8b23ada8fd264da3e015d18b03958e781c9678207bf61b7a49aa32e4"
+        operationDigest: "sha256:fc2e97fd865f11920ca39fd80640516d286c01d2e3858e79d5c5b2e623247e11"
+        operationId: "task.pre_merge_close"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:6908f895757a3252b3725a93834a867d4c5e6546871221fdcc6e9eaea055202e"
+        schemaVersion: 1
+        sequence: 7
+        stateFingerprintDigest: "sha256:443c314eed9460d32d629a5525d34e7224621db9fafb475f5525eb785dc41bc0"
     grants:
       -
         actor: "USER"
@@ -280,6 +293,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:8b1215e3b4524f9b7a6eb95ff5ebd620ba50f1385ed2746600e2f5a4e74d3734"
         stateScopeDigest: "sha256:d1a46e29d8d2c996b0c810fb88df46ca23ab66c7ff6b3bacc72719f55be5e7cb"
+      -
+        actor: "USER"
+        digest: "sha256:c3dbebd1e09b6c7cef7c08491247f61f2ff50cbc49bca8cbbf1d9268a82a1ab9"
+        expiresAt: "2026-07-27T02:05:04.692Z"
+        id: "authority-7dedcf70-0e78-4c61-a1c0-6d1a93bd44fa"
+        issuedAt: "2026-07-27T01:50:04.692Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:fc2e97fd865f11920ca39fd80640516d286c01d2e3858e79d5c5b2e623247e11"
+        operationId: "task.pre_merge_close"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:443c314eed9460d32d629a5525d34e7224621db9fafb475f5525eb785dc41bc0"
+        stateScopeDigest: "sha256:fa192646b5c515733d0c408fc0327f7dbea15462bbf3e55f848a47aba477e088"
     schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "518f9f4a62e09016262af2cbbeb89947550be2e0"

--- a/.agentplane/tasks/202607270107-GRJSV6/README.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/README.md
@@ -4,7 +4,7 @@ title: "Preserve authority-only tails during merged cleanup"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 10
+revision: 11
 origin:
   system: "manual"
 depends_on: []
@@ -137,6 +137,19 @@ extensions:
         schemaVersion: 1
         sequence: 4
         stateFingerprintDigest: "sha256:d6a1b201c654e8277758b09e04725560ab39a4d0c963c6b6e551a98859954247"
+      -
+        actor: "USER"
+        at: "2026-07-27T01:33:38.042Z"
+        authorityDigest: "sha256:4503d09968ebeadbc872b1cd317215612c1b2f8098ba709e2168c06b86750158"
+        digest: "sha256:4fd0902dc52b347552d1aa49e73f9a6d9abc5fb6e0658c114c1d83b82ec91f38"
+        operationDigest: "sha256:be6044036047203402ecf8652ec2bbb35b7818eb33cd08789d4498ed30691cd9"
+        operationId: "pr.head.publish"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:64dbee3b1eb18228a071fbdf1b34f7db84852944d9cd054161dddbf1395f70ed"
+        schemaVersion: 1
+        sequence: 5
+        stateFingerprintDigest: "sha256:2d1b5b30d7d48cb4087a9960d1105ae3e09c32fe55ce8c99cee1b5028c02d2ab"
     grants:
       -
         actor: "USER"
@@ -190,6 +203,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:d6a1b201c654e8277758b09e04725560ab39a4d0c963c6b6e551a98859954247"
         stateScopeDigest: "sha256:c109e28230076b1657037909c98751edda3dd80dea03de2cda8e63b863bded06"
+      -
+        actor: "USER"
+        digest: "sha256:4503d09968ebeadbc872b1cd317215612c1b2f8098ba709e2168c06b86750158"
+        expiresAt: "2026-07-27T01:48:38.042Z"
+        id: "authority-d72c00c1-c454-41fa-a09e-d82a18a4c379"
+        issuedAt: "2026-07-27T01:33:38.042Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:be6044036047203402ecf8652ec2bbb35b7818eb33cd08789d4498ed30691cd9"
+        operationId: "pr.head.publish"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:2d1b5b30d7d48cb4087a9960d1105ae3e09c32fe55ce8c99cee1b5028c02d2ab"
+        stateScopeDigest: "sha256:df50ff8a0a0763ca68cfc749918f0fdb621c412cc87f99fcfc9aa7e8e67b4868"
     schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "518f9f4a62e09016262af2cbbeb89947550be2e0"

--- a/.agentplane/tasks/202607270107-GRJSV6/README.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/README.md
@@ -4,7 +4,7 @@ title: "Preserve authority-only tails during merged cleanup"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 12
+revision: 13
 origin:
   system: "manual"
 depends_on: []
@@ -17,10 +17,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-07-27T01:49:26.181Z"
+  updated_by: "TESTER"
+  note: "Verified targeted cleanup acceptance, authority classification, ci:contract, and the complete hosted PR #4636 gate."
   attempts: 0
 quality_review:
   state: "pass"
@@ -57,8 +57,14 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: approved post-merge cleanup authority follow-up."
+  -
+    type: "verify"
+    at: "2026-07-27T01:49:26.181Z"
+    author: "TESTER"
+    state: "ok"
+    note: "Verified targeted cleanup acceptance, authority classification, ci:contract, and the complete hosted PR #4636 gate."
 doc_version: 3
-doc_updated_at: "2026-07-27T01:21:15.474Z"
+doc_updated_at: "2026-07-27T01:49:26.850Z"
 doc_updated_by: "ORCHESTRATOR"
 description: "Follow up RF13: permit targeted merged cleanup only when a local post-merge tail is proven authority-only against the provider-merged head, and classify hosted close finalization as local reversible after the merge and pre-merge closure are already durable."
 sections:
@@ -77,6 +83,38 @@ sections:
     4. Re-run RF13 targeted cleanup after integration. Expected: the previously blocked local authority-only tail is removed by the CLI, while no unrelated worktree or branch is touched.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-07-27T01:49:26.181Z — VERIFY — ok
+
+    By: TESTER
+
+    Note: Verified targeted cleanup acceptance, authority classification, ci:contract, and the complete hosted PR #4636 gate.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-27T01:21:15.474Z, excerpt_hash=sha256:a7f74adf4ab205b81f8995477b77230d92d5941956f20437d38e3c84bfd278e4
+
+    Details:
+
+    Focused Vitest: 31/31 passed (cleanup provider proof, authority-only tail, semantic-tail rejection, authority policy). Local: format, lint, typecheck, ci:contract. Hosted head 2601cd40: CodeQL, docs, runtime packages, contract, static, unit, critical CLI, workflow, coverage, and Windows all passed.
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/rf05b-integration-base/.agentplane/worktrees/202607270107-GRJSV6-preserve-authority-only-tails-during-merged-clea/.agentplane/tasks/202607270107-GRJSV6/blueprint/resolved-snapshot.json
+    - old_digest: 72eb0b2dea0be880388750fb4948c2139ce32e084ac338bcbba56c4f93f2946d
+    - current_digest: 72eb0b2dea0be880388750fb4948c2139ce32e084ac338bcbba56c4f93f2946d
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607270107-GRJSV6
+
+    DecisionContextRef:
+    - operator_action: provider_action
+    - can_execute_now: false
+    - safe_command: none
+    - diagnostic_command: none
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: none
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -273,6 +311,38 @@ Follow up RF13: permit targeted merged cleanup only when a local post-merge tail
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-07-27T01:49:26.181Z — VERIFY — ok
+
+By: TESTER
+
+Note: Verified targeted cleanup acceptance, authority classification, ci:contract, and the complete hosted PR #4636 gate.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-27T01:21:15.474Z, excerpt_hash=sha256:a7f74adf4ab205b81f8995477b77230d92d5941956f20437d38e3c84bfd278e4
+
+Details:
+
+Focused Vitest: 31/31 passed (cleanup provider proof, authority-only tail, semantic-tail rejection, authority policy). Local: format, lint, typecheck, ci:contract. Hosted head 2601cd40: CodeQL, docs, runtime packages, contract, static, unit, critical CLI, workflow, coverage, and Windows all passed.
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/rf05b-integration-base/.agentplane/worktrees/202607270107-GRJSV6-preserve-authority-only-tails-during-merged-clea/.agentplane/tasks/202607270107-GRJSV6/blueprint/resolved-snapshot.json
+- old_digest: 72eb0b2dea0be880388750fb4948c2139ce32e084ac338bcbba56c4f93f2946d
+- current_digest: 72eb0b2dea0be880388750fb4948c2139ce32e084ac338bcbba56c4f93f2946d
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607270107-GRJSV6
+
+DecisionContextRef:
+- operator_action: provider_action
+- can_execute_now: false
+- safe_command: none
+- diagnostic_command: none
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: none
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan

--- a/.agentplane/tasks/202607270107-GRJSV6/README.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/README.md
@@ -1,0 +1,101 @@
+---
+id: "202607270107-GRJSV6"
+title: "Preserve authority-only tails during merged cleanup"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 5
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "post-merge-followup"
+verify: []
+plan_approval:
+  state: "approved"
+  updated_at: "2026-07-27T01:07:38.771Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "ORCHESTRATOR"
+    body: "Start: approved post-merge cleanup authority follow-up."
+events:
+  -
+    type: "status"
+    at: "2026-07-27T01:07:39.057Z"
+    author: "ORCHESTRATOR"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: approved post-merge cleanup authority follow-up."
+doc_version: 3
+doc_updated_at: "2026-07-27T01:21:15.474Z"
+doc_updated_by: "ORCHESTRATOR"
+description: "Follow up RF13: permit targeted merged cleanup only when a local post-merge tail is proven authority-only against the provider-merged head, and classify hosted close finalization as local reversible after the merge and pre-merge closure are already durable."
+sections:
+  Summary: |-
+    Preserve authority-only tails during merged cleanup
+
+    Follow up RF13: permit targeted merged cleanup only when a local post-merge tail is proven authority-only against the provider-merged head, and classify hosted close finalization as local reversible after the merge and pre-merge closure are already durable.
+  Scope: |-
+    - In scope: Follow up RF13: permit targeted merged cleanup only when a local post-merge tail is proven authority-only against the provider-merged head, and classify hosted close finalization as local reversible after the merge and pre-merge closure are already durable.
+    - Out of scope: unrelated refactors not required for "Preserve authority-only tails during merged cleanup".
+  Plan: "1. CODER: add a narrowly scoped cleanup proof that accepts only a provider-merged task head followed by authority-only task README records; keep semantic or arbitrary post-merge tails blocked. 2. CODER: classify hosted-close finalization as local reversible because protected merge and task completion are already durable before cleanup. 3. TESTER: add regression coverage for accepted authority-only tails and rejected semantic tails, then run focused cleanup/authority checks. 4. EVALUATOR: record an independent pass against the new proof. 5. INTEGRATOR: merge the follow-up and rerun targeted cleanup for NWVCAG."
+  Verify Steps: |-
+    1. Run targeted cleanup proof tests. Expected: a provider-merged head followed only by authority-extension README commits is removable; a non-authority tail remains blocked.
+    2. Run authority policy tests. Expected: task.hosted_close.finalize is local_reversible and requires no authority because protected merge and close evidence already exist.
+    3. Run format, lint, type checks, and ci:contract. Expected: all pass without generated-artifact drift.
+    4. Re-run RF13 targeted cleanup after integration. Expected: the previously blocked local authority-only tail is removed by the CLI, while no unrelated worktree or branch is touched.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+extensions:
+  workflow_route_baseline:
+    start_head_sha: "518f9f4a62e09016262af2cbbeb89947550be2e0"
+    version: 1
+id_source: "generated"
+---
+## Summary
+
+Preserve authority-only tails during merged cleanup
+
+Follow up RF13: permit targeted merged cleanup only when a local post-merge tail is proven authority-only against the provider-merged head, and classify hosted close finalization as local reversible after the merge and pre-merge closure are already durable.
+
+## Scope
+
+- In scope: Follow up RF13: permit targeted merged cleanup only when a local post-merge tail is proven authority-only against the provider-merged head, and classify hosted close finalization as local reversible after the merge and pre-merge closure are already durable.
+- Out of scope: unrelated refactors not required for "Preserve authority-only tails during merged cleanup".
+
+## Plan
+
+1. CODER: add a narrowly scoped cleanup proof that accepts only a provider-merged task head followed by authority-only task README records; keep semantic or arbitrary post-merge tails blocked. 2. CODER: classify hosted-close finalization as local reversible because protected merge and task completion are already durable before cleanup. 3. TESTER: add regression coverage for accepted authority-only tails and rejected semantic tails, then run focused cleanup/authority checks. 4. EVALUATOR: record an independent pass against the new proof. 5. INTEGRATOR: merge the follow-up and rerun targeted cleanup for NWVCAG.
+
+## Verify Steps
+
+1. Run targeted cleanup proof tests. Expected: a provider-merged head followed only by authority-extension README commits is removable; a non-authority tail remains blocked.
+2. Run authority policy tests. Expected: task.hosted_close.finalize is local_reversible and requires no authority because protected merge and close evidence already exist.
+3. Run format, lint, type checks, and ci:contract. Expected: all pass without generated-artifact drift.
+4. Re-run RF13 targeted cleanup after integration. Expected: the previously blocked local authority-only tail is removed by the CLI, while no unrelated worktree or branch is touched.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202607270107-GRJSV6/README.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/README.md
@@ -4,7 +4,7 @@ title: "Preserve authority-only tails during merged cleanup"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 8
+revision: 9
 origin:
   system: "manual"
 depends_on: []
@@ -102,6 +102,19 @@ extensions:
         schemaVersion: 1
         sequence: 3
         stateFingerprintDigest: "sha256:91137e2815b5968a5d5e8cc1860c60ef50c7deb79fd0a36a57ad445af3635d31"
+      -
+        actor: "USER"
+        at: "2026-07-27T01:30:17.499Z"
+        authorityDigest: "sha256:ee8eaa910f22721f63c2951b04d55cd299978e97efdbcbbdec97bca62db87c21"
+        digest: "sha256:64dbee3b1eb18228a071fbdf1b34f7db84852944d9cd054161dddbf1395f70ed"
+        operationDigest: "sha256:be6044036047203402ecf8652ec2bbb35b7818eb33cd08789d4498ed30691cd9"
+        operationId: "pr.head.publish"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:536c88ed614377b316116b8693cdce0042259911630687c63fcb7138b5a54f95"
+        schemaVersion: 1
+        sequence: 4
+        stateFingerprintDigest: "sha256:d6a1b201c654e8277758b09e04725560ab39a4d0c963c6b6e551a98859954247"
     grants:
       -
         actor: "USER"
@@ -142,6 +155,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:91137e2815b5968a5d5e8cc1860c60ef50c7deb79fd0a36a57ad445af3635d31"
         stateScopeDigest: "sha256:e661950fb0e988c9efab7a8915a176e8e2b8ef44102f9450758c92c12dea7c16"
+      -
+        actor: "USER"
+        digest: "sha256:ee8eaa910f22721f63c2951b04d55cd299978e97efdbcbbdec97bca62db87c21"
+        expiresAt: "2026-07-27T01:45:17.499Z"
+        id: "authority-1db6ab2f-6bf9-498b-b4fe-6ca1db3d1410"
+        issuedAt: "2026-07-27T01:30:17.499Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:be6044036047203402ecf8652ec2bbb35b7818eb33cd08789d4498ed30691cd9"
+        operationId: "pr.head.publish"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:d6a1b201c654e8277758b09e04725560ab39a4d0c963c6b6e551a98859954247"
+        stateScopeDigest: "sha256:c109e28230076b1657037909c98751edda3dd80dea03de2cda8e63b863bded06"
     schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "518f9f4a62e09016262af2cbbeb89947550be2e0"

--- a/.agentplane/tasks/202607270107-GRJSV6/README.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/README.md
@@ -4,7 +4,7 @@ title: "Preserve authority-only tails during merged cleanup"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 9
+revision: 10
 origin:
   system: "manual"
 depends_on: []
@@ -22,6 +22,28 @@ verification:
   updated_by: null
   note: null
   attempts: 0
+quality_review:
+  state: "pass"
+  provenance: "evaluator_supplied"
+  updated_at: "2026-07-27T01:33:05.928Z"
+  updated_by: "EVALUATOR"
+  note: "Cleanup proof remains fail-closed: only a provider-merged ancestor followed solely by authority-extension README advances may be cleaned."
+  evaluated_sha: "d97c8521e502c765af00ebe5b4cc467edf812aa2"
+  blueprint_digest: "72eb0b2dea0be880388750fb4948c2139ce32e084ac338bcbba56c4f93f2946d"
+  evidence_refs:
+    - ".agentplane/tasks/202607270107-GRJSV6/README.md"
+    - ".agentplane/tasks/202607270107-GRJSV6/quality/20260727-013305928-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607270107-GRJSV6/quality/20260727-013305928-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607270107-GRJSV6/quality/20260727-013305928-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607270107-GRJSV6/blueprint/resolved-snapshot.json"
+    - "packages/agentplane/src/commands/branch/cleanup-merged.targeted.test.ts (31 focused tests)"
+    - "packages/agentplane/src/commands/shared/side-effect-authority.test.ts"
+    - "bun run ci:contract"
+    - "GitHub PR #4636 first hosted pass for semantic head 540ed68d883224b84211743e0c98bc04faa44938"
+  findings:
+    - "Accepted path is covered by a targeted provider-receipt fixture with an authority-only descendant chain."
+    - "Rejected path is covered by a semantic post-merge tail fixture; no non-authority changes are accepted."
+    - "Hosted-close finalization is local reversible only after protected merge and pre-merge closure evidence are already durable."
 commit: null
 comments:
   -

--- a/.agentplane/tasks/202607270107-GRJSV6/README.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/README.md
@@ -4,7 +4,7 @@ title: "Preserve authority-only tails during merged cleanup"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 5
+revision: 6
 origin:
   system: "manual"
 depends_on: []
@@ -61,6 +61,36 @@ sections:
     - Re-run required checks to confirm rollback safety.
   Findings: ""
 extensions:
+  agentplane.side_effect_authority:
+    audit:
+      -
+        actor: "USER"
+        at: "2026-07-27T01:22:11.621Z"
+        authorityDigest: "sha256:380140799ddcedbfce850b5b646d3e817edce64230776010aefcafcdccd42963"
+        digest: "sha256:9ec49f000de2e8ff95112a6b97e4021284871adb8250a18f93de09d3c5520780"
+        operationDigest: "sha256:457693dd75dab26a5967c46a9a5cbaed57cb8134a5955c165cc7a37fd1633032"
+        operationId: "pr.open"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: null
+        schemaVersion: 1
+        sequence: 1
+        stateFingerprintDigest: "sha256:447625bb985641e8e1e4b9a726a083688bcf78081d00ed1860a1ce1e7b127f05"
+    grants:
+      -
+        actor: "USER"
+        digest: "sha256:380140799ddcedbfce850b5b646d3e817edce64230776010aefcafcdccd42963"
+        expiresAt: "2026-07-27T01:37:11.621Z"
+        id: "authority-c54eac2c-890f-439a-8cbb-e699691b1996"
+        issuedAt: "2026-07-27T01:22:11.621Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:457693dd75dab26a5967c46a9a5cbaed57cb8134a5955c165cc7a37fd1633032"
+        operationId: "pr.open"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:447625bb985641e8e1e4b9a726a083688bcf78081d00ed1860a1ce1e7b127f05"
+        stateScopeDigest: "sha256:7315243d9bcacad97144422ba77090892cebb6d15843c223b6acfd376e355a88"
+    schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "518f9f4a62e09016262af2cbbeb89947550be2e0"
     version: 1

--- a/.agentplane/tasks/202607270107-GRJSV6/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202607270107-GRJSV6/blueprint/resolved-snapshot.json
@@ -1,0 +1,360 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607270107-GRJSV6",
+    "title": "Preserve authority-only tails during merged cleanup",
+    "description": "Follow up RF13: permit targeted merged cleanup only when a local post-merge tail is proven authority-only against the provider-merged head, and classify hosted close finalization as local reversible after the merge and pre-merge closure are already durable.",
+    "tags": [
+      "post-merge-followup"
+    ],
+    "owner": "CODER",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "none",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": []
+  },
+  "selectedBlueprint": {
+    "id": "analysis.light",
+    "version": 1,
+    "title": "Lightweight analysis",
+    "taskKinds": [
+      "analysis"
+    ],
+    "workflowModes": []
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "analysis.light",
+    "blueprintVersion": 1,
+    "title": "Lightweight analysis",
+    "taskId": "202607270107-GRJSV6",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "mutationScope": "none"
+    },
+    "whySelected": [
+      "task kind resolved to analysis",
+      "workflow mode: branch_pr",
+      "mutation scope: none"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "context_manifest",
+          "sources"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "weak_links",
+          "final_output"
+        ]
+      },
+      {
+        "id": "artifact_write",
+        "kind": "artifact_write",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "final_output"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "analysis.sources",
+        "kind": "sources",
+        "producedBy": "context_resolve",
+        "required": true,
+        "description": "Sources used for analysis."
+      },
+      {
+        "id": "analysis.assumptions",
+        "kind": "assumptions",
+        "producedBy": "scope",
+        "required": true,
+        "description": "Assumptions and constraints."
+      },
+      {
+        "id": "analysis.weak_links",
+        "kind": "weak_links",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Weak links or uncertainty."
+      },
+      {
+        "id": "analysis.final",
+        "kind": "final_output",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Final answer or report."
+      },
+      {
+        "id": "analysis.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      }
+    ],
+    "policyModules": [],
+    "allowedCommands": [],
+    "contextBudget": {
+      "maxPolicyModules": 0,
+      "maxPromptBlocks": 6,
+      "rationale": "Lightweight analysis should load sources and task context without policy modules."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "context_manifest",
+        "sources"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "weak_links",
+        "final_output"
+      ]
+    },
+    {
+      "id": "artifact_write",
+      "kind": "artifact_write",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "final_output"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "analysis.sources",
+      "kind": "sources",
+      "producedBy": "context_resolve",
+      "required": true,
+      "description": "Sources used for analysis."
+    },
+    {
+      "id": "analysis.assumptions",
+      "kind": "assumptions",
+      "producedBy": "scope",
+      "required": true,
+      "description": "Assumptions and constraints."
+    },
+    {
+      "id": "analysis.weak_links",
+      "kind": "weak_links",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Weak links or uncertainty."
+    },
+    {
+      "id": "analysis.final",
+      "kind": "final_output",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Final answer or report."
+    },
+    {
+      "id": "analysis.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    }
+  ],
+  "policyModules": [],
+  "allowedCommands": [],
+  "contextBudget": {
+    "maxPolicyModules": 0,
+    "maxPromptBlocks": 6,
+    "rationale": "Lightweight analysis should load sources and task context without policy modules."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "task kind resolved to analysis",
+    "workflow mode: branch_pr",
+    "mutation scope: none"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "72eb0b2dea0be880388750fb4948c2139ce32e084ac338bcbba56c4f93f2946d"
+  }
+}

--- a/.agentplane/tasks/202607270107-GRJSV6/pr/diffstat.txt
+++ b/.agentplane/tasks/202607270107-GRJSV6/pr/diffstat.txt
@@ -1,0 +1,6 @@
+ .../src/commands/branch/cleanup-merged-proof.ts    | 91 +++++++++++++++++++---
+ .../branch/cleanup-merged.targeted.test.ts         | 61 +++++++++++++++
+ .../src/commands/shared/quality-review-target.ts   |  2 +-
+ .../commands/shared/side-effect-authority.test.ts  |  4 +-
+ .../src/commands/shared/side-effect-authority.ts   |  5 +-
+ 5 files changed, 150 insertions(+), 13 deletions(-)

--- a/.agentplane/tasks/202607270107-GRJSV6/pr/github-body.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/pr/github-body.md
@@ -1,0 +1,38 @@
+Task: `202607270107-GRJSV6`
+Title: Preserve authority-only tails during merged cleanup
+Canonical task record: `.agentplane/tasks/202607270107-GRJSV6/README.md`
+
+## Summary
+
+Preserve authority-only tails during merged cleanup
+
+Follow up RF13: permit targeted merged cleanup only when a local post-merge tail is proven authority-only against the provider-merged head, and classify hosted close finalization as local reversible after the merge and pre-merge closure are already durable.
+
+## Scope
+
+- In scope: Follow up RF13: permit targeted merged cleanup only when a local post-merge tail is proven authority-only against the provider-merged head, and classify hosted close finalization as local reversible after the merge and pre-merge closure are already durable.
+- Out of scope: unrelated refactors not required for "Preserve authority-only tails during merged cleanup".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-27T01:22:25.252Z
+- Branch: task/202607270107-GRJSV6/preserve-authority-only-tails-during-merged-clea
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/commands/branch/cleanup-merged-proof.ts    | 91 +++++++++++++++++++---
+ .../branch/cleanup-merged.targeted.test.ts         | 61 +++++++++++++++
+ .../src/commands/shared/quality-review-target.ts   |  2 +-
+ .../commands/shared/side-effect-authority.test.ts  |  4 +-
+ .../src/commands/shared/side-effect-authority.ts   |  5 +-
+ 5 files changed, 150 insertions(+), 13 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202607270107-GRJSV6/pr/github-body.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/pr/github-body.md
@@ -15,8 +15,13 @@ Follow up RF13: permit targeted merged cleanup only when a local post-merge tail
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Verified targeted cleanup acceptance, authority classification, ci:contract, and the complete hosted
+PR #4636 gate.
+```
 - Canonical workflow state lives in the task README.
 
 <details>

--- a/.agentplane/tasks/202607270107-GRJSV6/pr/github-body.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/pr/github-body.md
@@ -22,7 +22,7 @@ Follow up RF13: permit targeted merged cleanup only when a local post-merge tail
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-27T01:22:25.252Z
+- Updated: 2026-07-27T01:23:26.428Z
 - Branch: task/202607270107-GRJSV6/preserve-authority-only-tails-during-merged-clea
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 

--- a/.agentplane/tasks/202607270107-GRJSV6/pr/github-title.txt
+++ b/.agentplane/tasks/202607270107-GRJSV6/pr/github-title.txt
@@ -1,1 +1,1 @@
-🚧 GRJSV6 task: Preserve authority-only tails during merged cleanup [202607270107-GRJSV6]
+✅ GRJSV6 task: Preserve authority-only tails during merged cleanup [202607270107-GRJSV6]

--- a/.agentplane/tasks/202607270107-GRJSV6/pr/github-title.txt
+++ b/.agentplane/tasks/202607270107-GRJSV6/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 GRJSV6 task: Preserve authority-only tails during merged cleanup [202607270107-GRJSV6]

--- a/.agentplane/tasks/202607270107-GRJSV6/pr/meta.json
+++ b/.agentplane/tasks/202607270107-GRJSV6/pr/meta.json
@@ -7,6 +7,13 @@
   "last_verified_diffstat_sha256": "sha256:3f322f0219ad3e159fbe302a2341d20eb798f90028d4896bdb77a576e55bbda9",
   "pr_number": 4636,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4636",
+  "pre_merge_closure": {
+    "basis_commit": "9af398bb45bbfcb5b9898c13612a4d14e9776c83",
+    "branch": "task/202607270107-GRJSV6/preserve-authority-only-tails-during-merged-clea",
+    "pr_number": 4636,
+    "recorded_at": "2026-07-27T01:50:22.330Z",
+    "state": "closed_before_merge"
+  },
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202607270107-GRJSV6",

--- a/.agentplane/tasks/202607270107-GRJSV6/pr/meta.json
+++ b/.agentplane/tasks/202607270107-GRJSV6/pr/meta.json
@@ -3,7 +3,8 @@
   "branch": "task/202607270107-GRJSV6/preserve-authority-only-tails-during-merged-clea",
   "created_at": "2026-07-27T01:22:25.252Z",
   "diffstat_sha256": "sha256:3f322f0219ad3e159fbe302a2341d20eb798f90028d4896bdb77a576e55bbda9",
-  "last_verified_at": null,
+  "last_verified_at": "2026-07-27T01:49:26.181Z",
+  "last_verified_diffstat_sha256": "sha256:3f322f0219ad3e159fbe302a2341d20eb798f90028d4896bdb77a576e55bbda9",
   "pr_number": 4636,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4636",
   "schema_version": 1,
@@ -11,6 +12,6 @@
   "task_id": "202607270107-GRJSV6",
   "updated_at": "2026-07-27T01:23:26.428Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202607270107-GRJSV6/pr/meta.json
+++ b/.agentplane/tasks/202607270107-GRJSV6/pr/meta.json
@@ -4,9 +4,12 @@
   "created_at": "2026-07-27T01:22:25.252Z",
   "diffstat_sha256": "sha256:3f322f0219ad3e159fbe302a2341d20eb798f90028d4896bdb77a576e55bbda9",
   "last_verified_at": null,
+  "pr_number": 4636,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4636",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202607270107-GRJSV6",
-  "updated_at": "2026-07-27T01:22:25.252Z",
+  "updated_at": "2026-07-27T01:23:26.428Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202607270107-GRJSV6/pr/meta.json
+++ b/.agentplane/tasks/202607270107-GRJSV6/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202607270107-GRJSV6/preserve-authority-only-tails-during-merged-clea",
+  "created_at": "2026-07-27T01:22:25.252Z",
+  "diffstat_sha256": "sha256:3f322f0219ad3e159fbe302a2341d20eb798f90028d4896bdb77a576e55bbda9",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202607270107-GRJSV6",
+  "updated_at": "2026-07-27T01:22:25.252Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202607270107-GRJSV6/pr/review.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/pr/review.md
@@ -1,0 +1,41 @@
+# PR Review
+
+Created: 2026-07-27T01:22:25.252Z
+
+## Task
+
+- Task: `202607270107-GRJSV6`
+- Title: Preserve authority-only tails during merged cleanup
+- Status: DOING
+- Branch: `task/202607270107-GRJSV6/preserve-authority-only-tails-during-merged-clea`
+- Canonical task record: `.agentplane/tasks/202607270107-GRJSV6/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-27T01:22:25.252Z
+- Branch: task/202607270107-GRJSV6/preserve-authority-only-tails-during-merged-clea
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../src/commands/branch/cleanup-merged-proof.ts    | 91 +++++++++++++++++++---
+ .../branch/cleanup-merged.targeted.test.ts         | 61 +++++++++++++++
+ .../src/commands/shared/quality-review-target.ts   |  2 +-
+ .../commands/shared/side-effect-authority.test.ts  |  4 +-
+ .../src/commands/shared/side-effect-authority.ts   |  5 +-
+ 5 files changed, 150 insertions(+), 13 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202607270107-GRJSV6/pr/review.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-07-27T01:22:25.252Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Verified targeted cleanup acceptance, authority classification, ci:contract, and the complete hosted PR #4636 gate.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes

--- a/.agentplane/tasks/202607270107-GRJSV6/pr/review.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/pr/review.md
@@ -24,7 +24,7 @@ Created: 2026-07-27T01:22:25.252Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-27T01:22:25.252Z
+- Updated: 2026-07-27T01:23:26.428Z
 - Branch: task/202607270107-GRJSV6/preserve-authority-only-tails-during-merged-clea
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 

--- a/.agentplane/tasks/202607270107-GRJSV6/pr/review.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/pr/review.md
@@ -6,7 +6,7 @@ Created: 2026-07-27T01:22:25.252Z
 
 - Task: `202607270107-GRJSV6`
 - Title: Preserve authority-only tails during merged cleanup
-- Status: DOING
+- Status: DONE
 - Branch: `task/202607270107-GRJSV6/preserve-authority-only-tails-during-merged-clea`
 - Canonical task record: `.agentplane/tasks/202607270107-GRJSV6/README.md`
 

--- a/.agentplane/tasks/202607270107-GRJSV6/quality/20260727-013305928-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/quality/20260727-013305928-recovery-context/evaluator-opinion.md
@@ -1,0 +1,26 @@
+# Semantic quality review: pass
+
+Provenance: evaluator_supplied
+
+Cleanup proof remains fail-closed: only a provider-merged ancestor followed solely by authority-extension README advances may be cleaned.
+
+## Findings
+- Accepted path is covered by a targeted provider-receipt fixture with an authority-only descendant chain.
+- Rejected path is covered by a semantic post-merge tail fixture; no non-authority changes are accepted.
+- Hosted-close finalization is local reversible only after protected merge and pre-merge closure evidence are already durable.
+
+## Evidence
+- .agentplane/tasks/202607270107-GRJSV6/README.md
+- packages/agentplane/src/commands/branch/cleanup-merged.targeted.test.ts (31 focused tests)
+- packages/agentplane/src/commands/shared/side-effect-authority.test.ts
+- bun run ci:contract
+- GitHub PR #4636 first hosted pass for semantic head 540ed68d883224b84211743e0c98bc04faa44938
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- Authority provenance is locally recorded and hash-chained, not a cryptographic signer identity.
+
+## Residual Risks
+- A tamper-evident local audit chain remains an alpha2 boundary; task cleanup does not treat it as external immutable proof.

--- a/.agentplane/tasks/202607270107-GRJSV6/quality/20260727-013305928-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607270107-GRJSV6/quality/20260727-013305928-recovery-context/evaluator-prompt.md
@@ -1,0 +1,75 @@
+# AgentPlane semantic quality review record
+
+AgentPlane records supplied review values here; this command does not execute an evaluator.
+Use the evaluator module below as the review procedure before supplying a result.
+Do not edit implementation files. Inspect task scope, diff, verification evidence, and residual risk.
+
+- task_id: 202607270107-GRJSV6
+- task_readme: .agentplane/tasks/202607270107-GRJSV6/README.md
+- report_path: .agentplane/tasks/202607270107-GRJSV6/quality/20260727-013305928-recovery-context/quality-report.json
+- provenance: evaluator_supplied
+
+Required report fields:
+- verdict: pass | rework | blocked | human_review
+- summary: concise judgement
+- findings: non-empty list for pass/rework/blocked
+- evidence_refs: concrete files, checks, PRs, traces, or reports inspected
+- missing_tests: tests or checks that should exist but do not
+- hidden_assumptions: assumptions the implementation relies on
+- residual_risks: known remaining risks
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607270107-GRJSV6/quality/20260727-013305928-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607270107-GRJSV6/quality/20260727-013305928-recovery-context/quality-report.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "task_id": "202607270107-GRJSV6",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-27T01:33:05.928Z",
+  "provenance": "evaluator_supplied",
+  "verdict": "pass",
+  "summary": "Cleanup proof remains fail-closed: only a provider-merged ancestor followed solely by authority-extension README advances may be cleaned.",
+  "evaluated_sha": "d97c8521e502c765af00ebe5b4cc467edf812aa2",
+  "blueprint_digest": "72eb0b2dea0be880388750fb4948c2139ce32e084ac338bcbba56c4f93f2946d",
+  "findings": [
+    "Accepted path is covered by a targeted provider-receipt fixture with an authority-only descendant chain.",
+    "Rejected path is covered by a semantic post-merge tail fixture; no non-authority changes are accepted.",
+    "Hosted-close finalization is local reversible only after protected merge and pre-merge closure evidence are already durable."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607270107-GRJSV6/README.md",
+    "packages/agentplane/src/commands/branch/cleanup-merged.targeted.test.ts (31 focused tests)",
+    "packages/agentplane/src/commands/shared/side-effect-authority.test.ts",
+    "bun run ci:contract",
+    "GitHub PR #4636 first hosted pass for semantic head 540ed68d883224b84211743e0c98bc04faa44938"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [
+    "Authority provenance is locally recorded and hash-chained, not a cryptographic signer identity."
+  ],
+  "residual_risks": [
+    "A tamper-evident local audit chain remains an alpha2 boundary; task cleanup does not treat it as external immutable proof."
+  ]
+}

--- a/packages/agentplane/src/commands/branch/cleanup-merged-proof.ts
+++ b/packages/agentplane/src/commands/branch/cleanup-merged-proof.ts
@@ -25,6 +25,7 @@ import {
   taskCloseAlreadyRecordedOnBase,
   taskPreMergeClosureRecordedOnBase,
 } from "../task/close-tail-state.js";
+import { isAuthorityOnlyTaskReadmeAdvance } from "../shared/quality-review-target.js";
 
 type CleanupBranchKind = "task" | "task-close";
 
@@ -172,14 +173,19 @@ async function validateMergedProviderReceipt(opts: {
   baseBranch: string;
   branchHead: string;
   result: GithubPrLookupResult;
-}): Promise<{ prNumber: number | null; reason: string | null }> {
+}): Promise<{ prNumber: number | null; reason: string | null; observedHeadSha: string | null }> {
   if (opts.result.state === "not_found") {
-    return { prNumber: null, reason: "provider PR was not found for the exact branch and base" };
+    return {
+      prNumber: null,
+      reason: "provider PR was not found for the exact branch and base",
+      observedHeadSha: null,
+    };
   }
   if (opts.result.state === "unavailable") {
     return {
       prNumber: null,
       reason: `provider lookup is unavailable: ${opts.result.reason}`,
+      observedHeadSha: null,
     };
   }
   const observed = opts.result.pr;
@@ -187,18 +193,14 @@ async function validateMergedProviderReceipt(opts: {
     return {
       prNumber: observed.prNumber,
       reason: `provider PR #${observed.prNumber} is ${observed.status.toLowerCase()}, not merged`,
+      observedHeadSha: null,
     };
   }
   if ((observed.base?.trim() ?? "") !== opts.baseBranch) {
     return {
       prNumber: observed.prNumber,
       reason: `provider base mismatch: expected=${opts.baseBranch} observed=${observed.base ?? "-"}`,
-    };
-  }
-  if (!observed.headSha?.trim() || observed.headSha.trim() !== opts.branchHead) {
-    return {
-      prNumber: observed.prNumber,
-      reason: `provider head mismatch: local=${opts.branchHead} observed=${observed.headSha ?? "-"}`,
+      observedHeadSha: null,
     };
   }
   const mergeCommit = observed.mergeCommit?.trim() ?? "";
@@ -206,9 +208,66 @@ async function validateMergedProviderReceipt(opts: {
     return {
       prNumber: observed.prNumber,
       reason: `provider merge commit is not on ${opts.baseBranch}: ${mergeCommit || "-"}`,
+      observedHeadSha: null,
     };
   }
-  return { prNumber: observed.prNumber, reason: null };
+  const observedHeadSha = observed.headSha?.trim() ?? "";
+  if (!observedHeadSha || observedHeadSha !== opts.branchHead) {
+    return {
+      prNumber: observed.prNumber,
+      reason: `provider head mismatch: local=${opts.branchHead} observed=${observed.headSha ?? "-"}`,
+      observedHeadSha: observedHeadSha || null,
+    };
+  }
+  return { prNumber: observed.prNumber, reason: null, observedHeadSha };
+}
+
+/**
+ * A durable authority record can be written after the provider has merged the
+ * task branch but before local cleanup runs. The record must not let arbitrary
+ * post-merge work masquerade as merged content, so accept only a non-empty
+ * descendant chain whose every commit changes this task README solely by its
+ * authority extension and revision.
+ */
+async function hasAuthorityOnlyPostMergeTail(opts: {
+  gitRoot: string;
+  workflowDir: string;
+  taskId: string;
+  providerHeadSha: string;
+  branchHeadSha: string;
+}): Promise<boolean> {
+  if (!(await gitIsAncestor(opts.gitRoot, opts.providerHeadSha, opts.branchHeadSha))) {
+    return false;
+  }
+  const { stdout } = await execFileAsync(
+    "git",
+    ["rev-list", "--reverse", `${opts.providerHeadSha}..${opts.branchHeadSha}`],
+    { cwd: opts.gitRoot, env: gitEnv() },
+  );
+  const commits = stdout
+    .split("\n")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (commits.length === 0) return false;
+
+  const taskReadme = path.posix.join(opts.workflowDir, opts.taskId, "README.md");
+  for (const current of commits) {
+    const { stdout: parentOutput } = await execFileAsync("git", ["rev-parse", `${current}^`], {
+      cwd: opts.gitRoot,
+      env: gitEnv(),
+    });
+    const parent = parentOutput.trim();
+    const changed = await gitDiffNames(opts.gitRoot, parent, current);
+    const authorityOnly = await isAuthorityOnlyTaskReadmeAdvance({
+      gitRoot: opts.gitRoot,
+      parent,
+      current,
+      changed,
+      taskRelativePath: (name) => (name === taskReadme ? "README.md" : null),
+    });
+    if (!authorityOnly) return false;
+  }
+  return true;
 }
 
 async function targetedCleanupProof(opts: {
@@ -252,12 +311,26 @@ async function targetedCleanupProof(opts: {
     baseBranch: opts.baseBranch,
     prNumber: recordedPrNumber,
   });
-  const providerReceipt = await validateMergedProviderReceipt({
+  let providerReceipt = await validateMergedProviderReceipt({
     gitRoot: opts.gitRoot,
     baseBranch: opts.baseBranch,
     branchHead,
     result: providerResult,
   });
+
+  if (
+    providerReceipt.reason &&
+    providerReceipt.observedHeadSha &&
+    (await hasAuthorityOnlyPostMergeTail({
+      gitRoot: opts.gitRoot,
+      workflowDir: opts.workflowDir,
+      taskId: opts.taskId,
+      providerHeadSha: providerReceipt.observedHeadSha,
+      branchHeadSha: branchHead,
+    }))
+  ) {
+    providerReceipt = { ...providerReceipt, reason: null };
+  }
 
   if (opts.kind === "task") {
     if (providerReceipt.reason) return result(null, providerReceipt.reason);

--- a/packages/agentplane/src/commands/branch/cleanup-merged.targeted.test.ts
+++ b/packages/agentplane/src/commands/branch/cleanup-merged.targeted.test.ts
@@ -282,6 +282,23 @@ async function configureFinalizationRemote(fixture: TargetedFixture): Promise<vo
   });
 }
 
+async function commitAuthorityOnlyTail(fixture: TargetedFixture): Promise<string> {
+  const task = await readTask({ cwd: fixture.worktreePath, taskId: fixture.taskId });
+  const readme = await readFile(task.readmePath, "utf8");
+  const updated = readme.replace(
+    /^comments:/mu,
+    "extensions:\n  agentplane.side_effect_authority:\n    schemaVersion: 1\n    grants: []\n    audit: []\ncomments:",
+  );
+  expect(updated).not.toBe(readme);
+  await writeFile(task.readmePath, updated, "utf8");
+  await commitAll(fixture.worktreePath, `authority ${fixture.taskId} post-merge cleanup`);
+  const { stdout } = await execFileAsync("git", ["rev-parse", fixture.branch], {
+    cwd: fixture.root,
+    env: cleanGitEnv(),
+  });
+  return stdout.trim();
+}
+
 async function installFakeGithubOriginLookup(fakeBin: string): Promise<void> {
   const locator = process.platform === "win32" ? "where" : "which";
   const { stdout } = await execFileAsync(locator, ["git"], { env: cleanGitEnv() });
@@ -508,6 +525,50 @@ describe("cleanup merged targeted provider proof", { timeout: TEST_TIMEOUT_MS },
     expect(await gitBranchExists(fixture.root, fixture.branch)).toBe(true);
     expect(await pathExists(fixture.worktreePath)).toBe(true);
     expect(await gitBranchExists(fixture.root, fixture.unrelatedBranch)).toBe(true);
+  });
+
+  it("cleans a provider-merged task with a local authority-only post-merge tail", async () => {
+    const fixture = await createTargetedFixture();
+    const localTail = await commitAuthorityOnlyTail(fixture);
+    expect(localTail).not.toBe(fixture.branchHead);
+    const fakeBin = await installFakeGh({ kind: "found", fixture });
+    const result = await runWithFakeGh(fakeBin, [
+      "cleanup",
+      "merged",
+      "--task-id",
+      fixture.taskId,
+      "--yes",
+      "--root",
+      fixture.root,
+    ]);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("proof=provider_merge");
+    expect(await gitBranchExists(fixture.root, fixture.branch)).toBe(false);
+    expect(await pathExists(fixture.worktreePath)).toBe(false);
+  });
+
+  it("keeps a semantic post-merge tail blocked despite a matching provider head", async () => {
+    const fixture = await createTargetedFixture();
+    await writeFile(
+      path.join(fixture.worktreePath, "semantic-tail.txt"),
+      "must not clean\n",
+      "utf8",
+    );
+    await commitAll(fixture.worktreePath, `semantic ${fixture.taskId} post-merge tail`);
+    const fakeBin = await installFakeGh({ kind: "found", fixture });
+    const result = await runWithFakeGh(fakeBin, [
+      "cleanup",
+      "merged",
+      "--task-id",
+      fixture.taskId,
+      "--yes",
+      "--root",
+      fixture.root,
+    ]);
+    expect(result.code).toBe(5);
+    expect(result.stderr).toContain("provider head mismatch");
+    expect(await gitBranchExists(fixture.root, fixture.branch)).toBe(true);
+    expect(await pathExists(fixture.worktreePath)).toBe(true);
   });
 
   it("fails closed on provider base mismatch before deleting the worktree", async () => {

--- a/packages/agentplane/src/commands/shared/quality-review-target.ts
+++ b/packages/agentplane/src/commands/shared/quality-review-target.ts
@@ -42,7 +42,7 @@ function authorityComparableTaskReadme(markdown: string): string | null {
   }
 }
 
-async function isAuthorityOnlyTaskReadmeAdvance(opts: {
+export async function isAuthorityOnlyTaskReadmeAdvance(opts: {
   gitRoot: string;
   parent: string;
   current: string;

--- a/packages/agentplane/src/commands/shared/side-effect-authority.test.ts
+++ b/packages/agentplane/src/commands/shared/side-effect-authority.test.ts
@@ -156,8 +156,8 @@ describe("side-effect authority", () => {
       });
     }
     expect(WORKFLOW_OPERATION_AUTHORITY_POLICY["task.hosted_close.finalize"]).toMatchObject({
-      class: "external_high_risk",
-      requiresAuthority: true,
+      class: "local_reversible",
+      requiresAuthority: false,
     });
   });
 

--- a/packages/agentplane/src/commands/shared/side-effect-authority.ts
+++ b/packages/agentplane/src/commands/shared/side-effect-authority.ts
@@ -67,7 +67,10 @@ export const WORKFLOW_OPERATION_AUTHORITY_POLICY = {
   "task.pre_merge_close": EXTERNAL_HIGH_RISK,
   "integration.enqueue": EXTERNAL_HIGH_RISK,
   "task.hosted_close.open": EXTERNAL_REVERSIBLE,
-  "task.hosted_close.finalize": EXTERNAL_HIGH_RISK,
+  // The protected merge and task completion have already been recorded before
+  // this route. `cleanup merged --finalize` only fast-forwards the local base
+  // and removes proven merged local worktrees/branches.
+  "task.hosted_close.finalize": LOCAL_REVERSIBLE,
   "task.worktree.cleanup": LOCAL_REVERSIBLE,
   "pr.sync_or_verify": EXTERNAL_REVERSIBLE,
 } as const satisfies Record<WorkflowOperationId, AuthorityRequirement>;


### PR DESCRIPTION
Task: `202607270107-GRJSV6`
Title: Preserve authority-only tails during merged cleanup
Canonical task record: `.agentplane/tasks/202607270107-GRJSV6/README.md`

## Summary

Preserve authority-only tails during merged cleanup

Follow up RF13: permit targeted merged cleanup only when a local post-merge tail is proven authority-only against the provider-merged head, and classify hosted close finalization as local reversible after the merge and pre-merge closure are already durable.

## Scope

- In scope: Follow up RF13: permit targeted merged cleanup only when a local post-merge tail is proven authority-only against the provider-merged head, and classify hosted close finalization as local reversible after the merge and pre-merge closure are already durable.
- Out of scope: unrelated refactors not required for "Preserve authority-only tails during merged cleanup".

## Verification

- State: pending
- Note: Not recorded yet.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-07-27T01:22:25.252Z
- Branch: task/202607270107-GRJSV6/preserve-authority-only-tails-during-merged-clea
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../src/commands/branch/cleanup-merged-proof.ts    | 91 +++++++++++++++++++---
 .../branch/cleanup-merged.targeted.test.ts         | 61 +++++++++++++++
 .../src/commands/shared/quality-review-target.ts   |  2 +-
 .../commands/shared/side-effect-authority.test.ts  |  4 +-
 .../src/commands/shared/side-effect-authority.ts   |  5 +-
 5 files changed, 150 insertions(+), 13 deletions(-)
```

</details>
