### PR TITLE
🚧 PTG9C7 task: Prevent self-invalidating side-effect authority records [202607280606-PTG9C7]

### DIFF
--- a/.agentplane/tasks/202607280606-PTG9C7/README.md
+++ b/.agentplane/tasks/202607280606-PTG9C7/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 17
+revision: 18
 origin:
   system: "manual"
 depends_on: []
@@ -206,6 +206,19 @@ extensions:
         schemaVersion: 1
         sequence: 3
         stateFingerprintDigest: "sha256:ec5a13ae0ba7dd240716563a188de42d3bd0d73a8ea36fdee1d4e25f3494e33b"
+      -
+        actor: "USER"
+        at: "2026-07-28T06:25:04.656Z"
+        authorityDigest: "sha256:989dc4dac257a16b3789e848d213c84192fa5b7b94bb5be9c4041df20a0fdfc3"
+        digest: "sha256:e2d64f810db430a08f8daa6309e89fdc283d0d577173e2716ae649acd68c055c"
+        operationDigest: "sha256:6357c43fdacac354dee0c924d8d64b8038933003fbc7f1c0a985d495d295d798"
+        operationId: "integration.enqueue"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:71baf8b21bd1f87529471f93c295ede94f632538acb251fc7f632938c009a141"
+        schemaVersion: 1
+        sequence: 4
+        stateFingerprintDigest: "sha256:5d4484e3df8443741cfb09344a02c4cb624cca22d0f6b1422fbed935ec475baa"
     grants:
       -
         actor: "USER"
@@ -246,6 +259,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:ec5a13ae0ba7dd240716563a188de42d3bd0d73a8ea36fdee1d4e25f3494e33b"
         stateScopeDigest: "sha256:382d7ee81909d1105f7c5862a41f88b643d5047ea355e11e2dfe9161096b7273"
+      -
+        actor: "USER"
+        digest: "sha256:989dc4dac257a16b3789e848d213c84192fa5b7b94bb5be9c4041df20a0fdfc3"
+        expiresAt: "2026-07-28T06:40:04.656Z"
+        id: "authority-a7dc1377-7e64-4cc8-a6a5-8ad896824833"
+        issuedAt: "2026-07-28T06:25:04.656Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:6357c43fdacac354dee0c924d8d64b8038933003fbc7f1c0a985d495d295d798"
+        operationId: "integration.enqueue"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:5d4484e3df8443741cfb09344a02c4cb624cca22d0f6b1422fbed935ec475baa"
+        stateScopeDigest: "sha256:8dad5393b760fc988272c93fb0eecfab44bb1ba09580030394e4a0299eb97697"
     schemaVersion: 1
   implementation_commit:
     hash: "1ec387cd29895158d5157c446a3913cc9598e440"

--- a/.agentplane/tasks/202607280606-PTG9C7/README.md
+++ b/.agentplane/tasks/202607280606-PTG9C7/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 19
+revision: 20
 origin:
   system: "manual"
 depends_on: []
@@ -232,6 +232,19 @@ extensions:
         schemaVersion: 1
         sequence: 5
         stateFingerprintDigest: "sha256:08fb27de3b22a808d83f15c39531899add1606ec70d21f01243694936148b914"
+      -
+        actor: "USER"
+        at: "2026-07-28T06:46:00.356Z"
+        authorityDigest: "sha256:a5351880d354b91bb8158794147c28a66fa901474d9fa8235c83a1c6b66bd0f5"
+        digest: "sha256:3f4a08b83d42e0e11b84f9cbca59cbbc3b8aceb3c1cb1de4ec369f5ecf0878e4"
+        operationDigest: "sha256:748ad576ec679574ddc902170b50dfa956a456268667b50d6f79ebf9ad7c678c"
+        operationId: "pr.head.publish"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:479543c946ee7d07d8c2467165cb6b370ce5d68285b48445253a660863e95c58"
+        schemaVersion: 1
+        sequence: 6
+        stateFingerprintDigest: "sha256:ed03eb13cd934841bec49a0018e6f2c2bc588339ff069db8cd649270f69ea5d7"
     grants:
       -
         actor: "USER"
@@ -298,6 +311,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:08fb27de3b22a808d83f15c39531899add1606ec70d21f01243694936148b914"
         stateScopeDigest: "sha256:97742fb14996a30af37be0f6c02d23ebf50daa3a836aa62a5a2667280a6fe7db"
+      -
+        actor: "USER"
+        digest: "sha256:a5351880d354b91bb8158794147c28a66fa901474d9fa8235c83a1c6b66bd0f5"
+        expiresAt: "2026-07-28T07:01:00.356Z"
+        id: "authority-1ea71e62-fc31-478f-b5f4-63ecca008d19"
+        issuedAt: "2026-07-28T06:46:00.356Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:748ad576ec679574ddc902170b50dfa956a456268667b50d6f79ebf9ad7c678c"
+        operationId: "pr.head.publish"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:ed03eb13cd934841bec49a0018e6f2c2bc588339ff069db8cd649270f69ea5d7"
+        stateScopeDigest: "sha256:382d7ee81909d1105f7c5862a41f88b643d5047ea355e11e2dfe9161096b7273"
     schemaVersion: 1
   implementation_commit:
     hash: "1ec387cd29895158d5157c446a3913cc9598e440"

--- a/.agentplane/tasks/202607280606-PTG9C7/README.md
+++ b/.agentplane/tasks/202607280606-PTG9C7/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202607280606-PTG9C7"
 title: "Prevent self-invalidating side-effect authority records"
-status: "DOING"
+result_summary: "pre-merge closure"
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 15
+revision: 16
 origin:
   system: "manual"
 depends_on: []
@@ -59,8 +60,8 @@ quality_review:
     - "Route resolution and AgentWorkOrder preparation now share branch snapshot precedence in branch_pr mode, so task.revision and state_fingerprint.task_revision cannot diverge solely by checkout."
     - "The regression advances and commits the task worktree document, invokes task next-action from main, and asserts both revision fields equal the branch snapshot."
 commit:
-  hash: "1ec387cd29895158d5157c446a3913cc9598e440"
-  message: "🚧 PTG9C7 task: align work-order task snapshot"
+  hash: "0e2bcb59e5931c267bb29ce4d9686b854e5fe724"
+  message: "🚧 PTG9C7 task: authorize pre-merge closure"
 comments:
   -
     author: "CODER"
@@ -71,6 +72,9 @@ comments:
   -
     author: "CODER"
     body: "Implementation: AgentWorkOrder preparation now uses the branch snapshot selected by branch_pr route resolution; regression covers invocation from base checkout."
+  -
+    author: "CODER"
+    body: "Verified: pre-merge closure packet is ready for the task PR."
 events:
   -
     type: "status"
@@ -99,8 +103,15 @@ events:
     author: "TESTER"
     state: "ok"
     note: "Focused AgentWorkOrder integration and side-effect authority suites passed: 13 tests. Typecheck and policy routing passed. The base-checkout route for 202607242236-1BFWEY now resolves without a task-revision schema error."
+  -
+    type: "status"
+    at: "2026-07-28T06:20:45.314Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-28T06:19:33.181Z"
+doc_updated_at: "2026-07-28T06:20:45.315Z"
 doc_updated_by: "CODER"
 description: "Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge."
 sections:
@@ -210,6 +221,9 @@ extensions:
         stateFingerprintDigest: "sha256:efd338becc8af6425572abac5c3fd2c89e214786dca8e7745182d9a513c8eaff"
         stateScopeDigest: "sha256:810f3027e076813b54d331eb0d02516c734ccef9c4c3afba2c279b8183bb76cc"
     schemaVersion: 1
+  implementation_commit:
+    hash: "1ec387cd29895158d5157c446a3913cc9598e440"
+    message: "🚧 PTG9C7 task: align work-order task snapshot"
   workflow_route_baseline:
     start_head_sha: "08dd47769434fc336d23a80d2d47f4fb0a265d74"
     version: 1

--- a/.agentplane/tasks/202607280606-PTG9C7/README.md
+++ b/.agentplane/tasks/202607280606-PTG9C7/README.md
@@ -4,7 +4,7 @@ title: "Prevent self-invalidating side-effect authority records"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 10
+revision: 11
 origin:
   system: "manual"
 depends_on: []
@@ -78,6 +78,36 @@ sections:
     - Re-run required checks to confirm rollback safety.
   Findings: ""
 extensions:
+  agentplane.side_effect_authority:
+    audit:
+      -
+        actor: "USER"
+        at: "2026-07-28T06:18:20.437Z"
+        authorityDigest: "sha256:70537b3ef8c0212f0f7f5ef921f22371981508c23fd5b6a6a35db242ab96092d"
+        digest: "sha256:a5e0278f5c78582008f90413654f1310ab1946ff1156218e949a3ebf88ea933e"
+        operationDigest: "sha256:fca746e05f2bdcf1d5c7f4a343da571be7f1a64a298ea05c0ba68f29f50f62aa"
+        operationId: "pr.open"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: null
+        schemaVersion: 1
+        sequence: 1
+        stateFingerprintDigest: "sha256:21b94b9565a67b32d8fab5cdcc6025ffaa794d007e399b844b36f1fd5c6212da"
+    grants:
+      -
+        actor: "USER"
+        digest: "sha256:70537b3ef8c0212f0f7f5ef921f22371981508c23fd5b6a6a35db242ab96092d"
+        expiresAt: "2026-07-28T06:33:20.437Z"
+        id: "authority-3f9fbb04-bfd7-4936-a548-ee082e185cb1"
+        issuedAt: "2026-07-28T06:18:20.437Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:fca746e05f2bdcf1d5c7f4a343da571be7f1a64a298ea05c0ba68f29f50f62aa"
+        operationId: "pr.open"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:21b94b9565a67b32d8fab5cdcc6025ffaa794d007e399b844b36f1fd5c6212da"
+        stateScopeDigest: "sha256:bfc9073aa48a7486231ea060ca83e4ad134d15c7447f37b94605a14fcafd9230"
+    schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "08dd47769434fc336d23a80d2d47f4fb0a265d74"
     version: 1

--- a/.agentplane/tasks/202607280606-PTG9C7/README.md
+++ b/.agentplane/tasks/202607280606-PTG9C7/README.md
@@ -4,7 +4,7 @@ title: "Prevent self-invalidating side-effect authority records"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 14
+revision: 15
 origin:
   system: "manual"
 depends_on: []
@@ -169,6 +169,19 @@ extensions:
         schemaVersion: 1
         sequence: 1
         stateFingerprintDigest: "sha256:21b94b9565a67b32d8fab5cdcc6025ffaa794d007e399b844b36f1fd5c6212da"
+      -
+        actor: "USER"
+        at: "2026-07-28T06:20:24.171Z"
+        authorityDigest: "sha256:2c3f2346767928c18e34854c36953856217b7cc1686ec57ed55935d607049bb8"
+        digest: "sha256:7559feffa163e6812d8839bbce626b885909f33af73d657b06b8a7b2a5a1ecec"
+        operationDigest: "sha256:4c1f59120de2ba60e38597224b676fc5a8739f540160b39ac3488a912074480c"
+        operationId: "task.pre_merge_close"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:a5e0278f5c78582008f90413654f1310ab1946ff1156218e949a3ebf88ea933e"
+        schemaVersion: 1
+        sequence: 2
+        stateFingerprintDigest: "sha256:efd338becc8af6425572abac5c3fd2c89e214786dca8e7745182d9a513c8eaff"
     grants:
       -
         actor: "USER"
@@ -183,6 +196,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:21b94b9565a67b32d8fab5cdcc6025ffaa794d007e399b844b36f1fd5c6212da"
         stateScopeDigest: "sha256:bfc9073aa48a7486231ea060ca83e4ad134d15c7447f37b94605a14fcafd9230"
+      -
+        actor: "USER"
+        digest: "sha256:2c3f2346767928c18e34854c36953856217b7cc1686ec57ed55935d607049bb8"
+        expiresAt: "2026-07-28T06:35:24.171Z"
+        id: "authority-68122422-89eb-4100-979c-a7c848083865"
+        issuedAt: "2026-07-28T06:20:24.171Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:4c1f59120de2ba60e38597224b676fc5a8739f540160b39ac3488a912074480c"
+        operationId: "task.pre_merge_close"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:efd338becc8af6425572abac5c3fd2c89e214786dca8e7745182d9a513c8eaff"
+        stateScopeDigest: "sha256:810f3027e076813b54d331eb0d02516c734ccef9c4c3afba2c279b8183bb76cc"
     schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "08dd47769434fc336d23a80d2d47f4fb0a265d74"

--- a/.agentplane/tasks/202607280606-PTG9C7/README.md
+++ b/.agentplane/tasks/202607280606-PTG9C7/README.md
@@ -4,7 +4,7 @@ title: "Prevent self-invalidating side-effect authority records"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 11
+revision: 12
 origin:
   system: "manual"
 depends_on: []
@@ -33,7 +33,9 @@ verification:
   updated_by: null
   note: null
   attempts: 0
-commit: null
+commit:
+  hash: "1ec387cd29895158d5157c446a3913cc9598e440"
+  message: "🚧 PTG9C7 task: align work-order task snapshot"
 comments:
   -
     author: "CODER"
@@ -41,6 +43,9 @@ comments:
   -
     author: "CODER"
     body: "Start: implement the branch-snapshot consistency regression and minimal preparation fix."
+  -
+    author: "CODER"
+    body: "Implementation: AgentWorkOrder preparation now uses the branch snapshot selected by branch_pr route resolution; regression covers invocation from base checkout."
 events:
   -
     type: "status"
@@ -56,8 +61,15 @@ events:
     from: "DOING"
     to: "DOING"
     note: "Start: implement the branch-snapshot consistency regression and minimal preparation fix."
+  -
+    type: "status"
+    at: "2026-07-28T06:18:54.021Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DOING"
+    note: "Implementation: AgentWorkOrder preparation now uses the branch snapshot selected by branch_pr route resolution; regression covers invocation from base checkout."
 doc_version: 3
-doc_updated_at: "2026-07-28T06:15:22.225Z"
+doc_updated_at: "2026-07-28T06:18:54.021Z"
 doc_updated_by: "CODER"
 description: "Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge."
 sections:

--- a/.agentplane/tasks/202607280606-PTG9C7/README.md
+++ b/.agentplane/tasks/202607280606-PTG9C7/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 18
+revision: 19
 origin:
   system: "manual"
 depends_on: []
@@ -219,6 +219,19 @@ extensions:
         schemaVersion: 1
         sequence: 4
         stateFingerprintDigest: "sha256:5d4484e3df8443741cfb09344a02c4cb624cca22d0f6b1422fbed935ec475baa"
+      -
+        actor: "USER"
+        at: "2026-07-28T06:45:38.438Z"
+        authorityDigest: "sha256:48f530435f938f95f0785923b0dda295e31c0d99ac349abbf2ebd391629e6957"
+        digest: "sha256:479543c946ee7d07d8c2467165cb6b370ce5d68285b48445253a660863e95c58"
+        operationDigest: "sha256:6357c43fdacac354dee0c924d8d64b8038933003fbc7f1c0a985d495d295d798"
+        operationId: "integration.enqueue"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:e2d64f810db430a08f8daa6309e89fdc283d0d577173e2716ae649acd68c055c"
+        schemaVersion: 1
+        sequence: 5
+        stateFingerprintDigest: "sha256:08fb27de3b22a808d83f15c39531899add1606ec70d21f01243694936148b914"
     grants:
       -
         actor: "USER"
@@ -272,6 +285,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:5d4484e3df8443741cfb09344a02c4cb624cca22d0f6b1422fbed935ec475baa"
         stateScopeDigest: "sha256:8dad5393b760fc988272c93fb0eecfab44bb1ba09580030394e4a0299eb97697"
+      -
+        actor: "USER"
+        digest: "sha256:48f530435f938f95f0785923b0dda295e31c0d99ac349abbf2ebd391629e6957"
+        expiresAt: "2026-07-28T07:00:38.438Z"
+        id: "authority-9f88f893-cd36-4b4a-a691-3a9485fedc42"
+        issuedAt: "2026-07-28T06:45:38.438Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:6357c43fdacac354dee0c924d8d64b8038933003fbc7f1c0a985d495d295d798"
+        operationId: "integration.enqueue"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:08fb27de3b22a808d83f15c39531899add1606ec70d21f01243694936148b914"
+        stateScopeDigest: "sha256:97742fb14996a30af37be0f6c02d23ebf50daa3a836aa62a5a2667280a6fe7db"
     schemaVersion: 1
   implementation_commit:
     hash: "1ec387cd29895158d5157c446a3913cc9598e440"

--- a/.agentplane/tasks/202607280606-PTG9C7/README.md
+++ b/.agentplane/tasks/202607280606-PTG9C7/README.md
@@ -1,0 +1,115 @@
+---
+id: "202607280606-PTG9C7"
+title: "Prevent self-invalidating side-effect authority records"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 10
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "authority"
+  - "branch-pr"
+  - "lifecycle"
+  - "v0.7"
+task_kind: "code"
+mutation_scope: "code"
+risk_flags:
+  - "security"
+blueprint_request: "code.branch_pr"
+verify:
+  - "Focused authority lifecycle regression"
+  - "bun run typecheck"
+  - "node .agentplane/policy/check-routing.mjs"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-07-28T06:15:21.657Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: reproduce the self-invalidating authority transition, then implement the smallest fail-closed lifecycle fix with focused regressions."
+  -
+    author: "CODER"
+    body: "Start: implement the branch-snapshot consistency regression and minimal preparation fix."
+events:
+  -
+    type: "status"
+    at: "2026-07-28T06:07:13.202Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: reproduce the self-invalidating authority transition, then implement the smallest fail-closed lifecycle fix with focused regressions."
+  -
+    type: "status"
+    at: "2026-07-28T06:15:22.225Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DOING"
+    note: "Start: implement the branch-snapshot consistency regression and minimal preparation fix."
+doc_version: 3
+doc_updated_at: "2026-07-28T06:15:22.225Z"
+doc_updated_by: "CODER"
+description: "Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge."
+sections:
+  Summary: |-
+    Prevent self-invalidating side-effect authority records
+
+    Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge.
+  Scope: |-
+    - In scope: Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge.
+    - Out of scope: unrelated refactors not required for "Prevent self-invalidating side-effect authority records".
+  Plan: "Align branch_pr AgentWorkOrder preparation with the same task branch snapshot used by route resolution. Prevent a base-checkout task next-action or task brief from combining a stale local task revision with a newer route fingerprint. Preserve fail-closed side-effect authority semantics; do not weaken authority validation. Add a regression where the task worktree has a newer task revision than main and preparation from main succeeds with matching work-order task and fingerprint revisions."
+  Verify Steps: "1. Add a regression for branch_pr: update the task in its task worktree, commit it, then invoke task next-action from main. Expected: the work-order task revision equals state_fingerprint.task_revision and the command returns JSON rather than schema validation error. 2. Run the focused AgentWorkOrder integration test and side-effect authority tests. Expected: both pass, including fail-closed negative authority cases. 3. Run bun run typecheck and node .agentplane/policy/check-routing.mjs. Expected: both pass. 4. Re-run task next-action for supervisor task 202607242236-1BFWEY from its integration/base context. Expected: no AgentWorkOrder task revision mismatch."
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+extensions:
+  workflow_route_baseline:
+    start_head_sha: "08dd47769434fc336d23a80d2d47f4fb0a265d74"
+    version: 1
+id_source: "generated"
+---
+## Summary
+
+Prevent self-invalidating side-effect authority records
+
+Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge.
+
+## Scope
+
+- In scope: Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge.
+- Out of scope: unrelated refactors not required for "Prevent self-invalidating side-effect authority records".
+
+## Plan
+
+Align branch_pr AgentWorkOrder preparation with the same task branch snapshot used by route resolution. Prevent a base-checkout task next-action or task brief from combining a stale local task revision with a newer route fingerprint. Preserve fail-closed side-effect authority semantics; do not weaken authority validation. Add a regression where the task worktree has a newer task revision than main and preparation from main succeeds with matching work-order task and fingerprint revisions.
+
+## Verify Steps
+
+1. Add a regression for branch_pr: update the task in its task worktree, commit it, then invoke task next-action from main. Expected: the work-order task revision equals state_fingerprint.task_revision and the command returns JSON rather than schema validation error. 2. Run the focused AgentWorkOrder integration test and side-effect authority tests. Expected: both pass, including fail-closed negative authority cases. 3. Run bun run typecheck and node .agentplane/policy/check-routing.mjs. Expected: both pass. 4. Re-run task next-action for supervisor task 202607242236-1BFWEY from its integration/base context. Expected: no AgentWorkOrder task revision mismatch.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202607280606-PTG9C7/README.md
+++ b/.agentplane/tasks/202607280606-PTG9C7/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 16
+revision: 17
 origin:
   system: "manual"
 depends_on: []
@@ -193,6 +193,19 @@ extensions:
         schemaVersion: 1
         sequence: 2
         stateFingerprintDigest: "sha256:efd338becc8af6425572abac5c3fd2c89e214786dca8e7745182d9a513c8eaff"
+      -
+        actor: "USER"
+        at: "2026-07-28T06:21:03.377Z"
+        authorityDigest: "sha256:1e0d40e027a95d3cea15d7e4a45d4ddc53e2bdce10a314d69fe769d6e7eb501a"
+        digest: "sha256:71baf8b21bd1f87529471f93c295ede94f632538acb251fc7f632938c009a141"
+        operationDigest: "sha256:748ad576ec679574ddc902170b50dfa956a456268667b50d6f79ebf9ad7c678c"
+        operationId: "pr.head.publish"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:7559feffa163e6812d8839bbce626b885909f33af73d657b06b8a7b2a5a1ecec"
+        schemaVersion: 1
+        sequence: 3
+        stateFingerprintDigest: "sha256:ec5a13ae0ba7dd240716563a188de42d3bd0d73a8ea36fdee1d4e25f3494e33b"
     grants:
       -
         actor: "USER"
@@ -220,6 +233,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:efd338becc8af6425572abac5c3fd2c89e214786dca8e7745182d9a513c8eaff"
         stateScopeDigest: "sha256:810f3027e076813b54d331eb0d02516c734ccef9c4c3afba2c279b8183bb76cc"
+      -
+        actor: "USER"
+        digest: "sha256:1e0d40e027a95d3cea15d7e4a45d4ddc53e2bdce10a314d69fe769d6e7eb501a"
+        expiresAt: "2026-07-28T06:36:03.377Z"
+        id: "authority-c08f9c38-e44b-46b4-8904-cb96c4e2f73d"
+        issuedAt: "2026-07-28T06:21:03.377Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:748ad576ec679574ddc902170b50dfa956a456268667b50d6f79ebf9ad7c678c"
+        operationId: "pr.head.publish"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:ec5a13ae0ba7dd240716563a188de42d3bd0d73a8ea36fdee1d4e25f3494e33b"
+        stateScopeDigest: "sha256:382d7ee81909d1105f7c5862a41f88b643d5047ea355e11e2dfe9161096b7273"
     schemaVersion: 1
   implementation_commit:
     hash: "1ec387cd29895158d5157c446a3913cc9598e440"

--- a/.agentplane/tasks/202607280606-PTG9C7/README.md
+++ b/.agentplane/tasks/202607280606-PTG9C7/README.md
@@ -4,7 +4,7 @@ title: "Prevent self-invalidating side-effect authority records"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 13
+revision: 14
 origin:
   system: "manual"
 depends_on: []
@@ -33,6 +33,31 @@ verification:
   updated_by: "TESTER"
   note: "Focused AgentWorkOrder integration and side-effect authority suites passed: 13 tests. Typecheck and policy routing passed. The base-checkout route for 202607242236-1BFWEY now resolves without a task-revision schema error."
   attempts: 0
+quality_review:
+  state: "pass"
+  provenance: "evaluator_supplied"
+  updated_at: "2026-07-28T06:20:05.095Z"
+  updated_by: "EVALUATOR"
+  note: "EVALUATOR returned pass with 2 typed finding(s)."
+  evaluated_sha: "1ec387cd29895158d5157c446a3913cc9598e440"
+  blueprint_digest: "6c3c595869d15122f3c343194be31715fc6f619c829d8d906e248ed80ae88ad4"
+  evidence_refs:
+    - ".agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-work-order.json"
+    - ".agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-result.json"
+    - ".agentplane/tasks/202607280606-PTG9C7/README.md"
+    - ".agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-diff.patch"
+    - ".agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-observed-checks.json"
+    - ".agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-blueprint.json"
+    - ".agentplane/policy/dod.code.md"
+    - ".agentplane/policy/dod.core.md"
+    - ".agentplane/policy/security.must.md"
+    - ".agentplane/policy/workflow.branch_pr.md"
+  findings:
+    - "Route resolution and AgentWorkOrder preparation now share branch snapshot precedence in branch_pr mode, so task.revision and state_fingerprint.task_revision cannot diverge solely by checkout."
+    - "The regression advances and commits the task worktree document, invokes task next-action from main, and asserts both revision fields equal the branch snapshot."
 commit:
   hash: "1ec387cd29895158d5157c446a3913cc9598e440"
   message: "🚧 PTG9C7 task: align work-order task snapshot"

--- a/.agentplane/tasks/202607280606-PTG9C7/README.md
+++ b/.agentplane/tasks/202607280606-PTG9C7/README.md
@@ -4,7 +4,7 @@ title: "Prevent self-invalidating side-effect authority records"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 12
+revision: 13
 origin:
   system: "manual"
 depends_on: []
@@ -28,10 +28,10 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-07-28T06:19:32.579Z"
+  updated_by: "TESTER"
+  note: "Focused AgentWorkOrder integration and side-effect authority suites passed: 13 tests. Typecheck and policy routing passed. The base-checkout route for 202607242236-1BFWEY now resolves without a task-revision schema error."
   attempts: 0
 commit:
   hash: "1ec387cd29895158d5157c446a3913cc9598e440"
@@ -68,8 +68,14 @@ events:
     from: "DOING"
     to: "DOING"
     note: "Implementation: AgentWorkOrder preparation now uses the branch snapshot selected by branch_pr route resolution; regression covers invocation from base checkout."
+  -
+    type: "verify"
+    at: "2026-07-28T06:19:32.579Z"
+    author: "TESTER"
+    state: "ok"
+    note: "Focused AgentWorkOrder integration and side-effect authority suites passed: 13 tests. Typecheck and policy routing passed. The base-checkout route for 202607242236-1BFWEY now resolves without a task-revision schema error."
 doc_version: 3
-doc_updated_at: "2026-07-28T06:18:54.021Z"
+doc_updated_at: "2026-07-28T06:19:33.181Z"
 doc_updated_by: "CODER"
 description: "Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge."
 sections:
@@ -84,11 +90,44 @@ sections:
   Verify Steps: "1. Add a regression for branch_pr: update the task in its task worktree, commit it, then invoke task next-action from main. Expected: the work-order task revision equals state_fingerprint.task_revision and the command returns JSON rather than schema validation error. 2. Run the focused AgentWorkOrder integration test and side-effect authority tests. Expected: both pass, including fail-closed negative authority cases. 3. Run bun run typecheck and node .agentplane/policy/check-routing.mjs. Expected: both pass. 4. Re-run task next-action for supervisor task 202607242236-1BFWEY from its integration/base context. Expected: no AgentWorkOrder task revision mismatch."
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-07-28T06:19:32.579Z — VERIFY — ok
+
+    By: TESTER
+
+    Note: Focused AgentWorkOrder integration and side-effect authority suites passed: 13 tests. Typecheck and policy routing passed. The base-checkout route for 202607242236-1BFWEY now resolves without a task-revision schema error.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T06:18:54.021Z, excerpt_hash=sha256:dbb7d0fbbad8e8c27f4b1a3c936bb899726a436166ddf5c35883d99078c1c092
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607280606-PTG9C7-prevent-self-invalidating-side-effect-authority/.agentplane/tasks/202607280606-PTG9C7/blueprint/resolved-snapshot.json
+    - old_digest: 6c3c595869d15122f3c343194be31715fc6f619c829d8d906e248ed80ae88ad4
+    - current_digest: 6c3c595869d15122f3c343194be31715fc6f619c829d8d906e248ed80ae88ad4
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607280606-PTG9C7
+
+    DecisionContextRef:
+    - operator_action: stop
+    - can_execute_now: false
+    - safe_command: none
+    - diagnostic_command: agentplane task verify-show 202607280606-PTG9C7
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: none
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
     - Re-run required checks to confirm rollback safety.
-  Findings: ""
+  Findings: |-
+    - Observation: Before the fix, a branch_pr command from main combined the base task revision with the task-worktree fingerprint and failed AgentWorkOrder validation.
+      Impact: The route oracle could not progress a valid task from the base checkout.
+      Resolution: AgentWorkOrder preparation now uses the branch snapshot in branch_pr mode; regression covers the mismatched revision path.
 extensions:
   agentplane.side_effect_authority:
     audit:
@@ -147,6 +186,36 @@ Align branch_pr AgentWorkOrder preparation with the same task branch snapshot us
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-07-28T06:19:32.579Z — VERIFY — ok
+
+By: TESTER
+
+Note: Focused AgentWorkOrder integration and side-effect authority suites passed: 13 tests. Typecheck and policy routing passed. The base-checkout route for 202607242236-1BFWEY now resolves without a task-revision schema error.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T06:18:54.021Z, excerpt_hash=sha256:dbb7d0fbbad8e8c27f4b1a3c936bb899726a436166ddf5c35883d99078c1c092
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607280606-PTG9C7-prevent-self-invalidating-side-effect-authority/.agentplane/tasks/202607280606-PTG9C7/blueprint/resolved-snapshot.json
+- old_digest: 6c3c595869d15122f3c343194be31715fc6f619c829d8d906e248ed80ae88ad4
+- current_digest: 6c3c595869d15122f3c343194be31715fc6f619c829d8d906e248ed80ae88ad4
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607280606-PTG9C7
+
+DecisionContextRef:
+- operator_action: stop
+- can_execute_now: false
+- safe_command: none
+- diagnostic_command: agentplane task verify-show 202607280606-PTG9C7
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: none
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -155,3 +224,7 @@ Align branch_pr AgentWorkOrder preparation with the same task branch snapshot us
 - Re-run required checks to confirm rollback safety.
 
 ## Findings
+
+- Observation: Before the fix, a branch_pr command from main combined the base task revision with the task-worktree fingerprint and failed AgentWorkOrder validation.
+  Impact: The route oracle could not progress a valid task from the base checkout.
+  Resolution: AgentWorkOrder preparation now uses the branch snapshot in branch_pr mode; regression covers the mismatched revision path.

--- a/.agentplane/tasks/202607280606-PTG9C7/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202607280606-PTG9C7/blueprint/resolved-snapshot.json
@@ -1,0 +1,585 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607280606-PTG9C7",
+    "title": "Prevent self-invalidating side-effect authority records",
+    "description": "Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge.",
+    "tags": [
+      "authority",
+      "branch-pr",
+      "lifecycle",
+      "v0.7"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [
+      "security"
+    ],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607280606-PTG9C7",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "riskFlags": [
+        "security"
+      ],
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "6c3c595869d15122f3c343194be31715fc6f619c829d8d906e248ed80ae88ad4"
+  }
+}

--- a/.agentplane/tasks/202607280606-PTG9C7/pr/diffstat.txt
+++ b/.agentplane/tasks/202607280606-PTG9C7/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../agentplane/src/runner/context/task-context.ts  | 12 ++++-
+ .../usecases/agent-work-order.integration.test.ts  | 61 +++++++++++++++++++++-
+ 2 files changed, 70 insertions(+), 3 deletions(-)

--- a/.agentplane/tasks/202607280606-PTG9C7/pr/github-body.md
+++ b/.agentplane/tasks/202607280606-PTG9C7/pr/github-body.md
@@ -1,0 +1,35 @@
+Task: `202607280606-PTG9C7`
+Title: Prevent self-invalidating side-effect authority records
+Canonical task record: `.agentplane/tasks/202607280606-PTG9C7/README.md`
+
+## Summary
+
+Prevent self-invalidating side-effect authority records
+
+Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge.
+
+## Scope
+
+- In scope: Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge.
+- Out of scope: unrelated refactors not required for "Prevent self-invalidating side-effect authority records".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-28T06:15:22.323Z
+- Branch: task/202607280606-PTG9C7/prevent-self-invalidating-side-effect-authority
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../agentplane/src/runner/context/task-context.ts  | 12 ++++-
+ .../usecases/agent-work-order.integration.test.ts  | 61 +++++++++++++++++++++-
+ 2 files changed, 70 insertions(+), 3 deletions(-)
+```
+
+</details>

--- a/.agentplane/tasks/202607280606-PTG9C7/pr/github-body.md
+++ b/.agentplane/tasks/202607280606-PTG9C7/pr/github-body.md
@@ -15,14 +15,20 @@ Fix the branch_pr lifecycle defect where a task authority grant changes the task
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Focused AgentWorkOrder integration and side-effect authority suites passed: 13 tests. Typecheck and
+policy routing passed. The base-checkout route for 202607242236-1BFWEY now resolves without a
+task-revision schema error.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-28T06:15:22.323Z
+- Updated: 2026-07-28T06:18:34.004Z
 - Branch: task/202607280606-PTG9C7/prevent-self-invalidating-side-effect-authority
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 

--- a/.agentplane/tasks/202607280606-PTG9C7/pr/github-title.txt
+++ b/.agentplane/tasks/202607280606-PTG9C7/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 PTG9C7 task: Prevent self-invalidating side-effect authority records [202607280606-PTG9C7]

--- a/.agentplane/tasks/202607280606-PTG9C7/pr/github-title.txt
+++ b/.agentplane/tasks/202607280606-PTG9C7/pr/github-title.txt
@@ -1,1 +1,1 @@
-🚧 PTG9C7 task: Prevent self-invalidating side-effect authority records [202607280606-PTG9C7]
+✅ PTG9C7 task: Prevent self-invalidating side-effect authority records [202607280606-PTG9C7]

--- a/.agentplane/tasks/202607280606-PTG9C7/pr/meta.json
+++ b/.agentplane/tasks/202607280606-PTG9C7/pr/meta.json
@@ -7,6 +7,13 @@
   "last_verified_diffstat_sha256": "sha256:55500b8fdbe38fdfcafe9d9088d2757134902286c63245f80fc28a290a55833d",
   "pr_number": 4652,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4652",
+  "pre_merge_closure": {
+    "basis_commit": "0e2bcb59e5931c267bb29ce4d9686b854e5fe724",
+    "branch": "task/202607280606-PTG9C7/prevent-self-invalidating-side-effect-authority",
+    "pr_number": 4652,
+    "recorded_at": "2026-07-28T06:20:45.365Z",
+    "state": "closed_before_merge"
+  },
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202607280606-PTG9C7",

--- a/.agentplane/tasks/202607280606-PTG9C7/pr/meta.json
+++ b/.agentplane/tasks/202607280606-PTG9C7/pr/meta.json
@@ -3,7 +3,8 @@
   "branch": "task/202607280606-PTG9C7/prevent-self-invalidating-side-effect-authority",
   "created_at": "2026-07-28T06:15:22.323Z",
   "diffstat_sha256": "sha256:55500b8fdbe38fdfcafe9d9088d2757134902286c63245f80fc28a290a55833d",
-  "last_verified_at": null,
+  "last_verified_at": "2026-07-28T06:19:32.579Z",
+  "last_verified_diffstat_sha256": "sha256:55500b8fdbe38fdfcafe9d9088d2757134902286c63245f80fc28a290a55833d",
   "pr_number": 4652,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4652",
   "schema_version": 1,
@@ -11,6 +12,6 @@
   "task_id": "202607280606-PTG9C7",
   "updated_at": "2026-07-28T06:18:34.004Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202607280606-PTG9C7/pr/meta.json
+++ b/.agentplane/tasks/202607280606-PTG9C7/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202607280606-PTG9C7/prevent-self-invalidating-side-effect-authority",
+  "created_at": "2026-07-28T06:15:22.323Z",
+  "diffstat_sha256": "sha256:55500b8fdbe38fdfcafe9d9088d2757134902286c63245f80fc28a290a55833d",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202607280606-PTG9C7",
+  "updated_at": "2026-07-28T06:15:22.323Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202607280606-PTG9C7/pr/meta.json
+++ b/.agentplane/tasks/202607280606-PTG9C7/pr/meta.json
@@ -4,9 +4,12 @@
   "created_at": "2026-07-28T06:15:22.323Z",
   "diffstat_sha256": "sha256:55500b8fdbe38fdfcafe9d9088d2757134902286c63245f80fc28a290a55833d",
   "last_verified_at": null,
+  "pr_number": 4652,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4652",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202607280606-PTG9C7",
-  "updated_at": "2026-07-28T06:15:22.323Z",
+  "updated_at": "2026-07-28T06:18:34.004Z",
   "verify": {
     "status": "skipped"
   }

--- a/.agentplane/tasks/202607280606-PTG9C7/pr/review.md
+++ b/.agentplane/tasks/202607280606-PTG9C7/pr/review.md
@@ -6,7 +6,7 @@ Created: 2026-07-28T06:15:22.323Z
 
 - Task: `202607280606-PTG9C7`
 - Title: Prevent self-invalidating side-effect authority records
-- Status: DOING
+- Status: DONE
 - Branch: `task/202607280606-PTG9C7/prevent-self-invalidating-side-effect-authority`
 - Canonical task record: `.agentplane/tasks/202607280606-PTG9C7/README.md`
 

--- a/.agentplane/tasks/202607280606-PTG9C7/pr/review.md
+++ b/.agentplane/tasks/202607280606-PTG9C7/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-07-28T06:15:22.323Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Focused AgentWorkOrder integration and side-effect authority suites passed: 13 tests. Typecheck and policy routing passed. The base-checkout route for 202607242236-1BFWEY now resolves without a task-revision schema error.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,7 +24,7 @@ Created: 2026-07-28T06:15:22.323Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-28T06:15:22.323Z
+- Updated: 2026-07-28T06:18:34.004Z
 - Branch: task/202607280606-PTG9C7/prevent-self-invalidating-side-effect-authority
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 

--- a/.agentplane/tasks/202607280606-PTG9C7/pr/review.md
+++ b/.agentplane/tasks/202607280606-PTG9C7/pr/review.md
@@ -1,0 +1,38 @@
+# PR Review
+
+Created: 2026-07-28T06:15:22.323Z
+
+## Task
+
+- Task: `202607280606-PTG9C7`
+- Title: Prevent self-invalidating side-effect authority records
+- Status: DOING
+- Branch: `task/202607280606-PTG9C7/prevent-self-invalidating-side-effect-authority`
+- Canonical task record: `.agentplane/tasks/202607280606-PTG9C7/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-28T06:15:22.323Z
+- Branch: task/202607280606-PTG9C7/prevent-self-invalidating-side-effect-authority
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+ .../agentplane/src/runner/context/task-context.ts  | 12 ++++-
+ .../usecases/agent-work-order.integration.test.ts  | 61 +++++++++++++++++++++-
+ 2 files changed, 70 insertions(+), 3 deletions(-)
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-blueprint.json
+++ b/.agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-blueprint.json
@@ -1,0 +1,585 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607280606-PTG9C7",
+    "title": "Prevent self-invalidating side-effect authority records",
+    "description": "Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge.",
+    "tags": [
+      "authority",
+      "branch-pr",
+      "lifecycle",
+      "v0.7"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [
+      "security"
+    ],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607280606-PTG9C7",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "riskFlags": [
+        "security"
+      ],
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "6c3c595869d15122f3c343194be31715fc6f619c829d8d906e248ed80ae88ad4"
+  }
+}

--- a/.agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-diff.patch
+++ b/.agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-diff.patch
@@ -1,0 +1,948 @@
+diff --git a/.agentplane/tasks/202607280606-PTG9C7/README.md b/.agentplane/tasks/202607280606-PTG9C7/README.md
+new file mode 100644
+index 000000000..4a2865263
+--- /dev/null
++++ b/.agentplane/tasks/202607280606-PTG9C7/README.md
+@@ -0,0 +1,115 @@
++---
++id: "202607280606-PTG9C7"
++title: "Prevent self-invalidating side-effect authority records"
++status: "DOING"
++priority: "high"
++owner: "CODER"
++revision: 10
++origin:
++  system: "manual"
++depends_on: []
++tags:
++  - "authority"
++  - "branch-pr"
++  - "lifecycle"
++  - "v0.7"
++task_kind: "code"
++mutation_scope: "code"
++risk_flags:
++  - "security"
++blueprint_request: "code.branch_pr"
++verify:
++  - "Focused authority lifecycle regression"
++  - "bun run typecheck"
++  - "node .agentplane/policy/check-routing.mjs"
++plan_approval:
++  state: "approved"
++  updated_at: "2026-07-28T06:15:21.657Z"
++  updated_by: "ORCHESTRATOR"
++  note: null
++verification:
++  state: "pending"
++  updated_at: null
++  updated_by: null
++  note: null
++  attempts: 0
++commit: null
++comments:
++  -
++    author: "CODER"
++    body: "Start: reproduce the self-invalidating authority transition, then implement the smallest fail-closed lifecycle fix with focused regressions."
++  -
++    author: "CODER"
++    body: "Start: implement the branch-snapshot consistency regression and minimal preparation fix."
++events:
++  -
++    type: "status"
++    at: "2026-07-28T06:07:13.202Z"
++    author: "CODER"
++    from: "TODO"
++    to: "DOING"
++    note: "Start: reproduce the self-invalidating authority transition, then implement the smallest fail-closed lifecycle fix with focused regressions."
++  -
++    type: "status"
++    at: "2026-07-28T06:15:22.225Z"
++    author: "CODER"
++    from: "DOING"
++    to: "DOING"
++    note: "Start: implement the branch-snapshot consistency regression and minimal preparation fix."
++doc_version: 3
++doc_updated_at: "2026-07-28T06:15:22.225Z"
++doc_updated_by: "CODER"
++description: "Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge."
++sections:
++  Summary: |-
++    Prevent self-invalidating side-effect authority records
++
++    Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge.
++  Scope: |-
++    - In scope: Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge.
++    - Out of scope: unrelated refactors not required for "Prevent self-invalidating side-effect authority records".
++  Plan: "Align branch_pr AgentWorkOrder preparation with the same task branch snapshot used by route resolution. Prevent a base-checkout task next-action or task brief from combining a stale local task revision with a newer route fingerprint. Preserve fail-closed side-effect authority semantics; do not weaken authority validation. Add a regression where the task worktree has a newer task revision than main and preparation from main succeeds with matching work-order task and fingerprint revisions."
++  Verify Steps: "1. Add a regression for branch_pr: update the task in its task worktree, commit it, then invoke task next-action from main. Expected: the work-order task revision equals state_fingerprint.task_revision and the command returns JSON rather than schema validation error. 2. Run the focused AgentWorkOrder integration test and side-effect authority tests. Expected: both pass, including fail-closed negative authority cases. 3. Run bun run typecheck and node .agentplane/policy/check-routing.mjs. Expected: both pass. 4. Re-run task next-action for supervisor task 202607242236-1BFWEY from its integration/base context. Expected: no AgentWorkOrder task revision mismatch."
++  Verification: |-
++    <!-- BEGIN VERIFICATION RESULTS -->
++    <!-- END VERIFICATION RESULTS -->
++  Rollback Plan: |-
++    - Revert task-related commit(s).
++    - Re-run required checks to confirm rollback safety.
++  Findings: ""
++extensions:
++  workflow_route_baseline:
++    start_head_sha: "08dd47769434fc336d23a80d2d47f4fb0a265d74"
++    version: 1
++id_source: "generated"
++---
++## Summary
++
++Prevent self-invalidating side-effect authority records
++
++Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge.
++
++## Scope
++
++- In scope: Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge.
++- Out of scope: unrelated refactors not required for "Prevent self-invalidating side-effect authority records".
++
++## Plan
++
++Align branch_pr AgentWorkOrder preparation with the same task branch snapshot used by route resolution. Prevent a base-checkout task next-action or task brief from combining a stale local task revision with a newer route fingerprint. Preserve fail-closed side-effect authority semantics; do not weaken authority validation. Add a regression where the task worktree has a newer task revision than main and preparation from main succeeds with matching work-order task and fingerprint revisions.
++
++## Verify Steps
++
++1. Add a regression for branch_pr: update the task in its task worktree, commit it, then invoke task next-action from main. Expected: the work-order task revision equals state_fingerprint.task_revision and the command returns JSON rather than schema validation error. 2. Run the focused AgentWorkOrder integration test and side-effect authority tests. Expected: both pass, including fail-closed negative authority cases. 3. Run bun run typecheck and node .agentplane/policy/check-routing.mjs. Expected: both pass. 4. Re-run task next-action for supervisor task 202607242236-1BFWEY from its integration/base context. Expected: no AgentWorkOrder task revision mismatch.
++
++## Verification
++
++<!-- BEGIN VERIFICATION RESULTS -->
++<!-- END VERIFICATION RESULTS -->
++
++## Rollback Plan
++
++- Revert task-related commit(s).
++- Re-run required checks to confirm rollback safety.
++
++## Findings
+diff --git a/.agentplane/tasks/202607280606-PTG9C7/blueprint/resolved-snapshot.json b/.agentplane/tasks/202607280606-PTG9C7/blueprint/resolved-snapshot.json
+new file mode 100644
+index 000000000..b780f7ef2
+--- /dev/null
++++ b/.agentplane/tasks/202607280606-PTG9C7/blueprint/resolved-snapshot.json
+@@ -0,0 +1,585 @@
++{
++  "schemaVersion": 1,
++  "artifactKind": "agentplane.blueprint.resolved_snapshot",
++  "resolverInput": {
++    "taskId": "202607280606-PTG9C7",
++    "title": "Prevent self-invalidating side-effect authority records",
++    "description": "Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge.",
++    "tags": [
++      "authority",
++      "branch-pr",
++      "lifecycle",
++      "v0.7"
++    ],
++    "owner": "CODER",
++    "taskKind": "code",
++    "workflowMode": "branch_pr",
++    "workflowGitCapabilities": {
++      "workflowMode": "branch_pr",
++      "implementationCommitLocation": "task_worktree",
++      "finishCommitSource": "explicit_hash",
++      "closeTailRequired": true,
++      "lifecycleCommentCommitLocation": "task_worktree",
++      "finishCommitFromComment": false
++    },
++    "mutation": "code",
++    "mutationScope": "code",
++    "touchedPaths": [],
++    "recipeHints": [],
++    "riskFlags": [
++      "security"
++    ],
++    "blueprintRequest": "code.branch_pr"
++  },
++  "selectedBlueprint": {
++    "id": "code.branch_pr",
++    "version": 1,
++    "title": "Branch PR code change",
++    "taskKinds": [
++      "code"
++    ],
++    "workflowModes": [
++      "branch_pr"
++    ]
++  },
++  "plan": {
++    "schemaVersion": 1,
++    "blueprintId": "code.branch_pr",
++    "blueprintVersion": 1,
++    "title": "Branch PR code change",
++    "taskId": "202607280606-PTG9C7",
++    "workflowMode": "branch_pr",
++    "workflowGitCapabilities": {
++      "workflowMode": "branch_pr",
++      "implementationCommitLocation": "task_worktree",
++      "finishCommitSource": "explicit_hash",
++      "closeTailRequired": true,
++      "lifecycleCommentCommitLocation": "task_worktree",
++      "finishCommitFromComment": false
++    },
++    "taskIntent": {
++      "taskKind": "code",
++      "mutationScope": "code",
++      "riskFlags": [
++        "security"
++      ],
++      "blueprintRequest": "code.branch_pr"
++    },
++    "whySelected": [
++      "explicit blueprint requested: code.branch_pr",
++      "task intent kind: code",
++      "workflow mode: branch_pr",
++      "task intent mutation scope: code"
++    ],
++    "states": [
++      {
++        "id": "intake",
++        "kind": "intake",
++        "mode": "agentic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": []
++      },
++      {
++        "id": "scope",
++        "kind": "scope",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "assumptions"
++        ]
++      },
++      {
++        "id": "approval_gate",
++        "kind": "approval_gate",
++        "mode": "approval",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "approval"
++        ]
++      },
++      {
++        "id": "context_resolve",
++        "kind": "context_resolve",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [
++          ".agentplane/policy/security.must.md",
++          ".agentplane/policy/dod.core.md",
++          ".agentplane/policy/dod.code.md",
++          ".agentplane/policy/workflow.branch_pr.md"
++        ],
++        "evidenceKinds": [
++          "context_manifest"
++        ]
++      },
++      {
++        "id": "worktree_start",
++        "kind": "worktree_start",
++        "mode": "deterministic",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [
++          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "changed_paths"
++        ]
++      },
++      {
++        "id": "work_unit",
++        "kind": "work_unit",
++        "mode": "agentic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "changed_paths"
++        ]
++      },
++      {
++        "id": "fast_local_checks",
++        "kind": "fast_local_checks",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [
++          "agentplane task verify-show <task-id>",
++          "project focused checks"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "check_result"
++        ]
++      },
++      {
++        "id": "pr_artifact",
++        "kind": "pr_artifact",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [
++          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "artifact",
++          "external_link"
++        ]
++      },
++      {
++        "id": "verify_record",
++        "kind": "verify_record",
++        "mode": "record",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "check_result"
++        ]
++      },
++      {
++        "id": "quality_gate",
++        "kind": "quality_gate",
++        "mode": "agentic",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [
++          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "quality_report"
++        ]
++      },
++      {
++        "id": "hosted_checks",
++        "kind": "hosted_checks",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "check_result",
++          "external_link"
++        ]
++      },
++      {
++        "id": "publish_or_integrate",
++        "kind": "publish_or_integrate",
++        "mode": "deterministic",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [
++          "agentplane integrate <task-id> --branch <branch> --run-verify"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "commit",
++          "external_link"
++        ]
++      },
++      {
++        "id": "finish",
++        "kind": "finish",
++        "mode": "deterministic",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "commit"
++        ]
++      }
++    ],
++    "requiredEvidence": [
++      {
++        "id": "code_pr.paths",
++        "kind": "changed_paths",
++        "producedBy": "work_unit",
++        "required": true,
++        "description": "Changed source paths."
++      },
++      {
++        "id": "code_pr.fast_checks",
++        "kind": "check_result",
++        "producedBy": "fast_local_checks",
++        "required": true,
++        "description": "Fast local checks."
++      },
++      {
++        "id": "code_pr.pr",
++        "kind": "external_link",
++        "producedBy": "pr_artifact",
++        "required": true,
++        "description": "Pull request artifact."
++      },
++      {
++        "id": "code_pr.verify",
++        "kind": "check_result",
++        "producedBy": "verify_record",
++        "required": true,
++        "description": "Task branch verification."
++      },
++      {
++        "id": "code_pr.quality",
++        "kind": "quality_report",
++        "producedBy": "quality_gate",
++        "required": true,
++        "description": "EVALUATOR quality verdict."
++      },
++      {
++        "id": "code_pr.hosted",
++        "kind": "check_result",
++        "producedBy": "hosted_checks",
++        "required": true,
++        "description": "Hosted check evidence."
++      },
++      {
++        "id": "code_pr.commit",
++        "kind": "commit",
++        "producedBy": "publish_or_integrate",
++        "required": true,
++        "description": "Integration commit."
++      }
++    ],
++    "policyModules": [
++      ".agentplane/policy/dod.code.md",
++      ".agentplane/policy/dod.core.md",
++      ".agentplane/policy/security.must.md",
++      ".agentplane/policy/workflow.branch_pr.md"
++    ],
++    "allowedCommands": [
++      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
++      "agentplane integrate <task-id> --branch <branch> --run-verify",
++      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
++      "agentplane task verify-show <task-id>",
++      "agentplane verify <task-id> --ok|--rework",
++      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
++      "project focused checks"
++    ],
++    "contextBudget": {
++      "maxPolicyModules": 4,
++      "maxPromptBlocks": 14,
++      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
++    },
++    "contextManifest": [],
++    "acceptedRecipeExtensions": [],
++    "rejectedRecipeExtensions": [],
++    "stopReasons": []
++  },
++  "nodes": [
++    {
++      "id": "intake",
++      "kind": "intake",
++      "mode": "agentic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": []
++    },
++    {
++      "id": "scope",
++      "kind": "scope",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "assumptions"
++      ]
++    },
++    {
++      "id": "approval_gate",
++      "kind": "approval_gate",
++      "mode": "approval",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "approval"
++      ]
++    },
++    {
++      "id": "context_resolve",
++      "kind": "context_resolve",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [
++        ".agentplane/policy/security.must.md",
++        ".agentplane/policy/dod.core.md",
++        ".agentplane/policy/dod.code.md",
++        ".agentplane/policy/workflow.branch_pr.md"
++      ],
++      "evidenceKinds": [
++        "context_manifest"
++      ]
++    },
++    {
++      "id": "worktree_start",
++      "kind": "worktree_start",
++      "mode": "deterministic",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [
++        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "changed_paths"
++      ]
++    },
++    {
++      "id": "work_unit",
++      "kind": "work_unit",
++      "mode": "agentic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "changed_paths"
++      ]
++    },
++    {
++      "id": "fast_local_checks",
++      "kind": "fast_local_checks",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [
++        "agentplane task verify-show <task-id>",
++        "project focused checks"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "check_result"
++      ]
++    },
++    {
++      "id": "pr_artifact",
++      "kind": "pr_artifact",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [
++        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "artifact",
++        "external_link"
++      ]
++    },
++    {
++      "id": "verify_record",
++      "kind": "verify_record",
++      "mode": "record",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "check_result"
++      ]
++    },
++    {
++      "id": "quality_gate",
++      "kind": "quality_gate",
++      "mode": "agentic",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [
++        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "quality_report"
++      ]
++    },
++    {
++      "id": "hosted_checks",
++      "kind": "hosted_checks",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "check_result",
++        "external_link"
++      ]
++    },
++    {
++      "id": "publish_or_integrate",
++      "kind": "publish_or_integrate",
++      "mode": "deterministic",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [
++        "agentplane integrate <task-id> --branch <branch> --run-verify"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "commit",
++        "external_link"
++      ]
++    },
++    {
++      "id": "finish",
++      "kind": "finish",
++      "mode": "deterministic",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "commit"
++      ]
++    }
++  ],
++  "requiredEvidence": [
++    {
++      "id": "code_pr.paths",
++      "kind": "changed_paths",
++      "producedBy": "work_unit",
++      "required": true,
++      "description": "Changed source paths."
++    },
++    {
++      "id": "code_pr.fast_checks",
++      "kind": "check_result",
++      "producedBy": "fast_local_checks",
++      "required": true,
++      "description": "Fast local checks."
++    },
++    {
++      "id": "code_pr.pr",
++      "kind": "external_link",
++      "producedBy": "pr_artifact",
++      "required": true,
++      "description": "Pull request artifact."
++    },
++    {
++      "id": "code_pr.verify",
++      "kind": "check_result",
++      "producedBy": "verify_record",
++      "required": true,
++      "description": "Task branch verification."
++    },
++    {
++      "id": "code_pr.quality",
++      "kind": "quality_report",
++      "producedBy": "quality_gate",
++      "required": true,
++      "description": "EVALUATOR quality verdict."
++    },
++    {
++      "id": "code_pr.hosted",
++      "kind": "check_result",
++      "producedBy": "hosted_checks",
++      "required": true,
++      "description": "Hosted check evidence."
++    },
++    {
++      "id": "code_pr.commit",
++      "kind": "commit",
++      "producedBy": "publish_or_integrate",
++      "required": true,
++      "description": "Integration commit."
++    }
++  ],
++  "policyModules": [
++    ".agentplane/policy/dod.code.md",
++    ".agentplane/policy/dod.core.md",
++    ".agentplane/policy/security.must.md",
++    ".agentplane/policy/workflow.branch_pr.md"
++  ],
++  "allowedCommands": [
++    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
++    "agentplane integrate <task-id> --branch <branch> --run-verify",
++    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
++    "agentplane task verify-show <task-id>",
++    "agentplane verify <task-id> --ok|--rework",
++    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
++    "project focused checks"
++  ],
++  "contextBudget": {
++    "maxPolicyModules": 4,
++    "maxPromptBlocks": 14,
++    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
++  },
++  "contextManifest": [],
++  "acceptedRecipeExtensions": [],
++  "rejectedRecipeExtensions": [],
++  "stopReasons": [],
++  "selectionReasons": [
++    "explicit blueprint requested: code.branch_pr",
++    "task intent kind: code",
++    "workflow mode: branch_pr",
++    "task intent mutation scope: code"
++  ],
++  "digest": {
++    "algorithm": "sha256",
++    "value": "6c3c595869d15122f3c343194be31715fc6f619c829d8d906e248ed80ae88ad4"
++  }
++}
+diff --git a/.agentplane/tasks/202607280606-PTG9C7/pr/diffstat.txt b/.agentplane/tasks/202607280606-PTG9C7/pr/diffstat.txt
+new file mode 100644
+index 000000000..cc1452a52
+--- /dev/null
++++ b/.agentplane/tasks/202607280606-PTG9C7/pr/diffstat.txt
+@@ -0,0 +1,3 @@
++ .../agentplane/src/runner/context/task-context.ts  | 12 ++++-
++ .../usecases/agent-work-order.integration.test.ts  | 61 +++++++++++++++++++++-
++ 2 files changed, 70 insertions(+), 3 deletions(-)
+diff --git a/.agentplane/tasks/202607280606-PTG9C7/pr/github-body.md b/.agentplane/tasks/202607280606-PTG9C7/pr/github-body.md
+new file mode 100644
+index 000000000..14dbc30da
+--- /dev/null
++++ b/.agentplane/tasks/202607280606-PTG9C7/pr/github-body.md
+@@ -0,0 +1,35 @@
++Task: `202607280606-PTG9C7`
++Title: Prevent self-invalidating side-effect authority records
++Canonical task record: `.agentplane/tasks/202607280606-PTG9C7/README.md`
++
++## Summary
++
++Prevent self-invalidating side-effect authority records
++
++Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge.
++
++## Scope
++
++- In scope: Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge.
++- Out of scope: unrelated refactors not required for "Prevent self-invalidating side-effect authority records".
++
++## Verification
++
++- State: pending
++- Note: Not recorded yet.
++- Canonical workflow state lives in the task README.
++
++<details>
++<summary>Raw evidence</summary>
++
++- Updated: 2026-07-28T06:15:22.323Z
++- Branch: task/202607280606-PTG9C7/prevent-self-invalidating-side-effect-authority
++- Head: computed live by `agentplane pr check` / `agentplane integrate`
++
++```text
++ .../agentplane/src/runner/context/task-context.ts  | 12 ++++-
++ .../usecases/agent-work-order.integration.test.ts  | 61 +++++++++++++++++++++-
++ 2 files changed, 70 insertions(+), 3 deletions(-)
++```
++
++</details>
+diff --git a/.agentplane/tasks/202607280606-PTG9C7/pr/github-title.txt b/.agentplane/tasks/202607280606-PTG9C7/pr/github-title.txt
+new file mode 100644
+index 000000000..cba858c44
+--- /dev/null
++++ b/.agentplane/tasks/202607280606-PTG9C7/pr/github-title.txt
+@@ -0,0 +1 @@
++🚧 PTG9C7 task: Prevent self-invalidating side-effect authority records [202607280606-PTG9C7]
+diff --git a/.agentplane/tasks/202607280606-PTG9C7/pr/meta.json b/.agentplane/tasks/202607280606-PTG9C7/pr/meta.json
+new file mode 100644
+index 000000000..893bb6405
+--- /dev/null
++++ b/.agentplane/tasks/202607280606-PTG9C7/pr/meta.json
+@@ -0,0 +1,13 @@
++{
++  "base": "main",
++  "branch": "task/202607280606-PTG9C7/prevent-self-invalidating-side-effect-authority",
++  "created_at": "2026-07-28T06:15:22.323Z",
++  "diffstat_sha256": "sha256:55500b8fdbe38fdfcafe9d9088d2757134902286c63245f80fc28a290a55833d",
++  "last_verified_at": null,
++  "schema_version": 1,
++  "task_id": "202607280606-PTG9C7",
++  "updated_at": "2026-07-28T06:15:22.323Z",
++  "verify": {
++    "status": "skipped"
++  }
++}
+diff --git a/.agentplane/tasks/202607280606-PTG9C7/pr/review.md b/.agentplane/tasks/202607280606-PTG9C7/pr/review.md
+new file mode 100644
+index 000000000..6b6672f3d
+--- /dev/null
++++ b/.agentplane/tasks/202607280606-PTG9C7/pr/review.md
+@@ -0,0 +1,38 @@
++# PR Review
++
++Created: 2026-07-28T06:15:22.323Z
++
++## Task
++
++- Task: `202607280606-PTG9C7`
++- Title: Prevent self-invalidating side-effect authority records
++- Status: DOING
++- Branch: `task/202607280606-PTG9C7/prevent-self-invalidating-side-effect-authority`
++- Canonical task record: `.agentplane/tasks/202607280606-PTG9C7/README.md`
++
++## Verification
++
++- State: pending
++- Note: Not recorded yet.
++- Canonical workflow state lives in the task README.
++
++## Handoff Notes
++
++- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
++
++<!-- BEGIN AUTO SUMMARY -->
++<details>
++<summary>Raw evidence</summary>
++
++- Updated: 2026-07-28T06:15:22.323Z
++- Branch: task/202607280606-PTG9C7/prevent-self-invalidating-side-effect-authority
++- Head: computed live by `agentplane pr check` / `agentplane integrate`
++
++```text
++ .../agentplane/src/runner/context/task-context.ts  | 12 ++++-
++ .../usecases/agent-work-order.integration.test.ts  | 61 +++++++++++++++++++++-
++ 2 files changed, 70 insertions(+), 3 deletions(-)
++```
++
++</details>
++<!-- END AUTO SUMMARY -->
+diff --git a/packages/agentplane/src/runner/context/task-context.ts b/packages/agentplane/src/runner/context/task-context.ts
+index 19b805769..944299a86 100644
+--- a/packages/agentplane/src/runner/context/task-context.ts
++++ b/packages/agentplane/src/runner/context/task-context.ts
+@@ -343,7 +343,17 @@ export async function assembleRunnerTaskContext(opts: {
+     const ctx =
+       opts.ctx ??
+       (await loadCommandContext({ cwd: opts.cwd, rootOverride: opts.rootOverride ?? null }));
+-    const task = opts.task ?? (await loadTaskFromContext({ ctx, taskId: opts.task_id }));
++    // Route resolution treats the task worktree snapshot as authoritative in
++    // branch_pr mode. AgentWorkOrder preparation must read that same snapshot;
++    // otherwise a command invoked from the base checkout can combine an older
++    // task revision with the route fingerprint from the task branch.
++    const task =
++      opts.task ??
++      (await loadTaskFromContext({
++        ctx,
++        taskId: opts.task_id,
++        preferBranchSnapshot: ctx.config.workflow_mode === "branch_pr",
++      }));
+     const dependencyState = toRunnerDependencyState(
+       await resolveTaskDependencyState(task, opts.dependency_backend ?? ctx.taskBackend),
+     );
+diff --git a/packages/agentplane/src/runner/usecases/agent-work-order.integration.test.ts b/packages/agentplane/src/runner/usecases/agent-work-order.integration.test.ts
+index 6643b3773..beaeb1d84 100644
+--- a/packages/agentplane/src/runner/usecases/agent-work-order.integration.test.ts
++++ b/packages/agentplane/src/runner/usecases/agent-work-order.integration.test.ts
+@@ -15,7 +15,7 @@ import { describe, expect, it } from "vitest";
+ import { runCli } from "../../cli/run-cli.js";
+ import { projectTaskBriefFromPreparedWorkOrder } from "../../commands/task/brief-model.js";
+ import { routePacket } from "../../commands/hermes/hermes-runtime.js";
+-import { loadCommandContext } from "../../commands/shared/task-backend.js";
++import { loadCommandContext, loadTaskFromContext } from "../../commands/shared/task-backend.js";
+ import {
+   evaluatePreparedAgentWorkOrderReadiness,
+   prepareAgentWorkOrder,
+@@ -31,7 +31,12 @@ const execFileAsync = promisify(execFile);
+ type WorkOrderView = {
+   work_order: {
+     work_order_id: string;
+-    state_fingerprint: unknown;
++    task: {
++      revision: number;
++    };
++    state_fingerprint: {
++      task_revision: number | null;
++    };
+     verification_intent: unknown;
+   };
+   work_order_preparation: {
+@@ -94,6 +99,15 @@ async function captureFailure(argv: string[]): Promise<{ code: number; stderr: s
+   }
+ }
+ 
++async function runCliExpectSuccess(argv: string[]): Promise<void> {
++  const io = captureStdIO();
++  try {
++    expect(await runCli(argv)).toBe(0);
++  } finally {
++    io.restore();
++  }
++}
++
+ async function createPreparedTask(
+   root: string,
+   workflowMode: "direct" | "branch_pr" = "direct",
+@@ -257,6 +271,49 @@ describe("AgentWorkOrder v2 surface integration", () => {
+     }
+   });
+ 
++  it("prepares from the task branch snapshot when next-action runs from the base checkout", async () => {
++    const root = await mkGitRepoRoot();
++    const taskId = await createPreparedTask(root, "branch_pr");
++    const worktree = await createBranchPrTaskWorktree(root, taskId);
++    const baseContext = await loadCommandContext({ cwd: root, rootOverride: root });
++    const baseTask = await loadTaskFromContext({ ctx: baseContext, taskId });
++
++    await runCliExpectSuccess([
++      "task",
++      "plan",
++      "set",
++      taskId,
++      "--text",
++      "Advance the task snapshot in the task worktree.",
++      "--updated-by",
++      "PLANNER",
++      "--root",
++      worktree,
++    ]);
++    await execFileAsync("git", ["add", ".agentplane/tasks", "--all"], { cwd: worktree });
++    await execFileAsync("git", ["commit", "-m", "test: advance task branch snapshot"], {
++      cwd: worktree,
++    });
++
++    const branchTask = await loadTaskFromContext({
++      ctx: baseContext,
++      taskId,
++      preferBranchSnapshot: true,
++    });
++    expect(branchTask.revision).toBeGreaterThan(baseTask.revision ?? 0);
++
++    const nextAction = (await captureJsonRun([
++      "task",
++      "next-action",
++      taskId,
++      "--json",
++      "--root",
++      root,
++    ])) as WorkOrderView;
++    expect(nextAction.work_order.task.revision).toBe(branchTask.revision);
++    expect(nextAction.work_order.state_fingerprint.task_revision).toBe(branchTask.revision);
++  });
++
+   it("uses one explicit remote opt-in through every comparable work-order surface", async () => {
+     const root = await mkGitRepoRoot();
+     const taskId = await createPreparedTask(root, "branch_pr");

--- a/.agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-observed-checks.json
+++ b/.agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-observed-checks.json
@@ -1,0 +1,16 @@
+{
+  "task_status": "DOING",
+  "declared_checks": [
+    "Focused authority lifecycle regression",
+    "bun run typecheck",
+    "node .agentplane/policy/check-routing.mjs"
+  ],
+  "verification": {
+    "state": "ok",
+    "attempts": 0,
+    "updated_at": "2026-07-28T06:19:32.579Z",
+    "updated_by": "TESTER",
+    "note": "Focused AgentWorkOrder integration and side-effect authority suites passed: 13 tests. Typecheck and policy routing passed. The base-checkout route for 202607242236-1BFWEY now resolves without a task-revision schema error."
+  },
+  "runner_history": []
+}

--- a/.agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-opinion.md
@@ -1,0 +1,21 @@
+# Semantic quality review: pass
+
+Provenance: evaluator_supplied
+
+EVALUATOR returned pass with 2 typed finding(s).
+
+## Findings
+- Route resolution and AgentWorkOrder preparation now share branch snapshot precedence in branch_pr mode, so task.revision and state_fingerprint.task_revision cannot diverge solely by checkout.
+- The regression advances and commits the task worktree document, invokes task next-action from main, and asserts both revision fields equal the branch snapshot.
+
+## Evidence
+- .agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-diff.patch
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- loadTaskFromBranchSnapshot remains the canonical branch_pr task source when a task branch exists.
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-prompt.md
@@ -1,0 +1,82 @@
+# AgentPlane EVALUATOR episode
+
+AgentPlane prepared and froze the authoritative review input. Perform the semantic evaluation; do not reproduce CLI discovery or lifecycle work.
+This prompt does not execute an evaluator. A caller must run the evaluator in the work-order authority boundary and persist its returned typed result at the declared output path.
+Do not edit implementation, task lifecycle, policy, or evidence files. You may read the frozen evidence and run read-only checks only.
+
+- task_id: 202607280606-PTG9C7
+- task_readme: .agentplane/tasks/202607280606-PTG9C7/README.md
+- work_order: .agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-work-order.json
+- result_output: .agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-result.json
+- report_path: .agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/quality-report.json
+- provenance: evaluator_supplied
+
+## Required result
+
+Return exactly one `sgr.evaluator_result.v1` JSON object through the evaluator result channel. The caller, not the read-only evaluator, persists it at `result_output`. It must contain:
+- schema_version: 1
+- kind: evaluator_result
+- evaluator_id: the evaluator id from the work order
+- verdict: pass | rework | blocked | human_review
+- findings: typed findings with id, severity, summary, broken_invariant, and non-empty evidence_refs
+- missing_tests and hidden_assumptions: string arrays
+- recovery_context: required non-empty string for rework, blocked, or human_review; for human_review it must be the single decision question for the human owner
+
+Every findings[].evidence_refs[].path must be an exact path from work_order.evidence. Do not add fields, commands, patches, lifecycle transitions, or a verdict outside this JSON result.
+The CLI validates the schema, frozen evidence digests, task revision, evaluated SHA, and blueprint before it records quality state.
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-result.json
+++ b/.agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-result.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_result",
+  "evaluator_id": "recovery-context",
+  "verdict": "pass",
+  "findings": [
+    {
+      "id": "compatibility-finding-1",
+      "severity": "medium",
+      "summary": "Route resolution and AgentWorkOrder preparation now share branch snapshot precedence in branch_pr mode, so task.revision and state_fingerprint.task_revision cannot diverge solely by checkout.",
+      "broken_invariant": "Compatibility evaluator facade requires independent review evidence.",
+      "evidence_refs": [
+        {
+          "path": ".agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-diff.patch"
+        }
+      ]
+    },
+    {
+      "id": "compatibility-finding-2",
+      "severity": "medium",
+      "summary": "The regression advances and commits the task worktree document, invokes task next-action from main, and asserts both revision fields equal the branch snapshot.",
+      "broken_invariant": "Compatibility evaluator facade requires independent review evidence.",
+      "evidence_refs": [
+        {
+          "path": ".agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-diff.patch"
+        }
+      ]
+    }
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [
+    "loadTaskFromBranchSnapshot remains the canonical branch_pr task source when a task branch exists."
+  ]
+}

--- a/.agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-work-order.json
+++ b/.agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-work-order.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_work_order",
+  "work_order_id": "evaluator-work-order-202607280606-PTG9C7-684d7c7ad45f8521e167dfcd",
+  "prepared_at": "2026-07-28T06:20:04.792Z",
+  "task": {
+    "id": "202607280606-PTG9C7",
+    "revision": 13,
+    "objective": "Prevent self-invalidating side-effect authority records\n\nFix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge.",
+    "acceptance_criteria": [
+      "Focused authority lifecycle regression",
+      "bun run typecheck",
+      "node .agentplane/policy/check-routing.mjs",
+      "- In scope: Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge.\n- Out of scope: unrelated refactors not required for \"Prevent self-invalidating side-effect authority records\".",
+      "Align branch_pr AgentWorkOrder preparation with the same task branch snapshot used by route resolution. Prevent a base-checkout task next-action or task brief from combining a stale local task revision with a newer route fingerprint. Preserve fail-closed side-effect authority semantics; do not weaken authority validation. Add a regression where the task worktree has a newer task revision than main and preparation from main succeeds with matching work-order task and fingerprint revisions.",
+      "1. Add a regression for branch_pr: update the task in its task worktree, commit it, then invoke task next-action from main. Expected: the work-order task revision equals state_fingerprint.task_revision and the command returns JSON rather than schema validation error. 2. Run the focused AgentWorkOrder integration test and side-effect authority tests. Expected: both pass, including fail-closed negative authority cases. 3. Run bun run typecheck and node .agentplane/policy/check-routing.mjs. Expected: both pass. 4. Re-run task next-action for supervisor task 202607242236-1BFWEY from its integration/base context. Expected: no AgentWorkOrder task revision mismatch."
+    ]
+  },
+  "evaluated_sha": "1ec387cd29895158d5157c446a3913cc9598e440",
+  "blueprint_digest": "6c3c595869d15122f3c343194be31715fc6f619c829d8d906e248ed80ae88ad4",
+  "evaluator": {
+    "id": "recovery-context",
+    "profile": "EVALUATOR",
+    "prompt_module_path": ".agentplane/evaluators/recovery-context.md"
+  },
+  "authority": {
+    "sandbox": "read-only",
+    "writable_roots": [],
+    "allowed_tool_classes": [
+      "repository_read",
+      "git_read",
+      "run_checks",
+      "report_result"
+    ],
+    "external_side_effects": []
+  },
+  "result_contract": "sgr.evaluator_result.v1",
+  "evidence": [
+    {
+      "id": "task-document",
+      "kind": "task_document",
+      "path": ".agentplane/tasks/202607280606-PTG9C7/README.md",
+      "sha256": "sha256:3b1591e815e33902342b8595af4e237b9f22a90a365915a00c5998097e98aa37",
+      "required": true
+    },
+    {
+      "id": "actual-diff",
+      "kind": "actual_diff",
+      "path": ".agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-diff.patch",
+      "sha256": "sha256:01fcb37cb638431a1d30e0a6e19f7890797111c33c9f515fab2ec19418f25509",
+      "required": true
+    },
+    {
+      "id": "observed-checks",
+      "kind": "observed_checks",
+      "path": ".agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-observed-checks.json",
+      "sha256": "sha256:b6544dbc6640d234600ef27ad6c0cde270c6be6a0d8f0c26fb18b84d728fb6b3",
+      "required": true
+    },
+    {
+      "id": "blueprint",
+      "kind": "blueprint",
+      "path": ".agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-blueprint.json",
+      "sha256": "sha256:25f9754f5df859d2e0e20545c84f5e7ccda12cd75a13ceb1d0e1fb685e431f2e",
+      "required": true
+    },
+    {
+      "id": "policy-1",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.code.md",
+      "sha256": "sha256:3fec50dfe0db2f9495a3fa96f36d95fb34262033299d57f6f3775af4b7cc1486",
+      "required": true
+    },
+    {
+      "id": "policy-2",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.core.md",
+      "sha256": "sha256:f6c11b8a2c55760c17af15f79fe13791b3e7bba4852fc7d311fc0657e490b0c7",
+      "required": true
+    },
+    {
+      "id": "policy-3",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/security.must.md",
+      "sha256": "sha256:96d01012e7ab67873bcb7a2cdd3818efa2c1fa500ee2eaf0e316f67e15bbcab2",
+      "required": true
+    },
+    {
+      "id": "policy-4",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/workflow.branch_pr.md",
+      "sha256": "sha256:12d3b942042c276d30593803ddcfe12b20dc794e3e8bfbd97b6ce59df13ba82b",
+      "required": true
+    }
+  ]
+}

--- a/.agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/quality-report.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "task_id": "202607280606-PTG9C7",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-28T06:20:05.095Z",
+  "provenance": "evaluator_supplied",
+  "verdict": "pass",
+  "summary": "EVALUATOR returned pass with 2 typed finding(s).",
+  "evaluated_sha": "1ec387cd29895158d5157c446a3913cc9598e440",
+  "blueprint_digest": "6c3c595869d15122f3c343194be31715fc6f619c829d8d906e248ed80ae88ad4",
+  "findings": [
+    "Route resolution and AgentWorkOrder preparation now share branch snapshot precedence in branch_pr mode, so task.revision and state_fingerprint.task_revision cannot diverge solely by checkout.",
+    "The regression advances and commits the task worktree document, invokes task next-action from main, and asserts both revision fields equal the branch snapshot."
+  ],
+  "evidence_refs": [
+    ".agentplane/tasks/202607280606-PTG9C7/quality/20260728-062004792-recovery-context/evaluator-diff.patch"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [
+    "loadTaskFromBranchSnapshot remains the canonical branch_pr task source when a task branch exists."
+  ],
+  "residual_risks": []
+}

--- a/packages/agentplane/src/runner/context/task-context.ts
+++ b/packages/agentplane/src/runner/context/task-context.ts
@@ -343,7 +343,17 @@ export async function assembleRunnerTaskContext(opts: {
     const ctx =
       opts.ctx ??
       (await loadCommandContext({ cwd: opts.cwd, rootOverride: opts.rootOverride ?? null }));
-    const task = opts.task ?? (await loadTaskFromContext({ ctx, taskId: opts.task_id }));
+    // Route resolution treats the task worktree snapshot as authoritative in
+    // branch_pr mode. AgentWorkOrder preparation must read that same snapshot;
+    // otherwise a command invoked from the base checkout can combine an older
+    // task revision with the route fingerprint from the task branch.
+    const task =
+      opts.task ??
+      (await loadTaskFromContext({
+        ctx,
+        taskId: opts.task_id,
+        preferBranchSnapshot: ctx.config.workflow_mode === "branch_pr",
+      }));
     const dependencyState = toRunnerDependencyState(
       await resolveTaskDependencyState(task, opts.dependency_backend ?? ctx.taskBackend),
     );

--- a/packages/agentplane/src/runner/usecases/agent-work-order.integration.test.ts
+++ b/packages/agentplane/src/runner/usecases/agent-work-order.integration.test.ts
@@ -15,7 +15,7 @@ import { describe, expect, it } from "vitest";
 import { runCli } from "../../cli/run-cli.js";
 import { projectTaskBriefFromPreparedWorkOrder } from "../../commands/task/brief-model.js";
 import { routePacket } from "../../commands/hermes/hermes-runtime.js";
-import { loadCommandContext } from "../../commands/shared/task-backend.js";
+import { loadCommandContext, loadTaskFromContext } from "../../commands/shared/task-backend.js";
 import {
   evaluatePreparedAgentWorkOrderReadiness,
   prepareAgentWorkOrder,
@@ -31,7 +31,12 @@ const execFileAsync = promisify(execFile);
 type WorkOrderView = {
   work_order: {
     work_order_id: string;
-    state_fingerprint: unknown;
+    task: {
+      revision: number;
+    };
+    state_fingerprint: {
+      task_revision: number | null;
+    };
     verification_intent: unknown;
   };
   work_order_preparation: {
@@ -89,6 +94,15 @@ async function captureFailure(argv: string[]): Promise<{ code: number; stderr: s
   try {
     const code = await runCli(argv);
     return { code, stderr: io.stderr };
+  } finally {
+    io.restore();
+  }
+}
+
+async function runCliExpectSuccess(argv: string[]): Promise<void> {
+  const io = captureStdIO();
+  try {
+    expect(await runCli(argv)).toBe(0);
   } finally {
     io.restore();
   }
@@ -255,6 +269,49 @@ describe("AgentWorkOrder v2 surface integration", () => {
         expectSnakeCaseOnly(view.work_order_preparation);
       }
     }
+  });
+
+  it("prepares from the task branch snapshot when next-action runs from the base checkout", async () => {
+    const root = await mkGitRepoRoot();
+    const taskId = await createPreparedTask(root, "branch_pr");
+    const worktree = await createBranchPrTaskWorktree(root, taskId);
+    const baseContext = await loadCommandContext({ cwd: root, rootOverride: root });
+    const baseTask = await loadTaskFromContext({ ctx: baseContext, taskId });
+
+    await runCliExpectSuccess([
+      "task",
+      "plan",
+      "set",
+      taskId,
+      "--text",
+      "Advance the task snapshot in the task worktree.",
+      "--updated-by",
+      "PLANNER",
+      "--root",
+      worktree,
+    ]);
+    await execFileAsync("git", ["add", ".agentplane/tasks", "--all"], { cwd: worktree });
+    await execFileAsync("git", ["commit", "-m", "test: advance task branch snapshot"], {
+      cwd: worktree,
+    });
+
+    const branchTask = await loadTaskFromContext({
+      ctx: baseContext,
+      taskId,
+      preferBranchSnapshot: true,
+    });
+    expect(branchTask.revision).toBeGreaterThan(baseTask.revision ?? 0);
+
+    const nextAction = (await captureJsonRun([
+      "task",
+      "next-action",
+      taskId,
+      "--json",
+      "--root",
+      root,
+    ])) as WorkOrderView;
+    expect(nextAction.work_order.task.revision).toBe(branchTask.revision);
+    expect(nextAction.work_order.state_fingerprint.task_revision).toBe(branchTask.revision);
   });
 
   it("uses one explicit remote opt-in through every comparable work-order surface", async () => {


### PR DESCRIPTION
Task: `202607280606-PTG9C7`
Title: Prevent self-invalidating side-effect authority records
Canonical task record: `.agentplane/tasks/202607280606-PTG9C7/README.md`

## Summary

Prevent self-invalidating side-effect authority records

Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge.

## Scope

- In scope: Fix the branch_pr lifecycle defect where a task authority grant changes the task revision/state fingerprint and makes the freshly recorded authority invalid before the required pre-merge closure or route refresh can execute. Preserve fail-closed authorization and support the documented grant -> clean commit -> recompute route path without manual GitHub merge.
- Out of scope: unrelated refactors not required for "Prevent self-invalidating side-effect authority records".

## Verification

- State: pending
- Note: Not recorded yet.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-07-28T06:15:22.323Z
- Branch: task/202607280606-PTG9C7/prevent-self-invalidating-side-effect-authority
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../agentplane/src/runner/context/task-context.ts  | 12 ++++-
 .../usecases/agent-work-order.integration.test.ts  | 61 +++++++++++++++++++++-
 2 files changed, 70 insertions(+), 3 deletions(-)
```

</details>
