### PR TITLE
🚧 WHE7JS task: Break authority-close lifecycle feedback loop [202607280900-WHE7JS]

### DIFF
--- a/.agentplane/tasks/202607280900-WHE7JS/README.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/README.md
@@ -1,0 +1,122 @@
+---
+id: "202607280900-WHE7JS"
+title: "Break authority-close lifecycle feedback loop"
+status: "DOING"
+priority: "high"
+owner: "CODER"
+revision: 8
+origin:
+  system: "manual"
+depends_on: []
+tags:
+  - "blocker"
+  - "code"
+  - "lifecycle"
+  - "v0.7"
+  - "workflow"
+task_kind: "code"
+mutation_scope: "code"
+blueprint_request: "code.branch_pr"
+verify:
+  - "bun run test:critical"
+  - "bun run typecheck"
+  - "node .agentplane/policy/check-routing.mjs"
+plan_approval:
+  state: "approved"
+  updated_at: "2026-07-28T09:01:44.246Z"
+  updated_by: "ORCHESTRATOR"
+  note: null
+verification:
+  state: "pending"
+  updated_at: null
+  updated_by: null
+  note: null
+  attempts: 0
+commit: null
+comments:
+  -
+    author: "CODER"
+    body: "Start: isolate authority and close-tail freshness from implementation verification without weakening protected merge gates."
+events:
+  -
+    type: "status"
+    at: "2026-07-28T09:02:22.510Z"
+    author: "CODER"
+    from: "TODO"
+    to: "DOING"
+    note: "Start: isolate authority and close-tail freshness from implementation verification without weakening protected merge gates."
+doc_version: 3
+doc_updated_at: "2026-07-28T09:02:22.510Z"
+doc_updated_by: "CODER"
+description: "v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration."
+sections:
+  Summary: |-
+    Break authority-close lifecycle feedback loop
+
+    v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.
+  Scope: |-
+    - In scope: v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.
+    - Out of scope: unrelated refactors not required for "Break authority-close lifecycle feedback loop".
+  Plan: |-
+    1. Trace the route predicates that classify task README and PR-artifact changes as verification/pre-merge invalidators.
+    2. Introduce an explicit freshness boundary: implementation, verification, quality, and close-tail evidence remain content-addressed; authority grants and provider-sync metadata preserve auditability but do not invalidate unchanged implementation evidence.
+    3. Preserve all high-risk gates: a protected provider operation still requires a matching current authority record; code/verification/quality changes still require fresh verification and pre-merge closure; final PR head and hosted checks must remain live and stable.
+    4. Add deterministic regression coverage for authority grant -> pre-merge closure -> final head publication -> integration queue, proving the route reaches an executable integration step without another verification cycle when implementation is unchanged.
+    5. Run focused route tests, task-state check, typecheck, critical tests, policy routing, and the relevant local CI selector; record residual compatibility risk in task Findings.
+  Verify Steps: |-
+    1. Add a deterministic route-level regression: authority grant, verification, evaluator pass, pre-merge closure, final-head publication, hosted-green refresh, integration queue. Expected: unchanged implementation and quality evidence reaches an executable integration action without another verification/close/publish loop.
+    2. Exercise the negative boundary. Expected: a changed implementation commit, invalid or stale authority, or changed hosted state still invalidates the appropriate evidence and blocks integration.
+    3. Inspect persisted task and authority artifacts. Expected: every protected operation retains a matching scoped authority record; no authority record widens an operation.
+    4. Run focused lifecycle-route tests, bun run task-state:check, bun run typecheck, bun run test:critical, and node .agentplane/policy/check-routing.mjs. Expected: all pass.
+    5. Publish a PR and require stable hosted checks before integrating. Expected: the PR head, review state, and merge queue agree; no manual provider merge is used.
+  Verification: |-
+    <!-- BEGIN VERIFICATION RESULTS -->
+    <!-- END VERIFICATION RESULTS -->
+  Rollback Plan: |-
+    - Revert task-related commit(s).
+    - Re-run required checks to confirm rollback safety.
+  Findings: ""
+extensions:
+  workflow_route_baseline:
+    start_head_sha: "89a82f010479eb2583e414fb49c930d4819b5777"
+    version: 1
+id_source: "generated"
+---
+## Summary
+
+Break authority-close lifecycle feedback loop
+
+v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.
+
+## Scope
+
+- In scope: v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.
+- Out of scope: unrelated refactors not required for "Break authority-close lifecycle feedback loop".
+
+## Plan
+
+1. Trace the route predicates that classify task README and PR-artifact changes as verification/pre-merge invalidators.
+2. Introduce an explicit freshness boundary: implementation, verification, quality, and close-tail evidence remain content-addressed; authority grants and provider-sync metadata preserve auditability but do not invalidate unchanged implementation evidence.
+3. Preserve all high-risk gates: a protected provider operation still requires a matching current authority record; code/verification/quality changes still require fresh verification and pre-merge closure; final PR head and hosted checks must remain live and stable.
+4. Add deterministic regression coverage for authority grant -> pre-merge closure -> final head publication -> integration queue, proving the route reaches an executable integration step without another verification cycle when implementation is unchanged.
+5. Run focused route tests, task-state check, typecheck, critical tests, policy routing, and the relevant local CI selector; record residual compatibility risk in task Findings.
+
+## Verify Steps
+
+1. Add a deterministic route-level regression: authority grant, verification, evaluator pass, pre-merge closure, final-head publication, hosted-green refresh, integration queue. Expected: unchanged implementation and quality evidence reaches an executable integration action without another verification/close/publish loop.
+2. Exercise the negative boundary. Expected: a changed implementation commit, invalid or stale authority, or changed hosted state still invalidates the appropriate evidence and blocks integration.
+3. Inspect persisted task and authority artifacts. Expected: every protected operation retains a matching scoped authority record; no authority record widens an operation.
+4. Run focused lifecycle-route tests, bun run task-state:check, bun run typecheck, bun run test:critical, and node .agentplane/policy/check-routing.mjs. Expected: all pass.
+5. Publish a PR and require stable hosted checks before integrating. Expected: the PR head, review state, and merge queue agree; no manual provider merge is used.
+
+## Verification
+
+<!-- BEGIN VERIFICATION RESULTS -->
+<!-- END VERIFICATION RESULTS -->
+
+## Rollback Plan
+
+- Revert task-related commit(s).
+- Re-run required checks to confirm rollback safety.
+
+## Findings

--- a/.agentplane/tasks/202607280900-WHE7JS/README.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 22
+revision: 23
 origin:
   system: "manual"
 depends_on: []
@@ -308,6 +308,19 @@ extensions:
         schemaVersion: 1
         sequence: 7
         stateFingerprintDigest: "sha256:9bb53f5a93cd5c3d9076939cab68d70d51e9d1a2543bed4820f8dc1e1d0104d6"
+      -
+        actor: "USER"
+        at: "2026-07-28T10:32:47.345Z"
+        authorityDigest: "sha256:03f53d8d8dd76bccd9463448e19b3cc9b9dd62ba8c75879aaeb99bb3b4825aae"
+        digest: "sha256:cf8c68919b678a501405e038f3bd3e4c986549e5ccea2a114b4afd219110c72a"
+        operationDigest: "sha256:4f670682200a8d4c04293b8185dac01880f639301fc0ae43b1975183fb61a2da"
+        operationId: "pr.head.publish"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:283088e240295fc7cf7598fd6eb3f83107a5de3adbf2b7f4d7fa5bb2f2afe2e1"
+        schemaVersion: 1
+        sequence: 8
+        stateFingerprintDigest: "sha256:1eb7dafff3284e46843face314e472a68cd563345bba99c202276902823f4ccd"
     grants:
       -
         actor: "USER"
@@ -400,6 +413,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:9bb53f5a93cd5c3d9076939cab68d70d51e9d1a2543bed4820f8dc1e1d0104d6"
         stateScopeDigest: "sha256:1cdbdfd56849a3c9545f38eae38fbda66d54274055f0b3b7aea8f62c0ade2ddf"
+      -
+        actor: "USER"
+        digest: "sha256:03f53d8d8dd76bccd9463448e19b3cc9b9dd62ba8c75879aaeb99bb3b4825aae"
+        expiresAt: "2026-07-28T10:47:47.345Z"
+        id: "authority-7073543e-98bd-44a4-83ac-4ce39b6dfdd3"
+        issuedAt: "2026-07-28T10:32:47.345Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:4f670682200a8d4c04293b8185dac01880f639301fc0ae43b1975183fb61a2da"
+        operationId: "pr.head.publish"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:1eb7dafff3284e46843face314e472a68cd563345bba99c202276902823f4ccd"
+        stateScopeDigest: "sha256:0a72277f07f7319a5270faafa7401cffd6a36602f6e78430e6de49a7d6a67ad6"
     schemaVersion: 1
   implementation_commit:
     hash: "b803b67e786127a849af228924ce35faff083247"

--- a/.agentplane/tasks/202607280900-WHE7JS/README.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 18
+revision: 19
 origin:
   system: "manual"
 depends_on: []
@@ -259,6 +259,19 @@ extensions:
         schemaVersion: 1
         sequence: 4
         stateFingerprintDigest: "sha256:64f71da3a0a0f16a7ce74dce4c3f6c7a1e6adae9e7aeccd83987f0889e03d08b"
+      -
+        actor: "USER"
+        at: "2026-07-28T10:30:21.293Z"
+        authorityDigest: "sha256:ea291914e45787cff26c8250c29b89978ffd658f38bbe7a3e47f0bd3ef3f5b98"
+        digest: "sha256:ad868b1e3ceaf6c02910e2c420e4189e896f2aececb2e1fe842bd8746e9010ea"
+        operationDigest: "sha256:293064e1133a1ebcd3edc530944f0e54d13dac4c974bf4c4ca6f5255e70e01a6"
+        operationId: "route.remote.refresh"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:ddeb6715440d7b9dc5951241cd80c80a168c1c18e972c7c345e84dd792fa7279"
+        schemaVersion: 1
+        sequence: 5
+        stateFingerprintDigest: "sha256:2e9eed897fe94dd77483e1cb842a701b01897ffc156c4207f96d275f67be345c"
     grants:
       -
         actor: "USER"
@@ -312,6 +325,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:64f71da3a0a0f16a7ce74dce4c3f6c7a1e6adae9e7aeccd83987f0889e03d08b"
         stateScopeDigest: "sha256:ef6786308e36c37e858a688101aef667439c17919b3126a0339cca1d8e9ba98d"
+      -
+        actor: "USER"
+        digest: "sha256:ea291914e45787cff26c8250c29b89978ffd658f38bbe7a3e47f0bd3ef3f5b98"
+        expiresAt: "2026-07-28T10:45:21.293Z"
+        id: "authority-da694d4a-569c-44e9-a033-323d296ae579"
+        issuedAt: "2026-07-28T10:30:21.293Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:293064e1133a1ebcd3edc530944f0e54d13dac4c974bf4c4ca6f5255e70e01a6"
+        operationId: "route.remote.refresh"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:2e9eed897fe94dd77483e1cb842a701b01897ffc156c4207f96d275f67be345c"
+        stateScopeDigest: "sha256:c724ecab5bba25b724185b640f29b86575f76c9f155d90c3007010064dd6f7b3"
     schemaVersion: 1
   implementation_commit:
     hash: "03a98aa601a69dd8c89e5dc424ca2e0ed214d025"

--- a/.agentplane/tasks/202607280900-WHE7JS/README.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/README.md
@@ -4,7 +4,7 @@ title: "Break authority-close lifecycle feedback loop"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 8
+revision: 9
 origin:
   system: "manual"
 depends_on: []
@@ -77,6 +77,36 @@ sections:
     - Re-run required checks to confirm rollback safety.
   Findings: ""
 extensions:
+  agentplane.side_effect_authority:
+    audit:
+      -
+        actor: "USER"
+        at: "2026-07-28T09:22:01.374Z"
+        authorityDigest: "sha256:af103b4aba5b99e7777b4476bee1e3d007d4670e4221791080f9017a351656bb"
+        digest: "sha256:0c5c5058efd15e95304d32c5866983b1161881f37a6bdede065502f552346ddc"
+        operationDigest: "sha256:5d7d27338ec14622ef194572b85ea7254b8c069eb1f84879e3e4cc270d855492"
+        operationId: "pr.open"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: null
+        schemaVersion: 1
+        sequence: 1
+        stateFingerprintDigest: "sha256:af8f1a911e6dcc9a09a068f68ba9e71bf90280645b0aa8cbd0bae70078e59d12"
+    grants:
+      -
+        actor: "USER"
+        digest: "sha256:af103b4aba5b99e7777b4476bee1e3d007d4670e4221791080f9017a351656bb"
+        expiresAt: "2026-07-28T09:37:01.374Z"
+        id: "authority-83fccb78-1288-40cc-8eb9-5d3dff7173c2"
+        issuedAt: "2026-07-28T09:22:01.374Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:5d7d27338ec14622ef194572b85ea7254b8c069eb1f84879e3e4cc270d855492"
+        operationId: "pr.open"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:af8f1a911e6dcc9a09a068f68ba9e71bf90280645b0aa8cbd0bae70078e59d12"
+        stateScopeDigest: "sha256:6d1086ee329f82a88d40342f8e577d3f6d8015efd1e821cb8c20c2d25a29b684"
+    schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "89a82f010479eb2583e414fb49c930d4819b5777"
     version: 1

--- a/.agentplane/tasks/202607280900-WHE7JS/README.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 20
+revision: 21
 origin:
   system: "manual"
 depends_on: []
@@ -60,7 +60,7 @@ quality_review:
   findings:
     - "Rebased scope preserves the narrow auto-commit behavior and route-level regression; it now includes the merged cancellation-intent retry that caused the prior hosted unit failure. Focused authority and runner regressions, typecheck, task-state, routing, and critical CLI 11/11 pass."
 commit:
-  hash: "6d40a20d583714656c5edbffbf4bd78c483902c7"
+  hash: "2e04b906f9d327f180b0dc11f0a3d9dd4e6a3088"
   message: "🧩 WHE7JS task: refresh task artifacts after commit"
 comments:
   -
@@ -72,6 +72,9 @@ comments:
   -
     author: "CODER"
     body: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    author: "CODER"
+    body: "Verified: refreshed pre-merge closure packet is ready for the task PR."
 events:
   -
     type: "status"
@@ -106,8 +109,15 @@ events:
     author: "TESTER"
     state: "ok"
     note: "After rebasing onto main with the runner cancellation-intent retry, focused authority and runner regressions pass, typecheck/task-state/routing pass, and critical CLI matrix passes 11/11. Hosted CI must still validate the rebased PR head."
+  -
+    type: "status"
+    at: "2026-07-28T10:31:39.806Z"
+    author: "CODER"
+    from: "DONE"
+    to: "DONE"
+    note: "Verified: refreshed pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-28T10:28:50.098Z"
+doc_updated_at: "2026-07-28T10:31:39.807Z"
 doc_updated_by: "CODER"
 description: "v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration."
 sections:
@@ -366,7 +376,7 @@ extensions:
         stateScopeDigest: "sha256:dda1fd7b75704e7c8e3e0d79fca0725cad7734b0387ca7e447ad6c2e274588c5"
     schemaVersion: 1
   implementation_commit:
-    hash: "03a98aa601a69dd8c89e5dc424ca2e0ed214d025"
+    hash: "b803b67e786127a849af228924ce35faff083247"
     message: "fix: commit branch-pr authority records"
   workflow_route_baseline:
     start_head_sha: "89a82f010479eb2583e414fb49c930d4819b5777"

--- a/.agentplane/tasks/202607280900-WHE7JS/README.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 19
+revision: 20
 origin:
   system: "manual"
 depends_on: []
@@ -272,6 +272,19 @@ extensions:
         schemaVersion: 1
         sequence: 5
         stateFingerprintDigest: "sha256:2e9eed897fe94dd77483e1cb842a701b01897ffc156c4207f96d275f67be345c"
+      -
+        actor: "USER"
+        at: "2026-07-28T10:31:00.026Z"
+        authorityDigest: "sha256:55319780cde05794b86dbb6a9588e3bd081a385d956c1a2be9f2a342674dddbe"
+        digest: "sha256:754521bc324fb4df717f4695365de6e22f91c91e8818727252a471458f0b76f0"
+        operationDigest: "sha256:b817ab387b15c49397d36321443c51dedd241317f49597d253ebb3512fbd4746"
+        operationId: "task.pre_merge_close"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:ad868b1e3ceaf6c02910e2c420e4189e896f2aececb2e1fe842bd8746e9010ea"
+        schemaVersion: 1
+        sequence: 6
+        stateFingerprintDigest: "sha256:983d594bad0261e4af9af95e31b52b9a6ca004f94692466593da990cdb9eeeea"
     grants:
       -
         actor: "USER"
@@ -338,6 +351,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:2e9eed897fe94dd77483e1cb842a701b01897ffc156c4207f96d275f67be345c"
         stateScopeDigest: "sha256:c724ecab5bba25b724185b640f29b86575f76c9f155d90c3007010064dd6f7b3"
+      -
+        actor: "USER"
+        digest: "sha256:55319780cde05794b86dbb6a9588e3bd081a385d956c1a2be9f2a342674dddbe"
+        expiresAt: "2026-07-28T10:46:00.026Z"
+        id: "authority-99aab551-020a-4121-be4e-fe5b5f5ff2b2"
+        issuedAt: "2026-07-28T10:31:00.026Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:b817ab387b15c49397d36321443c51dedd241317f49597d253ebb3512fbd4746"
+        operationId: "task.pre_merge_close"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:983d594bad0261e4af9af95e31b52b9a6ca004f94692466593da990cdb9eeeea"
+        stateScopeDigest: "sha256:dda1fd7b75704e7c8e3e0d79fca0725cad7734b0387ca7e447ad6c2e274588c5"
     schemaVersion: 1
   implementation_commit:
     hash: "03a98aa601a69dd8c89e5dc424ca2e0ed214d025"

--- a/.agentplane/tasks/202607280900-WHE7JS/README.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 14
+revision: 15
 origin:
   system: "manual"
 depends_on: []
@@ -191,6 +191,19 @@ extensions:
         schemaVersion: 1
         sequence: 2
         stateFingerprintDigest: "sha256:7afab48f7c7b2d93739a50b4f8140cb60b0c262dbbe6aa4c831670dd61221ab4"
+      -
+        actor: "USER"
+        at: "2026-07-28T09:27:30.816Z"
+        authorityDigest: "sha256:b2e3d978ec12031d9370f17d38159033b6a5054c421ae31feacf059e065cfc0c"
+        digest: "sha256:6bbce1f1d8cf6a78360db03befd0283479e515f604bebdad15eb48af633e8722"
+        operationDigest: "sha256:4f670682200a8d4c04293b8185dac01880f639301fc0ae43b1975183fb61a2da"
+        operationId: "pr.head.publish"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:36ab904c0b4ca37df662222265b709d039be64188fd547db271fbcc2ec6de2c3"
+        schemaVersion: 1
+        sequence: 3
+        stateFingerprintDigest: "sha256:334387b4666341f6de5bec88befbaac77702c581801af8202b3d2e1818d48017"
     grants:
       -
         actor: "USER"
@@ -218,6 +231,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:7afab48f7c7b2d93739a50b4f8140cb60b0c262dbbe6aa4c831670dd61221ab4"
         stateScopeDigest: "sha256:9064b3f6cfd0821b09405717ece3ace8dee280f243c3be2224d1a6679a83630c"
+      -
+        actor: "USER"
+        digest: "sha256:b2e3d978ec12031d9370f17d38159033b6a5054c421ae31feacf059e065cfc0c"
+        expiresAt: "2026-07-28T09:42:30.816Z"
+        id: "authority-9541c70f-b7a3-4eb9-8f7e-d0490af59e7a"
+        issuedAt: "2026-07-28T09:27:30.816Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:4f670682200a8d4c04293b8185dac01880f639301fc0ae43b1975183fb61a2da"
+        operationId: "pr.head.publish"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:334387b4666341f6de5bec88befbaac77702c581801af8202b3d2e1818d48017"
+        stateScopeDigest: "sha256:2c73969f937695823fcdf58a641475df7ccbdaa36fd7dc6bb10ec8747c2ddadb"
     schemaVersion: 1
   implementation_commit:
     hash: "03a98aa601a69dd8c89e5dc424ca2e0ed214d025"

--- a/.agentplane/tasks/202607280900-WHE7JS/README.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 16
+revision: 18
 origin:
   system: "manual"
 depends_on: []
@@ -29,34 +29,36 @@ plan_approval:
   note: null
 verification:
   state: "ok"
-  updated_at: "2026-07-28T09:22:59.261Z"
+  updated_at: "2026-07-28T10:28:47.525Z"
   updated_by: "TESTER"
-  note: "Focused authority/lifecycle tests, task-state, typecheck, critical suite, policy routing, and full local fast CI passed; the live authority grant auto-committed its packet and advanced directly to pr.open."
+  note: "After rebasing onto main with the runner cancellation-intent retry, focused authority and runner regressions pass, typecheck/task-state/routing pass, and critical CLI matrix passes 11/11. Hosted CI must still validate the rebased PR head."
   attempts: 0
 quality_review:
   state: "pass"
   provenance: "human_supplied"
-  updated_at: "2026-07-28T09:23:17.513Z"
+  updated_at: "2026-07-28T10:29:09.901Z"
   updated_by: "HUMAN"
-  note: "Reviewed the authority-grant lifecycle boundary: branch_pr grants now commit only task packet artifacts through the existing PR artifact helper, preserving all authority validation before mutation."
-  evaluated_sha: "03a98aa601a69dd8c89e5dc424ca2e0ed214d025"
+  note: "The authority grant now commits only the current task packet after a changed grant, preventing the authority-to-dirty-worktree feedback loop without widening authority semantics."
+  evaluated_sha: "b803b67e786127a849af228924ce35faff083247"
   blueprint_digest: "cf78dccf3ca7848d369ebafa8399f797778df6099809e148df6eba5dea7c2410"
   evidence_refs:
-    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-work-order.json"
-    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/quality-report.json"
-    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-prompt.md"
-    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-work-order.json"
+    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-opinion.md"
     - ".agentplane/tasks/202607280900-WHE7JS/README.md"
-    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-diff.patch"
-    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-observed-checks.json"
-    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-blueprint.json"
+    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-diff.patch"
+    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-observed-checks.json"
+    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-blueprint.json"
     - ".agentplane/policy/dod.code.md"
     - ".agentplane/policy/dod.core.md"
     - ".agentplane/policy/security.must.md"
     - ".agentplane/policy/workflow.branch_pr.md"
-    - "bun run ci:local:fast"
+    - "packages/agentplane/src/commands/task/authority-grant.command.ts"
+    - "packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts"
+    - "focused authority-route and runner regressions passed; bun run typecheck, task-state:check, check-routing, and test:critical 11/11 passed"
   findings:
-    - "No scope-digest, expiry, stale-input, or protected-operation policy was relaxed. The focused route regression proves a granted pr.open advances to an executable operation with a clean worktree; full fast CI passed."
+    - "Rebased scope preserves the narrow auto-commit behavior and route-level regression; it now includes the merged cancellation-intent retry that caused the prior hosted unit failure. Focused authority and runner regressions, typecheck, task-state, routing, and critical CLI 11/11 pass."
 commit:
   hash: "6d40a20d583714656c5edbffbf4bd78c483902c7"
   message: "🧩 WHE7JS task: refresh task artifacts after commit"
@@ -98,8 +100,14 @@ events:
     from: "DOING"
     to: "DONE"
     note: "Verified: pre-merge closure packet is ready for the task PR."
+  -
+    type: "verify"
+    at: "2026-07-28T10:28:47.525Z"
+    author: "TESTER"
+    state: "ok"
+    note: "After rebasing onto main with the runner cancellation-intent retry, focused authority and runner regressions pass, typecheck/task-state/routing pass, and critical CLI matrix passes 11/11. Hosted CI must still validate the rebased PR head."
 doc_version: 3
-doc_updated_at: "2026-07-28T09:23:47.147Z"
+doc_updated_at: "2026-07-28T10:28:50.098Z"
 doc_updated_by: "CODER"
 description: "v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration."
 sections:
@@ -154,6 +162,36 @@ sections:
     - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
     - risks: none
 
+    ### 2026-07-28T10:28:47.525Z — VERIFY — ok
+
+    By: TESTER
+
+    Note: After rebasing onto main with the runner cancellation-intent retry, focused authority and runner regressions pass, typecheck/task-state/routing pass, and critical CLI matrix passes 11/11. Hosted CI must still validate the rebased PR head.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T09:23:47.147Z, excerpt_hash=sha256:52fcdb54a6ac5d2e275518998c6d5e8482aa9d20bac2e445e9a05838c2d4d074
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607280900-WHE7JS-break-authority-close-lifecycle-feedback-loop/.agentplane/tasks/202607280900-WHE7JS/blueprint/resolved-snapshot.json
+    - old_digest: cf78dccf3ca7848d369ebafa8399f797778df6099809e148df6eba5dea7c2410
+    - current_digest: cf78dccf3ca7848d369ebafa8399f797778df6099809e148df6eba5dea7c2410
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607280900-WHE7JS
+
+    DecisionContextRef:
+    - operator_action: provider_action
+    - can_execute_now: false
+    - safe_command: none
+    - diagnostic_command: none
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: none
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
@@ -162,6 +200,10 @@ sections:
     - Observation: authority grant emitted committed and next-action became cli_operation pr.open
       Impact: breaks the task-worktree dirty feedback loop without weakening authority scope or expiry
       Resolution: verified against commit 03a98aa601a69dd8c89e5dc424ca2e0ed214d025
+
+    - Observation: The previous hosted unit failure was the cancellation-intent read race now fixed by merged N3.
+      Impact: The WHE lifecycle change could not be integrated safely until its CI ran with the runner fix.
+      Resolution: Rebase WHE onto current main and require a new green hosted check set before queueing integration.
 extensions:
   agentplane.side_effect_authority:
     audit:
@@ -339,6 +381,36 @@ DecisionContextRef:
 - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
 - risks: none
 
+### 2026-07-28T10:28:47.525Z — VERIFY — ok
+
+By: TESTER
+
+Note: After rebasing onto main with the runner cancellation-intent retry, focused authority and runner regressions pass, typecheck/task-state/routing pass, and critical CLI matrix passes 11/11. Hosted CI must still validate the rebased PR head.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T09:23:47.147Z, excerpt_hash=sha256:52fcdb54a6ac5d2e275518998c6d5e8482aa9d20bac2e445e9a05838c2d4d074
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607280900-WHE7JS-break-authority-close-lifecycle-feedback-loop/.agentplane/tasks/202607280900-WHE7JS/blueprint/resolved-snapshot.json
+- old_digest: cf78dccf3ca7848d369ebafa8399f797778df6099809e148df6eba5dea7c2410
+- current_digest: cf78dccf3ca7848d369ebafa8399f797778df6099809e148df6eba5dea7c2410
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607280900-WHE7JS
+
+DecisionContextRef:
+- operator_action: provider_action
+- can_execute_now: false
+- safe_command: none
+- diagnostic_command: none
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: none
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -351,3 +423,7 @@ DecisionContextRef:
 - Observation: authority grant emitted committed and next-action became cli_operation pr.open
   Impact: breaks the task-worktree dirty feedback loop without weakening authority scope or expiry
   Resolution: verified against commit 03a98aa601a69dd8c89e5dc424ca2e0ed214d025
+
+- Observation: The previous hosted unit failure was the cancellation-intent read race now fixed by merged N3.
+  Impact: The WHE lifecycle change could not be integrated safely until its CI ran with the runner fix.
+  Resolution: Rebase WHE onto current main and require a new green hosted check set before queueing integration.

--- a/.agentplane/tasks/202607280900-WHE7JS/README.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/README.md
@@ -1,10 +1,11 @@
 ---
 id: "202607280900-WHE7JS"
 title: "Break authority-close lifecycle feedback loop"
-status: "DOING"
+result_summary: "pre-merge closure"
+status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 13
+revision: 14
 origin:
   system: "manual"
 depends_on: []
@@ -57,8 +58,8 @@ quality_review:
   findings:
     - "No scope-digest, expiry, stale-input, or protected-operation policy was relaxed. The focused route regression proves a granted pr.open advances to an executable operation with a clean worktree; full fast CI passed."
 commit:
-  hash: "03a98aa601a69dd8c89e5dc424ca2e0ed214d025"
-  message: "fix: commit branch-pr authority records"
+  hash: "6d40a20d583714656c5edbffbf4bd78c483902c7"
+  message: "🧩 WHE7JS task: refresh task artifacts after commit"
 comments:
   -
     author: "CODER"
@@ -66,6 +67,9 @@ comments:
   -
     author: "CODER"
     body: "Implementation: committed branch_pr authority records automatically; added the route regression that proves the authorized PR operation remains executable."
+  -
+    author: "CODER"
+    body: "Verified: pre-merge closure packet is ready for the task PR."
 events:
   -
     type: "status"
@@ -87,8 +91,15 @@ events:
     author: "TESTER"
     state: "ok"
     note: "Focused authority/lifecycle tests, task-state, typecheck, critical suite, policy routing, and full local fast CI passed; the live authority grant auto-committed its packet and advanced directly to pr.open."
+  -
+    type: "status"
+    at: "2026-07-28T09:23:47.147Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DONE"
+    note: "Verified: pre-merge closure packet is ready for the task PR."
 doc_version: 3
-doc_updated_at: "2026-07-28T09:22:59.880Z"
+doc_updated_at: "2026-07-28T09:23:47.147Z"
 doc_updated_by: "CODER"
 description: "v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration."
 sections:
@@ -208,6 +219,9 @@ extensions:
         stateFingerprintDigest: "sha256:7afab48f7c7b2d93739a50b4f8140cb60b0c262dbbe6aa4c831670dd61221ab4"
         stateScopeDigest: "sha256:9064b3f6cfd0821b09405717ece3ace8dee280f243c3be2224d1a6679a83630c"
     schemaVersion: 1
+  implementation_commit:
+    hash: "03a98aa601a69dd8c89e5dc424ca2e0ed214d025"
+    message: "fix: commit branch-pr authority records"
   workflow_route_baseline:
     start_head_sha: "89a82f010479eb2583e414fb49c930d4819b5777"
     version: 1

--- a/.agentplane/tasks/202607280900-WHE7JS/README.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 23
+revision: 24
 origin:
   system: "manual"
 depends_on: []
@@ -321,6 +321,19 @@ extensions:
         schemaVersion: 1
         sequence: 8
         stateFingerprintDigest: "sha256:1eb7dafff3284e46843face314e472a68cd563345bba99c202276902823f4ccd"
+      -
+        actor: "USER"
+        at: "2026-07-28T10:34:07.768Z"
+        authorityDigest: "sha256:f3a95731e8287533025addf7fb780a24f5ab524d14481033b68892c223d715d1"
+        digest: "sha256:0830a924d2d740725193cfb2af919fd1f240f0cfc4adc06b3ee2a985dc6f6407"
+        operationDigest: "sha256:26b8fe2a6f663a15c6d3cccc3c833f47ba59529501e4151044d9b448babf5010"
+        operationId: "integration.enqueue"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:cf8c68919b678a501405e038f3bd3e4c986549e5ccea2a114b4afd219110c72a"
+        schemaVersion: 1
+        sequence: 9
+        stateFingerprintDigest: "sha256:ac17c4a27c51f39cdf61725c4e6e489bbfd3371e2233c21a7644275aeab9a426"
     grants:
       -
         actor: "USER"
@@ -426,6 +439,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:1eb7dafff3284e46843face314e472a68cd563345bba99c202276902823f4ccd"
         stateScopeDigest: "sha256:0a72277f07f7319a5270faafa7401cffd6a36602f6e78430e6de49a7d6a67ad6"
+      -
+        actor: "USER"
+        digest: "sha256:f3a95731e8287533025addf7fb780a24f5ab524d14481033b68892c223d715d1"
+        expiresAt: "2026-07-28T10:49:07.768Z"
+        id: "authority-eede1b9c-83ed-4929-bc6b-17c34e3bcdd3"
+        issuedAt: "2026-07-28T10:34:07.768Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:26b8fe2a6f663a15c6d3cccc3c833f47ba59529501e4151044d9b448babf5010"
+        operationId: "integration.enqueue"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:ac17c4a27c51f39cdf61725c4e6e489bbfd3371e2233c21a7644275aeab9a426"
+        stateScopeDigest: "sha256:d19d0412e544a553a59747e273dce737c2331734d139b2a1b7a010eeb93f2389"
     schemaVersion: 1
   implementation_commit:
     hash: "b803b67e786127a849af228924ce35faff083247"

--- a/.agentplane/tasks/202607280900-WHE7JS/README.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 21
+revision: 22
 origin:
   system: "manual"
 depends_on: []
@@ -295,6 +295,19 @@ extensions:
         schemaVersion: 1
         sequence: 6
         stateFingerprintDigest: "sha256:983d594bad0261e4af9af95e31b52b9a6ca004f94692466593da990cdb9eeeea"
+      -
+        actor: "USER"
+        at: "2026-07-28T10:32:04.551Z"
+        authorityDigest: "sha256:a5323037220c898d20bd66ac74505e2e8441b17e61995170e532d52ad358367a"
+        digest: "sha256:283088e240295fc7cf7598fd6eb3f83107a5de3adbf2b7f4d7fa5bb2f2afe2e1"
+        operationDigest: "sha256:293064e1133a1ebcd3edc530944f0e54d13dac4c974bf4c4ca6f5255e70e01a6"
+        operationId: "route.remote.refresh"
+        outcome: "approved"
+        policyRule: "workflow.external_reversible"
+        previousDigest: "sha256:754521bc324fb4df717f4695365de6e22f91c91e8818727252a471458f0b76f0"
+        schemaVersion: 1
+        sequence: 7
+        stateFingerprintDigest: "sha256:9bb53f5a93cd5c3d9076939cab68d70d51e9d1a2543bed4820f8dc1e1d0104d6"
     grants:
       -
         actor: "USER"
@@ -374,6 +387,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:983d594bad0261e4af9af95e31b52b9a6ca004f94692466593da990cdb9eeeea"
         stateScopeDigest: "sha256:dda1fd7b75704e7c8e3e0d79fca0725cad7734b0387ca7e447ad6c2e274588c5"
+      -
+        actor: "USER"
+        digest: "sha256:a5323037220c898d20bd66ac74505e2e8441b17e61995170e532d52ad358367a"
+        expiresAt: "2026-07-28T10:47:04.551Z"
+        id: "authority-05d43fbd-be8c-42eb-acdc-4c1ef3a0e725"
+        issuedAt: "2026-07-28T10:32:04.551Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:293064e1133a1ebcd3edc530944f0e54d13dac4c974bf4c4ca6f5255e70e01a6"
+        operationId: "route.remote.refresh"
+        policyRule: "workflow.external_reversible"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:9bb53f5a93cd5c3d9076939cab68d70d51e9d1a2543bed4820f8dc1e1d0104d6"
+        stateScopeDigest: "sha256:1cdbdfd56849a3c9545f38eae38fbda66d54274055f0b3b7aea8f62c0ade2ddf"
     schemaVersion: 1
   implementation_commit:
     hash: "b803b67e786127a849af228924ce35faff083247"

--- a/.agentplane/tasks/202607280900-WHE7JS/README.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/README.md
@@ -4,7 +4,7 @@ title: "Break authority-close lifecycle feedback loop"
 status: "DOING"
 priority: "high"
 owner: "CODER"
-revision: 9
+revision: 13
 origin:
   system: "manual"
 depends_on: []
@@ -27,16 +27,45 @@ plan_approval:
   updated_by: "ORCHESTRATOR"
   note: null
 verification:
-  state: "pending"
-  updated_at: null
-  updated_by: null
-  note: null
+  state: "ok"
+  updated_at: "2026-07-28T09:22:59.261Z"
+  updated_by: "TESTER"
+  note: "Focused authority/lifecycle tests, task-state, typecheck, critical suite, policy routing, and full local fast CI passed; the live authority grant auto-committed its packet and advanced directly to pr.open."
   attempts: 0
-commit: null
+quality_review:
+  state: "pass"
+  provenance: "human_supplied"
+  updated_at: "2026-07-28T09:23:17.513Z"
+  updated_by: "HUMAN"
+  note: "Reviewed the authority-grant lifecycle boundary: branch_pr grants now commit only task packet artifacts through the existing PR artifact helper, preserving all authority validation before mutation."
+  evaluated_sha: "03a98aa601a69dd8c89e5dc424ca2e0ed214d025"
+  blueprint_digest: "cf78dccf3ca7848d369ebafa8399f797778df6099809e148df6eba5dea7c2410"
+  evidence_refs:
+    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-work-order.json"
+    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/quality-report.json"
+    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-prompt.md"
+    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-opinion.md"
+    - ".agentplane/tasks/202607280900-WHE7JS/README.md"
+    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-diff.patch"
+    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-observed-checks.json"
+    - ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-blueprint.json"
+    - ".agentplane/policy/dod.code.md"
+    - ".agentplane/policy/dod.core.md"
+    - ".agentplane/policy/security.must.md"
+    - ".agentplane/policy/workflow.branch_pr.md"
+    - "bun run ci:local:fast"
+  findings:
+    - "No scope-digest, expiry, stale-input, or protected-operation policy was relaxed. The focused route regression proves a granted pr.open advances to an executable operation with a clean worktree; full fast CI passed."
+commit:
+  hash: "03a98aa601a69dd8c89e5dc424ca2e0ed214d025"
+  message: "fix: commit branch-pr authority records"
 comments:
   -
     author: "CODER"
     body: "Start: isolate authority and close-tail freshness from implementation verification without weakening protected merge gates."
+  -
+    author: "CODER"
+    body: "Implementation: committed branch_pr authority records automatically; added the route regression that proves the authorized PR operation remains executable."
 events:
   -
     type: "status"
@@ -45,8 +74,21 @@ events:
     from: "TODO"
     to: "DOING"
     note: "Start: isolate authority and close-tail freshness from implementation verification without weakening protected merge gates."
+  -
+    type: "status"
+    at: "2026-07-28T09:22:45.351Z"
+    author: "CODER"
+    from: "DOING"
+    to: "DOING"
+    note: "Implementation: committed branch_pr authority records automatically; added the route regression that proves the authorized PR operation remains executable."
+  -
+    type: "verify"
+    at: "2026-07-28T09:22:59.261Z"
+    author: "TESTER"
+    state: "ok"
+    note: "Focused authority/lifecycle tests, task-state, typecheck, critical suite, policy routing, and full local fast CI passed; the live authority grant auto-committed its packet and advanced directly to pr.open."
 doc_version: 3
-doc_updated_at: "2026-07-28T09:02:22.510Z"
+doc_updated_at: "2026-07-28T09:22:59.880Z"
 doc_updated_by: "CODER"
 description: "v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration."
 sections:
@@ -71,11 +113,44 @@ sections:
     5. Publish a PR and require stable hosted checks before integrating. Expected: the PR head, review state, and merge queue agree; no manual provider merge is used.
   Verification: |-
     <!-- BEGIN VERIFICATION RESULTS -->
+    ### 2026-07-28T09:22:59.261Z — VERIFY — ok
+
+    By: TESTER
+
+    Note: Focused authority/lifecycle tests, task-state, typecheck, critical suite, policy routing, and full local fast CI passed; the live authority grant auto-committed its packet and advanced directly to pr.open.
+    Attempts: 0
+
+    VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T09:22:45.351Z, excerpt_hash=sha256:52fcdb54a6ac5d2e275518998c6d5e8482aa9d20bac2e445e9a05838c2d4d074
+
+    Details:
+
+    BlueprintSnapshotRef:
+    - state: current
+    - path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607280900-WHE7JS-break-authority-close-lifecycle-feedback-loop/.agentplane/tasks/202607280900-WHE7JS/blueprint/resolved-snapshot.json
+    - old_digest: cf78dccf3ca7848d369ebafa8399f797778df6099809e148df6eba5dea7c2410
+    - current_digest: cf78dccf3ca7848d369ebafa8399f797778df6099809e148df6eba5dea7c2410
+    - route_changed: no
+    - safe_command: agentplane blueprint snapshot 202607280900-WHE7JS
+
+    DecisionContextRef:
+    - operator_action: stop
+    - can_execute_now: false
+    - safe_command: none
+    - diagnostic_command: agentplane task verify-show 202607280900-WHE7JS
+    - source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+    - freshness: route=computed_local remote=remote_skipped
+    - repeat_allowed: false
+    - repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+    - risks: none
+
     <!-- END VERIFICATION RESULTS -->
   Rollback Plan: |-
     - Revert task-related commit(s).
     - Re-run required checks to confirm rollback safety.
-  Findings: ""
+  Findings: |-
+    - Observation: authority grant emitted committed and next-action became cli_operation pr.open
+      Impact: breaks the task-worktree dirty feedback loop without weakening authority scope or expiry
+      Resolution: verified against commit 03a98aa601a69dd8c89e5dc424ca2e0ed214d025
 extensions:
   agentplane.side_effect_authority:
     audit:
@@ -92,6 +167,19 @@ extensions:
         schemaVersion: 1
         sequence: 1
         stateFingerprintDigest: "sha256:af8f1a911e6dcc9a09a068f68ba9e71bf90280645b0aa8cbd0bae70078e59d12"
+      -
+        actor: "USER"
+        at: "2026-07-28T09:23:30.889Z"
+        authorityDigest: "sha256:da0fae580c156b0a5473fc67c35c299b3b7690df925f044b649611a90b3442c4"
+        digest: "sha256:36ab904c0b4ca37df662222265b709d039be64188fd547db271fbcc2ec6de2c3"
+        operationDigest: "sha256:64fd58d047fb90bdfbd444c255ae309e86e6ad57d37765e1678bc81744c92356"
+        operationId: "task.pre_merge_close"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:0c5c5058efd15e95304d32c5866983b1161881f37a6bdede065502f552346ddc"
+        schemaVersion: 1
+        sequence: 2
+        stateFingerprintDigest: "sha256:7afab48f7c7b2d93739a50b4f8140cb60b0c262dbbe6aa4c831670dd61221ab4"
     grants:
       -
         actor: "USER"
@@ -106,6 +194,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:af8f1a911e6dcc9a09a068f68ba9e71bf90280645b0aa8cbd0bae70078e59d12"
         stateScopeDigest: "sha256:6d1086ee329f82a88d40342f8e577d3f6d8015efd1e821cb8c20c2d25a29b684"
+      -
+        actor: "USER"
+        digest: "sha256:da0fae580c156b0a5473fc67c35c299b3b7690df925f044b649611a90b3442c4"
+        expiresAt: "2026-07-28T09:38:30.889Z"
+        id: "authority-9aa8c749-069b-4d42-b453-606c4f109a78"
+        issuedAt: "2026-07-28T09:23:30.889Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:64fd58d047fb90bdfbd444c255ae309e86e6ad57d37765e1678bc81744c92356"
+        operationId: "task.pre_merge_close"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:7afab48f7c7b2d93739a50b4f8140cb60b0c262dbbe6aa4c831670dd61221ab4"
+        stateScopeDigest: "sha256:9064b3f6cfd0821b09405717ece3ace8dee280f243c3be2224d1a6679a83630c"
     schemaVersion: 1
   workflow_route_baseline:
     start_head_sha: "89a82f010479eb2583e414fb49c930d4819b5777"
@@ -142,6 +243,36 @@ v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority r
 ## Verification
 
 <!-- BEGIN VERIFICATION RESULTS -->
+### 2026-07-28T09:22:59.261Z — VERIFY — ok
+
+By: TESTER
+
+Note: Focused authority/lifecycle tests, task-state, typecheck, critical suite, policy routing, and full local fast CI passed; the live authority grant auto-committed its packet and advanced directly to pr.open.
+Attempts: 0
+
+VerifyStepsRef: doc_version=3, doc_updated_at=2026-07-28T09:22:45.351Z, excerpt_hash=sha256:52fcdb54a6ac5d2e275518998c6d5e8482aa9d20bac2e445e9a05838c2d4d074
+
+Details:
+
+BlueprintSnapshotRef:
+- state: current
+- path: /Users/densmirnov/Github/agentplane/.agentplane/tmp/inc-20260727-main-lane.prxk2f/repo/.agentplane/worktrees/202607280900-WHE7JS-break-authority-close-lifecycle-feedback-loop/.agentplane/tasks/202607280900-WHE7JS/blueprint/resolved-snapshot.json
+- old_digest: cf78dccf3ca7848d369ebafa8399f797778df6099809e148df6eba5dea7c2410
+- current_digest: cf78dccf3ca7848d369ebafa8399f797778df6099809e148df6eba5dea7c2410
+- route_changed: no
+- safe_command: agentplane blueprint snapshot 202607280900-WHE7JS
+
+DecisionContextRef:
+- operator_action: stop
+- can_execute_now: false
+- safe_command: none
+- diagnostic_command: agentplane task verify-show 202607280900-WHE7JS
+- source_of_truth: route=task_next_action diagnostic=task_next_action remote=not_checked
+- freshness: route=computed_local remote=remote_skipped
+- repeat_allowed: false
+- repeat_stop_condition: after any non-zero exit or completed mutation, recompute task next-action before a second step
+- risks: none
+
 <!-- END VERIFICATION RESULTS -->
 
 ## Rollback Plan
@@ -150,3 +281,7 @@ v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority r
 - Re-run required checks to confirm rollback safety.
 
 ## Findings
+
+- Observation: authority grant emitted committed and next-action became cli_operation pr.open
+  Impact: breaks the task-worktree dirty feedback loop without weakening authority scope or expiry
+  Resolution: verified against commit 03a98aa601a69dd8c89e5dc424ca2e0ed214d025

--- a/.agentplane/tasks/202607280900-WHE7JS/README.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/README.md
@@ -5,7 +5,7 @@ result_summary: "pre-merge closure"
 status: "DONE"
 priority: "high"
 owner: "CODER"
-revision: 15
+revision: 16
 origin:
   system: "manual"
 depends_on: []
@@ -204,6 +204,19 @@ extensions:
         schemaVersion: 1
         sequence: 3
         stateFingerprintDigest: "sha256:334387b4666341f6de5bec88befbaac77702c581801af8202b3d2e1818d48017"
+      -
+        actor: "USER"
+        at: "2026-07-28T09:28:25.405Z"
+        authorityDigest: "sha256:adfaa46a96c43e21ee93c5d66656326c1df9ecdbb70747d8fc176e3bc1a21d47"
+        digest: "sha256:ddeb6715440d7b9dc5951241cd80c80a168c1c18e972c7c345e84dd792fa7279"
+        operationDigest: "sha256:26b8fe2a6f663a15c6d3cccc3c833f47ba59529501e4151044d9b448babf5010"
+        operationId: "integration.enqueue"
+        outcome: "approved"
+        policyRule: "workflow.external_high_risk"
+        previousDigest: "sha256:6bbce1f1d8cf6a78360db03befd0283479e515f604bebdad15eb48af633e8722"
+        schemaVersion: 1
+        sequence: 4
+        stateFingerprintDigest: "sha256:64f71da3a0a0f16a7ce74dce4c3f6c7a1e6adae9e7aeccd83987f0889e03d08b"
     grants:
       -
         actor: "USER"
@@ -244,6 +257,19 @@ extensions:
         schemaVersion: 1
         stateFingerprintDigest: "sha256:334387b4666341f6de5bec88befbaac77702c581801af8202b3d2e1818d48017"
         stateScopeDigest: "sha256:2c73969f937695823fcdf58a641475df7ccbdaa36fd7dc6bb10ec8747c2ddadb"
+      -
+        actor: "USER"
+        digest: "sha256:adfaa46a96c43e21ee93c5d66656326c1df9ecdbb70747d8fc176e3bc1a21d47"
+        expiresAt: "2026-07-28T09:43:25.405Z"
+        id: "authority-0a46092a-843f-4e82-9246-02f9f4ee57ea"
+        issuedAt: "2026-07-28T09:28:25.405Z"
+        kind: "side_effect_authority"
+        operationDigest: "sha256:26b8fe2a6f663a15c6d3cccc3c833f47ba59529501e4151044d9b448babf5010"
+        operationId: "integration.enqueue"
+        policyRule: "workflow.external_high_risk"
+        schemaVersion: 1
+        stateFingerprintDigest: "sha256:64f71da3a0a0f16a7ce74dce4c3f6c7a1e6adae9e7aeccd83987f0889e03d08b"
+        stateScopeDigest: "sha256:ef6786308e36c37e858a688101aef667439c17919b3126a0339cca1d8e9ba98d"
     schemaVersion: 1
   implementation_commit:
     hash: "03a98aa601a69dd8c89e5dc424ca2e0ed214d025"

--- a/.agentplane/tasks/202607280900-WHE7JS/blueprint/resolved-snapshot.json
+++ b/.agentplane/tasks/202607280900-WHE7JS/blueprint/resolved-snapshot.json
@@ -1,0 +1,581 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607280900-WHE7JS",
+    "title": "Break authority-close lifecycle feedback loop",
+    "description": "v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.",
+    "tags": [
+      "blocker",
+      "code",
+      "lifecycle",
+      "v0.7",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607280900-WHE7JS",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "cf78dccf3ca7848d369ebafa8399f797778df6099809e148df6eba5dea7c2410"
+  }
+}

--- a/.agentplane/tasks/202607280900-WHE7JS/pr/diffstat.txt
+++ b/.agentplane/tasks/202607280900-WHE7JS/pr/diffstat.txt
@@ -1,0 +1,3 @@
+ .../cli/run-cli.core.task-next-action-json.test.ts | 133 +++++++++++++++++++++
+ .../src/commands/task/authority-grant.command.ts   |  16 ++-
+ 2 files changed, 147 insertions(+), 2 deletions(-)

--- a/.agentplane/tasks/202607280900-WHE7JS/pr/github-body.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/pr/github-body.md
@@ -19,9 +19,9 @@ v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority r
 - Note:
 
 ```text
-Focused authority/lifecycle tests, task-state, typecheck, critical suite, policy routing, and full
-local fast CI passed; the live authority grant auto-committed its packet and advanced directly to
-pr.open.
+After rebasing onto main with the runner cancellation-intent retry, focused authority and runner
+regressions pass, typecheck/task-state/routing pass, and critical CLI matrix passes 11/11. Hosted CI
+must still validate the rebased PR head.
 ```
 - Canonical workflow state lives in the task README.
 

--- a/.agentplane/tasks/202607280900-WHE7JS/pr/github-body.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/pr/github-body.md
@@ -15,14 +15,20 @@ v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority r
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note:
+
+```text
+Focused authority/lifecycle tests, task-state, typecheck, critical suite, policy routing, and full
+local fast CI passed; the live authority grant auto-committed its packet and advanced directly to
+pr.open.
+```
 - Canonical workflow state lives in the task README.
 
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-28T09:02:22.621Z
+- Updated: 2026-07-28T09:22:13.954Z
 - Branch: task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 

--- a/.agentplane/tasks/202607280900-WHE7JS/pr/github-body.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/pr/github-body.md
@@ -27,7 +27,9 @@ v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority r
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../cli/run-cli.core.task-next-action-json.test.ts | 133 +++++++++++++++++++++
+ .../src/commands/task/authority-grant.command.ts   |  16 ++-
+ 2 files changed, 147 insertions(+), 2 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607280900-WHE7JS/pr/github-body.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/pr/github-body.md
@@ -1,0 +1,33 @@
+Task: `202607280900-WHE7JS`
+Title: Break authority-close lifecycle feedback loop
+Canonical task record: `.agentplane/tasks/202607280900-WHE7JS/README.md`
+
+## Summary
+
+Break authority-close lifecycle feedback loop
+
+v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.
+
+## Scope
+
+- In scope: v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.
+- Out of scope: unrelated refactors not required for "Break authority-close lifecycle feedback loop".
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-28T09:02:22.621Z
+- Branch: task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>

--- a/.agentplane/tasks/202607280900-WHE7JS/pr/github-title.txt
+++ b/.agentplane/tasks/202607280900-WHE7JS/pr/github-title.txt
@@ -1,0 +1,1 @@
+🚧 WHE7JS task: Break authority-close lifecycle feedback loop [202607280900-WHE7JS]

--- a/.agentplane/tasks/202607280900-WHE7JS/pr/github-title.txt
+++ b/.agentplane/tasks/202607280900-WHE7JS/pr/github-title.txt
@@ -1,1 +1,1 @@
-🚧 WHE7JS task: Break authority-close lifecycle feedback loop [202607280900-WHE7JS]
+✅ WHE7JS task: Break authority-close lifecycle feedback loop [202607280900-WHE7JS]

--- a/.agentplane/tasks/202607280900-WHE7JS/pr/meta.json
+++ b/.agentplane/tasks/202607280900-WHE7JS/pr/meta.json
@@ -8,10 +8,10 @@
   "pr_number": 4655,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4655",
   "pre_merge_closure": {
-    "basis_commit": "6d40a20d583714656c5edbffbf4bd78c483902c7",
+    "basis_commit": "2e04b906f9d327f180b0dc11f0a3d9dd4e6a3088",
     "branch": "task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop",
     "pr_number": 4655,
-    "recorded_at": "2026-07-28T09:23:47.204Z",
+    "recorded_at": "2026-07-28T10:31:39.869Z",
     "state": "closed_before_merge"
   },
   "schema_version": 1,

--- a/.agentplane/tasks/202607280900-WHE7JS/pr/meta.json
+++ b/.agentplane/tasks/202607280900-WHE7JS/pr/meta.json
@@ -7,6 +7,13 @@
   "last_verified_diffstat_sha256": "sha256:87aea721cc43b1999b3b66f12b8b998e655f5818c6368d589d1c80ce7c8a6ee5",
   "pr_number": 4655,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4655",
+  "pre_merge_closure": {
+    "basis_commit": "6d40a20d583714656c5edbffbf4bd78c483902c7",
+    "branch": "task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop",
+    "pr_number": 4655,
+    "recorded_at": "2026-07-28T09:23:47.204Z",
+    "state": "closed_before_merge"
+  },
   "schema_version": 1,
   "status": "OPEN",
   "task_id": "202607280900-WHE7JS",

--- a/.agentplane/tasks/202607280900-WHE7JS/pr/meta.json
+++ b/.agentplane/tasks/202607280900-WHE7JS/pr/meta.json
@@ -3,11 +3,15 @@
   "branch": "task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop",
   "created_at": "2026-07-28T09:02:22.621Z",
   "diffstat_sha256": "sha256:87aea721cc43b1999b3b66f12b8b998e655f5818c6368d589d1c80ce7c8a6ee5",
-  "last_verified_at": null,
+  "last_verified_at": "2026-07-28T09:22:59.261Z",
+  "last_verified_diffstat_sha256": "sha256:87aea721cc43b1999b3b66f12b8b998e655f5818c6368d589d1c80ce7c8a6ee5",
+  "pr_number": 4655,
+  "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4655",
   "schema_version": 1,
+  "status": "OPEN",
   "task_id": "202607280900-WHE7JS",
-  "updated_at": "2026-07-28T09:02:22.621Z",
+  "updated_at": "2026-07-28T09:22:13.954Z",
   "verify": {
-    "status": "skipped"
+    "status": "pass"
   }
 }

--- a/.agentplane/tasks/202607280900-WHE7JS/pr/meta.json
+++ b/.agentplane/tasks/202607280900-WHE7JS/pr/meta.json
@@ -2,7 +2,7 @@
   "base": "main",
   "branch": "task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop",
   "created_at": "2026-07-28T09:02:22.621Z",
-  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "diffstat_sha256": "sha256:87aea721cc43b1999b3b66f12b8b998e655f5818c6368d589d1c80ce7c8a6ee5",
   "last_verified_at": null,
   "schema_version": 1,
   "task_id": "202607280900-WHE7JS",

--- a/.agentplane/tasks/202607280900-WHE7JS/pr/meta.json
+++ b/.agentplane/tasks/202607280900-WHE7JS/pr/meta.json
@@ -1,0 +1,13 @@
+{
+  "base": "main",
+  "branch": "task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop",
+  "created_at": "2026-07-28T09:02:22.621Z",
+  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "last_verified_at": null,
+  "schema_version": 1,
+  "task_id": "202607280900-WHE7JS",
+  "updated_at": "2026-07-28T09:02:22.621Z",
+  "verify": {
+    "status": "skipped"
+  }
+}

--- a/.agentplane/tasks/202607280900-WHE7JS/pr/meta.json
+++ b/.agentplane/tasks/202607280900-WHE7JS/pr/meta.json
@@ -3,7 +3,7 @@
   "branch": "task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop",
   "created_at": "2026-07-28T09:02:22.621Z",
   "diffstat_sha256": "sha256:87aea721cc43b1999b3b66f12b8b998e655f5818c6368d589d1c80ce7c8a6ee5",
-  "last_verified_at": "2026-07-28T09:22:59.261Z",
+  "last_verified_at": "2026-07-28T10:28:47.525Z",
   "last_verified_diffstat_sha256": "sha256:87aea721cc43b1999b3b66f12b8b998e655f5818c6368d589d1c80ce7c8a6ee5",
   "pr_number": 4655,
   "pr_url": "https://github.com/basilisk-labs/agentplane/pull/4655",

--- a/.agentplane/tasks/202607280900-WHE7JS/pr/review.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/pr/review.md
@@ -1,0 +1,36 @@
+# PR Review
+
+Created: 2026-07-28T09:02:22.621Z
+
+## Task
+
+- Task: `202607280900-WHE7JS`
+- Title: Break authority-close lifecycle feedback loop
+- Status: DOING
+- Branch: `task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop`
+- Canonical task record: `.agentplane/tasks/202607280900-WHE7JS/README.md`
+
+## Verification
+
+- State: pending
+- Note: Not recorded yet.
+- Canonical workflow state lives in the task README.
+
+## Handoff Notes
+
+- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
+
+<!-- BEGIN AUTO SUMMARY -->
+<details>
+<summary>Raw evidence</summary>
+
+- Updated: 2026-07-28T09:02:22.621Z
+- Branch: task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop
+- Head: computed live by `agentplane pr check` / `agentplane integrate`
+
+```text
+No changes detected.
+```
+
+</details>
+<!-- END AUTO SUMMARY -->

--- a/.agentplane/tasks/202607280900-WHE7JS/pr/review.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/pr/review.md
@@ -6,7 +6,7 @@ Created: 2026-07-28T09:02:22.621Z
 
 - Task: `202607280900-WHE7JS`
 - Title: Break authority-close lifecycle feedback loop
-- Status: DOING
+- Status: DONE
 - Branch: `task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop`
 - Canonical task record: `.agentplane/tasks/202607280900-WHE7JS/README.md`
 

--- a/.agentplane/tasks/202607280900-WHE7JS/pr/review.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/pr/review.md
@@ -12,8 +12,8 @@ Created: 2026-07-28T09:02:22.621Z
 
 ## Verification
 
-- State: pending
-- Note: Not recorded yet.
+- State: ok
+- Note: Focused authority/lifecycle tests, task-state, typecheck, critical suite, policy routing, and full local fast CI passed; the live authority grant auto-committed its packet and advanced directly to pr.open.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes
@@ -24,7 +24,7 @@ Created: 2026-07-28T09:02:22.621Z
 <details>
 <summary>Raw evidence</summary>
 
-- Updated: 2026-07-28T09:02:22.621Z
+- Updated: 2026-07-28T09:22:13.954Z
 - Branch: task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 

--- a/.agentplane/tasks/202607280900-WHE7JS/pr/review.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/pr/review.md
@@ -13,7 +13,7 @@ Created: 2026-07-28T09:02:22.621Z
 ## Verification
 
 - State: ok
-- Note: Focused authority/lifecycle tests, task-state, typecheck, critical suite, policy routing, and full local fast CI passed; the live authority grant auto-committed its packet and advanced directly to pr.open.
+- Note: After rebasing onto main with the runner cancellation-intent retry, focused authority and runner regressions pass, typecheck/task-state/routing pass, and critical CLI matrix passes 11/11. Hosted CI must still validate the rebased PR head.
 - Canonical workflow state lives in the task README.
 
 ## Handoff Notes

--- a/.agentplane/tasks/202607280900-WHE7JS/pr/review.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/pr/review.md
@@ -29,7 +29,9 @@ Created: 2026-07-28T09:02:22.621Z
 - Head: computed live by `agentplane pr check` / `agentplane integrate`
 
 ```text
-No changes detected.
+ .../cli/run-cli.core.task-next-action-json.test.ts | 133 +++++++++++++++++++++
+ .../src/commands/task/authority-grant.command.ts   |  16 ++-
+ 2 files changed, 147 insertions(+), 2 deletions(-)
 ```
 
 </details>

--- a/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-blueprint.json
+++ b/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-blueprint.json
@@ -1,0 +1,581 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607280900-WHE7JS",
+    "title": "Break authority-close lifecycle feedback loop",
+    "description": "v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.",
+    "tags": [
+      "blocker",
+      "code",
+      "lifecycle",
+      "v0.7",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607280900-WHE7JS",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "cf78dccf3ca7848d369ebafa8399f797778df6099809e148df6eba5dea7c2410"
+  }
+}

--- a/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-diff.patch
+++ b/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-diff.patch
@@ -1,0 +1,1025 @@
+diff --git a/.agentplane/tasks/202607280900-WHE7JS/README.md b/.agentplane/tasks/202607280900-WHE7JS/README.md
+new file mode 100644
+index 000000000..d8ba56eff
+--- /dev/null
++++ b/.agentplane/tasks/202607280900-WHE7JS/README.md
+@@ -0,0 +1,122 @@
++---
++id: "202607280900-WHE7JS"
++title: "Break authority-close lifecycle feedback loop"
++status: "DOING"
++priority: "high"
++owner: "CODER"
++revision: 8
++origin:
++  system: "manual"
++depends_on: []
++tags:
++  - "blocker"
++  - "code"
++  - "lifecycle"
++  - "v0.7"
++  - "workflow"
++task_kind: "code"
++mutation_scope: "code"
++blueprint_request: "code.branch_pr"
++verify:
++  - "bun run test:critical"
++  - "bun run typecheck"
++  - "node .agentplane/policy/check-routing.mjs"
++plan_approval:
++  state: "approved"
++  updated_at: "2026-07-28T09:01:44.246Z"
++  updated_by: "ORCHESTRATOR"
++  note: null
++verification:
++  state: "pending"
++  updated_at: null
++  updated_by: null
++  note: null
++  attempts: 0
++commit: null
++comments:
++  -
++    author: "CODER"
++    body: "Start: isolate authority and close-tail freshness from implementation verification without weakening protected merge gates."
++events:
++  -
++    type: "status"
++    at: "2026-07-28T09:02:22.510Z"
++    author: "CODER"
++    from: "TODO"
++    to: "DOING"
++    note: "Start: isolate authority and close-tail freshness from implementation verification without weakening protected merge gates."
++doc_version: 3
++doc_updated_at: "2026-07-28T09:02:22.510Z"
++doc_updated_by: "CODER"
++description: "v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration."
++sections:
++  Summary: |-
++    Break authority-close lifecycle feedback loop
++
++    v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.
++  Scope: |-
++    - In scope: v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.
++    - Out of scope: unrelated refactors not required for "Break authority-close lifecycle feedback loop".
++  Plan: |-
++    1. Trace the route predicates that classify task README and PR-artifact changes as verification/pre-merge invalidators.
++    2. Introduce an explicit freshness boundary: implementation, verification, quality, and close-tail evidence remain content-addressed; authority grants and provider-sync metadata preserve auditability but do not invalidate unchanged implementation evidence.
++    3. Preserve all high-risk gates: a protected provider operation still requires a matching current authority record; code/verification/quality changes still require fresh verification and pre-merge closure; final PR head and hosted checks must remain live and stable.
++    4. Add deterministic regression coverage for authority grant -> pre-merge closure -> final head publication -> integration queue, proving the route reaches an executable integration step without another verification cycle when implementation is unchanged.
++    5. Run focused route tests, task-state check, typecheck, critical tests, policy routing, and the relevant local CI selector; record residual compatibility risk in task Findings.
++  Verify Steps: |-
++    1. Add a deterministic route-level regression: authority grant, verification, evaluator pass, pre-merge closure, final-head publication, hosted-green refresh, integration queue. Expected: unchanged implementation and quality evidence reaches an executable integration action without another verification/close/publish loop.
++    2. Exercise the negative boundary. Expected: a changed implementation commit, invalid or stale authority, or changed hosted state still invalidates the appropriate evidence and blocks integration.
++    3. Inspect persisted task and authority artifacts. Expected: every protected operation retains a matching scoped authority record; no authority record widens an operation.
++    4. Run focused lifecycle-route tests, bun run task-state:check, bun run typecheck, bun run test:critical, and node .agentplane/policy/check-routing.mjs. Expected: all pass.
++    5. Publish a PR and require stable hosted checks before integrating. Expected: the PR head, review state, and merge queue agree; no manual provider merge is used.
++  Verification: |-
++    <!-- BEGIN VERIFICATION RESULTS -->
++    <!-- END VERIFICATION RESULTS -->
++  Rollback Plan: |-
++    - Revert task-related commit(s).
++    - Re-run required checks to confirm rollback safety.
++  Findings: ""
++extensions:
++  workflow_route_baseline:
++    start_head_sha: "89a82f010479eb2583e414fb49c930d4819b5777"
++    version: 1
++id_source: "generated"
++---
++## Summary
++
++Break authority-close lifecycle feedback loop
++
++v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.
++
++## Scope
++
++- In scope: v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.
++- Out of scope: unrelated refactors not required for "Break authority-close lifecycle feedback loop".
++
++## Plan
++
++1. Trace the route predicates that classify task README and PR-artifact changes as verification/pre-merge invalidators.
++2. Introduce an explicit freshness boundary: implementation, verification, quality, and close-tail evidence remain content-addressed; authority grants and provider-sync metadata preserve auditability but do not invalidate unchanged implementation evidence.
++3. Preserve all high-risk gates: a protected provider operation still requires a matching current authority record; code/verification/quality changes still require fresh verification and pre-merge closure; final PR head and hosted checks must remain live and stable.
++4. Add deterministic regression coverage for authority grant -> pre-merge closure -> final head publication -> integration queue, proving the route reaches an executable integration step without another verification cycle when implementation is unchanged.
++5. Run focused route tests, task-state check, typecheck, critical tests, policy routing, and the relevant local CI selector; record residual compatibility risk in task Findings.
++
++## Verify Steps
++
++1. Add a deterministic route-level regression: authority grant, verification, evaluator pass, pre-merge closure, final-head publication, hosted-green refresh, integration queue. Expected: unchanged implementation and quality evidence reaches an executable integration action without another verification/close/publish loop.
++2. Exercise the negative boundary. Expected: a changed implementation commit, invalid or stale authority, or changed hosted state still invalidates the appropriate evidence and blocks integration.
++3. Inspect persisted task and authority artifacts. Expected: every protected operation retains a matching scoped authority record; no authority record widens an operation.
++4. Run focused lifecycle-route tests, bun run task-state:check, bun run typecheck, bun run test:critical, and node .agentplane/policy/check-routing.mjs. Expected: all pass.
++5. Publish a PR and require stable hosted checks before integrating. Expected: the PR head, review state, and merge queue agree; no manual provider merge is used.
++
++## Verification
++
++<!-- BEGIN VERIFICATION RESULTS -->
++<!-- END VERIFICATION RESULTS -->
++
++## Rollback Plan
++
++- Revert task-related commit(s).
++- Re-run required checks to confirm rollback safety.
++
++## Findings
+diff --git a/.agentplane/tasks/202607280900-WHE7JS/blueprint/resolved-snapshot.json b/.agentplane/tasks/202607280900-WHE7JS/blueprint/resolved-snapshot.json
+new file mode 100644
+index 000000000..00ce27ec5
+--- /dev/null
++++ b/.agentplane/tasks/202607280900-WHE7JS/blueprint/resolved-snapshot.json
+@@ -0,0 +1,581 @@
++{
++  "schemaVersion": 1,
++  "artifactKind": "agentplane.blueprint.resolved_snapshot",
++  "resolverInput": {
++    "taskId": "202607280900-WHE7JS",
++    "title": "Break authority-close lifecycle feedback loop",
++    "description": "v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.",
++    "tags": [
++      "blocker",
++      "code",
++      "lifecycle",
++      "v0.7",
++      "workflow"
++    ],
++    "owner": "CODER",
++    "taskKind": "code",
++    "workflowMode": "branch_pr",
++    "workflowGitCapabilities": {
++      "workflowMode": "branch_pr",
++      "implementationCommitLocation": "task_worktree",
++      "finishCommitSource": "explicit_hash",
++      "closeTailRequired": true,
++      "lifecycleCommentCommitLocation": "task_worktree",
++      "finishCommitFromComment": false
++    },
++    "mutation": "code",
++    "mutationScope": "code",
++    "touchedPaths": [],
++    "recipeHints": [],
++    "riskFlags": [],
++    "blueprintRequest": "code.branch_pr"
++  },
++  "selectedBlueprint": {
++    "id": "code.branch_pr",
++    "version": 1,
++    "title": "Branch PR code change",
++    "taskKinds": [
++      "code"
++    ],
++    "workflowModes": [
++      "branch_pr"
++    ]
++  },
++  "plan": {
++    "schemaVersion": 1,
++    "blueprintId": "code.branch_pr",
++    "blueprintVersion": 1,
++    "title": "Branch PR code change",
++    "taskId": "202607280900-WHE7JS",
++    "workflowMode": "branch_pr",
++    "workflowGitCapabilities": {
++      "workflowMode": "branch_pr",
++      "implementationCommitLocation": "task_worktree",
++      "finishCommitSource": "explicit_hash",
++      "closeTailRequired": true,
++      "lifecycleCommentCommitLocation": "task_worktree",
++      "finishCommitFromComment": false
++    },
++    "taskIntent": {
++      "taskKind": "code",
++      "mutationScope": "code",
++      "blueprintRequest": "code.branch_pr"
++    },
++    "whySelected": [
++      "explicit blueprint requested: code.branch_pr",
++      "task intent kind: code",
++      "workflow mode: branch_pr",
++      "task intent mutation scope: code"
++    ],
++    "states": [
++      {
++        "id": "intake",
++        "kind": "intake",
++        "mode": "agentic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": []
++      },
++      {
++        "id": "scope",
++        "kind": "scope",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "assumptions"
++        ]
++      },
++      {
++        "id": "approval_gate",
++        "kind": "approval_gate",
++        "mode": "approval",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "approval"
++        ]
++      },
++      {
++        "id": "context_resolve",
++        "kind": "context_resolve",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [
++          ".agentplane/policy/security.must.md",
++          ".agentplane/policy/dod.core.md",
++          ".agentplane/policy/dod.code.md",
++          ".agentplane/policy/workflow.branch_pr.md"
++        ],
++        "evidenceKinds": [
++          "context_manifest"
++        ]
++      },
++      {
++        "id": "worktree_start",
++        "kind": "worktree_start",
++        "mode": "deterministic",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [
++          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "changed_paths"
++        ]
++      },
++      {
++        "id": "work_unit",
++        "kind": "work_unit",
++        "mode": "agentic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "changed_paths"
++        ]
++      },
++      {
++        "id": "fast_local_checks",
++        "kind": "fast_local_checks",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [
++          "agentplane task verify-show <task-id>",
++          "project focused checks"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "check_result"
++        ]
++      },
++      {
++        "id": "pr_artifact",
++        "kind": "pr_artifact",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [
++          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "artifact",
++          "external_link"
++        ]
++      },
++      {
++        "id": "verify_record",
++        "kind": "verify_record",
++        "mode": "record",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "check_result"
++        ]
++      },
++      {
++        "id": "quality_gate",
++        "kind": "quality_gate",
++        "mode": "agentic",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [
++          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "quality_report"
++        ]
++      },
++      {
++        "id": "hosted_checks",
++        "kind": "hosted_checks",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "check_result",
++          "external_link"
++        ]
++      },
++      {
++        "id": "publish_or_integrate",
++        "kind": "publish_or_integrate",
++        "mode": "deterministic",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [
++          "agentplane integrate <task-id> --branch <branch> --run-verify"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "commit",
++          "external_link"
++        ]
++      },
++      {
++        "id": "finish",
++        "kind": "finish",
++        "mode": "deterministic",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "commit"
++        ]
++      }
++    ],
++    "requiredEvidence": [
++      {
++        "id": "code_pr.paths",
++        "kind": "changed_paths",
++        "producedBy": "work_unit",
++        "required": true,
++        "description": "Changed source paths."
++      },
++      {
++        "id": "code_pr.fast_checks",
++        "kind": "check_result",
++        "producedBy": "fast_local_checks",
++        "required": true,
++        "description": "Fast local checks."
++      },
++      {
++        "id": "code_pr.pr",
++        "kind": "external_link",
++        "producedBy": "pr_artifact",
++        "required": true,
++        "description": "Pull request artifact."
++      },
++      {
++        "id": "code_pr.verify",
++        "kind": "check_result",
++        "producedBy": "verify_record",
++        "required": true,
++        "description": "Task branch verification."
++      },
++      {
++        "id": "code_pr.quality",
++        "kind": "quality_report",
++        "producedBy": "quality_gate",
++        "required": true,
++        "description": "EVALUATOR quality verdict."
++      },
++      {
++        "id": "code_pr.hosted",
++        "kind": "check_result",
++        "producedBy": "hosted_checks",
++        "required": true,
++        "description": "Hosted check evidence."
++      },
++      {
++        "id": "code_pr.commit",
++        "kind": "commit",
++        "producedBy": "publish_or_integrate",
++        "required": true,
++        "description": "Integration commit."
++      }
++    ],
++    "policyModules": [
++      ".agentplane/policy/dod.code.md",
++      ".agentplane/policy/dod.core.md",
++      ".agentplane/policy/security.must.md",
++      ".agentplane/policy/workflow.branch_pr.md"
++    ],
++    "allowedCommands": [
++      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
++      "agentplane integrate <task-id> --branch <branch> --run-verify",
++      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
++      "agentplane task verify-show <task-id>",
++      "agentplane verify <task-id> --ok|--rework",
++      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
++      "project focused checks"
++    ],
++    "contextBudget": {
++      "maxPolicyModules": 4,
++      "maxPromptBlocks": 14,
++      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
++    },
++    "contextManifest": [],
++    "acceptedRecipeExtensions": [],
++    "rejectedRecipeExtensions": [],
++    "stopReasons": []
++  },
++  "nodes": [
++    {
++      "id": "intake",
++      "kind": "intake",
++      "mode": "agentic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": []
++    },
++    {
++      "id": "scope",
++      "kind": "scope",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "assumptions"
++      ]
++    },
++    {
++      "id": "approval_gate",
++      "kind": "approval_gate",
++      "mode": "approval",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "approval"
++      ]
++    },
++    {
++      "id": "context_resolve",
++      "kind": "context_resolve",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [
++        ".agentplane/policy/security.must.md",
++        ".agentplane/policy/dod.core.md",
++        ".agentplane/policy/dod.code.md",
++        ".agentplane/policy/workflow.branch_pr.md"
++      ],
++      "evidenceKinds": [
++        "context_manifest"
++      ]
++    },
++    {
++      "id": "worktree_start",
++      "kind": "worktree_start",
++      "mode": "deterministic",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [
++        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "changed_paths"
++      ]
++    },
++    {
++      "id": "work_unit",
++      "kind": "work_unit",
++      "mode": "agentic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "changed_paths"
++      ]
++    },
++    {
++      "id": "fast_local_checks",
++      "kind": "fast_local_checks",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [
++        "agentplane task verify-show <task-id>",
++        "project focused checks"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "check_result"
++      ]
++    },
++    {
++      "id": "pr_artifact",
++      "kind": "pr_artifact",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [
++        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "artifact",
++        "external_link"
++      ]
++    },
++    {
++      "id": "verify_record",
++      "kind": "verify_record",
++      "mode": "record",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "check_result"
++      ]
++    },
++    {
++      "id": "quality_gate",
++      "kind": "quality_gate",
++      "mode": "agentic",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [
++        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "quality_report"
++      ]
++    },
++    {
++      "id": "hosted_checks",
++      "kind": "hosted_checks",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "check_result",
++        "external_link"
++      ]
++    },
++    {
++      "id": "publish_or_integrate",
++      "kind": "publish_or_integrate",
++      "mode": "deterministic",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [
++        "agentplane integrate <task-id> --branch <branch> --run-verify"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "commit",
++        "external_link"
++      ]
++    },
++    {
++      "id": "finish",
++      "kind": "finish",
++      "mode": "deterministic",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "commit"
++      ]
++    }
++  ],
++  "requiredEvidence": [
++    {
++      "id": "code_pr.paths",
++      "kind": "changed_paths",
++      "producedBy": "work_unit",
++      "required": true,
++      "description": "Changed source paths."
++    },
++    {
++      "id": "code_pr.fast_checks",
++      "kind": "check_result",
++      "producedBy": "fast_local_checks",
++      "required": true,
++      "description": "Fast local checks."
++    },
++    {
++      "id": "code_pr.pr",
++      "kind": "external_link",
++      "producedBy": "pr_artifact",
++      "required": true,
++      "description": "Pull request artifact."
++    },
++    {
++      "id": "code_pr.verify",
++      "kind": "check_result",
++      "producedBy": "verify_record",
++      "required": true,
++      "description": "Task branch verification."
++    },
++    {
++      "id": "code_pr.quality",
++      "kind": "quality_report",
++      "producedBy": "quality_gate",
++      "required": true,
++      "description": "EVALUATOR quality verdict."
++    },
++    {
++      "id": "code_pr.hosted",
++      "kind": "check_result",
++      "producedBy": "hosted_checks",
++      "required": true,
++      "description": "Hosted check evidence."
++    },
++    {
++      "id": "code_pr.commit",
++      "kind": "commit",
++      "producedBy": "publish_or_integrate",
++      "required": true,
++      "description": "Integration commit."
++    }
++  ],
++  "policyModules": [
++    ".agentplane/policy/dod.code.md",
++    ".agentplane/policy/dod.core.md",
++    ".agentplane/policy/security.must.md",
++    ".agentplane/policy/workflow.branch_pr.md"
++  ],
++  "allowedCommands": [
++    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
++    "agentplane integrate <task-id> --branch <branch> --run-verify",
++    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
++    "agentplane task verify-show <task-id>",
++    "agentplane verify <task-id> --ok|--rework",
++    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
++    "project focused checks"
++  ],
++  "contextBudget": {
++    "maxPolicyModules": 4,
++    "maxPromptBlocks": 14,
++    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
++  },
++  "contextManifest": [],
++  "acceptedRecipeExtensions": [],
++  "rejectedRecipeExtensions": [],
++  "stopReasons": [],
++  "selectionReasons": [
++    "explicit blueprint requested: code.branch_pr",
++    "task intent kind: code",
++    "workflow mode: branch_pr",
++    "task intent mutation scope: code"
++  ],
++  "digest": {
++    "algorithm": "sha256",
++    "value": "cf78dccf3ca7848d369ebafa8399f797778df6099809e148df6eba5dea7c2410"
++  }
++}
+diff --git a/.agentplane/tasks/202607280900-WHE7JS/pr/diffstat.txt b/.agentplane/tasks/202607280900-WHE7JS/pr/diffstat.txt
+new file mode 100644
+index 000000000..e69de29bb
+diff --git a/.agentplane/tasks/202607280900-WHE7JS/pr/github-body.md b/.agentplane/tasks/202607280900-WHE7JS/pr/github-body.md
+new file mode 100644
+index 000000000..3937d8cf1
+--- /dev/null
++++ b/.agentplane/tasks/202607280900-WHE7JS/pr/github-body.md
+@@ -0,0 +1,33 @@
++Task: `202607280900-WHE7JS`
++Title: Break authority-close lifecycle feedback loop
++Canonical task record: `.agentplane/tasks/202607280900-WHE7JS/README.md`
++
++## Summary
++
++Break authority-close lifecycle feedback loop
++
++v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.
++
++## Scope
++
++- In scope: v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.
++- Out of scope: unrelated refactors not required for "Break authority-close lifecycle feedback loop".
++
++## Verification
++
++- State: pending
++- Note: Not recorded yet.
++- Canonical workflow state lives in the task README.
++
++<details>
++<summary>Raw evidence</summary>
++
++- Updated: 2026-07-28T09:02:22.621Z
++- Branch: task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop
++- Head: computed live by `agentplane pr check` / `agentplane integrate`
++
++```text
++No changes detected.
++```
++
++</details>
+diff --git a/.agentplane/tasks/202607280900-WHE7JS/pr/github-title.txt b/.agentplane/tasks/202607280900-WHE7JS/pr/github-title.txt
+new file mode 100644
+index 000000000..f7afb1455
+--- /dev/null
++++ b/.agentplane/tasks/202607280900-WHE7JS/pr/github-title.txt
+@@ -0,0 +1 @@
++🚧 WHE7JS task: Break authority-close lifecycle feedback loop [202607280900-WHE7JS]
+diff --git a/.agentplane/tasks/202607280900-WHE7JS/pr/meta.json b/.agentplane/tasks/202607280900-WHE7JS/pr/meta.json
+new file mode 100644
+index 000000000..b10bdbead
+--- /dev/null
++++ b/.agentplane/tasks/202607280900-WHE7JS/pr/meta.json
+@@ -0,0 +1,13 @@
++{
++  "base": "main",
++  "branch": "task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop",
++  "created_at": "2026-07-28T09:02:22.621Z",
++  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
++  "last_verified_at": null,
++  "schema_version": 1,
++  "task_id": "202607280900-WHE7JS",
++  "updated_at": "2026-07-28T09:02:22.621Z",
++  "verify": {
++    "status": "skipped"
++  }
++}
+diff --git a/.agentplane/tasks/202607280900-WHE7JS/pr/review.md b/.agentplane/tasks/202607280900-WHE7JS/pr/review.md
+new file mode 100644
+index 000000000..b655cbc96
+--- /dev/null
++++ b/.agentplane/tasks/202607280900-WHE7JS/pr/review.md
+@@ -0,0 +1,36 @@
++# PR Review
++
++Created: 2026-07-28T09:02:22.621Z
++
++## Task
++
++- Task: `202607280900-WHE7JS`
++- Title: Break authority-close lifecycle feedback loop
++- Status: DOING
++- Branch: `task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop`
++- Canonical task record: `.agentplane/tasks/202607280900-WHE7JS/README.md`
++
++## Verification
++
++- State: pending
++- Note: Not recorded yet.
++- Canonical workflow state lives in the task README.
++
++## Handoff Notes
++
++- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
++
++<!-- BEGIN AUTO SUMMARY -->
++<details>
++<summary>Raw evidence</summary>
++
++- Updated: 2026-07-28T09:02:22.621Z
++- Branch: task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop
++- Head: computed live by `agentplane pr check` / `agentplane integrate`
++
++```text
++No changes detected.
++```
++
++</details>
++<!-- END AUTO SUMMARY -->
+diff --git a/packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts b/packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts
+index 9e788c968..433000aa3 100644
+--- a/packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts
++++ b/packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts
+@@ -9,10 +9,14 @@ import {
+ } from "@agentplaneorg/core/schemas";
+ import {
+   captureStdIO,
++  configureGitUser,
+   defaultConfig,
++  execFile,
+   expect,
++  extractTaskSuffix,
+   it,
+   mkGitRepoRootWithBranch,
++  promisify,
+   runCli,
+   runCliSilent,
+   writeConfig,
+@@ -61,7 +65,136 @@ async function createBranchPrTask(root: string): Promise<string> {
+   }
+ }
+ 
++type AuthorityRequest = {
++  type: string;
++  operationId: string;
++  operationDigest: string;
++  stateFingerprintDigest: string;
++  stateScopeDigest: string;
++};
++
++type NextActionJson = {
++  workflow_step: {
++    kind: string;
++    id: string;
++    request?: AuthorityRequest;
++    operation?: { id: string };
++  };
++};
++
++async function readNextActionJson(root: string, taskId: string): Promise<NextActionJson> {
++  const io = captureStdIO();
++  try {
++    const code = await runCli(["task", "next-action", taskId, "--json", "--root", root]);
++    if (code !== 0) process.stderr.write(io.stderr);
++    expect(code).toBe(0);
++    return JSON.parse(io.stdout) as NextActionJson;
++  } finally {
++    io.restore();
++  }
++}
++
+ describe("task next-action JSON", () => {
++  it("commits a branch_pr authority record before returning the authorized PR operation", async () => {
++    const root = await mkGitRepoRootWithBranch("main");
++    const config = defaultConfig();
++    config.workflow_mode = "branch_pr";
++    await writeConfig(root, config);
++    await writeRoutePolicies(root);
++    await configureGitUser(root);
++    const execFileAsync = promisify(execFile);
++    await writeFile(path.join(root, "seed.txt"), "seed\n", "utf8");
++    await runCliSilent(["branch", "base", "set", "main", "--root", root]);
++    await execFileAsync("git", ["add", "."], { cwd: root });
++    await execFileAsync("git", ["commit", "-m", "seed"], { cwd: root });
++
++    const taskId = await createBranchPrTask(root);
++    await runCliSilent([
++      "task",
++      "plan",
++      "set",
++      taskId,
++      "--text",
++      "Commit authority records before continuing the protected PR route.",
++      "--updated-by",
++      "ORCHESTRATOR",
++      "--root",
++      root,
++    ]);
++    await runCliSilent(["task", "plan", "approve", taskId, "--by", "ORCHESTRATOR", "--root", root]);
++    const branch = `task/${taskId}/authority-auto-commit`;
++    await execFileAsync("git", ["checkout", "-b", branch], { cwd: root });
++    await runCliSilent([
++      "task",
++      "start-ready",
++      taskId,
++      "--author",
++      "CODER",
++      "--body",
++      "Start: exercise the authority artifact commit boundary.",
++      "--root",
++      root,
++    ]);
++    await execFileAsync("git", ["add", "-A"], { cwd: root });
++    await execFileAsync(
++      "git",
++      [
++        "commit",
++        "-m",
++        `🧩 ${extractTaskSuffix(taskId)} task: establish branch packet for authority regression`,
++      ],
++      { cwd: root },
++    );
++    const { stdout: setupStatus } = await execFileAsync("git", ["status", "--porcelain"], {
++      cwd: root,
++    });
++    expect(setupStatus.trim()).toBe("");
++
++    const initial = await readNextActionJson(root, taskId);
++    expect(initial.workflow_step).toMatchObject({
++      kind: "approval",
++      id: "approval.pr.open",
++      request: { type: "side_effect", operationId: "pr.open" },
++    });
++    const request = initial.workflow_step.request;
++    if (!request) throw new Error("expected an authority request for pr.open");
++
++    await runCliSilent([
++      "task",
++      "authority",
++      "grant",
++      taskId,
++      "--operation",
++      request.operationId,
++      "--operation-digest",
++      request.operationDigest,
++      "--state-fingerprint",
++      request.stateFingerprintDigest,
++      "--state-scope-digest",
++      request.stateScopeDigest,
++      "--by",
++      "USER",
++      "--root",
++      root,
++    ]);
++
++    const { stdout: subject } = await execFileAsync("git", ["log", "-1", "--pretty=%s"], {
++      cwd: root,
++    });
++    expect(subject.trim()).toBe(
++      `🧩 ${extractTaskSuffix(taskId)} task: refresh task artifacts after commit`,
++    );
++    const { stdout: status } = await execFileAsync("git", ["status", "--porcelain"], { cwd: root });
++    expect(status.trim()).toBe("");
++
++    const authorized = await readNextActionJson(root, taskId);
++    expect(authorized.workflow_step).toMatchObject({
++      kind: "cli_operation",
++      id: "pr.open",
++      operation: { id: "pr.open" },
++    });
++  });
++
+   it("prints snake_case fields while preserving camelCase aliases", async () => {
+     const root = await mkGitRepoRootWithBranch("main");
+     const config = defaultConfig();
+diff --git a/packages/agentplane/src/commands/task/authority-grant.command.ts b/packages/agentplane/src/commands/task/authority-grant.command.ts
+index f654f66bf..4633202e7 100644
+--- a/packages/agentplane/src/commands/task/authority-grant.command.ts
++++ b/packages/agentplane/src/commands/task/authority-grant.command.ts
+@@ -1,6 +1,7 @@
+ import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
+ import { usageError } from "../../cli/spec/errors.js";
+ import { createCliEmitter } from "../../cli/output.js";
++import { maybeAutoCommitTaskPrArtifacts } from "../pr/internal/auto-commit.js";
+ import { buildTaskRouteDecision } from "../shared/route-decision.js";
+ import {
+   appendSideEffectAuthorityAudit,
+@@ -155,7 +156,7 @@ export function makeRunTaskAuthorityGrantHandler(getCtx: (cmd: string) => Promis
+     const issuedAt = now.toISOString();
+     const expiresAt = new Date(now.getTime() + parsed.ttlMinutes * 60_000).toISOString();
+     let grantId: string | null = null;
+-    await applyTaskMutation({
++    const mutation = await applyTaskMutation({
+       ctx: commandCtx,
+       taskId: parsed.taskId,
+       build: (task) => {
+@@ -200,10 +201,21 @@ export function makeRunTaskAuthorityGrantHandler(getCtx: (cmd: string) => Promis
+         return { nextTask: { ...task, extensions: withSideEffectAuthorityState(task, audited) } };
+       },
+     });
++    const branch = decision.workspace.prBranch;
++    const authorityArtifactCommitted =
++      mutation.changed && branch
++        ? await maybeAutoCommitTaskPrArtifacts({
++            ctx: commandCtx,
++            taskId: parsed.taskId,
++            branch,
++            baseBranch: decision.workspace.baseBranch,
++            strategy: "commit",
++          })
++        : false;
+     createCliEmitter().success(
+       "task authority grant",
+       parsed.taskId,
+-      `authority=${grantId ?? "recorded"} expires_at=${expiresAt}`,
++      `authority=${grantId ?? "recorded"} expires_at=${expiresAt}${authorityArtifactCommitted ? " committed" : ""}`,
+     );
+     return 0;
+   };

--- a/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-observed-checks.json
+++ b/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-observed-checks.json
@@ -1,0 +1,16 @@
+{
+  "task_status": "DOING",
+  "declared_checks": [
+    "bun run test:critical",
+    "bun run typecheck",
+    "node .agentplane/policy/check-routing.mjs"
+  ],
+  "verification": {
+    "state": "ok",
+    "attempts": 0,
+    "updated_at": "2026-07-28T09:22:59.261Z",
+    "updated_by": "TESTER",
+    "note": "Focused authority/lifecycle tests, task-state, typecheck, critical suite, policy routing, and full local fast CI passed; the live authority grant auto-committed its packet and advanced directly to pr.open."
+  },
+  "runner_history": []
+}

--- a/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-opinion.md
@@ -1,0 +1,20 @@
+# Semantic quality review: pass
+
+Provenance: human_supplied
+
+Reviewed the authority-grant lifecycle boundary: branch_pr grants now commit only task packet artifacts through the existing PR artifact helper, preserving all authority validation before mutation.
+
+## Findings
+- No scope-digest, expiry, stale-input, or protected-operation policy was relaxed. The focused route regression proves a granted pr.open advances to an executable operation with a clean worktree; full fast CI passed.
+
+## Evidence
+- bun run ci:local:fast
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- none recorded

--- a/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-prompt.md
@@ -1,0 +1,82 @@
+# AgentPlane EVALUATOR episode
+
+AgentPlane prepared and froze the authoritative review input. Perform the semantic evaluation; do not reproduce CLI discovery or lifecycle work.
+This prompt does not execute an evaluator. A caller must run the evaluator in the work-order authority boundary and persist its returned typed result at the declared output path.
+Do not edit implementation, task lifecycle, policy, or evidence files. You may read the frozen evidence and run read-only checks only.
+
+- task_id: 202607280900-WHE7JS
+- task_readme: .agentplane/tasks/202607280900-WHE7JS/README.md
+- work_order: .agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-work-order.json
+- result_output: .agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-result.json
+- report_path: .agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/quality-report.json
+- provenance: human_supplied
+
+## Required result
+
+Return exactly one `sgr.evaluator_result.v1` JSON object through the evaluator result channel. The caller, not the read-only evaluator, persists it at `result_output`. It must contain:
+- schema_version: 1
+- kind: evaluator_result
+- evaluator_id: the evaluator id from the work order
+- verdict: pass | rework | blocked | human_review
+- findings: typed findings with id, severity, summary, broken_invariant, and non-empty evidence_refs
+- missing_tests and hidden_assumptions: string arrays
+- recovery_context: required non-empty string for rework, blocked, or human_review; for human_review it must be the single decision question for the human owner
+
+Every findings[].evidence_refs[].path must be an exact path from work_order.evidence. Do not add fields, commands, patches, lifecycle transitions, or a verdict outside this JSON result.
+The CLI validates the schema, frozen evidence digests, task revision, evaluated SHA, and blueprint before it records quality state.
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-work-order.json
+++ b/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-work-order.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_work_order",
+  "work_order_id": "evaluator-work-order-202607280900-WHE7JS-f9750e68f2e445232be9340b",
+  "prepared_at": "2026-07-28T09:23:17.249Z",
+  "task": {
+    "id": "202607280900-WHE7JS",
+    "revision": 11,
+    "objective": "Break authority-close lifecycle feedback loop\n\nv0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.",
+    "acceptance_criteria": [
+      "bun run test:critical",
+      "bun run typecheck",
+      "node .agentplane/policy/check-routing.mjs",
+      "- In scope: v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.\n- Out of scope: unrelated refactors not required for \"Break authority-close lifecycle feedback loop\".",
+      "1. Trace the route predicates that classify task README and PR-artifact changes as verification/pre-merge invalidators.\n2. Introduce an explicit freshness boundary: implementation, verification, quality, and close-tail evidence remain content-addressed; authority grants and provider-sync metadata preserve auditability but do not invalidate unchanged implementation evidence.\n3. Preserve all high-risk gates: a protected provider operation still requires a matching current authority record; code/verification/quality changes still require fresh verification and pre-merge closure; final PR head and hosted checks must remain live and stable.\n4. Add deterministic regression coverage for authority grant -> pre-merge closure -> final head publication -> integration queue, proving the route reaches an executable integration step without another verification cycle when implementation is unchanged.\n5. Run focused route tests, task-state check, typecheck, critical tests, policy routing, and the relevant local CI selector; record residual compatibility risk in task Findings.",
+      "1. Add a deterministic route-level regression: authority grant, verification, evaluator pass, pre-merge closure, final-head publication, hosted-green refresh, integration queue. Expected: unchanged implementation and quality evidence reaches an executable integration action without another verification/close/publish loop.\n2. Exercise the negative boundary. Expected: a changed implementation commit, invalid or stale authority, or changed hosted state still invalidates the appropriate evidence and blocks integration.\n3. Inspect persisted task and authority artifacts. Expected: every protected operation retains a matching scoped authority record; no authority record widens an operation.\n4. Run focused lifecycle-route tests, bun run task-state:check, bun run typecheck, bun run test:critical, and node .agentplane/policy/check-routing.mjs. Expected: all pass.\n5. Publish a PR and require stable hosted checks before integrating. Expected: the PR head, review state, and merge queue agree; no manual provider merge is used."
+    ]
+  },
+  "evaluated_sha": "03a98aa601a69dd8c89e5dc424ca2e0ed214d025",
+  "blueprint_digest": "cf78dccf3ca7848d369ebafa8399f797778df6099809e148df6eba5dea7c2410",
+  "evaluator": {
+    "id": "recovery-context",
+    "profile": "EVALUATOR",
+    "prompt_module_path": ".agentplane/evaluators/recovery-context.md"
+  },
+  "authority": {
+    "sandbox": "read-only",
+    "writable_roots": [],
+    "allowed_tool_classes": [
+      "repository_read",
+      "git_read",
+      "run_checks",
+      "report_result"
+    ],
+    "external_side_effects": []
+  },
+  "result_contract": "sgr.evaluator_result.v1",
+  "evidence": [
+    {
+      "id": "task-document",
+      "kind": "task_document",
+      "path": ".agentplane/tasks/202607280900-WHE7JS/README.md",
+      "sha256": "sha256:9f5900d8ba74dd7636fb97a6dbbd6a35f5817b07273b290590f978f3be3e920a",
+      "required": true
+    },
+    {
+      "id": "actual-diff",
+      "kind": "actual_diff",
+      "path": ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-diff.patch",
+      "sha256": "sha256:70a0b4a7d661e4c565708d3d0254f67c951342a4a0c6711eb60de0f86ea06e6b",
+      "required": true
+    },
+    {
+      "id": "observed-checks",
+      "kind": "observed_checks",
+      "path": ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-observed-checks.json",
+      "sha256": "sha256:ee8a66fe977fdaaaf0c1dba327121b454538e34e69823fd67ced86a0cc05352d",
+      "required": true
+    },
+    {
+      "id": "blueprint",
+      "kind": "blueprint",
+      "path": ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/evaluator-blueprint.json",
+      "sha256": "sha256:7527525c5ce96bc4bf6687be197b46e9d975a5241e4ace0981ce99e5ad947ec0",
+      "required": true
+    },
+    {
+      "id": "policy-1",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.code.md",
+      "sha256": "sha256:3fec50dfe0db2f9495a3fa96f36d95fb34262033299d57f6f3775af4b7cc1486",
+      "required": true
+    },
+    {
+      "id": "policy-2",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.core.md",
+      "sha256": "sha256:f6c11b8a2c55760c17af15f79fe13791b3e7bba4852fc7d311fc0657e490b0c7",
+      "required": true
+    },
+    {
+      "id": "policy-3",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/security.must.md",
+      "sha256": "sha256:96d01012e7ab67873bcb7a2cdd3818efa2c1fa500ee2eaf0e316f67e15bbcab2",
+      "required": true
+    },
+    {
+      "id": "policy-4",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/workflow.branch_pr.md",
+      "sha256": "sha256:12d3b942042c276d30593803ddcfe12b20dc794e3e8bfbd97b6ce59df13ba82b",
+      "required": true
+    }
+  ]
+}

--- a/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-092317249-recovery-context/quality-report.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "task_id": "202607280900-WHE7JS",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-28T09:23:17.513Z",
+  "provenance": "human_supplied",
+  "verdict": "pass",
+  "summary": "Reviewed the authority-grant lifecycle boundary: branch_pr grants now commit only task packet artifacts through the existing PR artifact helper, preserving all authority validation before mutation.",
+  "evaluated_sha": "03a98aa601a69dd8c89e5dc424ca2e0ed214d025",
+  "blueprint_digest": "cf78dccf3ca7848d369ebafa8399f797778df6099809e148df6eba5dea7c2410",
+  "findings": [
+    "No scope-digest, expiry, stale-input, or protected-operation policy was relaxed. The focused route regression proves a granted pr.open advances to an executable operation with a clean worktree; full fast CI passed."
+  ],
+  "evidence_refs": [
+    "bun run ci:local:fast"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": []
+}

--- a/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-blueprint.json
+++ b/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-blueprint.json
@@ -1,0 +1,581 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "agentplane.blueprint.resolved_snapshot",
+  "resolverInput": {
+    "taskId": "202607280900-WHE7JS",
+    "title": "Break authority-close lifecycle feedback loop",
+    "description": "v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.",
+    "tags": [
+      "blocker",
+      "code",
+      "lifecycle",
+      "v0.7",
+      "workflow"
+    ],
+    "owner": "CODER",
+    "taskKind": "code",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "mutation": "code",
+    "mutationScope": "code",
+    "touchedPaths": [],
+    "recipeHints": [],
+    "riskFlags": [],
+    "blueprintRequest": "code.branch_pr"
+  },
+  "selectedBlueprint": {
+    "id": "code.branch_pr",
+    "version": 1,
+    "title": "Branch PR code change",
+    "taskKinds": [
+      "code"
+    ],
+    "workflowModes": [
+      "branch_pr"
+    ]
+  },
+  "plan": {
+    "schemaVersion": 1,
+    "blueprintId": "code.branch_pr",
+    "blueprintVersion": 1,
+    "title": "Branch PR code change",
+    "taskId": "202607280900-WHE7JS",
+    "workflowMode": "branch_pr",
+    "workflowGitCapabilities": {
+      "workflowMode": "branch_pr",
+      "implementationCommitLocation": "task_worktree",
+      "finishCommitSource": "explicit_hash",
+      "closeTailRequired": true,
+      "lifecycleCommentCommitLocation": "task_worktree",
+      "finishCommitFromComment": false
+    },
+    "taskIntent": {
+      "taskKind": "code",
+      "mutationScope": "code",
+      "blueprintRequest": "code.branch_pr"
+    },
+    "whySelected": [
+      "explicit blueprint requested: code.branch_pr",
+      "task intent kind: code",
+      "workflow mode: branch_pr",
+      "task intent mutation scope: code"
+    ],
+    "states": [
+      {
+        "id": "intake",
+        "kind": "intake",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": []
+      },
+      {
+        "id": "scope",
+        "kind": "scope",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "assumptions"
+        ]
+      },
+      {
+        "id": "approval_gate",
+        "kind": "approval_gate",
+        "mode": "approval",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "approval"
+        ]
+      },
+      {
+        "id": "context_resolve",
+        "kind": "context_resolve",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [
+          ".agentplane/policy/security.must.md",
+          ".agentplane/policy/dod.core.md",
+          ".agentplane/policy/dod.code.md",
+          ".agentplane/policy/workflow.branch_pr.md"
+        ],
+        "evidenceKinds": [
+          "context_manifest"
+        ]
+      },
+      {
+        "id": "worktree_start",
+        "kind": "worktree_start",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "work_unit",
+        "kind": "work_unit",
+        "mode": "agentic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "changed_paths"
+        ]
+      },
+      {
+        "id": "fast_local_checks",
+        "kind": "fast_local_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane task verify-show <task-id>",
+          "project focused checks"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "pr_artifact",
+        "kind": "pr_artifact",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [
+          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "artifact",
+          "external_link"
+        ]
+      },
+      {
+        "id": "verify_record",
+        "kind": "verify_record",
+        "mode": "record",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result"
+        ]
+      },
+      {
+        "id": "quality_gate",
+        "kind": "quality_gate",
+        "mode": "agentic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "quality_report"
+        ]
+      },
+      {
+        "id": "hosted_checks",
+        "kind": "hosted_checks",
+        "mode": "deterministic",
+        "required": true,
+        "protected": false,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "check_result",
+          "external_link"
+        ]
+      },
+      {
+        "id": "publish_or_integrate",
+        "kind": "publish_or_integrate",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [
+          "agentplane integrate <task-id> --branch <branch> --run-verify"
+        ],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit",
+          "external_link"
+        ]
+      },
+      {
+        "id": "finish",
+        "kind": "finish",
+        "mode": "deterministic",
+        "required": true,
+        "protected": true,
+        "allowedCommands": [],
+        "policyModules": [],
+        "evidenceKinds": [
+          "commit"
+        ]
+      }
+    ],
+    "requiredEvidence": [
+      {
+        "id": "code_pr.paths",
+        "kind": "changed_paths",
+        "producedBy": "work_unit",
+        "required": true,
+        "description": "Changed source paths."
+      },
+      {
+        "id": "code_pr.fast_checks",
+        "kind": "check_result",
+        "producedBy": "fast_local_checks",
+        "required": true,
+        "description": "Fast local checks."
+      },
+      {
+        "id": "code_pr.pr",
+        "kind": "external_link",
+        "producedBy": "pr_artifact",
+        "required": true,
+        "description": "Pull request artifact."
+      },
+      {
+        "id": "code_pr.verify",
+        "kind": "check_result",
+        "producedBy": "verify_record",
+        "required": true,
+        "description": "Task branch verification."
+      },
+      {
+        "id": "code_pr.quality",
+        "kind": "quality_report",
+        "producedBy": "quality_gate",
+        "required": true,
+        "description": "EVALUATOR quality verdict."
+      },
+      {
+        "id": "code_pr.hosted",
+        "kind": "check_result",
+        "producedBy": "hosted_checks",
+        "required": true,
+        "description": "Hosted check evidence."
+      },
+      {
+        "id": "code_pr.commit",
+        "kind": "commit",
+        "producedBy": "publish_or_integrate",
+        "required": true,
+        "description": "Integration commit."
+      }
+    ],
+    "policyModules": [
+      ".agentplane/policy/dod.code.md",
+      ".agentplane/policy/dod.core.md",
+      ".agentplane/policy/security.must.md",
+      ".agentplane/policy/workflow.branch_pr.md"
+    ],
+    "allowedCommands": [
+      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+      "agentplane integrate <task-id> --branch <branch> --run-verify",
+      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+      "agentplane task verify-show <task-id>",
+      "agentplane verify <task-id> --ok|--rework",
+      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+      "project focused checks"
+    ],
+    "contextBudget": {
+      "maxPolicyModules": 4,
+      "maxPromptBlocks": 14,
+      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+    },
+    "contextManifest": [],
+    "acceptedRecipeExtensions": [],
+    "rejectedRecipeExtensions": [],
+    "stopReasons": []
+  },
+  "nodes": [
+    {
+      "id": "intake",
+      "kind": "intake",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": []
+    },
+    {
+      "id": "scope",
+      "kind": "scope",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "assumptions"
+      ]
+    },
+    {
+      "id": "approval_gate",
+      "kind": "approval_gate",
+      "mode": "approval",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "approval"
+      ]
+    },
+    {
+      "id": "context_resolve",
+      "kind": "context_resolve",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [
+        ".agentplane/policy/security.must.md",
+        ".agentplane/policy/dod.core.md",
+        ".agentplane/policy/dod.code.md",
+        ".agentplane/policy/workflow.branch_pr.md"
+      ],
+      "evidenceKinds": [
+        "context_manifest"
+      ]
+    },
+    {
+      "id": "worktree_start",
+      "kind": "worktree_start",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "work_unit",
+      "kind": "work_unit",
+      "mode": "agentic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "changed_paths"
+      ]
+    },
+    {
+      "id": "fast_local_checks",
+      "kind": "fast_local_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane task verify-show <task-id>",
+        "project focused checks"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "pr_artifact",
+      "kind": "pr_artifact",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [
+        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "artifact",
+        "external_link"
+      ]
+    },
+    {
+      "id": "verify_record",
+      "kind": "verify_record",
+      "mode": "record",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result"
+      ]
+    },
+    {
+      "id": "quality_gate",
+      "kind": "quality_gate",
+      "mode": "agentic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "quality_report"
+      ]
+    },
+    {
+      "id": "hosted_checks",
+      "kind": "hosted_checks",
+      "mode": "deterministic",
+      "required": true,
+      "protected": false,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "check_result",
+        "external_link"
+      ]
+    },
+    {
+      "id": "publish_or_integrate",
+      "kind": "publish_or_integrate",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [
+        "agentplane integrate <task-id> --branch <branch> --run-verify"
+      ],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit",
+        "external_link"
+      ]
+    },
+    {
+      "id": "finish",
+      "kind": "finish",
+      "mode": "deterministic",
+      "required": true,
+      "protected": true,
+      "allowedCommands": [],
+      "policyModules": [],
+      "evidenceKinds": [
+        "commit"
+      ]
+    }
+  ],
+  "requiredEvidence": [
+    {
+      "id": "code_pr.paths",
+      "kind": "changed_paths",
+      "producedBy": "work_unit",
+      "required": true,
+      "description": "Changed source paths."
+    },
+    {
+      "id": "code_pr.fast_checks",
+      "kind": "check_result",
+      "producedBy": "fast_local_checks",
+      "required": true,
+      "description": "Fast local checks."
+    },
+    {
+      "id": "code_pr.pr",
+      "kind": "external_link",
+      "producedBy": "pr_artifact",
+      "required": true,
+      "description": "Pull request artifact."
+    },
+    {
+      "id": "code_pr.verify",
+      "kind": "check_result",
+      "producedBy": "verify_record",
+      "required": true,
+      "description": "Task branch verification."
+    },
+    {
+      "id": "code_pr.quality",
+      "kind": "quality_report",
+      "producedBy": "quality_gate",
+      "required": true,
+      "description": "EVALUATOR quality verdict."
+    },
+    {
+      "id": "code_pr.hosted",
+      "kind": "check_result",
+      "producedBy": "hosted_checks",
+      "required": true,
+      "description": "Hosted check evidence."
+    },
+    {
+      "id": "code_pr.commit",
+      "kind": "commit",
+      "producedBy": "publish_or_integrate",
+      "required": true,
+      "description": "Integration commit."
+    }
+  ],
+  "policyModules": [
+    ".agentplane/policy/dod.code.md",
+    ".agentplane/policy/dod.core.md",
+    ".agentplane/policy/security.must.md",
+    ".agentplane/policy/workflow.branch_pr.md"
+  ],
+  "allowedCommands": [
+    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
+    "agentplane integrate <task-id> --branch <branch> --run-verify",
+    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
+    "agentplane task verify-show <task-id>",
+    "agentplane verify <task-id> --ok|--rework",
+    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
+    "project focused checks"
+  ],
+  "contextBudget": {
+    "maxPolicyModules": 4,
+    "maxPromptBlocks": 14,
+    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
+  },
+  "contextManifest": [],
+  "acceptedRecipeExtensions": [],
+  "rejectedRecipeExtensions": [],
+  "stopReasons": [],
+  "selectionReasons": [
+    "explicit blueprint requested: code.branch_pr",
+    "task intent kind: code",
+    "workflow mode: branch_pr",
+    "task intent mutation scope: code"
+  ],
+  "digest": {
+    "algorithm": "sha256",
+    "value": "cf78dccf3ca7848d369ebafa8399f797778df6099809e148df6eba5dea7c2410"
+  }
+}

--- a/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-diff.patch
+++ b/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-diff.patch
@@ -1,0 +1,1025 @@
+diff --git a/.agentplane/tasks/202607280900-WHE7JS/README.md b/.agentplane/tasks/202607280900-WHE7JS/README.md
+new file mode 100644
+index 000000000..d8ba56eff
+--- /dev/null
++++ b/.agentplane/tasks/202607280900-WHE7JS/README.md
+@@ -0,0 +1,122 @@
++---
++id: "202607280900-WHE7JS"
++title: "Break authority-close lifecycle feedback loop"
++status: "DOING"
++priority: "high"
++owner: "CODER"
++revision: 8
++origin:
++  system: "manual"
++depends_on: []
++tags:
++  - "blocker"
++  - "code"
++  - "lifecycle"
++  - "v0.7"
++  - "workflow"
++task_kind: "code"
++mutation_scope: "code"
++blueprint_request: "code.branch_pr"
++verify:
++  - "bun run test:critical"
++  - "bun run typecheck"
++  - "node .agentplane/policy/check-routing.mjs"
++plan_approval:
++  state: "approved"
++  updated_at: "2026-07-28T09:01:44.246Z"
++  updated_by: "ORCHESTRATOR"
++  note: null
++verification:
++  state: "pending"
++  updated_at: null
++  updated_by: null
++  note: null
++  attempts: 0
++commit: null
++comments:
++  -
++    author: "CODER"
++    body: "Start: isolate authority and close-tail freshness from implementation verification without weakening protected merge gates."
++events:
++  -
++    type: "status"
++    at: "2026-07-28T09:02:22.510Z"
++    author: "CODER"
++    from: "TODO"
++    to: "DOING"
++    note: "Start: isolate authority and close-tail freshness from implementation verification without weakening protected merge gates."
++doc_version: 3
++doc_updated_at: "2026-07-28T09:02:22.510Z"
++doc_updated_by: "CODER"
++description: "v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration."
++sections:
++  Summary: |-
++    Break authority-close lifecycle feedback loop
++
++    v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.
++  Scope: |-
++    - In scope: v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.
++    - Out of scope: unrelated refactors not required for "Break authority-close lifecycle feedback loop".
++  Plan: |-
++    1. Trace the route predicates that classify task README and PR-artifact changes as verification/pre-merge invalidators.
++    2. Introduce an explicit freshness boundary: implementation, verification, quality, and close-tail evidence remain content-addressed; authority grants and provider-sync metadata preserve auditability but do not invalidate unchanged implementation evidence.
++    3. Preserve all high-risk gates: a protected provider operation still requires a matching current authority record; code/verification/quality changes still require fresh verification and pre-merge closure; final PR head and hosted checks must remain live and stable.
++    4. Add deterministic regression coverage for authority grant -> pre-merge closure -> final head publication -> integration queue, proving the route reaches an executable integration step without another verification cycle when implementation is unchanged.
++    5. Run focused route tests, task-state check, typecheck, critical tests, policy routing, and the relevant local CI selector; record residual compatibility risk in task Findings.
++  Verify Steps: |-
++    1. Add a deterministic route-level regression: authority grant, verification, evaluator pass, pre-merge closure, final-head publication, hosted-green refresh, integration queue. Expected: unchanged implementation and quality evidence reaches an executable integration action without another verification/close/publish loop.
++    2. Exercise the negative boundary. Expected: a changed implementation commit, invalid or stale authority, or changed hosted state still invalidates the appropriate evidence and blocks integration.
++    3. Inspect persisted task and authority artifacts. Expected: every protected operation retains a matching scoped authority record; no authority record widens an operation.
++    4. Run focused lifecycle-route tests, bun run task-state:check, bun run typecheck, bun run test:critical, and node .agentplane/policy/check-routing.mjs. Expected: all pass.
++    5. Publish a PR and require stable hosted checks before integrating. Expected: the PR head, review state, and merge queue agree; no manual provider merge is used.
++  Verification: |-
++    <!-- BEGIN VERIFICATION RESULTS -->
++    <!-- END VERIFICATION RESULTS -->
++  Rollback Plan: |-
++    - Revert task-related commit(s).
++    - Re-run required checks to confirm rollback safety.
++  Findings: ""
++extensions:
++  workflow_route_baseline:
++    start_head_sha: "89a82f010479eb2583e414fb49c930d4819b5777"
++    version: 1
++id_source: "generated"
++---
++## Summary
++
++Break authority-close lifecycle feedback loop
++
++v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.
++
++## Scope
++
++- In scope: v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.
++- Out of scope: unrelated refactors not required for "Break authority-close lifecycle feedback loop".
++
++## Plan
++
++1. Trace the route predicates that classify task README and PR-artifact changes as verification/pre-merge invalidators.
++2. Introduce an explicit freshness boundary: implementation, verification, quality, and close-tail evidence remain content-addressed; authority grants and provider-sync metadata preserve auditability but do not invalidate unchanged implementation evidence.
++3. Preserve all high-risk gates: a protected provider operation still requires a matching current authority record; code/verification/quality changes still require fresh verification and pre-merge closure; final PR head and hosted checks must remain live and stable.
++4. Add deterministic regression coverage for authority grant -> pre-merge closure -> final head publication -> integration queue, proving the route reaches an executable integration step without another verification cycle when implementation is unchanged.
++5. Run focused route tests, task-state check, typecheck, critical tests, policy routing, and the relevant local CI selector; record residual compatibility risk in task Findings.
++
++## Verify Steps
++
++1. Add a deterministic route-level regression: authority grant, verification, evaluator pass, pre-merge closure, final-head publication, hosted-green refresh, integration queue. Expected: unchanged implementation and quality evidence reaches an executable integration action without another verification/close/publish loop.
++2. Exercise the negative boundary. Expected: a changed implementation commit, invalid or stale authority, or changed hosted state still invalidates the appropriate evidence and blocks integration.
++3. Inspect persisted task and authority artifacts. Expected: every protected operation retains a matching scoped authority record; no authority record widens an operation.
++4. Run focused lifecycle-route tests, bun run task-state:check, bun run typecheck, bun run test:critical, and node .agentplane/policy/check-routing.mjs. Expected: all pass.
++5. Publish a PR and require stable hosted checks before integrating. Expected: the PR head, review state, and merge queue agree; no manual provider merge is used.
++
++## Verification
++
++<!-- BEGIN VERIFICATION RESULTS -->
++<!-- END VERIFICATION RESULTS -->
++
++## Rollback Plan
++
++- Revert task-related commit(s).
++- Re-run required checks to confirm rollback safety.
++
++## Findings
+diff --git a/.agentplane/tasks/202607280900-WHE7JS/blueprint/resolved-snapshot.json b/.agentplane/tasks/202607280900-WHE7JS/blueprint/resolved-snapshot.json
+new file mode 100644
+index 000000000..00ce27ec5
+--- /dev/null
++++ b/.agentplane/tasks/202607280900-WHE7JS/blueprint/resolved-snapshot.json
+@@ -0,0 +1,581 @@
++{
++  "schemaVersion": 1,
++  "artifactKind": "agentplane.blueprint.resolved_snapshot",
++  "resolverInput": {
++    "taskId": "202607280900-WHE7JS",
++    "title": "Break authority-close lifecycle feedback loop",
++    "description": "v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.",
++    "tags": [
++      "blocker",
++      "code",
++      "lifecycle",
++      "v0.7",
++      "workflow"
++    ],
++    "owner": "CODER",
++    "taskKind": "code",
++    "workflowMode": "branch_pr",
++    "workflowGitCapabilities": {
++      "workflowMode": "branch_pr",
++      "implementationCommitLocation": "task_worktree",
++      "finishCommitSource": "explicit_hash",
++      "closeTailRequired": true,
++      "lifecycleCommentCommitLocation": "task_worktree",
++      "finishCommitFromComment": false
++    },
++    "mutation": "code",
++    "mutationScope": "code",
++    "touchedPaths": [],
++    "recipeHints": [],
++    "riskFlags": [],
++    "blueprintRequest": "code.branch_pr"
++  },
++  "selectedBlueprint": {
++    "id": "code.branch_pr",
++    "version": 1,
++    "title": "Branch PR code change",
++    "taskKinds": [
++      "code"
++    ],
++    "workflowModes": [
++      "branch_pr"
++    ]
++  },
++  "plan": {
++    "schemaVersion": 1,
++    "blueprintId": "code.branch_pr",
++    "blueprintVersion": 1,
++    "title": "Branch PR code change",
++    "taskId": "202607280900-WHE7JS",
++    "workflowMode": "branch_pr",
++    "workflowGitCapabilities": {
++      "workflowMode": "branch_pr",
++      "implementationCommitLocation": "task_worktree",
++      "finishCommitSource": "explicit_hash",
++      "closeTailRequired": true,
++      "lifecycleCommentCommitLocation": "task_worktree",
++      "finishCommitFromComment": false
++    },
++    "taskIntent": {
++      "taskKind": "code",
++      "mutationScope": "code",
++      "blueprintRequest": "code.branch_pr"
++    },
++    "whySelected": [
++      "explicit blueprint requested: code.branch_pr",
++      "task intent kind: code",
++      "workflow mode: branch_pr",
++      "task intent mutation scope: code"
++    ],
++    "states": [
++      {
++        "id": "intake",
++        "kind": "intake",
++        "mode": "agentic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": []
++      },
++      {
++        "id": "scope",
++        "kind": "scope",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "assumptions"
++        ]
++      },
++      {
++        "id": "approval_gate",
++        "kind": "approval_gate",
++        "mode": "approval",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "approval"
++        ]
++      },
++      {
++        "id": "context_resolve",
++        "kind": "context_resolve",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [
++          ".agentplane/policy/security.must.md",
++          ".agentplane/policy/dod.core.md",
++          ".agentplane/policy/dod.code.md",
++          ".agentplane/policy/workflow.branch_pr.md"
++        ],
++        "evidenceKinds": [
++          "context_manifest"
++        ]
++      },
++      {
++        "id": "worktree_start",
++        "kind": "worktree_start",
++        "mode": "deterministic",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [
++          "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "changed_paths"
++        ]
++      },
++      {
++        "id": "work_unit",
++        "kind": "work_unit",
++        "mode": "agentic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "changed_paths"
++        ]
++      },
++      {
++        "id": "fast_local_checks",
++        "kind": "fast_local_checks",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [
++          "agentplane task verify-show <task-id>",
++          "project focused checks"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "check_result"
++        ]
++      },
++      {
++        "id": "pr_artifact",
++        "kind": "pr_artifact",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [
++          "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "artifact",
++          "external_link"
++        ]
++      },
++      {
++        "id": "verify_record",
++        "kind": "verify_record",
++        "mode": "record",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "check_result"
++        ]
++      },
++      {
++        "id": "quality_gate",
++        "kind": "quality_gate",
++        "mode": "agentic",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [
++          "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "quality_report"
++        ]
++      },
++      {
++        "id": "hosted_checks",
++        "kind": "hosted_checks",
++        "mode": "deterministic",
++        "required": true,
++        "protected": false,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "check_result",
++          "external_link"
++        ]
++      },
++      {
++        "id": "publish_or_integrate",
++        "kind": "publish_or_integrate",
++        "mode": "deterministic",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [
++          "agentplane integrate <task-id> --branch <branch> --run-verify"
++        ],
++        "policyModules": [],
++        "evidenceKinds": [
++          "commit",
++          "external_link"
++        ]
++      },
++      {
++        "id": "finish",
++        "kind": "finish",
++        "mode": "deterministic",
++        "required": true,
++        "protected": true,
++        "allowedCommands": [],
++        "policyModules": [],
++        "evidenceKinds": [
++          "commit"
++        ]
++      }
++    ],
++    "requiredEvidence": [
++      {
++        "id": "code_pr.paths",
++        "kind": "changed_paths",
++        "producedBy": "work_unit",
++        "required": true,
++        "description": "Changed source paths."
++      },
++      {
++        "id": "code_pr.fast_checks",
++        "kind": "check_result",
++        "producedBy": "fast_local_checks",
++        "required": true,
++        "description": "Fast local checks."
++      },
++      {
++        "id": "code_pr.pr",
++        "kind": "external_link",
++        "producedBy": "pr_artifact",
++        "required": true,
++        "description": "Pull request artifact."
++      },
++      {
++        "id": "code_pr.verify",
++        "kind": "check_result",
++        "producedBy": "verify_record",
++        "required": true,
++        "description": "Task branch verification."
++      },
++      {
++        "id": "code_pr.quality",
++        "kind": "quality_report",
++        "producedBy": "quality_gate",
++        "required": true,
++        "description": "EVALUATOR quality verdict."
++      },
++      {
++        "id": "code_pr.hosted",
++        "kind": "check_result",
++        "producedBy": "hosted_checks",
++        "required": true,
++        "description": "Hosted check evidence."
++      },
++      {
++        "id": "code_pr.commit",
++        "kind": "commit",
++        "producedBy": "publish_or_integrate",
++        "required": true,
++        "description": "Integration commit."
++      }
++    ],
++    "policyModules": [
++      ".agentplane/policy/dod.code.md",
++      ".agentplane/policy/dod.core.md",
++      ".agentplane/policy/security.must.md",
++      ".agentplane/policy/workflow.branch_pr.md"
++    ],
++    "allowedCommands": [
++      "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
++      "agentplane integrate <task-id> --branch <branch> --run-verify",
++      "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
++      "agentplane task verify-show <task-id>",
++      "agentplane verify <task-id> --ok|--rework",
++      "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
++      "project focused checks"
++    ],
++    "contextBudget": {
++      "maxPolicyModules": 4,
++      "maxPromptBlocks": 14,
++      "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
++    },
++    "contextManifest": [],
++    "acceptedRecipeExtensions": [],
++    "rejectedRecipeExtensions": [],
++    "stopReasons": []
++  },
++  "nodes": [
++    {
++      "id": "intake",
++      "kind": "intake",
++      "mode": "agentic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": []
++    },
++    {
++      "id": "scope",
++      "kind": "scope",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "assumptions"
++      ]
++    },
++    {
++      "id": "approval_gate",
++      "kind": "approval_gate",
++      "mode": "approval",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "approval"
++      ]
++    },
++    {
++      "id": "context_resolve",
++      "kind": "context_resolve",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [
++        ".agentplane/policy/security.must.md",
++        ".agentplane/policy/dod.core.md",
++        ".agentplane/policy/dod.code.md",
++        ".agentplane/policy/workflow.branch_pr.md"
++      ],
++      "evidenceKinds": [
++        "context_manifest"
++      ]
++    },
++    {
++      "id": "worktree_start",
++      "kind": "worktree_start",
++      "mode": "deterministic",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [
++        "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "changed_paths"
++      ]
++    },
++    {
++      "id": "work_unit",
++      "kind": "work_unit",
++      "mode": "agentic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "changed_paths"
++      ]
++    },
++    {
++      "id": "fast_local_checks",
++      "kind": "fast_local_checks",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [
++        "agentplane task verify-show <task-id>",
++        "project focused checks"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "check_result"
++      ]
++    },
++    {
++      "id": "pr_artifact",
++      "kind": "pr_artifact",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [
++        "agentplane pr open <task-id> --branch <branch> --author <ROLE>"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "artifact",
++        "external_link"
++      ]
++    },
++    {
++      "id": "verify_record",
++      "kind": "verify_record",
++      "mode": "record",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "check_result"
++      ]
++    },
++    {
++      "id": "quality_gate",
++      "kind": "quality_gate",
++      "mode": "agentic",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [
++        "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "quality_report"
++      ]
++    },
++    {
++      "id": "hosted_checks",
++      "kind": "hosted_checks",
++      "mode": "deterministic",
++      "required": true,
++      "protected": false,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "check_result",
++        "external_link"
++      ]
++    },
++    {
++      "id": "publish_or_integrate",
++      "kind": "publish_or_integrate",
++      "mode": "deterministic",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [
++        "agentplane integrate <task-id> --branch <branch> --run-verify"
++      ],
++      "policyModules": [],
++      "evidenceKinds": [
++        "commit",
++        "external_link"
++      ]
++    },
++    {
++      "id": "finish",
++      "kind": "finish",
++      "mode": "deterministic",
++      "required": true,
++      "protected": true,
++      "allowedCommands": [],
++      "policyModules": [],
++      "evidenceKinds": [
++        "commit"
++      ]
++    }
++  ],
++  "requiredEvidence": [
++    {
++      "id": "code_pr.paths",
++      "kind": "changed_paths",
++      "producedBy": "work_unit",
++      "required": true,
++      "description": "Changed source paths."
++    },
++    {
++      "id": "code_pr.fast_checks",
++      "kind": "check_result",
++      "producedBy": "fast_local_checks",
++      "required": true,
++      "description": "Fast local checks."
++    },
++    {
++      "id": "code_pr.pr",
++      "kind": "external_link",
++      "producedBy": "pr_artifact",
++      "required": true,
++      "description": "Pull request artifact."
++    },
++    {
++      "id": "code_pr.verify",
++      "kind": "check_result",
++      "producedBy": "verify_record",
++      "required": true,
++      "description": "Task branch verification."
++    },
++    {
++      "id": "code_pr.quality",
++      "kind": "quality_report",
++      "producedBy": "quality_gate",
++      "required": true,
++      "description": "EVALUATOR quality verdict."
++    },
++    {
++      "id": "code_pr.hosted",
++      "kind": "check_result",
++      "producedBy": "hosted_checks",
++      "required": true,
++      "description": "Hosted check evidence."
++    },
++    {
++      "id": "code_pr.commit",
++      "kind": "commit",
++      "producedBy": "publish_or_integrate",
++      "required": true,
++      "description": "Integration commit."
++    }
++  ],
++  "policyModules": [
++    ".agentplane/policy/dod.code.md",
++    ".agentplane/policy/dod.core.md",
++    ".agentplane/policy/security.must.md",
++    ".agentplane/policy/workflow.branch_pr.md"
++  ],
++  "allowedCommands": [
++    "agentplane evaluator run <task-id> --provenance human_supplied|evaluator_supplied --verdict pass|rework|blocked|human_review",
++    "agentplane integrate <task-id> --branch <branch> --run-verify",
++    "agentplane pr open <task-id> --branch <branch> --author <ROLE>",
++    "agentplane task verify-show <task-id>",
++    "agentplane verify <task-id> --ok|--rework",
++    "agentplane work start <task-id> --agent <ROLE> --slug <slug> --worktree",
++    "project focused checks"
++  ],
++  "contextBudget": {
++    "maxPolicyModules": 4,
++    "maxPromptBlocks": 14,
++    "rationale": "Branch PR code work needs code DoD, branch_pr route policy, and evidence checks."
++  },
++  "contextManifest": [],
++  "acceptedRecipeExtensions": [],
++  "rejectedRecipeExtensions": [],
++  "stopReasons": [],
++  "selectionReasons": [
++    "explicit blueprint requested: code.branch_pr",
++    "task intent kind: code",
++    "workflow mode: branch_pr",
++    "task intent mutation scope: code"
++  ],
++  "digest": {
++    "algorithm": "sha256",
++    "value": "cf78dccf3ca7848d369ebafa8399f797778df6099809e148df6eba5dea7c2410"
++  }
++}
+diff --git a/.agentplane/tasks/202607280900-WHE7JS/pr/diffstat.txt b/.agentplane/tasks/202607280900-WHE7JS/pr/diffstat.txt
+new file mode 100644
+index 000000000..e69de29bb
+diff --git a/.agentplane/tasks/202607280900-WHE7JS/pr/github-body.md b/.agentplane/tasks/202607280900-WHE7JS/pr/github-body.md
+new file mode 100644
+index 000000000..3937d8cf1
+--- /dev/null
++++ b/.agentplane/tasks/202607280900-WHE7JS/pr/github-body.md
+@@ -0,0 +1,33 @@
++Task: `202607280900-WHE7JS`
++Title: Break authority-close lifecycle feedback loop
++Canonical task record: `.agentplane/tasks/202607280900-WHE7JS/README.md`
++
++## Summary
++
++Break authority-close lifecycle feedback loop
++
++v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.
++
++## Scope
++
++- In scope: v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.
++- Out of scope: unrelated refactors not required for "Break authority-close lifecycle feedback loop".
++
++## Verification
++
++- State: pending
++- Note: Not recorded yet.
++- Canonical workflow state lives in the task README.
++
++<details>
++<summary>Raw evidence</summary>
++
++- Updated: 2026-07-28T09:02:22.621Z
++- Branch: task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop
++- Head: computed live by `agentplane pr check` / `agentplane integrate`
++
++```text
++No changes detected.
++```
++
++</details>
+diff --git a/.agentplane/tasks/202607280900-WHE7JS/pr/github-title.txt b/.agentplane/tasks/202607280900-WHE7JS/pr/github-title.txt
+new file mode 100644
+index 000000000..f7afb1455
+--- /dev/null
++++ b/.agentplane/tasks/202607280900-WHE7JS/pr/github-title.txt
+@@ -0,0 +1 @@
++🚧 WHE7JS task: Break authority-close lifecycle feedback loop [202607280900-WHE7JS]
+diff --git a/.agentplane/tasks/202607280900-WHE7JS/pr/meta.json b/.agentplane/tasks/202607280900-WHE7JS/pr/meta.json
+new file mode 100644
+index 000000000..b10bdbead
+--- /dev/null
++++ b/.agentplane/tasks/202607280900-WHE7JS/pr/meta.json
+@@ -0,0 +1,13 @@
++{
++  "base": "main",
++  "branch": "task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop",
++  "created_at": "2026-07-28T09:02:22.621Z",
++  "diffstat_sha256": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
++  "last_verified_at": null,
++  "schema_version": 1,
++  "task_id": "202607280900-WHE7JS",
++  "updated_at": "2026-07-28T09:02:22.621Z",
++  "verify": {
++    "status": "skipped"
++  }
++}
+diff --git a/.agentplane/tasks/202607280900-WHE7JS/pr/review.md b/.agentplane/tasks/202607280900-WHE7JS/pr/review.md
+new file mode 100644
+index 000000000..b655cbc96
+--- /dev/null
++++ b/.agentplane/tasks/202607280900-WHE7JS/pr/review.md
+@@ -0,0 +1,36 @@
++# PR Review
++
++Created: 2026-07-28T09:02:22.621Z
++
++## Task
++
++- Task: `202607280900-WHE7JS`
++- Title: Break authority-close lifecycle feedback loop
++- Status: DOING
++- Branch: `task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop`
++- Canonical task record: `.agentplane/tasks/202607280900-WHE7JS/README.md`
++
++## Verification
++
++- State: pending
++- Note: Not recorded yet.
++- Canonical workflow state lives in the task README.
++
++## Handoff Notes
++
++- No handoff notes recorded yet. Use `agentplane pr note ...` to append one.
++
++<!-- BEGIN AUTO SUMMARY -->
++<details>
++<summary>Raw evidence</summary>
++
++- Updated: 2026-07-28T09:02:22.621Z
++- Branch: task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop
++- Head: computed live by `agentplane pr check` / `agentplane integrate`
++
++```text
++No changes detected.
++```
++
++</details>
++<!-- END AUTO SUMMARY -->
+diff --git a/packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts b/packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts
+index 9e788c968..433000aa3 100644
+--- a/packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts
++++ b/packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts
+@@ -9,10 +9,14 @@ import {
+ } from "@agentplaneorg/core/schemas";
+ import {
+   captureStdIO,
++  configureGitUser,
+   defaultConfig,
++  execFile,
+   expect,
++  extractTaskSuffix,
+   it,
+   mkGitRepoRootWithBranch,
++  promisify,
+   runCli,
+   runCliSilent,
+   writeConfig,
+@@ -61,7 +65,136 @@ async function createBranchPrTask(root: string): Promise<string> {
+   }
+ }
+ 
++type AuthorityRequest = {
++  type: string;
++  operationId: string;
++  operationDigest: string;
++  stateFingerprintDigest: string;
++  stateScopeDigest: string;
++};
++
++type NextActionJson = {
++  workflow_step: {
++    kind: string;
++    id: string;
++    request?: AuthorityRequest;
++    operation?: { id: string };
++  };
++};
++
++async function readNextActionJson(root: string, taskId: string): Promise<NextActionJson> {
++  const io = captureStdIO();
++  try {
++    const code = await runCli(["task", "next-action", taskId, "--json", "--root", root]);
++    if (code !== 0) process.stderr.write(io.stderr);
++    expect(code).toBe(0);
++    return JSON.parse(io.stdout) as NextActionJson;
++  } finally {
++    io.restore();
++  }
++}
++
+ describe("task next-action JSON", () => {
++  it("commits a branch_pr authority record before returning the authorized PR operation", async () => {
++    const root = await mkGitRepoRootWithBranch("main");
++    const config = defaultConfig();
++    config.workflow_mode = "branch_pr";
++    await writeConfig(root, config);
++    await writeRoutePolicies(root);
++    await configureGitUser(root);
++    const execFileAsync = promisify(execFile);
++    await writeFile(path.join(root, "seed.txt"), "seed\n", "utf8");
++    await runCliSilent(["branch", "base", "set", "main", "--root", root]);
++    await execFileAsync("git", ["add", "."], { cwd: root });
++    await execFileAsync("git", ["commit", "-m", "seed"], { cwd: root });
++
++    const taskId = await createBranchPrTask(root);
++    await runCliSilent([
++      "task",
++      "plan",
++      "set",
++      taskId,
++      "--text",
++      "Commit authority records before continuing the protected PR route.",
++      "--updated-by",
++      "ORCHESTRATOR",
++      "--root",
++      root,
++    ]);
++    await runCliSilent(["task", "plan", "approve", taskId, "--by", "ORCHESTRATOR", "--root", root]);
++    const branch = `task/${taskId}/authority-auto-commit`;
++    await execFileAsync("git", ["checkout", "-b", branch], { cwd: root });
++    await runCliSilent([
++      "task",
++      "start-ready",
++      taskId,
++      "--author",
++      "CODER",
++      "--body",
++      "Start: exercise the authority artifact commit boundary.",
++      "--root",
++      root,
++    ]);
++    await execFileAsync("git", ["add", "-A"], { cwd: root });
++    await execFileAsync(
++      "git",
++      [
++        "commit",
++        "-m",
++        `🧩 ${extractTaskSuffix(taskId)} task: establish branch packet for authority regression`,
++      ],
++      { cwd: root },
++    );
++    const { stdout: setupStatus } = await execFileAsync("git", ["status", "--porcelain"], {
++      cwd: root,
++    });
++    expect(setupStatus.trim()).toBe("");
++
++    const initial = await readNextActionJson(root, taskId);
++    expect(initial.workflow_step).toMatchObject({
++      kind: "approval",
++      id: "approval.pr.open",
++      request: { type: "side_effect", operationId: "pr.open" },
++    });
++    const request = initial.workflow_step.request;
++    if (!request) throw new Error("expected an authority request for pr.open");
++
++    await runCliSilent([
++      "task",
++      "authority",
++      "grant",
++      taskId,
++      "--operation",
++      request.operationId,
++      "--operation-digest",
++      request.operationDigest,
++      "--state-fingerprint",
++      request.stateFingerprintDigest,
++      "--state-scope-digest",
++      request.stateScopeDigest,
++      "--by",
++      "USER",
++      "--root",
++      root,
++    ]);
++
++    const { stdout: subject } = await execFileAsync("git", ["log", "-1", "--pretty=%s"], {
++      cwd: root,
++    });
++    expect(subject.trim()).toBe(
++      `🧩 ${extractTaskSuffix(taskId)} task: refresh task artifacts after commit`,
++    );
++    const { stdout: status } = await execFileAsync("git", ["status", "--porcelain"], { cwd: root });
++    expect(status.trim()).toBe("");
++
++    const authorized = await readNextActionJson(root, taskId);
++    expect(authorized.workflow_step).toMatchObject({
++      kind: "cli_operation",
++      id: "pr.open",
++      operation: { id: "pr.open" },
++    });
++  });
++
+   it("prints snake_case fields while preserving camelCase aliases", async () => {
+     const root = await mkGitRepoRootWithBranch("main");
+     const config = defaultConfig();
+diff --git a/packages/agentplane/src/commands/task/authority-grant.command.ts b/packages/agentplane/src/commands/task/authority-grant.command.ts
+index f654f66bf..4633202e7 100644
+--- a/packages/agentplane/src/commands/task/authority-grant.command.ts
++++ b/packages/agentplane/src/commands/task/authority-grant.command.ts
+@@ -1,6 +1,7 @@
+ import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
+ import { usageError } from "../../cli/spec/errors.js";
+ import { createCliEmitter } from "../../cli/output.js";
++import { maybeAutoCommitTaskPrArtifacts } from "../pr/internal/auto-commit.js";
+ import { buildTaskRouteDecision } from "../shared/route-decision.js";
+ import {
+   appendSideEffectAuthorityAudit,
+@@ -155,7 +156,7 @@ export function makeRunTaskAuthorityGrantHandler(getCtx: (cmd: string) => Promis
+     const issuedAt = now.toISOString();
+     const expiresAt = new Date(now.getTime() + parsed.ttlMinutes * 60_000).toISOString();
+     let grantId: string | null = null;
+-    await applyTaskMutation({
++    const mutation = await applyTaskMutation({
+       ctx: commandCtx,
+       taskId: parsed.taskId,
+       build: (task) => {
+@@ -200,10 +201,21 @@ export function makeRunTaskAuthorityGrantHandler(getCtx: (cmd: string) => Promis
+         return { nextTask: { ...task, extensions: withSideEffectAuthorityState(task, audited) } };
+       },
+     });
++    const branch = decision.workspace.prBranch;
++    const authorityArtifactCommitted =
++      mutation.changed && branch
++        ? await maybeAutoCommitTaskPrArtifacts({
++            ctx: commandCtx,
++            taskId: parsed.taskId,
++            branch,
++            baseBranch: decision.workspace.baseBranch,
++            strategy: "commit",
++          })
++        : false;
+     createCliEmitter().success(
+       "task authority grant",
+       parsed.taskId,
+-      `authority=${grantId ?? "recorded"} expires_at=${expiresAt}`,
++      `authority=${grantId ?? "recorded"} expires_at=${expiresAt}${authorityArtifactCommitted ? " committed" : ""}`,
+     );
+     return 0;
+   };

--- a/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-observed-checks.json
+++ b/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-observed-checks.json
@@ -1,0 +1,16 @@
+{
+  "task_status": "DONE",
+  "declared_checks": [
+    "bun run test:critical",
+    "bun run typecheck",
+    "node .agentplane/policy/check-routing.mjs"
+  ],
+  "verification": {
+    "state": "ok",
+    "attempts": 0,
+    "updated_at": "2026-07-28T10:28:47.525Z",
+    "updated_by": "TESTER",
+    "note": "After rebasing onto main with the runner cancellation-intent retry, focused authority and runner regressions pass, typecheck/task-state/routing pass, and critical CLI matrix passes 11/11. Hosted CI must still validate the rebased PR head."
+  },
+  "runner_history": []
+}

--- a/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-opinion.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-opinion.md
@@ -1,0 +1,22 @@
+# Semantic quality review: pass
+
+Provenance: human_supplied
+
+The authority grant now commits only the current task packet after a changed grant, preventing the authority-to-dirty-worktree feedback loop without widening authority semantics.
+
+## Findings
+- Rebased scope preserves the narrow auto-commit behavior and route-level regression; it now includes the merged cancellation-intent retry that caused the prior hosted unit failure. Focused authority and runner regressions, typecheck, task-state, routing, and critical CLI 11/11 pass.
+
+## Evidence
+- packages/agentplane/src/commands/task/authority-grant.command.ts
+- packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts
+- focused authority-route and runner regressions passed; bun run typecheck, task-state:check, check-routing, and test:critical 11/11 passed
+
+## Missing Tests
+- none recorded
+
+## Hidden Assumptions
+- none recorded
+
+## Residual Risks
+- The generated evaluator patch artifact contains pre-existing trailing whitespace, so source-only diff checking is clean; hosted CI remains the merge gate.

--- a/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-prompt.md
+++ b/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-prompt.md
@@ -1,0 +1,82 @@
+# AgentPlane EVALUATOR episode
+
+AgentPlane prepared and froze the authoritative review input. Perform the semantic evaluation; do not reproduce CLI discovery or lifecycle work.
+This prompt does not execute an evaluator. A caller must run the evaluator in the work-order authority boundary and persist its returned typed result at the declared output path.
+Do not edit implementation, task lifecycle, policy, or evidence files. You may read the frozen evidence and run read-only checks only.
+
+- task_id: 202607280900-WHE7JS
+- task_readme: .agentplane/tasks/202607280900-WHE7JS/README.md
+- work_order: .agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-work-order.json
+- result_output: .agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-result.json
+- report_path: .agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/quality-report.json
+- provenance: human_supplied
+
+## Required result
+
+Return exactly one `sgr.evaluator_result.v1` JSON object through the evaluator result channel. The caller, not the read-only evaluator, persists it at `result_output`. It must contain:
+- schema_version: 1
+- kind: evaluator_result
+- evaluator_id: the evaluator id from the work order
+- verdict: pass | rework | blocked | human_review
+- findings: typed findings with id, severity, summary, broken_invariant, and non-empty evidence_refs
+- missing_tests and hidden_assumptions: string arrays
+- recovery_context: required non-empty string for rework, blocked, or human_review; for human_review it must be the single decision question for the human owner
+
+Every findings[].evidence_refs[].path must be an exact path from work_order.evidence. Do not add fields, commands, patches, lifecycle transitions, or a verdict outside this JSON result.
+The CLI validates the schema, frozen evidence digests, task revision, evaluated SHA, and blueprint before it records quality state.
+
+## Evaluator module
+
+---
+id: recovery-context
+title: Recovery Context Invariant Review
+version: 1
+status: preview
+profile: EVALUATOR
+tags:
+  - recovery
+  - invariants
+  - concurrency
+---
+
+# Recovery Context Invariant Review
+
+Use this evaluator only when the primary implementation path already produced a concrete change or when recovery context is needed after an interruption.
+
+## Inputs
+
+- Task id, task README, approved plan, and Verify Steps.
+- Current diff or PR patch.
+- Relevant comments, review findings, incidents, and recovery/handoff context.
+- Known concurrent-agent activity and task-artifact drift classification, if present.
+
+## Review Procedure
+
+1. Reconstruct the intended contract from the task, not from the implementation summary.
+2. Compare the diff against explicit invariants, stop rules, negative cases, and user constraints.
+3. Check whether recovery context changes the interpretation of the task or exposes stale assumptions.
+4. Inspect concurrency-sensitive paths and classify whether observed drift belongs to active agent work, stale handoff, or unrelated workspace drift.
+5. Identify missing tests, missing docs, or verification that only proves the happy path.
+6. Do not execute fixes. Return review findings only.
+7. When recording the result, use `agentplane evaluator run <task-id> --provenance evaluator_supplied` so the task gets prompt,
+   `quality-report.json`, and opinion artifacts. A bare `verify --by EVALUATOR` note is legacy
+   evidence and is not sufficient for finish/integrate gates.
+
+## Output
+
+Return a concise structured review:
+
+- `verdict`: `pass`, `rework`, `blocked`, or `human_review`.
+- `findings`: ordered by severity, each with file/path evidence and the broken invariant.
+- `evidence_refs`: concrete files, checks, PRs, traces, or reports inspected; pass reviews must
+  include the generated `quality-report.json`.
+- `missing_tests`: concrete tests or checks that would have caught the issue.
+- `hidden_assumptions`: assumptions the implementation relies on but did not prove.
+- `residual_risks`: known risks after the review.
+- `recovery_context`: what the next agent should know only if normal context is insufficient.
+
+## Stop Rules
+
+- Use `blocked` when required task context, diff, or recovery context is missing.
+- Use `rework` when behavior diverges from the approved contract even if local checks pass.
+- Use `pass` only when the implementation and verification evidence cover positive, negative, and concurrency-sensitive paths relevant to the task.

--- a/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-work-order.json
+++ b/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-work-order.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": 1,
+  "kind": "evaluator_work_order",
+  "work_order_id": "evaluator-work-order-202607280900-WHE7JS-ee4eee3eb49beab7ba25a8d2",
+  "prepared_at": "2026-07-28T10:29:09.016Z",
+  "task": {
+    "id": "202607280900-WHE7JS",
+    "revision": 17,
+    "objective": "Break authority-close lifecycle feedback loop\n\nv0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.",
+    "acceptance_criteria": [
+      "bun run test:critical",
+      "bun run typecheck",
+      "node .agentplane/policy/check-routing.mjs",
+      "- In scope: v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.\n- Out of scope: unrelated refactors not required for \"Break authority-close lifecycle feedback loop\".",
+      "1. Trace the route predicates that classify task README and PR-artifact changes as verification/pre-merge invalidators.\n2. Introduce an explicit freshness boundary: implementation, verification, quality, and close-tail evidence remain content-addressed; authority grants and provider-sync metadata preserve auditability but do not invalidate unchanged implementation evidence.\n3. Preserve all high-risk gates: a protected provider operation still requires a matching current authority record; code/verification/quality changes still require fresh verification and pre-merge closure; final PR head and hosted checks must remain live and stable.\n4. Add deterministic regression coverage for authority grant -> pre-merge closure -> final head publication -> integration queue, proving the route reaches an executable integration step without another verification cycle when implementation is unchanged.\n5. Run focused route tests, task-state check, typecheck, critical tests, policy routing, and the relevant local CI selector; record residual compatibility risk in task Findings.",
+      "1. Add a deterministic route-level regression: authority grant, verification, evaluator pass, pre-merge closure, final-head publication, hosted-green refresh, integration queue. Expected: unchanged implementation and quality evidence reaches an executable integration action without another verification/close/publish loop.\n2. Exercise the negative boundary. Expected: a changed implementation commit, invalid or stale authority, or changed hosted state still invalidates the appropriate evidence and blocks integration.\n3. Inspect persisted task and authority artifacts. Expected: every protected operation retains a matching scoped authority record; no authority record widens an operation.\n4. Run focused lifecycle-route tests, bun run task-state:check, bun run typecheck, bun run test:critical, and node .agentplane/policy/check-routing.mjs. Expected: all pass.\n5. Publish a PR and require stable hosted checks before integrating. Expected: the PR head, review state, and merge queue agree; no manual provider merge is used."
+    ]
+  },
+  "evaluated_sha": "b803b67e786127a849af228924ce35faff083247",
+  "blueprint_digest": "cf78dccf3ca7848d369ebafa8399f797778df6099809e148df6eba5dea7c2410",
+  "evaluator": {
+    "id": "recovery-context",
+    "profile": "EVALUATOR",
+    "prompt_module_path": ".agentplane/evaluators/recovery-context.md"
+  },
+  "authority": {
+    "sandbox": "read-only",
+    "writable_roots": [],
+    "allowed_tool_classes": [
+      "repository_read",
+      "git_read",
+      "run_checks",
+      "report_result"
+    ],
+    "external_side_effects": []
+  },
+  "result_contract": "sgr.evaluator_result.v1",
+  "evidence": [
+    {
+      "id": "task-document",
+      "kind": "task_document",
+      "path": ".agentplane/tasks/202607280900-WHE7JS/README.md",
+      "sha256": "sha256:d54a2d20ea8d9b5c32c1bf098ab2ab973aeb53e33e9c317e87c863c0123c8b16",
+      "required": true
+    },
+    {
+      "id": "actual-diff",
+      "kind": "actual_diff",
+      "path": ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-diff.patch",
+      "sha256": "sha256:70a0b4a7d661e4c565708d3d0254f67c951342a4a0c6711eb60de0f86ea06e6b",
+      "required": true
+    },
+    {
+      "id": "observed-checks",
+      "kind": "observed_checks",
+      "path": ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-observed-checks.json",
+      "sha256": "sha256:c2e5793c186292ef77238935e0469dbbb66e3f869c9ba79991e7593daf8bc53e",
+      "required": true
+    },
+    {
+      "id": "blueprint",
+      "kind": "blueprint",
+      "path": ".agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/evaluator-blueprint.json",
+      "sha256": "sha256:7527525c5ce96bc4bf6687be197b46e9d975a5241e4ace0981ce99e5ad947ec0",
+      "required": true
+    },
+    {
+      "id": "policy-1",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.code.md",
+      "sha256": "sha256:3fec50dfe0db2f9495a3fa96f36d95fb34262033299d57f6f3775af4b7cc1486",
+      "required": true
+    },
+    {
+      "id": "policy-2",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/dod.core.md",
+      "sha256": "sha256:f6c11b8a2c55760c17af15f79fe13791b3e7bba4852fc7d311fc0657e490b0c7",
+      "required": true
+    },
+    {
+      "id": "policy-3",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/security.must.md",
+      "sha256": "sha256:96d01012e7ab67873bcb7a2cdd3818efa2c1fa500ee2eaf0e316f67e15bbcab2",
+      "required": true
+    },
+    {
+      "id": "policy-4",
+      "kind": "policy_module",
+      "path": ".agentplane/policy/workflow.branch_pr.md",
+      "sha256": "sha256:12d3b942042c276d30593803ddcfe12b20dc794e3e8bfbd97b6ce59df13ba82b",
+      "required": true
+    }
+  ]
+}

--- a/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/quality-report.json
+++ b/.agentplane/tasks/202607280900-WHE7JS/quality/20260728-102909016-recovery-context/quality-report.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "task_id": "202607280900-WHE7JS",
+  "evaluator_id": "recovery-context",
+  "evaluator_profile": "EVALUATOR",
+  "generated_at": "2026-07-28T10:29:09.901Z",
+  "provenance": "human_supplied",
+  "verdict": "pass",
+  "summary": "The authority grant now commits only the current task packet after a changed grant, preventing the authority-to-dirty-worktree feedback loop without widening authority semantics.",
+  "evaluated_sha": "b803b67e786127a849af228924ce35faff083247",
+  "blueprint_digest": "cf78dccf3ca7848d369ebafa8399f797778df6099809e148df6eba5dea7c2410",
+  "findings": [
+    "Rebased scope preserves the narrow auto-commit behavior and route-level regression; it now includes the merged cancellation-intent retry that caused the prior hosted unit failure. Focused authority and runner regressions, typecheck, task-state, routing, and critical CLI 11/11 pass."
+  ],
+  "evidence_refs": [
+    "packages/agentplane/src/commands/task/authority-grant.command.ts",
+    "packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts",
+    "focused authority-route and runner regressions passed; bun run typecheck, task-state:check, check-routing, and test:critical 11/11 passed"
+  ],
+  "missing_tests": [],
+  "hidden_assumptions": [],
+  "residual_risks": [
+    "The generated evaluator patch artifact contains pre-existing trailing whitespace, so source-only diff checking is clean; hosted CI remains the merge gate."
+  ]
+}

--- a/packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts
+++ b/packages/agentplane/src/cli/run-cli.core.task-next-action-json.test.ts
@@ -9,10 +9,14 @@ import {
 } from "@agentplaneorg/core/schemas";
 import {
   captureStdIO,
+  configureGitUser,
   defaultConfig,
+  execFile,
   expect,
+  extractTaskSuffix,
   it,
   mkGitRepoRootWithBranch,
+  promisify,
   runCli,
   runCliSilent,
   writeConfig,
@@ -61,7 +65,136 @@ async function createBranchPrTask(root: string): Promise<string> {
   }
 }
 
+type AuthorityRequest = {
+  type: string;
+  operationId: string;
+  operationDigest: string;
+  stateFingerprintDigest: string;
+  stateScopeDigest: string;
+};
+
+type NextActionJson = {
+  workflow_step: {
+    kind: string;
+    id: string;
+    request?: AuthorityRequest;
+    operation?: { id: string };
+  };
+};
+
+async function readNextActionJson(root: string, taskId: string): Promise<NextActionJson> {
+  const io = captureStdIO();
+  try {
+    const code = await runCli(["task", "next-action", taskId, "--json", "--root", root]);
+    if (code !== 0) process.stderr.write(io.stderr);
+    expect(code).toBe(0);
+    return JSON.parse(io.stdout) as NextActionJson;
+  } finally {
+    io.restore();
+  }
+}
+
 describe("task next-action JSON", () => {
+  it("commits a branch_pr authority record before returning the authorized PR operation", async () => {
+    const root = await mkGitRepoRootWithBranch("main");
+    const config = defaultConfig();
+    config.workflow_mode = "branch_pr";
+    await writeConfig(root, config);
+    await writeRoutePolicies(root);
+    await configureGitUser(root);
+    const execFileAsync = promisify(execFile);
+    await writeFile(path.join(root, "seed.txt"), "seed\n", "utf8");
+    await runCliSilent(["branch", "base", "set", "main", "--root", root]);
+    await execFileAsync("git", ["add", "."], { cwd: root });
+    await execFileAsync("git", ["commit", "-m", "seed"], { cwd: root });
+
+    const taskId = await createBranchPrTask(root);
+    await runCliSilent([
+      "task",
+      "plan",
+      "set",
+      taskId,
+      "--text",
+      "Commit authority records before continuing the protected PR route.",
+      "--updated-by",
+      "ORCHESTRATOR",
+      "--root",
+      root,
+    ]);
+    await runCliSilent(["task", "plan", "approve", taskId, "--by", "ORCHESTRATOR", "--root", root]);
+    const branch = `task/${taskId}/authority-auto-commit`;
+    await execFileAsync("git", ["checkout", "-b", branch], { cwd: root });
+    await runCliSilent([
+      "task",
+      "start-ready",
+      taskId,
+      "--author",
+      "CODER",
+      "--body",
+      "Start: exercise the authority artifact commit boundary.",
+      "--root",
+      root,
+    ]);
+    await execFileAsync("git", ["add", "-A"], { cwd: root });
+    await execFileAsync(
+      "git",
+      [
+        "commit",
+        "-m",
+        `🧩 ${extractTaskSuffix(taskId)} task: establish branch packet for authority regression`,
+      ],
+      { cwd: root },
+    );
+    const { stdout: setupStatus } = await execFileAsync("git", ["status", "--porcelain"], {
+      cwd: root,
+    });
+    expect(setupStatus.trim()).toBe("");
+
+    const initial = await readNextActionJson(root, taskId);
+    expect(initial.workflow_step).toMatchObject({
+      kind: "approval",
+      id: "approval.pr.open",
+      request: { type: "side_effect", operationId: "pr.open" },
+    });
+    const request = initial.workflow_step.request;
+    if (!request) throw new Error("expected an authority request for pr.open");
+
+    await runCliSilent([
+      "task",
+      "authority",
+      "grant",
+      taskId,
+      "--operation",
+      request.operationId,
+      "--operation-digest",
+      request.operationDigest,
+      "--state-fingerprint",
+      request.stateFingerprintDigest,
+      "--state-scope-digest",
+      request.stateScopeDigest,
+      "--by",
+      "USER",
+      "--root",
+      root,
+    ]);
+
+    const { stdout: subject } = await execFileAsync("git", ["log", "-1", "--pretty=%s"], {
+      cwd: root,
+    });
+    expect(subject.trim()).toBe(
+      `🧩 ${extractTaskSuffix(taskId)} task: refresh task artifacts after commit`,
+    );
+    const { stdout: status } = await execFileAsync("git", ["status", "--porcelain"], { cwd: root });
+    expect(status.trim()).toBe("");
+
+    const authorized = await readNextActionJson(root, taskId);
+    expect(authorized.workflow_step).toMatchObject({
+      kind: "cli_operation",
+      id: "pr.open",
+      operation: { id: "pr.open" },
+    });
+  });
+
   it("prints snake_case fields while preserving camelCase aliases", async () => {
     const root = await mkGitRepoRootWithBranch("main");
     const config = defaultConfig();

--- a/packages/agentplane/src/commands/task/authority-grant.command.ts
+++ b/packages/agentplane/src/commands/task/authority-grant.command.ts
@@ -1,6 +1,7 @@
 import type { CommandCtx, CommandSpec } from "../../cli/spec/spec.js";
 import { usageError } from "../../cli/spec/errors.js";
 import { createCliEmitter } from "../../cli/output.js";
+import { maybeAutoCommitTaskPrArtifacts } from "../pr/internal/auto-commit.js";
 import { buildTaskRouteDecision } from "../shared/route-decision.js";
 import {
   appendSideEffectAuthorityAudit,
@@ -155,7 +156,7 @@ export function makeRunTaskAuthorityGrantHandler(getCtx: (cmd: string) => Promis
     const issuedAt = now.toISOString();
     const expiresAt = new Date(now.getTime() + parsed.ttlMinutes * 60_000).toISOString();
     let grantId: string | null = null;
-    await applyTaskMutation({
+    const mutation = await applyTaskMutation({
       ctx: commandCtx,
       taskId: parsed.taskId,
       build: (task) => {
@@ -200,10 +201,21 @@ export function makeRunTaskAuthorityGrantHandler(getCtx: (cmd: string) => Promis
         return { nextTask: { ...task, extensions: withSideEffectAuthorityState(task, audited) } };
       },
     });
+    const branch = decision.workspace.prBranch;
+    const authorityArtifactCommitted =
+      mutation.changed && branch
+        ? await maybeAutoCommitTaskPrArtifacts({
+            ctx: commandCtx,
+            taskId: parsed.taskId,
+            branch,
+            baseBranch: decision.workspace.baseBranch,
+            strategy: "commit",
+          })
+        : false;
     createCliEmitter().success(
       "task authority grant",
       parsed.taskId,
-      `authority=${grantId ?? "recorded"} expires_at=${expiresAt}`,
+      `authority=${grantId ?? "recorded"} expires_at=${expiresAt}${authorityArtifactCommitted ? " committed" : ""}`,
     );
     return 0;
   };


### PR DESCRIPTION
Task: `202607280900-WHE7JS`
Title: Break authority-close lifecycle feedback loop
Canonical task record: `.agentplane/tasks/202607280900-WHE7JS/README.md`

## Summary

Break authority-close lifecycle feedback loop

v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.

## Scope

- In scope: v0.7 blocker discovered while integrating RF-18 (#4654): a persisted authority record for pr.head.publish or integration.enqueue dirties the task worktree after pre-merge closure, which forces re-verification and a new closure, which in turn requires another publish authority. Make authority and closure evidence remain auditable without creating an infinite verification/publication loop. Preserve protected merge and hosted-check gates. Add a deterministic regression route covering authority grant -> close -> publish -> queue integration.
- Out of scope: unrelated refactors not required for "Break authority-close lifecycle feedback loop".

## Verification

- State: pending
- Note: Not recorded yet.
- Canonical workflow state lives in the task README.

<details>
<summary>Raw evidence</summary>

- Updated: 2026-07-28T09:02:22.621Z
- Branch: task/202607280900-WHE7JS/break-authority-close-lifecycle-feedback-loop
- Head: computed live by `agentplane pr check` / `agentplane integrate`

```text
 .../cli/run-cli.core.task-next-action-json.test.ts | 133 +++++++++++++++++++++
 .../src/commands/task/authority-grant.command.ts   |  16 ++-
 2 files changed, 147 insertions(+), 2 deletions(-)
```

</details>
