### PR TITLE
🚧 R7WS01 task: Return typed runner lifecycle results [202607221850-R7WS01]

### DIFF
--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 33
+revision: 34
 origin:
   system: "manual"
 depends_on:
@@ -484,6 +484,19 @@ extensions:
         schemaVersion: 1
         sequence: 12
         stateFingerprintDigest: "sha256:6ae5c51e164c5341487c8a0df1451358d905395d39aa927a5834456ccc24831a"
+      -
+        actor: "USER"
+        at: "2026-07-28T02:55:57.947Z"
+        authorityDigest: "sha256:4fe900ea1e614d2964e1bea96585ddb3e3d9cdeaa763c4c2fa8d9f34a1833995"
+        digest: "sha256:8e3b033ceda13ef0a0adb36f1fef07a01e4dbdf4276dd75272a2a52f0b539af6"
+        operationDigest: "sha256:d16a60500f5a0f56136ac778c6081895f77d3d54576676f28949ed7aebedb9f3"
+        operationId: "task.pre_merge_close"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:a06ca23aa80ad90da3b5d9c0c38096643b700ffed39796e0bc08aa6ecee2a5a9"
+        schemaVersion: 1
+        sequence: 13
+        stateFingerprintDigest: "sha256:ac36416c62a48038c23ac8fabb7d9b9570c2861f861d6dbcd0ae24fbe514466c"
     grants:
       -
         actor: "USER"
@@ -641,6 +654,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:6ae5c51e164c5341487c8a0df1451358d905395d39aa927a5834456ccc24831a"
         stateScopeDigest: "sha256:c298e302a5ff4bc26d2ad18bfa8e43cbcc7f1ddcecf0830935f25d2636b50af0"
+      -
+        actor: "USER"
+        digest: "sha256:4fe900ea1e614d2964e1bea96585ddb3e3d9cdeaa763c4c2fa8d9f34a1833995"
+        expiresAt: "2026-07-28T03:10:57.947Z"
+        id: "authority-23b9ccc0-287e-4935-a8bd-363058efb708"
+        issuedAt: "2026-07-28T02:55:57.947Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:d16a60500f5a0f56136ac778c6081895f77d3d54576676f28949ed7aebedb9f3"
+        operationId: "task.pre_merge_close"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:ac36416c62a48038c23ac8fabb7d9b9570c2861f861d6dbcd0ae24fbe514466c"
+        stateScopeDigest: "sha256:6d13b42978a9ba115f8705cb0fabb438263cd29b3938bf49880f110c14bbc46e"
     schemaVersion: 1
   implementation_commit:
     hash: "96ff9bab8db6e431077c9a7f60b357735e011f80"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 43
+revision: 44
 origin:
   system: "manual"
 depends_on:
@@ -43,27 +43,27 @@ verification:
 quality_review:
   state: "pass"
   provenance: "evaluator_supplied"
-  updated_at: "2026-07-28T03:01:49.505Z"
+  updated_at: "2026-07-28T03:12:42.195Z"
   updated_by: "EVALUATOR"
   note: "EVALUATOR returned pass with 1 typed finding(s)."
-  evaluated_sha: "8339ca9dc3ed7b3e59726ee240bc044fead4b89f"
+  evaluated_sha: "9474725b5ca119945c60338c7821e83f9fe40698"
   blueprint_digest: "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328"
   evidence_refs:
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-work-order.json"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/quality-report.json"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-prompt.md"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-opinion.md"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-result.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-work-order.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-result.json"
     - ".agentplane/tasks/202607221850-R7WS01/README.md"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-diff.patch"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-observed-checks.json"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-blueprint.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-diff.patch"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-observed-checks.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-blueprint.json"
     - ".agentplane/policy/dod.code.md"
     - ".agentplane/policy/dod.core.md"
     - ".agentplane/policy/security.must.md"
     - ".agentplane/policy/workflow.branch_pr.md"
   findings:
-    - "No blocking finding: the only new hosted static error was an unused import left after contract extraction; final lint and targeted regression tests pass."
+    - "No blocking finding: Knip and dependency-cruiser both pass; the implementation keeps only externally consumed symbols public."
 commit:
   hash: "fd963ada01fbd68926a2965d1471eb07b9618cce"
   message: "🛡️ R7WS01 task: authorize static rework closure"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 26
+revision: 27
 origin:
   system: "manual"
 depends_on:
@@ -382,6 +382,19 @@ extensions:
         schemaVersion: 1
         sequence: 8
         stateFingerprintDigest: "sha256:d8864fbc1d1bd9e8e8d164b21a4c193f3fd7b78a9309f857023b6f4b9f06bd3e"
+      -
+        actor: "USER"
+        at: "2026-07-28T02:45:19.435Z"
+        authorityDigest: "sha256:5f6b9be533402713e216037b102052cadfabfcc40bf2e8e14c05fa6e122144b9"
+        digest: "sha256:8baa4d575d547b43208834eb1d62809b050907da24aa4421f3b0eef244d9eb16"
+        operationDigest: "sha256:039e56089b32d9e6ac23685f7be4a4ddb2d49ac92f981c6b09d05a20b5018d0f"
+        operationId: "route.remote.refresh"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:95f84b541b9c41972c26d86ff8aab0f7d91071d4fde95971c95c1476bfce52aa"
+        schemaVersion: 1
+        sequence: 9
+        stateFingerprintDigest: "sha256:405d4401b565e725e8ff7e29963dae10a487ccb827c2d92b5347b9bcf7687396"
     grants:
       -
         actor: "USER"
@@ -487,6 +500,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:d8864fbc1d1bd9e8e8d164b21a4c193f3fd7b78a9309f857023b6f4b9f06bd3e"
         stateScopeDigest: "sha256:c9a851cbdc91ea92b01415b1f6ed63d958d52d3b2ffa8eb36a058a332fb62549"
+      -
+        actor: "USER"
+        digest: "sha256:5f6b9be533402713e216037b102052cadfabfcc40bf2e8e14c05fa6e122144b9"
+        expiresAt: "2026-07-28T03:00:19.435Z"
+        id: "authority-61afe1e5-5530-4054-8b9c-4c7614b97ce4"
+        issuedAt: "2026-07-28T02:45:19.435Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:039e56089b32d9e6ac23685f7be4a4ddb2d49ac92f981c6b09d05a20b5018d0f"
+        operationId: "route.remote.refresh"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:405d4401b565e725e8ff7e29963dae10a487ccb827c2d92b5347b9bcf7687396"
+        stateScopeDigest: "sha256:26a6e5053cac03b7433bdc7efd2a7b0819e01df40b27c8ad286e50a2bd8fe4c4"
     schemaVersion: 1
   implementation_commit:
     hash: "e7465b7377c6a8af392c605de7aa4315bf107100"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 46
+revision: 47
 origin:
   system: "manual"
 depends_on:
@@ -65,8 +65,8 @@ quality_review:
   findings:
     - "No blocking finding: Knip and dependency-cruiser both pass; the implementation keeps only externally consumed symbols public."
 commit:
-  hash: "fd963ada01fbd68926a2965d1471eb07b9618cce"
-  message: "🛡️ R7WS01 task: authorize static rework closure"
+  hash: "c931f4d10add0edfe1e50c237954907745250fce"
+  message: "🛡️ R7WS01 task: authorize dead-code closure"
 comments:
   -
     author: "CODER"
@@ -80,6 +80,9 @@ comments:
   -
     author: "CODER"
     body: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    author: "CODER"
+    body: "Verified: refreshed pre-merge closure packet is ready for the task PR."
   -
     author: "CODER"
     body: "Verified: refreshed pre-merge closure packet is ready for the task PR."
@@ -185,8 +188,15 @@ events:
     author: "TESTER"
     state: "ok"
     note: "PASS (dead-code rework): lifecycle-only exports are private; the public typed result and supervisor operation contract remain unchanged."
+  -
+    type: "status"
+    at: "2026-07-28T03:13:34.250Z"
+    author: "CODER"
+    from: "DONE"
+    to: "DONE"
+    note: "Verified: refreshed pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-28T03:12:27.990Z"
+doc_updated_at: "2026-07-28T03:13:34.250Z"
 doc_updated_by: "CODER"
 description: "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing."
 sections:
@@ -925,8 +935,8 @@ extensions:
         stateScopeDigest: "sha256:22620e96454ec74356f11bb0aa980bf5737fd648801739a70050da4740cc498d"
     schemaVersion: 1
   implementation_commit:
-    hash: "8339ca9dc3ed7b3e59726ee240bc044fead4b89f"
-    message: "🐛 R7WS01 runner: remove stale cleanup type import"
+    hash: "9474725b5ca119945c60338c7821e83f9fe40698"
+    message: "♻️ R7WS01 runner: keep lifecycle internals private"
   workflow_route_baseline:
     start_head_sha: "a27841b280b516dfb52d900db5559ba87adc4224"
     version: 1

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 24
+revision: 26
 origin:
   system: "manual"
 depends_on:
@@ -36,34 +36,34 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-07-28T02:36:22.966Z"
+  updated_at: "2026-07-28T02:43:38.519Z"
   updated_by: "TESTER"
-  note: "PASS (rework reverified): Hermes now uses the shared typed lifecycle exit mapping, including nonzero failure for incomplete active-claim cleanup."
+  note: "PASS (format reverified): typed lifecycle paths now pass repository Prettier format check as well as runner, renderer, and Hermes regression checks."
   attempts: 0
 quality_review:
   state: "pass"
   provenance: "evaluator_supplied"
-  updated_at: "2026-07-28T02:30:01.167Z"
+  updated_at: "2026-07-28T02:43:41.960Z"
   updated_by: "EVALUATOR"
   note: "EVALUATOR returned pass with 1 typed finding(s)."
-  evaluated_sha: "e7465b7377c6a8af392c605de7aa4315bf107100"
+  evaluated_sha: "96ff9bab8db6e431077c9a7f60b357735e011f80"
   blueprint_digest: "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328"
   evidence_refs:
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-work-order.json"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/quality-report.json"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-prompt.md"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-opinion.md"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-result.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-work-order.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-result.json"
     - ".agentplane/tasks/202607221850-R7WS01/README.md"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-diff.patch"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-observed-checks.json"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-blueprint.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-diff.patch"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-observed-checks.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-blueprint.json"
     - ".agentplane/policy/dod.code.md"
     - ".agentplane/policy/dod.core.md"
     - ".agentplane/policy/security.must.md"
     - ".agentplane/policy/workflow.branch_pr.md"
   findings:
-    - "The rework replaces the raw provider exit code with taskRunnerLifecycleExitCode(lifecycle), and a regression test proves that active_claim_cleanup yields failed plus exit_code 1 while retaining the typed result."
+    - "The only source changes are Prettier-normalized wrapping and import grouping in the previously reviewed lifecycle paths; targeted regression tests and format:check pass."
 commit:
   hash: "f63905e9ace209c7dd772d564e016782ea0984ab"
   message: "🛡️ R7WS01 task: record refreshed closure authority"
@@ -131,8 +131,14 @@ events:
     from: "DONE"
     to: "DONE"
     note: "Verified: refreshed pre-merge closure packet is ready for the task PR."
+  -
+    type: "verify"
+    at: "2026-07-28T02:43:38.519Z"
+    author: "TESTER"
+    state: "ok"
+    note: "PASS (format reverified): typed lifecycle paths now pass repository Prettier format check as well as runner, renderer, and Hermes regression checks."
 doc_version: 3
-doc_updated_at: "2026-07-28T02:37:57.846Z"
+doc_updated_at: "2026-07-28T02:43:39.221Z"
 doc_updated_by: "CODER"
 description: "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing."
 sections:
@@ -221,6 +227,36 @@ sections:
     - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
     - risks: none
 
+    ### 2026-07-28T02:43:38.519Z — VERIFY — ok
+
+    By: TESTER
+
+    Note: PASS (format reverified): typed lifecycle paths now pass repository Prettier format check as well as runner, renderer, and Hermes regression checks.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T02:37:57.846Z, excerpt_hash=sha256:02a389ca089e360cf76ff483bd84febcf2d5924eaa0f09fb89eb4a0ab64c794d
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607221850-R7WS01-return-typed-runner-lifecycle-results/.agentplane/tasks/202607221850-R7WS01/blueprint/resolved-snapshot.json
+    - old_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+    - current_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607221850-R7WS01
+
+    DecisionContextRef:
+    - operator_action: provider_action
+    - can_execute_now: false
+    - safe_command: none
+    - diagnostic_command: none
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: none
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert the migrated vertical slice while preserving the typed contracts consumed by later tasks.
@@ -235,6 +271,10 @@ sections:
     - Observation: Hermes lifecycle, renderer, and effect-resolution tests passed; typecheck, lint, and lifecycle invariants passed on e7465b737.
       Impact: Hosted verify-contract evidence now covers the rework commit rather than the superseded implementation head.
       Resolution: Refresh PR head and rerun hosted validation.
+
+    - Observation: format:check, targeted Hermes/renderer/effect-resolution tests, typecheck, lint, and lifecycle invariants passed on 96ff9bab8.
+      Impact: Hosted verify-contract now records evidence for the formatted implementation head.
+      Resolution: Refresh evaluator review and pre-merge closure.
 extensions:
   agentplane.side_effect_authority:
     audit:
@@ -550,6 +590,36 @@ DecisionContextRef:
 - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
 - risks: none
 
+### 2026-07-28T02:43:38.519Z — VERIFY — ok
+
+By: TESTER
+
+Note: PASS (format reverified): typed lifecycle paths now pass repository Prettier format check as well as runner, renderer, and Hermes regression checks.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T02:37:57.846Z, excerpt_hash=sha256:02a389ca089e360cf76ff483bd84febcf2d5924eaa0f09fb89eb4a0ab64c794d
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607221850-R7WS01-return-typed-runner-lifecycle-results/.agentplane/tasks/202607221850-R7WS01/blueprint/resolved-snapshot.json
+- old_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+- current_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607221850-R7WS01
+
+DecisionContextRef:
+- operator_action: provider_action
+- can_execute_now: false
+- safe_command: none
+- diagnostic_command: none
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: none
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -568,3 +638,7 @@ DecisionContextRef:
 - Observation: Hermes lifecycle, renderer, and effect-resolution tests passed; typecheck, lint, and lifecycle invariants passed on e7465b737.
   Impact: Hosted verify-contract evidence now covers the rework commit rather than the superseded implementation head.
   Resolution: Refresh PR head and rerun hosted validation.
+
+- Observation: format:check, targeted Hermes/renderer/effect-resolution tests, typecheck, lint, and lifecycle invariants passed on 96ff9bab8.
+  Impact: Hosted verify-contract now records evidence for the formatted implementation head.
+  Resolution: Refresh evaluator review and pre-merge closure.

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 36
+revision: 37
 origin:
   system: "manual"
 depends_on:
@@ -36,9 +36,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-07-28T02:54:35.229Z"
+  updated_at: "2026-07-28T03:01:34.362Z"
   updated_by: "TESTER"
-  note: "PASS (hosted rework): split execution contracts keeps task-run below the hotspot threshold and replaces unsafe Hermes matcher assignments with typed assertions."
+  note: "PASS (static rework): stale type import removed after contract extraction; no runner lifecycle behavior changed."
   attempts: 0
 quality_review:
   state: "pass"
@@ -163,8 +163,14 @@ events:
     from: "DONE"
     to: "DONE"
     note: "Verified: refreshed pre-merge closure packet is ready for the task PR."
+  -
+    type: "verify"
+    at: "2026-07-28T03:01:34.362Z"
+    author: "TESTER"
+    state: "ok"
+    note: "PASS (static rework): stale type import removed after contract extraction; no runner lifecycle behavior changed."
 doc_version: 3
-doc_updated_at: "2026-07-28T02:56:13.467Z"
+doc_updated_at: "2026-07-28T03:01:35.078Z"
 doc_updated_by: "CODER"
 description: "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing."
 sections:
@@ -313,6 +319,36 @@ sections:
     - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
     - risks: none
 
+    ### 2026-07-28T03:01:34.362Z — VERIFY — ok
+
+    By: TESTER
+
+    Note: PASS (static rework): stale type import removed after contract extraction; no runner lifecycle behavior changed.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T02:56:13.467Z, excerpt_hash=sha256:02a389ca089e360cf76ff483bd84febcf2d5924eaa0f09fb89eb4a0ab64c794d
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607221850-R7WS01-return-typed-runner-lifecycle-results/.agentplane/tasks/202607221850-R7WS01/blueprint/resolved-snapshot.json
+    - old_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+    - current_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607221850-R7WS01
+
+    DecisionContextRef:
+    - operator_action: provider_action
+    - can_execute_now: false
+    - safe_command: none
+    - diagnostic_command: none
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: none
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert the migrated vertical slice while preserving the typed contracts consumed by later tasks.
@@ -335,6 +371,10 @@ sections:
     - Observation: format, typecheck, lint:core, hotspots:check, lifecycle invariants, and the runner/Hermes/CLI rework test set passed on 8cd703b66.
       Impact: The hosted contract and static-analysis failures are addressed without changing runner lifecycle behavior.
       Resolution: Refresh evaluator quality review and publish the verified rework head.
+
+    - Observation: format, typecheck, lint:core, hotspots:check, and 41 runner/Hermes/CLI assertions passed on 8339ca9dc.
+      Impact: The final hosted static-analysis finding is resolved while the typed lifecycle contract remains covered.
+      Resolution: Refresh evaluator review and publish the final verified rework head.
 extensions:
   agentplane.side_effect_authority:
     audit:
@@ -866,6 +906,36 @@ DecisionContextRef:
 - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
 - risks: none
 
+### 2026-07-28T03:01:34.362Z — VERIFY — ok
+
+By: TESTER
+
+Note: PASS (static rework): stale type import removed after contract extraction; no runner lifecycle behavior changed.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T02:56:13.467Z, excerpt_hash=sha256:02a389ca089e360cf76ff483bd84febcf2d5924eaa0f09fb89eb4a0ab64c794d
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607221850-R7WS01-return-typed-runner-lifecycle-results/.agentplane/tasks/202607221850-R7WS01/blueprint/resolved-snapshot.json
+- old_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+- current_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607221850-R7WS01
+
+DecisionContextRef:
+- operator_action: provider_action
+- can_execute_now: false
+- safe_command: none
+- diagnostic_command: none
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: none
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -892,3 +962,7 @@ DecisionContextRef:
 - Observation: format, typecheck, lint:core, hotspots:check, lifecycle invariants, and the runner/Hermes/CLI rework test set passed on 8cd703b66.
   Impact: The hosted contract and static-analysis failures are addressed without changing runner lifecycle behavior.
   Resolution: Refresh evaluator quality review and publish the verified rework head.
+
+- Observation: format, typecheck, lint:core, hotspots:check, and 41 runner/Hermes/CLI assertions passed on 8339ca9dc.
+  Impact: The final hosted static-analysis finding is resolved while the typed lifecycle contract remains covered.
+  Resolution: Refresh evaluator review and publish the final verified rework head.

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 39
+revision: 40
 origin:
   system: "manual"
 depends_on:
@@ -573,6 +573,19 @@ extensions:
         schemaVersion: 1
         sequence: 15
         stateFingerprintDigest: "sha256:8796351c7beb8e715db78aa12b88b968319689e75d50c808b0c664041f617542"
+      -
+        actor: "USER"
+        at: "2026-07-28T03:02:23.097Z"
+        authorityDigest: "sha256:b071cafc5bd59e129b8355e6ea0627afbfdff7bc94c6a199ddb09b80f4b9b836"
+        digest: "sha256:02baf87110ef2c3a2a7a17df51cbb33e9d5a406794919ee3c7f226af9febf0bf"
+        operationDigest: "sha256:d16a60500f5a0f56136ac778c6081895f77d3d54576676f28949ed7aebedb9f3"
+        operationId: "task.pre_merge_close"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:05735b486b424f03c011cd483c4b1785e72604e36bc4a84eadc2122493c6d82b"
+        schemaVersion: 1
+        sequence: 16
+        stateFingerprintDigest: "sha256:6ec5772e8d13e6ff56ca2b3951e2f26b10fa75750ff3b98ecf035c2d4c27d5bf"
     grants:
       -
         actor: "USER"
@@ -769,6 +782,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:8796351c7beb8e715db78aa12b88b968319689e75d50c808b0c664041f617542"
         stateScopeDigest: "sha256:a134d1dddc349c813618d76a851df1406f96d8e65a6fd91009e70fbd9104e2a5"
+      -
+        actor: "USER"
+        digest: "sha256:b071cafc5bd59e129b8355e6ea0627afbfdff7bc94c6a199ddb09b80f4b9b836"
+        expiresAt: "2026-07-28T03:17:23.097Z"
+        id: "authority-55f51ddf-164f-42d7-b187-09bc3d8eaf03"
+        issuedAt: "2026-07-28T03:02:23.097Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:d16a60500f5a0f56136ac778c6081895f77d3d54576676f28949ed7aebedb9f3"
+        operationId: "task.pre_merge_close"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:6ec5772e8d13e6ff56ca2b3951e2f26b10fa75750ff3b98ecf035c2d4c27d5bf"
+        stateScopeDigest: "sha256:c183b07e0fd4b947db6d5e194cf4f080c472d1888bb7519a597d521fc21dc562"
     schemaVersion: 1
   implementation_commit:
     hash: "8cd703b66e4c14daae26b244f551e705068e178d"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -4,7 +4,7 @@ title: "Return typed runner lifecycle results"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 9
+revision: 12
 origin:
   system: "manual"
 depends_on:
@@ -34,16 +34,46 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-07-28T02:26:16.727Z"
+  updated_by: "TESTER"
+  note: "PASS: typed runner lifecycle results stay in-process through task CLI and Hermes; human and JSON renderers preserve effect authority, observed evidence, claim generation, and operator-resolution provenance."
   attempts: 0
-commit: null
+quality_review:
+  state: "rework"
+  provenance: "evaluator_supplied"
+  updated_at: "2026-07-28T02:26:58.563Z"
+  updated_by: "EVALUATOR"
+  note: "EVALUATOR returned rework with 1 typed finding(s)."
+  evaluated_sha: "3f11077e583fb131713af53835139885b4406b60"
+  blueprint_digest: "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328"
+  evidence_refs:
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-work-order.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-result.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-follow-up.json"
+    - ".agentplane/tasks/202607221850-R7WS01/README.md"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-diff.patch"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-observed-checks.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-blueprint.json"
+    - ".agentplane/policy/dod.code.md"
+    - ".agentplane/policy/dod.core.md"
+    - ".agentplane/policy/security.must.md"
+    - ".agentplane/policy/workflow.branch_pr.md"
+  findings:
+    - "executeHermesWorkflowOperation marks an execution with active_claim_cleanup as failed but currently forwards executed.result.exit_code, which can still be 0. This splits supervisor semantics from task-run's typed exit mapping."
+commit:
+  hash: "3f11077e583fb131713af53835139885b4406b60"
+  message: "✨ R7WS01 runner: return typed lifecycle results"
 comments:
   -
     author: "CODER"
     body: "Start: continue branch_pr task in the dedicated task worktree."
+  -
+    author: "CODER"
+    body: "Implementation committed: 3f11077e5. Typed lifecycle result, renderers, Hermes in-process projection, and effect identity coverage are ready for TESTER verification."
 events:
   -
     type: "status"
@@ -52,8 +82,21 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: continue branch_pr task in the dedicated task worktree."
+  -
+    type: "status"
+    at: "2026-07-28T02:22:27.906Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DOING"
+    note: "Implementation committed: 3f11077e5. Typed lifecycle result, renderers, Hermes in-process projection, and effect identity coverage are ready for TESTER verification."
+  -
+    type: "verify"
+    at: "2026-07-28T02:26:16.727Z"
+    author: "TESTER"
+    state: "ok"
+    note: "PASS: typed runner lifecycle results stay in-process through task CLI and Hermes; human and JSON renderers preserve effect authority, observed evidence, claim generation, and operator-resolution provenance."
 doc_version: 3
-doc_updated_at: "2026-07-28T01:55:50.050Z"
+doc_updated_at: "2026-07-28T02:26:17.333Z"
 doc_updated_by: "CODER"
 description: "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing."
 sections:
@@ -82,13 +125,46 @@ sections:
     6. Run runner/supervisor/lifecycle tests and typecheck.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-07-28T02:26:16.727Z — VERIFY — ok
+
+    By: TESTER
+
+    Note: PASS: typed runner lifecycle results stay in-process through task CLI and Hermes; human and JSON renderers preserve effect authority, observed evidence, claim generation, and operator-resolution provenance.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T02:22:27.906Z, excerpt_hash=sha256:02a389ca089e360cf76ff483bd84febcf2d5924eaa0f09fb89eb4a0ab64c794d
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607221850-R7WS01-return-typed-runner-lifecycle-results/.agentplane/tasks/202607221850-R7WS01/blueprint/resolved-snapshot.json
+    - old_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+    - current_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607221850-R7WS01
+
+    DecisionContextRef:
+    - operator_action: stop
+    - can_execute_now: false
+    - safe_command: none
+    - diagnostic_command: agentplane task verify-show 202607221850-R7WS01
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: none
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert the migrated vertical slice while preserving the typed contracts consumed by later tasks.
     - Preserve `effect_in_doubt`, `applied` and `not_applied` states plus resolution provenance in any compatibility boundary; do not restore a generic retry path for unresolved effects.
     - Restore the previous compatibility path only when it cannot bypass the explicit operator-resolution protocol or invoke the adapter for unresolved `effect_in_doubt`.
     - Re-run lifecycle, focused, and type checks before resuming dependent work.
-  Findings: ""
+  Findings: |-
+    - Observation: Focused runner/supervisor/lifecycle suite passed; critical-cli passed 11/11 files (72 tests) in canonical Node mode; lifecycle invariants, typecheck, lint, and routing checks passed.
+      Impact: No stdout parsing or generic replay path was reintroduced for effect_in_doubt.
+      Resolution: Approve branch for PR update and hosted validation.
 extensions:
   agentplane.side_effect_authority:
     audit:
@@ -159,6 +235,36 @@ RF-25d: make runner preparation, invocation, observation, evaluation, and lifecy
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-07-28T02:26:16.727Z — VERIFY — ok
+
+By: TESTER
+
+Note: PASS: typed runner lifecycle results stay in-process through task CLI and Hermes; human and JSON renderers preserve effect authority, observed evidence, claim generation, and operator-resolution provenance.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T02:22:27.906Z, excerpt_hash=sha256:02a389ca089e360cf76ff483bd84febcf2d5924eaa0f09fb89eb4a0ab64c794d
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607221850-R7WS01-return-typed-runner-lifecycle-results/.agentplane/tasks/202607221850-R7WS01/blueprint/resolved-snapshot.json
+- old_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+- current_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607221850-R7WS01
+
+DecisionContextRef:
+- operator_action: stop
+- can_execute_now: false
+- safe_command: none
+- diagnostic_command: agentplane task verify-show 202607221850-R7WS01
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: none
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -169,3 +275,7 @@ RF-25d: make runner preparation, invocation, observation, evaluation, and lifecy
 - Re-run lifecycle, focused, and type checks before resuming dependent work.
 
 ## Findings
+
+- Observation: Focused runner/supervisor/lifecycle suite passed; critical-cli passed 11/11 files (72 tests) in canonical Node mode; lifecycle invariants, typecheck, lint, and routing checks passed.
+  Impact: No stdout parsing or generic replay path was reintroduced for effect_in_doubt.
+  Resolution: Approve branch for PR update and hosted validation.

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 41
+revision: 42
 origin:
   system: "manual"
 depends_on:
@@ -596,6 +596,19 @@ extensions:
         schemaVersion: 1
         sequence: 16
         stateFingerprintDigest: "sha256:6ec5772e8d13e6ff56ca2b3951e2f26b10fa75750ff3b98ecf035c2d4c27d5bf"
+      -
+        actor: "USER"
+        at: "2026-07-28T03:02:57.463Z"
+        authorityDigest: "sha256:705bbdcd33054004f394ce963aec8cb22a9189b5d42ca6830911e2ebb2813427"
+        digest: "sha256:288186154b455dc6f9d44d7551cbce9f4f9fa310de7fd431dcdad92ea9b16282"
+        operationDigest: "sha256:f2ca459bfd8a7bc3ceee075226c85474f5e4162624efe65ac900b59d3e4127d5"
+        operationId: "pr.head.publish"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:02baf87110ef2c3a2a7a17df51cbb33e9d5a406794919ee3c7f226af9febf0bf"
+        schemaVersion: 1
+        sequence: 17
+        stateFingerprintDigest: "sha256:ea802eb7b60faeeea4f6690142d2d5cdda7f652782fc7db69428796ec03703b0"
     grants:
       -
         actor: "USER"
@@ -805,6 +818,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:6ec5772e8d13e6ff56ca2b3951e2f26b10fa75750ff3b98ecf035c2d4c27d5bf"
         stateScopeDigest: "sha256:c183b07e0fd4b947db6d5e194cf4f080c472d1888bb7519a597d521fc21dc562"
+      -
+        actor: "USER"
+        digest: "sha256:705bbdcd33054004f394ce963aec8cb22a9189b5d42ca6830911e2ebb2813427"
+        expiresAt: "2026-07-28T03:17:57.463Z"
+        id: "authority-8dfe2ff3-4a72-47f2-b178-3ea8f7052708"
+        issuedAt: "2026-07-28T03:02:57.463Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:f2ca459bfd8a7bc3ceee075226c85474f5e4162624efe65ac900b59d3e4127d5"
+        operationId: "pr.head.publish"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:ea802eb7b60faeeea4f6690142d2d5cdda7f652782fc7db69428796ec03703b0"
+        stateScopeDigest: "sha256:83f56f849372d9d40e71f98bd90f7a6e6328860008536c349800d7c5b65a6358"
     schemaVersion: 1
   implementation_commit:
     hash: "8339ca9dc3ed7b3e59726ee240bc044fead4b89f"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 44
+revision: 45
 origin:
   system: "manual"
 depends_on:
@@ -649,6 +649,19 @@ extensions:
         schemaVersion: 1
         sequence: 17
         stateFingerprintDigest: "sha256:ea802eb7b60faeeea4f6690142d2d5cdda7f652782fc7db69428796ec03703b0"
+      -
+        actor: "USER"
+        at: "2026-07-28T03:12:56.237Z"
+        authorityDigest: "sha256:d0ac337aaa5407ad25b5dc17b3b21b1b0d1a5aad5330b04d32577fda44b971fb"
+        digest: "sha256:fff5a32d76dfcd72cd964a495595c74fcf86cb10e0fc2fb78bbbd2b81d8dff70"
+        operationDigest: "sha256:039e56089b32d9e6ac23685f7be4a4ddb2d49ac92f981c6b09d05a20b5018d0f"
+        operationId: "route.remote.refresh"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:288186154b455dc6f9d44d7551cbce9f4f9fa310de7fd431dcdad92ea9b16282"
+        schemaVersion: 1
+        sequence: 18
+        stateFingerprintDigest: "sha256:2f4eaf0ecf58c62d6e0f33bee64f501ff3eb1dd2631b7ca3fa85a3a63136519d"
     grants:
       -
         actor: "USER"
@@ -871,6 +884,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:ea802eb7b60faeeea4f6690142d2d5cdda7f652782fc7db69428796ec03703b0"
         stateScopeDigest: "sha256:83f56f849372d9d40e71f98bd90f7a6e6328860008536c349800d7c5b65a6358"
+      -
+        actor: "USER"
+        digest: "sha256:d0ac337aaa5407ad25b5dc17b3b21b1b0d1a5aad5330b04d32577fda44b971fb"
+        expiresAt: "2026-07-28T03:27:56.237Z"
+        id: "authority-c9c596d6-a9a8-4b97-9072-e15dad097d5b"
+        issuedAt: "2026-07-28T03:12:56.237Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:039e56089b32d9e6ac23685f7be4a4ddb2d49ac92f981c6b09d05a20b5018d0f"
+        operationId: "route.remote.refresh"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:2f4eaf0ecf58c62d6e0f33bee64f501ff3eb1dd2631b7ca3fa85a3a63136519d"
+        stateScopeDigest: "sha256:63cff8ae623f0559266c7c0aada331f519c74c493f668595aacdf25cfedc9ea9"
     schemaVersion: 1
   implementation_commit:
     hash: "8339ca9dc3ed7b3e59726ee240bc044fead4b89f"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 40
+revision: 41
 origin:
   system: "manual"
 depends_on:
@@ -65,8 +65,8 @@ quality_review:
   findings:
     - "No blocking finding: the only new hosted static error was an unused import left after contract extraction; final lint and targeted regression tests pass."
 commit:
-  hash: "9013722fdf3806b630cdce0a39610e671216af5a"
-  message: "🛡️ R7WS01 task: authorize rework closure"
+  hash: "fd963ada01fbd68926a2965d1471eb07b9618cce"
+  message: "🛡️ R7WS01 task: authorize static rework closure"
 comments:
   -
     author: "CODER"
@@ -80,6 +80,9 @@ comments:
   -
     author: "CODER"
     body: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    author: "CODER"
+    body: "Verified: refreshed pre-merge closure packet is ready for the task PR."
   -
     author: "CODER"
     body: "Verified: refreshed pre-merge closure packet is ready for the task PR."
@@ -169,8 +172,15 @@ events:
     author: "TESTER"
     state: "ok"
     note: "PASS (static rework): stale type import removed after contract extraction; no runner lifecycle behavior changed."
+  -
+    type: "status"
+    at: "2026-07-28T03:02:39.662Z"
+    author: "CODER"
+    from: "DONE"
+    to: "DONE"
+    note: "Verified: refreshed pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-28T03:01:35.078Z"
+doc_updated_at: "2026-07-28T03:02:39.662Z"
 doc_updated_by: "CODER"
 description: "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing."
 sections:
@@ -797,8 +807,8 @@ extensions:
         stateScopeDigest: "sha256:c183b07e0fd4b947db6d5e194cf4f080c472d1888bb7519a597d521fc21dc562"
     schemaVersion: 1
   implementation_commit:
-    hash: "8cd703b66e4c14daae26b244f551e705068e178d"
-    message: "♻️ R7WS01 runner: split execution contracts"
+    hash: "8339ca9dc3ed7b3e59726ee240bc044fead4b89f"
+    message: "🐛 R7WS01 runner: remove stale cleanup type import"
   workflow_route_baseline:
     start_head_sha: "a27841b280b516dfb52d900db5559ba87adc4224"
     version: 1

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 35
+revision: 36
 origin:
   system: "manual"
 depends_on:
@@ -507,6 +507,19 @@ extensions:
         schemaVersion: 1
         sequence: 13
         stateFingerprintDigest: "sha256:ac36416c62a48038c23ac8fabb7d9b9570c2861f861d6dbcd0ae24fbe514466c"
+      -
+        actor: "USER"
+        at: "2026-07-28T02:56:32.957Z"
+        authorityDigest: "sha256:c7f5c704604f65c41f0506e76867d3672c315ec8909144445a1972b0b167aa63"
+        digest: "sha256:d2b18f41a9172e1422befbcfe24bc35989bf41138fa501e97c53f9a060106b7e"
+        operationDigest: "sha256:f2ca459bfd8a7bc3ceee075226c85474f5e4162624efe65ac900b59d3e4127d5"
+        operationId: "pr.head.publish"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:8e3b033ceda13ef0a0adb36f1fef07a01e4dbdf4276dd75272a2a52f0b539af6"
+        schemaVersion: 1
+        sequence: 14
+        stateFingerprintDigest: "sha256:eec75406bddd0ce1719102b31d2be4b3da065985b60b380ae71307d9fad39fb7"
     grants:
       -
         actor: "USER"
@@ -677,6 +690,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:ac36416c62a48038c23ac8fabb7d9b9570c2861f861d6dbcd0ae24fbe514466c"
         stateScopeDigest: "sha256:6d13b42978a9ba115f8705cb0fabb438263cd29b3938bf49880f110c14bbc46e"
+      -
+        actor: "USER"
+        digest: "sha256:c7f5c704604f65c41f0506e76867d3672c315ec8909144445a1972b0b167aa63"
+        expiresAt: "2026-07-28T03:11:32.957Z"
+        id: "authority-25f0d686-c678-417c-bbd8-69a9be2c66f5"
+        issuedAt: "2026-07-28T02:56:32.957Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:f2ca459bfd8a7bc3ceee075226c85474f5e4162624efe65ac900b59d3e4127d5"
+        operationId: "pr.head.publish"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:eec75406bddd0ce1719102b31d2be4b3da065985b60b380ae71307d9fad39fb7"
+        stateScopeDigest: "sha256:800d6db6a1c8e89abe4f3d2f20e9e558e80daa7b11f64de902ee05ff6d3a3108"
     schemaVersion: 1
   implementation_commit:
     hash: "8cd703b66e4c14daae26b244f551e705068e178d"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202607221850-R7WS01"
 title: "Return typed runner lifecycle results"
-status: "DOING"
+result_summary: "pre-merge closure"
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 12
+revision: 16
 origin:
   system: "manual"
 depends_on:
@@ -40,33 +41,32 @@ verification:
   note: "PASS: typed runner lifecycle results stay in-process through task CLI and Hermes; human and JSON renderers preserve effect authority, observed evidence, claim generation, and operator-resolution provenance."
   attempts: 0
 quality_review:
-  state: "rework"
+  state: "pass"
   provenance: "evaluator_supplied"
-  updated_at: "2026-07-28T02:26:58.563Z"
+  updated_at: "2026-07-28T02:30:01.167Z"
   updated_by: "EVALUATOR"
-  note: "EVALUATOR returned rework with 1 typed finding(s)."
-  evaluated_sha: "3f11077e583fb131713af53835139885b4406b60"
+  note: "EVALUATOR returned pass with 1 typed finding(s)."
+  evaluated_sha: "e7465b7377c6a8af392c605de7aa4315bf107100"
   blueprint_digest: "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328"
   evidence_refs:
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-work-order.json"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/quality-report.json"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-prompt.md"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-opinion.md"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-result.json"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-follow-up.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-work-order.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-result.json"
     - ".agentplane/tasks/202607221850-R7WS01/README.md"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-diff.patch"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-observed-checks.json"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-blueprint.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-diff.patch"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-observed-checks.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-blueprint.json"
     - ".agentplane/policy/dod.code.md"
     - ".agentplane/policy/dod.core.md"
     - ".agentplane/policy/security.must.md"
     - ".agentplane/policy/workflow.branch_pr.md"
   findings:
-    - "executeHermesWorkflowOperation marks an execution with active_claim_cleanup as failed but currently forwards executed.result.exit_code, which can still be 0. This splits supervisor semantics from task-run's typed exit mapping."
+    - "The rework replaces the raw provider exit code with taskRunnerLifecycleExitCode(lifecycle), and a regression test proves that active_claim_cleanup yields failed plus exit_code 1 while retaining the typed result."
 commit:
-  hash: "3f11077e583fb131713af53835139885b4406b60"
-  message: "✨ R7WS01 runner: return typed lifecycle results"
+  hash: "e7465b7377c6a8af392c605de7aa4315bf107100"
+  message: "🐛 R7WS01 hermes: preserve lifecycle exit failures"
 comments:
   -
     author: "CODER"
@@ -74,6 +74,12 @@ comments:
   -
     author: "CODER"
     body: "Implementation committed: 3f11077e5. Typed lifecycle result, renderers, Hermes in-process projection, and effect identity coverage are ready for TESTER verification."
+  -
+    author: "CODER"
+    body: "Rework committed: e7465b737. Hermes now uses the shared typed lifecycle exit mapping when active-claim cleanup fails; regression coverage added."
+  -
+    author: "CODER"
+    body: "Verified: pre-merge closure packet is ready for the task PR."
 events:
   -
     type: "status"
@@ -95,8 +101,22 @@ events:
     author: "TESTER"
     state: "ok"
     note: "PASS: typed runner lifecycle results stay in-process through task CLI and Hermes; human and JSON renderers preserve effect authority, observed evidence, claim generation, and operator-resolution provenance."
+  -
+    type: "status"
+    at: "2026-07-28T02:29:32.508Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DOING"
+    note: "Rework committed: e7465b737. Hermes now uses the shared typed lifecycle exit mapping when active-claim cleanup fails; regression coverage added."
+  -
+    type: "status"
+    at: "2026-07-28T02:30:28.612Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-28T02:26:17.333Z"
+doc_updated_at: "2026-07-28T02:30:28.613Z"
 doc_updated_by: "CODER"
 description: "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing."
 sections:
@@ -181,6 +201,19 @@ extensions:
         schemaVersion: 1
         sequence: 1
         stateFingerprintDigest: "sha256:62937b83576dd303313dfc83af04e7e3d0efff9106778d0bff0de00fcea2cf6f"
+      -
+        actor: "USER"
+        at: "2026-07-28T02:30:15.445Z"
+        authorityDigest: "sha256:159cf8da0a1adfd479ed1c9fe769214d27e092f038a4ebb0455db5994c8dfa05"
+        digest: "sha256:72385c150011fff45819893bd41e87d865ca9439a9d4272dc184a55b0978d928"
+        operationDigest: "sha256:7fd8c7ae1909c2269ce1bf5711b983199426325c913ac6c206ee455fc48e748f"
+        operationId: "task.pre_merge_close"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:bb166118ccb9d0ee8a50c75fcf8950df306b9378527648dc7a9c5e66e2c16206"
+        schemaVersion: 1
+        sequence: 2
+        stateFingerprintDigest: "sha256:3378a88965fa1fd31b000cfb7e1e4ee9d5264bfde20221f0605a8e190524a16d"
     grants:
       -
         actor: "USER"
@@ -195,6 +228,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:62937b83576dd303313dfc83af04e7e3d0efff9106778d0bff0de00fcea2cf6f"
         stateScopeDigest: "sha256:193bc7d44785382c8251ed54e1158f5778d84d491257d68adc3646854e5b28bc"
+      -
+        actor: "USER"
+        digest: "sha256:159cf8da0a1adfd479ed1c9fe769214d27e092f038a4ebb0455db5994c8dfa05"
+        expiresAt: "2026-07-28T02:45:15.445Z"
+        id: "authority-ecf0791d-21a5-42f0-a207-0a74e5cf92f1"
+        issuedAt: "2026-07-28T02:30:15.445Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:7fd8c7ae1909c2269ce1bf5711b983199426325c913ac6c206ee455fc48e748f"
+        operationId: "task.pre_merge_close"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:3378a88965fa1fd31b000cfb7e1e4ee9d5264bfde20221f0605a8e190524a16d"
+        stateScopeDigest: "sha256:d7289a717eae5c0660324db1e6a877d0b3b043e9cd1f584fb0155f138e9e1254"
     schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "a27841b280b516dfb52d900db5559ba87adc4224"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 22
+revision: 23
 origin:
   system: "manual"
 depends_on:
@@ -65,8 +65,8 @@ quality_review:
   findings:
     - "The rework replaces the raw provider exit code with taskRunnerLifecycleExitCode(lifecycle), and a regression test proves that active_claim_cleanup yields failed plus exit_code 1 while retaining the typed result."
 commit:
-  hash: "e7465b7377c6a8af392c605de7aa4315bf107100"
-  message: "🐛 R7WS01 hermes: preserve lifecycle exit failures"
+  hash: "f63905e9ace209c7dd772d564e016782ea0984ab"
+  message: "🛡️ R7WS01 task: record refreshed closure authority"
 comments:
   -
     author: "CODER"
@@ -80,6 +80,9 @@ comments:
   -
     author: "CODER"
     body: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    author: "CODER"
+    body: "Verified: refreshed pre-merge closure packet is ready for the task PR."
 events:
   -
     type: "status"
@@ -121,8 +124,15 @@ events:
     author: "TESTER"
     state: "ok"
     note: "PASS (rework reverified): Hermes now uses the shared typed lifecycle exit mapping, including nonzero failure for incomplete active-claim cleanup."
+  -
+    type: "status"
+    at: "2026-07-28T02:37:57.845Z"
+    author: "CODER"
+    from: "DONE"
+    to: "DONE"
+    note: "Verified: refreshed pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-28T02:36:24.002Z"
+doc_updated_at: "2026-07-28T02:37:57.846Z"
 doc_updated_by: "CODER"
 description: "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing."
 sections:
@@ -412,6 +422,9 @@ extensions:
         stateFingerprintDigest: "sha256:23ca034da05724478f1f5e1ccecde49327120d00f0e1bde20df569fcbef022e8"
         stateScopeDigest: "sha256:87e029cd9f844739d0647f8380a221ff13ab79f9cc66ba0c2b2faa15f5a60797"
     schemaVersion: 1
+  implementation_commit:
+    hash: "e7465b7377c6a8af392c605de7aa4315bf107100"
+    message: "🐛 R7WS01 hermes: preserve lifecycle exit failures"
   workflow_route_baseline:
     start_head_sha: "a27841b280b516dfb52d900db5559ba87adc4224"
     version: 1

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 23
+revision: 24
 origin:
   system: "manual"
 depends_on:
@@ -329,6 +329,19 @@ extensions:
         schemaVersion: 1
         sequence: 7
         stateFingerprintDigest: "sha256:23ca034da05724478f1f5e1ccecde49327120d00f0e1bde20df569fcbef022e8"
+      -
+        actor: "USER"
+        at: "2026-07-28T02:38:19.544Z"
+        authorityDigest: "sha256:f830d0f2ad0b1d871b6b53fe7b928b77d6b8f292130e28f7fb861b186b1dfd7b"
+        digest: "sha256:95f84b541b9c41972c26d86ff8aab0f7d91071d4fde95971c95c1476bfce52aa"
+        operationDigest: "sha256:f2ca459bfd8a7bc3ceee075226c85474f5e4162624efe65ac900b59d3e4127d5"
+        operationId: "pr.head.publish"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:b58ca429ed6f8399cf88fc6a6ecd49fb00e3511e031870d38bd92ba2f15e01d2"
+        schemaVersion: 1
+        sequence: 8
+        stateFingerprintDigest: "sha256:d8864fbc1d1bd9e8e8d164b21a4c193f3fd7b78a9309f857023b6f4b9f06bd3e"
     grants:
       -
         actor: "USER"
@@ -421,6 +434,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:23ca034da05724478f1f5e1ccecde49327120d00f0e1bde20df569fcbef022e8"
         stateScopeDigest: "sha256:87e029cd9f844739d0647f8380a221ff13ab79f9cc66ba0c2b2faa15f5a60797"
+      -
+        actor: "USER"
+        digest: "sha256:f830d0f2ad0b1d871b6b53fe7b928b77d6b8f292130e28f7fb861b186b1dfd7b"
+        expiresAt: "2026-07-28T02:53:19.544Z"
+        id: "authority-7402f01f-62c7-4207-829e-afb4c0fa1691"
+        issuedAt: "2026-07-28T02:38:19.544Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:f2ca459bfd8a7bc3ceee075226c85474f5e4162624efe65ac900b59d3e4127d5"
+        operationId: "pr.head.publish"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:d8864fbc1d1bd9e8e8d164b21a4c193f3fd7b78a9309f857023b6f4b9f06bd3e"
+        stateScopeDigest: "sha256:c9a851cbdc91ea92b01415b1f6ed63d958d52d3b2ffa8eb36a058a332fb62549"
     schemaVersion: 1
   implementation_commit:
     hash: "e7465b7377c6a8af392c605de7aa4315bf107100"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 38
+revision: 39
 origin:
   system: "manual"
 depends_on:
@@ -560,6 +560,19 @@ extensions:
         schemaVersion: 1
         sequence: 14
         stateFingerprintDigest: "sha256:eec75406bddd0ce1719102b31d2be4b3da065985b60b380ae71307d9fad39fb7"
+      -
+        actor: "USER"
+        at: "2026-07-28T03:02:04.709Z"
+        authorityDigest: "sha256:b28158026017414ede8663e380b16d929a47e198677c048552885ed036c9b155"
+        digest: "sha256:05735b486b424f03c011cd483c4b1785e72604e36bc4a84eadc2122493c6d82b"
+        operationDigest: "sha256:039e56089b32d9e6ac23685f7be4a4ddb2d49ac92f981c6b09d05a20b5018d0f"
+        operationId: "route.remote.refresh"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:d2b18f41a9172e1422befbcfe24bc35989bf41138fa501e97c53f9a060106b7e"
+        schemaVersion: 1
+        sequence: 15
+        stateFingerprintDigest: "sha256:8796351c7beb8e715db78aa12b88b968319689e75d50c808b0c664041f617542"
     grants:
       -
         actor: "USER"
@@ -743,6 +756,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:eec75406bddd0ce1719102b31d2be4b3da065985b60b380ae71307d9fad39fb7"
         stateScopeDigest: "sha256:800d6db6a1c8e89abe4f3d2f20e9e558e80daa7b11f64de902ee05ff6d3a3108"
+      -
+        actor: "USER"
+        digest: "sha256:b28158026017414ede8663e380b16d929a47e198677c048552885ed036c9b155"
+        expiresAt: "2026-07-28T03:17:04.709Z"
+        id: "authority-fb98ed53-df17-41ba-a7dd-4ec99b2be5d3"
+        issuedAt: "2026-07-28T03:02:04.709Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:039e56089b32d9e6ac23685f7be4a4ddb2d49ac92f981c6b09d05a20b5018d0f"
+        operationId: "route.remote.refresh"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:8796351c7beb8e715db78aa12b88b968319689e75d50c808b0c664041f617542"
+        stateScopeDigest: "sha256:a134d1dddc349c813618d76a851df1406f96d8e65a6fd91009e70fbd9104e2a5"
     schemaVersion: 1
   implementation_commit:
     hash: "8cd703b66e4c14daae26b244f551e705068e178d"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 28
+revision: 29
 origin:
   system: "manual"
 depends_on:
@@ -65,8 +65,8 @@ quality_review:
   findings:
     - "The only source changes are Prettier-normalized wrapping and import grouping in the previously reviewed lifecycle paths; targeted regression tests and format:check pass."
 commit:
-  hash: "f63905e9ace209c7dd772d564e016782ea0984ab"
-  message: "🛡️ R7WS01 task: record refreshed closure authority"
+  hash: "fb7da2d8aac146ef830003f4b2ab20e220f5c2d2"
+  message: "🛡️ R7WS01 task: authorize fresh format closure"
 comments:
   -
     author: "CODER"
@@ -80,6 +80,9 @@ comments:
   -
     author: "CODER"
     body: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    author: "CODER"
+    body: "Verified: refreshed pre-merge closure packet is ready for the task PR."
   -
     author: "CODER"
     body: "Verified: refreshed pre-merge closure packet is ready for the task PR."
@@ -137,8 +140,15 @@ events:
     author: "TESTER"
     state: "ok"
     note: "PASS (format reverified): typed lifecycle paths now pass repository Prettier format check as well as runner, renderer, and Hermes regression checks."
+  -
+    type: "status"
+    at: "2026-07-28T02:46:10.968Z"
+    author: "CODER"
+    from: "DONE"
+    to: "DONE"
+    note: "Verified: refreshed pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-28T02:43:39.221Z"
+doc_updated_at: "2026-07-28T02:46:10.968Z"
 doc_updated_by: "CODER"
 description: "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing."
 sections:
@@ -541,8 +551,8 @@ extensions:
         stateScopeDigest: "sha256:d982377aa1e9b923101daf24fe57602f59d8bb6c08066c469b9bbe96403a9354"
     schemaVersion: 1
   implementation_commit:
-    hash: "e7465b7377c6a8af392c605de7aa4315bf107100"
-    message: "🐛 R7WS01 hermes: preserve lifecycle exit failures"
+    hash: "96ff9bab8db6e431077c9a7f60b357735e011f80"
+    message: "🎨 R7WS01 runner: format typed lifecycle paths"
   workflow_route_baseline:
     start_head_sha: "a27841b280b516dfb52d900db5559ba87adc4224"
     version: 1

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 34
+revision: 35
 origin:
   system: "manual"
 depends_on:
@@ -65,8 +65,8 @@ quality_review:
   findings:
     - "No blocking finding: task-run execution contracts are isolated in a dedicated type module; Hermes checks concrete typed values rather than assigning matcher any values."
 commit:
-  hash: "fb7da2d8aac146ef830003f4b2ab20e220f5c2d2"
-  message: "🛡️ R7WS01 task: authorize fresh format closure"
+  hash: "9013722fdf3806b630cdce0a39610e671216af5a"
+  message: "🛡️ R7WS01 task: authorize rework closure"
 comments:
   -
     author: "CODER"
@@ -80,6 +80,9 @@ comments:
   -
     author: "CODER"
     body: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    author: "CODER"
+    body: "Verified: refreshed pre-merge closure packet is ready for the task PR."
   -
     author: "CODER"
     body: "Verified: refreshed pre-merge closure packet is ready for the task PR."
@@ -153,8 +156,15 @@ events:
     author: "TESTER"
     state: "ok"
     note: "PASS (hosted rework): split execution contracts keeps task-run below the hotspot threshold and replaces unsafe Hermes matcher assignments with typed assertions."
+  -
+    type: "status"
+    at: "2026-07-28T02:56:13.467Z"
+    author: "CODER"
+    from: "DONE"
+    to: "DONE"
+    note: "Verified: refreshed pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-28T02:54:35.937Z"
+doc_updated_at: "2026-07-28T02:56:13.467Z"
 doc_updated_by: "CODER"
 description: "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing."
 sections:
@@ -669,8 +679,8 @@ extensions:
         stateScopeDigest: "sha256:6d13b42978a9ba115f8705cb0fabb438263cd29b3938bf49880f110c14bbc46e"
     schemaVersion: 1
   implementation_commit:
-    hash: "96ff9bab8db6e431077c9a7f60b357735e011f80"
-    message: "🎨 R7WS01 runner: format typed lifecycle paths"
+    hash: "8cd703b66e4c14daae26b244f551e705068e178d"
+    message: "♻️ R7WS01 runner: split execution contracts"
   workflow_route_baseline:
     start_head_sha: "a27841b280b516dfb52d900db5559ba87adc4224"
     version: 1

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 21
+revision: 22
 origin:
   system: "manual"
 depends_on:
@@ -306,6 +306,19 @@ extensions:
         schemaVersion: 1
         sequence: 6
         stateFingerprintDigest: "sha256:468574a137bee1db39c200c3e1a29461b1badc261a26eb0a01e0acbcd6505e08"
+      -
+        actor: "USER"
+        at: "2026-07-28T02:37:22.167Z"
+        authorityDigest: "sha256:3e082db9f215947aa7c4f7cd824922c883d200ee6dbdf28f4641280c84c60048"
+        digest: "sha256:b58ca429ed6f8399cf88fc6a6ecd49fb00e3511e031870d38bd92ba2f15e01d2"
+        operationDigest: "sha256:d16a60500f5a0f56136ac778c6081895f77d3d54576676f28949ed7aebedb9f3"
+        operationId: "task.pre_merge_close"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:3c2226dc25ce8a63c4201f931e383576964108667b7532288a1e04d1ad9e7660"
+        schemaVersion: 1
+        sequence: 7
+        stateFingerprintDigest: "sha256:23ca034da05724478f1f5e1ccecde49327120d00f0e1bde20df569fcbef022e8"
     grants:
       -
         actor: "USER"
@@ -385,6 +398,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:468574a137bee1db39c200c3e1a29461b1badc261a26eb0a01e0acbcd6505e08"
         stateScopeDigest: "sha256:ec4b0b391c8099a28632a8db47702745506b2bee3a05c91315c729df028f3a20"
+      -
+        actor: "USER"
+        digest: "sha256:3e082db9f215947aa7c4f7cd824922c883d200ee6dbdf28f4641280c84c60048"
+        expiresAt: "2026-07-28T02:52:22.167Z"
+        id: "authority-d6020ce4-7456-4fd9-8473-c9135cf71231"
+        issuedAt: "2026-07-28T02:37:22.167Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:d16a60500f5a0f56136ac778c6081895f77d3d54576676f28949ed7aebedb9f3"
+        operationId: "task.pre_merge_close"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:23ca034da05724478f1f5e1ccecde49327120d00f0e1bde20df569fcbef022e8"
+        stateScopeDigest: "sha256:87e029cd9f844739d0647f8380a221ff13ab79f9cc66ba0c2b2faa15f5a60797"
     schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "a27841b280b516dfb52d900db5559ba87adc4224"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 29
+revision: 30
 origin:
   system: "manual"
 depends_on:
@@ -418,6 +418,19 @@ extensions:
         schemaVersion: 1
         sequence: 10
         stateFingerprintDigest: "sha256:5a045e4e58650e5cd374ee28c2432dc1828e7cefe2d871e75e6ba4f3a15b870a"
+      -
+        actor: "USER"
+        at: "2026-07-28T02:46:31.404Z"
+        authorityDigest: "sha256:5019f6bd86e18d36171ebc7a589b923d1f468dd4e7eb54bf533f663b76cd9348"
+        digest: "sha256:0e0fbaa7f5ccfd09585f654a614d196deb815a3ba12d595beb559bfe8ab66d31"
+        operationDigest: "sha256:f2ca459bfd8a7bc3ceee075226c85474f5e4162624efe65ac900b59d3e4127d5"
+        operationId: "pr.head.publish"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:8521190e3af3a7e0cb9315554033812f07f7578d98e135897127c2263f768197"
+        schemaVersion: 1
+        sequence: 11
+        stateFingerprintDigest: "sha256:58147e8ed38a5d410942971af03b18e6a2ee48bdf010bec6f155b54fbe825d60"
     grants:
       -
         actor: "USER"
@@ -549,6 +562,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:5a045e4e58650e5cd374ee28c2432dc1828e7cefe2d871e75e6ba4f3a15b870a"
         stateScopeDigest: "sha256:d982377aa1e9b923101daf24fe57602f59d8bb6c08066c469b9bbe96403a9354"
+      -
+        actor: "USER"
+        digest: "sha256:5019f6bd86e18d36171ebc7a589b923d1f468dd4e7eb54bf533f663b76cd9348"
+        expiresAt: "2026-07-28T03:01:31.404Z"
+        id: "authority-5d607444-2962-4578-85cb-f62759434161"
+        issuedAt: "2026-07-28T02:46:31.404Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:f2ca459bfd8a7bc3ceee075226c85474f5e4162624efe65ac900b59d3e4127d5"
+        operationId: "pr.head.publish"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:58147e8ed38a5d410942971af03b18e6a2ee48bdf010bec6f155b54fbe825d60"
+        stateScopeDigest: "sha256:89b3476e1ee44f950665b99756e3ed9d8d1eba1da28bd7e3219dadfb5fe3e6a8"
     schemaVersion: 1
   implementation_commit:
     hash: "96ff9bab8db6e431077c9a7f60b357735e011f80"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 37
+revision: 38
 origin:
   system: "manual"
 depends_on:
@@ -43,27 +43,27 @@ verification:
 quality_review:
   state: "pass"
   provenance: "evaluator_supplied"
-  updated_at: "2026-07-28T02:55:18.124Z"
+  updated_at: "2026-07-28T03:01:49.505Z"
   updated_by: "EVALUATOR"
   note: "EVALUATOR returned pass with 1 typed finding(s)."
-  evaluated_sha: "8cd703b66e4c14daae26b244f551e705068e178d"
+  evaluated_sha: "8339ca9dc3ed7b3e59726ee240bc044fead4b89f"
   blueprint_digest: "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328"
   evidence_refs:
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-work-order.json"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/quality-report.json"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-prompt.md"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-opinion.md"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-result.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-work-order.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-result.json"
     - ".agentplane/tasks/202607221850-R7WS01/README.md"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-diff.patch"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-observed-checks.json"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-blueprint.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-diff.patch"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-observed-checks.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-blueprint.json"
     - ".agentplane/policy/dod.code.md"
     - ".agentplane/policy/dod.core.md"
     - ".agentplane/policy/security.must.md"
     - ".agentplane/policy/workflow.branch_pr.md"
   findings:
-    - "No blocking finding: task-run execution contracts are isolated in a dedicated type module; Hermes checks concrete typed values rather than assigning matcher any values."
+    - "No blocking finding: the only new hosted static error was an unused import left after contract extraction; final lint and targeted regression tests pass."
 commit:
   hash: "9013722fdf3806b630cdce0a39610e671216af5a"
   message: "🛡️ R7WS01 task: authorize rework closure"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 16
+revision: 17
 origin:
   system: "manual"
 depends_on:
@@ -214,6 +214,19 @@ extensions:
         schemaVersion: 1
         sequence: 2
         stateFingerprintDigest: "sha256:3378a88965fa1fd31b000cfb7e1e4ee9d5264bfde20221f0605a8e190524a16d"
+      -
+        actor: "USER"
+        at: "2026-07-28T02:30:41.699Z"
+        authorityDigest: "sha256:f9e2e15cbe93e26bbe1e8de6816f3e2d7d78aaff7e8c81c87b7fb1c87ce62fa4"
+        digest: "sha256:1ccdb12945a851cbd47607537b1b3728e8dba2184cc34404e7a8583d4e889681"
+        operationDigest: "sha256:039e56089b32d9e6ac23685f7be4a4ddb2d49ac92f981c6b09d05a20b5018d0f"
+        operationId: "route.remote.refresh"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:72385c150011fff45819893bd41e87d865ca9439a9d4272dc184a55b0978d928"
+        schemaVersion: 1
+        sequence: 3
+        stateFingerprintDigest: "sha256:31b171b621f24bd5682574df9e0f0c8b7011bb6ae5a1df912487733c7db26abc"
     grants:
       -
         actor: "USER"
@@ -241,6 +254,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:3378a88965fa1fd31b000cfb7e1e4ee9d5264bfde20221f0605a8e190524a16d"
         stateScopeDigest: "sha256:d7289a717eae5c0660324db1e6a877d0b3b043e9cd1f584fb0155f138e9e1254"
+      -
+        actor: "USER"
+        digest: "sha256:f9e2e15cbe93e26bbe1e8de6816f3e2d7d78aaff7e8c81c87b7fb1c87ce62fa4"
+        expiresAt: "2026-07-28T02:45:41.699Z"
+        id: "authority-e75ce4ca-102f-4b31-bd51-c1803fd16863"
+        issuedAt: "2026-07-28T02:30:41.699Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:039e56089b32d9e6ac23685f7be4a4ddb2d49ac92f981c6b09d05a20b5018d0f"
+        operationId: "route.remote.refresh"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:31b171b621f24bd5682574df9e0f0c8b7011bb6ae5a1df912487733c7db26abc"
+        stateScopeDigest: "sha256:7540cacf8efeeca3214999fedb2524b3f1bc96bd4c1b0f23c00b177b720a89aa"
     schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "a27841b280b516dfb52d900db5559ba87adc4224"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 19
+revision: 20
 origin:
   system: "manual"
 depends_on:
@@ -36,9 +36,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-07-28T02:26:16.727Z"
+  updated_at: "2026-07-28T02:36:22.966Z"
   updated_by: "TESTER"
-  note: "PASS: typed runner lifecycle results stay in-process through task CLI and Hermes; human and JSON renderers preserve effect authority, observed evidence, claim generation, and operator-resolution provenance."
+  note: "PASS (rework reverified): Hermes now uses the shared typed lifecycle exit mapping, including nonzero failure for incomplete active-claim cleanup."
   attempts: 0
 quality_review:
   state: "pass"
@@ -115,8 +115,14 @@ events:
     from: "DOING"
     to: "DONE"
     note: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    type: "verify"
+    at: "2026-07-28T02:36:22.966Z"
+    author: "TESTER"
+    state: "ok"
+    note: "PASS (rework reverified): Hermes now uses the shared typed lifecycle exit mapping, including nonzero failure for incomplete active-claim cleanup."
 doc_version: 3
-doc_updated_at: "2026-07-28T02:30:28.613Z"
+doc_updated_at: "2026-07-28T02:36:24.002Z"
 doc_updated_by: "CODER"
 description: "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing."
 sections:
@@ -175,6 +181,36 @@ sections:
     - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
     - risks: none
 
+    ### 2026-07-28T02:36:22.966Z — VERIFY — ok
+
+    By: TESTER
+
+    Note: PASS (rework reverified): Hermes now uses the shared typed lifecycle exit mapping, including nonzero failure for incomplete active-claim cleanup.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T02:30:28.613Z, excerpt_hash=sha256:02a389ca089e360cf76ff483bd84febcf2d5924eaa0f09fb89eb4a0ab64c794d
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607221850-R7WS01-return-typed-runner-lifecycle-results/.agentplane/tasks/202607221850-R7WS01/blueprint/resolved-snapshot.json
+    - old_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+    - current_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607221850-R7WS01
+
+    DecisionContextRef:
+    - operator_action: run_exact_argv
+    - can_execute_now: true
+    - safe_command: agentplane task next-action 202607221850-R7WS01 --remote --explain
+    - diagnostic_command: agentplane task next-action 202607221850-R7WS01 --remote --explain
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: true
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: none
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert the migrated vertical slice while preserving the typed contracts consumed by later tasks.
@@ -185,6 +221,10 @@ sections:
     - Observation: Focused runner/supervisor/lifecycle suite passed; critical-cli passed 11/11 files (72 tests) in canonical Node mode; lifecycle invariants, typecheck, lint, and routing checks passed.
       Impact: No stdout parsing or generic replay path was reintroduced for effect_in_doubt.
       Resolution: Approve branch for PR update and hosted validation.
+
+    - Observation: Hermes lifecycle, renderer, and effect-resolution tests passed; typecheck, lint, and lifecycle invariants passed on e7465b737.
+      Impact: Hosted verify-contract evidence now covers the rework commit rather than the superseded implementation head.
+      Resolution: Refresh PR head and rerun hosted validation.
 extensions:
   agentplane.side_effect_authority:
     audit:
@@ -389,6 +429,36 @@ DecisionContextRef:
 - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
 - risks: none
 
+### 2026-07-28T02:36:22.966Z — VERIFY — ok
+
+By: TESTER
+
+Note: PASS (rework reverified): Hermes now uses the shared typed lifecycle exit mapping, including nonzero failure for incomplete active-claim cleanup.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T02:30:28.613Z, excerpt_hash=sha256:02a389ca089e360cf76ff483bd84febcf2d5924eaa0f09fb89eb4a0ab64c794d
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607221850-R7WS01-return-typed-runner-lifecycle-results/.agentplane/tasks/202607221850-R7WS01/blueprint/resolved-snapshot.json
+- old_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+- current_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607221850-R7WS01
+
+DecisionContextRef:
+- operator_action: run_exact_argv
+- can_execute_now: true
+- safe_command: agentplane task next-action 202607221850-R7WS01 --remote --explain
+- diagnostic_command: agentplane task next-action 202607221850-R7WS01 --remote --explain
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: true
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: none
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -403,3 +473,7 @@ DecisionContextRef:
 - Observation: Focused runner/supervisor/lifecycle suite passed; critical-cli passed 11/11 files (72 tests) in canonical Node mode; lifecycle invariants, typecheck, lint, and routing checks passed.
   Impact: No stdout parsing or generic replay path was reintroduced for effect_in_doubt.
   Resolution: Approve branch for PR update and hosted validation.
+
+- Observation: Hermes lifecycle, renderer, and effect-resolution tests passed; typecheck, lint, and lifecycle invariants passed on e7465b737.
+  Impact: Hosted verify-contract evidence now covers the rework commit rather than the superseded implementation head.
+  Resolution: Refresh PR head and rerun hosted validation.

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 45
+revision: 46
 origin:
   system: "manual"
 depends_on:
@@ -662,6 +662,19 @@ extensions:
         schemaVersion: 1
         sequence: 18
         stateFingerprintDigest: "sha256:2f4eaf0ecf58c62d6e0f33bee64f501ff3eb1dd2631b7ca3fa85a3a63136519d"
+      -
+        actor: "USER"
+        at: "2026-07-28T03:13:15.355Z"
+        authorityDigest: "sha256:8d3c288f212ce11161cbe7d203f044957dc107698522de5d056927fdce050a54"
+        digest: "sha256:86d0d78bad40e3c4c4b2100568398c23ae6b25b9127939f50f5108edbd9ee980"
+        operationDigest: "sha256:d16a60500f5a0f56136ac778c6081895f77d3d54576676f28949ed7aebedb9f3"
+        operationId: "task.pre_merge_close"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:fff5a32d76dfcd72cd964a495595c74fcf86cb10e0fc2fb78bbbd2b81d8dff70"
+        schemaVersion: 1
+        sequence: 19
+        stateFingerprintDigest: "sha256:ad1fcdb63f12cdd7482dce44ed3a484b258b53c15979d21b973daf82c812e870"
     grants:
       -
         actor: "USER"
@@ -897,6 +910,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:2f4eaf0ecf58c62d6e0f33bee64f501ff3eb1dd2631b7ca3fa85a3a63136519d"
         stateScopeDigest: "sha256:63cff8ae623f0559266c7c0aada331f519c74c493f668595aacdf25cfedc9ea9"
+      -
+        actor: "USER"
+        digest: "sha256:8d3c288f212ce11161cbe7d203f044957dc107698522de5d056927fdce050a54"
+        expiresAt: "2026-07-28T03:28:15.355Z"
+        id: "authority-44c13772-c119-4307-a336-a4b6672c3f75"
+        issuedAt: "2026-07-28T03:13:15.355Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:d16a60500f5a0f56136ac778c6081895f77d3d54576676f28949ed7aebedb9f3"
+        operationId: "task.pre_merge_close"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:ad1fcdb63f12cdd7482dce44ed3a484b258b53c15979d21b973daf82c812e870"
+        stateScopeDigest: "sha256:22620e96454ec74356f11bb0aa980bf5737fd648801739a70050da4740cc498d"
     schemaVersion: 1
   implementation_commit:
     hash: "8339ca9dc3ed7b3e59726ee240bc044fead4b89f"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 42
+revision: 43
 origin:
   system: "manual"
 depends_on:
@@ -36,9 +36,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-07-28T03:01:34.362Z"
+  updated_at: "2026-07-28T03:12:27.262Z"
   updated_by: "TESTER"
-  note: "PASS (static rework): stale type import removed after contract extraction; no runner lifecycle behavior changed."
+  note: "PASS (dead-code rework): lifecycle-only exports are private; the public typed result and supervisor operation contract remain unchanged."
   attempts: 0
 quality_review:
   state: "pass"
@@ -179,8 +179,14 @@ events:
     from: "DONE"
     to: "DONE"
     note: "Verified: refreshed pre-merge closure packet is ready for the task PR."
+  -
+    type: "verify"
+    at: "2026-07-28T03:12:27.262Z"
+    author: "TESTER"
+    state: "ok"
+    note: "PASS (dead-code rework): lifecycle-only exports are private; the public typed result and supervisor operation contract remain unchanged."
 doc_version: 3
-doc_updated_at: "2026-07-28T03:02:39.662Z"
+doc_updated_at: "2026-07-28T03:12:27.990Z"
 doc_updated_by: "CODER"
 description: "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing."
 sections:
@@ -359,6 +365,36 @@ sections:
     - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
     - risks: none
 
+    ### 2026-07-28T03:12:27.262Z — VERIFY — ok
+
+    By: TESTER
+
+    Note: PASS (dead-code rework): lifecycle-only exports are private; the public typed result and supervisor operation contract remain unchanged.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T03:02:39.662Z, excerpt_hash=sha256:02a389ca089e360cf76ff483bd84febcf2d5924eaa0f09fb89eb4a0ab64c794d
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607221850-R7WS01-return-typed-runner-lifecycle-results/.agentplane/tasks/202607221850-R7WS01/blueprint/resolved-snapshot.json
+    - old_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+    - current_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607221850-R7WS01
+
+    DecisionContextRef:
+    - operator_action: provider_action
+    - can_execute_now: false
+    - safe_command: none
+    - diagnostic_command: none
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: none
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert the migrated vertical slice while preserving the typed contracts consumed by later tasks.
@@ -384,6 +420,10 @@ sections:
 
     - Observation: format, typecheck, lint:core, hotspots:check, and 41 runner/Hermes/CLI assertions passed on 8339ca9dc.
       Impact: The final hosted static-analysis finding is resolved while the typed lifecycle contract remains covered.
+      Resolution: Refresh evaluator review and publish the final verified rework head.
+
+    - Observation: format, typecheck, lint:core, hotspots:check, knip:check, arch:check, and 41 runner/Hermes/CLI assertions passed on 9474725b5.
+      Impact: The final hosted static baseline finding is resolved without widening API surface or changing runner semantics.
       Resolution: Refresh evaluator review and publish the final verified rework head.
 extensions:
   agentplane.side_effect_authority:
@@ -1024,6 +1064,36 @@ DecisionContextRef:
 - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
 - risks: none
 
+### 2026-07-28T03:12:27.262Z — VERIFY — ok
+
+By: TESTER
+
+Note: PASS (dead-code rework): lifecycle-only exports are private; the public typed result and supervisor operation contract remain unchanged.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T03:02:39.662Z, excerpt_hash=sha256:02a389ca089e360cf76ff483bd84febcf2d5924eaa0f09fb89eb4a0ab64c794d
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607221850-R7WS01-return-typed-runner-lifecycle-results/.agentplane/tasks/202607221850-R7WS01/blueprint/resolved-snapshot.json
+- old_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+- current_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607221850-R7WS01
+
+DecisionContextRef:
+- operator_action: provider_action
+- can_execute_now: false
+- safe_command: none
+- diagnostic_command: none
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: none
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -1053,4 +1123,8 @@ DecisionContextRef:
 
 - Observation: format, typecheck, lint:core, hotspots:check, and 41 runner/Hermes/CLI assertions passed on 8339ca9dc.
   Impact: The final hosted static-analysis finding is resolved while the typed lifecycle contract remains covered.
+  Resolution: Refresh evaluator review and publish the final verified rework head.
+
+- Observation: format, typecheck, lint:core, hotspots:check, knip:check, arch:check, and 41 runner/Hermes/CLI assertions passed on 9474725b5.
+  Impact: The final hosted static baseline finding is resolved without widening API surface or changing runner semantics.
   Resolution: Refresh evaluator review and publish the final verified rework head.

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -1,10 +1,10 @@
 ---
 id: "202607221850-R7WS01"
 title: "Return typed runner lifecycle results"
-status: "TODO"
+status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 6
+revision: 9
 origin:
   system: "manual"
 depends_on:
@@ -29,9 +29,9 @@ verify:
   - "bun run test:critical"
   - "bun run typecheck"
 plan_approval:
-  state: "pending"
-  updated_at: null
-  updated_by: null
+  state: "approved"
+  updated_at: "2026-07-28T01:55:33.967Z"
+  updated_by: "ORCHESTRATOR"
   note: null
 verification:
   state: "pending"
@@ -40,11 +40,21 @@ verification:
   note: null
   attempts: 0
 commit: null
-comments: []
-events: []
+comments:
+  -
+    author: "CODER"
+    body: "Start: continue branch_pr task in the dedicated task worktree."
+events:
+  -
+    type: "status"
+    at: "2026-07-28T01:55:50.050Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: continue branch_pr task in the dedicated task worktree."
 doc_version: 3
-doc_updated_at: "2026-07-22T18:50:23.048Z"
-doc_updated_by: "PLANNER"
+doc_updated_at: "2026-07-28T01:55:50.050Z"
+doc_updated_by: "CODER"
 description: "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing."
 sections:
   Summary: |-
@@ -79,6 +89,40 @@ sections:
     - Restore the previous compatibility path only when it cannot bypass the explicit operator-resolution protocol or invoke the adapter for unresolved `effect_in_doubt`.
     - Re-run lifecycle, focused, and type checks before resuming dependent work.
   Findings: ""
+extensions:
+  agentplane.side_effect_authority:
+    audit:
+      -
+        actor: "USER"
+        at: "2026-07-28T01:56:04.216Z"
+        authorityDigest: "sha256:1a9163585644b8044fd2623ebaae04eaa5ff72007319049788e911b2d0a8c050"
+        digest: "sha256:bb166118ccb9d0ee8a50c75fcf8950df306b9378527648dc7a9c5e66e2c16206"
+        operationDigest: "sha256:926afbf65c3bb7e5beecf6a240900f188305b43ba476802772444569bc54f1fd"
+        operationId: "pr.open"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: null
+        schemaVersion: 1
+        sequence: 1
+        stateFingerprintDigest: "sha256:62937b83576dd303313dfc83af04e7e3d0efff9106778d0bff0de00fcea2cf6f"
+    grants:
+      -
+        actor: "USER"
+        digest: "sha256:1a9163585644b8044fd2623ebaae04eaa5ff72007319049788e911b2d0a8c050"
+        expiresAt: "2026-07-28T02:11:04.216Z"
+        id: "authority-c43fa0c7-9d23-4abf-9b92-7214c7b1d03e"
+        issuedAt: "2026-07-28T01:56:04.216Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:926afbf65c3bb7e5beecf6a240900f188305b43ba476802772444569bc54f1fd"
+        operationId: "pr.open"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:62937b83576dd303313dfc83af04e7e3d0efff9106778d0bff0de00fcea2cf6f"
+        stateScopeDigest: "sha256:193bc7d44785382c8251ed54e1158f5778d84d491257d68adc3646854e5b28bc"
+    schemaVersion: 1
+  workflow_route_baseline:
+    start_head_sha: "a27841b280b516dfb52d900db5559ba87adc4224"
+    version: 1
 id_source: "generated"
 ---
 ## Summary

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 30
+revision: 31
 origin:
   system: "manual"
 depends_on:
@@ -36,9 +36,9 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-07-28T02:43:38.519Z"
+  updated_at: "2026-07-28T02:54:35.229Z"
   updated_by: "TESTER"
-  note: "PASS (format reverified): typed lifecycle paths now pass repository Prettier format check as well as runner, renderer, and Hermes regression checks."
+  note: "PASS (hosted rework): split execution contracts keeps task-run below the hotspot threshold and replaces unsafe Hermes matcher assignments with typed assertions."
   attempts: 0
 quality_review:
   state: "pass"
@@ -147,8 +147,14 @@ events:
     from: "DONE"
     to: "DONE"
     note: "Verified: refreshed pre-merge closure packet is ready for the task PR."
+  -
+    type: "verify"
+    at: "2026-07-28T02:54:35.229Z"
+    author: "TESTER"
+    state: "ok"
+    note: "PASS (hosted rework): split execution contracts keeps task-run below the hotspot threshold and replaces unsafe Hermes matcher assignments with typed assertions."
 doc_version: 3
-doc_updated_at: "2026-07-28T02:46:10.968Z"
+doc_updated_at: "2026-07-28T02:54:35.937Z"
 doc_updated_by: "CODER"
 description: "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing."
 sections:
@@ -267,6 +273,36 @@ sections:
     - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
     - risks: none
 
+    ### 2026-07-28T02:54:35.229Z — VERIFY — ok
+
+    By: TESTER
+
+    Note: PASS (hosted rework): split execution contracts keeps task-run below the hotspot threshold and replaces unsafe Hermes matcher assignments with typed assertions.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T02:46:10.968Z, excerpt_hash=sha256:02a389ca089e360cf76ff483bd84febcf2d5924eaa0f09fb89eb4a0ab64c794d
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607221850-R7WS01-return-typed-runner-lifecycle-results/.agentplane/tasks/202607221850-R7WS01/blueprint/resolved-snapshot.json
+    - old_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+    - current_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607221850-R7WS01
+
+    DecisionContextRef:
+    - operator_action: provider_action
+    - can_execute_now: false
+    - safe_command: none
+    - diagnostic_command: none
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: none
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert the migrated vertical slice while preserving the typed contracts consumed by later tasks.
@@ -285,6 +321,10 @@ sections:
     - Observation: format:check, targeted Hermes/renderer/effect-resolution tests, typecheck, lint, and lifecycle invariants passed on 96ff9bab8.
       Impact: Hosted verify-contract now records evidence for the formatted implementation head.
       Resolution: Refresh evaluator review and pre-merge closure.
+
+    - Observation: format, typecheck, lint:core, hotspots:check, lifecycle invariants, and the runner/Hermes/CLI rework test set passed on 8cd703b66.
+      Impact: The hosted contract and static-analysis failures are addressed without changing runner lifecycle behavior.
+      Resolution: Refresh evaluator quality review and publish the verified rework head.
 extensions:
   agentplane.side_effect_authority:
     audit:
@@ -708,6 +748,36 @@ DecisionContextRef:
 - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
 - risks: none
 
+### 2026-07-28T02:54:35.229Z — VERIFY — ok
+
+By: TESTER
+
+Note: PASS (hosted rework): split execution contracts keeps task-run below the hotspot threshold and replaces unsafe Hermes matcher assignments with typed assertions.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T02:46:10.968Z, excerpt_hash=sha256:02a389ca089e360cf76ff483bd84febcf2d5924eaa0f09fb89eb4a0ab64c794d
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607221850-R7WS01-return-typed-runner-lifecycle-results/.agentplane/tasks/202607221850-R7WS01/blueprint/resolved-snapshot.json
+- old_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+- current_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607221850-R7WS01
+
+DecisionContextRef:
+- operator_action: provider_action
+- can_execute_now: false
+- safe_command: none
+- diagnostic_command: none
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: none
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -730,3 +800,7 @@ DecisionContextRef:
 - Observation: format:check, targeted Hermes/renderer/effect-resolution tests, typecheck, lint, and lifecycle invariants passed on 96ff9bab8.
   Impact: Hosted verify-contract now records evidence for the formatted implementation head.
   Resolution: Refresh evaluator review and pre-merge closure.
+
+- Observation: format, typecheck, lint:core, hotspots:check, lifecycle invariants, and the runner/Hermes/CLI rework test set passed on 8cd703b66.
+  Impact: The hosted contract and static-analysis failures are addressed without changing runner lifecycle behavior.
+  Resolution: Refresh evaluator quality review and publish the verified rework head.

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 47
+revision: 48
 origin:
   system: "manual"
 depends_on:
@@ -685,6 +685,19 @@ extensions:
         schemaVersion: 1
         sequence: 19
         stateFingerprintDigest: "sha256:ad1fcdb63f12cdd7482dce44ed3a484b258b53c15979d21b973daf82c812e870"
+      -
+        actor: "USER"
+        at: "2026-07-28T03:13:53.239Z"
+        authorityDigest: "sha256:ab45383f921c8b5663dbbb5b06f2d95bf5c4006e9004d74a67d666b7fcec9683"
+        digest: "sha256:7513ff4ab69e0941546791e6f465b06acd373e55d02482b9e894151821f1d1f7"
+        operationDigest: "sha256:f2ca459bfd8a7bc3ceee075226c85474f5e4162624efe65ac900b59d3e4127d5"
+        operationId: "pr.head.publish"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:86d0d78bad40e3c4c4b2100568398c23ae6b25b9127939f50f5108edbd9ee980"
+        schemaVersion: 1
+        sequence: 20
+        stateFingerprintDigest: "sha256:73adaf7c8771e3a7645a69913f7e28acc24507276acab3aabc523cafcc9cff8e"
     grants:
       -
         actor: "USER"
@@ -933,6 +946,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:ad1fcdb63f12cdd7482dce44ed3a484b258b53c15979d21b973daf82c812e870"
         stateScopeDigest: "sha256:22620e96454ec74356f11bb0aa980bf5737fd648801739a70050da4740cc498d"
+      -
+        actor: "USER"
+        digest: "sha256:ab45383f921c8b5663dbbb5b06f2d95bf5c4006e9004d74a67d666b7fcec9683"
+        expiresAt: "2026-07-28T03:28:53.239Z"
+        id: "authority-3099c770-78ff-4fee-b739-92f3392e6632"
+        issuedAt: "2026-07-28T03:13:53.239Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:f2ca459bfd8a7bc3ceee075226c85474f5e4162624efe65ac900b59d3e4127d5"
+        operationId: "pr.head.publish"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:73adaf7c8771e3a7645a69913f7e28acc24507276acab3aabc523cafcc9cff8e"
+        stateScopeDigest: "sha256:61966e4a59603420c29e39ec6e5c07cf1b1f9ac745118467fe1a1e3b60a5edcd"
     schemaVersion: 1
   implementation_commit:
     hash: "9474725b5ca119945c60338c7821e83f9fe40698"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 31
+revision: 32
 origin:
   system: "manual"
 depends_on:
@@ -43,27 +43,27 @@ verification:
 quality_review:
   state: "pass"
   provenance: "evaluator_supplied"
-  updated_at: "2026-07-28T02:43:41.960Z"
+  updated_at: "2026-07-28T02:55:18.124Z"
   updated_by: "EVALUATOR"
   note: "EVALUATOR returned pass with 1 typed finding(s)."
-  evaluated_sha: "96ff9bab8db6e431077c9a7f60b357735e011f80"
+  evaluated_sha: "8cd703b66e4c14daae26b244f551e705068e178d"
   blueprint_digest: "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328"
   evidence_refs:
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-work-order.json"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/quality-report.json"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-prompt.md"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-opinion.md"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-result.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-work-order.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-result.json"
     - ".agentplane/tasks/202607221850-R7WS01/README.md"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-diff.patch"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-observed-checks.json"
-    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-blueprint.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-diff.patch"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-observed-checks.json"
+    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-blueprint.json"
     - ".agentplane/policy/dod.code.md"
     - ".agentplane/policy/dod.core.md"
     - ".agentplane/policy/security.must.md"
     - ".agentplane/policy/workflow.branch_pr.md"
   findings:
-    - "The only source changes are Prettier-normalized wrapping and import grouping in the previously reviewed lifecycle paths; targeted regression tests and format:check pass."
+    - "No blocking finding: task-run execution contracts are isolated in a dedicated type module; Hermes checks concrete typed values rather than assigning matcher any values."
 commit:
   hash: "fb7da2d8aac146ef830003f4b2ab20e220f5c2d2"
   message: "🛡️ R7WS01 task: authorize fresh format closure"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 32
+revision: 33
 origin:
   system: "manual"
 depends_on:
@@ -471,6 +471,19 @@ extensions:
         schemaVersion: 1
         sequence: 11
         stateFingerprintDigest: "sha256:58147e8ed38a5d410942971af03b18e6a2ee48bdf010bec6f155b54fbe825d60"
+      -
+        actor: "USER"
+        at: "2026-07-28T02:55:39.703Z"
+        authorityDigest: "sha256:676fd0b240c635274a584b9ab48c4d2572f710bcd5ab179e6e6d03855fb87957"
+        digest: "sha256:a06ca23aa80ad90da3b5d9c0c38096643b700ffed39796e0bc08aa6ecee2a5a9"
+        operationDigest: "sha256:039e56089b32d9e6ac23685f7be4a4ddb2d49ac92f981c6b09d05a20b5018d0f"
+        operationId: "route.remote.refresh"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:0e0fbaa7f5ccfd09585f654a614d196deb815a3ba12d595beb559bfe8ab66d31"
+        schemaVersion: 1
+        sequence: 12
+        stateFingerprintDigest: "sha256:6ae5c51e164c5341487c8a0df1451358d905395d39aa927a5834456ccc24831a"
     grants:
       -
         actor: "USER"
@@ -615,6 +628,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:58147e8ed38a5d410942971af03b18e6a2ee48bdf010bec6f155b54fbe825d60"
         stateScopeDigest: "sha256:89b3476e1ee44f950665b99756e3ed9d8d1eba1da28bd7e3219dadfb5fe3e6a8"
+      -
+        actor: "USER"
+        digest: "sha256:676fd0b240c635274a584b9ab48c4d2572f710bcd5ab179e6e6d03855fb87957"
+        expiresAt: "2026-07-28T03:10:39.703Z"
+        id: "authority-4ad879d4-287d-4119-a6c9-c76cb88e1e16"
+        issuedAt: "2026-07-28T02:55:39.703Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:039e56089b32d9e6ac23685f7be4a4ddb2d49ac92f981c6b09d05a20b5018d0f"
+        operationId: "route.remote.refresh"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:6ae5c51e164c5341487c8a0df1451358d905395d39aa927a5834456ccc24831a"
+        stateScopeDigest: "sha256:c298e302a5ff4bc26d2ad18bfa8e43cbcc7f1ddcecf0830935f25d2636b50af0"
     schemaVersion: 1
   implementation_commit:
     hash: "96ff9bab8db6e431077c9a7f60b357735e011f80"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 27
+revision: 28
 origin:
   system: "manual"
 depends_on:
@@ -395,6 +395,19 @@ extensions:
         schemaVersion: 1
         sequence: 9
         stateFingerprintDigest: "sha256:405d4401b565e725e8ff7e29963dae10a487ccb827c2d92b5347b9bcf7687396"
+      -
+        actor: "USER"
+        at: "2026-07-28T02:45:52.339Z"
+        authorityDigest: "sha256:eb37c486e601fdfbf75a1c351e3e0227c47804787ff6f85f609b7b6ad96a5019"
+        digest: "sha256:8521190e3af3a7e0cb9315554033812f07f7578d98e135897127c2263f768197"
+        operationDigest: "sha256:d16a60500f5a0f56136ac778c6081895f77d3d54576676f28949ed7aebedb9f3"
+        operationId: "task.pre_merge_close"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:8baa4d575d547b43208834eb1d62809b050907da24aa4421f3b0eef244d9eb16"
+        schemaVersion: 1
+        sequence: 10
+        stateFingerprintDigest: "sha256:5a045e4e58650e5cd374ee28c2432dc1828e7cefe2d871e75e6ba4f3a15b870a"
     grants:
       -
         actor: "USER"
@@ -513,6 +526,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:405d4401b565e725e8ff7e29963dae10a487ccb827c2d92b5347b9bcf7687396"
         stateScopeDigest: "sha256:26a6e5053cac03b7433bdc7efd2a7b0819e01df40b27c8ad286e50a2bd8fe4c4"
+      -
+        actor: "USER"
+        digest: "sha256:eb37c486e601fdfbf75a1c351e3e0227c47804787ff6f85f609b7b6ad96a5019"
+        expiresAt: "2026-07-28T03:00:52.339Z"
+        id: "authority-7fd08415-6cbc-43e0-aa0c-7ccd2c9291c0"
+        issuedAt: "2026-07-28T02:45:52.339Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:d16a60500f5a0f56136ac778c6081895f77d3d54576676f28949ed7aebedb9f3"
+        operationId: "task.pre_merge_close"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:5a045e4e58650e5cd374ee28c2432dc1828e7cefe2d871e75e6ba4f3a15b870a"
+        stateScopeDigest: "sha256:d982377aa1e9b923101daf24fe57602f59d8bb6c08066c469b9bbe96403a9354"
     schemaVersion: 1
   implementation_commit:
     hash: "e7465b7377c6a8af392c605de7aa4315bf107100"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 17
+revision: 18
 origin:
   system: "manual"
 depends_on:
@@ -227,6 +227,19 @@ extensions:
         schemaVersion: 1
         sequence: 3
         stateFingerprintDigest: "sha256:31b171b621f24bd5682574df9e0f0c8b7011bb6ae5a1df912487733c7db26abc"
+      -
+        actor: "USER"
+        at: "2026-07-28T02:31:15.314Z"
+        authorityDigest: "sha256:3e64206364bb916cc05dc02dfb01ccaaa8863a032ba864bf0d5342151304e6c3"
+        digest: "sha256:88a0f5fcba9da843f5b38907f03a7634aa09524fe6e5409f329b5dc1489a77e9"
+        operationDigest: "sha256:f2ca459bfd8a7bc3ceee075226c85474f5e4162624efe65ac900b59d3e4127d5"
+        operationId: "pr.head.publish"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:1ccdb12945a851cbd47607537b1b3728e8dba2184cc34404e7a8583d4e889681"
+        schemaVersion: 1
+        sequence: 4
+        stateFingerprintDigest: "sha256:08c8b5995be029db1b7589267debfdeb7586ca2cea7aaabdd2a3cb7378ba186f"
     grants:
       -
         actor: "USER"
@@ -267,6 +280,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:31b171b621f24bd5682574df9e0f0c8b7011bb6ae5a1df912487733c7db26abc"
         stateScopeDigest: "sha256:7540cacf8efeeca3214999fedb2524b3f1bc96bd4c1b0f23c00b177b720a89aa"
+      -
+        actor: "USER"
+        digest: "sha256:3e64206364bb916cc05dc02dfb01ccaaa8863a032ba864bf0d5342151304e6c3"
+        expiresAt: "2026-07-28T02:46:15.314Z"
+        id: "authority-05c08bc7-0a37-4cd8-8ce6-859927ab2a2f"
+        issuedAt: "2026-07-28T02:31:15.314Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:f2ca459bfd8a7bc3ceee075226c85474f5e4162624efe65ac900b59d3e4127d5"
+        operationId: "pr.head.publish"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:08c8b5995be029db1b7589267debfdeb7586ca2cea7aaabdd2a3cb7378ba186f"
+        stateScopeDigest: "sha256:5f03b3cfba42be2576dede28ac1532149930472227b86eb09cb2f82d55ec40ec"
     schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "a27841b280b516dfb52d900db5559ba87adc4224"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 18
+revision: 19
 origin:
   system: "manual"
 depends_on:
@@ -240,6 +240,19 @@ extensions:
         schemaVersion: 1
         sequence: 4
         stateFingerprintDigest: "sha256:08c8b5995be029db1b7589267debfdeb7586ca2cea7aaabdd2a3cb7378ba186f"
+      -
+        actor: "USER"
+        at: "2026-07-28T02:32:12.127Z"
+        authorityDigest: "sha256:44a86fab87de67f48c6ecbddc339d9aa2fb97bfc5fc935578154035e9658198e"
+        digest: "sha256:ade0d5c4c0d0535f130b08ac036404a22d3cebf7dea5de1b833db746b1779e37"
+        operationDigest: "sha256:092a8cec160474308bde6f0a7fc1b0baf84ea8497b53c42e267d6e73307dba55"
+        operationId: "integration.enqueue"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:88a0f5fcba9da843f5b38907f03a7634aa09524fe6e5409f329b5dc1489a77e9"
+        schemaVersion: 1
+        sequence: 5
+        stateFingerprintDigest: "sha256:f8ed7f6a1642f121b030666cf790bc2c5916dc36ffff86d5dac1331125870f2d"
     grants:
       -
         actor: "USER"
@@ -293,6 +306,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:08c8b5995be029db1b7589267debfdeb7586ca2cea7aaabdd2a3cb7378ba186f"
         stateScopeDigest: "sha256:5f03b3cfba42be2576dede28ac1532149930472227b86eb09cb2f82d55ec40ec"
+      -
+        actor: "USER"
+        digest: "sha256:44a86fab87de67f48c6ecbddc339d9aa2fb97bfc5fc935578154035e9658198e"
+        expiresAt: "2026-07-28T02:47:12.127Z"
+        id: "authority-0a312059-d254-44c0-84d2-0bc320ca9fe7"
+        issuedAt: "2026-07-28T02:32:12.127Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:092a8cec160474308bde6f0a7fc1b0baf84ea8497b53c42e267d6e73307dba55"
+        operationId: "integration.enqueue"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:f8ed7f6a1642f121b030666cf790bc2c5916dc36ffff86d5dac1331125870f2d"
+        stateScopeDigest: "sha256:3ba21a8ded336b327105940ead18f67f1d70e16095fcad93a8a7310490cae1ee"
     schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "a27841b280b516dfb52d900db5559ba87adc4224"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 20
+revision: 21
 origin:
   system: "manual"
 depends_on:
@@ -293,6 +293,19 @@ extensions:
         schemaVersion: 1
         sequence: 5
         stateFingerprintDigest: "sha256:f8ed7f6a1642f121b030666cf790bc2c5916dc36ffff86d5dac1331125870f2d"
+      -
+        actor: "USER"
+        at: "2026-07-28T02:36:59.462Z"
+        authorityDigest: "sha256:28a45e5cc9a5736da81c0a43b7b772e0e402ff1a68408b8c87956cf907ef6bda"
+        digest: "sha256:3c2226dc25ce8a63c4201f931e383576964108667b7532288a1e04d1ad9e7660"
+        operationDigest: "sha256:039e56089b32d9e6ac23685f7be4a4ddb2d49ac92f981c6b09d05a20b5018d0f"
+        operationId: "route.remote.refresh"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:ade0d5c4c0d0535f130b08ac036404a22d3cebf7dea5de1b833db746b1779e37"
+        schemaVersion: 1
+        sequence: 6
+        stateFingerprintDigest: "sha256:468574a137bee1db39c200c3e1a29461b1badc261a26eb0a01e0acbcd6505e08"
     grants:
       -
         actor: "USER"
@@ -359,6 +372,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:f8ed7f6a1642f121b030666cf790bc2c5916dc36ffff86d5dac1331125870f2d"
         stateScopeDigest: "sha256:3ba21a8ded336b327105940ead18f67f1d70e16095fcad93a8a7310490cae1ee"
+      -
+        actor: "USER"
+        digest: "sha256:28a45e5cc9a5736da81c0a43b7b772e0e402ff1a68408b8c87956cf907ef6bda"
+        expiresAt: "2026-07-28T02:51:59.462Z"
+        id: "authority-a0db5a50-241c-4bcf-ab00-d1d45e4bc39a"
+        issuedAt: "2026-07-28T02:36:59.462Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:039e56089b32d9e6ac23685f7be4a4ddb2d49ac92f981c6b09d05a20b5018d0f"
+        operationId: "route.remote.refresh"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:468574a137bee1db39c200c3e1a29461b1badc261a26eb0a01e0acbcd6505e08"
+        stateScopeDigest: "sha256:ec4b0b391c8099a28632a8db47702745506b2bee3a05c91315c729df028f3a20"
     schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "a27841b280b516dfb52d900db5559ba87adc4224"

--- a/.agentplane/tasks/202607221850-R7WS01/README.md
+++ b/.agentplane/tasks/202607221850-R7WS01/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 48
+revision: 49
 origin:
   system: "manual"
 depends_on:
@@ -698,6 +698,19 @@ extensions:
         schemaVersion: 1
         sequence: 20
         stateFingerprintDigest: "sha256:73adaf7c8771e3a7645a69913f7e28acc24507276acab3aabc523cafcc9cff8e"
+      -
+        actor: "USER"
+        at: "2026-07-28T03:20:25.307Z"
+        authorityDigest: "sha256:e897c5138832d2c893f41140898b313100f41fdaa1a2fdeade03596a697eb727"
+        digest: "sha256:6ac4950127fbe233c101018f0b4344ccf75f586ccca53e978f4d95c6172dd7d4"
+        operationDigest: "sha256:092a8cec160474308bde6f0a7fc1b0baf84ea8497b53c42e267d6e73307dba55"
+        operationId: "integration.enqueue"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:7513ff4ab69e0941546791e6f465b06acd373e55d02482b9e894151821f1d1f7"
+        schemaVersion: 1
+        sequence: 21
+        stateFingerprintDigest: "sha256:ce376ae7d65382b5084b9e378af5dcdbd22dffc152b09e0eb139bf3f77580f91"
     grants:
       -
         actor: "USER"
@@ -959,6 +972,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:73adaf7c8771e3a7645a69913f7e28acc24507276acab3aabc523cafcc9cff8e"
         stateScopeDigest: "sha256:61966e4a59603420c29e39ec6e5c07cf1b1f9ac745118467fe1a1e3b60a5edcd"
+      -
+        actor: "USER"
+        digest: "sha256:e897c5138832d2c893f41140898b313100f41fdaa1a2fdeade03596a697eb727"
+        expiresAt: "2026-07-28T03:35:25.307Z"
+        id: "authority-c430fe6b-65a2-440a-b208-6d5fda7dbe22"
+        issuedAt: "2026-07-28T03:20:25.307Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:092a8cec160474308bde6f0a7fc1b0baf84ea8497b53c42e267d6e73307dba55"
+        operationId: "integration.enqueue"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:ce376ae7d65382b5084b9e378af5dcdbd22dffc152b09e0eb139bf3f77580f91"
+        stateScopeDigest: "sha256:592bda3e60122146005f2e46a4d6f72a04f7fc06b0d9db53ce9ec0350394b907"
     schemaVersion: 1
   implementation_commit:
     hash: "9474725b5ca119945c60338c7821e83f9fe40698"

--- a/.agentplane/tasks/202607221850-R7WS01/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202607221850-R7WS01/blueprint/resolved-snapshot.json
@@ -1,0 +1,583 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607221850-R7WS01",
+    "title": "Return typed runner lifecycle results",
+    "description": "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing.",
+    "tags": [
+      "milestone-beta1",
+      "refactor",
+      "rf-25",
+      "runner",
+      "use-case",
+      "v0.7",
+      "wave-supervisor"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607221850-R7WS01",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328"
+  }
+}

--- a/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
@@ -1,0 +1,14 @@
+ .../src/cli/run-cli.core.task-run.test.ts          |   6 +
+ .../src/commands/hermes/hermes-runtime.ts          |  17 +-
+ .../src/commands/hermes/hermes.command.test.ts     |  45 +++++-
+ .../src/commands/shared/workflow-supervisor.ts     |   8 +
+ .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
+ .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
+ .../agentplane/src/commands/task/run.command.ts    |  41 ++---
+ .../task/task-run-effect-resolution.command.ts     |  28 ++--
+ .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
+ .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
+ .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
+ .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
+ .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
+ 13 files changed, 552 insertions(+), 60 deletions(-)

--- a/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
@@ -11,5 +11,5 @@
  .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
  .../runner/usecases/task-run-lifecycle-result.ts   | 172 +++++++++++++++++++++
  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
- .../agentplane/src/runner/usecases/task-run.ts     |  43 ++----
- 14 files changed, 643 insertions(+), 94 deletions(-)
+ .../agentplane/src/runner/usecases/task-run.ts     |  44 ++----
+ 14 files changed, 643 insertions(+), 95 deletions(-)

--- a/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
@@ -1,6 +1,6 @@
  .../src/cli/run-cli.core.task-run.test.ts          |   6 +
- .../src/commands/hermes/hermes-runtime.ts          |  17 +-
- .../src/commands/hermes/hermes.command.test.ts     |  45 +++++-
+ .../src/commands/hermes/hermes-runtime.ts          |  19 ++-
+ .../src/commands/hermes/hermes.command.test.ts     | 107 ++++++++++++-
  .../src/commands/shared/workflow-supervisor.ts     |   8 +
  .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
  .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
@@ -11,4 +11,4 @@
  .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
  .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
- 13 files changed, 552 insertions(+), 60 deletions(-)
+ 13 files changed, 613 insertions(+), 63 deletions(-)

--- a/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
@@ -9,7 +9,7 @@
  .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
  .../src/runner/usecases/task-run-execution.ts      |  36 +++++
  .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
- .../runner/usecases/task-run-lifecycle-result.ts   | 172 +++++++++++++++++++++
+ .../runner/usecases/task-run-lifecycle-result.ts   | 171 +++++++++++++++++++++
  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
  .../agentplane/src/runner/usecases/task-run.ts     |  44 ++----
- 14 files changed, 643 insertions(+), 95 deletions(-)
+ 14 files changed, 642 insertions(+), 95 deletions(-)

--- a/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
@@ -1,14 +1,15 @@
  .../src/cli/run-cli.core.task-run.test.ts          |   6 +
  .../src/commands/hermes/hermes-runtime.ts          |  19 ++-
- .../src/commands/hermes/hermes.command.test.ts     | 109 ++++++++++++-
+ .../src/commands/hermes/hermes.command.test.ts     | 100 +++++++++++-
  .../src/commands/shared/workflow-supervisor.ts     |   8 +
  .../src/commands/task/run-render.test.ts           | 138 +++++++++++++++++
  .../agentplane/src/commands/task/run-render.ts     |  91 ++++++++++-
  .../agentplane/src/commands/task/run.command.ts    |  41 ++---
  .../task/task-run-effect-resolution.command.ts     |  28 ++--
  .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
+ .../src/runner/usecases/task-run-execution.ts      |  36 +++++
  .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
  .../runner/usecases/task-run-lifecycle-result.ts   | 172 +++++++++++++++++++++
  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
- .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
- 13 files changed, 612 insertions(+), 69 deletions(-)
+ .../agentplane/src/runner/usecases/task-run.ts     |  43 ++----
+ 14 files changed, 643 insertions(+), 94 deletions(-)

--- a/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
@@ -1,14 +1,14 @@
  .../src/cli/run-cli.core.task-run.test.ts          |   6 +
  .../src/commands/hermes/hermes-runtime.ts          |  19 ++-
- .../src/commands/hermes/hermes.command.test.ts     | 107 ++++++++++++-
+ .../src/commands/hermes/hermes.command.test.ts     | 109 ++++++++++++-
  .../src/commands/shared/workflow-supervisor.ts     |   8 +
- .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
- .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
+ .../src/commands/task/run-render.test.ts           | 138 +++++++++++++++++
+ .../agentplane/src/commands/task/run-render.ts     |  91 ++++++++++-
  .../agentplane/src/commands/task/run.command.ts    |  41 ++---
  .../task/task-run-effect-resolution.command.ts     |  28 ++--
  .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
  .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
- .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
+ .../runner/usecases/task-run-lifecycle-result.ts   | 172 +++++++++++++++++++++
  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
  .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
- 13 files changed, 613 insertions(+), 63 deletions(-)
+ 13 files changed, 612 insertions(+), 69 deletions(-)

--- a/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
@@ -21,8 +21,8 @@ RF-25d: make runner preparation, invocation, observation, evaluation, and lifecy
 - Note:
 
 ```text
-PASS (format reverified): typed lifecycle paths now pass repository Prettier format check as well as
-runner, renderer, and Hermes regression checks.
+PASS (hosted rework): split execution contracts keeps task-run below the hotspot threshold and
+replaces unsafe Hermes matcher assignments with typed assertions.
 ```
 - Canonical workflow state lives in the task README.
 
@@ -36,18 +36,19 @@ runner, renderer, and Hermes regression checks.
 ```text
  .../src/cli/run-cli.core.task-run.test.ts          |   6 +
  .../src/commands/hermes/hermes-runtime.ts          |  19 ++-
- .../src/commands/hermes/hermes.command.test.ts     | 109 ++++++++++++-
+ .../src/commands/hermes/hermes.command.test.ts     | 100 +++++++++++-
  .../src/commands/shared/workflow-supervisor.ts     |   8 +
  .../src/commands/task/run-render.test.ts           | 138 +++++++++++++++++
  .../agentplane/src/commands/task/run-render.ts     |  91 ++++++++++-
  .../agentplane/src/commands/task/run.command.ts    |  41 ++---
  .../task/task-run-effect-resolution.command.ts     |  28 ++--
  .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
+ .../src/runner/usecases/task-run-execution.ts      |  36 +++++
  .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
  .../runner/usecases/task-run-lifecycle-result.ts   | 172 +++++++++++++++++++++
  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
- .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
- 13 files changed, 612 insertions(+), 69 deletions(-)
+ .../agentplane/src/runner/usecases/task-run.ts     |  43 ++----
+ 14 files changed, 643 insertions(+), 94 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
@@ -17,8 +17,14 @@ RF-25d: make runner preparation, invocation, observation, evaluation, and lifecy
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+PASS: typed runner lifecycle results stay in-process through task CLI and Hermes; human and JSON
+renderers preserve effect authority, observed evidence, claim generation, and operator-resolution
+provenance.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
@@ -30,8 +36,8 @@ RF-25d: make runner preparation, invocation, observation, evaluation, and lifecy
 
 ```text
  .../src/cli/run-cli.core.task-run.test.ts          |   6 +
- .../src/commands/hermes/hermes-runtime.ts          |  17 +-
- .../src/commands/hermes/hermes.command.test.ts     |  45 +++++-
+ .../src/commands/hermes/hermes-runtime.ts          |  19 ++-
+ .../src/commands/hermes/hermes.command.test.ts     | 107 ++++++++++++-
  .../src/commands/shared/workflow-supervisor.ts     |   8 +
  .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
  .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
@@ -42,7 +48,7 @@ RF-25d: make runner preparation, invocation, observation, evaluation, and lifecy
  .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
  .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
- 13 files changed, 552 insertions(+), 60 deletions(-)
+ 13 files changed, 613 insertions(+), 63 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
@@ -21,8 +21,8 @@ RF-25d: make runner preparation, invocation, observation, evaluation, and lifecy
 - Note:
 
 ```text
-PASS (hosted rework): split execution contracts keeps task-run below the hotspot threshold and
-replaces unsafe Hermes matcher assignments with typed assertions.
+PASS (static rework): stale type import removed after contract extraction; no runner lifecycle
+behavior changed.
 ```
 - Canonical workflow state lives in the task README.
 
@@ -47,8 +47,8 @@ replaces unsafe Hermes matcher assignments with typed assertions.
  .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
  .../runner/usecases/task-run-lifecycle-result.ts   | 172 +++++++++++++++++++++
  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
- .../agentplane/src/runner/usecases/task-run.ts     |  43 ++----
- 14 files changed, 643 insertions(+), 94 deletions(-)
+ .../agentplane/src/runner/usecases/task-run.ts     |  44 ++----
+ 14 files changed, 643 insertions(+), 95 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
@@ -21,8 +21,8 @@ RF-25d: make runner preparation, invocation, observation, evaluation, and lifecy
 - Note:
 
 ```text
-PASS (rework reverified): Hermes now uses the shared typed lifecycle exit mapping, including nonzero
-failure for incomplete active-claim cleanup.
+PASS (format reverified): typed lifecycle paths now pass repository Prettier format check as well as
+runner, renderer, and Hermes regression checks.
 ```
 - Canonical workflow state lives in the task README.
 

--- a/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
@@ -36,18 +36,18 @@ failure for incomplete active-claim cleanup.
 ```text
  .../src/cli/run-cli.core.task-run.test.ts          |   6 +
  .../src/commands/hermes/hermes-runtime.ts          |  19 ++-
- .../src/commands/hermes/hermes.command.test.ts     | 107 ++++++++++++-
+ .../src/commands/hermes/hermes.command.test.ts     | 109 ++++++++++++-
  .../src/commands/shared/workflow-supervisor.ts     |   8 +
- .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
- .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
+ .../src/commands/task/run-render.test.ts           | 138 +++++++++++++++++
+ .../agentplane/src/commands/task/run-render.ts     |  91 ++++++++++-
  .../agentplane/src/commands/task/run.command.ts    |  41 ++---
  .../task/task-run-effect-resolution.command.ts     |  28 ++--
  .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
  .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
- .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
+ .../runner/usecases/task-run-lifecycle-result.ts   | 172 +++++++++++++++++++++
  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
  .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
- 13 files changed, 613 insertions(+), 63 deletions(-)
+ 13 files changed, 612 insertions(+), 69 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
@@ -24,12 +24,25 @@ RF-25d: make runner preparation, invocation, observation, evaluation, and lifecy
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-28T01:55:50.166Z
+- Updated: 2026-07-28T01:56:15.744Z
 - Branch: task/202607221850-R7WS01/return-typed-runner-lifecycle-results
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/cli/run-cli.core.task-run.test.ts          |   6 +
+ .../src/commands/hermes/hermes-runtime.ts          |  17 +-
+ .../src/commands/hermes/hermes.command.test.ts     |  45 +++++-
+ .../src/commands/shared/workflow-supervisor.ts     |   8 +
+ .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
+ .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
+ .../agentplane/src/commands/task/run.command.ts    |  41 ++---
+ .../task/task-run-effect-resolution.command.ts     |  28 ++--
+ .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
+ .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
+ .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
+ .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
+ .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
+ 13 files changed, 552 insertions(+), 60 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
@@ -21,9 +21,8 @@ RF-25d: make runner preparation, invocation, observation, evaluation, and lifecy
 - Note:
 
 ```text
-PASS: typed runner lifecycle results stay in-process through task CLI and Hermes; human and JSON
-renderers preserve effect authority, observed evidence, claim generation, and operator-resolution
-provenance.
+PASS (rework reverified): Hermes now uses the shared typed lifecycle exit mapping, including nonzero
+failure for incomplete active-claim cleanup.
 ```
 - Canonical workflow state lives in the task README.
 

--- a/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
@@ -1,0 +1,35 @@
+Task: `202607221850-R7WS01`
+Title: Return typed runner lifecycle results
+Canonical task record: `.agentplane/tasks/202607221850-R7WS01/README.md`
+
+## Summary
+
+Return typed runner lifecycle results
+
+RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing.
+
+## Scope
+
+- In scope: typed runner use-case results, adapter ports, error/result union, human/JSON renderers, compatibility snapshots, and supervisor invocation without subprocess/stdout capture.
+- Consume the durable effect-resolution contract as typed `effect_in_doubt`, `applied` and `not_applied` states, preserving resolution provenance, authority/evidence identity and claim generation in every in-process result and renderer.
+- An unresolved `effect_in_doubt` result is terminally blocked for generic retry, replay, resume and restart paths; only the explicit resolution protocol from task 202607242158-QV09NA may transition it to `applied` or `not_applied`.
+- Out of scope: automating the complete direct route, delivered by the next task.
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-28T01:55:50.166Z
+- Branch: task/202607221850-R7WS01/return-typed-runner-lifecycle-results
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
@@ -21,8 +21,8 @@ RF-25d: make runner preparation, invocation, observation, evaluation, and lifecy
 - Note:
 
 ```text
-PASS (static rework): stale type import removed after contract extraction; no runner lifecycle
-behavior changed.
+PASS (dead-code rework): lifecycle-only exports are private; the public typed result and supervisor
+operation contract remain unchanged.
 ```
 - Canonical workflow state lives in the task README.
 
@@ -45,10 +45,10 @@ behavior changed.
  .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
  .../src/runner/usecases/task-run-execution.ts      |  36 +++++
  .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
- .../runner/usecases/task-run-lifecycle-result.ts   | 172 +++++++++++++++++++++
+ .../runner/usecases/task-run-lifecycle-result.ts   | 171 +++++++++++++++++++++
  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
  .../agentplane/src/runner/usecases/task-run.ts     |  44 ++----
- 14 files changed, 643 insertions(+), 95 deletions(-)
+ 14 files changed, 642 insertions(+), 95 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607221850-R7WS01/pr/github-title.txt
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 R7WS01 task: Return typed runner lifecycle results [202607221850-R7WS01]

--- a/.agentplane/tasks/202607221850-R7WS01/pr/github-title.txt
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/github-title.txt
@@ -1,1 +1,1 @@
-🚧 R7WS01 task: Return typed runner lifecycle results [202607221850-R7WS01]
+✅ R7WS01 task: Return typed runner lifecycle results [202607221850-R7WS01]

--- a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
@@ -2,9 +2,9 @@
   "base": "main",
   "branch": "task/202607221850-R7WS01/return-typed-runner-lifecycle-results",
   "created_at": "2026-07-28T01:55:50.166Z",
-  "diffstat_sha256": "sha256:d40723930c9322e23558f4c0840f80bcd2e3d14b01df741eea881ef31f64289b",
-  "last_verified_at": "2026-07-28T03:01:34.362Z",
-  "last_verified_diffstat_sha256": "sha256:d40723930c9322e23558f4c0840f80bcd2e3d14b01df741eea881ef31f64289b",
+  "diffstat_sha256": "sha256:8a33c5a6dc1f0a35e4e1739373e3796aa406f8695e9a14570080cd2f32e8cd25",
+  "last_verified_at": "2026-07-28T03:12:27.262Z",
+  "last_verified_diffstat_sha256": "sha256:8a33c5a6dc1f0a35e4e1739373e3796aa406f8695e9a14570080cd2f32e8cd25",
   "pr_number": 4650,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4650",
   "pre_merge_closure": {

--- a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
@@ -2,8 +2,9 @@
   "base": "main",
   "branch": "task/202607221850-R7WS01/return-typed-runner-lifecycle-results",
   "created_at": "2026-07-28T01:55:50.166Z",
-  "diffstat_sha256": "sha256:da831a54df8e685f7cb8a449136121ba3ff3501a78568ca3c61e81df7cbb34c4",
-  "last_verified_at": null,
+  "diffstat_sha256": "sha256:65d97a5753250f37a246a401fcbc4accf833ce3f83665209a24340b616f3cba4",
+  "last_verified_at": "2026-07-28T02:26:16.727Z",
+  "last_verified_diffstat_sha256": "sha256:da831a54df8e685f7cb8a449136121ba3ff3501a78568ca3c61e81df7cbb34c4",
   "pr_number": 4650,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4650",
   "schema_version": 1,
@@ -11,6 +12,6 @@
   "task_id": "202607221850-R7WS01",
   "updated_at": "2026-07-28T01:56:15.744Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
@@ -2,9 +2,9 @@
   "base": "main",
   "branch": "task/202607221850-R7WS01/return-typed-runner-lifecycle-results",
   "created_at": "2026-07-28T01:55:50.166Z",
-  "diffstat_sha256": "sha256:673a68f99342c6f9fd6c21b3ff265f37f8a32a4e959ade1cd6b8677af44bac00",
-  "last_verified_at": "2026-07-28T02:43:38.519Z",
-  "last_verified_diffstat_sha256": "sha256:673a68f99342c6f9fd6c21b3ff265f37f8a32a4e959ade1cd6b8677af44bac00",
+  "diffstat_sha256": "sha256:4d9e86738daa9648e741c5aaa4871cece4f7da8139e3000163c2235457056a60",
+  "last_verified_at": "2026-07-28T02:54:35.229Z",
+  "last_verified_diffstat_sha256": "sha256:4d9e86738daa9648e741c5aaa4871cece4f7da8139e3000163c2235457056a60",
   "pr_number": 4650,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4650",
   "pre_merge_closure": {

--- a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
@@ -3,8 +3,8 @@
   "branch": "task/202607221850-R7WS01/return-typed-runner-lifecycle-results",
   "created_at": "2026-07-28T01:55:50.166Z",
   "diffstat_sha256": "sha256:65d97a5753250f37a246a401fcbc4accf833ce3f83665209a24340b616f3cba4",
-  "last_verified_at": "2026-07-28T02:26:16.727Z",
-  "last_verified_diffstat_sha256": "sha256:da831a54df8e685f7cb8a449136121ba3ff3501a78568ca3c61e81df7cbb34c4",
+  "last_verified_at": "2026-07-28T02:36:22.966Z",
+  "last_verified_diffstat_sha256": "sha256:65d97a5753250f37a246a401fcbc4accf833ce3f83665209a24340b616f3cba4",
   "pr_number": 4650,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4650",
   "pre_merge_closure": {

--- a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
@@ -8,10 +8,10 @@
   "pr_number": 4650,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4650",
   "pre_merge_closure": {
-    "basis_commit": "f63905e9ace209c7dd772d564e016782ea0984ab",
+    "basis_commit": "fb7da2d8aac146ef830003f4b2ab20e220f5c2d2",
     "branch": "task/202607221850-R7WS01/return-typed-runner-lifecycle-results",
     "pr_number": 4650,
-    "recorded_at": "2026-07-28T02:37:57.897Z",
+    "recorded_at": "2026-07-28T02:46:11.019Z",
     "state": "closed_before_merge"
   },
   "schema_version": 1,

--- a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
@@ -8,10 +8,10 @@
   "pr_number": 4650,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4650",
   "pre_merge_closure": {
-    "basis_commit": "e7465b7377c6a8af392c605de7aa4315bf107100",
+    "basis_commit": "f63905e9ace209c7dd772d564e016782ea0984ab",
     "branch": "task/202607221850-R7WS01/return-typed-runner-lifecycle-results",
     "pr_number": 4650,
-    "recorded_at": "2026-07-28T02:30:28.669Z",
+    "recorded_at": "2026-07-28T02:37:57.897Z",
     "state": "closed_before_merge"
   },
   "schema_version": 1,

--- a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
@@ -3,8 +3,8 @@
   "branch": "task/202607221850-R7WS01/return-typed-runner-lifecycle-results",
   "created_at": "2026-07-28T01:55:50.166Z",
   "diffstat_sha256": "sha256:673a68f99342c6f9fd6c21b3ff265f37f8a32a4e959ade1cd6b8677af44bac00",
-  "last_verified_at": "2026-07-28T02:36:22.966Z",
-  "last_verified_diffstat_sha256": "sha256:65d97a5753250f37a246a401fcbc4accf833ce3f83665209a24340b616f3cba4",
+  "last_verified_at": "2026-07-28T02:43:38.519Z",
+  "last_verified_diffstat_sha256": "sha256:673a68f99342c6f9fd6c21b3ff265f37f8a32a4e959ade1cd6b8677af44bac00",
   "pr_number": 4650,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4650",
   "pre_merge_closure": {

--- a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202607221850-R7WS01/return-typed-runner-lifecycle-results",
   "created_at": "2026-07-28T01:55:50.166Z",
-  "diffstat_sha256": "sha256:65d97a5753250f37a246a401fcbc4accf833ce3f83665209a24340b616f3cba4",
+  "diffstat_sha256": "sha256:673a68f99342c6f9fd6c21b3ff265f37f8a32a4e959ade1cd6b8677af44bac00",
   "last_verified_at": "2026-07-28T02:36:22.966Z",
   "last_verified_diffstat_sha256": "sha256:65d97a5753250f37a246a401fcbc4accf833ce3f83665209a24340b616f3cba4",
   "pr_number": 4650,

--- a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
@@ -8,10 +8,10 @@
   "pr_number": 4650,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4650",
   "pre_merge_closure": {
-    "basis_commit": "9013722fdf3806b630cdce0a39610e671216af5a",
+    "basis_commit": "fd963ada01fbd68926a2965d1471eb07b9618cce",
     "branch": "task/202607221850-R7WS01/return-typed-runner-lifecycle-results",
     "pr_number": 4650,
-    "recorded_at": "2026-07-28T02:56:13.515Z",
+    "recorded_at": "2026-07-28T03:02:39.718Z",
     "state": "closed_before_merge"
   },
   "schema_version": 1,

--- a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202607221850-R7WS01/return-typed-runner-lifecycle-results",
+  "created_at": "2026-07-28T01:55:50.166Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202607221850-R7WS01",
+  "updated_at": "2026-07-28T01:55:50.166Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
@@ -8,10 +8,10 @@
   "pr_number": 4650,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4650",
   "pre_merge_closure": {
-    "basis_commit": "fd963ada01fbd68926a2965d1471eb07b9618cce",
+    "basis_commit": "c931f4d10add0edfe1e50c237954907745250fce",
     "branch": "task/202607221850-R7WS01/return-typed-runner-lifecycle-results",
     "pr_number": 4650,
-    "recorded_at": "2026-07-28T03:02:39.718Z",
+    "recorded_at": "2026-07-28T03:13:34.302Z",
     "state": "closed_before_merge"
   },
   "schema_version": 1,

--- a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
@@ -8,10 +8,10 @@
   "pr_number": 4650,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4650",
   "pre_merge_closure": {
-    "basis_commit": "fb7da2d8aac146ef830003f4b2ab20e220f5c2d2",
+    "basis_commit": "9013722fdf3806b630cdce0a39610e671216af5a",
     "branch": "task/202607221850-R7WS01/return-typed-runner-lifecycle-results",
     "pr_number": 4650,
-    "recorded_at": "2026-07-28T02:46:11.019Z",
+    "recorded_at": "2026-07-28T02:56:13.515Z",
     "state": "closed_before_merge"
   },
   "schema_version": 1,

--- a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
@@ -7,6 +7,13 @@
   "last_verified_diffstat_sha256": "sha256:da831a54df8e685f7cb8a449136121ba3ff3501a78568ca3c61e81df7cbb34c4",
   "pr_number": 4650,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4650",
+  "pre_merge_closure": {
+    "basis_commit": "e7465b7377c6a8af392c605de7aa4315bf107100",
+    "branch": "task/202607221850-R7WS01/return-typed-runner-lifecycle-results",
+    "pr_number": 4650,
+    "recorded_at": "2026-07-28T02:30:28.669Z",
+    "state": "closed_before_merge"
+  },
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202607221850-R7WS01",

--- a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
@@ -2,9 +2,9 @@
   "base": "main",
   "branch": "task/202607221850-R7WS01/return-typed-runner-lifecycle-results",
   "created_at": "2026-07-28T01:55:50.166Z",
-  "diffstat_sha256": "sha256:4d9e86738daa9648e741c5aaa4871cece4f7da8139e3000163c2235457056a60",
-  "last_verified_at": "2026-07-28T02:54:35.229Z",
-  "last_verified_diffstat_sha256": "sha256:4d9e86738daa9648e741c5aaa4871cece4f7da8139e3000163c2235457056a60",
+  "diffstat_sha256": "sha256:d40723930c9322e23558f4c0840f80bcd2e3d14b01df741eea881ef31f64289b",
+  "last_verified_at": "2026-07-28T03:01:34.362Z",
+  "last_verified_diffstat_sha256": "sha256:d40723930c9322e23558f4c0840f80bcd2e3d14b01df741eea881ef31f64289b",
   "pr_number": 4650,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4650",
   "pre_merge_closure": {

--- a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
@@ -2,11 +2,14 @@
   "base": "main",
   "branch": "task/202607221850-R7WS01/return-typed-runner-lifecycle-results",
   "created_at": "2026-07-28T01:55:50.166Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "diffstat_sha256": "sha256:da831a54df8e685f7cb8a449136121ba3ff3501a78568ca3c61e81df7cbb34c4",
   "last_verified_at": null,
+  "pr_number": 4650,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4650",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202607221850-R7WS01",
-  "updated_at": "2026-07-28T01:55:50.166Z",
+  "updated_at": "2026-07-28T01:56:15.744Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202607221850-R7WS01/pr/review.md
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-07-28T01:55:50.166Z
+
+## Task
+
+- Task: `202607221850-R7WS01`
+- Title: Return typed runner lifecycle results
+- Status: DOING
+- Branch: `task/202607221850-R7WS01/return-typed-runner-lifecycle-results`
+- Canonical task record: `.agentplane/tasks/202607221850-R7WS01/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-28T01:55:50.166Z
+- Branch: task/202607221850-R7WS01/return-typed-runner-lifecycle-results
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202607221850-R7WS01/pr/review.md
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-07-28T01:55:50.166Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: PASS: typed runner lifecycle results stay in-process through task CLI and Hermes; human and JSON renderers preserve effect authority, observed evidence, claim generation, and operator-resolution provenance.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -30,8 +30,8 @@ Created: 2026-07-28T01:55:50.166Z
 
 ```text
  .../src/cli/run-cli.core.task-run.test.ts          |   6 +
- .../src/commands/hermes/hermes-runtime.ts          |  17 +-
- .../src/commands/hermes/hermes.command.test.ts     |  45 +++++-
+ .../src/commands/hermes/hermes-runtime.ts          |  19 ++-
+ .../src/commands/hermes/hermes.command.test.ts     | 107 ++++++++++++-
  .../src/commands/shared/workflow-supervisor.ts     |   8 +
  .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
  .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
@@ -42,7 +42,7 @@ Created: 2026-07-28T01:55:50.166Z
  .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
  .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
- 13 files changed, 552 insertions(+), 60 deletions(-)
+ 13 files changed, 613 insertions(+), 63 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607221850-R7WS01/pr/review.md
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/review.md
@@ -24,12 +24,25 @@ Created: 2026-07-28T01:55:50.166Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-28T01:55:50.166Z
+- Updated: 2026-07-28T01:56:15.744Z
 - Branch: task/202607221850-R7WS01/return-typed-runner-lifecycle-results
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../src/cli/run-cli.core.task-run.test.ts          |   6 +
+ .../src/commands/hermes/hermes-runtime.ts          |  17 +-
+ .../src/commands/hermes/hermes.command.test.ts     |  45 +++++-
+ .../src/commands/shared/workflow-supervisor.ts     |   8 +
+ .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
+ .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
+ .../agentplane/src/commands/task/run.command.ts    |  41 ++---
+ .../task/task-run-effect-resolution.command.ts     |  28 ++--
+ .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
+ .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
+ .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
+ .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
+ .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
+ 13 files changed, 552 insertions(+), 60 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607221850-R7WS01/pr/review.md
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-07-28T01:55:50.166Z
 ## Verification
 
 - State: ok
-- Note: PASS: typed runner lifecycle results stay in-process through task CLI and Hermes; human and JSON renderers preserve effect authority, observed evidence, claim generation, and operator-resolution provenance.
+- Note: PASS (rework reverified): Hermes now uses the shared typed lifecycle exit mapping, including nonzero failure for incomplete active-claim cleanup.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes

--- a/.agentplane/tasks/202607221850-R7WS01/pr/review.md
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-07-28T01:55:50.166Z
 ## Verification
 
 - State: ok
-- Note: PASS (rework reverified): Hermes now uses the shared typed lifecycle exit mapping, including nonzero failure for incomplete active-claim cleanup.
+- Note: PASS (format reverified): typed lifecycle paths now pass repository Prettier format check as well as runner, renderer, and Hermes regression checks.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes

--- a/.agentplane/tasks/202607221850-R7WS01/pr/review.md
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/review.md
@@ -6,7 +6,7 @@ Created: 2026-07-28T01:55:50.166Z
 
 - Task: `202607221850-R7WS01`
 - Title: Return typed runner lifecycle results
-- Status: DOING
+- Status: DONE
 - Branch: `task/202607221850-R7WS01/return-typed-runner-lifecycle-results`
 - Canonical task record: `.agentplane/tasks/202607221850-R7WS01/README.md`
 

--- a/.agentplane/tasks/202607221850-R7WS01/pr/review.md
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-07-28T01:55:50.166Z
 ## Verification
 
 - State: ok
-- Note: PASS (static rework): stale type import removed after contract extraction; no runner lifecycle behavior changed.
+- Note: PASS (dead-code rework): lifecycle-only exports are private; the public typed result and supervisor operation contract remain unchanged.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -40,10 +40,10 @@ Created: 2026-07-28T01:55:50.166Z
  .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
  .../src/runner/usecases/task-run-execution.ts      |  36 +++++
  .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
- .../runner/usecases/task-run-lifecycle-result.ts   | 172 +++++++++++++++++++++
+ .../runner/usecases/task-run-lifecycle-result.ts   | 171 +++++++++++++++++++++
  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
  .../agentplane/src/runner/usecases/task-run.ts     |  44 ++----
- 14 files changed, 643 insertions(+), 95 deletions(-)
+ 14 files changed, 642 insertions(+), 95 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607221850-R7WS01/pr/review.md
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-07-28T01:55:50.166Z
 ## Verification
 
 - State: ok
-- Note: PASS (hosted rework): split execution contracts keeps task-run below the hotspot threshold and replaces unsafe Hermes matcher assignments with typed assertions.
+- Note: PASS (static rework): stale type import removed after contract extraction; no runner lifecycle behavior changed.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -42,8 +42,8 @@ Created: 2026-07-28T01:55:50.166Z
  .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
  .../runner/usecases/task-run-lifecycle-result.ts   | 172 +++++++++++++++++++++
  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
- .../agentplane/src/runner/usecases/task-run.ts     |  43 ++----
- 14 files changed, 643 insertions(+), 94 deletions(-)
+ .../agentplane/src/runner/usecases/task-run.ts     |  44 ++----
+ 14 files changed, 643 insertions(+), 95 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607221850-R7WS01/pr/review.md
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/review.md
@@ -31,18 +31,18 @@ Created: 2026-07-28T01:55:50.166Z
 ```text
  .../src/cli/run-cli.core.task-run.test.ts          |   6 +
  .../src/commands/hermes/hermes-runtime.ts          |  19 ++-
- .../src/commands/hermes/hermes.command.test.ts     | 107 ++++++++++++-
+ .../src/commands/hermes/hermes.command.test.ts     | 109 ++++++++++++-
  .../src/commands/shared/workflow-supervisor.ts     |   8 +
- .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
- .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
+ .../src/commands/task/run-render.test.ts           | 138 +++++++++++++++++
+ .../agentplane/src/commands/task/run-render.ts     |  91 ++++++++++-
  .../agentplane/src/commands/task/run.command.ts    |  41 ++---
  .../task/task-run-effect-resolution.command.ts     |  28 ++--
  .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
  .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
- .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
+ .../runner/usecases/task-run-lifecycle-result.ts   | 172 +++++++++++++++++++++
  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
  .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
- 13 files changed, 613 insertions(+), 63 deletions(-)
+ 13 files changed, 612 insertions(+), 69 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607221850-R7WS01/pr/review.md
+++ b/.agentplane/tasks/202607221850-R7WS01/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-07-28T01:55:50.166Z
 ## Verification
 
 - State: ok
-- Note: PASS (format reverified): typed lifecycle paths now pass repository Prettier format check as well as runner, renderer, and Hermes regression checks.
+- Note: PASS (hosted rework): split execution contracts keeps task-run below the hotspot threshold and replaces unsafe Hermes matcher assignments with typed assertions.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -31,18 +31,19 @@ Created: 2026-07-28T01:55:50.166Z
 ```text
  .../src/cli/run-cli.core.task-run.test.ts          |   6 +
  .../src/commands/hermes/hermes-runtime.ts          |  19 ++-
- .../src/commands/hermes/hermes.command.test.ts     | 109 ++++++++++++-
+ .../src/commands/hermes/hermes.command.test.ts     | 100 +++++++++++-
  .../src/commands/shared/workflow-supervisor.ts     |   8 +
  .../src/commands/task/run-render.test.ts           | 138 +++++++++++++++++
  .../agentplane/src/commands/task/run-render.ts     |  91 ++++++++++-
  .../agentplane/src/commands/task/run.command.ts    |  41 ++---
  .../task/task-run-effect-resolution.command.ts     |  28 ++--
  .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
+ .../src/runner/usecases/task-run-execution.ts      |  36 +++++
  .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
  .../runner/usecases/task-run-lifecycle-result.ts   | 172 +++++++++++++++++++++
  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
- .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
- 13 files changed, 612 insertions(+), 69 deletions(-)
+ .../agentplane/src/runner/usecases/task-run.ts     |  43 ++----
+ 14 files changed, 643 insertions(+), 94 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-blueprint.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-blueprint.json
@@ -1,0 +1,583 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607221850-R7WS01",
+    "title": "Return typed runner lifecycle results",
+    "description": "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing.",
+    "tags": [
+      "milestone-beta1",
+      "refactor",
+      "rf-25",
+      "runner",
+      "use-case",
+      "v0.7",
+      "wave-supervisor"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607221850-R7WS01",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328"
+  }
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-diff.patch
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-diff.patch
@@ -1,0 +1,1119 @@
+diff --git a/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt b/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
+index e69de29bb..52631f73e 100644
+--- a/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
++++ b/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
+@@ -0,0 +1,14 @@
++ .../src/cli/run-cli.core.task-run.test.ts          |   6 +
++ .../src/commands/hermes/hermes-runtime.ts          |  17 +-
++ .../src/commands/hermes/hermes.command.test.ts     |  45 +++++-
++ .../src/commands/shared/workflow-supervisor.ts     |   8 +
++ .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
++ .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
++ .../agentplane/src/commands/task/run.command.ts    |  41 ++---
++ .../task/task-run-effect-resolution.command.ts     |  28 ++--
++ .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
++ .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
++ .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
++ .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
++ .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
++ 13 files changed, 552 insertions(+), 60 deletions(-)
+diff --git a/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md b/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
+index a8e0b91f7..93a630f1c 100644
+--- a/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
++++ b/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
+@@ -24,12 +24,25 @@ RF-25d: make runner preparation, invocation, observation, evaluation, and lifecy
+ <details>
+ <summary>Raw evidence</summary>
+ 
+-- Updated: 2026-07-28T01:55:50.166Z
++- Updated: 2026-07-28T01:56:15.744Z
+ - Branch: task/202607221850-R7WS01/return-typed-runner-lifecycle-results
+ - Head: computed live by `agentplane pr check` / `agentplane integrate`
+ 
+ ```text
+-No changes detected.
++ .../src/cli/run-cli.core.task-run.test.ts          |   6 +
++ .../src/commands/hermes/hermes-runtime.ts          |  17 +-
++ .../src/commands/hermes/hermes.command.test.ts     |  45 +++++-
++ .../src/commands/shared/workflow-supervisor.ts     |   8 +
++ .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
++ .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
++ .../agentplane/src/commands/task/run.command.ts    |  41 ++---
++ .../task/task-run-effect-resolution.command.ts     |  28 ++--
++ .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
++ .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
++ .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
++ .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
++ .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
++ 13 files changed, 552 insertions(+), 60 deletions(-)
+ ```
+ 
+ </details>
+diff --git a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+index 3cb7d5fb7..d56bd6627 100644
+--- a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
++++ b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+@@ -2,11 +2,14 @@
+   "base": "main",
+   "branch": "task/202607221850-R7WS01/return-typed-runner-lifecycle-results",
+   "created_at": "2026-07-28T01:55:50.166Z",
+-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
++  "diffstat_sha256": "sha256:da831a54df8e685f7cb8a449136121ba3ff3501a78568ca3c61e81df7cbb34c4",
+   "last_verified_at": null,
++  "pr_number": 4650,
++  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4650",
+   "schema_version": 1,
++  "status": "OPEN",
+   "task_id": "202607221850-R7WS01",
+-  "updated_at": "2026-07-28T01:55:50.166Z",
++  "updated_at": "2026-07-28T01:56:15.744Z",
+   "verify": {
+     "status": "skipped"
+   }
+diff --git a/.agentplane/tasks/202607221850-R7WS01/pr/review.md b/.agentplane/tasks/202607221850-R7WS01/pr/review.md
+index 3fea7a892..95c56904d 100644
+--- a/.agentplane/tasks/202607221850-R7WS01/pr/review.md
++++ b/.agentplane/tasks/202607221850-R7WS01/pr/review.md
+@@ -24,12 +24,25 @@ Created: 2026-07-28T01:55:50.166Z
+ <details>
+ <summary>Raw evidence</summary>
+ 
+-- Updated: 2026-07-28T01:55:50.166Z
++- Updated: 2026-07-28T01:56:15.744Z
+ - Branch: task/202607221850-R7WS01/return-typed-runner-lifecycle-results
+ - Head: computed live by `agentplane pr check` / `agentplane integrate`
+ 
+ ```text
+-No changes detected.
++ .../src/cli/run-cli.core.task-run.test.ts          |   6 +
++ .../src/commands/hermes/hermes-runtime.ts          |  17 +-
++ .../src/commands/hermes/hermes.command.test.ts     |  45 +++++-
++ .../src/commands/shared/workflow-supervisor.ts     |   8 +
++ .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
++ .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
++ .../agentplane/src/commands/task/run.command.ts    |  41 ++---
++ .../task/task-run-effect-resolution.command.ts     |  28 ++--
++ .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
++ .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
++ .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
++ .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
++ .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
++ 13 files changed, 552 insertions(+), 60 deletions(-)
+ ```
+ 
+ </details>
+diff --git a/packages/agentplane/src/cli/run-cli.core.task-run.test.ts b/packages/agentplane/src/cli/run-cli.core.task-run.test.ts
+index 038ffcc9b..fc89ead4a 100644
+--- a/packages/agentplane/src/cli/run-cli.core.task-run.test.ts
++++ b/packages/agentplane/src/cli/run-cli.core.task-run.test.ts
+@@ -126,6 +126,7 @@ describe("runCli task run", () => {
+       invocation: {
+         adapter_id: "custom",
+         run_id: "run-degraded-cleanup",
++        work_order_id: "work-order-degraded-cleanup",
+         run_dir: "/repo/run",
+         bundle_path: "/repo/run/bundle.json",
+         bootstrap_path: "/repo/run/bootstrap.md",
+@@ -136,6 +137,11 @@ describe("runCli task run", () => {
+         exit_code: 0,
+         summary: "provider completed",
+       },
++      state: {
++        mode: "execute",
++        status: "success",
++      },
++      bundle: {},
+       active_claim_cleanup: cleanup,
+     } as unknown as Awaited<ReturnType<typeof taskRunUsecases.executeTaskRunnerExecution>>;
+     const executeSpy = vi
+diff --git a/packages/agentplane/src/commands/hermes/hermes-runtime.ts b/packages/agentplane/src/commands/hermes/hermes-runtime.ts
+index 1bf76e7fd..e50890cc7 100644
+--- a/packages/agentplane/src/commands/hermes/hermes-runtime.ts
++++ b/packages/agentplane/src/commands/hermes/hermes-runtime.ts
+@@ -6,6 +6,11 @@ import {
+   executeTaskRunnerExecution,
+   prepareTaskRunnerExecution,
+ } from "../../runner/usecases/task-run.js";
++import {
++  projectExecutedTaskRunnerLifecycleResult,
++  projectPreparedTaskRunnerLifecycleResult,
++  taskRunnerLifecycleExitCode,
++} from "../../runner/usecases/task-run-lifecycle-result.js";
+ import {
+   prepareAgentWorkOrder,
+   requirePreparedAgentWorkOrder,
+@@ -271,11 +276,16 @@ export async function executeHermesWorkflowOperation(opts: {
+       mode: "dry_run",
+       ...(opts.includeRemote ? { include_remote: true } : {}),
+     });
++    const lifecycle = projectPreparedTaskRunnerLifecycleResult({
++      task_id: taskId,
++      execution: prepared,
++    });
+     return {
+       status: "succeeded",
+       observed_postconditions: ["runner_state_observed"],
+       detail: `prepared runner invocation ${prepared.invocation.run_id} for ${taskId}`,
+       exit_code: null,
++      operation_result: { kind: "runner_lifecycle", value: lifecycle },
+     };
+   }
+ 
+@@ -286,12 +296,17 @@ export async function executeHermesWorkflowOperation(opts: {
+     task_id: taskId,
+     ...(opts.includeRemote ? { include_remote: true } : {}),
+   });
+-  const succeeded = executed.result.status === "success" && !executed.active_claim_cleanup;
++  const lifecycle = projectExecutedTaskRunnerLifecycleResult({
++    task_id: taskId,
++    execution: executed,
++  });
++  const succeeded = taskRunnerLifecycleExitCode(lifecycle) === 0;
+   return {
+     status: succeeded ? "succeeded" : "failed",
+     observed_postconditions: ["runner_state_observed"],
+     detail: executed.result.summary ?? `runner execution completed for ${taskId}`,
+     exit_code: executed.result.exit_code,
++    operation_result: { kind: "runner_lifecycle", value: lifecycle },
+   };
+ }
+ 
+diff --git a/packages/agentplane/src/commands/hermes/hermes.command.test.ts b/packages/agentplane/src/commands/hermes/hermes.command.test.ts
+index 6536f4b90..c2758bcfc 100644
+--- a/packages/agentplane/src/commands/hermes/hermes.command.test.ts
++++ b/packages/agentplane/src/commands/hermes/hermes.command.test.ts
+@@ -233,7 +233,27 @@ describe("hermes adapter commands", () => {
+           requested: boolean;
+           dry_run: boolean;
+           allowed: boolean;
+-          result: { detail: string; exit_code: number | null };
++          result: {
++            detail: string;
++            exit_code: number | null;
++            operation_result: {
++              kind: string;
++              value: {
++                schema: string;
++                phase: string;
++                task_id: string;
++                invocation: { work_order_id: string };
++                lifecycle: {
++                  effect: {
++                    state: string;
++                    authority: { ref: string; digest: string } | null;
++                    observed_evidence: { code: string; digest: string | null } | null;
++                    claim_generation: string | null;
++                  };
++                };
++              };
++            };
++          };
+         };
+         workflow_supervision: { audit: { event: string }[] };
+         refreshed_route: { task: { id: string } };
+@@ -244,6 +264,29 @@ describe("hermes adapter commands", () => {
+       expect(payload.execution.allowed).toBe(true);
+       expect(payload.execution.result.detail).toContain(taskId);
+       expect(payload.execution.result.exit_code).toBeNull();
++      expect(payload.execution.result.operation_result).toMatchObject({
++        kind: "runner_lifecycle",
++        value: {
++          schema: "agentplane.task_runner_lifecycle_result.v1",
++          phase: "prepared",
++          task_id: taskId,
++          lifecycle: {
++            effect: {
++              state: "not_recorded",
++              authority: {
++                ref: expect.stringContaining("work-order:"),
++                digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
++              },
++              observed_evidence: {
++                code: "runner_effect_operation_prepared",
++                digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
++              },
++              claim_generation: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
++            },
++          },
++        },
++      });
++      expect(payload.execution.result.operation_result.value.invocation.work_order_id).toContain(taskId);
+       expect(payload.workflow_supervision.audit.map((entry) => entry.event)).toEqual([
+         "decision_observed",
+         "operation_executed",
+diff --git a/packages/agentplane/src/commands/shared/workflow-supervisor.ts b/packages/agentplane/src/commands/shared/workflow-supervisor.ts
+index bb565b5d9..8b433e5d6 100644
+--- a/packages/agentplane/src/commands/shared/workflow-supervisor.ts
++++ b/packages/agentplane/src/commands/shared/workflow-supervisor.ts
+@@ -1,4 +1,5 @@
+ import type { TaskRouteDecision } from "./route-decision-types.js";
++import type { TaskRunnerLifecycleResult } from "../../runner/usecases/task-run-lifecycle-result.js";
+ import { projectWorkflowOperationArgv } from "./workflow-operation-projection.js";
+ import { WORKFLOW_OPERATION_REGISTRY, type WorkflowOperation } from "./workflow-step.js";
+ 
+@@ -23,11 +24,18 @@ type WorkflowSupervisorAuditEntry = {
+   detail: string;
+ };
+ 
++export type WorkflowSupervisorOperationPayload = {
++  kind: "runner_lifecycle";
++  value: TaskRunnerLifecycleResult;
++};
++
+ export type WorkflowSupervisorOperationResult = {
+   status: "succeeded" | "failed";
+   observed_postconditions: readonly string[];
+   detail: string;
+   exit_code: number | null;
++  /** Typed in-process data for migrated operation slices; never parsed from stdout. */
++  operation_result?: WorkflowSupervisorOperationPayload;
+ };
+ 
+ export type WorkflowSupervisorExecution = {
+diff --git a/packages/agentplane/src/commands/task/run-render.test.ts b/packages/agentplane/src/commands/task/run-render.test.ts
+index 98acc2538..f63ca29ff 100644
+--- a/packages/agentplane/src/commands/task/run-render.test.ts
++++ b/packages/agentplane/src/commands/task/run-render.test.ts
+@@ -4,13 +4,151 @@ import { captureStdIO } from "@agentplane/testkit";
+ import { readObservedProcessIdentity } from "../../runner/process-supervision/signals.js";
+ import type { LoadedTaskRunnerInspection } from "../../runner/usecases/task-run-inspect.js";
+ import {
++  projectExecutedTaskRunnerLifecycleResult,
++  type TaskRunnerLifecycleResult,
++} from "../../runner/usecases/task-run-lifecycle-result.js";
++import {
++  reportExecutedTaskRun,
+   reportRunnerStatus,
++  renderTaskRunnerLifecyclePayload,
+   renderRunnerStatusPayload,
+   renderTaskRunPayload,
+   runnerReconciliationWarning,
+ } from "./run-render.js";
+ 
+ describe("task run rendering", () => {
++  it("renders the typed effect lifecycle without parsing a runner report", () => {
++    const lifecycle = {
++      schema: "agentplane.task_runner_lifecycle_result.v1",
++      phase: "executed",
++      task_id: "TASK-EFFECT",
++      invocation: {
++        adapter_id: "codex",
++        run_id: "run-effect",
++        work_order_id: "work-order-effect",
++        run_dir: "/repo/runs/run-effect",
++        bundle_path: "/repo/runs/run-effect/bundle.json",
++        bootstrap_path: "/repo/runs/run-effect/bootstrap.md",
++        result_path: "/repo/runs/run-effect/result.json",
++      },
++      lifecycle: {
++        mode: "execute",
++        status: "failed",
++        state_fingerprint: null,
++        effect: {
++          state: "effect_in_doubt",
++          operation: {
++            operation_key: `sha256:${"a".repeat(64)}`,
++            operation_digest: `sha256:${"b".repeat(64)}`,
++            claim_generation: `sha256:${"c".repeat(64)}`,
++          },
++          authority: {
++            ref: "work-order:work-order-effect",
++            digest: `sha256:${"e".repeat(64)}`,
++          },
++          observed_evidence: {
++            code: "runner_adapter_effect_error",
++            digest: `sha256:${"f".repeat(64)}`,
++          },
++          claim_generation: `sha256:${"c".repeat(64)}`,
++          resolution: null,
++          resolution_provenance: null,
++          source_resolution: null,
++          source_resolution_provenance: null,
++        },
++        work_order_authority: null,
++      },
++      result: {
++        status: "failed",
++        exit_code: 1,
++        started_at: "2026-07-28T00:00:00.000Z",
++        ended_at: "2026-07-28T00:00:01.000Z",
++        summary: "provider outcome is uncertain",
++      },
++      active_claim_cleanup: null,
++    } as unknown as TaskRunnerLifecycleResult;
++
++    const payload = renderTaskRunnerLifecyclePayload(lifecycle);
++    expect(payload).toMatchObject({
++      task_id: "TASK-EFFECT",
++      work_order_id: "work-order-effect",
++      lifecycle_result: {
++        lifecycle: {
++          effect: {
++            state: "effect_in_doubt",
++            operation: { claim_generation: `sha256:${"c".repeat(64)}` },
++            authority: { digest: `sha256:${"e".repeat(64)}` },
++            observed_evidence: { digest: `sha256:${"f".repeat(64)}` },
++            resolution: null,
++          },
++        },
++      },
++    });
++
++    const io = captureStdIO();
++    try {
++      reportExecutedTaskRun(payload, "TASK-EFFECT");
++      expect(io.stdout).toMatch(/work_order:\s+work-order-effect/u);
++      expect(io.stdout).toMatch(/effect:\s+effect_in_doubt/u);
++      expect(io.stdout).toMatch(new RegExp(`effect_authority:\\s+sha256:${"e".repeat(64)}`, "u"));
++      expect(io.stdout).toMatch(new RegExp(`effect_evidence:\\s+sha256:${"f".repeat(64)}`, "u"));
++      expect(io.stdout).toMatch(
++        new RegExp(`effect_claim_generation:\\s+sha256:${"c".repeat(64)}`, "u"),
++      );
++    } finally {
++      io.restore();
++    }
++
++    for (const verdict of ["applied", "not_applied"] as const) {
++      const resolved = projectExecutedTaskRunnerLifecycleResult({
++        task_id: "TASK-EFFECT",
++        execution: {
++          ...lifecycle,
++          bundle: {},
++          state: {
++            mode: "execute",
++            status: "blocked",
++            effect_resolution: {
++              verdict,
++              digest: `sha256:${"d".repeat(64)}`,
++            },
++          },
++          effect_operation: {
++            operation: {
++              authority_ref: "work-order:work-order-effect",
++              authority_digest: `sha256:${"e".repeat(64)}`,
++              claim_generation: `sha256:${"c".repeat(64)}`,
++            },
++            journal: {
++              observed_evidence: {
++                code: "operator_resolution_evidence",
++                digest: `sha256:${"f".repeat(64)}`,
++              },
++            },
++          },
++          source_effect_resolution: {
++            verdict: "not_applied",
++            digest: `sha256:${"g".repeat(64)}`,
++          },
++        } as unknown as Parameters<typeof projectExecutedTaskRunnerLifecycleResult>[0]["execution"],
++        source_effect_resolution: {
++          verdict: "not_applied",
++          digest: `sha256:${"g".repeat(64)}`,
++        } as unknown as TaskRunnerLifecycleResult["lifecycle"]["effect"]["source_resolution"],
++      });
++      expect(resolved.lifecycle.effect).toMatchObject({
++        state: verdict,
++        resolution: { verdict },
++        resolution_provenance: "operator_supplied",
++        authority: { digest: `sha256:${"e".repeat(64)}` },
++        observed_evidence: { digest: `sha256:${"f".repeat(64)}` },
++        claim_generation: `sha256:${"c".repeat(64)}`,
++        source_resolution: { verdict: "not_applied" },
++        source_resolution_provenance: "operator_supplied",
++      });
++    }
++  });
++
+   it("keeps execution status and verification confidence distinct", () => {
+     expect(
+       renderTaskRunPayload({
+diff --git a/packages/agentplane/src/commands/task/run-render.ts b/packages/agentplane/src/commands/task/run-render.ts
+index 70aa55bb1..3b8b69c58 100644
+--- a/packages/agentplane/src/commands/task/run-render.ts
++++ b/packages/agentplane/src/commands/task/run-render.ts
+@@ -5,6 +5,7 @@ import type {
+   TaskRunnerDiagnosticInspection,
+ } from "../../runner/usecases/task-run-inspect.js";
+ import type { TaskRunnerActiveClaimCleanupDiagnostic } from "../../runner/usecases/task-run-active-claim-runtime.js";
++import type { TaskRunnerLifecycleResult } from "../../runner/usecases/task-run-lifecycle-result.js";
+ import type { RunnerLifecycleStatus } from "../../runner/types.js";
+ import {
+   isProcessAlive,
+@@ -51,6 +52,38 @@ export function renderTaskRunPayload(opts: {
+   };
+ }
+ 
++/**
++ * Compatibility renderer for the typed in-process lifecycle result. The
++ * existing top-level fields stay stable while the additive lifecycle object
++ * exposes durable effect and authority evidence without stdout parsing.
++ */
++export function renderTaskRunnerLifecyclePayload(result: TaskRunnerLifecycleResult) {
++  return {
++    ...renderTaskRunPayload({
++      taskId: result.task_id,
++      mode: result.lifecycle.mode,
++      adapterId: result.invocation.adapter_id,
++      runId: result.invocation.run_id,
++      runDir: result.invocation.run_dir,
++      bundlePath: result.invocation.bundle_path,
++      bootstrapPath: result.invocation.bootstrap_path ?? "",
++      resultPath: result.invocation.result_path,
++      ...(result.phase === "executed" ? { status: result.result?.status } : {}),
++      verificationState: result.result?.execution_receipt?.verification_state,
++      receiptPath: result.result?.execution_receipt?.path,
++      exitCode: result.result?.exit_code,
++      summary: result.result?.summary,
++      activeClaimCleanup: result.active_claim_cleanup ?? undefined,
++    }),
++    work_order_id: result.invocation.work_order_id,
++    lifecycle_result: result,
++  };
++}
++
++type TaskRunRendererPayload =
++  | ReturnType<typeof renderTaskRunPayload>
++  | ReturnType<typeof renderTaskRunnerLifecyclePayload>;
++
+ export function isTerminalRunnerStatus(status: RunnerLifecycleStatus): boolean {
+   return (
+     status === "success" || status === "failed" || status === "blocked" || status === "cancelled"
+@@ -379,7 +412,7 @@ export async function loadRunnerLogText(
+ }
+ 
+ export function reportPreparedTaskRun(
+-  payload: ReturnType<typeof renderTaskRunPayload>,
++  payload: TaskRunRendererPayload,
+   taskId: string,
+ ): void {
+   createCliEmitter().report(
+@@ -388,6 +421,24 @@ export function reportPreparedTaskRun(
+       { label: "mode", value: payload.mode },
+       { label: "adapter", value: payload.adapter_id },
+       { label: "run", value: payload.run_id },
++      ...("lifecycle_result" in payload
++        ? [
++            { label: "work_order", value: payload.lifecycle_result.invocation.work_order_id },
++            { label: "effect", value: payload.lifecycle_result.lifecycle.effect.state },
++            {
++              label: "effect_authority",
++              value: payload.lifecycle_result.lifecycle.effect.authority?.digest ?? null,
++            },
++            {
++              label: "effect_evidence",
++              value: payload.lifecycle_result.lifecycle.effect.observed_evidence?.digest ?? null,
++            },
++            {
++              label: "effect_claim_generation",
++              value: payload.lifecycle_result.lifecycle.effect.claim_generation,
++            },
++          ]
++        : []),
+       { label: "bundle", value: payload.bundle_path },
+       { label: "bootstrap", value: payload.bootstrap_path },
+       { label: "result", value: payload.result_path },
+@@ -397,7 +448,7 @@ export function reportPreparedTaskRun(
+ }
+ 
+ export function reportExecutedTaskRun(
+-  payload: ReturnType<typeof renderTaskRunPayload>,
++  payload: TaskRunRendererPayload,
+   taskId: string,
+ ): void {
+   createCliEmitter().report(
+@@ -406,6 +457,36 @@ export function reportExecutedTaskRun(
+       { label: "mode", value: payload.mode },
+       { label: "adapter", value: payload.adapter_id },
+       { label: "run", value: payload.run_id },
++      ...("lifecycle_result" in payload
++        ? [
++            { label: "work_order", value: payload.lifecycle_result.invocation.work_order_id },
++            { label: "effect", value: payload.lifecycle_result.lifecycle.effect.state },
++            {
++              label: "effect_resolution",
++              value: payload.lifecycle_result.lifecycle.effect.resolution?.verdict ?? null,
++            },
++            {
++              label: "effect_authority",
++              value: payload.lifecycle_result.lifecycle.effect.authority?.digest ?? null,
++            },
++            {
++              label: "effect_evidence",
++              value: payload.lifecycle_result.lifecycle.effect.observed_evidence?.digest ?? null,
++            },
++            {
++              label: "effect_claim_generation",
++              value: payload.lifecycle_result.lifecycle.effect.claim_generation,
++            },
++            ...(payload.lifecycle_result.lifecycle.effect.source_resolution
++              ? [
++                  {
++                    label: "source_effect_resolution",
++                    value: payload.lifecycle_result.lifecycle.effect.source_resolution.verdict,
++                  },
++                ]
++              : []),
++          ]
++        : []),
+       { label: "status", value: payload.status ?? "unknown" },
+       { label: "verification", value: payload.verification_state ?? "unavailable" },
+       { label: "exit_code", value: payload.exit_code ?? null },
+diff --git a/packages/agentplane/src/commands/task/run.command.ts b/packages/agentplane/src/commands/task/run.command.ts
+index 1f8c31213..7836ade9a 100644
+--- a/packages/agentplane/src/commands/task/run.command.ts
++++ b/packages/agentplane/src/commands/task/run.command.ts
+@@ -5,6 +5,11 @@ import {
+   executeTaskRunnerExecution,
+   prepareTaskRunnerExecution,
+ } from "../../runner/usecases/task-run.js";
++import {
++  projectExecutedTaskRunnerLifecycleResult,
++  projectPreparedTaskRunnerLifecycleResult,
++  taskRunnerLifecycleExitCode,
++} from "../../runner/usecases/task-run-lifecycle-result.js";
+ import { RUNNER_SANDBOX_MODES } from "../../runner/types.js";
+ import {
+   loadTaskRunnerDiagnosticInspection,
+@@ -19,7 +24,7 @@ import {
+   renderRunnerDiagnosticStatusPayload,
+   renderRunnerStatusPayload,
+   runnerReconciliationWarning,
+-  renderTaskRunPayload,
++  renderTaskRunnerLifecyclePayload,
+   reportExecutedTaskRun,
+   reportPreparedTaskRun,
+   tailText,
+@@ -277,16 +282,11 @@ export function makeRunTaskRunHandler(getCtx: (cmd: string) => Promise<CommandCo
+         danger_authority: dangerAuthority,
+         sandbox_override: parsed.sandbox,
+       });
+-      const payload = renderTaskRunPayload({
+-        taskId: parsed.taskId,
+-        mode: "dry_run",
+-        adapterId: prepared.invocation.adapter_id,
+-        runId: prepared.invocation.run_id,
+-        runDir: prepared.invocation.run_dir,
+-        bundlePath: prepared.invocation.bundle_path,
+-        bootstrapPath: prepared.invocation.bootstrap_path ?? "",
+-        resultPath: prepared.invocation.result_path,
++      const lifecycle = projectPreparedTaskRunnerLifecycleResult({
++        task_id: parsed.taskId,
++        execution: prepared,
+       });
++      const payload = renderTaskRunnerLifecyclePayload(lifecycle);
+       if (parsed.json) {
+         output.json(payload);
+       } else {
+@@ -304,28 +304,17 @@ export function makeRunTaskRunHandler(getCtx: (cmd: string) => Promise<CommandCo
+       danger_authority: dangerAuthority,
+       sandbox_override: parsed.sandbox,
+     });
+-    const payload = renderTaskRunPayload({
+-      taskId: parsed.taskId,
+-      mode: "execute",
+-      adapterId: executed.invocation.adapter_id,
+-      runId: executed.invocation.run_id,
+-      runDir: executed.invocation.run_dir,
+-      bundlePath: executed.invocation.bundle_path,
+-      bootstrapPath: executed.invocation.bootstrap_path ?? "",
+-      resultPath: executed.invocation.result_path,
+-      status: executed.result.status,
+-      verificationState: executed.result.execution_receipt?.verification_state,
+-      receiptPath: executed.result.execution_receipt?.path,
+-      exitCode: executed.result.exit_code,
+-      summary: executed.result.summary,
+-      activeClaimCleanup: executed.active_claim_cleanup,
++    const lifecycle = projectExecutedTaskRunnerLifecycleResult({
++      task_id: parsed.taskId,
++      execution: executed,
+     });
++    const payload = renderTaskRunnerLifecyclePayload(lifecycle);
+     if (parsed.json) {
+       output.json(payload);
+     } else {
+       reportExecutedTaskRun(payload, parsed.taskId);
+     }
+-    return executed.result.status === "success" && !executed.active_claim_cleanup ? 0 : 1;
++    return taskRunnerLifecycleExitCode(lifecycle);
+   };
+ }
+ 
+diff --git a/packages/agentplane/src/commands/task/task-run-effect-resolution.command.ts b/packages/agentplane/src/commands/task/task-run-effect-resolution.command.ts
+index 0271ced3d..686d6c678 100644
+--- a/packages/agentplane/src/commands/task/task-run-effect-resolution.command.ts
++++ b/packages/agentplane/src/commands/task/task-run-effect-resolution.command.ts
+@@ -3,12 +3,16 @@ import { RUNNER_EFFECT_RESOLUTION_VERDICT_VALUES } from "@agentplaneorg/core/sch
+ import { createCliEmitter, infoMessage } from "../../cli/output.js";
+ import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
+ import { resumeTaskRunnerEffectExecution } from "../../runner/usecases/task-run-lifecycle.js";
++import {
++  projectExecutedTaskRunnerLifecycleResult,
++  taskRunnerLifecycleExitCode,
++} from "../../runner/usecases/task-run-lifecycle-result.js";
+ import {
+   acceptLegacyTaskRunnerEffect,
+   resolveTaskRunnerEffect,
+ } from "../../runner/usecases/task-run-effect-resolution.js";
+ import type { CommandContext } from "../shared/task-backend.js";
+-import { renderTaskRunPayload, reportExecutedTaskRun } from "./run-render.js";
++import { renderTaskRunnerLifecyclePayload, reportExecutedTaskRun } from "./run-render.js";
+ 
+ type TaskRunResolveEffectParsed = {
+   taskId: string;
+@@ -258,25 +262,15 @@ export function makeRunTaskRunResumeEffectHandler(
+       run_id: parsed.runId,
+       ...(parsed.newRunId ? { new_run_id: parsed.newRunId } : {}),
+     });
+-    const payload = renderTaskRunPayload({
+-      taskId: parsed.taskId,
+-      mode: "execute",
+-      adapterId: resumed.invocation.adapter_id,
+-      runId: resumed.invocation.run_id,
+-      runDir: resumed.invocation.run_dir,
+-      bundlePath: resumed.invocation.bundle_path,
+-      bootstrapPath: resumed.invocation.bootstrap_path ?? "",
+-      resultPath: resumed.invocation.result_path,
+-      status: resumed.result.status,
+-      verificationState: resumed.result.execution_receipt?.verification_state,
+-      receiptPath: resumed.result.execution_receipt?.path,
+-      exitCode: resumed.result.exit_code,
+-      summary: resumed.result.summary,
+-      activeClaimCleanup: resumed.active_claim_cleanup,
++    const lifecycle = projectExecutedTaskRunnerLifecycleResult({
++      task_id: parsed.taskId,
++      execution: resumed,
++      source_effect_resolution: resumed.source_effect_resolution,
+     });
++    const payload = renderTaskRunnerLifecyclePayload(lifecycle);
+     const output = createCliEmitter();
+     if (parsed.json) output.json(payload);
+     else reportExecutedTaskRun(payload, parsed.taskId);
+-    return resumed.result.status === "success" && !resumed.active_claim_cleanup ? 0 : 1;
++    return taskRunnerLifecycleExitCode(lifecycle);
+   };
+ }
+diff --git a/packages/agentplane/src/runner/usecases/task-run-effect-journal.ts b/packages/agentplane/src/runner/usecases/task-run-effect-journal.ts
+index d0c2a0f57..5444170f7 100644
+--- a/packages/agentplane/src/runner/usecases/task-run-effect-journal.ts
++++ b/packages/agentplane/src/runner/usecases/task-run-effect-journal.ts
+@@ -1,4 +1,8 @@
+-import { digestRunnerEffectValue } from "@agentplaneorg/core/schemas";
++import {
++  digestRunnerEffectValue,
++  type RunnerEffectJournal,
++  type RunnerEffectOperation,
++} from "@agentplaneorg/core/schemas";
+ 
+ import {
+   advanceRunnerEffectJournal,
+@@ -16,6 +20,11 @@ import type {
+   RunnerStateFingerprintRecord,
+ } from "../types.js";
+ 
++export type TaskRunnerEffectOperationSnapshot = {
++  operation: RunnerEffectOperation;
++  journal: RunnerEffectJournal;
++};
++
+ export async function persistPreparedTaskRunnerEffectOperation(opts: {
+   repository: RunnerRunRepository;
+   bundle: RunnerContextBundle;
+@@ -24,7 +33,10 @@ export async function persistPreparedTaskRunnerEffectOperation(opts: {
+   task_id: string;
+   source_run_id?: string | null;
+   resolved_not_applied_source?: boolean;
+-}): Promise<RunnerRunState> {
++}): Promise<{
++  state: RunnerRunState;
++  effect_operation: TaskRunnerEffectOperationSnapshot;
++}> {
+   if (!opts.state.state_fingerprint) {
+     throw new Error(
+       `Runner prepared state is missing effect-journal fingerprint authority for ` +
+@@ -44,7 +56,13 @@ export async function persistPreparedTaskRunnerEffectOperation(opts: {
+     updated_at: new Date().toISOString(),
+   };
+   await opts.repository.writeState(state);
+-  return state;
++  return {
++    state,
++    effect_operation: {
++      operation: effectOperation.operation,
++      journal: effectOperation.journal,
++    },
++  };
+ }
+ 
+ export async function startTaskRunnerEffectOperation(opts: {
+@@ -102,8 +120,8 @@ async function recordTaskRunnerEffectAccepted(opts: {
+   session: StartedRunnerEffectOperation;
+   result: RunnerResult;
+   state_fingerprint: RunnerStateFingerprintRecord;
+-}): Promise<void> {
+-  await advanceRunnerEffectJournal({
++}): Promise<RunnerEffectJournal> {
++  return await advanceRunnerEffectJournal({
+     session: opts.session,
+     phase: "accepted",
+     evidence: {
+@@ -125,7 +143,7 @@ export async function persistTaskRunnerEffectAccepted<T>(opts: {
+   result: RunnerResult;
+   state_fingerprint: RunnerStateFingerprintRecord;
+   persist_post_effect_state: () => Promise<T>;
+-}): Promise<T> {
++}): Promise<{ state: T; journal: RunnerEffectJournal }> {
+   if (!opts.session) {
+     throw new Error(
+       `Runner adapter returned without a durable effect operation for ` +
+@@ -144,10 +162,10 @@ export async function persistTaskRunnerEffectAccepted<T>(opts: {
+     });
+     throw error;
+   }
+-  await recordTaskRunnerEffectAccepted({
++  const journal = await recordTaskRunnerEffectAccepted({
+     session: opts.session,
+     result: opts.result,
+     state_fingerprint: opts.state_fingerprint,
+   });
+-  return state;
++  return { state, journal };
+ }
+diff --git a/packages/agentplane/src/runner/usecases/task-run-lifecycle-replay.ts b/packages/agentplane/src/runner/usecases/task-run-lifecycle-replay.ts
+index 5650776fb..960868c23 100644
+--- a/packages/agentplane/src/runner/usecases/task-run-lifecycle-replay.ts
++++ b/packages/agentplane/src/runner/usecases/task-run-lifecycle-replay.ts
+@@ -1,4 +1,5 @@
+ import type { TaskData, TaskRunnerHistoryEntry } from "../../backends/task-backend.js";
++import type { RunnerEffectResolutionRef } from "@agentplaneorg/core/schemas";
+ import { loadCommandContext, type CommandContext } from "../../commands/shared/task-backend.js";
+ import { CliError } from "../../shared/errors.js";
+ import { RunnerRunDirectoryBoundaryError } from "../run-directory-boundary.js";
+@@ -24,6 +25,7 @@ type FreshReplayExecution = ExecutedTaskRunnerExecution & {
+   ctx: CommandContext;
+   source_run_id: string;
+   source_status: RunnerLifecycleStatus;
++  source_effect_resolution: RunnerEffectResolutionRef | null;
+ };
+ 
+ function replaySourceGuidance(source: TaskRunnerHistoryEntry, taskId: string): string {
+@@ -254,6 +256,7 @@ async function executeFreshReplay(opts: {
+     run_id: opts.run_id,
+     task,
+   });
++  let sourceEffectResolution: RunnerEffectResolutionRef | null = null;
+   if (opts.action === "resume_effect") {
+     const sourceRepository = await RunnerRunRepository.openExistingTaskRun({
+       git_root: ctx.resolvedProject.gitRoot,
+@@ -281,6 +284,7 @@ async function executeFreshReplay(opts: {
+         },
+       });
+     }
++    sourceEffectResolution = sourceRecord.state.effect_resolution;
+   }
+   assertFreshReplayDangerAuthority(opts);
+   const destinationRunId = resolveFreshReplayRunId({
+@@ -323,6 +327,7 @@ async function executeFreshReplay(opts: {
+     ctx,
+     source_run_id: source.run_id,
+     source_status: source.status,
++    source_effect_resolution: sourceEffectResolution,
+   };
+ }
+ 
+@@ -339,8 +344,9 @@ export async function resumeTaskRunnerExecution(opts: {
+     ...opts,
+     action: "resume",
+   });
++  const { source_effect_resolution: _sourceEffectResolution, ...execution } = resumed;
+   return {
+-    ...resumed,
++    ...execution,
+     previous_status: resumed.source_status,
+   };
+ }
+@@ -373,8 +379,16 @@ export async function resumeTaskRunnerEffectExecution(opts: {
+     ...opts,
+     action: "resume_effect",
+   });
++  const sourceEffectResolution = resumed.source_effect_resolution;
++  if (!sourceEffectResolution) {
++    throw new Error(
++      `resume-effect completed without its required source resolution for ${opts.task_id}:${opts.run_id}.`,
++    );
++  }
++  const { source_effect_resolution: _sourceEffectResolution, ...execution } = resumed;
+   return {
+-    ...resumed,
++    ...execution,
+     previous_status: resumed.source_status,
++    source_effect_resolution: sourceEffectResolution,
+   };
+ }
+diff --git a/packages/agentplane/src/runner/usecases/task-run-lifecycle-result.ts b/packages/agentplane/src/runner/usecases/task-run-lifecycle-result.ts
+new file mode 100644
+index 000000000..4b8a3ccdf
+--- /dev/null
++++ b/packages/agentplane/src/runner/usecases/task-run-lifecycle-result.ts
+@@ -0,0 +1,175 @@
++import type { AgentWorkOrderV2 } from "@agentplaneorg/core/schemas";
++
++import type { TaskRunnerActiveClaimCleanupDiagnostic } from "./task-run-active-claim-runtime.js";
++import type { TaskRunnerEffectOperationSnapshot } from "./task-run-effect-journal.js";
++import type {
++  ExecutedTaskRunnerExecution,
++  PreparedTaskRunnerExecution,
++} from "./task-run.js";
++import type {
++  RunnerInvocation,
++  RunnerLifecycleStatus,
++  RunnerResult,
++  RunnerRunState,
++} from "../types.js";
++
++export const TASK_RUNNER_LIFECYCLE_RESULT_SCHEMA =
++  "agentplane.task_runner_lifecycle_result.v1" as const;
++
++export type TaskRunnerLifecycleEffectState =
++  | "not_recorded"
++  | "effect_in_doubt"
++  | "applied"
++  | "not_applied";
++
++export type TaskRunnerLifecycleResult = {
++  schema: typeof TASK_RUNNER_LIFECYCLE_RESULT_SCHEMA;
++  phase: "prepared" | "executed";
++  task_id: string;
++  invocation: Pick<
++    RunnerInvocation,
++    | "adapter_id"
++    | "run_id"
++    | "work_order_id"
++    | "run_dir"
++    | "bundle_path"
++    | "bootstrap_path"
++    | "result_path"
++  >;
++  lifecycle: {
++    mode: RunnerRunState["mode"];
++    status: RunnerLifecycleStatus;
++    state_fingerprint: RunnerRunState["state_fingerprint"] | null;
++    /**
++     * These immutable references retain the effect authority, journal evidence,
++     * claim generation, and any operator-supplied resolution without parsing
++     * renderer output or replaying a provider operation.
++     */
++    effect: {
++      state: TaskRunnerLifecycleEffectState;
++      operation: RunnerRunState["effect_operation"] | null;
++      /** Exact authority and observed-evidence identities from the durable journal. */
++      authority: {
++        ref: string;
++        digest: string;
++      } | null;
++      observed_evidence: {
++        code: string;
++        digest: string | null;
++      } | null;
++      claim_generation: string | null;
++      resolution: RunnerRunState["effect_resolution"] | null;
++      resolution_provenance: "operator_supplied" | null;
++      source_resolution: RunnerRunState["effect_resolution"] | null;
++      source_resolution_provenance: "operator_supplied" | null;
++    };
++    work_order_authority: AgentWorkOrderV2["authority"] | null;
++  };
++  result: RunnerResult | null;
++  active_claim_cleanup: TaskRunnerActiveClaimCleanupDiagnostic | null;
++};
++
++function effectState(state: RunnerRunState): TaskRunnerLifecycleEffectState {
++  if (state.effect_resolution?.verdict === "applied") return "applied";
++  if (state.effect_resolution?.verdict === "not_applied") return "not_applied";
++  if (
++    state.state_fingerprint?.outcome === "effect_unknown" ||
++    state.state_fingerprint?.outcome === "post_state_unknown"
++  ) {
++    return "effect_in_doubt";
++  }
++  return "not_recorded";
++}
++
++function projectTaskRunnerLifecycleResult(opts: {
++  phase: TaskRunnerLifecycleResult["phase"];
++  task_id: string;
++  invocation: RunnerInvocation;
++  state: RunnerRunState;
++  bundle: PreparedTaskRunnerExecution["bundle"];
++  effect_operation?: TaskRunnerEffectOperationSnapshot;
++  result: RunnerResult | null;
++  active_claim_cleanup?: TaskRunnerActiveClaimCleanupDiagnostic;
++  source_effect_resolution?: RunnerRunState["effect_resolution"] | null;
++}): TaskRunnerLifecycleResult {
++  const effect = effectState(opts.state);
++  return {
++    schema: TASK_RUNNER_LIFECYCLE_RESULT_SCHEMA,
++    phase: opts.phase,
++    task_id: opts.task_id,
++    invocation: {
++      adapter_id: opts.invocation.adapter_id,
++      run_id: opts.invocation.run_id,
++      work_order_id: opts.invocation.work_order_id,
++      run_dir: opts.invocation.run_dir,
++      bundle_path: opts.invocation.bundle_path,
++      bootstrap_path: opts.invocation.bootstrap_path ?? null,
++      result_path: opts.invocation.result_path,
++    },
++    lifecycle: {
++      mode: opts.state.mode,
++      status: opts.state.status,
++      state_fingerprint: opts.state.state_fingerprint ?? null,
++      effect: {
++        state: effect,
++        operation: opts.state.effect_operation ?? null,
++        authority: opts.effect_operation
++          ? {
++              ref: opts.effect_operation.operation.authority_ref,
++              digest: opts.effect_operation.operation.authority_digest,
++            }
++          : null,
++        observed_evidence: opts.effect_operation?.journal.observed_evidence ?? null,
++        claim_generation:
++          opts.effect_operation?.operation.claim_generation ??
++          opts.state.effect_operation?.claim_generation ??
++          null,
++        resolution: opts.state.effect_resolution ?? null,
++        resolution_provenance: opts.state.effect_resolution ? "operator_supplied" : null,
++        source_resolution: opts.source_effect_resolution ?? null,
++        source_resolution_provenance: opts.source_effect_resolution ? "operator_supplied" : null,
++      },
++      work_order_authority: opts.bundle.work_order?.authority ?? null,
++    },
++    result: opts.result,
++    active_claim_cleanup: opts.active_claim_cleanup ?? null,
++  };
++}
++
++export function projectPreparedTaskRunnerLifecycleResult(opts: {
++  task_id: string;
++  execution: PreparedTaskRunnerExecution;
++}): TaskRunnerLifecycleResult {
++  return projectTaskRunnerLifecycleResult({
++    phase: "prepared",
++    task_id: opts.task_id,
++    invocation: opts.execution.invocation,
++    state: opts.execution.state,
++    bundle: opts.execution.bundle,
++    effect_operation: opts.execution.effect_operation,
++    result: null,
++  });
++}
++
++export function projectExecutedTaskRunnerLifecycleResult(opts: {
++  task_id: string;
++  execution: ExecutedTaskRunnerExecution;
++  source_effect_resolution?: RunnerRunState["effect_resolution"] | null;
++}): TaskRunnerLifecycleResult {
++  return projectTaskRunnerLifecycleResult({
++    phase: "executed",
++    task_id: opts.task_id,
++    invocation: opts.execution.invocation,
++    state: opts.execution.state,
++    bundle: opts.execution.bundle,
++    effect_operation: opts.execution.effect_operation,
++    result: opts.execution.result,
++    active_claim_cleanup: opts.execution.active_claim_cleanup,
++    source_effect_resolution: opts.source_effect_resolution,
++  });
++}
++
++export function taskRunnerLifecycleExitCode(result: TaskRunnerLifecycleResult): number {
++  if (result.phase === "prepared") return 0;
++  return result.result?.status === "success" && !result.active_claim_cleanup ? 0 : 1;
++}
+diff --git a/packages/agentplane/src/runner/usecases/task-run-lifecycle-shared.ts b/packages/agentplane/src/runner/usecases/task-run-lifecycle-shared.ts
+index cfedcba64..1b718818e 100644
+--- a/packages/agentplane/src/runner/usecases/task-run-lifecycle-shared.ts
++++ b/packages/agentplane/src/runner/usecases/task-run-lifecycle-shared.ts
+@@ -2,6 +2,7 @@ import { realpath } from "node:fs/promises";
+ import path from "node:path";
+ 
+ import { normalizeTaskStatus } from "@agentplaneorg/core/tasks";
++import type { RunnerEffectResolutionRef } from "@agentplaneorg/core/schemas";
+ 
+ import type { TaskData } from "../../backends/task-backend.js";
+ import { loadCommandContext, type CommandContext } from "../../commands/shared/task-backend.js";
+@@ -45,6 +46,8 @@ export type EffectResumedTaskRunnerExecution = ExecutedTaskRunnerExecution & {
+   source_run_id: string;
+   source_status: RunnerLifecycleStatus;
+   previous_status: RunnerLifecycleStatus;
++  /** Immutable operator disposition that authorized this fresh effect attempt. */
++  source_effect_resolution: RunnerEffectResolutionRef;
+ };
+ 
+ export type RunnerReplayAction = "resume" | "retry" | "resume_effect";
+diff --git a/packages/agentplane/src/runner/usecases/task-run.ts b/packages/agentplane/src/runner/usecases/task-run.ts
+index e4e3e3939..6b01854f6 100644
+--- a/packages/agentplane/src/runner/usecases/task-run.ts
++++ b/packages/agentplane/src/runner/usecases/task-run.ts
+@@ -58,6 +58,7 @@ import {
+   recordTaskRunnerPostStateUnknown,
+   persistTaskRunnerEffectAccepted,
+   startTaskRunnerEffectOperation,
++  type TaskRunnerEffectOperationSnapshot,
+   type StartedRunnerEffectOperation,
+ } from "./task-run-effect-journal.js";
+ import { finalizeTaskRunnerActiveClaimCleanup } from "./task-run-active-claim-cleanup.js";
+@@ -92,6 +93,8 @@ export type PreparedTaskRunnerExecution = {
+   bundle: RunnerContextBundle;
+   invocation: RunnerInvocation;
+   state: RunnerRunState;
++  /** Durable operation and journal identity already established by preparation. */
++  effect_operation?: TaskRunnerEffectOperationSnapshot;
+   precondition_fingerprint?: StateFingerprint;
+   precondition_policy?: StateFingerprintPolicy;
+ };
+@@ -302,7 +305,7 @@ export async function prepareTaskRunnerExecution(opts: {
+     bootstrap_markdown: renderTaskRunnerBootstrap(bundle, invocation),
+     invocation,
+   });
+-  const stateWithEffectOperation = await persistPreparedTaskRunnerEffectOperation({
++  const preparedEffectOperation = await persistPreparedTaskRunnerEffectOperation({
+     repository,
+     bundle,
+     invocation,
+@@ -314,7 +317,8 @@ export async function prepareTaskRunnerExecution(opts: {
+   return {
+     bundle,
+     invocation,
+-    state: stateWithEffectOperation,
++    state: preparedEffectOperation.state,
++    effect_operation: preparedEffectOperation.effect_operation,
+     precondition_fingerprint,
+     precondition_policy,
+   };
+@@ -520,7 +524,7 @@ export async function executeTaskRunnerExecution(opts: {
+     const preconditionFingerprint = guardedExecution.precondition_fingerprint;
+     const preconditionPolicy = guardedExecution.precondition_policy;
+     const result = guardedExecution.result;
+-    const state = await persistTaskRunnerEffectAccepted({
++    const acceptedEffect = await persistTaskRunnerEffectAccepted({
+       session: effectOperation,
+       task_id: opts.task_id,
+       run_id: prepared.invocation.run_id,
+@@ -537,6 +541,7 @@ export async function executeTaskRunnerExecution(opts: {
+           state_fingerprint: guardedExecution.state_fingerprint,
+         }),
+     });
++    const state = acceptedEffect.state;
+     const claimedRunAuthority = await inspectTaskRunnerClaimedRunAuthority(
+       {
+         git_root: ctx.resolvedProject.gitRoot,
+@@ -549,6 +554,9 @@ export async function executeTaskRunnerExecution(opts: {
+     releaseActiveClaim = cleanupConfirmed;
+     completed = {
+       ...prepared,
++      effect_operation: prepared.effect_operation
++        ? { ...prepared.effect_operation, journal: acceptedEffect.journal }
++        : undefined,
+       precondition_fingerprint: preconditionFingerprint,
+       precondition_policy: preconditionPolicy,
+       state,

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-follow-up.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-follow-up.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_rework_work_order",
+  "source_work_order_id": "evaluator-work-order-202607221850-R7WS01-96b4eeb6e8bc42925295141e",
+  "task_id": "202607221850-R7WS01",
+  "verdict": "rework",
+  "next_owner": "CODER",
+  "instruction": "Set Hermes exit_code from taskRunnerLifecycleExitCode(lifecycle) and add a narrow cleanup-failure regression test.",
+  "findings": [
+    {
+      "id": "compatibility-finding-1",
+      "summary": "executeHermesWorkflowOperation marks an execution with active_claim_cleanup as failed but currently forwards executed.result.exit_code, which can still be 0. This splits supervisor semantics from task-run's typed exit mapping.",
+      "evidence_refs": [
+        {
+          "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-diff.patch"
+        }
+      ]
+    }
+  ],
+  "source_result": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-result.json"
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-observed-checks.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-observed-checks.json
@@ -1,0 +1,16 @@
+{
+  "task_status": "DOING",
+  "declared_checks": [
+    "bun run lifecycle:invariants",
+    "bun run test:critical",
+    "bun run typecheck"
+  ],
+  "verification": {
+    "state": "ok",
+    "attempts": 0,
+    "updated_at": "2026-07-28T02:26:16.727Z",
+    "updated_by": "TESTER",
+    "note": "PASS: typed runner lifecycle results stay in-process through task CLI and Hermes; human and JSON renderers preserve effect authority, observed evidence, claim generation, and operator-resolution provenance."
+  },
+  "runner_history": []
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-opinion.md
@@ -1,0 +1,20 @@
+# Semantic quality review: rework
+
+Provenance: evaluator_supplied
+
+EVALUATOR returned rework with 1 typed finding(s).
+
+## Findings
+- executeHermesWorkflowOperation marks an execution with active_claim_cleanup as failed but currently forwards executed.result.exit_code, which can still be 0. This splits supervisor semantics from task-run's typed exit mapping.
+
+## Evidence
+- .agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-diff.patch
+
+## Missing Tests
+- Hermes execution with active_claim_cleanup returns failed and a nonzero exit_code.
+
+## Hidden Assumptions
+- The provider exit code always reflects supervisor cleanup state.
+
+## Residual Risks
+- Set Hermes exit_code from taskRunnerLifecycleExitCode(lifecycle) and add a narrow cleanup-failure regression test.

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-prompt.md
@@ -1,0 +1,82 @@
+# AgentPlane EVALUATOR episode
+
+AgentPlane prepared and froze the authoritative review input. Perform the semantic evaluation; do not reproduce CLI discovery or lifecycle work.
+This prompt does not execute an evaluator. A caller must run the evaluator in the work-order authority boundary and persist its returned typed result at the declared output path.
+Do not edit implementation, task lifecycle, policy, or evidence files. You may read the frozen evidence and run read-only checks only.
+
+- task_id: 202607221850-R7WS01
+- task_readme: .agentplane/tasks/202607221850-R7WS01/README.md
+- work_order: .agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-work-order.json
+- result_output: .agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-result.json
+- report_path: .agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/quality-report.json
+- provenance: evaluator_supplied
+
+## Required result
+
+Return exactly one `sgr.evaluator_result.v1` JSON object through the evaluator result channel. The caller, not the read-only evaluator, persists it at `result_output`. It must contain:
+- schema_version: 1
+- kind: evaluator_result
+- evaluator_id: the evaluator id from the work order
+- verdict: pass | rework | blocked | human_review
+- findings: typed findings with id, severity, summary, broken_invariant, and non-empty evidence_refs
+- missing_tests and hidden_assumptions: string arrays
+- recovery_context: required non-empty string for rework, blocked, or human_review; for human_review it must be the single decision question for the human owner
+
+Every findings[].evidence_refs[].path must be an exact path from work_order.evidence. Do not add fields, commands, patches, lifecycle transitions, or a verdict outside this JSON result.
+The CLI validates the schema, frozen evidence digests, task revision, evaluated SHA, and blueprint before it records quality state.
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-result.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-result.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_result",
+  "evaluator_id": "recovery-context",
+  "verdict": "rework",
+  "findings": [
+    {
+      "id": "compatibility-finding-1",
+      "severity": "medium",
+      "summary": "executeHermesWorkflowOperation marks an execution with active_claim_cleanup as failed but currently forwards executed.result.exit_code, which can still be 0. This splits supervisor semantics from task-run's typed exit mapping.",
+      "broken_invariant": "Compatibility evaluator facade requires independent review evidence.",
+      "evidence_refs": [
+        {
+          "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-diff.patch"
+        }
+      ]
+    }
+  ],
+  "missing_tests": [
+    "Hermes execution with active_claim_cleanup returns failed and a nonzero exit_code."
+  ],
+  "hidden_assumptions": [
+    "The provider exit code always reflects supervisor cleanup state."
+  ],
+  "recovery_context": "Set Hermes exit_code from taskRunnerLifecycleExitCode(lifecycle) and add a narrow cleanup-failure regression test."
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-work-order.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-work-order.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_work_order",
+  "work_order_id": "evaluator-work-order-202607221850-R7WS01-96b4eeb6e8bc42925295141e",
+  "prepared_at": "2026-07-28T02:26:58.471Z",
+  "task": {
+    "id": "202607221850-R7WS01",
+    "revision": 11,
+    "objective": "Return typed runner lifecycle results\n\nRF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing.",
+    "acceptance_criteria": [
+      "bun run lifecycle:invariants",
+      "bun run test:critical",
+      "bun run typecheck",
+      "- In scope: typed runner use-case results, adapter ports, error/result union, human/JSON renderers, compatibility snapshots, and supervisor invocation without subprocess/stdout capture.\n- Consume the durable effect-resolution contract as typed `effect_in_doubt`, `applied` and `not_applied` states, preserving resolution provenance, authority/evidence identity and claim generation in every in-process result and renderer.\n- An unresolved `effect_in_doubt` result is terminally blocked for generic retry, replay, resume and restart paths; only the explicit resolution protocol from task 202607242158-QV09NA may transition it to `applied` or `not_applied`.\n- Out of scope: automating the complete direct route, delivered by the next task.",
+      "1. Define typed results for runner preparation, invocation, observation, evaluation handoff, and terminal outcomes.\n2. Separate rendering/exit mapping from use-case logic.\n3. Call runner phases in-process from the supervisor.\n4. Map durable journal/resolution input to typed `effect_in_doubt`, `applied` and `not_applied` outcomes with resolution provenance, and reject any generic retry path for unresolved effects.\n5. Preserve documented human and JSON output through compatibility renderers without dropping resolution provenance.\n6. Add result/renderer parity, adapter error, cancellation, timeout, stale-work-order and effect-resolution transition tests.",
+      "1. Invoke each runner phase in-process. Expected: structured results carry work-order/fingerprint/receipt identities without reading stdout.\n2. Render the same result to human and JSON formats. Expected: compatibility snapshots and exit codes remain stable.\n3. Feed durable journal states for `effect_in_doubt`, operator-resolved `applied` and operator-resolved `not_applied` into each runner/supervisor entry point. Expected: typed results and both renderers preserve the state, operator-supplied resolution provenance, evidence/authority digests and claim generation without stdout parsing.\n4. Invoke generic retry, replay, resume and restart against unresolved `effect_in_doubt`. Expected: every path returns the typed blocked outcome, performs no adapter invocation and directs callers only to the explicit operator-resolution protocol; no generic retry can reinterpret the effect as `not_applied`.\n5. Exercise cancellation, timeout, adapter crash, stale input, and policy denial. Expected: typed outcomes and observed receipts remain complete.\n6. Run runner/supervisor/lifecycle tests and typecheck."
+    ]
+  },
+  "evaluated_sha": "3f11077e583fb131713af53835139885b4406b60",
+  "blueprint_digest": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328",
+  "evaluator": {
+    "id": "recovery-context",
+    "profile": "EVALUATOR",
+    "prompt_module_path": ".agentplane/evaluators/recovery-context.md"
+  },
+  "authority": {
+    "sandbox": "read-only",
+    "writable_roots": [],
+    "allowed_tool_classes": [
+      "repository_read",
+      "git_read",
+      "run_checks",
+      "report_result"
+    ],
+    "external_side_effects": []
+  },
+  "result_contract": "sgr.evaluator_result.v1",
+  "evidence": [
+    {
+      "id": "task-document",
+      "kind": "task_document",
+      "path": ".agentplane/tasks/202607221850-R7WS01/README.md",
+      "sha256": "sha256:693da2bec8d44660040dbe741c5609f29a4142e580149ad6a25990a4c26418d1",
+      "required": true
+    },
+    {
+      "id": "actual-diff",
+      "kind": "actual_diff",
+      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-diff.patch",
+      "sha256": "sha256:12eea898cce09dd7c3cbc38e6cd668a977164b9f393314504e6c3245e314c6ed",
+      "required": true
+    },
+    {
+      "id": "observed-checks",
+      "kind": "observed_checks",
+      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-observed-checks.json",
+      "sha256": "sha256:5bdcf94f6d74b42ad558003b7ce5c82d0e996ddec13efe32ac55773603fa3e69",
+      "required": true
+    },
+    {
+      "id": "blueprint",
+      "kind": "blueprint",
+      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-blueprint.json",
+      "sha256": "sha256:d348dedab56fd1219b3127a4ff3da0570f1904829944b3609e64139f6309b3fb",
+      "required": true
+    },
+    {
+      "id": "policy-1",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.code.md",
+      "sha256": "sha256:3fec50dfe0db2f9495a3fa96f36d95fb34262033299d57f6f3775af4b7cc1486",
+      "required": true
+    },
+    {
+      "id": "policy-2",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.core.md",
+      "sha256": "sha256:f6c11b8a2c55760c17af15f79fe13791b3e7bba4852fc7d311fc0657e490b0c7",
+      "required": true
+    },
+    {
+      "id": "policy-3",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/security.must.md",
+      "sha256": "sha256:96d01012e7ab67873bcb7a2cdd3818efa2c1fa500ee2eaf0e316f67e15bbcab2",
+      "required": true
+    },
+    {
+      "id": "policy-4",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/workflow.branch_pr.md",
+      "sha256": "sha256:12d3b942042c276d30593803ddcfe12b20dc794e3e8bfbd97b6ce59df13ba82b",
+      "required": true
+    }
+  ]
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/quality-report.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "task_id": "202607221850-R7WS01",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-28T02:26:58.563Z",
+  "provenance": "evaluator_supplied",
+  "verdict": "rework",
+  "summary": "EVALUATOR returned rework with 1 typed finding(s).",
+  "evaluated_sha": "3f11077e583fb131713af53835139885b4406b60",
+  "blueprint_digest": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328",
+  "findings": [
+    "executeHermesWorkflowOperation marks an execution with active_claim_cleanup as failed but currently forwards executed.result.exit_code, which can still be 0. This splits supervisor semantics from task-run's typed exit mapping."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-diff.patch"
+  ],
+  "missing_tests": [
+    "Hermes execution with active_claim_cleanup returns failed and a nonzero exit_code."
+  ],
+  "hidden_assumptions": [
+    "The provider exit code always reflects supervisor cleanup state."
+  ],
+  "residual_risks": [
+    "Set Hermes exit_code from taskRunnerLifecycleExitCode(lifecycle) and add a narrow cleanup-failure regression test."
+  ]
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-blueprint.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-blueprint.json
@@ -1,0 +1,583 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607221850-R7WS01",
+    "title": "Return typed runner lifecycle results",
+    "description": "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing.",
+    "tags": [
+      "milestone-beta1",
+      "refactor",
+      "rf-25",
+      "runner",
+      "use-case",
+      "v0.7",
+      "wave-supervisor"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607221850-R7WS01",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328"
+  }
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-diff.patch
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-diff.patch
@@ -1,0 +1,2438 @@
+diff --git a/.agentplane/tasks/202607221850-R7WS01/README.md b/.agentplane/tasks/202607221850-R7WS01/README.md
+index 55a85fc56..889f875eb 100644
+--- a/.agentplane/tasks/202607221850-R7WS01/README.md
++++ b/.agentplane/tasks/202607221850-R7WS01/README.md
+@@ -4,7 +4,7 @@ title: "Return typed runner lifecycle results"
+ status: "DOING"
+ priority: "high"
+ owner: "CODER"
+-revision: 9
++revision: 12
+ origin:
+   system: "manual"
+ depends_on:
+@@ -34,16 +34,46 @@ plan_approval:
+   updated_by: "ORCHESTRATOR"
+   note: null
+ verification:
+-  state: "pending"
+-  updated_at: null
+-  updated_by: null
+-  note: null
++  state: "ok"
++  updated_at: "2026-07-28T02:26:16.727Z"
++  updated_by: "TESTER"
++  note: "PASS: typed runner lifecycle results stay in-process through task CLI and Hermes; human and JSON renderers preserve effect authority, observed evidence, claim generation, and operator-resolution provenance."
+   attempts: 0
+-commit: null
++quality_review:
++  state: "rework"
++  provenance: "evaluator_supplied"
++  updated_at: "2026-07-28T02:26:58.563Z"
++  updated_by: "EVALUATOR"
++  note: "EVALUATOR returned rework with 1 typed finding(s)."
++  evaluated_sha: "3f11077e583fb131713af53835139885b4406b60"
++  blueprint_digest: "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328"
++  evidence_refs:
++    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-work-order.json"
++    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/quality-report.json"
++    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-prompt.md"
++    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-opinion.md"
++    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-result.json"
++    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-follow-up.json"
++    - ".agentplane/tasks/202607221850-R7WS01/README.md"
++    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-diff.patch"
++    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-observed-checks.json"
++    - ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-blueprint.json"
++    - ".agentplane/policy/dod.code.md"
++    - ".agentplane/policy/dod.core.md"
++    - ".agentplane/policy/security.must.md"
++    - ".agentplane/policy/workflow.branch_pr.md"
++  findings:
++    - "executeHermesWorkflowOperation marks an execution with active_claim_cleanup as failed but currently forwards executed.result.exit_code, which can still be 0. This splits supervisor semantics from task-run's typed exit mapping."
++commit:
++  hash: "3f11077e583fb131713af53835139885b4406b60"
++  message: "✨ R7WS01 runner: return typed lifecycle results"
+ comments:
+   -
+     author: "CODER"
+     body: "Start: continue branch_pr task in the dedicated task worktree."
++  -
++    author: "CODER"
++    body: "Implementation committed: 3f11077e5. Typed lifecycle result, renderers, Hermes in-process projection, and effect identity coverage are ready for TESTER verification."
+ events:
+   -
+     type: "status"
+@@ -52,8 +82,21 @@ events:
+     from: "TODO"
+     to: "DOING"
+     note: "Start: continue branch_pr task in the dedicated task worktree."
++  -
++    type: "status"
++    at: "2026-07-28T02:22:27.906Z"
++    author: "CODER"
++    from: "DOING"
++    to: "DOING"
++    note: "Implementation committed: 3f11077e5. Typed lifecycle result, renderers, Hermes in-process projection, and effect identity coverage are ready for TESTER verification."
++  -
++    type: "verify"
++    at: "2026-07-28T02:26:16.727Z"
++    author: "TESTER"
++    state: "ok"
++    note: "PASS: typed runner lifecycle results stay in-process through task CLI and Hermes; human and JSON renderers preserve effect authority, observed evidence, claim generation, and operator-resolution provenance."
+ doc_version: 3
+-doc_updated_at: "2026-07-28T01:55:50.050Z"
++doc_updated_at: "2026-07-28T02:26:17.333Z"
+ doc_updated_by: "CODER"
+ description: "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing."
+ sections:
+@@ -82,13 +125,46 @@ sections:
+     6. Run runner/supervisor/lifecycle tests and typecheck.
+   Verification: |-
+     <!-- BEGIN VERIFICATION RESULTS -->
++    ### 2026-07-28T02:26:16.727Z — VERIFY — ok
++
++    By: TESTER
++
++    Note: PASS: typed runner lifecycle results stay in-process through task CLI and Hermes; human and JSON renderers preserve effect authority, observed evidence, claim generation, and operator-resolution provenance.
++    Attempts: 0
++
++    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T02:22:27.906Z, excerpt_hash=sha256:02a389ca089e360cf76ff483bd84febcf2d5924eaa0f09fb89eb4a0ab64c794d
++
++    Details:
++
++    BlueprintSnapshotRef:
++    - state: current
++    - path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607221850-R7WS01-return-typed-runner-lifecycle-results/.agentplane/tasks/202607221850-R7WS01/blueprint/resolved-snapshot.json
++    - old_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
++    - current_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
++    - route_changed: no
++    - safe_command: agentplane blueprint snapshot 202607221850-R7WS01
++
++    DecisionContextRef:
++    - operator_action: stop
++    - can_execute_now: false
++    - safe_command: none
++    - diagnostic_command: agentplane task verify-show 202607221850-R7WS01
++    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
++    - freshness: route=computed_local remote=remote_skipped
++    - repeat_allowed: false
++    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
++    - risks: none
++
+     <!-- END VERIFICATION RESULTS -->
+   Rollback Plan: |-
+     - Revert the migrated vertical slice while preserving the typed contracts consumed by later tasks.
+     - Preserve `effect_in_doubt`, `applied` and `not_applied` states plus resolution provenance in any compatibility boundary; do not restore a generic retry path for unresolved effects.
+     - Restore the previous compatibility path only when it cannot bypass the explicit operator-resolution protocol or invoke the adapter for unresolved `effect_in_doubt`.
+     - Re-run lifecycle, focused, and type checks before resuming dependent work.
+-  Findings: ""
++  Findings: |-
++    - Observation: Focused runner/supervisor/lifecycle suite passed; critical-cli passed 11/11 files (72 tests) in canonical Node mode; lifecycle invariants, typecheck, lint, and routing checks passed.
++      Impact: No stdout parsing or generic replay path was reintroduced for effect_in_doubt.
++      Resolution: Approve branch for PR update and hosted validation.
+ extensions:
+   agentplane.side_effect_authority:
+     audit:
+@@ -159,6 +235,36 @@ RF-25d: make runner preparation, invocation, observation, evaluation, and lifecy
+ ## Verification
+ 
+ <!-- BEGIN VERIFICATION RESULTS -->
++### 2026-07-28T02:26:16.727Z — VERIFY — ok
++
++By: TESTER
++
++Note: PASS: typed runner lifecycle results stay in-process through task CLI and Hermes; human and JSON renderers preserve effect authority, observed evidence, claim generation, and operator-resolution provenance.
++Attempts: 0
++
++VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T02:22:27.906Z, excerpt_hash=sha256:02a389ca089e360cf76ff483bd84febcf2d5924eaa0f09fb89eb4a0ab64c794d
++
++Details:
++
++BlueprintSnapshotRef:
++- state: current
++- path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607221850-R7WS01-return-typed-runner-lifecycle-results/.agentplane/tasks/202607221850-R7WS01/blueprint/resolved-snapshot.json
++- old_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
++- current_digest: 97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328
++- route_changed: no
++- safe_command: agentplane blueprint snapshot 202607221850-R7WS01
++
++DecisionContextRef:
++- operator_action: stop
++- can_execute_now: false
++- safe_command: none
++- diagnostic_command: agentplane task verify-show 202607221850-R7WS01
++- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
++- freshness: route=computed_local remote=remote_skipped
++- repeat_allowed: false
++- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
++- risks: none
++
+ <!-- END VERIFICATION RESULTS -->
+ 
+ ## Rollback Plan
+@@ -169,3 +275,7 @@ RF-25d: make runner preparation, invocation, observation, evaluation, and lifecy
+ - Re-run lifecycle, focused, and type checks before resuming dependent work.
+ 
+ ## Findings
++
++- Observation: Focused runner/supervisor/lifecycle suite passed; critical-cli passed 11/11 files (72 tests) in canonical Node mode; lifecycle invariants, typecheck, lint, and routing checks passed.
++  Impact: No stdout parsing or generic replay path was reintroduced for effect_in_doubt.
++  Resolution: Approve branch for PR update and hosted validation.
+diff --git a/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt b/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
+index 52631f73e..ef33244b2 100644
+--- a/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
++++ b/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
+@@ -1,6 +1,6 @@
+  .../src/cli/run-cli.core.task-run.test.ts          |   6 +
+- .../src/commands/hermes/hermes-runtime.ts          |  17 +-
+- .../src/commands/hermes/hermes.command.test.ts     |  45 +++++-
++ .../src/commands/hermes/hermes-runtime.ts          |  19 ++-
++ .../src/commands/hermes/hermes.command.test.ts     | 107 ++++++++++++-
+  .../src/commands/shared/workflow-supervisor.ts     |   8 +
+  .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
+  .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
+@@ -11,4 +11,4 @@
+  .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
+  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
+  .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
+- 13 files changed, 552 insertions(+), 60 deletions(-)
++ 13 files changed, 613 insertions(+), 63 deletions(-)
+diff --git a/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md b/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
+index 93a630f1c..8be23b936 100644
+--- a/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
++++ b/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
+@@ -17,8 +17,14 @@ RF-25d: make runner preparation, invocation, observation, evaluation, and lifecy
+ 
+ ## Verification
+ 
+-- State: pending
+-- Note: Not recorded yet.
++- State: ok
++- Note:
++
++```text
++PASS: typed runner lifecycle results stay in-process through task CLI and Hermes; human and JSON
++renderers preserve effect authority, observed evidence, claim generation, and operator-resolution
++provenance.
++```
+ - Canonical workflow state lives in the task README.
+ 
+ <details>
+@@ -30,8 +36,8 @@ RF-25d: make runner preparation, invocation, observation, evaluation, and lifecy
+ 
+ ```text
+  .../src/cli/run-cli.core.task-run.test.ts          |   6 +
+- .../src/commands/hermes/hermes-runtime.ts          |  17 +-
+- .../src/commands/hermes/hermes.command.test.ts     |  45 +++++-
++ .../src/commands/hermes/hermes-runtime.ts          |  19 ++-
++ .../src/commands/hermes/hermes.command.test.ts     | 107 ++++++++++++-
+  .../src/commands/shared/workflow-supervisor.ts     |   8 +
+  .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
+  .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
+@@ -42,7 +48,7 @@ RF-25d: make runner preparation, invocation, observation, evaluation, and lifecy
+  .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
+  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
+  .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
+- 13 files changed, 552 insertions(+), 60 deletions(-)
++ 13 files changed, 613 insertions(+), 63 deletions(-)
+ ```
+ 
+ </details>
+diff --git a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+index d56bd6627..d81fcc4d0 100644
+--- a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
++++ b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+@@ -2,8 +2,9 @@
+   "base": "main",
+   "branch": "task/202607221850-R7WS01/return-typed-runner-lifecycle-results",
+   "created_at": "2026-07-28T01:55:50.166Z",
+-  "diffstat_sha256": "sha256:da831a54df8e685f7cb8a449136121ba3ff3501a78568ca3c61e81df7cbb34c4",
+-  "last_verified_at": null,
++  "diffstat_sha256": "sha256:65d97a5753250f37a246a401fcbc4accf833ce3f83665209a24340b616f3cba4",
++  "last_verified_at": "2026-07-28T02:26:16.727Z",
++  "last_verified_diffstat_sha256": "sha256:da831a54df8e685f7cb8a449136121ba3ff3501a78568ca3c61e81df7cbb34c4",
+   "pr_number": 4650,
+   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4650",
+   "schema_version": 1,
+@@ -11,6 +12,6 @@
+   "task_id": "202607221850-R7WS01",
+   "updated_at": "2026-07-28T01:56:15.744Z",
+   "verify": {
+-    "status": "skipped"
++    "status": "pass"
+   }
+ }
+diff --git a/.agentplane/tasks/202607221850-R7WS01/pr/review.md b/.agentplane/tasks/202607221850-R7WS01/pr/review.md
+index 95c56904d..e28c3852f 100644
+--- a/.agentplane/tasks/202607221850-R7WS01/pr/review.md
++++ b/.agentplane/tasks/202607221850-R7WS01/pr/review.md
+@@ -12,8 +12,8 @@ Created: 2026-07-28T01:55:50.166Z
+ 
+ ## Verification
+ 
+-- State: pending
+-- Note: Not recorded yet.
++- State: ok
++- Note: PASS: typed runner lifecycle results stay in-process through task CLI and Hermes; human and JSON renderers preserve effect authority, observed evidence, claim generation, and operator-resolution provenance.
+ - Canonical workflow state lives in the task README.
+ 
+ ## Handoff Notes
+@@ -30,8 +30,8 @@ Created: 2026-07-28T01:55:50.166Z
+ 
+ ```text
+  .../src/cli/run-cli.core.task-run.test.ts          |   6 +
+- .../src/commands/hermes/hermes-runtime.ts          |  17 +-
+- .../src/commands/hermes/hermes.command.test.ts     |  45 +++++-
++ .../src/commands/hermes/hermes-runtime.ts          |  19 ++-
++ .../src/commands/hermes/hermes.command.test.ts     | 107 ++++++++++++-
+  .../src/commands/shared/workflow-supervisor.ts     |   8 +
+  .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
+  .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
+@@ -42,7 +42,7 @@ Created: 2026-07-28T01:55:50.166Z
+  .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
+  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
+  .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
+- 13 files changed, 552 insertions(+), 60 deletions(-)
++ 13 files changed, 613 insertions(+), 63 deletions(-)
+ ```
+ 
+ </details>
+diff --git a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-blueprint.json b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-blueprint.json
+new file mode 100644
+index 000000000..4f9e5cd52
+--- /dev/null
++++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-blueprint.json
+@@ -0,0 +1,583 @@
++{
++  "schemaVersion": 1,
++  "artifactKind": "agentplane.blueprint.resolved_snapshot",
++  "resolverInput": {
++    "taskId": "202607221850-R7WS01",
++    "title": "Return typed runner lifecycle results",
++    "description": "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing.",
++    "tags": [
++      "milestone-beta1",
++      "refactor",
++      "rf-25",
++      "runner",
++      "use-case",
++      "v0.7",
++      "wave-supervisor"
++    ],
++    "owner": "CODER",
++    "taskKind": "code",
++    "workflowMode": "branch_pr",
++    "workflowGitCapabilities": {
++      "workflowMode": "branch_pr",
++      "implementationCommitLocation": "task_worktree",
++      "finishCommitSource": "explicit_hash",
++      "closeTailRequired": true,
++      "lifecycleCommentCommitLocation": "task_worktree",
++      "finishCommitFromComment": false
++    },
++    "mutation": "code",
++    "mutationScope": "code",
++    "touchedPaths": [],
++    "recipeHints": [],
++    "riskFlags": [],
++    "blueprintRequest": "code.branch_pr"
++  },
++  "selectedBlueprint": {
++    "id": "code.branch_pr",
++    "version": 1,
++    "title": "Branch PR code change",
++    "taskKinds": [
++      "code"
++    ],
++    "workflowModes": [
++      "branch_pr"
++    ]
++  },
++  "plan": {
++    "schemaVersion": 1,
++    "blueprintId": "code.branch_pr",
++    "blueprintVersion": 1,
++    "title": "Branch PR code change",
++    "taskId": "202607221850-R7WS01",
++    "workflowMode": "branch_pr",
++    "workflowGitCapabilities": {
++      "workflowMode": "branch_pr",
++      "implementationCommitLocation": "task_worktree",
++      "finishCommitSource": "explicit_hash",
++      "closeTailRequired": true,
++      "lifecycleCommentCommitLocation": "task_worktree",
++      "finishCommitFromComment": false
++    },
++    "taskIntent": {
++      "taskKind": "code",
++      "mutationScope": "code",
++      "blueprintRequest": "code.branch_pr"
++    },
++    "whySelected": [
++      "explicit blueprint requested: code.branch_pr",
++      "task intent kind: code",
++      "workflow mode: branch_pr",
++      "task intent mutation scope: code"
++    ],
++    "states": [
++      {
++        "id": "intake",
++        "kind": "intake",
++        "mode": "agentic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": []
++      },
++      {
++        "id": "scope",
++        "kind": "scope",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "assumptions"
++        ]
++      },
++      {
++        "id": "approval_gate",
++        "kind": "approval_gate",
++        "mode": "approval",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "approval"
++        ]
++      },
++      {
++        "id": "context_resolve",
++        "kind": "context_resolve",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [
++          ".agentplane/policy/security.must.md",
++          ".agentplane/policy/dod.core.md",
++          ".agentplane/policy/dod.code.md",
++          ".agentplane/policy/workflow.branch_pr.md"
++        ],
++        "evidenceKinds": [
++          "context_manifest"
++        ]
++      },
++      {
++        "id": "worktree_start",
++        "kind": "worktree_start",
++        "mode": "deterministic",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [
++          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "changed_paths"
++        ]
++      },
++      {
++        "id": "work_unit",
++        "kind": "work_unit",
++        "mode": "agentic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "changed_paths"
++        ]
++      },
++      {
++        "id": "fast_local_checks",
++        "kind": "fast_local_checks",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [
++          "agentplane task verify-show <task-id>",
++          "project focused checks"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "check_result"
++        ]
++      },
++      {
++        "id": "pr_artifact",
++        "kind": "pr_artifact",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [
++          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "artifact",
++          "external_link"
++        ]
++      },
++      {
++        "id": "verify_record",
++        "kind": "verify_record",
++        "mode": "record",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "check_result"
++        ]
++      },
++      {
++        "id": "quality_gate",
++        "kind": "quality_gate",
++        "mode": "agentic",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [
++          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "quality_report"
++        ]
++      },
++      {
++        "id": "hosted_checks",
++        "kind": "hosted_checks",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "check_result",
++          "external_link"
++        ]
++      },
++      {
++        "id": "publish_or_integrate",
++        "kind": "publish_or_integrate",
++        "mode": "deterministic",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [
++          "agentplane integrate <task-id> --branch <branch> --run-verify"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "commit",
++          "external_link"
++        ]
++      },
++      {
++        "id": "finish",
++        "kind": "finish",
++        "mode": "deterministic",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "commit"
++        ]
++      }
++    ],
++    "requiredEvidence": [
++      {
++        "id": "code_pr.paths",
++        "kind": "changed_paths",
++        "producedBy": "work_unit",
++        "required": true,
++        "description": "Changed source paths."
++      },
++      {
++        "id": "code_pr.fast_checks",
++        "kind": "check_result",
++        "producedBy": "fast_local_checks",
++        "required": true,
++        "description": "Fast local checks."
++      },
++      {
++        "id": "code_pr.pr",
++        "kind": "external_link",
++        "producedBy": "pr_artifact",
++        "required": true,
++        "description": "Pull request artifact."
++      },
++      {
++        "id": "code_pr.verify",
++        "kind": "check_result",
++        "producedBy": "verify_record",
++        "required": true,
++        "description": "Task branch verification."
++      },
++      {
++        "id": "code_pr.quality",
++        "kind": "quality_report",
++        "producedBy": "quality_gate",
++        "required": true,
++        "description": "EVALUATOR quality verdict."
++      },
++      {
++        "id": "code_pr.hosted",
++        "kind": "check_result",
++        "producedBy": "hosted_checks",
++        "required": true,
++        "description": "Hosted check evidence."
++      },
++      {
++        "id": "code_pr.commit",
++        "kind": "commit",
++        "producedBy": "publish_or_integrate",
++        "required": true,
++        "description": "Integration commit."
++      }
++    ],
++    "policyModules": [
++      ".agentplane/policy/dod.code.md",
++      ".agentplane/policy/dod.core.md",
++      ".agentplane/policy/security.must.md",
++      ".agentplane/policy/workflow.branch_pr.md"
++    ],
++    "allowedCommands": [
++      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
++      "agentplane integrate <task-id> --branch <branch> --run-verify",
++      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
++      "agentplane task verify-show <task-id>",
++      "agentplane verify <task-id> --ok|--rework",
++      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
++      "project focused checks"
++    ],
++    "contextBudget": {
++      "maxPolicyModules": 4,
++      "maxPromptBlocks": 14,
++      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
++    },
++    "contextManifest": [],
++    "acceptedRecipeExtensions": [],
++    "rejectedRecipeExtensions": [],
++    "stopReasons": []
++  },
++  "nodes": [
++    {
++      "id": "intake",
++      "kind": "intake",
++      "mode": "agentic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": []
++    },
++    {
++      "id": "scope",
++      "kind": "scope",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "assumptions"
++      ]
++    },
++    {
++      "id": "approval_gate",
++      "kind": "approval_gate",
++      "mode": "approval",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "approval"
++      ]
++    },
++    {
++      "id": "context_resolve",
++      "kind": "context_resolve",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [
++        ".agentplane/policy/security.must.md",
++        ".agentplane/policy/dod.core.md",
++        ".agentplane/policy/dod.code.md",
++        ".agentplane/policy/workflow.branch_pr.md"
++      ],
++      "evidenceKinds": [
++        "context_manifest"
++      ]
++    },
++    {
++      "id": "worktree_start",
++      "kind": "worktree_start",
++      "mode": "deterministic",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [
++        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "changed_paths"
++      ]
++    },
++    {
++      "id": "work_unit",
++      "kind": "work_unit",
++      "mode": "agentic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "changed_paths"
++      ]
++    },
++    {
++      "id": "fast_local_checks",
++      "kind": "fast_local_checks",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [
++        "agentplane task verify-show <task-id>",
++        "project focused checks"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "check_result"
++      ]
++    },
++    {
++      "id": "pr_artifact",
++      "kind": "pr_artifact",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [
++        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "artifact",
++        "external_link"
++      ]
++    },
++    {
++      "id": "verify_record",
++      "kind": "verify_record",
++      "mode": "record",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "check_result"
++      ]
++    },
++    {
++      "id": "quality_gate",
++      "kind": "quality_gate",
++      "mode": "agentic",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [
++        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "quality_report"
++      ]
++    },
++    {
++      "id": "hosted_checks",
++      "kind": "hosted_checks",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "check_result",
++        "external_link"
++      ]
++    },
++    {
++      "id": "publish_or_integrate",
++      "kind": "publish_or_integrate",
++      "mode": "deterministic",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [
++        "agentplane integrate <task-id> --branch <branch> --run-verify"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "commit",
++        "external_link"
++      ]
++    },
++    {
++      "id": "finish",
++      "kind": "finish",
++      "mode": "deterministic",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "commit"
++      ]
++    }
++  ],
++  "requiredEvidence": [
++    {
++      "id": "code_pr.paths",
++      "kind": "changed_paths",
++      "producedBy": "work_unit",
++      "required": true,
++      "description": "Changed source paths."
++    },
++    {
++      "id": "code_pr.fast_checks",
++      "kind": "check_result",
++      "producedBy": "fast_local_checks",
++      "required": true,
++      "description": "Fast local checks."
++    },
++    {
++      "id": "code_pr.pr",
++      "kind": "external_link",
++      "producedBy": "pr_artifact",
++      "required": true,
++      "description": "Pull request artifact."
++    },
++    {
++      "id": "code_pr.verify",
++      "kind": "check_result",
++      "producedBy": "verify_record",
++      "required": true,
++      "description": "Task branch verification."
++    },
++    {
++      "id": "code_pr.quality",
++      "kind": "quality_report",
++      "producedBy": "quality_gate",
++      "required": true,
++      "description": "EVALUATOR quality verdict."
++    },
++    {
++      "id": "code_pr.hosted",
++      "kind": "check_result",
++      "producedBy": "hosted_checks",
++      "required": true,
++      "description": "Hosted check evidence."
++    },
++    {
++      "id": "code_pr.commit",
++      "kind": "commit",
++      "producedBy": "publish_or_integrate",
++      "required": true,
++      "description": "Integration commit."
++    }
++  ],
++  "policyModules": [
++    ".agentplane/policy/dod.code.md",
++    ".agentplane/policy/dod.core.md",
++    ".agentplane/policy/security.must.md",
++    ".agentplane/policy/workflow.branch_pr.md"
++  ],
++  "allowedCommands": [
++    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
++    "agentplane integrate <task-id> --branch <branch> --run-verify",
++    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
++    "agentplane task verify-show <task-id>",
++    "agentplane verify <task-id> --ok|--rework",
++    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
++    "project focused checks"
++  ],
++  "contextBudget": {
++    "maxPolicyModules": 4,
++    "maxPromptBlocks": 14,
++    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
++  },
++  "contextManifest": [],
++  "acceptedRecipeExtensions": [],
++  "rejectedRecipeExtensions": [],
++  "stopReasons": [],
++  "selectionReasons": [
++    "explicit blueprint requested: code.branch_pr",
++    "task intent kind: code",
++    "workflow mode: branch_pr",
++    "task intent mutation scope: code"
++  ],
++  "digest": {
++    "algorithm": "sha256",
++    "value": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328"
++  }
++}
+diff --git a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-diff.patch b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-diff.patch
+new file mode 100644
+index 000000000..998197253
+--- /dev/null
++++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-diff.patch
+@@ -0,0 +1,1119 @@
++diff --git a/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt b/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
++index e69de29bb..52631f73e 100644
++--- a/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
+++++ b/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
++@@ -0,0 +1,14 @@
+++ .../src/cli/run-cli.core.task-run.test.ts          |   6 +
+++ .../src/commands/hermes/hermes-runtime.ts          |  17 +-
+++ .../src/commands/hermes/hermes.command.test.ts     |  45 +++++-
+++ .../src/commands/shared/workflow-supervisor.ts     |   8 +
+++ .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
+++ .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
+++ .../agentplane/src/commands/task/run.command.ts    |  41 ++---
+++ .../task/task-run-effect-resolution.command.ts     |  28 ++--
+++ .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
+++ .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
+++ .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
+++ .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
+++ .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
+++ 13 files changed, 552 insertions(+), 60 deletions(-)
++diff --git a/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md b/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
++index a8e0b91f7..93a630f1c 100644
++--- a/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
+++++ b/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
++@@ -24,12 +24,25 @@ RF-25d: make runner preparation, invocation, observation, evaluation, and lifecy
++ <details>
++ <summary>Raw evidence</summary>
++ 
++-- Updated: 2026-07-28T01:55:50.166Z
+++- Updated: 2026-07-28T01:56:15.744Z
++ - Branch: task/202607221850-R7WS01/return-typed-runner-lifecycle-results
++ - Head: computed live by `agentplane pr check` / `agentplane integrate`
++ 
++ ```text
++-No changes detected.
+++ .../src/cli/run-cli.core.task-run.test.ts          |   6 +
+++ .../src/commands/hermes/hermes-runtime.ts          |  17 +-
+++ .../src/commands/hermes/hermes.command.test.ts     |  45 +++++-
+++ .../src/commands/shared/workflow-supervisor.ts     |   8 +
+++ .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
+++ .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
+++ .../agentplane/src/commands/task/run.command.ts    |  41 ++---
+++ .../task/task-run-effect-resolution.command.ts     |  28 ++--
+++ .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
+++ .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
+++ .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
+++ .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
+++ .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
+++ 13 files changed, 552 insertions(+), 60 deletions(-)
++ ```
++ 
++ </details>
++diff --git a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
++index 3cb7d5fb7..d56bd6627 100644
++--- a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+++++ b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
++@@ -2,11 +2,14 @@
++   "base": "main",
++   "branch": "task/202607221850-R7WS01/return-typed-runner-lifecycle-results",
++   "created_at": "2026-07-28T01:55:50.166Z",
++-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+++  "diffstat_sha256": "sha256:da831a54df8e685f7cb8a449136121ba3ff3501a78568ca3c61e81df7cbb34c4",
++   "last_verified_at": null,
+++  "pr_number": 4650,
+++  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4650",
++   "schema_version": 1,
+++  "status": "OPEN",
++   "task_id": "202607221850-R7WS01",
++-  "updated_at": "2026-07-28T01:55:50.166Z",
+++  "updated_at": "2026-07-28T01:56:15.744Z",
++   "verify": {
++     "status": "skipped"
++   }
++diff --git a/.agentplane/tasks/202607221850-R7WS01/pr/review.md b/.agentplane/tasks/202607221850-R7WS01/pr/review.md
++index 3fea7a892..95c56904d 100644
++--- a/.agentplane/tasks/202607221850-R7WS01/pr/review.md
+++++ b/.agentplane/tasks/202607221850-R7WS01/pr/review.md
++@@ -24,12 +24,25 @@ Created: 2026-07-28T01:55:50.166Z
++ <details>
++ <summary>Raw evidence</summary>
++ 
++-- Updated: 2026-07-28T01:55:50.166Z
+++- Updated: 2026-07-28T01:56:15.744Z
++ - Branch: task/202607221850-R7WS01/return-typed-runner-lifecycle-results
++ - Head: computed live by `agentplane pr check` / `agentplane integrate`
++ 
++ ```text
++-No changes detected.
+++ .../src/cli/run-cli.core.task-run.test.ts          |   6 +
+++ .../src/commands/hermes/hermes-runtime.ts          |  17 +-
+++ .../src/commands/hermes/hermes.command.test.ts     |  45 +++++-
+++ .../src/commands/shared/workflow-supervisor.ts     |   8 +
+++ .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
+++ .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
+++ .../agentplane/src/commands/task/run.command.ts    |  41 ++---
+++ .../task/task-run-effect-resolution.command.ts     |  28 ++--
+++ .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
+++ .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
+++ .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
+++ .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
+++ .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
+++ 13 files changed, 552 insertions(+), 60 deletions(-)
++ ```
++ 
++ </details>
++diff --git a/packages/agentplane/src/cli/run-cli.core.task-run.test.ts b/packages/agentplane/src/cli/run-cli.core.task-run.test.ts
++index 038ffcc9b..fc89ead4a 100644
++--- a/packages/agentplane/src/cli/run-cli.core.task-run.test.ts
+++++ b/packages/agentplane/src/cli/run-cli.core.task-run.test.ts
++@@ -126,6 +126,7 @@ describe("runCli task run", () => {
++       invocation: {
++         adapter_id: "custom",
++         run_id: "run-degraded-cleanup",
+++        work_order_id: "work-order-degraded-cleanup",
++         run_dir: "/repo/run",
++         bundle_path: "/repo/run/bundle.json",
++         bootstrap_path: "/repo/run/bootstrap.md",
++@@ -136,6 +137,11 @@ describe("runCli task run", () => {
++         exit_code: 0,
++         summary: "provider completed",
++       },
+++      state: {
+++        mode: "execute",
+++        status: "success",
+++      },
+++      bundle: {},
++       active_claim_cleanup: cleanup,
++     } as unknown as Awaited<ReturnType<typeof taskRunUsecases.executeTaskRunnerExecution>>;
++     const executeSpy = vi
++diff --git a/packages/agentplane/src/commands/hermes/hermes-runtime.ts b/packages/agentplane/src/commands/hermes/hermes-runtime.ts
++index 1bf76e7fd..e50890cc7 100644
++--- a/packages/agentplane/src/commands/hermes/hermes-runtime.ts
+++++ b/packages/agentplane/src/commands/hermes/hermes-runtime.ts
++@@ -6,6 +6,11 @@ import {
++   executeTaskRunnerExecution,
++   prepareTaskRunnerExecution,
++ } from "../../runner/usecases/task-run.js";
+++import {
+++  projectExecutedTaskRunnerLifecycleResult,
+++  projectPreparedTaskRunnerLifecycleResult,
+++  taskRunnerLifecycleExitCode,
+++} from "../../runner/usecases/task-run-lifecycle-result.js";
++ import {
++   prepareAgentWorkOrder,
++   requirePreparedAgentWorkOrder,
++@@ -271,11 +276,16 @@ export async function executeHermesWorkflowOperation(opts: {
++       mode: "dry_run",
++       ...(opts.includeRemote ? { include_remote: true } : {}),
++     });
+++    const lifecycle = projectPreparedTaskRunnerLifecycleResult({
+++      task_id: taskId,
+++      execution: prepared,
+++    });
++     return {
++       status: "succeeded",
++       observed_postconditions: ["runner_state_observed"],
++       detail: `prepared runner invocation ${prepared.invocation.run_id} for ${taskId}`,
++       exit_code: null,
+++      operation_result: { kind: "runner_lifecycle", value: lifecycle },
++     };
++   }
++ 
++@@ -286,12 +296,17 @@ export async function executeHermesWorkflowOperation(opts: {
++     task_id: taskId,
++     ...(opts.includeRemote ? { include_remote: true } : {}),
++   });
++-  const succeeded = executed.result.status === "success" && !executed.active_claim_cleanup;
+++  const lifecycle = projectExecutedTaskRunnerLifecycleResult({
+++    task_id: taskId,
+++    execution: executed,
+++  });
+++  const succeeded = taskRunnerLifecycleExitCode(lifecycle) === 0;
++   return {
++     status: succeeded ? "succeeded" : "failed",
++     observed_postconditions: ["runner_state_observed"],
++     detail: executed.result.summary ?? `runner execution completed for ${taskId}`,
++     exit_code: executed.result.exit_code,
+++    operation_result: { kind: "runner_lifecycle", value: lifecycle },
++   };
++ }
++ 
++diff --git a/packages/agentplane/src/commands/hermes/hermes.command.test.ts b/packages/agentplane/src/commands/hermes/hermes.command.test.ts
++index 6536f4b90..c2758bcfc 100644
++--- a/packages/agentplane/src/commands/hermes/hermes.command.test.ts
+++++ b/packages/agentplane/src/commands/hermes/hermes.command.test.ts
++@@ -233,7 +233,27 @@ describe("hermes adapter commands", () => {
++           requested: boolean;
++           dry_run: boolean;
++           allowed: boolean;
++-          result: { detail: string; exit_code: number | null };
+++          result: {
+++            detail: string;
+++            exit_code: number | null;
+++            operation_result: {
+++              kind: string;
+++              value: {
+++                schema: string;
+++                phase: string;
+++                task_id: string;
+++                invocation: { work_order_id: string };
+++                lifecycle: {
+++                  effect: {
+++                    state: string;
+++                    authority: { ref: string; digest: string } | null;
+++                    observed_evidence: { code: string; digest: string | null } | null;
+++                    claim_generation: string | null;
+++                  };
+++                };
+++              };
+++            };
+++          };
++         };
++         workflow_supervision: { audit: { event: string }[] };
++         refreshed_route: { task: { id: string } };
++@@ -244,6 +264,29 @@ describe("hermes adapter commands", () => {
++       expect(payload.execution.allowed).toBe(true);
++       expect(payload.execution.result.detail).toContain(taskId);
++       expect(payload.execution.result.exit_code).toBeNull();
+++      expect(payload.execution.result.operation_result).toMatchObject({
+++        kind: "runner_lifecycle",
+++        value: {
+++          schema: "agentplane.task_runner_lifecycle_result.v1",
+++          phase: "prepared",
+++          task_id: taskId,
+++          lifecycle: {
+++            effect: {
+++              state: "not_recorded",
+++              authority: {
+++                ref: expect.stringContaining("work-order:"),
+++                digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+++              },
+++              observed_evidence: {
+++                code: "runner_effect_operation_prepared",
+++                digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+++              },
+++              claim_generation: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+++            },
+++          },
+++        },
+++      });
+++      expect(payload.execution.result.operation_result.value.invocation.work_order_id).toContain(taskId);
++       expect(payload.workflow_supervision.audit.map((entry) => entry.event)).toEqual([
++         "decision_observed",
++         "operation_executed",
++diff --git a/packages/agentplane/src/commands/shared/workflow-supervisor.ts b/packages/agentplane/src/commands/shared/workflow-supervisor.ts
++index bb565b5d9..8b433e5d6 100644
++--- a/packages/agentplane/src/commands/shared/workflow-supervisor.ts
+++++ b/packages/agentplane/src/commands/shared/workflow-supervisor.ts
++@@ -1,4 +1,5 @@
++ import type { TaskRouteDecision } from "./route-decision-types.js";
+++import type { TaskRunnerLifecycleResult } from "../../runner/usecases/task-run-lifecycle-result.js";
++ import { projectWorkflowOperationArgv } from "./workflow-operation-projection.js";
++ import { WORKFLOW_OPERATION_REGISTRY, type WorkflowOperation } from "./workflow-step.js";
++ 
++@@ -23,11 +24,18 @@ type WorkflowSupervisorAuditEntry = {
++   detail: string;
++ };
++ 
+++export type WorkflowSupervisorOperationPayload = {
+++  kind: "runner_lifecycle";
+++  value: TaskRunnerLifecycleResult;
+++};
+++
++ export type WorkflowSupervisorOperationResult = {
++   status: "succeeded" | "failed";
++   observed_postconditions: readonly string[];
++   detail: string;
++   exit_code: number | null;
+++  /** Typed in-process data for migrated operation slices; never parsed from stdout. */
+++  operation_result?: WorkflowSupervisorOperationPayload;
++ };
++ 
++ export type WorkflowSupervisorExecution = {
++diff --git a/packages/agentplane/src/commands/task/run-render.test.ts b/packages/agentplane/src/commands/task/run-render.test.ts
++index 98acc2538..f63ca29ff 100644
++--- a/packages/agentplane/src/commands/task/run-render.test.ts
+++++ b/packages/agentplane/src/commands/task/run-render.test.ts
++@@ -4,13 +4,151 @@ import { captureStdIO } from "@agentplane/testkit";
++ import { readObservedProcessIdentity } from "../../runner/process-supervision/signals.js";
++ import type { LoadedTaskRunnerInspection } from "../../runner/usecases/task-run-inspect.js";
++ import {
+++  projectExecutedTaskRunnerLifecycleResult,
+++  type TaskRunnerLifecycleResult,
+++} from "../../runner/usecases/task-run-lifecycle-result.js";
+++import {
+++  reportExecutedTaskRun,
++   reportRunnerStatus,
+++  renderTaskRunnerLifecyclePayload,
++   renderRunnerStatusPayload,
++   renderTaskRunPayload,
++   runnerReconciliationWarning,
++ } from "./run-render.js";
++ 
++ describe("task run rendering", () => {
+++  it("renders the typed effect lifecycle without parsing a runner report", () => {
+++    const lifecycle = {
+++      schema: "agentplane.task_runner_lifecycle_result.v1",
+++      phase: "executed",
+++      task_id: "TASK-EFFECT",
+++      invocation: {
+++        adapter_id: "codex",
+++        run_id: "run-effect",
+++        work_order_id: "work-order-effect",
+++        run_dir: "/repo/runs/run-effect",
+++        bundle_path: "/repo/runs/run-effect/bundle.json",
+++        bootstrap_path: "/repo/runs/run-effect/bootstrap.md",
+++        result_path: "/repo/runs/run-effect/result.json",
+++      },
+++      lifecycle: {
+++        mode: "execute",
+++        status: "failed",
+++        state_fingerprint: null,
+++        effect: {
+++          state: "effect_in_doubt",
+++          operation: {
+++            operation_key: `sha256:${"a".repeat(64)}`,
+++            operation_digest: `sha256:${"b".repeat(64)}`,
+++            claim_generation: `sha256:${"c".repeat(64)}`,
+++          },
+++          authority: {
+++            ref: "work-order:work-order-effect",
+++            digest: `sha256:${"e".repeat(64)}`,
+++          },
+++          observed_evidence: {
+++            code: "runner_adapter_effect_error",
+++            digest: `sha256:${"f".repeat(64)}`,
+++          },
+++          claim_generation: `sha256:${"c".repeat(64)}`,
+++          resolution: null,
+++          resolution_provenance: null,
+++          source_resolution: null,
+++          source_resolution_provenance: null,
+++        },
+++        work_order_authority: null,
+++      },
+++      result: {
+++        status: "failed",
+++        exit_code: 1,
+++        started_at: "2026-07-28T00:00:00.000Z",
+++        ended_at: "2026-07-28T00:00:01.000Z",
+++        summary: "provider outcome is uncertain",
+++      },
+++      active_claim_cleanup: null,
+++    } as unknown as TaskRunnerLifecycleResult;
+++
+++    const payload = renderTaskRunnerLifecyclePayload(lifecycle);
+++    expect(payload).toMatchObject({
+++      task_id: "TASK-EFFECT",
+++      work_order_id: "work-order-effect",
+++      lifecycle_result: {
+++        lifecycle: {
+++          effect: {
+++            state: "effect_in_doubt",
+++            operation: { claim_generation: `sha256:${"c".repeat(64)}` },
+++            authority: { digest: `sha256:${"e".repeat(64)}` },
+++            observed_evidence: { digest: `sha256:${"f".repeat(64)}` },
+++            resolution: null,
+++          },
+++        },
+++      },
+++    });
+++
+++    const io = captureStdIO();
+++    try {
+++      reportExecutedTaskRun(payload, "TASK-EFFECT");
+++      expect(io.stdout).toMatch(/work_order:\s+work-order-effect/u);
+++      expect(io.stdout).toMatch(/effect:\s+effect_in_doubt/u);
+++      expect(io.stdout).toMatch(new RegExp(`effect_authority:\\s+sha256:${"e".repeat(64)}`, "u"));
+++      expect(io.stdout).toMatch(new RegExp(`effect_evidence:\\s+sha256:${"f".repeat(64)}`, "u"));
+++      expect(io.stdout).toMatch(
+++        new RegExp(`effect_claim_generation:\\s+sha256:${"c".repeat(64)}`, "u"),
+++      );
+++    } finally {
+++      io.restore();
+++    }
+++
+++    for (const verdict of ["applied", "not_applied"] as const) {
+++      const resolved = projectExecutedTaskRunnerLifecycleResult({
+++        task_id: "TASK-EFFECT",
+++        execution: {
+++          ...lifecycle,
+++          bundle: {},
+++          state: {
+++            mode: "execute",
+++            status: "blocked",
+++            effect_resolution: {
+++              verdict,
+++              digest: `sha256:${"d".repeat(64)}`,
+++            },
+++          },
+++          effect_operation: {
+++            operation: {
+++              authority_ref: "work-order:work-order-effect",
+++              authority_digest: `sha256:${"e".repeat(64)}`,
+++              claim_generation: `sha256:${"c".repeat(64)}`,
+++            },
+++            journal: {
+++              observed_evidence: {
+++                code: "operator_resolution_evidence",
+++                digest: `sha256:${"f".repeat(64)}`,
+++              },
+++            },
+++          },
+++          source_effect_resolution: {
+++            verdict: "not_applied",
+++            digest: `sha256:${"g".repeat(64)}`,
+++          },
+++        } as unknown as Parameters<typeof projectExecutedTaskRunnerLifecycleResult>[0]["execution"],
+++        source_effect_resolution: {
+++          verdict: "not_applied",
+++          digest: `sha256:${"g".repeat(64)}`,
+++        } as unknown as TaskRunnerLifecycleResult["lifecycle"]["effect"]["source_resolution"],
+++      });
+++      expect(resolved.lifecycle.effect).toMatchObject({
+++        state: verdict,
+++        resolution: { verdict },
+++        resolution_provenance: "operator_supplied",
+++        authority: { digest: `sha256:${"e".repeat(64)}` },
+++        observed_evidence: { digest: `sha256:${"f".repeat(64)}` },
+++        claim_generation: `sha256:${"c".repeat(64)}`,
+++        source_resolution: { verdict: "not_applied" },
+++        source_resolution_provenance: "operator_supplied",
+++      });
+++    }
+++  });
+++
++   it("keeps execution status and verification confidence distinct", () => {
++     expect(
++       renderTaskRunPayload({
++diff --git a/packages/agentplane/src/commands/task/run-render.ts b/packages/agentplane/src/commands/task/run-render.ts
++index 70aa55bb1..3b8b69c58 100644
++--- a/packages/agentplane/src/commands/task/run-render.ts
+++++ b/packages/agentplane/src/commands/task/run-render.ts
++@@ -5,6 +5,7 @@ import type {
++   TaskRunnerDiagnosticInspection,
++ } from "../../runner/usecases/task-run-inspect.js";
++ import type { TaskRunnerActiveClaimCleanupDiagnostic } from "../../runner/usecases/task-run-active-claim-runtime.js";
+++import type { TaskRunnerLifecycleResult } from "../../runner/usecases/task-run-lifecycle-result.js";
++ import type { RunnerLifecycleStatus } from "../../runner/types.js";
++ import {
++   isProcessAlive,
++@@ -51,6 +52,38 @@ export function renderTaskRunPayload(opts: {
++   };
++ }
++ 
+++/**
+++ * Compatibility renderer for the typed in-process lifecycle result. The
+++ * existing top-level fields stay stable while the additive lifecycle object
+++ * exposes durable effect and authority evidence without stdout parsing.
+++ */
+++export function renderTaskRunnerLifecyclePayload(result: TaskRunnerLifecycleResult) {
+++  return {
+++    ...renderTaskRunPayload({
+++      taskId: result.task_id,
+++      mode: result.lifecycle.mode,
+++      adapterId: result.invocation.adapter_id,
+++      runId: result.invocation.run_id,
+++      runDir: result.invocation.run_dir,
+++      bundlePath: result.invocation.bundle_path,
+++      bootstrapPath: result.invocation.bootstrap_path ?? "",
+++      resultPath: result.invocation.result_path,
+++      ...(result.phase === "executed" ? { status: result.result?.status } : {}),
+++      verificationState: result.result?.execution_receipt?.verification_state,
+++      receiptPath: result.result?.execution_receipt?.path,
+++      exitCode: result.result?.exit_code,
+++      summary: result.result?.summary,
+++      activeClaimCleanup: result.active_claim_cleanup ?? undefined,
+++    }),
+++    work_order_id: result.invocation.work_order_id,
+++    lifecycle_result: result,
+++  };
+++}
+++
+++type TaskRunRendererPayload =
+++  | ReturnType<typeof renderTaskRunPayload>
+++  | ReturnType<typeof renderTaskRunnerLifecyclePayload>;
+++
++ export function isTerminalRunnerStatus(status: RunnerLifecycleStatus): boolean {
++   return (
++     status === "success" || status === "failed" || status === "blocked" || status === "cancelled"
++@@ -379,7 +412,7 @@ export async function loadRunnerLogText(
++ }
++ 
++ export function reportPreparedTaskRun(
++-  payload: ReturnType<typeof renderTaskRunPayload>,
+++  payload: TaskRunRendererPayload,
++   taskId: string,
++ ): void {
++   createCliEmitter().report(
++@@ -388,6 +421,24 @@ export function reportPreparedTaskRun(
++       { label: "mode", value: payload.mode },
++       { label: "adapter", value: payload.adapter_id },
++       { label: "run", value: payload.run_id },
+++      ...("lifecycle_result" in payload
+++        ? [
+++            { label: "work_order", value: payload.lifecycle_result.invocation.work_order_id },
+++            { label: "effect", value: payload.lifecycle_result.lifecycle.effect.state },
+++            {
+++              label: "effect_authority",
+++              value: payload.lifecycle_result.lifecycle.effect.authority?.digest ?? null,
+++            },
+++            {
+++              label: "effect_evidence",
+++              value: payload.lifecycle_result.lifecycle.effect.observed_evidence?.digest ?? null,
+++            },
+++            {
+++              label: "effect_claim_generation",
+++              value: payload.lifecycle_result.lifecycle.effect.claim_generation,
+++            },
+++          ]
+++        : []),
++       { label: "bundle", value: payload.bundle_path },
++       { label: "bootstrap", value: payload.bootstrap_path },
++       { label: "result", value: payload.result_path },
++@@ -397,7 +448,7 @@ export function reportPreparedTaskRun(
++ }
++ 
++ export function reportExecutedTaskRun(
++-  payload: ReturnType<typeof renderTaskRunPayload>,
+++  payload: TaskRunRendererPayload,
++   taskId: string,
++ ): void {
++   createCliEmitter().report(
++@@ -406,6 +457,36 @@ export function reportExecutedTaskRun(
++       { label: "mode", value: payload.mode },
++       { label: "adapter", value: payload.adapter_id },
++       { label: "run", value: payload.run_id },
+++      ...("lifecycle_result" in payload
+++        ? [
+++            { label: "work_order", value: payload.lifecycle_result.invocation.work_order_id },
+++            { label: "effect", value: payload.lifecycle_result.lifecycle.effect.state },
+++            {
+++              label: "effect_resolution",
+++              value: payload.lifecycle_result.lifecycle.effect.resolution?.verdict ?? null,
+++            },
+++            {
+++              label: "effect_authority",
+++              value: payload.lifecycle_result.lifecycle.effect.authority?.digest ?? null,
+++            },
+++            {
+++              label: "effect_evidence",
+++              value: payload.lifecycle_result.lifecycle.effect.observed_evidence?.digest ?? null,
+++            },
+++            {
+++              label: "effect_claim_generation",
+++              value: payload.lifecycle_result.lifecycle.effect.claim_generation,
+++            },
+++            ...(payload.lifecycle_result.lifecycle.effect.source_resolution
+++              ? [
+++                  {
+++                    label: "source_effect_resolution",
+++                    value: payload.lifecycle_result.lifecycle.effect.source_resolution.verdict,
+++                  },
+++                ]
+++              : []),
+++          ]
+++        : []),
++       { label: "status", value: payload.status ?? "unknown" },
++       { label: "verification", value: payload.verification_state ?? "unavailable" },
++       { label: "exit_code", value: payload.exit_code ?? null },
++diff --git a/packages/agentplane/src/commands/task/run.command.ts b/packages/agentplane/src/commands/task/run.command.ts
++index 1f8c31213..7836ade9a 100644
++--- a/packages/agentplane/src/commands/task/run.command.ts
+++++ b/packages/agentplane/src/commands/task/run.command.ts
++@@ -5,6 +5,11 @@ import {
++   executeTaskRunnerExecution,
++   prepareTaskRunnerExecution,
++ } from "../../runner/usecases/task-run.js";
+++import {
+++  projectExecutedTaskRunnerLifecycleResult,
+++  projectPreparedTaskRunnerLifecycleResult,
+++  taskRunnerLifecycleExitCode,
+++} from "../../runner/usecases/task-run-lifecycle-result.js";
++ import { RUNNER_SANDBOX_MODES } from "../../runner/types.js";
++ import {
++   loadTaskRunnerDiagnosticInspection,
++@@ -19,7 +24,7 @@ import {
++   renderRunnerDiagnosticStatusPayload,
++   renderRunnerStatusPayload,
++   runnerReconciliationWarning,
++-  renderTaskRunPayload,
+++  renderTaskRunnerLifecyclePayload,
++   reportExecutedTaskRun,
++   reportPreparedTaskRun,
++   tailText,
++@@ -277,16 +282,11 @@ export function makeRunTaskRunHandler(getCtx: (cmd: string) => Promise<CommandCo
++         danger_authority: dangerAuthority,
++         sandbox_override: parsed.sandbox,
++       });
++-      const payload = renderTaskRunPayload({
++-        taskId: parsed.taskId,
++-        mode: "dry_run",
++-        adapterId: prepared.invocation.adapter_id,
++-        runId: prepared.invocation.run_id,
++-        runDir: prepared.invocation.run_dir,
++-        bundlePath: prepared.invocation.bundle_path,
++-        bootstrapPath: prepared.invocation.bootstrap_path ?? "",
++-        resultPath: prepared.invocation.result_path,
+++      const lifecycle = projectPreparedTaskRunnerLifecycleResult({
+++        task_id: parsed.taskId,
+++        execution: prepared,
++       });
+++      const payload = renderTaskRunnerLifecyclePayload(lifecycle);
++       if (parsed.json) {
++         output.json(payload);
++       } else {
++@@ -304,28 +304,17 @@ export function makeRunTaskRunHandler(getCtx: (cmd: string) => Promise<CommandCo
++       danger_authority: dangerAuthority,
++       sandbox_override: parsed.sandbox,
++     });
++-    const payload = renderTaskRunPayload({
++-      taskId: parsed.taskId,
++-      mode: "execute",
++-      adapterId: executed.invocation.adapter_id,
++-      runId: executed.invocation.run_id,
++-      runDir: executed.invocation.run_dir,
++-      bundlePath: executed.invocation.bundle_path,
++-      bootstrapPath: executed.invocation.bootstrap_path ?? "",
++-      resultPath: executed.invocation.result_path,
++-      status: executed.result.status,
++-      verificationState: executed.result.execution_receipt?.verification_state,
++-      receiptPath: executed.result.execution_receipt?.path,
++-      exitCode: executed.result.exit_code,
++-      summary: executed.result.summary,
++-      activeClaimCleanup: executed.active_claim_cleanup,
+++    const lifecycle = projectExecutedTaskRunnerLifecycleResult({
+++      task_id: parsed.taskId,
+++      execution: executed,
++     });
+++    const payload = renderTaskRunnerLifecyclePayload(lifecycle);
++     if (parsed.json) {
++       output.json(payload);
++     } else {
++       reportExecutedTaskRun(payload, parsed.taskId);
++     }
++-    return executed.result.status === "success" && !executed.active_claim_cleanup ? 0 : 1;
+++    return taskRunnerLifecycleExitCode(lifecycle);
++   };
++ }
++ 
++diff --git a/packages/agentplane/src/commands/task/task-run-effect-resolution.command.ts b/packages/agentplane/src/commands/task/task-run-effect-resolution.command.ts
++index 0271ced3d..686d6c678 100644
++--- a/packages/agentplane/src/commands/task/task-run-effect-resolution.command.ts
+++++ b/packages/agentplane/src/commands/task/task-run-effect-resolution.command.ts
++@@ -3,12 +3,16 @@ import { RUNNER_EFFECT_RESOLUTION_VERDICT_VALUES } from "@agentplaneorg/core/sch
++ import { createCliEmitter, infoMessage } from "../../cli/output.js";
++ import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
++ import { resumeTaskRunnerEffectExecution } from "../../runner/usecases/task-run-lifecycle.js";
+++import {
+++  projectExecutedTaskRunnerLifecycleResult,
+++  taskRunnerLifecycleExitCode,
+++} from "../../runner/usecases/task-run-lifecycle-result.js";
++ import {
++   acceptLegacyTaskRunnerEffect,
++   resolveTaskRunnerEffect,
++ } from "../../runner/usecases/task-run-effect-resolution.js";
++ import type { CommandContext } from "../shared/task-backend.js";
++-import { renderTaskRunPayload, reportExecutedTaskRun } from "./run-render.js";
+++import { renderTaskRunnerLifecyclePayload, reportExecutedTaskRun } from "./run-render.js";
++ 
++ type TaskRunResolveEffectParsed = {
++   taskId: string;
++@@ -258,25 +262,15 @@ export function makeRunTaskRunResumeEffectHandler(
++       run_id: parsed.runId,
++       ...(parsed.newRunId ? { new_run_id: parsed.newRunId } : {}),
++     });
++-    const payload = renderTaskRunPayload({
++-      taskId: parsed.taskId,
++-      mode: "execute",
++-      adapterId: resumed.invocation.adapter_id,
++-      runId: resumed.invocation.run_id,
++-      runDir: resumed.invocation.run_dir,
++-      bundlePath: resumed.invocation.bundle_path,
++-      bootstrapPath: resumed.invocation.bootstrap_path ?? "",
++-      resultPath: resumed.invocation.result_path,
++-      status: resumed.result.status,
++-      verificationState: resumed.result.execution_receipt?.verification_state,
++-      receiptPath: resumed.result.execution_receipt?.path,
++-      exitCode: resumed.result.exit_code,
++-      summary: resumed.result.summary,
++-      activeClaimCleanup: resumed.active_claim_cleanup,
+++    const lifecycle = projectExecutedTaskRunnerLifecycleResult({
+++      task_id: parsed.taskId,
+++      execution: resumed,
+++      source_effect_resolution: resumed.source_effect_resolution,
++     });
+++    const payload = renderTaskRunnerLifecyclePayload(lifecycle);
++     const output = createCliEmitter();
++     if (parsed.json) output.json(payload);
++     else reportExecutedTaskRun(payload, parsed.taskId);
++-    return resumed.result.status === "success" && !resumed.active_claim_cleanup ? 0 : 1;
+++    return taskRunnerLifecycleExitCode(lifecycle);
++   };
++ }
++diff --git a/packages/agentplane/src/runner/usecases/task-run-effect-journal.ts b/packages/agentplane/src/runner/usecases/task-run-effect-journal.ts
++index d0c2a0f57..5444170f7 100644
++--- a/packages/agentplane/src/runner/usecases/task-run-effect-journal.ts
+++++ b/packages/agentplane/src/runner/usecases/task-run-effect-journal.ts
++@@ -1,4 +1,8 @@
++-import { digestRunnerEffectValue } from "@agentplaneorg/core/schemas";
+++import {
+++  digestRunnerEffectValue,
+++  type RunnerEffectJournal,
+++  type RunnerEffectOperation,
+++} from "@agentplaneorg/core/schemas";
++ 
++ import {
++   advanceRunnerEffectJournal,
++@@ -16,6 +20,11 @@ import type {
++   RunnerStateFingerprintRecord,
++ } from "../types.js";
++ 
+++export type TaskRunnerEffectOperationSnapshot = {
+++  operation: RunnerEffectOperation;
+++  journal: RunnerEffectJournal;
+++};
+++
++ export async function persistPreparedTaskRunnerEffectOperation(opts: {
++   repository: RunnerRunRepository;
++   bundle: RunnerContextBundle;
++@@ -24,7 +33,10 @@ export async function persistPreparedTaskRunnerEffectOperation(opts: {
++   task_id: string;
++   source_run_id?: string | null;
++   resolved_not_applied_source?: boolean;
++-}): Promise<RunnerRunState> {
+++}): Promise<{
+++  state: RunnerRunState;
+++  effect_operation: TaskRunnerEffectOperationSnapshot;
+++}> {
++   if (!opts.state.state_fingerprint) {
++     throw new Error(
++       `Runner prepared state is missing effect-journal fingerprint authority for ` +
++@@ -44,7 +56,13 @@ export async function persistPreparedTaskRunnerEffectOperation(opts: {
++     updated_at: new Date().toISOString(),
++   };
++   await opts.repository.writeState(state);
++-  return state;
+++  return {
+++    state,
+++    effect_operation: {
+++      operation: effectOperation.operation,
+++      journal: effectOperation.journal,
+++    },
+++  };
++ }
++ 
++ export async function startTaskRunnerEffectOperation(opts: {
++@@ -102,8 +120,8 @@ async function recordTaskRunnerEffectAccepted(opts: {
++   session: StartedRunnerEffectOperation;
++   result: RunnerResult;
++   state_fingerprint: RunnerStateFingerprintRecord;
++-}): Promise<void> {
++-  await advanceRunnerEffectJournal({
+++}): Promise<RunnerEffectJournal> {
+++  return await advanceRunnerEffectJournal({
++     session: opts.session,
++     phase: "accepted",
++     evidence: {
++@@ -125,7 +143,7 @@ export async function persistTaskRunnerEffectAccepted<T>(opts: {
++   result: RunnerResult;
++   state_fingerprint: RunnerStateFingerprintRecord;
++   persist_post_effect_state: () => Promise<T>;
++-}): Promise<T> {
+++}): Promise<{ state: T; journal: RunnerEffectJournal }> {
++   if (!opts.session) {
++     throw new Error(
++       `Runner adapter returned without a durable effect operation for ` +
++@@ -144,10 +162,10 @@ export async function persistTaskRunnerEffectAccepted<T>(opts: {
++     });
++     throw error;
++   }
++-  await recordTaskRunnerEffectAccepted({
+++  const journal = await recordTaskRunnerEffectAccepted({
++     session: opts.session,
++     result: opts.result,
++     state_fingerprint: opts.state_fingerprint,
++   });
++-  return state;
+++  return { state, journal };
++ }
++diff --git a/packages/agentplane/src/runner/usecases/task-run-lifecycle-replay.ts b/packages/agentplane/src/runner/usecases/task-run-lifecycle-replay.ts
++index 5650776fb..960868c23 100644
++--- a/packages/agentplane/src/runner/usecases/task-run-lifecycle-replay.ts
+++++ b/packages/agentplane/src/runner/usecases/task-run-lifecycle-replay.ts
++@@ -1,4 +1,5 @@
++ import type { TaskData, TaskRunnerHistoryEntry } from "../../backends/task-backend.js";
+++import type { RunnerEffectResolutionRef } from "@agentplaneorg/core/schemas";
++ import { loadCommandContext, type CommandContext } from "../../commands/shared/task-backend.js";
++ import { CliError } from "../../shared/errors.js";
++ import { RunnerRunDirectoryBoundaryError } from "../run-directory-boundary.js";
++@@ -24,6 +25,7 @@ type FreshReplayExecution = ExecutedTaskRunnerExecution & {
++   ctx: CommandContext;
++   source_run_id: string;
++   source_status: RunnerLifecycleStatus;
+++  source_effect_resolution: RunnerEffectResolutionRef | null;
++ };
++ 
++ function replaySourceGuidance(source: TaskRunnerHistoryEntry, taskId: string): string {
++@@ -254,6 +256,7 @@ async function executeFreshReplay(opts: {
++     run_id: opts.run_id,
++     task,
++   });
+++  let sourceEffectResolution: RunnerEffectResolutionRef | null = null;
++   if (opts.action === "resume_effect") {
++     const sourceRepository = await RunnerRunRepository.openExistingTaskRun({
++       git_root: ctx.resolvedProject.gitRoot,
++@@ -281,6 +284,7 @@ async function executeFreshReplay(opts: {
++         },
++       });
++     }
+++    sourceEffectResolution = sourceRecord.state.effect_resolution;
++   }
++   assertFreshReplayDangerAuthority(opts);
++   const destinationRunId = resolveFreshReplayRunId({
++@@ -323,6 +327,7 @@ async function executeFreshReplay(opts: {
++     ctx,
++     source_run_id: source.run_id,
++     source_status: source.status,
+++    source_effect_resolution: sourceEffectResolution,
++   };
++ }
++ 
++@@ -339,8 +344,9 @@ export async function resumeTaskRunnerExecution(opts: {
++     ...opts,
++     action: "resume",
++   });
+++  const { source_effect_resolution: _sourceEffectResolution, ...execution } = resumed;
++   return {
++-    ...resumed,
+++    ...execution,
++     previous_status: resumed.source_status,
++   };
++ }
++@@ -373,8 +379,16 @@ export async function resumeTaskRunnerEffectExecution(opts: {
++     ...opts,
++     action: "resume_effect",
++   });
+++  const sourceEffectResolution = resumed.source_effect_resolution;
+++  if (!sourceEffectResolution) {
+++    throw new Error(
+++      `resume-effect completed without its required source resolution for ${opts.task_id}:${opts.run_id}.`,
+++    );
+++  }
+++  const { source_effect_resolution: _sourceEffectResolution, ...execution } = resumed;
++   return {
++-    ...resumed,
+++    ...execution,
++     previous_status: resumed.source_status,
+++    source_effect_resolution: sourceEffectResolution,
++   };
++ }
++diff --git a/packages/agentplane/src/runner/usecases/task-run-lifecycle-result.ts b/packages/agentplane/src/runner/usecases/task-run-lifecycle-result.ts
++new file mode 100644
++index 000000000..4b8a3ccdf
++--- /dev/null
+++++ b/packages/agentplane/src/runner/usecases/task-run-lifecycle-result.ts
++@@ -0,0 +1,175 @@
+++import type { AgentWorkOrderV2 } from "@agentplaneorg/core/schemas";
+++
+++import type { TaskRunnerActiveClaimCleanupDiagnostic } from "./task-run-active-claim-runtime.js";
+++import type { TaskRunnerEffectOperationSnapshot } from "./task-run-effect-journal.js";
+++import type {
+++  ExecutedTaskRunnerExecution,
+++  PreparedTaskRunnerExecution,
+++} from "./task-run.js";
+++import type {
+++  RunnerInvocation,
+++  RunnerLifecycleStatus,
+++  RunnerResult,
+++  RunnerRunState,
+++} from "../types.js";
+++
+++export const TASK_RUNNER_LIFECYCLE_RESULT_SCHEMA =
+++  "agentplane.task_runner_lifecycle_result.v1" as const;
+++
+++export type TaskRunnerLifecycleEffectState =
+++  | "not_recorded"
+++  | "effect_in_doubt"
+++  | "applied"
+++  | "not_applied";
+++
+++export type TaskRunnerLifecycleResult = {
+++  schema: typeof TASK_RUNNER_LIFECYCLE_RESULT_SCHEMA;
+++  phase: "prepared" | "executed";
+++  task_id: string;
+++  invocation: Pick<
+++    RunnerInvocation,
+++    | "adapter_id"
+++    | "run_id"
+++    | "work_order_id"
+++    | "run_dir"
+++    | "bundle_path"
+++    | "bootstrap_path"
+++    | "result_path"
+++  >;
+++  lifecycle: {
+++    mode: RunnerRunState["mode"];
+++    status: RunnerLifecycleStatus;
+++    state_fingerprint: RunnerRunState["state_fingerprint"] | null;
+++    /**
+++     * These immutable references retain the effect authority, journal evidence,
+++     * claim generation, and any operator-supplied resolution without parsing
+++     * renderer output or replaying a provider operation.
+++     */
+++    effect: {
+++      state: TaskRunnerLifecycleEffectState;
+++      operation: RunnerRunState["effect_operation"] | null;
+++      /** Exact authority and observed-evidence identities from the durable journal. */
+++      authority: {
+++        ref: string;
+++        digest: string;
+++      } | null;
+++      observed_evidence: {
+++        code: string;
+++        digest: string | null;
+++      } | null;
+++      claim_generation: string | null;
+++      resolution: RunnerRunState["effect_resolution"] | null;
+++      resolution_provenance: "operator_supplied" | null;
+++      source_resolution: RunnerRunState["effect_resolution"] | null;
+++      source_resolution_provenance: "operator_supplied" | null;
+++    };
+++    work_order_authority: AgentWorkOrderV2["authority"] | null;
+++  };
+++  result: RunnerResult | null;
+++  active_claim_cleanup: TaskRunnerActiveClaimCleanupDiagnostic | null;
+++};
+++
+++function effectState(state: RunnerRunState): TaskRunnerLifecycleEffectState {
+++  if (state.effect_resolution?.verdict === "applied") return "applied";
+++  if (state.effect_resolution?.verdict === "not_applied") return "not_applied";
+++  if (
+++    state.state_fingerprint?.outcome === "effect_unknown" ||
+++    state.state_fingerprint?.outcome === "post_state_unknown"
+++  ) {
+++    return "effect_in_doubt";
+++  }
+++  return "not_recorded";
+++}
+++
+++function projectTaskRunnerLifecycleResult(opts: {
+++  phase: TaskRunnerLifecycleResult["phase"];
+++  task_id: string;
+++  invocation: RunnerInvocation;
+++  state: RunnerRunState;
+++  bundle: PreparedTaskRunnerExecution["bundle"];
+++  effect_operation?: TaskRunnerEffectOperationSnapshot;
+++  result: RunnerResult | null;
+++  active_claim_cleanup?: TaskRunnerActiveClaimCleanupDiagnostic;
+++  source_effect_resolution?: RunnerRunState["effect_resolution"] | null;
+++}): TaskRunnerLifecycleResult {
+++  const effect = effectState(opts.state);
+++  return {
+++    schema: TASK_RUNNER_LIFECYCLE_RESULT_SCHEMA,
+++    phase: opts.phase,
+++    task_id: opts.task_id,
+++    invocation: {
+++      adapter_id: opts.invocation.adapter_id,
+++      run_id: opts.invocation.run_id,
+++      work_order_id: opts.invocation.work_order_id,
+++      run_dir: opts.invocation.run_dir,
+++      bundle_path: opts.invocation.bundle_path,
+++      bootstrap_path: opts.invocation.bootstrap_path ?? null,
+++      result_path: opts.invocation.result_path,
+++    },
+++    lifecycle: {
+++      mode: opts.state.mode,
+++      status: opts.state.status,
+++      state_fingerprint: opts.state.state_fingerprint ?? null,
+++      effect: {
+++        state: effect,
+++        operation: opts.state.effect_operation ?? null,
+++        authority: opts.effect_operation
+++          ? {
+++              ref: opts.effect_operation.operation.authority_ref,
+++              digest: opts.effect_operation.operation.authority_digest,
+++            }
+++          : null,
+++        observed_evidence: opts.effect_operation?.journal.observed_evidence ?? null,
+++        claim_generation:
+++          opts.effect_operation?.operation.claim_generation ??
+++          opts.state.effect_operation?.claim_generation ??
+++          null,
+++        resolution: opts.state.effect_resolution ?? null,
+++        resolution_provenance: opts.state.effect_resolution ? "operator_supplied" : null,
+++        source_resolution: opts.source_effect_resolution ?? null,
+++        source_resolution_provenance: opts.source_effect_resolution ? "operator_supplied" : null,
+++      },
+++      work_order_authority: opts.bundle.work_order?.authority ?? null,
+++    },
+++    result: opts.result,
+++    active_claim_cleanup: opts.active_claim_cleanup ?? null,
+++  };
+++}
+++
+++export function projectPreparedTaskRunnerLifecycleResult(opts: {
+++  task_id: string;
+++  execution: PreparedTaskRunnerExecution;
+++}): TaskRunnerLifecycleResult {
+++  return projectTaskRunnerLifecycleResult({
+++    phase: "prepared",
+++    task_id: opts.task_id,
+++    invocation: opts.execution.invocation,
+++    state: opts.execution.state,
+++    bundle: opts.execution.bundle,
+++    effect_operation: opts.execution.effect_operation,
+++    result: null,
+++  });
+++}
+++
+++export function projectExecutedTaskRunnerLifecycleResult(opts: {
+++  task_id: string;
+++  execution: ExecutedTaskRunnerExecution;
+++  source_effect_resolution?: RunnerRunState["effect_resolution"] | null;
+++}): TaskRunnerLifecycleResult {
+++  return projectTaskRunnerLifecycleResult({
+++    phase: "executed",
+++    task_id: opts.task_id,
+++    invocation: opts.execution.invocation,
+++    state: opts.execution.state,
+++    bundle: opts.execution.bundle,
+++    effect_operation: opts.execution.effect_operation,
+++    result: opts.execution.result,
+++    active_claim_cleanup: opts.execution.active_claim_cleanup,
+++    source_effect_resolution: opts.source_effect_resolution,
+++  });
+++}
+++
+++export function taskRunnerLifecycleExitCode(result: TaskRunnerLifecycleResult): number {
+++  if (result.phase === "prepared") return 0;
+++  return result.result?.status === "success" && !result.active_claim_cleanup ? 0 : 1;
+++}
++diff --git a/packages/agentplane/src/runner/usecases/task-run-lifecycle-shared.ts b/packages/agentplane/src/runner/usecases/task-run-lifecycle-shared.ts
++index cfedcba64..1b718818e 100644
++--- a/packages/agentplane/src/runner/usecases/task-run-lifecycle-shared.ts
+++++ b/packages/agentplane/src/runner/usecases/task-run-lifecycle-shared.ts
++@@ -2,6 +2,7 @@ import { realpath } from "node:fs/promises";
++ import path from "node:path";
++ 
++ import { normalizeTaskStatus } from "@agentplaneorg/core/tasks";
+++import type { RunnerEffectResolutionRef } from "@agentplaneorg/core/schemas";
++ 
++ import type { TaskData } from "../../backends/task-backend.js";
++ import { loadCommandContext, type CommandContext } from "../../commands/shared/task-backend.js";
++@@ -45,6 +46,8 @@ export type EffectResumedTaskRunnerExecution = ExecutedTaskRunnerExecution & {
++   source_run_id: string;
++   source_status: RunnerLifecycleStatus;
++   previous_status: RunnerLifecycleStatus;
+++  /** Immutable operator disposition that authorized this fresh effect attempt. */
+++  source_effect_resolution: RunnerEffectResolutionRef;
++ };
++ 
++ export type RunnerReplayAction = "resume" | "retry" | "resume_effect";
++diff --git a/packages/agentplane/src/runner/usecases/task-run.ts b/packages/agentplane/src/runner/usecases/task-run.ts
++index e4e3e3939..6b01854f6 100644
++--- a/packages/agentplane/src/runner/usecases/task-run.ts
+++++ b/packages/agentplane/src/runner/usecases/task-run.ts
++@@ -58,6 +58,7 @@ import {
++   recordTaskRunnerPostStateUnknown,
++   persistTaskRunnerEffectAccepted,
++   startTaskRunnerEffectOperation,
+++  type TaskRunnerEffectOperationSnapshot,
++   type StartedRunnerEffectOperation,
++ } from "./task-run-effect-journal.js";
++ import { finalizeTaskRunnerActiveClaimCleanup } from "./task-run-active-claim-cleanup.js";
++@@ -92,6 +93,8 @@ export type PreparedTaskRunnerExecution = {
++   bundle: RunnerContextBundle;
++   invocation: RunnerInvocation;
++   state: RunnerRunState;
+++  /** Durable operation and journal identity already established by preparation. */
+++  effect_operation?: TaskRunnerEffectOperationSnapshot;
++   precondition_fingerprint?: StateFingerprint;
++   precondition_policy?: StateFingerprintPolicy;
++ };
++@@ -302,7 +305,7 @@ export async function prepareTaskRunnerExecution(opts: {
++     bootstrap_markdown: renderTaskRunnerBootstrap(bundle, invocation),
++     invocation,
++   });
++-  const stateWithEffectOperation = await persistPreparedTaskRunnerEffectOperation({
+++  const preparedEffectOperation = await persistPreparedTaskRunnerEffectOperation({
++     repository,
++     bundle,
++     invocation,
++@@ -314,7 +317,8 @@ export async function prepareTaskRunnerExecution(opts: {
++   return {
++     bundle,
++     invocation,
++-    state: stateWithEffectOperation,
+++    state: preparedEffectOperation.state,
+++    effect_operation: preparedEffectOperation.effect_operation,
++     precondition_fingerprint,
++     precondition_policy,
++   };
++@@ -520,7 +524,7 @@ export async function executeTaskRunnerExecution(opts: {
++     const preconditionFingerprint = guardedExecution.precondition_fingerprint;
++     const preconditionPolicy = guardedExecution.precondition_policy;
++     const result = guardedExecution.result;
++-    const state = await persistTaskRunnerEffectAccepted({
+++    const acceptedEffect = await persistTaskRunnerEffectAccepted({
++       session: effectOperation,
++       task_id: opts.task_id,
++       run_id: prepared.invocation.run_id,
++@@ -537,6 +541,7 @@ export async function executeTaskRunnerExecution(opts: {
++           state_fingerprint: guardedExecution.state_fingerprint,
++         }),
++     });
+++    const state = acceptedEffect.state;
++     const claimedRunAuthority = await inspectTaskRunnerClaimedRunAuthority(
++       {
++         git_root: ctx.resolvedProject.gitRoot,
++@@ -549,6 +554,9 @@ export async function executeTaskRunnerExecution(opts: {
++     releaseActiveClaim = cleanupConfirmed;
++     completed = {
++       ...prepared,
+++      effect_operation: prepared.effect_operation
+++        ? { ...prepared.effect_operation, journal: acceptedEffect.journal }
+++        : undefined,
++       precondition_fingerprint: preconditionFingerprint,
++       precondition_policy: preconditionPolicy,
++       state,
+diff --git a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-follow-up.json b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-follow-up.json
+new file mode 100644
+index 000000000..1a6d2faf3
+--- /dev/null
++++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-follow-up.json
+@@ -0,0 +1,21 @@
++{
++  "schema_version": 1,
++  "kind": "evaluator_rework_work_order",
++  "source_work_order_id": "evaluator-work-order-202607221850-R7WS01-96b4eeb6e8bc42925295141e",
++  "task_id": "202607221850-R7WS01",
++  "verdict": "rework",
++  "next_owner": "CODER",
++  "instruction": "Set Hermes exit_code from taskRunnerLifecycleExitCode(lifecycle) and add a narrow cleanup-failure regression test.",
++  "findings": [
++    {
++      "id": "compatibility-finding-1",
++      "summary": "executeHermesWorkflowOperation marks an execution with active_claim_cleanup as failed but currently forwards executed.result.exit_code, which can still be 0. This splits supervisor semantics from task-run's typed exit mapping.",
++      "evidence_refs": [
++        {
++          "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-diff.patch"
++        }
++      ]
++    }
++  ],
++  "source_result": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-result.json"
++}
+diff --git a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-observed-checks.json b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-observed-checks.json
+new file mode 100644
+index 000000000..f21db477b
+--- /dev/null
++++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-observed-checks.json
+@@ -0,0 +1,16 @@
++{
++  "task_status": "DOING",
++  "declared_checks": [
++    "bun run lifecycle:invariants",
++    "bun run test:critical",
++    "bun run typecheck"
++  ],
++  "verification": {
++    "state": "ok",
++    "attempts": 0,
++    "updated_at": "2026-07-28T02:26:16.727Z",
++    "updated_by": "TESTER",
++    "note": "PASS: typed runner lifecycle results stay in-process through task CLI and Hermes; human and JSON renderers preserve effect authority, observed evidence, claim generation, and operator-resolution provenance."
++  },
++  "runner_history": []
++}
+diff --git a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-opinion.md b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-opinion.md
+new file mode 100644
+index 000000000..8dc7b6594
+--- /dev/null
++++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-opinion.md
+@@ -0,0 +1,20 @@
++# Semantic quality review: rework
++
++Provenance: evaluator_supplied
++
++EVALUATOR returned rework with 1 typed finding(s).
++
++## Findings
++- executeHermesWorkflowOperation marks an execution with active_claim_cleanup as failed but currently forwards executed.result.exit_code, which can still be 0. This splits supervisor semantics from task-run's typed exit mapping.
++
++## Evidence
++- .agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-diff.patch
++
++## Missing Tests
++- Hermes execution with active_claim_cleanup returns failed and a nonzero exit_code.
++
++## Hidden Assumptions
++- The provider exit code always reflects supervisor cleanup state.
++
++## Residual Risks
++- Set Hermes exit_code from taskRunnerLifecycleExitCode(lifecycle) and add a narrow cleanup-failure regression test.
+diff --git a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-prompt.md b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-prompt.md
+new file mode 100644
+index 000000000..d7ce3bfa8
+--- /dev/null
++++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-prompt.md
+@@ -0,0 +1,82 @@
++# AgentPlane EVALUATOR episode
++
++AgentPlane prepared and froze the authoritative review input. Perform the semantic evaluation; do not reproduce CLI discovery or lifecycle work.
++This prompt does not execute an evaluator. A caller must run the evaluator in the work-order authority boundary and persist its returned typed result at the declared output path.
++Do not edit implementation, task lifecycle, policy, or evidence files. You may read the frozen evidence and run read-only checks only.
++
++- task_id: 202607221850-R7WS01
++- task_readme: .agentplane/tasks/202607221850-R7WS01/README.md
++- work_order: .agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-work-order.json
++- result_output: .agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-result.json
++- report_path: .agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/quality-report.json
++- provenance: evaluator_supplied
++
++## Required result
++
++Return exactly one `sgr.evaluator_result.v1` JSON object through the evaluator result channel. The caller, not the read-only evaluator, persists it at `result_output`. It must contain:
++- schema_version: 1
++- kind: evaluator_result
++- evaluator_id: the evaluator id from the work order
++- verdict: pass | rework | blocked | human_review
++- findings: typed findings with id, severity, summary, broken_invariant, and non-empty evidence_refs
++- missing_tests and hidden_assumptions: string arrays
++- recovery_context: required non-empty string for rework, blocked, or human_review; for human_review it must be the single decision question for the human owner
++
++Every findings[].evidence_refs[].path must be an exact path from work_order.evidence. Do not add fields, commands, patches, lifecycle transitions, or a verdict outside this JSON result.
++The CLI validates the schema, frozen evidence digests, task revision, evaluated SHA, and blueprint before it records quality state.
++
++## Evaluator module
++
++---
++id: recovery-context
++title: Recovery Context Invariant Review
++version: 1
++status: preview
++profile: EVALUATOR
++tags:
++  - recovery
++  - invariants
++  - concurrency
++---
++
++# Recovery Context Invariant Review
++
++Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
++
++## Inputs
++
++- Task id, task README, approved plan, and Verify Steps.
++- Current diff or PR patch.
++- Relevant comments, review findings, incidents, and recovery/handoff context.
++- Known concurrent-agent activity and task-artifact drift classification, if present.
++
++## Review Procedure
++
++1. Reconstruct the intended contract from the task, not from the implementation summary.
++2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
++3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
++4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
++5. Identify missing tests, missing docs, or verification that only proves the happy path.
++6. Do not execute fixes. Return review findings only.
++7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
++   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
++   evidence and is not sufficient for finish/integrate gates.
++
++## Output
++
++Return a concise structured review:
++
++- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
++- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
++- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
++  include the generated `quality-report.json`.
++- `missing_tests`: concrete tests or checks that would have caught the issue.
++- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
++- `residual_risks`: known risks after the review.
++- `recovery_context`: what the next agent should know only if normal context is insufficient.
++
++## Stop Rules
++
++- Use `blocked` when required task context, diff, or recovery context is missing.
++- Use `rework` when behavior diverges from the approved contract even if local checks pass.
++- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.
+diff --git a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-result.json b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-result.json
+new file mode 100644
+index 000000000..a09404feb
+--- /dev/null
++++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-result.json
+@@ -0,0 +1,26 @@
++{
++  "schema_version": 1,
++  "kind": "evaluator_result",
++  "evaluator_id": "recovery-context",
++  "verdict": "rework",
++  "findings": [
++    {
++      "id": "compatibility-finding-1",
++      "severity": "medium",
++      "summary": "executeHermesWorkflowOperation marks an execution with active_claim_cleanup as failed but currently forwards executed.result.exit_code, which can still be 0. This splits supervisor semantics from task-run's typed exit mapping.",
++      "broken_invariant": "Compatibility evaluator facade requires independent review evidence.",
++      "evidence_refs": [
++        {
++          "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-diff.patch"
++        }
++      ]
++    }
++  ],
++  "missing_tests": [
++    "Hermes execution with active_claim_cleanup returns failed and a nonzero exit_code."
++  ],
++  "hidden_assumptions": [
++    "The provider exit code always reflects supervisor cleanup state."
++  ],
++  "recovery_context": "Set Hermes exit_code from taskRunnerLifecycleExitCode(lifecycle) and add a narrow cleanup-failure regression test."
++}
+diff --git a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-work-order.json b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-work-order.json
+new file mode 100644
+index 000000000..00e829552
+--- /dev/null
++++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-work-order.json
+@@ -0,0 +1,96 @@
++{
++  "schema_version": 1,
++  "kind": "evaluator_work_order",
++  "work_order_id": "evaluator-work-order-202607221850-R7WS01-96b4eeb6e8bc42925295141e",
++  "prepared_at": "2026-07-28T02:26:58.471Z",
++  "task": {
++    "id": "202607221850-R7WS01",
++    "revision": 11,
++    "objective": "Return typed runner lifecycle results\n\nRF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing.",
++    "acceptance_criteria": [
++      "bun run lifecycle:invariants",
++      "bun run test:critical",
++      "bun run typecheck",
++      "- In scope: typed runner use-case results, adapter ports, error/result union, human/JSON renderers, compatibility snapshots, and supervisor invocation without subprocess/stdout capture.\n- Consume the durable effect-resolution contract as typed `effect_in_doubt`, `applied` and `not_applied` states, preserving resolution provenance, authority/evidence identity and claim generation in every in-process result and renderer.\n- An unresolved `effect_in_doubt` result is terminally blocked for generic retry, replay, resume and restart paths; only the explicit resolution protocol from task 202607242158-QV09NA may transition it to `applied` or `not_applied`.\n- Out of scope: automating the complete direct route, delivered by the next task.",
++      "1. Define typed results for runner preparation, invocation, observation, evaluation handoff, and terminal outcomes.\n2. Separate rendering/exit mapping from use-case logic.\n3. Call runner phases in-process from the supervisor.\n4. Map durable journal/resolution input to typed `effect_in_doubt`, `applied` and `not_applied` outcomes with resolution provenance, and reject any generic retry path for unresolved effects.\n5. Preserve documented human and JSON output through compatibility renderers without dropping resolution provenance.\n6. Add result/renderer parity, adapter error, cancellation, timeout, stale-work-order and effect-resolution transition tests.",
++      "1. Invoke each runner phase in-process. Expected: structured results carry work-order/fingerprint/receipt identities without reading stdout.\n2. Render the same result to human and JSON formats. Expected: compatibility snapshots and exit codes remain stable.\n3. Feed durable journal states for `effect_in_doubt`, operator-resolved `applied` and operator-resolved `not_applied` into each runner/supervisor entry point. Expected: typed results and both renderers preserve the state, operator-supplied resolution provenance, evidence/authority digests and claim generation without stdout parsing.\n4. Invoke generic retry, replay, resume and restart against unresolved `effect_in_doubt`. Expected: every path returns the typed blocked outcome, performs no adapter invocation and directs callers only to the explicit operator-resolution protocol; no generic retry can reinterpret the effect as `not_applied`.\n5. Exercise cancellation, timeout, adapter crash, stale input, and policy denial. Expected: typed outcomes and observed receipts remain complete.\n6. Run runner/supervisor/lifecycle tests and typecheck."
++    ]
++  },
++  "evaluated_sha": "3f11077e583fb131713af53835139885b4406b60",
++  "blueprint_digest": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328",
++  "evaluator": {
++    "id": "recovery-context",
++    "profile": "EVALUATOR",
++    "prompt_module_path": ".agentplane/evaluators/recovery-context.md"
++  },
++  "authority": {
++    "sandbox": "read-only",
++    "writable_roots": [],
++    "allowed_tool_classes": [
++      "repository_read",
++      "git_read",
++      "run_checks",
++      "report_result"
++    ],
++    "external_side_effects": []
++  },
++  "result_contract": "sgr.evaluator_result.v1",
++  "evidence": [
++    {
++      "id": "task-document",
++      "kind": "task_document",
++      "path": ".agentplane/tasks/202607221850-R7WS01/README.md",
++      "sha256": "sha256:693da2bec8d44660040dbe741c5609f29a4142e580149ad6a25990a4c26418d1",
++      "required": true
++    },
++    {
++      "id": "actual-diff",
++      "kind": "actual_diff",
++      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-diff.patch",
++      "sha256": "sha256:12eea898cce09dd7c3cbc38e6cd668a977164b9f393314504e6c3245e314c6ed",
++      "required": true
++    },
++    {
++      "id": "observed-checks",
++      "kind": "observed_checks",
++      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-observed-checks.json",
++      "sha256": "sha256:5bdcf94f6d74b42ad558003b7ce5c82d0e996ddec13efe32ac55773603fa3e69",
++      "required": true
++    },
++    {
++      "id": "blueprint",
++      "kind": "blueprint",
++      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-blueprint.json",
++      "sha256": "sha256:d348dedab56fd1219b3127a4ff3da0570f1904829944b3609e64139f6309b3fb",
++      "required": true
++    },
++    {
++      "id": "policy-1",
++      "kind": "policy_module",
++      "path": ".agentplane/policy/dod.code.md",
++      "sha256": "sha256:3fec50dfe0db2f9495a3fa96f36d95fb34262033299d57f6f3775af4b7cc1486",
++      "required": true
++    },
++    {
++      "id": "policy-2",
++      "kind": "policy_module",
++      "path": ".agentplane/policy/dod.core.md",
++      "sha256": "sha256:f6c11b8a2c55760c17af15f79fe13791b3e7bba4852fc7d311fc0657e490b0c7",
++      "required": true
++    },
++    {
++      "id": "policy-3",
++      "kind": "policy_module",
++      "path": ".agentplane/policy/security.must.md",
++      "sha256": "sha256:96d01012e7ab67873bcb7a2cdd3818efa2c1fa500ee2eaf0e316f67e15bbcab2",
++      "required": true
++    },
++    {
++      "id": "policy-4",
++      "kind": "policy_module",
++      "path": ".agentplane/policy/workflow.branch_pr.md",
++      "sha256": "sha256:12d3b942042c276d30593803ddcfe12b20dc794e3e8bfbd97b6ce59df13ba82b",
++      "required": true
++    }
++  ]
++}
+diff --git a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/quality-report.json b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/quality-report.json
+new file mode 100644
+index 000000000..8c5552b99
+--- /dev/null
++++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/quality-report.json
+@@ -0,0 +1,27 @@
++{
++  "schema_version": 1,
++  "task_id": "202607221850-R7WS01",
++  "evaluator_id": "recovery-context",
++  "evaluator_profile": "EVALUATOR",
++  "generated_at": "2026-07-28T02:26:58.563Z",
++  "provenance": "evaluator_supplied",
++  "verdict": "rework",
++  "summary": "EVALUATOR returned rework with 1 typed finding(s).",
++  "evaluated_sha": "3f11077e583fb131713af53835139885b4406b60",
++  "blueprint_digest": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328",
++  "findings": [
++    "executeHermesWorkflowOperation marks an execution with active_claim_cleanup as failed but currently forwards executed.result.exit_code, which can still be 0. This splits supervisor semantics from task-run's typed exit mapping."
++  ],
++  "evidence_refs": [
++    ".agentplane/tasks/202607221850-R7WS01/quality/20260728-022658471-recovery-context/evaluator-diff.patch"
++  ],
++  "missing_tests": [
++    "Hermes execution with active_claim_cleanup returns failed and a nonzero exit_code."
++  ],
++  "hidden_assumptions": [
++    "The provider exit code always reflects supervisor cleanup state."
++  ],
++  "residual_risks": [
++    "Set Hermes exit_code from taskRunnerLifecycleExitCode(lifecycle) and add a narrow cleanup-failure regression test."
++  ]
++}
+diff --git a/packages/agentplane/src/commands/hermes/hermes-runtime.ts b/packages/agentplane/src/commands/hermes/hermes-runtime.ts
+index e50890cc7..b9800fe4f 100644
+--- a/packages/agentplane/src/commands/hermes/hermes-runtime.ts
++++ b/packages/agentplane/src/commands/hermes/hermes-runtime.ts
+@@ -305,7 +305,7 @@ export async function executeHermesWorkflowOperation(opts: {
+     status: succeeded ? "succeeded" : "failed",
+     observed_postconditions: ["runner_state_observed"],
+     detail: executed.result.summary ?? `runner execution completed for ${taskId}`,
+-    exit_code: executed.result.exit_code,
++    exit_code: taskRunnerLifecycleExitCode(lifecycle),
+     operation_result: { kind: "runner_lifecycle", value: lifecycle },
+   };
+ }
+diff --git a/packages/agentplane/src/commands/hermes/hermes.command.test.ts b/packages/agentplane/src/commands/hermes/hermes.command.test.ts
+index c2758bcfc..1e01bc660 100644
+--- a/packages/agentplane/src/commands/hermes/hermes.command.test.ts
++++ b/packages/agentplane/src/commands/hermes/hermes.command.test.ts
+@@ -1,9 +1,10 @@
+-import { describe, expect, it } from "vitest";
++import { describe, expect, it, vi } from "vitest";
+ 
+ import { buildStateFingerprint } from "@agentplaneorg/core/schemas";
+ 
+ import { runCli } from "../../cli/run-cli.js";
+-import { routeNeedsRunnerProjection } from "./hermes-runtime.js";
++import * as taskRunUsecases from "../../runner/usecases/task-run.js";
++import { executeHermesWorkflowOperation, routeNeedsRunnerProjection } from "./hermes-runtime.js";
+ import type { TaskRouteDecision } from "../shared/route-decision-types.js";
+ import { captureStdIO, mkGitRepoRoot, runCliSilent } from "@agentplane/testkit";
+ import { mkdir, writeFile } from "node:fs/promises";
+@@ -84,6 +85,63 @@ async function createRunnableDirectTask(root: string): Promise<string> {
+ }
+ 
+ describe("hermes adapter commands", () => {
++  it("returns the typed nonzero exit code when runner cleanup remains incomplete", async () => {
++    const executed = {
++      invocation: {
++        adapter_id: "codex",
++        run_id: "run-degraded-cleanup",
++        work_order_id: "work-order-degraded-cleanup",
++        run_dir: "/repo/runs/run-degraded-cleanup",
++        bundle_path: "/repo/runs/run-degraded-cleanup/bundle.json",
++        bootstrap_path: "/repo/runs/run-degraded-cleanup/bootstrap.md",
++        result_path: "/repo/runs/run-degraded-cleanup/result.json",
++      },
++      bundle: {},
++      state: { mode: "execute", status: "success" },
++      result: {
++        status: "success",
++        exit_code: 0,
++        started_at: "2026-07-28T00:00:00.000Z",
++        ended_at: "2026-07-28T00:00:01.000Z",
++        summary: "provider completed",
++      },
++      active_claim_cleanup: {
++        status: "cleanup_failed",
++        code: "E_RUNTIME",
++        message: "active claim could not be retired",
++        event_recorded: true,
++      },
++    } as unknown as Awaited<ReturnType<typeof taskRunUsecases.executeTaskRunnerExecution>>;
++    const executeSpy = vi
++      .spyOn(taskRunUsecases, "executeTaskRunnerExecution")
++      .mockResolvedValue(executed);
++    try {
++      const result = await executeHermesWorkflowOperation({
++        ctx: {} as never,
++        cwd: "/repo",
++        rootOverride: "/repo",
++        includeRemote: false,
++        dryRun: false,
++        operation: {
++          id: "runner.follow",
++          params: { mode: "run", taskId: "TASK-CLEANUP" },
++        } as never,
++      });
++      expect(result).toMatchObject({
++        status: "failed",
++        exit_code: 1,
++        operation_result: {
++          kind: "runner_lifecycle",
++          value: {
++            active_claim_cleanup: { status: "cleanup_failed" },
++          },
++        },
++      });
++    } finally {
++      executeSpy.mockRestore();
++    }
++  });
++
+   it("renders a provider-safe enqueue projection", async () => {
+     const root = await mkGitRepoRoot();
+     const taskId = await createApprovedTask(root);

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-observed-checks.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-observed-checks.json
@@ -1,0 +1,16 @@
+{
+  "task_status": "DOING",
+  "declared_checks": [
+    "bun run lifecycle:invariants",
+    "bun run test:critical",
+    "bun run typecheck"
+  ],
+  "verification": {
+    "state": "ok",
+    "attempts": 0,
+    "updated_at": "2026-07-28T02:26:16.727Z",
+    "updated_by": "TESTER",
+    "note": "PASS: typed runner lifecycle results stay in-process through task CLI and Hermes; human and JSON renderers preserve effect authority, observed evidence, claim generation, and operator-resolution provenance."
+  },
+  "runner_history": []
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-opinion.md
@@ -1,0 +1,20 @@
+# Semantic quality review: pass
+
+Provenance: evaluator_supplied
+
+EVALUATOR returned pass with 1 typed finding(s).
+
+## Findings
+- The rework replaces the raw provider exit code with taskRunnerLifecycleExitCode(lifecycle), and a regression test proves that active_claim_cleanup yields failed plus exit_code 1 while retaining the typed result.
+
+## Evidence
+- .agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-diff.patch
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-prompt.md
@@ -1,0 +1,82 @@
+# AgentPlane EVALUATOR episode
+
+AgentPlane prepared and froze the authoritative review input. Perform the semantic evaluation; do not reproduce CLI discovery or lifecycle work.
+This prompt does not execute an evaluator. A caller must run the evaluator in the work-order authority boundary and persist its returned typed result at the declared output path.
+Do not edit implementation, task lifecycle, policy, or evidence files. You may read the frozen evidence and run read-only checks only.
+
+- task_id: 202607221850-R7WS01
+- task_readme: .agentplane/tasks/202607221850-R7WS01/README.md
+- work_order: .agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-work-order.json
+- result_output: .agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-result.json
+- report_path: .agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/quality-report.json
+- provenance: evaluator_supplied
+
+## Required result
+
+Return exactly one `sgr.evaluator_result.v1` JSON object through the evaluator result channel. The caller, not the read-only evaluator, persists it at `result_output`. It must contain:
+- schema_version: 1
+- kind: evaluator_result
+- evaluator_id: the evaluator id from the work order
+- verdict: pass | rework | blocked | human_review
+- findings: typed findings with id, severity, summary, broken_invariant, and non-empty evidence_refs
+- missing_tests and hidden_assumptions: string arrays
+- recovery_context: required non-empty string for rework, blocked, or human_review; for human_review it must be the single decision question for the human owner
+
+Every findings[].evidence_refs[].path must be an exact path from work_order.evidence. Do not add fields, commands, patches, lifecycle transitions, or a verdict outside this JSON result.
+The CLI validates the schema, frozen evidence digests, task revision, evaluated SHA, and blueprint before it records quality state.
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-result.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-result.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_result",
+  "evaluator_id": "recovery-context",
+  "verdict": "pass",
+  "findings": [
+    {
+      "id": "compatibility-finding-1",
+      "severity": "medium",
+      "summary": "The rework replaces the raw provider exit code with taskRunnerLifecycleExitCode(lifecycle), and a regression test proves that active_claim_cleanup yields failed plus exit_code 1 while retaining the typed result.",
+      "broken_invariant": "Compatibility evaluator facade requires independent review evidence.",
+      "evidence_refs": [
+        {
+          "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-diff.patch"
+        }
+      ]
+    }
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": []
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-work-order.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-work-order.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_work_order",
+  "work_order_id": "evaluator-work-order-202607221850-R7WS01-3b7c77b69200b3f4d6dacab6",
+  "prepared_at": "2026-07-28T02:30:01.043Z",
+  "task": {
+    "id": "202607221850-R7WS01",
+    "revision": 13,
+    "objective": "Return typed runner lifecycle results\n\nRF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing.",
+    "acceptance_criteria": [
+      "bun run lifecycle:invariants",
+      "bun run test:critical",
+      "bun run typecheck",
+      "- In scope: typed runner use-case results, adapter ports, error/result union, human/JSON renderers, compatibility snapshots, and supervisor invocation without subprocess/stdout capture.\n- Consume the durable effect-resolution contract as typed `effect_in_doubt`, `applied` and `not_applied` states, preserving resolution provenance, authority/evidence identity and claim generation in every in-process result and renderer.\n- An unresolved `effect_in_doubt` result is terminally blocked for generic retry, replay, resume and restart paths; only the explicit resolution protocol from task 202607242158-QV09NA may transition it to `applied` or `not_applied`.\n- Out of scope: automating the complete direct route, delivered by the next task.",
+      "1. Define typed results for runner preparation, invocation, observation, evaluation handoff, and terminal outcomes.\n2. Separate rendering/exit mapping from use-case logic.\n3. Call runner phases in-process from the supervisor.\n4. Map durable journal/resolution input to typed `effect_in_doubt`, `applied` and `not_applied` outcomes with resolution provenance, and reject any generic retry path for unresolved effects.\n5. Preserve documented human and JSON output through compatibility renderers without dropping resolution provenance.\n6. Add result/renderer parity, adapter error, cancellation, timeout, stale-work-order and effect-resolution transition tests.",
+      "1. Invoke each runner phase in-process. Expected: structured results carry work-order/fingerprint/receipt identities without reading stdout.\n2. Render the same result to human and JSON formats. Expected: compatibility snapshots and exit codes remain stable.\n3. Feed durable journal states for `effect_in_doubt`, operator-resolved `applied` and operator-resolved `not_applied` into each runner/supervisor entry point. Expected: typed results and both renderers preserve the state, operator-supplied resolution provenance, evidence/authority digests and claim generation without stdout parsing.\n4. Invoke generic retry, replay, resume and restart against unresolved `effect_in_doubt`. Expected: every path returns the typed blocked outcome, performs no adapter invocation and directs callers only to the explicit operator-resolution protocol; no generic retry can reinterpret the effect as `not_applied`.\n5. Exercise cancellation, timeout, adapter crash, stale input, and policy denial. Expected: typed outcomes and observed receipts remain complete.\n6. Run runner/supervisor/lifecycle tests and typecheck."
+    ]
+  },
+  "evaluated_sha": "e7465b7377c6a8af392c605de7aa4315bf107100",
+  "blueprint_digest": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328",
+  "evaluator": {
+    "id": "recovery-context",
+    "profile": "EVALUATOR",
+    "prompt_module_path": ".agentplane/evaluators/recovery-context.md"
+  },
+  "authority": {
+    "sandbox": "read-only",
+    "writable_roots": [],
+    "allowed_tool_classes": [
+      "repository_read",
+      "git_read",
+      "run_checks",
+      "report_result"
+    ],
+    "external_side_effects": []
+  },
+  "result_contract": "sgr.evaluator_result.v1",
+  "evidence": [
+    {
+      "id": "task-document",
+      "kind": "task_document",
+      "path": ".agentplane/tasks/202607221850-R7WS01/README.md",
+      "sha256": "sha256:77a720e69879eba5f53aad72e256597c8e63437f5ddf8eb3ea3ecdea628f64b4",
+      "required": true
+    },
+    {
+      "id": "actual-diff",
+      "kind": "actual_diff",
+      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-diff.patch",
+      "sha256": "sha256:949bfaebee5ee4dfd199bdeb26c675f1daf9dadd9e15b9c0e562be0aca1165b2",
+      "required": true
+    },
+    {
+      "id": "observed-checks",
+      "kind": "observed_checks",
+      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-observed-checks.json",
+      "sha256": "sha256:5bdcf94f6d74b42ad558003b7ce5c82d0e996ddec13efe32ac55773603fa3e69",
+      "required": true
+    },
+    {
+      "id": "blueprint",
+      "kind": "blueprint",
+      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-blueprint.json",
+      "sha256": "sha256:d348dedab56fd1219b3127a4ff3da0570f1904829944b3609e64139f6309b3fb",
+      "required": true
+    },
+    {
+      "id": "policy-1",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.code.md",
+      "sha256": "sha256:3fec50dfe0db2f9495a3fa96f36d95fb34262033299d57f6f3775af4b7cc1486",
+      "required": true
+    },
+    {
+      "id": "policy-2",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.core.md",
+      "sha256": "sha256:f6c11b8a2c55760c17af15f79fe13791b3e7bba4852fc7d311fc0657e490b0c7",
+      "required": true
+    },
+    {
+      "id": "policy-3",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/security.must.md",
+      "sha256": "sha256:96d01012e7ab67873bcb7a2cdd3818efa2c1fa500ee2eaf0e316f67e15bbcab2",
+      "required": true
+    },
+    {
+      "id": "policy-4",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/workflow.branch_pr.md",
+      "sha256": "sha256:12d3b942042c276d30593803ddcfe12b20dc794e3e8bfbd97b6ce59df13ba82b",
+      "required": true
+    }
+  ]
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/quality-report.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "task_id": "202607221850-R7WS01",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-28T02:30:01.167Z",
+  "provenance": "evaluator_supplied",
+  "verdict": "pass",
+  "summary": "EVALUATOR returned pass with 1 typed finding(s).",
+  "evaluated_sha": "e7465b7377c6a8af392c605de7aa4315bf107100",
+  "blueprint_digest": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328",
+  "findings": [
+    "The rework replaces the raw provider exit code with taskRunnerLifecycleExitCode(lifecycle), and a regression test proves that active_claim_cleanup yields failed plus exit_code 1 while retaining the typed result."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607221850-R7WS01/quality/20260728-023001043-recovery-context/evaluator-diff.patch"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-blueprint.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-blueprint.json
@@ -1,0 +1,583 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607221850-R7WS01",
+    "title": "Return typed runner lifecycle results",
+    "description": "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing.",
+    "tags": [
+      "milestone-beta1",
+      "refactor",
+      "rf-25",
+      "runner",
+      "use-case",
+      "v0.7",
+      "wave-supervisor"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607221850-R7WS01",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328"
+  }
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-diff.patch
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-diff.patch
@@ -1,0 +1,152 @@
+diff --git a/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt b/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
+index ef33244b2..ee0ce4dff 100644
+--- a/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
++++ b/.agentplane/tasks/202607221850-R7WS01/pr/diffstat.txt
+@@ -1,14 +1,14 @@
+  .../src/cli/run-cli.core.task-run.test.ts          |   6 +
+  .../src/commands/hermes/hermes-runtime.ts          |  19 ++-
+- .../src/commands/hermes/hermes.command.test.ts     | 107 ++++++++++++-
++ .../src/commands/hermes/hermes.command.test.ts     | 109 ++++++++++++-
+  .../src/commands/shared/workflow-supervisor.ts     |   8 +
+- .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
+- .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
++ .../src/commands/task/run-render.test.ts           | 138 +++++++++++++++++
++ .../agentplane/src/commands/task/run-render.ts     |  91 ++++++++++-
+  .../agentplane/src/commands/task/run.command.ts    |  41 ++---
+  .../task/task-run-effect-resolution.command.ts     |  28 ++--
+  .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
+  .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
+- .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
++ .../runner/usecases/task-run-lifecycle-result.ts   | 172 +++++++++++++++++++++
+  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
+  .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
+- 13 files changed, 613 insertions(+), 63 deletions(-)
++ 13 files changed, 612 insertions(+), 69 deletions(-)
+diff --git a/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md b/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
+index 31835ffe1..20c2bfadd 100644
+--- a/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
++++ b/.agentplane/tasks/202607221850-R7WS01/pr/github-body.md
+@@ -36,18 +36,18 @@ failure for incomplete active-claim cleanup.
+ ```text
+  .../src/cli/run-cli.core.task-run.test.ts          |   6 +
+  .../src/commands/hermes/hermes-runtime.ts          |  19 ++-
+- .../src/commands/hermes/hermes.command.test.ts     | 107 ++++++++++++-
++ .../src/commands/hermes/hermes.command.test.ts     | 109 ++++++++++++-
+  .../src/commands/shared/workflow-supervisor.ts     |   8 +
+- .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
+- .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
++ .../src/commands/task/run-render.test.ts           | 138 +++++++++++++++++
++ .../agentplane/src/commands/task/run-render.ts     |  91 ++++++++++-
+  .../agentplane/src/commands/task/run.command.ts    |  41 ++---
+  .../task/task-run-effect-resolution.command.ts     |  28 ++--
+  .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
+  .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
+- .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
++ .../runner/usecases/task-run-lifecycle-result.ts   | 172 +++++++++++++++++++++
+  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
+  .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
+- 13 files changed, 613 insertions(+), 63 deletions(-)
++ 13 files changed, 612 insertions(+), 69 deletions(-)
+ ```
+ 
+ </details>
+diff --git a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+index d382d0075..e67cce766 100644
+--- a/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
++++ b/.agentplane/tasks/202607221850-R7WS01/pr/meta.json
+@@ -2,7 +2,7 @@
+   "base": "main",
+   "branch": "task/202607221850-R7WS01/return-typed-runner-lifecycle-results",
+   "created_at": "2026-07-28T01:55:50.166Z",
+-  "diffstat_sha256": "sha256:65d97a5753250f37a246a401fcbc4accf833ce3f83665209a24340b616f3cba4",
++  "diffstat_sha256": "sha256:673a68f99342c6f9fd6c21b3ff265f37f8a32a4e959ade1cd6b8677af44bac00",
+   "last_verified_at": "2026-07-28T02:36:22.966Z",
+   "last_verified_diffstat_sha256": "sha256:65d97a5753250f37a246a401fcbc4accf833ce3f83665209a24340b616f3cba4",
+   "pr_number": 4650,
+diff --git a/.agentplane/tasks/202607221850-R7WS01/pr/review.md b/.agentplane/tasks/202607221850-R7WS01/pr/review.md
+index ad606d7e9..e0bf61f4a 100644
+--- a/.agentplane/tasks/202607221850-R7WS01/pr/review.md
++++ b/.agentplane/tasks/202607221850-R7WS01/pr/review.md
+@@ -31,18 +31,18 @@ Created: 2026-07-28T01:55:50.166Z
+ ```text
+  .../src/cli/run-cli.core.task-run.test.ts          |   6 +
+  .../src/commands/hermes/hermes-runtime.ts          |  19 ++-
+- .../src/commands/hermes/hermes.command.test.ts     | 107 ++++++++++++-
++ .../src/commands/hermes/hermes.command.test.ts     | 109 ++++++++++++-
+  .../src/commands/shared/workflow-supervisor.ts     |   8 +
+- .../src/commands/task/run-render.test.ts           | 138 ++++++++++++++++
+- .../agentplane/src/commands/task/run-render.ts     |  85 +++++++++-
++ .../src/commands/task/run-render.test.ts           | 138 +++++++++++++++++
++ .../agentplane/src/commands/task/run-render.ts     |  91 ++++++++++-
+  .../agentplane/src/commands/task/run.command.ts    |  41 ++---
+  .../task/task-run-effect-resolution.command.ts     |  28 ++--
+  .../src/runner/usecases/task-run-effect-journal.ts |  34 +++-
+  .../runner/usecases/task-run-lifecycle-replay.ts   |  18 ++-
+- .../runner/usecases/task-run-lifecycle-result.ts   | 175 +++++++++++++++++++++
++ .../runner/usecases/task-run-lifecycle-result.ts   | 172 +++++++++++++++++++++
+  .../runner/usecases/task-run-lifecycle-shared.ts   |   3 +
+  .../agentplane/src/runner/usecases/task-run.ts     |  14 +-
+- 13 files changed, 613 insertions(+), 63 deletions(-)
++ 13 files changed, 612 insertions(+), 69 deletions(-)
+ ```
+ 
+ </details>
+diff --git a/packages/agentplane/src/commands/hermes/hermes.command.test.ts b/packages/agentplane/src/commands/hermes/hermes.command.test.ts
+index 1e01bc660..d9b4950c4 100644
+--- a/packages/agentplane/src/commands/hermes/hermes.command.test.ts
++++ b/packages/agentplane/src/commands/hermes/hermes.command.test.ts
+@@ -344,7 +344,9 @@ describe("hermes adapter commands", () => {
+           },
+         },
+       });
+-      expect(payload.execution.result.operation_result.value.invocation.work_order_id).toContain(taskId);
++      expect(payload.execution.result.operation_result.value.invocation.work_order_id).toContain(
++        taskId,
++      );
+       expect(payload.workflow_supervision.audit.map((entry) => entry.event)).toEqual([
+         "decision_observed",
+         "operation_executed",
+diff --git a/packages/agentplane/src/commands/task/run-render.ts b/packages/agentplane/src/commands/task/run-render.ts
+index 3b8b69c58..26b8d1527 100644
+--- a/packages/agentplane/src/commands/task/run-render.ts
++++ b/packages/agentplane/src/commands/task/run-render.ts
+@@ -411,10 +411,7 @@ export async function loadRunnerLogText(
+   });
+ }
+ 
+-export function reportPreparedTaskRun(
+-  payload: TaskRunRendererPayload,
+-  taskId: string,
+-): void {
++export function reportPreparedTaskRun(payload: TaskRunRendererPayload, taskId: string): void {
+   createCliEmitter().report(
+     [
+       { label: "task", value: payload.task_id },
+@@ -447,10 +444,7 @@ export function reportPreparedTaskRun(
+   );
+ }
+ 
+-export function reportExecutedTaskRun(
+-  payload: TaskRunRendererPayload,
+-  taskId: string,
+-): void {
++export function reportExecutedTaskRun(payload: TaskRunRendererPayload, taskId: string): void {
+   createCliEmitter().report(
+     [
+       { label: "task", value: payload.task_id },
+diff --git a/packages/agentplane/src/runner/usecases/task-run-lifecycle-result.ts b/packages/agentplane/src/runner/usecases/task-run-lifecycle-result.ts
+index 4b8a3ccdf..c3a543f55 100644
+--- a/packages/agentplane/src/runner/usecases/task-run-lifecycle-result.ts
++++ b/packages/agentplane/src/runner/usecases/task-run-lifecycle-result.ts
+@@ -2,10 +2,7 @@ import type { AgentWorkOrderV2 } from "@agentplaneorg/core/schemas";
+ 
+ import type { TaskRunnerActiveClaimCleanupDiagnostic } from "./task-run-active-claim-runtime.js";
+ import type { TaskRunnerEffectOperationSnapshot } from "./task-run-effect-journal.js";
+-import type {
+-  ExecutedTaskRunnerExecution,
+-  PreparedTaskRunnerExecution,
+-} from "./task-run.js";
++import type { ExecutedTaskRunnerExecution, PreparedTaskRunnerExecution } from "./task-run.js";
+ import type {
+   RunnerInvocation,
+   RunnerLifecycleStatus,

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-observed-checks.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-observed-checks.json
@@ -1,0 +1,16 @@
+{
+  "task_status": "DONE",
+  "declared_checks": [
+    "bun run lifecycle:invariants",
+    "bun run test:critical",
+    "bun run typecheck"
+  ],
+  "verification": {
+    "state": "ok",
+    "attempts": 0,
+    "updated_at": "2026-07-28T02:43:38.519Z",
+    "updated_by": "TESTER",
+    "note": "PASS (format reverified): typed lifecycle paths now pass repository Prettier format check as well as runner, renderer, and Hermes regression checks."
+  },
+  "runner_history": []
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-opinion.md
@@ -1,0 +1,20 @@
+# Semantic quality review: pass
+
+Provenance: evaluator_supplied
+
+EVALUATOR returned pass with 1 typed finding(s).
+
+## Findings
+- The only source changes are Prettier-normalized wrapping and import grouping in the previously reviewed lifecycle paths; targeted regression tests and format:check pass.
+
+## Evidence
+- .agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-diff.patch
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-prompt.md
@@ -1,0 +1,82 @@
+# AgentPlane EVALUATOR episode
+
+AgentPlane prepared and froze the authoritative review input. Perform the semantic evaluation; do not reproduce CLI discovery or lifecycle work.
+This prompt does not execute an evaluator. A caller must run the evaluator in the work-order authority boundary and persist its returned typed result at the declared output path.
+Do not edit implementation, task lifecycle, policy, or evidence files. You may read the frozen evidence and run read-only checks only.
+
+- task_id: 202607221850-R7WS01
+- task_readme: .agentplane/tasks/202607221850-R7WS01/README.md
+- work_order: .agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-work-order.json
+- result_output: .agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-result.json
+- report_path: .agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/quality-report.json
+- provenance: evaluator_supplied
+
+## Required result
+
+Return exactly one `sgr.evaluator_result.v1` JSON object through the evaluator result channel. The caller, not the read-only evaluator, persists it at `result_output`. It must contain:
+- schema_version: 1
+- kind: evaluator_result
+- evaluator_id: the evaluator id from the work order
+- verdict: pass | rework | blocked | human_review
+- findings: typed findings with id, severity, summary, broken_invariant, and non-empty evidence_refs
+- missing_tests and hidden_assumptions: string arrays
+- recovery_context: required non-empty string for rework, blocked, or human_review; for human_review it must be the single decision question for the human owner
+
+Every findings[].evidence_refs[].path must be an exact path from work_order.evidence. Do not add fields, commands, patches, lifecycle transitions, or a verdict outside this JSON result.
+The CLI validates the schema, frozen evidence digests, task revision, evaluated SHA, and blueprint before it records quality state.
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-result.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-result.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_result",
+  "evaluator_id": "recovery-context",
+  "verdict": "pass",
+  "findings": [
+    {
+      "id": "compatibility-finding-1",
+      "severity": "medium",
+      "summary": "The only source changes are Prettier-normalized wrapping and import grouping in the previously reviewed lifecycle paths; targeted regression tests and format:check pass.",
+      "broken_invariant": "Compatibility evaluator facade requires independent review evidence.",
+      "evidence_refs": [
+        {
+          "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-diff.patch"
+        }
+      ]
+    }
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": []
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-work-order.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-work-order.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_work_order",
+  "work_order_id": "evaluator-work-order-202607221850-R7WS01-2862078551c790c477c9db04",
+  "prepared_at": "2026-07-28T02:43:41.835Z",
+  "task": {
+    "id": "202607221850-R7WS01",
+    "revision": 25,
+    "objective": "Return typed runner lifecycle results\n\nRF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing.",
+    "acceptance_criteria": [
+      "bun run lifecycle:invariants",
+      "bun run test:critical",
+      "bun run typecheck",
+      "- In scope: typed runner use-case results, adapter ports, error/result union, human/JSON renderers, compatibility snapshots, and supervisor invocation without subprocess/stdout capture.\n- Consume the durable effect-resolution contract as typed `effect_in_doubt`, `applied` and `not_applied` states, preserving resolution provenance, authority/evidence identity and claim generation in every in-process result and renderer.\n- An unresolved `effect_in_doubt` result is terminally blocked for generic retry, replay, resume and restart paths; only the explicit resolution protocol from task 202607242158-QV09NA may transition it to `applied` or `not_applied`.\n- Out of scope: automating the complete direct route, delivered by the next task.",
+      "1. Define typed results for runner preparation, invocation, observation, evaluation handoff, and terminal outcomes.\n2. Separate rendering/exit mapping from use-case logic.\n3. Call runner phases in-process from the supervisor.\n4. Map durable journal/resolution input to typed `effect_in_doubt`, `applied` and `not_applied` outcomes with resolution provenance, and reject any generic retry path for unresolved effects.\n5. Preserve documented human and JSON output through compatibility renderers without dropping resolution provenance.\n6. Add result/renderer parity, adapter error, cancellation, timeout, stale-work-order and effect-resolution transition tests.",
+      "1. Invoke each runner phase in-process. Expected: structured results carry work-order/fingerprint/receipt identities without reading stdout.\n2. Render the same result to human and JSON formats. Expected: compatibility snapshots and exit codes remain stable.\n3. Feed durable journal states for `effect_in_doubt`, operator-resolved `applied` and operator-resolved `not_applied` into each runner/supervisor entry point. Expected: typed results and both renderers preserve the state, operator-supplied resolution provenance, evidence/authority digests and claim generation without stdout parsing.\n4. Invoke generic retry, replay, resume and restart against unresolved `effect_in_doubt`. Expected: every path returns the typed blocked outcome, performs no adapter invocation and directs callers only to the explicit operator-resolution protocol; no generic retry can reinterpret the effect as `not_applied`.\n5. Exercise cancellation, timeout, adapter crash, stale input, and policy denial. Expected: typed outcomes and observed receipts remain complete.\n6. Run runner/supervisor/lifecycle tests and typecheck."
+    ]
+  },
+  "evaluated_sha": "96ff9bab8db6e431077c9a7f60b357735e011f80",
+  "blueprint_digest": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328",
+  "evaluator": {
+    "id": "recovery-context",
+    "profile": "EVALUATOR",
+    "prompt_module_path": ".agentplane/evaluators/recovery-context.md"
+  },
+  "authority": {
+    "sandbox": "read-only",
+    "writable_roots": [],
+    "allowed_tool_classes": [
+      "repository_read",
+      "git_read",
+      "run_checks",
+      "report_result"
+    ],
+    "external_side_effects": []
+  },
+  "result_contract": "sgr.evaluator_result.v1",
+  "evidence": [
+    {
+      "id": "task-document",
+      "kind": "task_document",
+      "path": ".agentplane/tasks/202607221850-R7WS01/README.md",
+      "sha256": "sha256:7bb35dc8c3d22a898453a3a1516ae6ac69d75443db2a82dd274e62e9afec24f9",
+      "required": true
+    },
+    {
+      "id": "actual-diff",
+      "kind": "actual_diff",
+      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-diff.patch",
+      "sha256": "sha256:f42efb19775181a781bb475141a38d19fab00676186d084cb496a79ef0c0b45c",
+      "required": true
+    },
+    {
+      "id": "observed-checks",
+      "kind": "observed_checks",
+      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-observed-checks.json",
+      "sha256": "sha256:acde75c5a7b70e94f625d73d36761532009022d7ecc50fd394fa712b86460596",
+      "required": true
+    },
+    {
+      "id": "blueprint",
+      "kind": "blueprint",
+      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-blueprint.json",
+      "sha256": "sha256:d348dedab56fd1219b3127a4ff3da0570f1904829944b3609e64139f6309b3fb",
+      "required": true
+    },
+    {
+      "id": "policy-1",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.code.md",
+      "sha256": "sha256:3fec50dfe0db2f9495a3fa96f36d95fb34262033299d57f6f3775af4b7cc1486",
+      "required": true
+    },
+    {
+      "id": "policy-2",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.core.md",
+      "sha256": "sha256:f6c11b8a2c55760c17af15f79fe13791b3e7bba4852fc7d311fc0657e490b0c7",
+      "required": true
+    },
+    {
+      "id": "policy-3",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/security.must.md",
+      "sha256": "sha256:96d01012e7ab67873bcb7a2cdd3818efa2c1fa500ee2eaf0e316f67e15bbcab2",
+      "required": true
+    },
+    {
+      "id": "policy-4",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/workflow.branch_pr.md",
+      "sha256": "sha256:12d3b942042c276d30593803ddcfe12b20dc794e3e8bfbd97b6ce59df13ba82b",
+      "required": true
+    }
+  ]
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/quality-report.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "task_id": "202607221850-R7WS01",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-28T02:43:41.960Z",
+  "provenance": "evaluator_supplied",
+  "verdict": "pass",
+  "summary": "EVALUATOR returned pass with 1 typed finding(s).",
+  "evaluated_sha": "96ff9bab8db6e431077c9a7f60b357735e011f80",
+  "blueprint_digest": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328",
+  "findings": [
+    "The only source changes are Prettier-normalized wrapping and import grouping in the previously reviewed lifecycle paths; targeted regression tests and format:check pass."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607221850-R7WS01/quality/20260728-024341835-recovery-context/evaluator-diff.patch"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-blueprint.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-blueprint.json
@@ -1,0 +1,583 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607221850-R7WS01",
+    "title": "Return typed runner lifecycle results",
+    "description": "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing.",
+    "tags": [
+      "milestone-beta1",
+      "refactor",
+      "rf-25",
+      "runner",
+      "use-case",
+      "v0.7",
+      "wave-supervisor"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607221850-R7WS01",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328"
+  }
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-diff.patch
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-diff.patch
@@ -1,0 +1,154 @@
+diff --git a/packages/agentplane/src/commands/hermes/hermes.command.test.ts b/packages/agentplane/src/commands/hermes/hermes.command.test.ts
+index d9b4950c4..36a7adaec 100644
+--- a/packages/agentplane/src/commands/hermes/hermes.command.test.ts
++++ b/packages/agentplane/src/commands/hermes/hermes.command.test.ts
+@@ -322,31 +322,22 @@ describe("hermes adapter commands", () => {
+       expect(payload.execution.allowed).toBe(true);
+       expect(payload.execution.result.detail).toContain(taskId);
+       expect(payload.execution.result.exit_code).toBeNull();
+-      expect(payload.execution.result.operation_result).toMatchObject({
+-        kind: "runner_lifecycle",
+-        value: {
+-          schema: "agentplane.task_runner_lifecycle_result.v1",
+-          phase: "prepared",
+-          task_id: taskId,
+-          lifecycle: {
+-            effect: {
+-              state: "not_recorded",
+-              authority: {
+-                ref: expect.stringContaining("work-order:"),
+-                digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+-              },
+-              observed_evidence: {
+-                code: "runner_effect_operation_prepared",
+-                digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+-              },
+-              claim_generation: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+-            },
+-          },
+-        },
+-      });
+-      expect(payload.execution.result.operation_result.value.invocation.work_order_id).toContain(
+-        taskId,
+-      );
++      const operationResult = payload.execution.result.operation_result;
++      const lifecycle = operationResult.value;
++      const effect = lifecycle.lifecycle.effect;
++      expect(operationResult.kind).toBe("runner_lifecycle");
++      expect(lifecycle.schema).toBe("agentplane.task_runner_lifecycle_result.v1");
++      expect(lifecycle.phase).toBe("prepared");
++      expect(lifecycle.task_id).toBe(taskId);
++      expect(effect.state).toBe("not_recorded");
++      expect(effect.authority).not.toBeNull();
++      expect(effect.authority?.ref).toContain("work-order:");
++      expect(effect.authority?.digest).toMatch(/^sha256:[0-9a-f]{64}$/u);
++      expect(effect.observed_evidence).not.toBeNull();
++      expect(effect.observed_evidence?.code).toBe("runner_effect_operation_prepared");
++      expect(effect.observed_evidence?.digest).toMatch(/^sha256:[0-9a-f]{64}$/u);
++      expect(effect.claim_generation).toMatch(/^sha256:[0-9a-f]{64}$/u);
++      expect(lifecycle.invocation.work_order_id).toContain(taskId);
+       expect(payload.workflow_supervision.audit.map((entry) => entry.event)).toEqual([
+         "decision_observed",
+         "operation_executed",
+diff --git a/packages/agentplane/src/runner/usecases/task-run-execution.ts b/packages/agentplane/src/runner/usecases/task-run-execution.ts
+new file mode 100644
+index 000000000..0286fe97a
+--- /dev/null
++++ b/packages/agentplane/src/runner/usecases/task-run-execution.ts
+@@ -0,0 +1,36 @@
++import type {
++  StateFingerprint,
++  StateFingerprintPolicy,
++  StateFingerprintPreconditionDiagnostic,
++} from "@agentplaneorg/core/schemas";
++
++import type { TaskRunnerActiveClaimCleanupDiagnostic } from "./task-run-active-claim-runtime.js";
++import type { TaskRunnerEffectOperationSnapshot } from "./task-run-effect-journal.js";
++import type {
++  RunnerContextBundle,
++  RunnerInvocation,
++  RunnerResult,
++  RunnerRunState,
++} from "../types.js";
++
++export type PreparedTaskRunnerExecution = {
++  bundle: RunnerContextBundle;
++  invocation: RunnerInvocation;
++  state: RunnerRunState;
++  effect_operation?: TaskRunnerEffectOperationSnapshot;
++  precondition_fingerprint?: StateFingerprint;
++  precondition_policy?: StateFingerprintPolicy;
++};
++
++export type ExecutedTaskRunnerExecution = Omit<
++  PreparedTaskRunnerExecution,
++  "precondition_fingerprint" | "precondition_policy"
++> & {
++  precondition_fingerprint: StateFingerprint;
++  precondition_policy: StateFingerprintPolicy;
++  result: RunnerResult;
++  state_before: StateFingerprint;
++  state_after: StateFingerprint;
++  precondition: StateFingerprintPreconditionDiagnostic;
++  active_claim_cleanup?: TaskRunnerActiveClaimCleanupDiagnostic;
++};
+diff --git a/packages/agentplane/src/runner/usecases/task-run.ts b/packages/agentplane/src/runner/usecases/task-run.ts
+index 6b01854f6..b503528ad 100644
+--- a/packages/agentplane/src/runner/usecases/task-run.ts
++++ b/packages/agentplane/src/runner/usecases/task-run.ts
+@@ -1,8 +1,3 @@
+-import {
+-  type StateFingerprint,
+-  type StateFingerprintPolicy,
+-  type StateFingerprintPreconditionDiagnostic,
+-} from "@agentplaneorg/core/schemas";
+ import { loadCommandContext, type CommandContext } from "../../commands/shared/task-backend.js";
+ import { CliError } from "../../shared/errors.js";
+ import { resolveRunnerAdapterCapabilityRegistry } from "../../runtime/capabilities/index.js";
+@@ -58,7 +53,6 @@ import {
+   recordTaskRunnerPostStateUnknown,
+   persistTaskRunnerEffectAccepted,
+   startTaskRunnerEffectOperation,
+-  type TaskRunnerEffectOperationSnapshot,
+   type StartedRunnerEffectOperation,
+ } from "./task-run-effect-journal.js";
+ import { finalizeTaskRunnerActiveClaimCleanup } from "./task-run-active-claim-cleanup.js";
+@@ -85,31 +79,16 @@ import {
+   type RunnerExecutionContract,
+   type RunnerInvocation,
+   type RunnerRecipeContext,
+-  type RunnerResult,
+-  type RunnerRunState,
+   type RunnerTarget,
+ } from "../types.js";
+-export type PreparedTaskRunnerExecution = {
+-  bundle: RunnerContextBundle;
+-  invocation: RunnerInvocation;
+-  state: RunnerRunState;
+-  /** Durable operation and journal identity already established by preparation. */
+-  effect_operation?: TaskRunnerEffectOperationSnapshot;
+-  precondition_fingerprint?: StateFingerprint;
+-  precondition_policy?: StateFingerprintPolicy;
+-};
+-export type ExecutedTaskRunnerExecution = Omit<
++import type {
++  ExecutedTaskRunnerExecution,
++  PreparedTaskRunnerExecution,
++} from "./task-run-execution.js";
++export type {
++  ExecutedTaskRunnerExecution,
+   PreparedTaskRunnerExecution,
+-  "precondition_fingerprint" | "precondition_policy"
+-> & {
+-  precondition_fingerprint: StateFingerprint;
+-  precondition_policy: StateFingerprintPolicy;
+-  result: RunnerResult;
+-  state_before: StateFingerprint;
+-  state_after: StateFingerprint;
+-  precondition: StateFingerprintPreconditionDiagnostic;
+-  active_claim_cleanup?: TaskRunnerActiveClaimCleanupDiagnostic;
+-};
++} from "./task-run-execution.js";
+ export type { TaskRunnerReplayProvenance } from "./task-run-replay-anchor.js";
+ 
+ export async function prepareTaskRunnerExecution(opts: {

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-observed-checks.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-observed-checks.json
@@ -1,0 +1,16 @@
+{
+  "task_status": "DONE",
+  "declared_checks": [
+    "bun run lifecycle:invariants",
+    "bun run test:critical",
+    "bun run typecheck"
+  ],
+  "verification": {
+    "state": "ok",
+    "attempts": 0,
+    "updated_at": "2026-07-28T02:54:35.229Z",
+    "updated_by": "TESTER",
+    "note": "PASS (hosted rework): split execution contracts keeps task-run below the hotspot threshold and replaces unsafe Hermes matcher assignments with typed assertions."
+  },
+  "runner_history": []
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-opinion.md
@@ -1,0 +1,20 @@
+# Semantic quality review: pass
+
+Provenance: evaluator_supplied
+
+EVALUATOR returned pass with 1 typed finding(s).
+
+## Findings
+- No blocking finding: task-run execution contracts are isolated in a dedicated type module; Hermes checks concrete typed values rather than assigning matcher any values.
+
+## Evidence
+- .agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-diff.patch
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-prompt.md
@@ -1,0 +1,82 @@
+# AgentPlane EVALUATOR episode
+
+AgentPlane prepared and froze the authoritative review input. Perform the semantic evaluation; do not reproduce CLI discovery or lifecycle work.
+This prompt does not execute an evaluator. A caller must run the evaluator in the work-order authority boundary and persist its returned typed result at the declared output path.
+Do not edit implementation, task lifecycle, policy, or evidence files. You may read the frozen evidence and run read-only checks only.
+
+- task_id: 202607221850-R7WS01
+- task_readme: .agentplane/tasks/202607221850-R7WS01/README.md
+- work_order: .agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-work-order.json
+- result_output: .agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-result.json
+- report_path: .agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/quality-report.json
+- provenance: evaluator_supplied
+
+## Required result
+
+Return exactly one `sgr.evaluator_result.v1` JSON object through the evaluator result channel. The caller, not the read-only evaluator, persists it at `result_output`. It must contain:
+- schema_version: 1
+- kind: evaluator_result
+- evaluator_id: the evaluator id from the work order
+- verdict: pass | rework | blocked | human_review
+- findings: typed findings with id, severity, summary, broken_invariant, and non-empty evidence_refs
+- missing_tests and hidden_assumptions: string arrays
+- recovery_context: required non-empty string for rework, blocked, or human_review; for human_review it must be the single decision question for the human owner
+
+Every findings[].evidence_refs[].path must be an exact path from work_order.evidence. Do not add fields, commands, patches, lifecycle transitions, or a verdict outside this JSON result.
+The CLI validates the schema, frozen evidence digests, task revision, evaluated SHA, and blueprint before it records quality state.
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-result.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-result.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_result",
+  "evaluator_id": "recovery-context",
+  "verdict": "pass",
+  "findings": [
+    {
+      "id": "compatibility-finding-1",
+      "severity": "medium",
+      "summary": "No blocking finding: task-run execution contracts are isolated in a dedicated type module; Hermes checks concrete typed values rather than assigning matcher any values.",
+      "broken_invariant": "Compatibility evaluator facade requires independent review evidence.",
+      "evidence_refs": [
+        {
+          "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-diff.patch"
+        }
+      ]
+    }
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": []
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-work-order.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-work-order.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_work_order",
+  "work_order_id": "evaluator-work-order-202607221850-R7WS01-a9baa04a0db43e1ec0600c9c",
+  "prepared_at": "2026-07-28T02:55:17.959Z",
+  "task": {
+    "id": "202607221850-R7WS01",
+    "revision": 31,
+    "objective": "Return typed runner lifecycle results\n\nRF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing.",
+    "acceptance_criteria": [
+      "bun run lifecycle:invariants",
+      "bun run test:critical",
+      "bun run typecheck",
+      "- In scope: typed runner use-case results, adapter ports, error/result union, human/JSON renderers, compatibility snapshots, and supervisor invocation without subprocess/stdout capture.\n- Consume the durable effect-resolution contract as typed `effect_in_doubt`, `applied` and `not_applied` states, preserving resolution provenance, authority/evidence identity and claim generation in every in-process result and renderer.\n- An unresolved `effect_in_doubt` result is terminally blocked for generic retry, replay, resume and restart paths; only the explicit resolution protocol from task 202607242158-QV09NA may transition it to `applied` or `not_applied`.\n- Out of scope: automating the complete direct route, delivered by the next task.",
+      "1. Define typed results for runner preparation, invocation, observation, evaluation handoff, and terminal outcomes.\n2. Separate rendering/exit mapping from use-case logic.\n3. Call runner phases in-process from the supervisor.\n4. Map durable journal/resolution input to typed `effect_in_doubt`, `applied` and `not_applied` outcomes with resolution provenance, and reject any generic retry path for unresolved effects.\n5. Preserve documented human and JSON output through compatibility renderers without dropping resolution provenance.\n6. Add result/renderer parity, adapter error, cancellation, timeout, stale-work-order and effect-resolution transition tests.",
+      "1. Invoke each runner phase in-process. Expected: structured results carry work-order/fingerprint/receipt identities without reading stdout.\n2. Render the same result to human and JSON formats. Expected: compatibility snapshots and exit codes remain stable.\n3. Feed durable journal states for `effect_in_doubt`, operator-resolved `applied` and operator-resolved `not_applied` into each runner/supervisor entry point. Expected: typed results and both renderers preserve the state, operator-supplied resolution provenance, evidence/authority digests and claim generation without stdout parsing.\n4. Invoke generic retry, replay, resume and restart against unresolved `effect_in_doubt`. Expected: every path returns the typed blocked outcome, performs no adapter invocation and directs callers only to the explicit operator-resolution protocol; no generic retry can reinterpret the effect as `not_applied`.\n5. Exercise cancellation, timeout, adapter crash, stale input, and policy denial. Expected: typed outcomes and observed receipts remain complete.\n6. Run runner/supervisor/lifecycle tests and typecheck."
+    ]
+  },
+  "evaluated_sha": "8cd703b66e4c14daae26b244f551e705068e178d",
+  "blueprint_digest": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328",
+  "evaluator": {
+    "id": "recovery-context",
+    "profile": "EVALUATOR",
+    "prompt_module_path": ".agentplane/evaluators/recovery-context.md"
+  },
+  "authority": {
+    "sandbox": "read-only",
+    "writable_roots": [],
+    "allowed_tool_classes": [
+      "repository_read",
+      "git_read",
+      "run_checks",
+      "report_result"
+    ],
+    "external_side_effects": []
+  },
+  "result_contract": "sgr.evaluator_result.v1",
+  "evidence": [
+    {
+      "id": "task-document",
+      "kind": "task_document",
+      "path": ".agentplane/tasks/202607221850-R7WS01/README.md",
+      "sha256": "sha256:159d4bd40e05b76cfdb5dc2cd6f340fddac0bfaaba94dd714c2857f777b27fa2",
+      "required": true
+    },
+    {
+      "id": "actual-diff",
+      "kind": "actual_diff",
+      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-diff.patch",
+      "sha256": "sha256:dd0abb0685a901d6d20d3b51fea65326922e2a7ffa5ac404af7bd96b1fd8110b",
+      "required": true
+    },
+    {
+      "id": "observed-checks",
+      "kind": "observed_checks",
+      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-observed-checks.json",
+      "sha256": "sha256:8291d43b821fea4f880202a7f9b2ac5edd90b50d30c11a9c894367d680d7e0e5",
+      "required": true
+    },
+    {
+      "id": "blueprint",
+      "kind": "blueprint",
+      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-blueprint.json",
+      "sha256": "sha256:d348dedab56fd1219b3127a4ff3da0570f1904829944b3609e64139f6309b3fb",
+      "required": true
+    },
+    {
+      "id": "policy-1",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.code.md",
+      "sha256": "sha256:3fec50dfe0db2f9495a3fa96f36d95fb34262033299d57f6f3775af4b7cc1486",
+      "required": true
+    },
+    {
+      "id": "policy-2",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.core.md",
+      "sha256": "sha256:f6c11b8a2c55760c17af15f79fe13791b3e7bba4852fc7d311fc0657e490b0c7",
+      "required": true
+    },
+    {
+      "id": "policy-3",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/security.must.md",
+      "sha256": "sha256:96d01012e7ab67873bcb7a2cdd3818efa2c1fa500ee2eaf0e316f67e15bbcab2",
+      "required": true
+    },
+    {
+      "id": "policy-4",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/workflow.branch_pr.md",
+      "sha256": "sha256:12d3b942042c276d30593803ddcfe12b20dc794e3e8bfbd97b6ce59df13ba82b",
+      "required": true
+    }
+  ]
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/quality-report.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "task_id": "202607221850-R7WS01",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-28T02:55:18.124Z",
+  "provenance": "evaluator_supplied",
+  "verdict": "pass",
+  "summary": "EVALUATOR returned pass with 1 typed finding(s).",
+  "evaluated_sha": "8cd703b66e4c14daae26b244f551e705068e178d",
+  "blueprint_digest": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328",
+  "findings": [
+    "No blocking finding: task-run execution contracts are isolated in a dedicated type module; Hermes checks concrete typed values rather than assigning matcher any values."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607221850-R7WS01/quality/20260728-025517959-recovery-context/evaluator-diff.patch"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-blueprint.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-blueprint.json
@@ -1,0 +1,583 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607221850-R7WS01",
+    "title": "Return typed runner lifecycle results",
+    "description": "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing.",
+    "tags": [
+      "milestone-beta1",
+      "refactor",
+      "rf-25",
+      "runner",
+      "use-case",
+      "v0.7",
+      "wave-supervisor"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607221850-R7WS01",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328"
+  }
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-diff.patch
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-diff.patch
@@ -1,0 +1,12 @@
+diff --git a/packages/agentplane/src/runner/usecases/task-run.ts b/packages/agentplane/src/runner/usecases/task-run.ts
+index b503528ad..3b8337461 100644
+--- a/packages/agentplane/src/runner/usecases/task-run.ts
++++ b/packages/agentplane/src/runner/usecases/task-run.ts
+@@ -31,7 +31,6 @@ import {
+   reconcileStaleTerminalTaskRunnerActiveClaim,
+   reconcileTerminalTaskRunnerActiveClaim,
+   recordActiveClaimCleanupFailure,
+-  type TaskRunnerActiveClaimCleanupDiagnostic,
+ } from "./task-run-active-claim-runtime.js";
+ import { renderTaskRunnerBootstrap } from "./task-run-bootstrap.js";
+ export { renderTaskRunnerBootstrap } from "./task-run-bootstrap.js";

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-observed-checks.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-observed-checks.json
@@ -1,0 +1,16 @@
+{
+  "task_status": "DONE",
+  "declared_checks": [
+    "bun run lifecycle:invariants",
+    "bun run test:critical",
+    "bun run typecheck"
+  ],
+  "verification": {
+    "state": "ok",
+    "attempts": 0,
+    "updated_at": "2026-07-28T03:01:34.362Z",
+    "updated_by": "TESTER",
+    "note": "PASS (static rework): stale type import removed after contract extraction; no runner lifecycle behavior changed."
+  },
+  "runner_history": []
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-opinion.md
@@ -1,0 +1,20 @@
+# Semantic quality review: pass
+
+Provenance: evaluator_supplied
+
+EVALUATOR returned pass with 1 typed finding(s).
+
+## Findings
+- No blocking finding: the only new hosted static error was an unused import left after contract extraction; final lint and targeted regression tests pass.
+
+## Evidence
+- .agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-diff.patch
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-prompt.md
@@ -1,0 +1,82 @@
+# AgentPlane EVALUATOR episode
+
+AgentPlane prepared and froze the authoritative review input. Perform the semantic evaluation; do not reproduce CLI discovery or lifecycle work.
+This prompt does not execute an evaluator. A caller must run the evaluator in the work-order authority boundary and persist its returned typed result at the declared output path.
+Do not edit implementation, task lifecycle, policy, or evidence files. You may read the frozen evidence and run read-only checks only.
+
+- task_id: 202607221850-R7WS01
+- task_readme: .agentplane/tasks/202607221850-R7WS01/README.md
+- work_order: .agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-work-order.json
+- result_output: .agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-result.json
+- report_path: .agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/quality-report.json
+- provenance: evaluator_supplied
+
+## Required result
+
+Return exactly one `sgr.evaluator_result.v1` JSON object through the evaluator result channel. The caller, not the read-only evaluator, persists it at `result_output`. It must contain:
+- schema_version: 1
+- kind: evaluator_result
+- evaluator_id: the evaluator id from the work order
+- verdict: pass | rework | blocked | human_review
+- findings: typed findings with id, severity, summary, broken_invariant, and non-empty evidence_refs
+- missing_tests and hidden_assumptions: string arrays
+- recovery_context: required non-empty string for rework, blocked, or human_review; for human_review it must be the single decision question for the human owner
+
+Every findings[].evidence_refs[].path must be an exact path from work_order.evidence. Do not add fields, commands, patches, lifecycle transitions, or a verdict outside this JSON result.
+The CLI validates the schema, frozen evidence digests, task revision, evaluated SHA, and blueprint before it records quality state.
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-result.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-result.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_result",
+  "evaluator_id": "recovery-context",
+  "verdict": "pass",
+  "findings": [
+    {
+      "id": "compatibility-finding-1",
+      "severity": "medium",
+      "summary": "No blocking finding: the only new hosted static error was an unused import left after contract extraction; final lint and targeted regression tests pass.",
+      "broken_invariant": "Compatibility evaluator facade requires independent review evidence.",
+      "evidence_refs": [
+        {
+          "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-diff.patch"
+        }
+      ]
+    }
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": []
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-work-order.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-work-order.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_work_order",
+  "work_order_id": "evaluator-work-order-202607221850-R7WS01-356359999bef4bbe56cc2500",
+  "prepared_at": "2026-07-28T03:01:49.331Z",
+  "task": {
+    "id": "202607221850-R7WS01",
+    "revision": 37,
+    "objective": "Return typed runner lifecycle results\n\nRF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing.",
+    "acceptance_criteria": [
+      "bun run lifecycle:invariants",
+      "bun run test:critical",
+      "bun run typecheck",
+      "- In scope: typed runner use-case results, adapter ports, error/result union, human/JSON renderers, compatibility snapshots, and supervisor invocation without subprocess/stdout capture.\n- Consume the durable effect-resolution contract as typed `effect_in_doubt`, `applied` and `not_applied` states, preserving resolution provenance, authority/evidence identity and claim generation in every in-process result and renderer.\n- An unresolved `effect_in_doubt` result is terminally blocked for generic retry, replay, resume and restart paths; only the explicit resolution protocol from task 202607242158-QV09NA may transition it to `applied` or `not_applied`.\n- Out of scope: automating the complete direct route, delivered by the next task.",
+      "1. Define typed results for runner preparation, invocation, observation, evaluation handoff, and terminal outcomes.\n2. Separate rendering/exit mapping from use-case logic.\n3. Call runner phases in-process from the supervisor.\n4. Map durable journal/resolution input to typed `effect_in_doubt`, `applied` and `not_applied` outcomes with resolution provenance, and reject any generic retry path for unresolved effects.\n5. Preserve documented human and JSON output through compatibility renderers without dropping resolution provenance.\n6. Add result/renderer parity, adapter error, cancellation, timeout, stale-work-order and effect-resolution transition tests.",
+      "1. Invoke each runner phase in-process. Expected: structured results carry work-order/fingerprint/receipt identities without reading stdout.\n2. Render the same result to human and JSON formats. Expected: compatibility snapshots and exit codes remain stable.\n3. Feed durable journal states for `effect_in_doubt`, operator-resolved `applied` and operator-resolved `not_applied` into each runner/supervisor entry point. Expected: typed results and both renderers preserve the state, operator-supplied resolution provenance, evidence/authority digests and claim generation without stdout parsing.\n4. Invoke generic retry, replay, resume and restart against unresolved `effect_in_doubt`. Expected: every path returns the typed blocked outcome, performs no adapter invocation and directs callers only to the explicit operator-resolution protocol; no generic retry can reinterpret the effect as `not_applied`.\n5. Exercise cancellation, timeout, adapter crash, stale input, and policy denial. Expected: typed outcomes and observed receipts remain complete.\n6. Run runner/supervisor/lifecycle tests and typecheck."
+    ]
+  },
+  "evaluated_sha": "8339ca9dc3ed7b3e59726ee240bc044fead4b89f",
+  "blueprint_digest": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328",
+  "evaluator": {
+    "id": "recovery-context",
+    "profile": "EVALUATOR",
+    "prompt_module_path": ".agentplane/evaluators/recovery-context.md"
+  },
+  "authority": {
+    "sandbox": "read-only",
+    "writable_roots": [],
+    "allowed_tool_classes": [
+      "repository_read",
+      "git_read",
+      "run_checks",
+      "report_result"
+    ],
+    "external_side_effects": []
+  },
+  "result_contract": "sgr.evaluator_result.v1",
+  "evidence": [
+    {
+      "id": "task-document",
+      "kind": "task_document",
+      "path": ".agentplane/tasks/202607221850-R7WS01/README.md",
+      "sha256": "sha256:bb90368540280b0ffeaa9f9b9a2d9e006f31793e651849b4b8553b5d131e0b06",
+      "required": true
+    },
+    {
+      "id": "actual-diff",
+      "kind": "actual_diff",
+      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-diff.patch",
+      "sha256": "sha256:6f4aa26be504f205ea526babeeaabae316a80dcf7cf8a5612debc30dc7431419",
+      "required": true
+    },
+    {
+      "id": "observed-checks",
+      "kind": "observed_checks",
+      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-observed-checks.json",
+      "sha256": "sha256:8f41f73352bd6a77e589ff5d07839aa227789ab412099162b4f58b002b2ab52a",
+      "required": true
+    },
+    {
+      "id": "blueprint",
+      "kind": "blueprint",
+      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-blueprint.json",
+      "sha256": "sha256:d348dedab56fd1219b3127a4ff3da0570f1904829944b3609e64139f6309b3fb",
+      "required": true
+    },
+    {
+      "id": "policy-1",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.code.md",
+      "sha256": "sha256:3fec50dfe0db2f9495a3fa96f36d95fb34262033299d57f6f3775af4b7cc1486",
+      "required": true
+    },
+    {
+      "id": "policy-2",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.core.md",
+      "sha256": "sha256:f6c11b8a2c55760c17af15f79fe13791b3e7bba4852fc7d311fc0657e490b0c7",
+      "required": true
+    },
+    {
+      "id": "policy-3",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/security.must.md",
+      "sha256": "sha256:96d01012e7ab67873bcb7a2cdd3818efa2c1fa500ee2eaf0e316f67e15bbcab2",
+      "required": true
+    },
+    {
+      "id": "policy-4",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/workflow.branch_pr.md",
+      "sha256": "sha256:12d3b942042c276d30593803ddcfe12b20dc794e3e8bfbd97b6ce59df13ba82b",
+      "required": true
+    }
+  ]
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/quality-report.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "task_id": "202607221850-R7WS01",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-28T03:01:49.505Z",
+  "provenance": "evaluator_supplied",
+  "verdict": "pass",
+  "summary": "EVALUATOR returned pass with 1 typed finding(s).",
+  "evaluated_sha": "8339ca9dc3ed7b3e59726ee240bc044fead4b89f",
+  "blueprint_digest": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328",
+  "findings": [
+    "No blocking finding: the only new hosted static error was an unused import left after contract extraction; final lint and targeted regression tests pass."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607221850-R7WS01/quality/20260728-030149331-recovery-context/evaluator-diff.patch"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-blueprint.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-blueprint.json
@@ -1,0 +1,583 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607221850-R7WS01",
+    "title": "Return typed runner lifecycle results",
+    "description": "RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing.",
+    "tags": [
+      "milestone-beta1",
+      "refactor",
+      "rf-25",
+      "runner",
+      "use-case",
+      "v0.7",
+      "wave-supervisor"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607221850-R7WS01",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328"
+  }
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-diff.patch
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-diff.patch
@@ -1,0 +1,30 @@
+diff --git a/packages/agentplane/src/commands/shared/workflow-supervisor.ts b/packages/agentplane/src/commands/shared/workflow-supervisor.ts
+index 8b433e5d6..d899bd27b 100644
+--- a/packages/agentplane/src/commands/shared/workflow-supervisor.ts
++++ b/packages/agentplane/src/commands/shared/workflow-supervisor.ts
+@@ -24,7 +24,7 @@ type WorkflowSupervisorAuditEntry = {
+   detail: string;
+ };
+ 
+-export type WorkflowSupervisorOperationPayload = {
++type WorkflowSupervisorOperationPayload = {
+   kind: "runner_lifecycle";
+   value: TaskRunnerLifecycleResult;
+ };
+diff --git a/packages/agentplane/src/runner/usecases/task-run-lifecycle-result.ts b/packages/agentplane/src/runner/usecases/task-run-lifecycle-result.ts
+index c3a543f55..6422fb137 100644
+--- a/packages/agentplane/src/runner/usecases/task-run-lifecycle-result.ts
++++ b/packages/agentplane/src/runner/usecases/task-run-lifecycle-result.ts
+@@ -10,10 +10,9 @@ import type {
+   RunnerRunState,
+ } from "../types.js";
+ 
+-export const TASK_RUNNER_LIFECYCLE_RESULT_SCHEMA =
+-  "agentplane.task_runner_lifecycle_result.v1" as const;
++const TASK_RUNNER_LIFECYCLE_RESULT_SCHEMA = "agentplane.task_runner_lifecycle_result.v1" as const;
+ 
+-export type TaskRunnerLifecycleEffectState =
++type TaskRunnerLifecycleEffectState =
+   | "not_recorded"
+   | "effect_in_doubt"
+   | "applied"

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-observed-checks.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-observed-checks.json
@@ -1,0 +1,16 @@
+{
+  "task_status": "DONE",
+  "declared_checks": [
+    "bun run lifecycle:invariants",
+    "bun run test:critical",
+    "bun run typecheck"
+  ],
+  "verification": {
+    "state": "ok",
+    "attempts": 0,
+    "updated_at": "2026-07-28T03:12:27.262Z",
+    "updated_by": "TESTER",
+    "note": "PASS (dead-code rework): lifecycle-only exports are private; the public typed result and supervisor operation contract remain unchanged."
+  },
+  "runner_history": []
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-opinion.md
@@ -1,0 +1,20 @@
+# Semantic quality review: pass
+
+Provenance: evaluator_supplied
+
+EVALUATOR returned pass with 1 typed finding(s).
+
+## Findings
+- No blocking finding: Knip and dependency-cruiser both pass; the implementation keeps only externally consumed symbols public.
+
+## Evidence
+- .agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-diff.patch
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-prompt.md
@@ -1,0 +1,82 @@
+# AgentPlane EVALUATOR episode
+
+AgentPlane prepared and froze the authoritative review input. Perform the semantic evaluation; do not reproduce CLI discovery or lifecycle work.
+This prompt does not execute an evaluator. A caller must run the evaluator in the work-order authority boundary and persist its returned typed result at the declared output path.
+Do not edit implementation, task lifecycle, policy, or evidence files. You may read the frozen evidence and run read-only checks only.
+
+- task_id: 202607221850-R7WS01
+- task_readme: .agentplane/tasks/202607221850-R7WS01/README.md
+- work_order: .agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-work-order.json
+- result_output: .agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-result.json
+- report_path: .agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/quality-report.json
+- provenance: evaluator_supplied
+
+## Required result
+
+Return exactly one `sgr.evaluator_result.v1` JSON object through the evaluator result channel. The caller, not the read-only evaluator, persists it at `result_output`. It must contain:
+- schema_version: 1
+- kind: evaluator_result
+- evaluator_id: the evaluator id from the work order
+- verdict: pass | rework | blocked | human_review
+- findings: typed findings with id, severity, summary, broken_invariant, and non-empty evidence_refs
+- missing_tests and hidden_assumptions: string arrays
+- recovery_context: required non-empty string for rework, blocked, or human_review; for human_review it must be the single decision question for the human owner
+
+Every findings[].evidence_refs[].path must be an exact path from work_order.evidence. Do not add fields, commands, patches, lifecycle transitions, or a verdict outside this JSON result.
+The CLI validates the schema, frozen evidence digests, task revision, evaluated SHA, and blueprint before it records quality state.
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-result.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-result.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_result",
+  "evaluator_id": "recovery-context",
+  "verdict": "pass",
+  "findings": [
+    {
+      "id": "compatibility-finding-1",
+      "severity": "medium",
+      "summary": "No blocking finding: Knip and dependency-cruiser both pass; the implementation keeps only externally consumed symbols public.",
+      "broken_invariant": "Compatibility evaluator facade requires independent review evidence.",
+      "evidence_refs": [
+        {
+          "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-diff.patch"
+        }
+      ]
+    }
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": []
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-work-order.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-work-order.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_work_order",
+  "work_order_id": "evaluator-work-order-202607221850-R7WS01-9aa2acc27d23ffbd92301c8e",
+  "prepared_at": "2026-07-28T03:12:42.011Z",
+  "task": {
+    "id": "202607221850-R7WS01",
+    "revision": 43,
+    "objective": "Return typed runner lifecycle results\n\nRF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing.",
+    "acceptance_criteria": [
+      "bun run lifecycle:invariants",
+      "bun run test:critical",
+      "bun run typecheck",
+      "- In scope: typed runner use-case results, adapter ports, error/result union, human/JSON renderers, compatibility snapshots, and supervisor invocation without subprocess/stdout capture.\n- Consume the durable effect-resolution contract as typed `effect_in_doubt`, `applied` and `not_applied` states, preserving resolution provenance, authority/evidence identity and claim generation in every in-process result and renderer.\n- An unresolved `effect_in_doubt` result is terminally blocked for generic retry, replay, resume and restart paths; only the explicit resolution protocol from task 202607242158-QV09NA may transition it to `applied` or `not_applied`.\n- Out of scope: automating the complete direct route, delivered by the next task.",
+      "1. Define typed results for runner preparation, invocation, observation, evaluation handoff, and terminal outcomes.\n2. Separate rendering/exit mapping from use-case logic.\n3. Call runner phases in-process from the supervisor.\n4. Map durable journal/resolution input to typed `effect_in_doubt`, `applied` and `not_applied` outcomes with resolution provenance, and reject any generic retry path for unresolved effects.\n5. Preserve documented human and JSON output through compatibility renderers without dropping resolution provenance.\n6. Add result/renderer parity, adapter error, cancellation, timeout, stale-work-order and effect-resolution transition tests.",
+      "1. Invoke each runner phase in-process. Expected: structured results carry work-order/fingerprint/receipt identities without reading stdout.\n2. Render the same result to human and JSON formats. Expected: compatibility snapshots and exit codes remain stable.\n3. Feed durable journal states for `effect_in_doubt`, operator-resolved `applied` and operator-resolved `not_applied` into each runner/supervisor entry point. Expected: typed results and both renderers preserve the state, operator-supplied resolution provenance, evidence/authority digests and claim generation without stdout parsing.\n4. Invoke generic retry, replay, resume and restart against unresolved `effect_in_doubt`. Expected: every path returns the typed blocked outcome, performs no adapter invocation and directs callers only to the explicit operator-resolution protocol; no generic retry can reinterpret the effect as `not_applied`.\n5. Exercise cancellation, timeout, adapter crash, stale input, and policy denial. Expected: typed outcomes and observed receipts remain complete.\n6. Run runner/supervisor/lifecycle tests and typecheck."
+    ]
+  },
+  "evaluated_sha": "9474725b5ca119945c60338c7821e83f9fe40698",
+  "blueprint_digest": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328",
+  "evaluator": {
+    "id": "recovery-context",
+    "profile": "EVALUATOR",
+    "prompt_module_path": ".agentplane/evaluators/recovery-context.md"
+  },
+  "authority": {
+    "sandbox": "read-only",
+    "writable_roots": [],
+    "allowed_tool_classes": [
+      "repository_read",
+      "git_read",
+      "run_checks",
+      "report_result"
+    ],
+    "external_side_effects": []
+  },
+  "result_contract": "sgr.evaluator_result.v1",
+  "evidence": [
+    {
+      "id": "task-document",
+      "kind": "task_document",
+      "path": ".agentplane/tasks/202607221850-R7WS01/README.md",
+      "sha256": "sha256:a504b35e15c039855c268115218b2c2cc42dbf57eb64312c5dd26cb6439c48a9",
+      "required": true
+    },
+    {
+      "id": "actual-diff",
+      "kind": "actual_diff",
+      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-diff.patch",
+      "sha256": "sha256:d4423692535e81e16e262f84c84f43af42571b08908d1bd95a7ea5cae36db8f4",
+      "required": true
+    },
+    {
+      "id": "observed-checks",
+      "kind": "observed_checks",
+      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-observed-checks.json",
+      "sha256": "sha256:0af1ac39d0095e319c54c4dbd10decef6ec4403351fab1dbdcca6431e89ea6ab",
+      "required": true
+    },
+    {
+      "id": "blueprint",
+      "kind": "blueprint",
+      "path": ".agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-blueprint.json",
+      "sha256": "sha256:d348dedab56fd1219b3127a4ff3da0570f1904829944b3609e64139f6309b3fb",
+      "required": true
+    },
+    {
+      "id": "policy-1",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.code.md",
+      "sha256": "sha256:3fec50dfe0db2f9495a3fa96f36d95fb34262033299d57f6f3775af4b7cc1486",
+      "required": true
+    },
+    {
+      "id": "policy-2",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.core.md",
+      "sha256": "sha256:f6c11b8a2c55760c17af15f79fe13791b3e7bba4852fc7d311fc0657e490b0c7",
+      "required": true
+    },
+    {
+      "id": "policy-3",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/security.must.md",
+      "sha256": "sha256:96d01012e7ab67873bcb7a2cdd3818efa2c1fa500ee2eaf0e316f67e15bbcab2",
+      "required": true
+    },
+    {
+      "id": "policy-4",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/workflow.branch_pr.md",
+      "sha256": "sha256:12d3b942042c276d30593803ddcfe12b20dc794e3e8bfbd97b6ce59df13ba82b",
+      "required": true
+    }
+  ]
+}

--- a/.agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/quality-report.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "task_id": "202607221850-R7WS01",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-28T03:12:42.195Z",
+  "provenance": "evaluator_supplied",
+  "verdict": "pass",
+  "summary": "EVALUATOR returned pass with 1 typed finding(s).",
+  "evaluated_sha": "9474725b5ca119945c60338c7821e83f9fe40698",
+  "blueprint_digest": "97dbd5ae24a9308fca905710dccc07fa250b9db1f6435363f589cdbc72b6a328",
+  "findings": [
+    "No blocking finding: Knip and dependency-cruiser both pass; the implementation keeps only externally consumed symbols public."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607221850-R7WS01/quality/20260728-031242011-recovery-context/evaluator-diff.patch"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/cli/run-cli.core.task-run.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.task-run.test.ts
@@ -126,6 +126,7 @@ describe("runCli task run", () => {
       invocation: {
         adapter_id: "custom",
         run_id: "run-degraded-cleanup",
+        work_order_id: "work-order-degraded-cleanup",
         run_dir: "/repo/run",
         bundle_path: "/repo/run/bundle.json",
         bootstrap_path: "/repo/run/bootstrap.md",
@@ -136,6 +137,11 @@ describe("runCli task run", () => {
         exit_code: 0,
         summary: "provider completed",
       },
+      state: {
+        mode: "execute",
+        status: "success",
+      },
+      bundle: {},
       active_claim_cleanup: cleanup,
     } as unknown as Awaited<ReturnType<typeof taskRunUsecases.executeTaskRunnerExecution>>;
     const executeSpy = vi

--- a/packages/agentplane/src/commands/hermes/hermes-runtime.ts
+++ b/packages/agentplane/src/commands/hermes/hermes-runtime.ts
@@ -305,7 +305,7 @@ export async function executeHermesWorkflowOperation(opts: {
     status: succeeded ? "succeeded" : "failed",
     observed_postconditions: ["runner_state_observed"],
     detail: executed.result.summary ?? `runner execution completed for ${taskId}`,
-    exit_code: executed.result.exit_code,
+    exit_code: taskRunnerLifecycleExitCode(lifecycle),
     operation_result: { kind: "runner_lifecycle", value: lifecycle },
   };
 }

--- a/packages/agentplane/src/commands/hermes/hermes-runtime.ts
+++ b/packages/agentplane/src/commands/hermes/hermes-runtime.ts
@@ -7,6 +7,11 @@ import {
   prepareTaskRunnerExecution,
 } from "../../runner/usecases/task-run.js";
 import {
+  projectExecutedTaskRunnerLifecycleResult,
+  projectPreparedTaskRunnerLifecycleResult,
+  taskRunnerLifecycleExitCode,
+} from "../../runner/usecases/task-run-lifecycle-result.js";
+import {
   prepareAgentWorkOrder,
   requirePreparedAgentWorkOrder,
 } from "../../runner/usecases/agent-work-order.js";
@@ -271,11 +276,16 @@ export async function executeHermesWorkflowOperation(opts: {
       mode: "dry_run",
       ...(opts.includeRemote ? { include_remote: true } : {}),
     });
+    const lifecycle = projectPreparedTaskRunnerLifecycleResult({
+      task_id: taskId,
+      execution: prepared,
+    });
     return {
       status: "succeeded",
       observed_postconditions: ["runner_state_observed"],
       detail: `prepared runner invocation ${prepared.invocation.run_id} for ${taskId}`,
       exit_code: null,
+      operation_result: { kind: "runner_lifecycle", value: lifecycle },
     };
   }
 
@@ -286,12 +296,17 @@ export async function executeHermesWorkflowOperation(opts: {
     task_id: taskId,
     ...(opts.includeRemote ? { include_remote: true } : {}),
   });
-  const succeeded = executed.result.status === "success" && !executed.active_claim_cleanup;
+  const lifecycle = projectExecutedTaskRunnerLifecycleResult({
+    task_id: taskId,
+    execution: executed,
+  });
+  const succeeded = taskRunnerLifecycleExitCode(lifecycle) === 0;
   return {
     status: succeeded ? "succeeded" : "failed",
     observed_postconditions: ["runner_state_observed"],
     detail: executed.result.summary ?? `runner execution completed for ${taskId}`,
     exit_code: executed.result.exit_code,
+    operation_result: { kind: "runner_lifecycle", value: lifecycle },
   };
 }
 

--- a/packages/agentplane/src/commands/hermes/hermes.command.test.ts
+++ b/packages/agentplane/src/commands/hermes/hermes.command.test.ts
@@ -344,7 +344,9 @@ describe("hermes adapter commands", () => {
           },
         },
       });
-      expect(payload.execution.result.operation_result.value.invocation.work_order_id).toContain(taskId);
+      expect(payload.execution.result.operation_result.value.invocation.work_order_id).toContain(
+        taskId,
+      );
       expect(payload.workflow_supervision.audit.map((entry) => entry.event)).toEqual([
         "decision_observed",
         "operation_executed",

--- a/packages/agentplane/src/commands/hermes/hermes.command.test.ts
+++ b/packages/agentplane/src/commands/hermes/hermes.command.test.ts
@@ -322,31 +322,22 @@ describe("hermes adapter commands", () => {
       expect(payload.execution.allowed).toBe(true);
       expect(payload.execution.result.detail).toContain(taskId);
       expect(payload.execution.result.exit_code).toBeNull();
-      expect(payload.execution.result.operation_result).toMatchObject({
-        kind: "runner_lifecycle",
-        value: {
-          schema: "agentplane.task_runner_lifecycle_result.v1",
-          phase: "prepared",
-          task_id: taskId,
-          lifecycle: {
-            effect: {
-              state: "not_recorded",
-              authority: {
-                ref: expect.stringContaining("work-order:"),
-                digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
-              },
-              observed_evidence: {
-                code: "runner_effect_operation_prepared",
-                digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
-              },
-              claim_generation: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
-            },
-          },
-        },
-      });
-      expect(payload.execution.result.operation_result.value.invocation.work_order_id).toContain(
-        taskId,
-      );
+      const operationResult = payload.execution.result.operation_result;
+      const lifecycle = operationResult.value;
+      const effect = lifecycle.lifecycle.effect;
+      expect(operationResult.kind).toBe("runner_lifecycle");
+      expect(lifecycle.schema).toBe("agentplane.task_runner_lifecycle_result.v1");
+      expect(lifecycle.phase).toBe("prepared");
+      expect(lifecycle.task_id).toBe(taskId);
+      expect(effect.state).toBe("not_recorded");
+      expect(effect.authority).not.toBeNull();
+      expect(effect.authority?.ref).toContain("work-order:");
+      expect(effect.authority?.digest).toMatch(/^sha256:[0-9a-f]{64}$/u);
+      expect(effect.observed_evidence).not.toBeNull();
+      expect(effect.observed_evidence?.code).toBe("runner_effect_operation_prepared");
+      expect(effect.observed_evidence?.digest).toMatch(/^sha256:[0-9a-f]{64}$/u);
+      expect(effect.claim_generation).toMatch(/^sha256:[0-9a-f]{64}$/u);
+      expect(lifecycle.invocation.work_order_id).toContain(taskId);
       expect(payload.workflow_supervision.audit.map((entry) => entry.event)).toEqual([
         "decision_observed",
         "operation_executed",

--- a/packages/agentplane/src/commands/hermes/hermes.command.test.ts
+++ b/packages/agentplane/src/commands/hermes/hermes.command.test.ts
@@ -233,7 +233,27 @@ describe("hermes adapter commands", () => {
           requested: boolean;
           dry_run: boolean;
           allowed: boolean;
-          result: { detail: string; exit_code: number | null };
+          result: {
+            detail: string;
+            exit_code: number | null;
+            operation_result: {
+              kind: string;
+              value: {
+                schema: string;
+                phase: string;
+                task_id: string;
+                invocation: { work_order_id: string };
+                lifecycle: {
+                  effect: {
+                    state: string;
+                    authority: { ref: string; digest: string } | null;
+                    observed_evidence: { code: string; digest: string | null } | null;
+                    claim_generation: string | null;
+                  };
+                };
+              };
+            };
+          };
         };
         workflow_supervision: { audit: { event: string }[] };
         refreshed_route: { task: { id: string } };
@@ -244,6 +264,29 @@ describe("hermes adapter commands", () => {
       expect(payload.execution.allowed).toBe(true);
       expect(payload.execution.result.detail).toContain(taskId);
       expect(payload.execution.result.exit_code).toBeNull();
+      expect(payload.execution.result.operation_result).toMatchObject({
+        kind: "runner_lifecycle",
+        value: {
+          schema: "agentplane.task_runner_lifecycle_result.v1",
+          phase: "prepared",
+          task_id: taskId,
+          lifecycle: {
+            effect: {
+              state: "not_recorded",
+              authority: {
+                ref: expect.stringContaining("work-order:"),
+                digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+              },
+              observed_evidence: {
+                code: "runner_effect_operation_prepared",
+                digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+              },
+              claim_generation: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+            },
+          },
+        },
+      });
+      expect(payload.execution.result.operation_result.value.invocation.work_order_id).toContain(taskId);
       expect(payload.workflow_supervision.audit.map((entry) => entry.event)).toEqual([
         "decision_observed",
         "operation_executed",

--- a/packages/agentplane/src/commands/hermes/hermes.command.test.ts
+++ b/packages/agentplane/src/commands/hermes/hermes.command.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { buildStateFingerprint } from "@agentplaneorg/core/schemas";
 
 import { runCli } from "../../cli/run-cli.js";
-import { routeNeedsRunnerProjection } from "./hermes-runtime.js";
+import * as taskRunUsecases from "../../runner/usecases/task-run.js";
+import { executeHermesWorkflowOperation, routeNeedsRunnerProjection } from "./hermes-runtime.js";
 import type { TaskRouteDecision } from "../shared/route-decision-types.js";
 import { captureStdIO, mkGitRepoRoot, runCliSilent } from "@agentplane/testkit";
 import { mkdir, writeFile } from "node:fs/promises";
@@ -84,6 +85,63 @@ async function createRunnableDirectTask(root: string): Promise<string> {
 }
 
 describe("hermes adapter commands", () => {
+  it("returns the typed nonzero exit code when runner cleanup remains incomplete", async () => {
+    const executed = {
+      invocation: {
+        adapter_id: "codex",
+        run_id: "run-degraded-cleanup",
+        work_order_id: "work-order-degraded-cleanup",
+        run_dir: "/repo/runs/run-degraded-cleanup",
+        bundle_path: "/repo/runs/run-degraded-cleanup/bundle.json",
+        bootstrap_path: "/repo/runs/run-degraded-cleanup/bootstrap.md",
+        result_path: "/repo/runs/run-degraded-cleanup/result.json",
+      },
+      bundle: {},
+      state: { mode: "execute", status: "success" },
+      result: {
+        status: "success",
+        exit_code: 0,
+        started_at: "2026-07-28T00:00:00.000Z",
+        ended_at: "2026-07-28T00:00:01.000Z",
+        summary: "provider completed",
+      },
+      active_claim_cleanup: {
+        status: "cleanup_failed",
+        code: "E_RUNTIME",
+        message: "active claim could not be retired",
+        event_recorded: true,
+      },
+    } as unknown as Awaited<ReturnType<typeof taskRunUsecases.executeTaskRunnerExecution>>;
+    const executeSpy = vi
+      .spyOn(taskRunUsecases, "executeTaskRunnerExecution")
+      .mockResolvedValue(executed);
+    try {
+      const result = await executeHermesWorkflowOperation({
+        ctx: {} as never,
+        cwd: "/repo",
+        rootOverride: "/repo",
+        includeRemote: false,
+        dryRun: false,
+        operation: {
+          id: "runner.follow",
+          params: { mode: "run", taskId: "TASK-CLEANUP" },
+        } as never,
+      });
+      expect(result).toMatchObject({
+        status: "failed",
+        exit_code: 1,
+        operation_result: {
+          kind: "runner_lifecycle",
+          value: {
+            active_claim_cleanup: { status: "cleanup_failed" },
+          },
+        },
+      });
+    } finally {
+      executeSpy.mockRestore();
+    }
+  });
+
   it("renders a provider-safe enqueue projection", async () => {
     const root = await mkGitRepoRoot();
     const taskId = await createApprovedTask(root);

--- a/packages/agentplane/src/commands/shared/workflow-supervisor.ts
+++ b/packages/agentplane/src/commands/shared/workflow-supervisor.ts
@@ -24,7 +24,7 @@ type WorkflowSupervisorAuditEntry = {
   detail: string;
 };
 
-export type WorkflowSupervisorOperationPayload = {
+type WorkflowSupervisorOperationPayload = {
   kind: "runner_lifecycle";
   value: TaskRunnerLifecycleResult;
 };

--- a/packages/agentplane/src/commands/shared/workflow-supervisor.ts
+++ b/packages/agentplane/src/commands/shared/workflow-supervisor.ts
@@ -1,4 +1,5 @@
 import type { TaskRouteDecision } from "./route-decision-types.js";
+import type { TaskRunnerLifecycleResult } from "../../runner/usecases/task-run-lifecycle-result.js";
 import { projectWorkflowOperationArgv } from "./workflow-operation-projection.js";
 import { WORKFLOW_OPERATION_REGISTRY, type WorkflowOperation } from "./workflow-step.js";
 
@@ -23,11 +24,18 @@ type WorkflowSupervisorAuditEntry = {
   detail: string;
 };
 
+export type WorkflowSupervisorOperationPayload = {
+  kind: "runner_lifecycle";
+  value: TaskRunnerLifecycleResult;
+};
+
 export type WorkflowSupervisorOperationResult = {
   status: "succeeded" | "failed";
   observed_postconditions: readonly string[];
   detail: string;
   exit_code: number | null;
+  /** Typed in-process data for migrated operation slices; never parsed from stdout. */
+  operation_result?: WorkflowSupervisorOperationPayload;
 };
 
 export type WorkflowSupervisorExecution = {

--- a/packages/agentplane/src/commands/task/run-render.test.ts
+++ b/packages/agentplane/src/commands/task/run-render.test.ts
@@ -4,13 +4,151 @@ import { captureStdIO } from "@agentplane/testkit";
 import { readObservedProcessIdentity } from "../../runner/process-supervision/signals.js";
 import type { LoadedTaskRunnerInspection } from "../../runner/usecases/task-run-inspect.js";
 import {
+  projectExecutedTaskRunnerLifecycleResult,
+  type TaskRunnerLifecycleResult,
+} from "../../runner/usecases/task-run-lifecycle-result.js";
+import {
+  reportExecutedTaskRun,
   reportRunnerStatus,
+  renderTaskRunnerLifecyclePayload,
   renderRunnerStatusPayload,
   renderTaskRunPayload,
   runnerReconciliationWarning,
 } from "./run-render.js";
 
 describe("task run rendering", () => {
+  it("renders the typed effect lifecycle without parsing a runner report", () => {
+    const lifecycle = {
+      schema: "agentplane.task_runner_lifecycle_result.v1",
+      phase: "executed",
+      task_id: "TASK-EFFECT",
+      invocation: {
+        adapter_id: "codex",
+        run_id: "run-effect",
+        work_order_id: "work-order-effect",
+        run_dir: "/repo/runs/run-effect",
+        bundle_path: "/repo/runs/run-effect/bundle.json",
+        bootstrap_path: "/repo/runs/run-effect/bootstrap.md",
+        result_path: "/repo/runs/run-effect/result.json",
+      },
+      lifecycle: {
+        mode: "execute",
+        status: "failed",
+        state_fingerprint: null,
+        effect: {
+          state: "effect_in_doubt",
+          operation: {
+            operation_key: `sha256:${"a".repeat(64)}`,
+            operation_digest: `sha256:${"b".repeat(64)}`,
+            claim_generation: `sha256:${"c".repeat(64)}`,
+          },
+          authority: {
+            ref: "work-order:work-order-effect",
+            digest: `sha256:${"e".repeat(64)}`,
+          },
+          observed_evidence: {
+            code: "runner_adapter_effect_error",
+            digest: `sha256:${"f".repeat(64)}`,
+          },
+          claim_generation: `sha256:${"c".repeat(64)}`,
+          resolution: null,
+          resolution_provenance: null,
+          source_resolution: null,
+          source_resolution_provenance: null,
+        },
+        work_order_authority: null,
+      },
+      result: {
+        status: "failed",
+        exit_code: 1,
+        started_at: "2026-07-28T00:00:00.000Z",
+        ended_at: "2026-07-28T00:00:01.000Z",
+        summary: "provider outcome is uncertain",
+      },
+      active_claim_cleanup: null,
+    } as unknown as TaskRunnerLifecycleResult;
+
+    const payload = renderTaskRunnerLifecyclePayload(lifecycle);
+    expect(payload).toMatchObject({
+      task_id: "TASK-EFFECT",
+      work_order_id: "work-order-effect",
+      lifecycle_result: {
+        lifecycle: {
+          effect: {
+            state: "effect_in_doubt",
+            operation: { claim_generation: `sha256:${"c".repeat(64)}` },
+            authority: { digest: `sha256:${"e".repeat(64)}` },
+            observed_evidence: { digest: `sha256:${"f".repeat(64)}` },
+            resolution: null,
+          },
+        },
+      },
+    });
+
+    const io = captureStdIO();
+    try {
+      reportExecutedTaskRun(payload, "TASK-EFFECT");
+      expect(io.stdout).toMatch(/work_order:\s+work-order-effect/u);
+      expect(io.stdout).toMatch(/effect:\s+effect_in_doubt/u);
+      expect(io.stdout).toMatch(new RegExp(`effect_authority:\\s+sha256:${"e".repeat(64)}`, "u"));
+      expect(io.stdout).toMatch(new RegExp(`effect_evidence:\\s+sha256:${"f".repeat(64)}`, "u"));
+      expect(io.stdout).toMatch(
+        new RegExp(`effect_claim_generation:\\s+sha256:${"c".repeat(64)}`, "u"),
+      );
+    } finally {
+      io.restore();
+    }
+
+    for (const verdict of ["applied", "not_applied"] as const) {
+      const resolved = projectExecutedTaskRunnerLifecycleResult({
+        task_id: "TASK-EFFECT",
+        execution: {
+          ...lifecycle,
+          bundle: {},
+          state: {
+            mode: "execute",
+            status: "blocked",
+            effect_resolution: {
+              verdict,
+              digest: `sha256:${"d".repeat(64)}`,
+            },
+          },
+          effect_operation: {
+            operation: {
+              authority_ref: "work-order:work-order-effect",
+              authority_digest: `sha256:${"e".repeat(64)}`,
+              claim_generation: `sha256:${"c".repeat(64)}`,
+            },
+            journal: {
+              observed_evidence: {
+                code: "operator_resolution_evidence",
+                digest: `sha256:${"f".repeat(64)}`,
+              },
+            },
+          },
+          source_effect_resolution: {
+            verdict: "not_applied",
+            digest: `sha256:${"g".repeat(64)}`,
+          },
+        } as unknown as Parameters<typeof projectExecutedTaskRunnerLifecycleResult>[0]["execution"],
+        source_effect_resolution: {
+          verdict: "not_applied",
+          digest: `sha256:${"g".repeat(64)}`,
+        } as unknown as TaskRunnerLifecycleResult["lifecycle"]["effect"]["source_resolution"],
+      });
+      expect(resolved.lifecycle.effect).toMatchObject({
+        state: verdict,
+        resolution: { verdict },
+        resolution_provenance: "operator_supplied",
+        authority: { digest: `sha256:${"e".repeat(64)}` },
+        observed_evidence: { digest: `sha256:${"f".repeat(64)}` },
+        claim_generation: `sha256:${"c".repeat(64)}`,
+        source_resolution: { verdict: "not_applied" },
+        source_resolution_provenance: "operator_supplied",
+      });
+    }
+  });
+
   it("keeps execution status and verification confidence distinct", () => {
     expect(
       renderTaskRunPayload({

--- a/packages/agentplane/src/commands/task/run-render.ts
+++ b/packages/agentplane/src/commands/task/run-render.ts
@@ -5,6 +5,7 @@ import type {
   TaskRunnerDiagnosticInspection,
 } from "../../runner/usecases/task-run-inspect.js";
 import type { TaskRunnerActiveClaimCleanupDiagnostic } from "../../runner/usecases/task-run-active-claim-runtime.js";
+import type { TaskRunnerLifecycleResult } from "../../runner/usecases/task-run-lifecycle-result.js";
 import type { RunnerLifecycleStatus } from "../../runner/types.js";
 import {
   isProcessAlive,
@@ -50,6 +51,38 @@ export function renderTaskRunPayload(opts: {
       : {}),
   };
 }
+
+/**
+ * Compatibility renderer for the typed in-process lifecycle result. The
+ * existing top-level fields stay stable while the additive lifecycle object
+ * exposes durable effect and authority evidence without stdout parsing.
+ */
+export function renderTaskRunnerLifecyclePayload(result: TaskRunnerLifecycleResult) {
+  return {
+    ...renderTaskRunPayload({
+      taskId: result.task_id,
+      mode: result.lifecycle.mode,
+      adapterId: result.invocation.adapter_id,
+      runId: result.invocation.run_id,
+      runDir: result.invocation.run_dir,
+      bundlePath: result.invocation.bundle_path,
+      bootstrapPath: result.invocation.bootstrap_path ?? "",
+      resultPath: result.invocation.result_path,
+      ...(result.phase === "executed" ? { status: result.result?.status } : {}),
+      verificationState: result.result?.execution_receipt?.verification_state,
+      receiptPath: result.result?.execution_receipt?.path,
+      exitCode: result.result?.exit_code,
+      summary: result.result?.summary,
+      activeClaimCleanup: result.active_claim_cleanup ?? undefined,
+    }),
+    work_order_id: result.invocation.work_order_id,
+    lifecycle_result: result,
+  };
+}
+
+type TaskRunRendererPayload =
+  | ReturnType<typeof renderTaskRunPayload>
+  | ReturnType<typeof renderTaskRunnerLifecyclePayload>;
 
 export function isTerminalRunnerStatus(status: RunnerLifecycleStatus): boolean {
   return (
@@ -379,7 +412,7 @@ export async function loadRunnerLogText(
 }
 
 export function reportPreparedTaskRun(
-  payload: ReturnType<typeof renderTaskRunPayload>,
+  payload: TaskRunRendererPayload,
   taskId: string,
 ): void {
   createCliEmitter().report(
@@ -388,6 +421,24 @@ export function reportPreparedTaskRun(
       { label: "mode", value: payload.mode },
       { label: "adapter", value: payload.adapter_id },
       { label: "run", value: payload.run_id },
+      ...("lifecycle_result" in payload
+        ? [
+            { label: "work_order", value: payload.lifecycle_result.invocation.work_order_id },
+            { label: "effect", value: payload.lifecycle_result.lifecycle.effect.state },
+            {
+              label: "effect_authority",
+              value: payload.lifecycle_result.lifecycle.effect.authority?.digest ?? null,
+            },
+            {
+              label: "effect_evidence",
+              value: payload.lifecycle_result.lifecycle.effect.observed_evidence?.digest ?? null,
+            },
+            {
+              label: "effect_claim_generation",
+              value: payload.lifecycle_result.lifecycle.effect.claim_generation,
+            },
+          ]
+        : []),
       { label: "bundle", value: payload.bundle_path },
       { label: "bootstrap", value: payload.bootstrap_path },
       { label: "result", value: payload.result_path },
@@ -397,7 +448,7 @@ export function reportPreparedTaskRun(
 }
 
 export function reportExecutedTaskRun(
-  payload: ReturnType<typeof renderTaskRunPayload>,
+  payload: TaskRunRendererPayload,
   taskId: string,
 ): void {
   createCliEmitter().report(
@@ -406,6 +457,36 @@ export function reportExecutedTaskRun(
       { label: "mode", value: payload.mode },
       { label: "adapter", value: payload.adapter_id },
       { label: "run", value: payload.run_id },
+      ...("lifecycle_result" in payload
+        ? [
+            { label: "work_order", value: payload.lifecycle_result.invocation.work_order_id },
+            { label: "effect", value: payload.lifecycle_result.lifecycle.effect.state },
+            {
+              label: "effect_resolution",
+              value: payload.lifecycle_result.lifecycle.effect.resolution?.verdict ?? null,
+            },
+            {
+              label: "effect_authority",
+              value: payload.lifecycle_result.lifecycle.effect.authority?.digest ?? null,
+            },
+            {
+              label: "effect_evidence",
+              value: payload.lifecycle_result.lifecycle.effect.observed_evidence?.digest ?? null,
+            },
+            {
+              label: "effect_claim_generation",
+              value: payload.lifecycle_result.lifecycle.effect.claim_generation,
+            },
+            ...(payload.lifecycle_result.lifecycle.effect.source_resolution
+              ? [
+                  {
+                    label: "source_effect_resolution",
+                    value: payload.lifecycle_result.lifecycle.effect.source_resolution.verdict,
+                  },
+                ]
+              : []),
+          ]
+        : []),
       { label: "status", value: payload.status ?? "unknown" },
       { label: "verification", value: payload.verification_state ?? "unavailable" },
       { label: "exit_code", value: payload.exit_code ?? null },

--- a/packages/agentplane/src/commands/task/run-render.ts
+++ b/packages/agentplane/src/commands/task/run-render.ts
@@ -411,10 +411,7 @@ export async function loadRunnerLogText(
   });
 }
 
-export function reportPreparedTaskRun(
-  payload: TaskRunRendererPayload,
-  taskId: string,
-): void {
+export function reportPreparedTaskRun(payload: TaskRunRendererPayload, taskId: string): void {
   createCliEmitter().report(
     [
       { label: "task", value: payload.task_id },
@@ -447,10 +444,7 @@ export function reportPreparedTaskRun(
   );
 }
 
-export function reportExecutedTaskRun(
-  payload: TaskRunRendererPayload,
-  taskId: string,
-): void {
+export function reportExecutedTaskRun(payload: TaskRunRendererPayload, taskId: string): void {
   createCliEmitter().report(
     [
       { label: "task", value: payload.task_id },

--- a/packages/agentplane/src/commands/task/run.command.ts
+++ b/packages/agentplane/src/commands/task/run.command.ts
@@ -5,6 +5,11 @@ import {
   executeTaskRunnerExecution,
   prepareTaskRunnerExecution,
 } from "../../runner/usecases/task-run.js";
+import {
+  projectExecutedTaskRunnerLifecycleResult,
+  projectPreparedTaskRunnerLifecycleResult,
+  taskRunnerLifecycleExitCode,
+} from "../../runner/usecases/task-run-lifecycle-result.js";
 import { RUNNER_SANDBOX_MODES } from "../../runner/types.js";
 import {
   loadTaskRunnerDiagnosticInspection,
@@ -19,7 +24,7 @@ import {
   renderRunnerDiagnosticStatusPayload,
   renderRunnerStatusPayload,
   runnerReconciliationWarning,
-  renderTaskRunPayload,
+  renderTaskRunnerLifecyclePayload,
   reportExecutedTaskRun,
   reportPreparedTaskRun,
   tailText,
@@ -277,16 +282,11 @@ export function makeRunTaskRunHandler(getCtx: (cmd: string) => Promise<CommandCo
         danger_authority: dangerAuthority,
         sandbox_override: parsed.sandbox,
       });
-      const payload = renderTaskRunPayload({
-        taskId: parsed.taskId,
-        mode: "dry_run",
-        adapterId: prepared.invocation.adapter_id,
-        runId: prepared.invocation.run_id,
-        runDir: prepared.invocation.run_dir,
-        bundlePath: prepared.invocation.bundle_path,
-        bootstrapPath: prepared.invocation.bootstrap_path ?? "",
-        resultPath: prepared.invocation.result_path,
+      const lifecycle = projectPreparedTaskRunnerLifecycleResult({
+        task_id: parsed.taskId,
+        execution: prepared,
       });
+      const payload = renderTaskRunnerLifecyclePayload(lifecycle);
       if (parsed.json) {
         output.json(payload);
       } else {
@@ -304,28 +304,17 @@ export function makeRunTaskRunHandler(getCtx: (cmd: string) => Promise<CommandCo
       danger_authority: dangerAuthority,
       sandbox_override: parsed.sandbox,
     });
-    const payload = renderTaskRunPayload({
-      taskId: parsed.taskId,
-      mode: "execute",
-      adapterId: executed.invocation.adapter_id,
-      runId: executed.invocation.run_id,
-      runDir: executed.invocation.run_dir,
-      bundlePath: executed.invocation.bundle_path,
-      bootstrapPath: executed.invocation.bootstrap_path ?? "",
-      resultPath: executed.invocation.result_path,
-      status: executed.result.status,
-      verificationState: executed.result.execution_receipt?.verification_state,
-      receiptPath: executed.result.execution_receipt?.path,
-      exitCode: executed.result.exit_code,
-      summary: executed.result.summary,
-      activeClaimCleanup: executed.active_claim_cleanup,
+    const lifecycle = projectExecutedTaskRunnerLifecycleResult({
+      task_id: parsed.taskId,
+      execution: executed,
     });
+    const payload = renderTaskRunnerLifecyclePayload(lifecycle);
     if (parsed.json) {
       output.json(payload);
     } else {
       reportExecutedTaskRun(payload, parsed.taskId);
     }
-    return executed.result.status === "success" && !executed.active_claim_cleanup ? 0 : 1;
+    return taskRunnerLifecycleExitCode(lifecycle);
   };
 }
 

--- a/packages/agentplane/src/commands/task/task-run-effect-resolution.command.ts
+++ b/packages/agentplane/src/commands/task/task-run-effect-resolution.command.ts
@@ -4,11 +4,15 @@ import { createCliEmitter, infoMessage } from "../../cli/output.js";
 import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
 import { resumeTaskRunnerEffectExecution } from "../../runner/usecases/task-run-lifecycle.js";
 import {
+  projectExecutedTaskRunnerLifecycleResult,
+  taskRunnerLifecycleExitCode,
+} from "../../runner/usecases/task-run-lifecycle-result.js";
+import {
   acceptLegacyTaskRunnerEffect,
   resolveTaskRunnerEffect,
 } from "../../runner/usecases/task-run-effect-resolution.js";
 import type { CommandContext } from "../shared/task-backend.js";
-import { renderTaskRunPayload, reportExecutedTaskRun } from "./run-render.js";
+import { renderTaskRunnerLifecyclePayload, reportExecutedTaskRun } from "./run-render.js";
 
 type TaskRunResolveEffectParsed = {
   taskId: string;
@@ -258,25 +262,15 @@ export function makeRunTaskRunResumeEffectHandler(
       run_id: parsed.runId,
       ...(parsed.newRunId ? { new_run_id: parsed.newRunId } : {}),
     });
-    const payload = renderTaskRunPayload({
-      taskId: parsed.taskId,
-      mode: "execute",
-      adapterId: resumed.invocation.adapter_id,
-      runId: resumed.invocation.run_id,
-      runDir: resumed.invocation.run_dir,
-      bundlePath: resumed.invocation.bundle_path,
-      bootstrapPath: resumed.invocation.bootstrap_path ?? "",
-      resultPath: resumed.invocation.result_path,
-      status: resumed.result.status,
-      verificationState: resumed.result.execution_receipt?.verification_state,
-      receiptPath: resumed.result.execution_receipt?.path,
-      exitCode: resumed.result.exit_code,
-      summary: resumed.result.summary,
-      activeClaimCleanup: resumed.active_claim_cleanup,
+    const lifecycle = projectExecutedTaskRunnerLifecycleResult({
+      task_id: parsed.taskId,
+      execution: resumed,
+      source_effect_resolution: resumed.source_effect_resolution,
     });
+    const payload = renderTaskRunnerLifecyclePayload(lifecycle);
     const output = createCliEmitter();
     if (parsed.json) output.json(payload);
     else reportExecutedTaskRun(payload, parsed.taskId);
-    return resumed.result.status === "success" && !resumed.active_claim_cleanup ? 0 : 1;
+    return taskRunnerLifecycleExitCode(lifecycle);
   };
 }

--- a/packages/agentplane/src/runner/usecases/task-run-effect-journal.ts
+++ b/packages/agentplane/src/runner/usecases/task-run-effect-journal.ts
@@ -1,4 +1,8 @@
-import { digestRunnerEffectValue } from "@agentplaneorg/core/schemas";
+import {
+  digestRunnerEffectValue,
+  type RunnerEffectJournal,
+  type RunnerEffectOperation,
+} from "@agentplaneorg/core/schemas";
 
 import {
   advanceRunnerEffectJournal,
@@ -16,6 +20,11 @@ import type {
   RunnerStateFingerprintRecord,
 } from "../types.js";
 
+export type TaskRunnerEffectOperationSnapshot = {
+  operation: RunnerEffectOperation;
+  journal: RunnerEffectJournal;
+};
+
 export async function persistPreparedTaskRunnerEffectOperation(opts: {
   repository: RunnerRunRepository;
   bundle: RunnerContextBundle;
@@ -24,7 +33,10 @@ export async function persistPreparedTaskRunnerEffectOperation(opts: {
   task_id: string;
   source_run_id?: string | null;
   resolved_not_applied_source?: boolean;
-}): Promise<RunnerRunState> {
+}): Promise<{
+  state: RunnerRunState;
+  effect_operation: TaskRunnerEffectOperationSnapshot;
+}> {
   if (!opts.state.state_fingerprint) {
     throw new Error(
       `Runner prepared state is missing effect-journal fingerprint authority for ` +
@@ -44,7 +56,13 @@ export async function persistPreparedTaskRunnerEffectOperation(opts: {
     updated_at: new Date().toISOString(),
   };
   await opts.repository.writeState(state);
-  return state;
+  return {
+    state,
+    effect_operation: {
+      operation: effectOperation.operation,
+      journal: effectOperation.journal,
+    },
+  };
 }
 
 export async function startTaskRunnerEffectOperation(opts: {
@@ -102,8 +120,8 @@ async function recordTaskRunnerEffectAccepted(opts: {
   session: StartedRunnerEffectOperation;
   result: RunnerResult;
   state_fingerprint: RunnerStateFingerprintRecord;
-}): Promise<void> {
-  await advanceRunnerEffectJournal({
+}): Promise<RunnerEffectJournal> {
+  return await advanceRunnerEffectJournal({
     session: opts.session,
     phase: "accepted",
     evidence: {
@@ -125,7 +143,7 @@ export async function persistTaskRunnerEffectAccepted<T>(opts: {
   result: RunnerResult;
   state_fingerprint: RunnerStateFingerprintRecord;
   persist_post_effect_state: () => Promise<T>;
-}): Promise<T> {
+}): Promise<{ state: T; journal: RunnerEffectJournal }> {
   if (!opts.session) {
     throw new Error(
       `Runner adapter returned without a durable effect operation for ` +
@@ -144,10 +162,10 @@ export async function persistTaskRunnerEffectAccepted<T>(opts: {
     });
     throw error;
   }
-  await recordTaskRunnerEffectAccepted({
+  const journal = await recordTaskRunnerEffectAccepted({
     session: opts.session,
     result: opts.result,
     state_fingerprint: opts.state_fingerprint,
   });
-  return state;
+  return { state, journal };
 }

--- a/packages/agentplane/src/runner/usecases/task-run-execution.ts
+++ b/packages/agentplane/src/runner/usecases/task-run-execution.ts
@@ -1,0 +1,36 @@
+import type {
+  StateFingerprint,
+  StateFingerprintPolicy,
+  StateFingerprintPreconditionDiagnostic,
+} from "@agentplaneorg/core/schemas";
+
+import type { TaskRunnerActiveClaimCleanupDiagnostic } from "./task-run-active-claim-runtime.js";
+import type { TaskRunnerEffectOperationSnapshot } from "./task-run-effect-journal.js";
+import type {
+  RunnerContextBundle,
+  RunnerInvocation,
+  RunnerResult,
+  RunnerRunState,
+} from "../types.js";
+
+export type PreparedTaskRunnerExecution = {
+  bundle: RunnerContextBundle;
+  invocation: RunnerInvocation;
+  state: RunnerRunState;
+  effect_operation?: TaskRunnerEffectOperationSnapshot;
+  precondition_fingerprint?: StateFingerprint;
+  precondition_policy?: StateFingerprintPolicy;
+};
+
+export type ExecutedTaskRunnerExecution = Omit<
+  PreparedTaskRunnerExecution,
+  "precondition_fingerprint" | "precondition_policy"
+> & {
+  precondition_fingerprint: StateFingerprint;
+  precondition_policy: StateFingerprintPolicy;
+  result: RunnerResult;
+  state_before: StateFingerprint;
+  state_after: StateFingerprint;
+  precondition: StateFingerprintPreconditionDiagnostic;
+  active_claim_cleanup?: TaskRunnerActiveClaimCleanupDiagnostic;
+};

--- a/packages/agentplane/src/runner/usecases/task-run-lifecycle-replay.ts
+++ b/packages/agentplane/src/runner/usecases/task-run-lifecycle-replay.ts
@@ -1,4 +1,5 @@
 import type { TaskData, TaskRunnerHistoryEntry } from "../../backends/task-backend.js";
+import type { RunnerEffectResolutionRef } from "@agentplaneorg/core/schemas";
 import { loadCommandContext, type CommandContext } from "../../commands/shared/task-backend.js";
 import { CliError } from "../../shared/errors.js";
 import { RunnerRunDirectoryBoundaryError } from "../run-directory-boundary.js";
@@ -24,6 +25,7 @@ type FreshReplayExecution = ExecutedTaskRunnerExecution & {
   ctx: CommandContext;
   source_run_id: string;
   source_status: RunnerLifecycleStatus;
+  source_effect_resolution: RunnerEffectResolutionRef | null;
 };
 
 function replaySourceGuidance(source: TaskRunnerHistoryEntry, taskId: string): string {
@@ -254,6 +256,7 @@ async function executeFreshReplay(opts: {
     run_id: opts.run_id,
     task,
   });
+  let sourceEffectResolution: RunnerEffectResolutionRef | null = null;
   if (opts.action === "resume_effect") {
     const sourceRepository = await RunnerRunRepository.openExistingTaskRun({
       git_root: ctx.resolvedProject.gitRoot,
@@ -281,6 +284,7 @@ async function executeFreshReplay(opts: {
         },
       });
     }
+    sourceEffectResolution = sourceRecord.state.effect_resolution;
   }
   assertFreshReplayDangerAuthority(opts);
   const destinationRunId = resolveFreshReplayRunId({
@@ -323,6 +327,7 @@ async function executeFreshReplay(opts: {
     ctx,
     source_run_id: source.run_id,
     source_status: source.status,
+    source_effect_resolution: sourceEffectResolution,
   };
 }
 
@@ -339,8 +344,9 @@ export async function resumeTaskRunnerExecution(opts: {
     ...opts,
     action: "resume",
   });
+  const { source_effect_resolution: _sourceEffectResolution, ...execution } = resumed;
   return {
-    ...resumed,
+    ...execution,
     previous_status: resumed.source_status,
   };
 }
@@ -373,8 +379,16 @@ export async function resumeTaskRunnerEffectExecution(opts: {
     ...opts,
     action: "resume_effect",
   });
+  const sourceEffectResolution = resumed.source_effect_resolution;
+  if (!sourceEffectResolution) {
+    throw new Error(
+      `resume-effect completed without its required source resolution for ${opts.task_id}:${opts.run_id}.`,
+    );
+  }
+  const { source_effect_resolution: _sourceEffectResolution, ...execution } = resumed;
   return {
-    ...resumed,
+    ...execution,
     previous_status: resumed.source_status,
+    source_effect_resolution: sourceEffectResolution,
   };
 }

--- a/packages/agentplane/src/runner/usecases/task-run-lifecycle-result.ts
+++ b/packages/agentplane/src/runner/usecases/task-run-lifecycle-result.ts
@@ -10,10 +10,9 @@ import type {
   RunnerRunState,
 } from "../types.js";
 
-export const TASK_RUNNER_LIFECYCLE_RESULT_SCHEMA =
-  "agentplane.task_runner_lifecycle_result.v1" as const;
+const TASK_RUNNER_LIFECYCLE_RESULT_SCHEMA = "agentplane.task_runner_lifecycle_result.v1" as const;
 
-export type TaskRunnerLifecycleEffectState =
+type TaskRunnerLifecycleEffectState =
   | "not_recorded"
   | "effect_in_doubt"
   | "applied"

--- a/packages/agentplane/src/runner/usecases/task-run-lifecycle-result.ts
+++ b/packages/agentplane/src/runner/usecases/task-run-lifecycle-result.ts
@@ -1,0 +1,175 @@
+import type { AgentWorkOrderV2 } from "@agentplaneorg/core/schemas";
+
+import type { TaskRunnerActiveClaimCleanupDiagnostic } from "./task-run-active-claim-runtime.js";
+import type { TaskRunnerEffectOperationSnapshot } from "./task-run-effect-journal.js";
+import type {
+  ExecutedTaskRunnerExecution,
+  PreparedTaskRunnerExecution,
+} from "./task-run.js";
+import type {
+  RunnerInvocation,
+  RunnerLifecycleStatus,
+  RunnerResult,
+  RunnerRunState,
+} from "../types.js";
+
+export const TASK_RUNNER_LIFECYCLE_RESULT_SCHEMA =
+  "agentplane.task_runner_lifecycle_result.v1" as const;
+
+export type TaskRunnerLifecycleEffectState =
+  | "not_recorded"
+  | "effect_in_doubt"
+  | "applied"
+  | "not_applied";
+
+export type TaskRunnerLifecycleResult = {
+  schema: typeof TASK_RUNNER_LIFECYCLE_RESULT_SCHEMA;
+  phase: "prepared" | "executed";
+  task_id: string;
+  invocation: Pick<
+    RunnerInvocation,
+    | "adapter_id"
+    | "run_id"
+    | "work_order_id"
+    | "run_dir"
+    | "bundle_path"
+    | "bootstrap_path"
+    | "result_path"
+  >;
+  lifecycle: {
+    mode: RunnerRunState["mode"];
+    status: RunnerLifecycleStatus;
+    state_fingerprint: RunnerRunState["state_fingerprint"] | null;
+    /**
+     * These immutable references retain the effect authority, journal evidence,
+     * claim generation, and any operator-supplied resolution without parsing
+     * renderer output or replaying a provider operation.
+     */
+    effect: {
+      state: TaskRunnerLifecycleEffectState;
+      operation: RunnerRunState["effect_operation"] | null;
+      /** Exact authority and observed-evidence identities from the durable journal. */
+      authority: {
+        ref: string;
+        digest: string;
+      } | null;
+      observed_evidence: {
+        code: string;
+        digest: string | null;
+      } | null;
+      claim_generation: string | null;
+      resolution: RunnerRunState["effect_resolution"] | null;
+      resolution_provenance: "operator_supplied" | null;
+      source_resolution: RunnerRunState["effect_resolution"] | null;
+      source_resolution_provenance: "operator_supplied" | null;
+    };
+    work_order_authority: AgentWorkOrderV2["authority"] | null;
+  };
+  result: RunnerResult | null;
+  active_claim_cleanup: TaskRunnerActiveClaimCleanupDiagnostic | null;
+};
+
+function effectState(state: RunnerRunState): TaskRunnerLifecycleEffectState {
+  if (state.effect_resolution?.verdict === "applied") return "applied";
+  if (state.effect_resolution?.verdict === "not_applied") return "not_applied";
+  if (
+    state.state_fingerprint?.outcome === "effect_unknown" ||
+    state.state_fingerprint?.outcome === "post_state_unknown"
+  ) {
+    return "effect_in_doubt";
+  }
+  return "not_recorded";
+}
+
+function projectTaskRunnerLifecycleResult(opts: {
+  phase: TaskRunnerLifecycleResult["phase"];
+  task_id: string;
+  invocation: RunnerInvocation;
+  state: RunnerRunState;
+  bundle: PreparedTaskRunnerExecution["bundle"];
+  effect_operation?: TaskRunnerEffectOperationSnapshot;
+  result: RunnerResult | null;
+  active_claim_cleanup?: TaskRunnerActiveClaimCleanupDiagnostic;
+  source_effect_resolution?: RunnerRunState["effect_resolution"] | null;
+}): TaskRunnerLifecycleResult {
+  const effect = effectState(opts.state);
+  return {
+    schema: TASK_RUNNER_LIFECYCLE_RESULT_SCHEMA,
+    phase: opts.phase,
+    task_id: opts.task_id,
+    invocation: {
+      adapter_id: opts.invocation.adapter_id,
+      run_id: opts.invocation.run_id,
+      work_order_id: opts.invocation.work_order_id,
+      run_dir: opts.invocation.run_dir,
+      bundle_path: opts.invocation.bundle_path,
+      bootstrap_path: opts.invocation.bootstrap_path ?? null,
+      result_path: opts.invocation.result_path,
+    },
+    lifecycle: {
+      mode: opts.state.mode,
+      status: opts.state.status,
+      state_fingerprint: opts.state.state_fingerprint ?? null,
+      effect: {
+        state: effect,
+        operation: opts.state.effect_operation ?? null,
+        authority: opts.effect_operation
+          ? {
+              ref: opts.effect_operation.operation.authority_ref,
+              digest: opts.effect_operation.operation.authority_digest,
+            }
+          : null,
+        observed_evidence: opts.effect_operation?.journal.observed_evidence ?? null,
+        claim_generation:
+          opts.effect_operation?.operation.claim_generation ??
+          opts.state.effect_operation?.claim_generation ??
+          null,
+        resolution: opts.state.effect_resolution ?? null,
+        resolution_provenance: opts.state.effect_resolution ? "operator_supplied" : null,
+        source_resolution: opts.source_effect_resolution ?? null,
+        source_resolution_provenance: opts.source_effect_resolution ? "operator_supplied" : null,
+      },
+      work_order_authority: opts.bundle.work_order?.authority ?? null,
+    },
+    result: opts.result,
+    active_claim_cleanup: opts.active_claim_cleanup ?? null,
+  };
+}
+
+export function projectPreparedTaskRunnerLifecycleResult(opts: {
+  task_id: string;
+  execution: PreparedTaskRunnerExecution;
+}): TaskRunnerLifecycleResult {
+  return projectTaskRunnerLifecycleResult({
+    phase: "prepared",
+    task_id: opts.task_id,
+    invocation: opts.execution.invocation,
+    state: opts.execution.state,
+    bundle: opts.execution.bundle,
+    effect_operation: opts.execution.effect_operation,
+    result: null,
+  });
+}
+
+export function projectExecutedTaskRunnerLifecycleResult(opts: {
+  task_id: string;
+  execution: ExecutedTaskRunnerExecution;
+  source_effect_resolution?: RunnerRunState["effect_resolution"] | null;
+}): TaskRunnerLifecycleResult {
+  return projectTaskRunnerLifecycleResult({
+    phase: "executed",
+    task_id: opts.task_id,
+    invocation: opts.execution.invocation,
+    state: opts.execution.state,
+    bundle: opts.execution.bundle,
+    effect_operation: opts.execution.effect_operation,
+    result: opts.execution.result,
+    active_claim_cleanup: opts.execution.active_claim_cleanup,
+    source_effect_resolution: opts.source_effect_resolution,
+  });
+}
+
+export function taskRunnerLifecycleExitCode(result: TaskRunnerLifecycleResult): number {
+  if (result.phase === "prepared") return 0;
+  return result.result?.status === "success" && !result.active_claim_cleanup ? 0 : 1;
+}

--- a/packages/agentplane/src/runner/usecases/task-run-lifecycle-result.ts
+++ b/packages/agentplane/src/runner/usecases/task-run-lifecycle-result.ts
@@ -2,10 +2,7 @@ import type { AgentWorkOrderV2 } from "@agentplaneorg/core/schemas";
 
 import type { TaskRunnerActiveClaimCleanupDiagnostic } from "./task-run-active-claim-runtime.js";
 import type { TaskRunnerEffectOperationSnapshot } from "./task-run-effect-journal.js";
-import type {
-  ExecutedTaskRunnerExecution,
-  PreparedTaskRunnerExecution,
-} from "./task-run.js";
+import type { ExecutedTaskRunnerExecution, PreparedTaskRunnerExecution } from "./task-run.js";
 import type {
   RunnerInvocation,
   RunnerLifecycleStatus,

--- a/packages/agentplane/src/runner/usecases/task-run-lifecycle-shared.ts
+++ b/packages/agentplane/src/runner/usecases/task-run-lifecycle-shared.ts
@@ -2,6 +2,7 @@ import { realpath } from "node:fs/promises";
 import path from "node:path";
 
 import { normalizeTaskStatus } from "@agentplaneorg/core/tasks";
+import type { RunnerEffectResolutionRef } from "@agentplaneorg/core/schemas";
 
 import type { TaskData } from "../../backends/task-backend.js";
 import { loadCommandContext, type CommandContext } from "../../commands/shared/task-backend.js";
@@ -45,6 +46,8 @@ export type EffectResumedTaskRunnerExecution = ExecutedTaskRunnerExecution & {
   source_run_id: string;
   source_status: RunnerLifecycleStatus;
   previous_status: RunnerLifecycleStatus;
+  /** Immutable operator disposition that authorized this fresh effect attempt. */
+  source_effect_resolution: RunnerEffectResolutionRef;
 };
 
 export type RunnerReplayAction = "resume" | "retry" | "resume_effect";

--- a/packages/agentplane/src/runner/usecases/task-run.ts
+++ b/packages/agentplane/src/runner/usecases/task-run.ts
@@ -1,8 +1,3 @@
-import {
-  type StateFingerprint,
-  type StateFingerprintPolicy,
-  type StateFingerprintPreconditionDiagnostic,
-} from "@agentplaneorg/core/schemas";
 import { loadCommandContext, type CommandContext } from "../../commands/shared/task-backend.js";
 import { CliError } from "../../shared/errors.js";
 import { resolveRunnerAdapterCapabilityRegistry } from "../../runtime/capabilities/index.js";
@@ -58,7 +53,6 @@ import {
   recordTaskRunnerPostStateUnknown,
   persistTaskRunnerEffectAccepted,
   startTaskRunnerEffectOperation,
-  type TaskRunnerEffectOperationSnapshot,
   type StartedRunnerEffectOperation,
 } from "./task-run-effect-journal.js";
 import { finalizeTaskRunnerActiveClaimCleanup } from "./task-run-active-claim-cleanup.js";
@@ -85,31 +79,16 @@ import {
   type RunnerExecutionContract,
   type RunnerInvocation,
   type RunnerRecipeContext,
-  type RunnerResult,
-  type RunnerRunState,
   type RunnerTarget,
 } from "../types.js";
-export type PreparedTaskRunnerExecution = {
-  bundle: RunnerContextBundle;
-  invocation: RunnerInvocation;
-  state: RunnerRunState;
-  /** Durable operation and journal identity already established by preparation. */
-  effect_operation?: TaskRunnerEffectOperationSnapshot;
-  precondition_fingerprint?: StateFingerprint;
-  precondition_policy?: StateFingerprintPolicy;
-};
-export type ExecutedTaskRunnerExecution = Omit<
+import type {
+  ExecutedTaskRunnerExecution,
   PreparedTaskRunnerExecution,
-  "precondition_fingerprint" | "precondition_policy"
-> & {
-  precondition_fingerprint: StateFingerprint;
-  precondition_policy: StateFingerprintPolicy;
-  result: RunnerResult;
-  state_before: StateFingerprint;
-  state_after: StateFingerprint;
-  precondition: StateFingerprintPreconditionDiagnostic;
-  active_claim_cleanup?: TaskRunnerActiveClaimCleanupDiagnostic;
-};
+} from "./task-run-execution.js";
+export type {
+  ExecutedTaskRunnerExecution,
+  PreparedTaskRunnerExecution,
+} from "./task-run-execution.js";
 export type { TaskRunnerReplayProvenance } from "./task-run-replay-anchor.js";
 
 export async function prepareTaskRunnerExecution(opts: {

--- a/packages/agentplane/src/runner/usecases/task-run.ts
+++ b/packages/agentplane/src/runner/usecases/task-run.ts
@@ -58,6 +58,7 @@ import {
   recordTaskRunnerPostStateUnknown,
   persistTaskRunnerEffectAccepted,
   startTaskRunnerEffectOperation,
+  type TaskRunnerEffectOperationSnapshot,
   type StartedRunnerEffectOperation,
 } from "./task-run-effect-journal.js";
 import { finalizeTaskRunnerActiveClaimCleanup } from "./task-run-active-claim-cleanup.js";
@@ -92,6 +93,8 @@ export type PreparedTaskRunnerExecution = {
   bundle: RunnerContextBundle;
   invocation: RunnerInvocation;
   state: RunnerRunState;
+  /** Durable operation and journal identity already established by preparation. */
+  effect_operation?: TaskRunnerEffectOperationSnapshot;
   precondition_fingerprint?: StateFingerprint;
   precondition_policy?: StateFingerprintPolicy;
 };
@@ -302,7 +305,7 @@ export async function prepareTaskRunnerExecution(opts: {
     bootstrap_markdown: renderTaskRunnerBootstrap(bundle, invocation),
     invocation,
   });
-  const stateWithEffectOperation = await persistPreparedTaskRunnerEffectOperation({
+  const preparedEffectOperation = await persistPreparedTaskRunnerEffectOperation({
     repository,
     bundle,
     invocation,
@@ -314,7 +317,8 @@ export async function prepareTaskRunnerExecution(opts: {
   return {
     bundle,
     invocation,
-    state: stateWithEffectOperation,
+    state: preparedEffectOperation.state,
+    effect_operation: preparedEffectOperation.effect_operation,
     precondition_fingerprint,
     precondition_policy,
   };
@@ -520,7 +524,7 @@ export async function executeTaskRunnerExecution(opts: {
     const preconditionFingerprint = guardedExecution.precondition_fingerprint;
     const preconditionPolicy = guardedExecution.precondition_policy;
     const result = guardedExecution.result;
-    const state = await persistTaskRunnerEffectAccepted({
+    const acceptedEffect = await persistTaskRunnerEffectAccepted({
       session: effectOperation,
       task_id: opts.task_id,
       run_id: prepared.invocation.run_id,
@@ -537,6 +541,7 @@ export async function executeTaskRunnerExecution(opts: {
           state_fingerprint: guardedExecution.state_fingerprint,
         }),
     });
+    const state = acceptedEffect.state;
     const claimedRunAuthority = await inspectTaskRunnerClaimedRunAuthority(
       {
         git_root: ctx.resolvedProject.gitRoot,
@@ -549,6 +554,9 @@ export async function executeTaskRunnerExecution(opts: {
     releaseActiveClaim = cleanupConfirmed;
     completed = {
       ...prepared,
+      effect_operation: prepared.effect_operation
+        ? { ...prepared.effect_operation, journal: acceptedEffect.journal }
+        : undefined,
       precondition_fingerprint: preconditionFingerprint,
       precondition_policy: preconditionPolicy,
       state,

--- a/packages/agentplane/src/runner/usecases/task-run.ts
+++ b/packages/agentplane/src/runner/usecases/task-run.ts
@@ -31,7 +31,6 @@ import {
   reconcileStaleTerminalTaskRunnerActiveClaim,
   reconcileTerminalTaskRunnerActiveClaim,
   recordActiveClaimCleanupFailure,
-  type TaskRunnerActiveClaimCleanupDiagnostic,
 } from "./task-run-active-claim-runtime.js";
 import { renderTaskRunnerBootstrap } from "./task-run-bootstrap.js";
 export { renderTaskRunnerBootstrap } from "./task-run-bootstrap.js";


### PR DESCRIPTION
Task: `202607221850-R7WS01`
Title: Return typed runner lifecycle results
Canonical task record: `.agentplane/tasks/202607221850-R7WS01/README.md`

## Summary

Return typed runner lifecycle results

RF-25d: make runner preparation, invocation, observation, evaluation, and lifecycle operations return typed in-process results with compatibility renderers instead of stdout parsing.

## Scope

- In scope: typed runner use-case results, adapter ports, error/result union, human/JSON renderers, compatibility snapshots, and supervisor invocation without subprocess/stdout capture.
- Consume the durable effect-resolution contract as typed `effect_in_doubt`, `applied` and `not_applied` states, preserving resolution provenance, authority/evidence identity and claim generation in every in-process result and renderer.
- An unresolved `effect_in_doubt` result is terminally blocked for generic retry, replay, resume and restart paths; only the explicit resolution protocol from task 202607242158-QV09NA may transition it to `applied` or `not_applied`.
- Out of scope: automating the complete direct route, delivered by the next task.

## Verification

- State: pending
- Note: Not recorded yet.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-07-28T01:55:50.166Z
- Branch: task/202607221850-R7WS01/return-typed-runner-lifecycle-results
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
No changes detected.
```

</details>
